### PR TITLE
Make CacheHelperExtensions public so we can call CachedPartialView and C...

### DIFF
--- a/src/Umbraco.Web/CacheHelperExtensions.cs
+++ b/src/Umbraco.Web/CacheHelperExtensions.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Web
 	/// <summary>
 	/// Extension methods for the cache helper
 	/// </summary>
-	internal static class CacheHelperExtensions
+	public static class CacheHelperExtensions
 	{
 		/// <summary>
 		/// Application event handler to bind to events to clear the cache for the cache helper extensions


### PR DESCRIPTION
...learPartialViewCache

In order to allow extensions to the logic and usage of the CachedPartial HtmlHelper, expose CachedPartialView and ClearPartialViewCache by making the wrapping static class public.
