### PR TITLE
Bugfix for previous pullrequest "Duplicate e-mail addresses: U4-315, U4-...

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMember.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMember.aspx.cs
@@ -142,7 +142,15 @@ namespace umbraco.cms.presentation.members
 
         void MemberEmailExistCheck_ServerValidate(object source, ServerValidateEventArgs args)
         {
-            if (MemberEmail.Text != "" && Member.GetMemberFromEmail(MemberEmail.Text.ToLower()) != null && Membership.Providers[Member.UmbracoMemberProviderName].RequiresUniqueEmail)
+            var oldEmail = MemberEmail.Text.ToLower();
+            var newEmail = _document.Email.ToLower();
+            var requireUniqueEmail = Membership.Providers[Member.UmbracoMemberProviderName].RequiresUniqueEmail;
+            var howManyMembersWithEmail = Member.GetMembersFromEmail(newEmail).Length;
+            if (((oldEmail == newEmail && howManyMembersWithEmail > 1) ||
+                (oldEmail != newEmail && howManyMembersWithEmail > 0))
+                && requireUniqueEmail)
+                // If the value hasn't changed and there are more than 1 member with that email, then false
+                // If the value has changed and there are any member with that new email, then false
                 args.IsValid = false;
             else
                 args.IsValid = true;

--- a/src/umbraco.cms/businesslogic/member/Member.cs
+++ b/src/umbraco.cms/businesslogic/member/Member.cs
@@ -228,7 +228,7 @@ namespace umbraco.cms.businesslogic.member
                 throw new Exception(String.Format("Duplicate User name! A member with the user name {0} already exists", loginName));
 
             // Lowercased to prevent duplicates
-            Email = Email.ToLowerInvariant();
+            Email = Email.ToLower();
             Guid newId = Guid.NewGuid();
 
             //create the cms node first
@@ -563,14 +563,23 @@ namespace umbraco.cms.businesslogic.member
             }
             set
             {
-                var m = Member.GetMemberFromEmail(value);
-                if (m != null && Membership.Providers[UmbracoMemberProviderName].RequiresUniqueEmail)
+                var oldEmail = Email;
+                var newEmail = value.ToLower();
+                var requireUniqueEmail = Membership.Providers[UmbracoMemberProviderName].RequiresUniqueEmail;
+                var howManyMembersWithEmail = Member.GetMembersFromEmail(newEmail).Length;
+                if (((oldEmail == newEmail && howManyMembersWithEmail > 1) ||
+                    (oldEmail != newEmail && howManyMembersWithEmail > 0))
+                    && requireUniqueEmail)
                 {
-                    throw new Exception(String.Format("Duplicate Email! A member with the e-mail {0} already exists", value.ToLower()));
+                    // If the value hasn't changed and there are more than 1 member with that email, then throw
+                    // If the value has changed and there are any member with that new email, then throw
+                    throw new Exception(String.Format("Duplicate Email! A member with the e-mail {0} already exists", newEmail));
                 }
                 SqlHelper.ExecuteNonQuery(
                     "update cmsMember set Email = @email where nodeId = @id",
-                    SqlHelper.CreateParameter("@id", Id), SqlHelper.CreateParameter("@email", value.ToLower()));
+                    SqlHelper.CreateParameter("@id", Id), SqlHelper.CreateParameter("@email", newEmail));
+                // Set the backing field to new value
+                m_Email = newEmail;
             }
         }
         #endregion


### PR DESCRIPTION
...2147, U4-304"

There was a bug in the previous pullrequest that didn't allow a member
to saved if the email wasn't changed. Furthermore duplicate emails are
now prevented if requireUniqueEmail was false, but is switched to true
(when saving a member)
