### PR TITLE
Fix for issue U4-2958 Member can edit & Show on profile do not persist on Member Type editor

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMemberType.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMemberType.aspx.cs
@@ -64,7 +64,7 @@ namespace umbraco.cms.presentation.members
 				}
 				handled = true;
 			}
-			setupExtraEditorControls();
+			
 			return handled;
 		}
 		private void setupExtraEditorControls(){


### PR DESCRIPTION
Looks to just require the removal of a call to recreate the properties data grid after a save.
