### PR TITLE
Fixes issue U4-3396

### DIFF
--- a/build/NuSpecs/tools/install.ps1
+++ b/build/NuSpecs/tools/install.ps1
@@ -26,7 +26,7 @@ if ($project) {
 	# If we don't do this, the correct version never gets copied in
 	$projectDestinationPath = Split-Path $project.FullName -Parent
 	$jsonDllFile = Join-Path $projectDestinationPath "bin\Newtonsoft.Json.dll"
-	Remove-Item $jsonDllFile -Confirm:$false
+	if (Test-Path $jsonDllFile) { Remove-Item $jsonDllFile -Confirm:$false }
 	
 	# Open readme.txt file
 	$DTE.ItemOperations.OpenFile($toolsPath + '\Readme.txt')


### PR DESCRIPTION
Fixes U4-3396, removes error that is shown when installing Umbraco via Nuget in an empty project.
