### PR TITLE
Duplicate e-mail addresses: U4-315, U4-2147, U4-304

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/member.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/member.ascx.cs
@@ -123,7 +123,7 @@ namespace umbraco.cms.presentation.create.controls
         /// <param name="e"></param>
         protected void EmailExistsCheck(object sender, ServerValidateEventArgs e)
         {
-            if (Email.Text != "" && Member.GetMemberFromEmail(Email.Text.ToLower()) != null)
+            if (Email.Text != "" && Member.GetMemberFromEmail(Email.Text.ToLower()) != null && Membership.Providers[Member.UmbracoMemberProviderName].RequiresUniqueEmail)
                 e.IsValid = false;
             else
                 e.IsValid = true;

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMember.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMember.aspx.cs
@@ -28,6 +28,7 @@ namespace umbraco.cms.presentation.members
 
 		protected PlaceHolder MemberPasswordTxt = new PlaceHolder();
 		protected TextBox MemberEmail = new TextBox();
+        protected CustomValidator MemberEmailExistCheck = new CustomValidator();
 		protected controls.DualSelectbox _memberGroups = new controls.DualSelectbox();
 
 
@@ -65,8 +66,15 @@ namespace umbraco.cms.presentation.members
                 MemberLoginNameVal.EnableClientScript = false;
                 MemberLoginNameVal.Display = ValidatorDisplay.Dynamic;
 
+                MemberEmailExistCheck.ErrorMessage = ui.Text("errorHandling", "errorExistsWithoutTab", "E-mail", BasePages.UmbracoEnsuredPage.CurrentUser);
+                MemberEmailExistCheck.EnableClientScript = false;
+                MemberEmailExistCheck.ValidateEmptyText = false;
+                MemberEmailExistCheck.ControlToValidate = MemberEmail.ID;
+                MemberEmailExistCheck.ServerValidate += MemberEmailExistCheck_ServerValidate;
+
                 _contentControl.PropertiesPane.addProperty(ui.Text("login"), ph);
                 _contentControl.PropertiesPane.addProperty(ui.Text("password"), MemberPasswordTxt);
+                _contentControl.PropertiesPane.addProperty("", MemberEmailExistCheck);
                 _contentControl.PropertiesPane.addProperty("Email", MemberEmail);
             }
             else
@@ -131,6 +139,14 @@ namespace umbraco.cms.presentation.members
                 m_MemberShipPanel.Controls.Add(p);
 
 		}
+
+        void MemberEmailExistCheck_ServerValidate(object source, ServerValidateEventArgs args)
+        {
+            if (MemberEmail.Text != "" && Member.GetMemberFromEmail(MemberEmail.Text.ToLower()) != null && Membership.Providers[Member.UmbracoMemberProviderName].RequiresUniqueEmail)
+                args.IsValid = false;
+            else
+                args.IsValid = true;
+        }
 
         void MenuSaveClick(object sender, ImageClickEventArgs e)
         {

--- a/src/umbraco.cms/businesslogic/member/Member.cs
+++ b/src/umbraco.cms/businesslogic/member/Member.cs
@@ -222,11 +222,13 @@ namespace umbraco.cms.businesslogic.member
                 throw new ArgumentException("The loginname must be different from an empty string", "loginName");
 
             // Test for e-mail
-            if (Email != "" && Member.GetMemberFromEmail(Email) != null)
+            if (Email != "" && Member.GetMemberFromEmail(Email) != null && Membership.Providers[UmbracoMemberProviderName].RequiresUniqueEmail)
                 throw new Exception(String.Format("Duplicate Email! A member with the e-mail {0} already exists", Email));
             else if (Member.GetMemberFromLoginName(loginName) != null)
                 throw new Exception(String.Format("Duplicate User name! A member with the user name {0} already exists", loginName));
 
+            // Lowercased to prevent duplicates
+            Email = Email.ToLowerInvariant();
             Guid newId = Guid.NewGuid();
 
             //create the cms node first
@@ -292,7 +294,7 @@ namespace umbraco.cms.businesslogic.member
         }
 
         /// <summary>
-        /// Retrieve a Member given an email
+        /// Retrieve a Member given an email, the first if there multiple members with same email
         /// 
         /// Used when authentifying the Member
         /// </summary>
@@ -306,7 +308,7 @@ namespace umbraco.cms.businesslogic.member
 
             object o = SqlHelper.ExecuteScalar<object>(
                 "select nodeID from cmsMember where Email = @email",
-                SqlHelper.CreateParameter("@email", email));
+                SqlHelper.CreateParameter("@email", email.ToLower()));
 
             if (o == null)
                 return null;
@@ -316,6 +318,35 @@ namespace umbraco.cms.businesslogic.member
                 return null;
 
             return new Member(tmpId);
+        }
+
+        /// <summary>
+        /// Retrieve Members given an email
+        /// 
+        /// Used when authentifying a Member
+        /// </summary>
+        /// <param name="email">The email of the member(s)</param>
+        /// <returns>The members with the specified email</returns>
+        public static Member[] GetMembersFromEmail(string email)
+        {
+            if (string.IsNullOrEmpty(email))
+                return null;
+
+            var tmp = new List<Member>();
+            using (IRecordsReader dr = SqlHelper.ExecuteReader(string.Format(m_SQLOptimizedMany.Trim(),
+                                        "Email = @email",
+                                        "umbracoNode.text"),
+                                            SqlHelper.CreateParameter("@nodeObjectType", Member._objectType),
+                                            SqlHelper.CreateParameter("@email", email.ToLower())))
+            {
+                while (dr.Read())
+                {
+                    Member m = new Member(dr.GetInt("id"), true);
+                    m.PopulateMemberFromReader(dr);
+                    tmp.Add(m);
+                }
+            }
+            return tmp.ToArray();
         }
 
         /// <summary>
@@ -528,13 +559,18 @@ namespace umbraco.cms.businesslogic.member
                        SqlHelper.CreateParameter("@id", Id));
                 }
 
-                return m_Email;
+                return m_Email.ToLower();
             }
             set
             {
+                var m = Member.GetMemberFromEmail(value);
+                if (m != null && Membership.Providers[UmbracoMemberProviderName].RequiresUniqueEmail)
+                {
+                    throw new Exception(String.Format("Duplicate Email! A member with the e-mail {0} already exists", value.ToLower()));
+                }
                 SqlHelper.ExecuteNonQuery(
                     "update cmsMember set Email = @email where nodeId = @id",
-                    SqlHelper.CreateParameter("@id", Id), SqlHelper.CreateParameter("@email", value));
+                    SqlHelper.CreateParameter("@id", Id), SqlHelper.CreateParameter("@email", value.ToLower()));
             }
         }
         #endregion

--- a/src/umbraco.providers/members/MembersMembershipProvider.cs
+++ b/src/umbraco.providers/members/MembersMembershipProvider.cs
@@ -373,7 +373,7 @@ namespace umbraco.providers.members
         {
             if (Member.GetMemberFromLoginName(username) != null)
                 status = MembershipCreateStatus.DuplicateUserName;
-            else if (Member.GetMemberFromEmail(email) != null)
+            else if (Member.GetMemberFromEmail(email) != null && RequiresUniqueEmail)
                 status = MembershipCreateStatus.DuplicateEmail;
             else
             {


### PR DESCRIPTION
- Allows for duplicate e-mail addresses in member section by opt-in
  (requiresUniqueEmail="false" in
  web.config/membership/providers/"UmbracoMembershipProvider").
- Fixes issues with backoffice not checking for duplicate emails when
  changing member after creation.
- Lower cases email addresses upon creating member and when searching to
  prevent duplicates.
- Added Member.GetMembersByEmail to get alle members with specific email
