### PR TITLE
Fix for U4-3432Rollback Dialog - CreateDate/Creator formatting tweaks

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -287,7 +287,7 @@
     <key alias="alias">Alias</key>
     <key alias="areyousure">Are you sure?</key>
     <key alias="border">Border</key>
-    <key alias="by">or</key>
+    <key alias="by">by</key>
     <key alias="cancel">Cancel</key>
     <key alias="cellMargin">Cell margin</key>
     <key alias="choose">Choose</key>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/rollBack.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/rollBack.aspx.cs
@@ -33,7 +33,7 @@ namespace umbraco.presentation.dialogs
                 Document rollback = new Document(currentDoc.Id, new Guid(allVersions.SelectedValue));
                 
                 propertiesCompare.Text = "<tr><th style='width: 25%;' valign='top'>" + ui.Text("general", "name") + ":</th><td>" + rollback.Text + "</td></tr>";
-                propertiesCompare.Text += "<tr><th style='width: 25%;' valign='top'>" + ui.Text("content", "createDate") + ":</th><td>" + rollback.VersionDate.ToLongDateString() + " " + rollback.VersionDate.ToLongTimeString() + ui.Text("general", "by") + ": " + rollback.User.Name + "</td></tr>";
+                propertiesCompare.Text += "<tr><th style='width: 25%;' valign='top'>" + ui.Text("content", "createDate") + ":</th><td>" + rollback.VersionDate.ToLongDateString() + " " + rollback.VersionDate.ToLongTimeString() + " " + ui.Text("general", "by") + ": " + rollback.User.Name + "</td></tr>";
 
                 if (rbl_mode.SelectedValue == "diff")
                     lt_notice.Text = ui.Text("rollback", "diffHelp");


### PR DESCRIPTION
Adds a space between date and creator and also updates en language file for key "by" to "by" instead of "or"
