### PR TITLE
Return null when a node doesn't have a template

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -114,7 +114,7 @@ namespace Umbraco.Web
 		public static string GetTemplateAlias(this IPublishedContent doc)
 		{
 			var template = Template.GetTemplate(doc.TemplateId);
-			return template.Alias;
+			return template != null ? template.Alias : null;
 		}
 
 		#region GetPropertyValue


### PR DESCRIPTION
Return null when a node doesn't have a template instead of a "object not
set to an instance of an object" exception. One case where this comes in handy is when on a cycle (menu, site map, etc) you only want to create anchors for nodes with templates associated, only checking if the TemplateAlias is null, instead of a try/catch.
