### PR TITLE
Fixes: U4-2833 Packages using DataEditorSetting install alias.

### DIFF
--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -208,6 +208,16 @@ namespace Umbraco.Core.Services
         /// <param name="values">List of string values to save</param>
         public void SavePreValues(int id, IEnumerable<string> values)
         {
+            SavePreValues(id, values.Select(x => new Tuple<string, string>(string.Empty, x)));
+        }
+
+        /// <summary>
+        /// Saves a list of PreValues for a given DataTypeDefinition
+        /// </summary>
+        /// <param name="id">Id of the DataTypeDefinition to save PreValues for</param>
+        /// <param name="prevalues">List of prevalues to save</param>
+        public void SavePreValues(int id, IEnumerable<Tuple<string, string>> prevalues)
+        {
             using (new WriteLock(Locker))
             {
                 using (var uow = _uowProvider.GetUnitOfWork())
@@ -223,9 +233,9 @@ namespace Umbraco.Core.Services
 
                     using (var transaction = uow.Database.GetTransaction())
                     {
-                        foreach (var value in values)
+                        foreach (var prevalue in prevalues)
                         {
-                            var dto = new DataTypePreValueDto { DataTypeNodeId = id, Value = value, SortOrder = sortOrder };
+                            var dto = new DataTypePreValueDto { DataTypeNodeId = id, Value = prevalue.Item2, SortOrder = sortOrder, Alias = prevalue.Item1 };
                             uow.Database.Insert(dto);
                             sortOrder++;
                         }

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -91,6 +91,13 @@ namespace Umbraco.Core.Services
         void SavePreValues(int id, IEnumerable<string> values);
 
         /// <summary>
+        /// Saves a list of PreValues for a given DataTypeDefinition
+        /// </summary>
+        /// <param name="id">Id of the DataTypeDefinition to save PreValues for</param>
+        /// <param name="values">List of prevalues to save</param>
+        void SavePreValues(int id, IEnumerable<Tuple<string,string>> prevalues);
+
+        /// <summary>
         /// Gets a specific PreValue by its Id
         /// </summary>
         /// <param name="id">Id of the PreValue to retrieve the value from</param>

--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -791,8 +791,25 @@ namespace Umbraco.Core.Services
                 var dataTypeDefinitionName = dataTypeElement.Attribute("Name").Value;
                 var dataTypeDefinition = dataTypes.First(x => x.Name == dataTypeDefinitionName);
 
-                var values = prevaluesElement.Elements("PreValue").Select(prevalue => prevalue.Attribute("Value").Value).ToList();
-                _dataTypeService.SavePreValues(dataTypeDefinition.Id, values);
+                var values = new List<string>();
+                var prevalues = new List<Tuple<string, string>>();
+                foreach (var prevalue in prevaluesElement.Elements("PreValue"))
+                {
+                    if (prevalue.Attribute("Alias") != null)
+                    {
+                        prevalues.Add(new Tuple<string, string>(prevalue.Attribute("Alias").Value, prevalue.Attribute("Value").Value));
+                    }
+                    else
+                    {
+                        values.Add(prevalue.Attribute("Value").Value);
+                    }
+                }
+
+                if (values.Count > 0)
+                    _dataTypeService.SavePreValues(dataTypeDefinition.Id, values);
+
+                if (prevalues.Count > 0)
+                    _dataTypeService.SavePreValues(dataTypeDefinition.Id, prevalues);
             }
         }
 

--- a/src/umbraco.cms/businesslogic/datatype/DataTypeDefinition.cs
+++ b/src/umbraco.cms/businesslogic/datatype/DataTypeDefinition.cs
@@ -180,7 +180,9 @@ namespace umbraco.cms.businesslogic.datatype
 
                     if (val != null)
                     {
-                        PreValue p = new PreValue(0, 0, val.Value);
+                        var alias = xmlPv.Attributes["Alias"] != null ? xmlPv.Attributes["Alias"].Value : string.Empty;
+
+                        PreValue p = new PreValue(0, 0, val.Value, alias);
                         p.DataTypeId = dtd.Id;
                         p.Save();
                     }

--- a/src/umbraco.cms/businesslogic/datatype/PreValue.cs
+++ b/src/umbraco.cms/businesslogic/datatype/PreValue.cs
@@ -46,6 +46,21 @@ namespace umbraco.cms.businesslogic.datatype
         /// <summary>
         /// Initializes a new instance of the <see cref="PreValue"/> class.
         /// </summary>
+        /// <param name="Id">The unique identifier.</param>
+        /// <param name="SortOrder">The sort order.</param>
+        /// <param name="Value">The value.</param>
+        /// <param name="Alias">The alias.</param>
+        public PreValue(int Id, int SortOrder, string Value, string Alias)
+        {
+            _id = Id;
+            _sortOrder = SortOrder;
+            _value = Value;
+            _alias = Alias;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PreValue"/> class.
+        /// </summary>
         /// <param name="Id">The id.</param>
         public PreValue(int Id)
         {
@@ -92,7 +107,8 @@ namespace umbraco.cms.businesslogic.datatype
         private int _dataTypeId;
         private int? _id;
         private string _value;
-        private int _sortOrder; 
+        private int _sortOrder;
+        private string _alias;
         #endregion
 
         #region Public properties
@@ -134,7 +150,23 @@ namespace umbraco.cms.businesslogic.datatype
         {
             get { return _sortOrder; }
             set { _sortOrder = value; }
-        } 
+        }
+
+        /// <summary>
+        /// Gets or sets the alias.
+        /// </summary>
+        /// <value>The alias.</value>
+        public string Alias
+        {
+            get
+            {
+                if (_alias == null)
+                    _alias = string.Empty;
+
+                return _alias;
+            }
+            set { _alias = value; }
+        }
         #endregion
 
         #region Public methods
@@ -171,11 +203,15 @@ namespace umbraco.cms.businesslogic.datatype
                 else
                     SortOrder = 1;
 
-                IParameter[] SqlParams = new IParameter[] {
-								SqlHelper.CreateParameter("@value",Value),
-								SqlHelper.CreateParameter("@dtdefid",DataTypeId)};
+                var SqlParams = new IParameter[]
+                {
+                    SqlHelper.CreateParameter("@value", Value),
+                    SqlHelper.CreateParameter("@dtdefid", DataTypeId),
+                    SqlHelper.CreateParameter("@alias", Alias)
+                };
+
                 // The method is synchronized
-                SqlHelper.ExecuteNonQuery("INSERT INTO cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) VALUES (@dtdefid,@value,0,'')", SqlParams);
+                SqlHelper.ExecuteNonQuery("INSERT INTO cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) VALUES (@dtdefid,@value,0,@alias)", SqlParams);
                 _id = SqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM cmsDataTypePreValues");
             }
 
@@ -183,7 +219,8 @@ namespace umbraco.cms.businesslogic.datatype
                 "update cmsDataTypePreValues set sortorder = @sortOrder, [value] = @value where id = @id",
                 SqlHelper.CreateParameter("@sortOrder", SortOrder),
                 SqlHelper.CreateParameter("@value", Value),
-                SqlHelper.CreateParameter("@id", Id));
+                SqlHelper.CreateParameter("@id", Id),
+                SqlHelper.CreateParameter("@alias", Alias));
         } 
         
         #endregion


### PR DESCRIPTION
Extends the package installer to check if a `PreValue` element has an `Alias` value.
Updates the `DataTypeService` to write the alias to the `cmsDataTypePreValues` database table.
