### PR TITLE
Fix multiple words in search U4-2509

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Search/QuickSearchHandler.ashx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Search/QuickSearchHandler.ashx.cs
@@ -59,7 +59,11 @@ namespace umbraco.presentation.umbraco.Search
             }
             else
             {
-				var operation = criteria.GroupedAnd(new[] { "__nodeName" }, txt.Split(' '));
+				var words = txt.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Select(w => w.ToLower().MultipleCharacterWildcard()).ToList();
+				var operation = criteria.GroupedOr(new[] { "__nodeName" }, new[] { words[0] });
+				words.RemoveAt(0);
+				foreach (var word in words)
+					operation = operation.And().GroupedOr(new[] { "__nodeName" }, new[] { word });
 
                 // ensure the user can only find nodes they are allowed to see
                 if (UmbracoContext.Current.UmbracoUser.StartNodeId > 0)


### PR DESCRIPTION
When multiple words are entered in the search field no results are
returned.
This pull req. contains the fix suggested by Tony.
