### PR TITLE
Shibboleth ISAPI extension not working when umbracoDebugMode enabled

### DIFF
--- a/src/Umbraco.Core/Profiling/WebProfiler.cs
+++ b/src/Umbraco.Core/Profiling/WebProfiler.cs
@@ -82,7 +82,7 @@ namespace Umbraco.Core.Profiling
                 return false;
 
             var request = TryGetRequest(sender);
-            if (request.Success == false || request.Result.Url.IsClientSideRequest() || string.IsNullOrEmpty(request.Result["umbDebug"]))
+            if (request.Success == false || request.Result.Url.IsClientSideRequest() || string.IsNullOrEmpty(request.Result.QueryString["umbDebug"]))
                 return false;
             
             return true;


### PR DESCRIPTION
Calling the HttpRequest's indexer caused scanning not only of QueryString but also of form variables, cookies and server variables. Turns out, Shibboleth ISAPI extension doesn't like when the Form property on HttpRequest gets called (probably has something to do with .NET request validation). The form collection gets changed and shibboleth throws an error.
