### PR TITLE
Fix U4-2372 Save and Publish creates fewer versions

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
@@ -249,7 +249,7 @@ namespace Umbraco.Core.Persistence.Repositories
         {
             var publishedState = ((Content) entity).PublishedState;
             //A new version should only be created if published state (or language) has changed
-            bool shouldCreateNewVersion = (((ICanBeDirty)entity).IsPropertyDirty("Published") && publishedState != PublishedState.Unpublished) || ((ICanBeDirty)entity).IsPropertyDirty("Language");
+            bool shouldCreateNewVersion = ((Content)entity).Published || ((ICanBeDirty)entity).IsPropertyDirty("Language");
             if (shouldCreateNewVersion)
             {
                 //Updates Modified date and Version Guid


### PR DESCRIPTION
This PR is to fix http://issues.umbraco.org/issue/U4-2372.

Previous to 6.1.0, when this [line](https://github.com/umbraco/Umbraco-CMS/blob/6.1.2/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs#L252) in ContentRepository was reached:
`bool shouldCreateNewVersion = (((ICanBeDirty)entity).IsPropertyDirty("Published") 
&& publishedState != PublishedState.Unpublished)
 || ((ICanBeDirty)entity).IsPropertyDirty("Language");`
the property Published was dirty when a Save and Publish was initiated from the front end.

This is no longer always the case. Because of this, this [line](https://github.com/umbraco/Umbraco-CMS/blob/6.1.2/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs#L256) in ContentRepository:
`((Content)entity).UpdatingEntity();` 
is being called only for new Content and for Content moving between Unpublished to Published. The UpdatingEntity method is responsible for setting a new guid on the Version property on the Content. Because of this, only new Content and Content moving between Unpublished to Published is getting a new version number. In this context, by unpublished, I mean Content that has not yet been published before the Save And Publish was initiated.

I've changed the check in shouldCreateNewVersion to be based on the actual Published property itself. This restores the original functionality of a new cmsDocument row being created everytime a user clicks Save and Publish and this results in a successful Publish.

Please note the issue in http://issues.umbraco.org/issue/U4-2361 appears worse as there are more versions being saved so this will also need to be fixed.
