### PR TITLE
Fix U4-2711 - exception on image upload with image cropper

### DIFF
--- a/src/umbraco.editorControls/imagecropper/DataTypeData.cs
+++ b/src/umbraco.editorControls/imagecropper/DataTypeData.cs
@@ -8,7 +8,7 @@ namespace umbraco.editorControls.imagecropper
 
         public override XmlNode ToXMl(XmlDocument data)
         {
-            if (Value.ToString() != "") {
+            if (Value!=null && Value.ToString() != "") {
                 XmlDocument xd = new XmlDocument();
                 xd.LoadXml(Value.ToString());
                 return data.ImportNode(xd.DocumentElement, true);


### PR DESCRIPTION
Fixes Object reference not set to an instance of an object. at
umbraco.editorControls.imagecropper.DataTypeData.ToXMl(XmlDocument data)

see issue U4-2711
