### PR TITLE
Fix Error on saving User Permissions

### DIFF
--- a/src/Umbraco.Web/Cache/CacheRefresherEventHandler.cs
+++ b/src/Umbraco.Web/Cache/CacheRefresherEventHandler.cs
@@ -402,7 +402,7 @@ namespace Umbraco.Web.Cache
             {
                 DistributedCache.Instance.RefreshUserCache(sender.UserId);
             }
-            if (sender.Nodes.Any())
+            if (sender.NodeIds.Any())
             {
                 DistributedCache.Instance.RefreshAllUserCache();
             }


### PR DESCRIPTION
This fixes the bug here:
http://issues.umbraco.org/issue/U4-2320

My extended commit comment:
Nodes can be null but NodeIds property always returns a collection and this will return Ids from Nodes if _nodeIds are null and Nodes is not.

A bit more detail: DeletePermissions in Permission.cs calls the constructor of UserPermissions with an array of NodeIds and so when InvalidateCacheForPermissionsChange is called with one of these objects only NodeIds are available, not Nodes.
