### PR TITLE
Add node type to search results

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/Search/quickSearch.js
+++ b/src/Umbraco.Web.UI/umbraco/Search/quickSearch.js
@@ -56,7 +56,10 @@
                 return parsed;
             },
             formatItem: function (item) {
-                return item.Fields.nodeName + " <span class='nodeId'>(" + item.Id + ")</span>";
+                return item.Fields.nodeName + " <span class='nodeId'>(" + item.Id + ") </span>";
+            },
+            focus: function (event, ui) {
+                $(ui).attr("title", $(ui).find("span[title]").attr("title"));
             }
         };
 

--- a/src/Umbraco.Web.UI/umbraco/xslt/searchResult.xslt
+++ b/src/Umbraco.Web.UI/umbraco/xslt/searchResult.xslt
@@ -18,6 +18,7 @@
               </xsl:if>
               <xsl:value-of select="@title"/>
             </a>
+			      <small><strong>Node Type: </strong> <xsl:value-of select="@type"/></small>
           </h4>
           <p>
             <em>Last updated <xsl:value-of select="@author"/> on <xsl:value-of select="@changeDate"/>

--- a/src/Umbraco.Web.UI/umbraco_client/Application/JQuery/jquery.autocomplete.js
+++ b/src/Umbraco.Web.UI/umbraco_client/Application/JQuery/jquery.autocomplete.js
@@ -429,7 +429,8 @@
             return value.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + term.replace(/([\^\$\(\)\[\]\{\}\*\.\+\?\|\\])/gi, "\\$1") + ")(?![^<>]*>)(?![^&;]+;)", "gi"), "<strong>$1</strong>");
         },
         scroll: true,
-        scrollHeight: 180
+        scrollHeight: 180,
+        focus: function (event, ui) { }
     };
 
     $.Autocompleter.Cache = function(options) {
@@ -599,6 +600,7 @@
                 if (target(event).nodeName && target(event).nodeName.toUpperCase() == 'LI') {
                     active = $("li", list).removeClass(CLASSES.ACTIVE).index(target(event));
                     $(target(event)).addClass(CLASSES.ACTIVE);
+                    options.focus(event, target(event));
                 }
             }).click(function(event) {
                 $(target(event)).addClass(CLASSES.ACTIVE);
@@ -632,6 +634,8 @@
             listItems.slice(active, active + 1).removeClass(CLASSES.ACTIVE);
             movePosition(step);
             var activeItem = listItems.slice(active, active + 1).addClass(CLASSES.ACTIVE);
+            options.focus(null, activeItem);
+
             if (options.scroll) {
                 var offset = 0;
                 listItems.slice(0, active).each(function() {

--- a/src/Umbraco.Web.UI/umbraco_client/propertypane/style.css
+++ b/src/Umbraco.Web.UI/umbraco_client/propertypane/style.css
@@ -35,6 +35,10 @@
 		{
 			font-weight: normal;
 			color: #666;
+			font-size: .9em;
+		}
+		.propertypane small strong {
+			color: #000;
 		}
 		
 		.propertypane div.propertyItem{

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/search.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/search.aspx.cs
@@ -100,6 +100,7 @@ namespace umbraco.presentation.dialogs
                 x.Attributes.Append(XmlHelper.AddAttribute(result, "title", r.Fields["nodeName"]));
                 x.Attributes.Append(XmlHelper.AddAttribute(result, "author", r.Fields["writerName"]));
                 x.Attributes.Append(XmlHelper.AddAttribute(result, "changeDate", r.Fields["updateDate"]));
+                x.Attributes.Append(xmlHelper.addAttribute(result, "type", r.Fields["nodeTypeAlias"]));
                 result.DocumentElement.AppendChild(x);
             }
 


### PR DESCRIPTION
This is a simple change to add the node type(alias actually) to the quick-search and search results panes.

We have 2-3 entries per page that end up having very similar names so it is mostly useless if we can't easily identify the search result type.  

An alternate approach could to be to display the node path name in a tooltip instead, or maybe even the the icon used in the nav but these were more complex changes so I went with the simple addition of the node type alias. (as the note type name isn't in the SearchResults object and I didn't want to add extra lag with a lookup) 
