### PR TITLE
Fixes U4-2187 - Enable support for MySQL on Linux

### DIFF
--- a/src/Umbraco.Core/DatabaseContext.cs
+++ b/src/Umbraco.Core/DatabaseContext.cs
@@ -393,8 +393,8 @@ namespace Umbraco.Core
                 if (supportsCaseInsensitiveQueries  == false)
                 {
                     message = "<p>&nbsp;</p><p>The database you're trying to use does not support case insensitive queries. <br />We currently do not support these types of databases.</p>" +
-                              "<p>You can fix this by changing the following two settings in your my.ini file in your MySQL installation directory:</p>" +
-                              "<pre>lower_case_table_names=1\nlower_case_file_system=1</pre><br />" +
+                              "<p>You can fix this by changing the following setting in your my.ini file in your MySQL installation directory:</p>" +
+                              "<pre>lower_case_table_names=1</pre><br />" +
                               "<p>Note: Make sure to check with your hosting provider if they support case insensitive queries as well.</p>" +
                               "<p>For more technical information on case sensitivity in MySQL, have a look at " +
                               "<a href='http://dev.mysql.com/doc/refman/5.0/en/identifier-case-sensitivity.html'>the documentation on the subject</a></p>";
@@ -404,8 +404,8 @@ namespace Umbraco.Core
                 else if (supportsCaseInsensitiveQueries == null)
                 {
                     message = "<p>&nbsp;</p><p>Warning! Could not check if your database type supports case insensitive queries. <br />We currently do not support these databases that do not support case insensitive queries.</p>" +
-                              "<p>You can check this by looking for the following two settings in your my.ini file in your MySQL installation directory:</p>" +
-                              "<pre>lower_case_table_names=1\nlower_case_file_system=1</pre><br />" +
+                              "<p>You can check this by looking for the following setting in your my.ini file in your MySQL installation directory:</p>" +
+                              "<pre>lower_case_table_names=1</pre><br />" +
                               "<p>Note: Make sure to check with your hosting provider if they support case insensitive queries as well.</p>" +
                               "<p>For more technical information on case sensitivity in MySQL, have a look at " +
                               "<a href='http://dev.mysql.com/doc/refman/5.0/en/identifier-case-sensitivity.html'>the documentation on the subject</a></p>";
@@ -418,8 +418,8 @@ namespace Umbraco.Core
                                   "<p>Note: You're using MySQL and the database instance you're connecting to seems to support case insensitive queries.</p>" +
                                   "<p>However, your hosting provider may not support this option. Umbraco does not currently support MySQL installs that do not support case insensitive queries</p>" +
                                   "<p>Make sure to check with your hosting provider if they support case insensitive queries as well.</p>" +
-                                  "<p>They can check this by looking for the following two settings in the my.ini file in their MySQL installation directory:</p>" +
-                                  "<pre>lower_case_table_names=1\nlower_case_file_system=1</pre><br />" +
+                                  "<p>They can check this by looking for the following setting in the my.ini file in their MySQL installation directory:</p>" +
+                                  "<pre>lower_case_table_names=1</pre><br />" +
                                   "<p>For more technical information on case sensitivity in MySQL, have a look at " +
                                   "<a href='http://dev.mysql.com/doc/refman/5.0/en/identifier-case-sensitivity.html'>the documentation on the subject</a></p>";
                     }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/MySqlSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/MySqlSyntaxProvider.cs
@@ -317,11 +317,10 @@ namespace Umbraco.Core.Persistence.SqlSyntax
             {
                 db.OpenSharedConnection();
                 // Need 4 @ signs as it is regarded as a parameter, @@ escapes it once, @@@@ escapes it twice
-                var lowerCaseFileSystem = db.Fetch<int>("SELECT @@@@Global.lower_case_file_system");
                 var lowerCaseTableNames = db.Fetch<int>("SELECT @@@@Global.lower_case_table_names");
                 
-                if(lowerCaseFileSystem.Any() && lowerCaseTableNames.Any())
-                    supportsCaseInsensitiveQueries = lowerCaseFileSystem.First() == 1 && lowerCaseTableNames.First() == 1;
+                if(lowerCaseTableNames.Any())
+                    supportsCaseInsensitiveQueries = lowerCaseTableNames.First() == 1;
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
This pull request is migrated from the patch supplied in http://issues.umbraco.org/issue/U4-2187

It allows Umbraco to be installed with a connection to a MySQL server running on Linux.

It is very simple and works on our production website but as @nul800sebastiaan mentions at the end of the issue comments, it is not possible to replicate the problem (and test this fix) with a Windows installation of MySQL.

Thanks,
Chris
