### PR TITLE
Fix U4-2320 - Error on saving User Permissions (for 6.1.2 release)

### DIFF
--- a/src/Umbraco.Web/Cache/CacheRefresherEventHandler.cs
+++ b/src/Umbraco.Web/Cache/CacheRefresherEventHandler.cs
@@ -402,7 +402,7 @@ namespace Umbraco.Web.Cache
             {
                 DistributedCache.Instance.RefreshUserCache(sender.UserId);
             }
-            if (sender.Nodes.Any())
+            if (sender.NodeIds.Any())
             {
                 DistributedCache.Instance.RefreshAllUserCache();
             }


### PR DESCRIPTION
NB This is the same fix as #4.Since sending #4, I've discovered this release and this fix is for an issue arising from 6.1.1 so the branch for this release seems to be the appropriate place to submit.

Nodes can be null but NodeIds property always returns a collection and this will return Ids from Nodes if _nodeIds are null and Nodes is not.
