### PR TITLE
Really Fix U4-3033 - inserting extra blank line at end of CSS

### DIFF
--- a/src/umbraco.cms/businesslogic/web/StyleSheet.cs
+++ b/src/umbraco.cms/businesslogic/web/StyleSheet.cs
@@ -268,7 +268,7 @@ namespace umbraco.cms.businesslogic.web
         {
             using (StreamWriter SW = File.CreateText(IOHelper.MapPath(string.Format("{0}/{1}.css", SystemDirectories.Css, this.Text))))
             {
-                string tmpCss = this.Content + "\n";
+                string tmpCss = this.Content ;
                 tmpCss += "/* EDITOR PROPERTIES - PLEASE DON'T DELETE THIS LINE TO AVOID DUPLICATE PROPERTIES */\n";
                 foreach (StylesheetProperty p in this.Properties)
                 {


### PR DESCRIPTION
Try again, to really stop the css editor from adding unneeded blank lines. 
