### PR TITLE
Fixes issue U4-3228, where dictionary item names are not trimmed.

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/simple.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/simple.ascx.cs
@@ -49,7 +49,7 @@ namespace umbraco.cms.presentation.create.controls
 				string returnUrl = umbraco.presentation.create.dialogHandler_temp.Create(
 					umbraco.helper.Request("nodeType"),
 					nodeId,
-					rename.Text);
+					rename.Text.Trim());
 
 
 				BasePage.Current.ClientTools


### PR DESCRIPTION
Anything created using the "simple" create issue is not trimmed, meaning you can have dictionary items like "spork " or "   fish ". Have added .Trim() to the save method to remove leading/trailing spaces.

Fixes U4-3228: http://issues.umbraco.org/issue/U4-3228
