### PR TITLE
Umbraco back-office error previewing dummy.txt

### DIFF
--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -20,7 +20,7 @@
       <!-- Path to script folder - no ending "/" -->
       <scriptFolderPath>/scripts</scriptFolderPath>
       <!-- what files can be opened/created in the script editor -->
-      <scriptFileTypes>js,xml</scriptFileTypes>
+      <scriptFileTypes>js,xml,txt</scriptFileTypes>
       <!-- disable the codemirror editor and use a simple textarea instead -->
       <scriptDisableEditor>false</scriptDisableEditor>
     </scripteditor>


### PR DESCRIPTION
This is my first github pull request - so I hope it's not a disaster!  From the package manager in Visual Studio 2012 I did a:

install-package umbracocms 

It dropped the dummy.txt file in the scripting files, but this file errors if you try to preview it in the back-office.  This is previously reported here: http://issues.umbraco.org/issue/U4-1620 
