### PR TITLE
U4-667

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/developer/Macros/editMacro.aspx
+++ b/src/Umbraco.Web.UI/umbraco/developer/Macros/editMacro.aspx
@@ -223,9 +223,28 @@
             </FooterTemplate>
         </asp:Repeater>
     </cc1:Pane>
-    <script type="text/javascript">
-        jQuery(document).ready(function () {
-            UmbClientMgr.appActions().bindSaveShortCut();
-        });
-    </script>
+    <asp:PlaceHolder runat="server">
+        <script type="text/javascript">
+            jQuery(document).ready(function () {
+                UmbClientMgr.appActions().bindSaveShortCut();
+
+                (function ($) {
+                    // U4-667: Make the "Render content in editor" checkbox dependent on the "Use in editor checkbox"
+                    var useInEditorCheckBox = $("#<%= macroEditor.ClientID %>");
+                    var renderInEditorCheckBox = $("#<%= macroRenderContent.ClientID %>");
+
+                    toggle();
+
+                    useInEditorCheckBox.on("change", function() {
+                        toggle();
+                    });
+                    
+                    function toggle() {
+                        var disabled = useInEditorCheckBox.is(":checked") == false;
+                        renderInEditorCheckBox.prop("disabled", disabled);
+                    }
+                })(jQuery);
+            });
+        </script>
+    </asp:PlaceHolder>
 </asp:Content>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create.aspx.cs
@@ -1,21 +1,11 @@
 ﻿using System;
-using System.Collections;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Web;
-using System.Web.SessionState;
-using System.Web.UI;
 using System.Web.UI.WebControls;
-using System.Web.UI.HtmlControls;
 
-using System.Xml.XPath;
 using System.Xml;
 using Umbraco.Core.IO;
 
 namespace umbraco.cms.presentation
 {
-
     public class Create : BasePages.UmbracoEnsuredPage
     {
         protected umbWindow createWindow;
@@ -43,18 +33,17 @@ namespace umbraco.cms.presentation
             {
                 throw new ArgumentException("The create dialog for \"" + nodeType + "\" does not match anything defined in the \"" + SystemFiles.CreateUiXml + "\". This could mean an incorrectly installed package or a corrupt UI file");
             }
-            //title.Text = ui.Text("create") + " " + ui.Text(def.SelectSingleNode("./header").FirstChild.Value.ToLower(), base.getUser());
+
             try
             {
-                //headerTitle.Text = title.Text;
-                UI.Controls.Add(LoadControl(SystemDirectories.Umbraco + def.SelectSingleNode("./usercontrol").FirstChild.Value));
+                var virtualPath = SystemDirectories.Umbraco + def.SelectSingleNode("./usercontrol").FirstChild.Value;
+                var mainControl = LoadControl(virtualPath);
+                UI.Controls.Add(mainControl);
             }
             catch (Exception ex)
             {
                 throw new ArgumentException("ERROR CREATING CONTROL FOR NODETYPE: " + nodeType, ex);
             }
         }
-
-
     }
 }


### PR DESCRIPTION
Fixes http://issues.umbraco.org/issue/U4-667

Added a script to make the checkbox "Render content in editor" dependent on the "Use in editor" checkbox.
Also refactored the create.aspx code-behind so it's easier to see what control is loaded in the dialog when debugging.
