### PR TITLE
Solved conversion "datetime to SQLServer" issue: the correct conversion ...

### DIFF
--- a/src/Umbraco.Core/DateTimeExtensions.cs
+++ b/src/Umbraco.Core/DateTimeExtensions.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Core
         /// <returns></returns>
         public static string ToIsoString(this DateTime dt)
         {
-            return dt.ToString("yyyy-MM-dd HH:mm:ss");
+            return dt.ToString(@"yyyy-MM-dd\THH\:mm\:ss");
         }
 
     }

--- a/src/Umbraco.Web/PublishedCache/XmlPublishedCache/PublishedMediaCache.cs
+++ b/src/Umbraco.Web/PublishedCache/XmlPublishedCache/PublishedMediaCache.cs
@@ -230,7 +230,7 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
 			if (!new[] { "creatorID" }.Any(values.ContainsKey))
 				values.Add("creatorID", 0.ToString());
 			if (!new[] { "createDate" }.Any(values.ContainsKey))
-				values.Add("createDate", default(DateTime).ToString("yyyy-MM-dd HH:mm:ss"));
+				values.Add("createDate", default(DateTime).ToIsoString());
 			if (!new[] { "level" }.Any(values.ContainsKey))
 			{				
 				values.Add("level", values["__Path"].Split(',').Length.ToString());

--- a/src/Umbraco.Web/umbraco.presentation/library.cs
+++ b/src/Umbraco.Web/umbraco.presentation/library.cs
@@ -349,9 +349,9 @@ namespace umbraco
 				case "sortOrder":
 			        return doc.SortOrder.ToString();
 				case "createDate":
-					return doc.CreateDate.ToString("yyyy-MM-dd'T'HH:mm:ss");
+					return doc.CreateDate.ToIsoString();
 				case "updateDate":
-					return doc.UpdateDate.ToString("yyyy-MM-dd'T'HH:mm:ss");
+					return doc.UpdateDate.ToIsoString();
 				case "nodeName":
 			        return doc.Name;
 				case "writerName":

--- a/src/umbraco.businesslogic/Log.cs
+++ b/src/umbraco.businesslogic/Log.cs
@@ -257,7 +257,7 @@ namespace umbraco.BusinessLogic
                 try
                 {
                     DateTime oldestPermittedLogEntry = DateTime.Now.Subtract(new TimeSpan(0, maximumAgeOfLogsInMinutes, 0));
-                    var formattedDate = oldestPermittedLogEntry.ToString("yyyy-MM-dd HH:mm:ss");
+                    var formattedDate = oldestPermittedLogEntry.ToIsoString();
 
                     SqlHelper.ExecuteNonQuery("delete from umbracoLog where datestamp < @oldestPermittedLogEntry and logHeader in ('open','system')",
                         SqlHelper.CreateParameter("@oldestPermittedLogEntry", formattedDate));

--- a/src/umbraco.controls/DatePicker/DateTimePicker.cs
+++ b/src/umbraco.controls/DatePicker/DateTimePicker.cs
@@ -54,7 +54,7 @@ namespace umbraco.uicontrols.DatePicker
                 }
                 else
                 {
-                    m_DateTextBox.Text = value.ToString(ShowTime ? "yyyy-MM-dd HH:mm" : "yyyy-MM-dd");
+                    m_DateTextBox.Text = value.ToString(ShowTime ? @"yyyy-MM-dd\THH\:mm" : "yyyy-MM-dd");
                 }
             }
         }


### PR DESCRIPTION
Solved conversion "datetime to SQLServer" issue.
The correct conversion format (ISO) of datetime data type is "yyyy-MM-dd\THH\:mm\:ss" instead of "yyyy-MM-dd HH:mm:ss". The second don't works correctly in DB with Italian culture.