### PR TITLE
Fixes issue U4-3063

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/moveOrCopy.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/moveOrCopy.aspx.cs
@@ -146,8 +146,9 @@ namespace umbraco.dialogs
             var contentType = contentTypeService.GetContentType(
                 int.Parse(Request.GetItemAsString("id")));
 
-            var alias = rename.Text.Replace("'", "''");
+            var alias = rename.Text.Trim().Replace("'", "''");
             var clone = ((Umbraco.Core.Models.ContentType) contentType).Clone(alias);
+			clone.Name = rename.Text.Trim();
             contentTypeService.Save(clone);
 
             var returnUrl = string.Format("{0}/settings/editNodeTypeNew.aspx?id={1}", SystemDirectories.Umbraco, clone.Id);


### PR DESCRIPTION
Where copying a document type uses the renamed name for the node alias, but not the title, resulting in two Doctypes with the same name, but different aliases, rather than different names AND aliases.

http://issues.umbraco.org/issue/U4-3063
