### PR TITLE
Fixes U4-2641

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentControl.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentControl.cs
@@ -395,7 +395,7 @@ namespace umbraco.controls
             if (p.PropertyType.DataTypeDefinition.DataType.DataEditor.ShowLabel)
             {
                 string caption = p.PropertyType.Name;
-                if (p.PropertyType.Description != null && p.PropertyType.Description != String.Empty)
+                if (!string.IsNullOrEmpty(p.PropertyType.Description))
                     switch (UmbracoSettings.PropertyContextHelpOption)
                     {
                         case "icon":

--- a/src/umbraco.cms/businesslogic/propertytype/propertytype.cs
+++ b/src/umbraco.cms/businesslogic/propertytype/propertytype.cs
@@ -146,28 +146,27 @@ namespace umbraco.cms.businesslogic.propertytype
         {
             get
             {
-                if (_description != null)
-                {
-                    if (!_description.StartsWith("#"))
-                        return _description;
-                    else
-                    {
-                        Language lang = Language.GetByCultureCode(Thread.CurrentThread.CurrentCulture.Name);
-                        if (lang != null)
-                        {
-                            if (Dictionary.DictionaryItem.hasKey(_description.Substring(1, _description.Length - 1)))
-                            {
-                                var di =
-                                    new Dictionary.DictionaryItem(_description.Substring(1, _description.Length - 1));
-                                return di.Value(lang.id);
-                            }
-                        }
-                    }
+				if (string.IsNullOrEmpty(_description))
+					return string.Empty;
 
-                    return "[" + _description + "]";
-                }
 
-                return _description;
+				if (!_description.StartsWith("#"))
+					return _description;
+				else
+				{
+					Language lang = Language.GetByCultureCode(Thread.CurrentThread.CurrentCulture.Name);
+					if (lang != null)
+					{
+						if (Dictionary.DictionaryItem.hasKey(_description.Substring(1, _description.Length - 1)))
+						{
+							var di =
+								new Dictionary.DictionaryItem(_description.Substring(1, _description.Length - 1));
+							return di.Value(lang.id);
+						}
+					}
+				}
+
+				return "[" + _description + "]";
             }
             set
             {


### PR DESCRIPTION
Hi,
This is related to http://issues.umbraco.org/issue/U4-2641 and reporting in the forums http://our.umbraco.org/forum/ourumb-dev-forum/bugs/44143-Null-ref-exception-in-media-section

We have found that in our Umbraco build (4.9.1), whenever we attempt to access an image for editing we are receiving a Null Ref exception error, being traced down to the Description property in the property type class. This fix puts some in defensive measures to prevent the issue and has resolved the problem for us.
