### PR TITLE
Fix order of null-check versus dotting through to .UmbracoContext.

### DIFF
--- a/src/Umbraco.Web/Routing/PublishedContentRequestEngine.cs
+++ b/src/Umbraco.Web/Routing/PublishedContentRequestEngine.cs
@@ -28,11 +28,13 @@ namespace Umbraco.Web.Routing
 		/// <param name="pcr">The content request.</param>
 		public PublishedContentRequestEngine(PublishedContentRequest pcr)
 		{
+			if (pcr == null) throw new ArgumentException("pcr is null.");
 			_pcr = pcr;
+			
 			_routingContext = pcr.RoutingContext;
-
-			var umbracoContext = _routingContext.UmbracoContext;
 			if (_routingContext == null) throw new ArgumentException("pcr.RoutingContext is null.");
+			
+			var umbracoContext = _routingContext.UmbracoContext;
 			if (umbracoContext == null) throw new ArgumentException("pcr.RoutingContext.UmbracoContext is null.");
 			if (umbracoContext.RoutingContext != _routingContext) throw new ArgumentException("RoutingContext confusion.");
 			// no! not set yet.


### PR DESCRIPTION
The order of operations in the constructor dots through to the _routingContext.UmbracoContext before checking if the value was null and throwing the argument exception (which really isn't an ArgumentException...)
