### PR TITLE
Added code to display inherited properties when editing document types.

### DIFF
--- a/src/Umbraco.Web.UI/umbraco_client/GenericProperty/genericproperty.css
+++ b/src/Umbraco.Web.UI/umbraco_client/GenericProperty/genericproperty.css
@@ -14,6 +14,10 @@
   list-style: none;
 }
 
+.genericPropertyList .inherited {
+    opacity: .6;
+}
+
 .genericPropertyList li {
   padding: 7px;
   display: block;

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -369,6 +369,7 @@
     <Compile Include="umbraco.presentation\umbraco\controls\ContentTypeControlNew.ascx.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
+    <Compile Include="umbraco.presentation\umbraco\controls\GenericProperties\GenericPropertyInherited.cs" />
     <Compile Include="umbraco.presentation\umbraco\developer\Packages\directoryBrowser.aspx.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
@@ -1815,7 +1816,9 @@
     <Content Include="umbraco.presentation\umbraco\controls\ProgressBar.ascx">
       <SubType>ASPXCodeBehind</SubType>
     </Content>
-    <Content Include="umbraco.presentation\umbraco\controls\GenericProperties\GenericProperty.ascx" />
+    <Content Include="umbraco.presentation\umbraco\controls\GenericProperties\GenericProperty.ascx">
+      <SubType>ASPXCodeBehind</SubType>
+    </Content>
     <Content Include="umbraco.presentation\umbraco\create\DLRScripting.ascx">
       <SubType>ASPXCodeBehind</SubType>
     </Content>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentControl.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentControl.cs
@@ -197,7 +197,7 @@ namespace umbraco.controls
         private void LoadPropertyTypes(IContentTypeComposition contentType, TabPage tabPage, Hashtable inTab, int tabId, string tabCaption)
         {
             var propertyGroups = contentType.CompositionPropertyGroups.Where(x => x.Id == tabId || x.ParentId == tabId);
-            var propertyTypeAliases = propertyGroups.SelectMany(x => x.PropertyTypes.OrderBy(y => y.SortOrder).Select(y => new Tuple<int, string, int>(y.Id, y.Alias, y.SortOrder)));
+            var propertyTypeAliases = propertyGroups.SelectMany(x => x.PropertyTypes.OrderBy(y => y.SortOrder).Select(y => new Tuple<int, string, int>(y.Id, y.Alias, y.SortOrder))).OrderBy(s => s.Item3);
             foreach (var items in propertyTypeAliases)
             {
                 var property = _content.getProperty(items.Item2);

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentTypeControlNew.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentTypeControlNew.ascx.cs
@@ -646,12 +646,12 @@ jQuery(document).ready(function() {{ refreshDropDowns(); }});
 
                 var propertyGroup = propertyTypeGroups.SingleOrDefault(x => x.ParentId == tab.Id);
                 var propertyTypes = propertyGroup == null
-                                        ? tab.GetPropertyTypes(_contentType.Id, false)
-                                        : propertyGroup.GetPropertyTypes();
+                                        ? tab.GetPropertyTypes(_contentType.Id, true)
+                                        : propertyGroup.GetPropertyTypes(true);
 
                 var propertyGroupId = tab.Id;
 
-                if (propertyTypes.Any(x => x.ContentTypeId == _contentType.Id))
+                if (true) //propertyTypes.Any(x => x.ContentTypeId == _contentType.Id))
                 {
                     var propSort = new HtmlInputHidden();
                     propSort.ID = "propSort_" + propertyGroupId.ToString() + "_Content";
@@ -660,11 +660,22 @@ jQuery(document).ready(function() {{ refreshDropDowns(); }});
 
                     PropertyTypes.Controls.Add(new LiteralControl("<ul class='genericPropertyList' id=\"t_" + propertyGroupId.ToString() + "_Contents\">"));
 
-                    foreach (cms.businesslogic.propertytype.PropertyType pt in propertyTypes)
+                    foreach (cms.businesslogic.propertytype.PropertyType pt in propertyTypes.OrderBy(s => s.SortOrder))
                     {
-                        //If the PropertyType doesn't belong on this ContentType skip it and continue to the next one
-                        if (pt.ContentTypeId != _contentType.Id) continue;
+                        //If the PropertyType doesn't belong on this ContentType add a disabled version for reference.
+                        if (pt.ContentTypeId != _contentType.Id)
+                        {
+                            var gpw_inh = new GenericPropertyInherited();
+                            gpw_inh.ID = "gpw_" + pt.Id;
+                            gpw_inh.PropertyType = pt;
+                            gpw_inh.ContentType = pt.ContentTypeId != _contentType.Id ? ContentType.GetContentType(pt.ContentTypeId) : _contentType;
+                            gpw_inh.FullId = "t_" + propertyGroupId.ToString() + "_Contents_" + +pt.Id;
 
+                            PropertyTypes.Controls.Add(gpw_inh);
+
+                            continue;
+                        }
+                        
                         var gpw = new GenericPropertyWrapper();
                         gpw.ID = "gpw_" + pt.Id;
                         gpw.PropertyType = pt;
@@ -901,6 +912,11 @@ jQuery(document).ready(function() {{ refreshDropDowns(); }});
                         {
                             var propertyType = contentTypeItem.PropertyTypes.First(x => x.Id == propertyTypeId);
                             propertyType.SortOrder = i;
+                        }
+                        else
+                        {
+                            // Update property directly.  This can include inherited properties.
+                            cms.businesslogic.propertytype.PropertyType.GetPropertyType(propertyTypeId).SortOrder = i;
                         }
                     }
                 }

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/controls/GenericProperties/GenericPropertyInherited.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/controls/GenericProperties/GenericPropertyInherited.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using umbraco.IO;
+using umbraco.cms.businesslogic.propertytype;
+using ClientDependency.Core;
+
+namespace umbraco.controls.GenericProperties
+{
+	/// <summary>
+	/// Summary description for GenericPropertyWrapper.
+    /// </summary>
+    [ClientDependency(ClientDependencyType.Css, "GenericProperty/genericproperty.css", "UmbracoClient")]
+	public class GenericPropertyInherited : System.Web.UI.WebControls.PlaceHolder
+	{
+        private cms.businesslogic.propertytype.PropertyType _pt;
+        private cms.businesslogic.ContentType _ct;
+		private string _fullId = "";
+
+		public cms.businesslogic.propertytype.PropertyType PropertyType 
+		{
+			set {_pt = value;}
+			get {return _pt;}
+		}
+
+        public cms.businesslogic.ContentType ContentType
+        {
+            set { _ct = value; }
+        }
+
+		public string FullId 
+		{
+			set 
+			{
+				_fullId = value;
+			}
+		}
+
+        public GenericPropertyInherited()
+		{
+			//
+			// TODO: Add constructor logic here
+			//
+		}
+
+		protected override void OnInit(EventArgs e)
+		{
+			base.OnInit (e);
+            var FullHeader = _pt.GetRawName() + " (" + _pt.Alias + "), Type: " + _pt.DataTypeDefinition.Text + " (inherited from " + _ct.Text + ")";
+            System.Web.UI.Control u = new System.Web.UI.LiteralControl(String.Format(@"
+<li id='{0}' class='inherited'>
+	<div class='propertyForm' id='{0}_form'>
+		<div id='desc{0}' style='padding: 0px; display: block; margin: 0px;'>
+			<h3 style='padding: 0px; margin: 0px;'>{1}</h3>
+        </div>
+    </div>
+</li>
+            ", this._fullId, FullHeader));
+			u.ID = this.ID + "_control";
+			this.Controls.Add(u);
+			
+		}
+    }
+}

--- a/src/umbraco.cms/businesslogic/propertytype/PropertyTypeGroup.cs
+++ b/src/umbraco.cms/businesslogic/propertytype/PropertyTypeGroup.cs
@@ -44,6 +44,25 @@ namespace umbraco.cms.businesslogic.propertytype
             return PropertyType.GetPropertyTypesByGroup(Id);
         }
 
+        public IEnumerable<PropertyType> GetPropertyTypes(bool includeInheritedProperties)
+        {
+            var list = PropertyType.GetPropertyTypesByGroup(Id);
+
+            if (includeInheritedProperties && ParentId != 0)
+            {
+                var ct = ContentType.GetContentType(ContentTypeId);
+                if (ct.ParentId > -1)
+                {
+                    var parent = ContentType.GetContentType(ct.ParentId);
+                    var propertyGroup = parent.PropertyTypeGroups.SingleOrDefault(x => x.ParentId == ParentId || x.Id == ParentId);
+                    if (propertyGroup != null)
+                        list = list.Concat(propertyGroup.GetPropertyTypes(true));
+                }
+            }
+
+            return list;
+        }
+
         //TODO: Verify support for master doctypes / mixins!
         public IEnumerable<PropertyTypeGroup> GetPropertyTypeGroups()
         {


### PR DESCRIPTION
Added code to save the sort order between direct and inherited properties when saving a document type.
Updated content editor to sort all properties by sortOrder instead of grouping by inheritance level then sorting.

 for U4-2355
