### PR TITLE
SVG as static content so backoffice-icons will be served

### DIFF
--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -211,6 +211,7 @@
     <staticContent>
       <remove fileExtension=".air" />
       <mimeMap fileExtension=".air" mimeType="application/vnd.adobe.air-application-installer-package+zip" />
+      <remove fileExtension=".svg" />
       <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
     </staticContent>
 


### PR DESCRIPTION
Added this configuration so that IIS will serve the SVG-icons included in the new Umbraco Belle UI.
