### PR TITLE
Allow for absolute URLs as well as virtual in ResolveUrl

### DIFF
--- a/src/Umbraco.Core/IO/IOHelper.cs
+++ b/src/Umbraco.Core/IO/IOHelper.cs
@@ -45,6 +45,8 @@ namespace Umbraco.Core.IO
         {
             if (virtualPath.StartsWith("~"))
                 return virtualPath.Replace("~", SystemDirectories.Root).Replace("//", "/");
+            else if (Uri.IsWellFormedUriString(virtualPath, UriKind.Absolute))
+                return virtualPath;
             else
                 return VirtualPathUtility.ToAbsolute(virtualPath, SystemDirectories.Root);
         }


### PR DESCRIPTION
This is to allow for FileSystemProviders that use CDNs which have absolute URLs, I've documented the issue here:

https://groups.google.com/forum/#!topic/umbraco-dev/GjToBgs0mHk
