### PR TITLE
Added contextualKeyBuilder optional argument to allow the key used for cachin...

### DIFF
--- a/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
@@ -82,7 +82,8 @@ namespace Umbraco.Web
 			int cachedSeconds,
 			bool cacheByPage = false,
 			bool cacheByMember = false,
-			ViewDataDictionary viewData = null)
+			ViewDataDictionary viewData = null,
+			Func<object, ViewDataDictionary, string> contextualKeyBuilder = null)
 		{
 			var cacheKey = new StringBuilder(partialViewName);
 			if (cacheByPage)
@@ -97,7 +98,12 @@ namespace Umbraco.Web
 			{
 				var currentMember = Member.GetCurrentMember();
 				cacheKey.AppendFormat("m{0}-", currentMember == null ? 0 : currentMember.Id);
-			}			
+			}
+			if (contextualKeyBuilder != null)
+		    {
+		        var contextualKey = contextualKeyBuilder(model, viewData);
+		        cacheKey.Append("c{0}-", contextualKey);
+		    }
 			return ApplicationContext.Current.ApplicationCache.CachedPartialView(htmlHelper, partialViewName, model, cachedSeconds, cacheKey.ToString(), viewData);
 		}
 


### PR DESCRIPTION
...g to be contextual.

when building cached partials that work with many different instances of the same  partial view (e.g. using the same partial more than once on a page with different ViewDataDictionary or different model), it is necessary to either name each instance differently (ugh), or not cache.

By adding an optional argument to the CachedPartial Html helper method, we can vary the cache-key depending on the context of insertion. For maximum flexibility, pass the model and the viewData to the function so it can use that data to format a cacheKey suffix.

A typical use would be something like:

@Html.CachedPartial(
"EventListings"
, FeedRepository.getFeed(new CalendarEventsModel
  {
     StartingDate = DateTime.UtcNow.Date
     , Count = 10
  })
, 0
, contextualKeyBuilder: (model, viewData) =>
  {
     return (model as CalendarEventsModel).StartingDate.ToString();
  }
)
