### PR TITLE
Fix U4-2379 InvalidOperationException: Sequence contains no elements...

### DIFF
--- a/src/umbraco.businesslogic/ApplicationTreeRegistrar.cs
+++ b/src/umbraco.businesslogic/ApplicationTreeRegistrar.cs
@@ -24,8 +24,8 @@ namespace umbraco.BusinessLogic
 
         	var items = types
         		.Select(x =>
-        		        new Tuple<Type, TreeAttribute>(x, x.GetCustomAttributes<TreeAttribute>(false).Single()))
-        		.Where(x => ApplicationTree.getByAlias(x.Item2.Alias) == null);
+        		        new Tuple<Type, TreeAttribute>(x, x.GetCustomAttributes<TreeAttribute>(false).SingleOrDefault()))
+        		.Where(x => x.Item2 != null && ApplicationTree.getByAlias(x.Item2.Alias) == null);
 
             var allAliases = ApplicationTree.getAll().Select(x => x.Alias).Concat(items.Select(x => x.Item2.Alias));
             var inString = "'" + string.Join("','", allAliases) + "'";


### PR DESCRIPTION
... in ApplicationTreeRegistrar

http://issues.umbraco.org/issue/U4-2379

issue stems from a package that inherits baseTree however does not add the TreeAttribrute to the class declaration.
