### PR TITLE
Dictionary sections

### DIFF
--- a/src/Umbraco.Web/DictionarySection.cs
+++ b/src/Umbraco.Web/DictionarySection.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Umbraco.Web
+{
+    /// <summary>
+    /// Helper class to simplify querying section(folders).
+    /// 
+    /// Eg:
+    ///   var Dictionary = Umbraco.GetDictionarySection("[Contact Us] ");
+    ///   @Dictionary["My Sub Key"];
+    /// </summary>
+    public class DictionarySection
+    {
+        public string Section { get; private set; }
+        private UmbracoHelper Umbraco;
+
+        /// <summary>
+        /// Use GetDictionarySection to access.
+        /// </summary>
+        public DictionarySection(UmbracoHelper umbraco, string section)
+        {
+            Section = section;
+            Umbraco = umbraco;
+        }
+
+        /// <summary>
+        /// Get a dictionary value by combining the section key and child key.
+        /// </summary>
+        /// <param name="key">child key.</param>
+        /// <returns>string</returns>
+        public string GetDictionaryValue(string key)
+        {
+            return Umbraco.GetDictionaryValue(Section + key);
+        }
+
+        /// <summary>
+        /// Chain a sub category by appending the section key and sub section key.
+        /// </summary>
+        /// <param name="key">Sub sectin key</param>
+        /// <returns>DictionarySection</returns>
+        public DictionarySection GetDictionarySection(string key)
+        {
+            return new DictionarySection(Umbraco, Section + key);
+        }
+
+        /// <summary>
+        /// Get a dictionary value by combining the section key and child key.
+        /// </summary>
+        /// <param name="key">child key.</param>
+        /// <returns>string</returns>
+        public string this[string key]
+        {
+            get
+            {
+                return Umbraco.GetDictionaryValue(Section + key);
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/DictionarySection.cs
+++ b/src/Umbraco.Web/DictionarySection.cs
@@ -33,7 +33,7 @@ namespace Umbraco.Web
         /// <returns>string</returns>
         public string GetDictionaryValue(string key)
         {
-            return Umbraco.GetDictionaryValue(Section + key);
+            return Umbraco.GetDictionaryValue(Section + "." + key);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Umbraco.Web
         /// <returns>DictionarySection</returns>
         public DictionarySection GetDictionarySection(string key)
         {
-            return new DictionarySection(Umbraco, Section + key);
+            return new DictionarySection(Umbraco, Section + "." + key);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Umbraco.Web
         {
             get
             {
-                return Umbraco.GetDictionaryValue(Section + key);
+                return Umbraco.GetDictionaryValue(Section + "." + key);
             }
         }
     }

--- a/src/Umbraco.Web/DictionarySection.cs
+++ b/src/Umbraco.Web/DictionarySection.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Text;
+using Umbraco.Core;
 
 namespace Umbraco.Web
 {
@@ -26,6 +28,13 @@ namespace Umbraco.Web
             Umbraco = umbraco;
         }
 
+        private string GetHierarchyJoin
+        {
+            get {
+                return ConfigurationManager.AppSettings.ContainsKey("dictionaryIsHierarchy") ? ConfigurationManager.AppSettings["dictionaryIsHierarchy"] : "";
+            }
+        }
+
         /// <summary>
         /// Get a dictionary value by combining the section key and child key.
         /// </summary>
@@ -33,7 +42,7 @@ namespace Umbraco.Web
         /// <returns>string</returns>
         public string GetDictionaryValue(string key)
         {
-            return Umbraco.GetDictionaryValue(Section + "." + key);
+            return Umbraco.GetDictionaryValue(Section + GetHierarchyJoin + key);
         }
 
         /// <summary>
@@ -43,7 +52,7 @@ namespace Umbraco.Web
         /// <returns>DictionarySection</returns>
         public DictionarySection GetDictionarySection(string key)
         {
-            return new DictionarySection(Umbraco, Section + "." + key);
+            return new DictionarySection(Umbraco, Section + GetHierarchyJoin + key);
         }
 
         /// <summary>
@@ -66,7 +75,7 @@ namespace Umbraco.Web
         {
             get
             {
-                return Umbraco.GetDictionaryValue(Section + "." + key);
+                return Umbraco.GetDictionaryValue(Section + GetHierarchyJoin + key);
             }
         }
     }

--- a/src/Umbraco.Web/DictionarySection.cs
+++ b/src/Umbraco.Web/DictionarySection.cs
@@ -47,6 +47,17 @@ namespace Umbraco.Web
         }
 
         /// <summary>
+        ///  Get this sections dictionary value.
+        /// </summary>
+        public string Value
+        {
+            get
+            {
+                return Umbraco.GetDictionaryValue(Section);
+            }
+        }
+
+        /// <summary>
         /// Get a dictionary value by combining the section key and child key.
         /// </summary>
         /// <param name="key">child key.</param>

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -288,6 +288,7 @@
     <Compile Include="Cache\UserCacheRefresher.cs" />
     <Compile Include="Cache\UserTypeCacheRefresher.cs" />
     <Compile Include="Configuration\WebRouting.cs" />
+    <Compile Include="DictionarySection.cs" />
     <Compile Include="Security\Providers\MembersMembershipProvider.cs" />
     <Compile Include="Security\Providers\UsersMembershipProvider.cs" />
     <Compile Include="Standalone\ServiceContextManager.cs" />
@@ -1827,12 +1828,16 @@
     <Content Include="umbraco.presentation\umbraco\controls\Images\UploadMediaImage.ascx">
       <SubType>ASPXCodeBehind</SubType>
     </Content>
-    <Content Include="umbraco.presentation\umbraco\controls\Tree\TreeControl.ascx" />
+    <Content Include="umbraco.presentation\umbraco\controls\Tree\TreeControl.ascx">
+      <SubType>ASPXCodeBehind</SubType>
+    </Content>
     <Content Include="umbraco.presentation\umbraco\actions\delete.aspx" />
     <Content Include="umbraco.presentation\umbraco\actions\editContent.aspx" />
     <Content Include="umbraco.presentation\umbraco\actions\preview.aspx" />
     <Content Include="umbraco.presentation\umbraco\actions\publish.aspx" />
-    <Content Include="umbraco.presentation\umbraco\dialogs\mediaPicker.aspx" />
+    <Content Include="umbraco.presentation\umbraco\dialogs\mediaPicker.aspx">
+      <SubType>ASPXCodeBehind</SubType>
+    </Content>
     <Content Include="umbraco.presentation\umbraco\webservices\MacroContainerService.asmx" />
     <Content Include="umbraco.presentation\umbraco\developer\Xslt\xsltVisualize.aspx" />
     <Content Include="umbraco.presentation\umbraco\dialogs\empty.htm" />
@@ -1867,12 +1872,16 @@
     </Content>
     <Content Include="umbraco.presentation\umbraco\dialogs\cruds.aspx" />
     <Content Include="umbraco.presentation\umbraco\dialogs\emptyTrashcan.aspx" />
-    <Content Include="umbraco.presentation\umbraco\dialogs\exportDocumenttype.aspx" />
+    <Content Include="umbraco.presentation\umbraco\dialogs\exportDocumenttype.aspx">
+      <SubType>ASPXCodeBehind</SubType>
+    </Content>
     <Content Include="umbraco.presentation\umbraco\dialogs\imageViewer.aspx" />
     <Content Include="umbraco.presentation\umbraco\dialogs\importDocumenttype.aspx" />
     <Content Include="umbraco.presentation\umbraco\dialogs\insertMacro.aspx" />
     <Content Include="umbraco.presentation\umbraco\dialogs\insertTable.aspx" />
-    <Content Include="umbraco.presentation\umbraco\dialogs\moveOrCopy.aspx" />
+    <Content Include="umbraco.presentation\umbraco\dialogs\moveOrCopy.aspx">
+      <SubType>ASPXCodeBehind</SubType>
+    </Content>
     <Content Include="umbraco.presentation\umbraco\dialogs\notifications.aspx" />
     <Content Include="umbraco.presentation\umbraco\developer\Packages\installer.aspx" />
     <Content Include="umbraco.presentation\umbraco\dialogs\protectPage.aspx" />

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -362,6 +362,16 @@ namespace Umbraco.Web
 			return _cultureDictionary[key];
 		}
 
+        /// <summary>
+        /// Returns a dictionary section(folder) for clearner dictionary queries.
+        /// </summary>
+        /// <param name="key">Name of the dictionary folder. (All key in this folder must start with this key also.)</param>
+        /// <returns>DictionarySection</returns>
+        public DictionarySection GetDictionarySection(string key)
+        {
+            return new DictionarySection(this, key);
+        }
+
 		#endregion
 
 		#region Membership

--- a/src/Umbraco.Web/umbraco.presentation/library.cs
+++ b/src/Umbraco.Web/umbraco.presentation/library.cs
@@ -1330,6 +1330,16 @@ namespace umbraco
         }
 
         /// <summary>
+        /// Gets the dictionary item with the specified key.
+        /// </summary>
+        /// <param name="Key">The key.</param>
+        /// <returns>A dictionary section for futher querying.</returns>
+        public static Umbraco.Web.DictionarySection GetDictionarySection(string Key)
+        {
+            return GetUmbracoHelper().GetDictionarySection(Key);
+        }
+
+        /// <summary>
         /// Gets the current page.
         /// </summary>
         /// <returns>An XpathNodeIterator containing the current page as Xml.</returns>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/dictionaryTasks.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/dictionaryTasks.cs
@@ -58,7 +58,10 @@ namespace umbraco
             // Create new dictionary item if name no already exist
             if (ParentID > 0)
             {
-                int id = cms.businesslogic.Dictionary.DictionaryItem.addKey(Alias, "", new cms.businesslogic.Dictionary.DictionaryItem(ParentID).key);
+                // Prepend parent keys to keep unique
+                var parentKey = new cms.businesslogic.Dictionary.DictionaryItem(ParentID).key;
+
+                int id = cms.businesslogic.Dictionary.DictionaryItem.addKey(parentKey + "." + Alias, "", parentKey);
                 m_returnUrl = string.Format("settings/editDictionaryItem.aspx?id={0}", id);
             }
             else

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/dictionaryTasks.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/dictionaryTasks.cs
@@ -7,6 +7,8 @@ using umbraco.DataLayer;
 using umbraco.BasePages;
 using umbraco.IO;
 using umbraco.cms.businesslogic.member;
+using System.Configuration;
+using Umbraco.Core;
 
 namespace umbraco
 {
@@ -58,10 +60,15 @@ namespace umbraco
             // Create new dictionary item if name no already exist
             if (ParentID > 0)
             {
-                // Prepend parent keys to keep unique
                 var parentKey = new cms.businesslogic.Dictionary.DictionaryItem(ParentID).key;
+                string alias = "";
+                if(ConfigurationManager.AppSettings.ContainsKey("dictionaryIsHierarchy") && !String.IsNullOrEmpty(ConfigurationManager.AppSettings["dictionaryIsHierarchy"]))
+                    // Prepend parent keys to keep unique
+                    alias = parentKey + (string)ConfigurationManager.AppSettings["dictionaryIsHierarchy"] + Alias;
+                else
+                    alias = Alias;
 
-                int id = cms.businesslogic.Dictionary.DictionaryItem.addKey(parentKey + "." + Alias, "", parentKey);
+                int id = cms.businesslogic.Dictionary.DictionaryItem.addKey(alias, "", parentKey);
                 m_returnUrl = string.Format("settings/editDictionaryItem.aspx?id={0}", id);
             }
             else


### PR DESCRIPTION
Updated version of https://github.com/umbraco/Umbraco-CMS/pull/108.

This isn't really a big thing but adds a bit of hierarchy to reading Dictionary items programmatically.  Now it only prepends parent dictionary names if the dictionaryIsHierarchy setting is set(and uses that value as the glue).  One can still read dictionary sections with that off(assuming the child items start with the parent item's name).

Anyway, no't really a big thing, but I find it useful in our code, so  maybe others can enjoy.  (There is probably a better way to get the same hierarchical logic that this exposes via the node hierarchy, but this was simpler and required less changes to the existing code.