### PR TITLE
Fixes issue with opening VS solution when only Visual Studio 2013 is installed (fixes U4-3445)

### DIFF
--- a/src/umbraco.presentation.targets
+++ b/src/umbraco.presentation.targets
@@ -48,7 +48,7 @@
     <WebPublishingTasks>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v11.0\Web\Microsoft.Web.Publishing.Tasks.dll</WebPublishingTasks>
   </PropertyGroup>
   
-    <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v12.0\Web\Microsoft.Web.Publishing.Tasks.dll')">
+  <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v12.0\Web\Microsoft.Web.Publishing.Tasks.dll')">
     <WebPublishingTasks>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v12.0\Web\Microsoft.Web.Publishing.Tasks.dll</WebPublishingTasks>
   </PropertyGroup>
 


### PR DESCRIPTION
The WebPublishingTasks was being loaded for 2010 and 2012, but there was no check for VS 2013. This fixes the issue with loading Umbraco.Web.UI when only Visual Studio 2013 is installed
