### PR TITLE
Check for existance of TreeAttribute

### DIFF
--- a/src/umbraco.businesslogic/ApplicationTreeRegistrar.cs
+++ b/src/umbraco.businesslogic/ApplicationTreeRegistrar.cs
@@ -23,6 +23,7 @@ namespace umbraco.BusinessLogic
 			var types = PluginManager.Current.ResolveAttributedTrees();
 
         	var items = types
+        		.Where(x => x.GetCustomAttributes<TreeAttribute>(false).Any())
         		.Select(x =>
         		        new Tuple<Type, TreeAttribute>(x, x.GetCustomAttributes<TreeAttribute>(false).Single()))
         		.Where(x => ApplicationTree.getByAlias(x.Item2.Alias) == null);


### PR DESCRIPTION
I got a NullRef on this line: new Tuple<Type, TreeAttribute>(x, x.GetCustomAttributes<TreeAttribute>(false).Single())

x.GetCustomAttributes<TreeAttribute>(false) returned no elements for the assembly DictionaryFix.dll (http://our.umbraco.org/projects/backoffice-extensions/digibiz-dictionary-section)

Ps. Sorry about the name of the branch (patch-1), I haven't got a clue where to rename it...
