### PR TITLE
PluginManager's typeList shouldn't contain duplicates

### DIFF
--- a/src/Umbraco.Core/PluginManager.cs
+++ b/src/Umbraco.Core/PluginManager.cs
@@ -697,7 +697,8 @@ namespace Umbraco.Core
             //we don't have a cache for this so proceed to look them up by scanning
             foreach (var t in finder())
             {
-                typeList.AddType(t);
+                if (!typeList.GetTypes().Contains(t))
+                    typeList.AddType(t);
             }
             UpdateCachedPluginsFile<T>(typeList.GetTypes(), resolutionKind);
         }


### PR DESCRIPTION
I'm using the Digibiz Dictionary Section (http://our.umbraco.org/projects/backoffice-extensions/digibiz-dictionary-section) in a v6.1.3 project, but the Tree is showing up twice in the UI.
By debugging I found out the type is added twice, I couldn't figure out why though...
Adding this line prevents the tree showing up twice.

(duplicate of https://github.com/umbraco/Umbraco-CMS/pull/71)
