### PR TITLE
6.1.2 media absolute urls

### DIFF
--- a/src/Umbraco.Core/IO/IOHelper.cs
+++ b/src/Umbraco.Core/IO/IOHelper.cs
@@ -49,12 +49,12 @@ namespace Umbraco.Core.IO
                 return VirtualPathUtility.ToAbsolute(virtualPath, SystemDirectories.Root);
         }
 
-		public static string AbsoluteUrl(string pathOrUrl)
-		{
-			return Uri.IsWellFormedUriString(pathOrUrl, UriKind.Absolute)
-			 ? pathOrUrl
-			 : Umbraco.Core.IO.IOHelper.ResolveUrl(pathOrUrl);
-		}
+        public static string AbsoluteUrl(string pathOrUrl)
+        {
+            return Uri.IsWellFormedUriString(pathOrUrl, UriKind.Absolute)
+		        ? pathOrUrl
+                : Umbraco.Core.IO.IOHelper.ResolveUrl(pathOrUrl);
+        }
 
 		[Obsolete("Use Umbraco.Web.Templates.TemplateUtilities.ResolveUrlsFromTextString instead, this method on this class will be removed in future versions")]
         internal static string ResolveUrlsFromTextString(string text)

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/controls/Images/ImageViewer.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/controls/Images/ImageViewer.ascx.cs
@@ -95,7 +95,7 @@ namespace umbraco.controls.Images
                 }
 
                 MediaItemPath = pFile.Value != null && !string.IsNullOrEmpty(pFile.Value.ToString())
-					? Umbraco.Core.IO.IOHelper.AbsoluteUrl(pFile.Value.ToString())
+                    ? Umbraco.Core.IO.IOHelper.AbsoluteUrl(pFile.Value.ToString())
                     : "#";
                 AltText = MediaItemPath != "#" ? m.Text : ui.GetText("no") + " " + ui.GetText("media");
 

--- a/src/umbraco.editorControls/tinyMCE3/webcontrol/TinyMCEWebControl.cs
+++ b/src/umbraco.editorControls/tinyMCE3/webcontrol/TinyMCEWebControl.cs
@@ -330,7 +330,7 @@ namespace umbraco.editorControls.tinyMCE3.webcontrol
 
                 if (imageMedia == null)
                 {
-					tempTag = string.Format("{0} src=\"{1}\" />", tempTag, IOHelper.AbsoluteUrl(orgSrc));
+                    tempTag = string.Format("{0} src=\"{1}\" />", tempTag, IOHelper.AbsoluteUrl(orgSrc));
                 }
                 else
                 {


### PR DESCRIPTION
This is to allow media items to be stored with absolute URLs like: https://s3-eu-west-1.amazonaws.com/gibedigital/1012/tosc-042013.jpg

For use with CDNs and block storage, this allows new FileSystemProviders that don't write to any physical location on the server. Currently they error at cehttps://s3-eu-west-1.amazonaws.com/gibedigital/1012/tosc-042013.jpg

The full discussion is here:
https://groups.google.com/forum/#!topic/umbraco-dev/GjToBgs0mHk
