### PR TITLE
Fixes: U4-3450 Prevalue alias is not added to package XML

### DIFF
--- a/src/umbraco.cms/businesslogic/datatype/DataTypeDefinition.cs
+++ b/src/umbraco.cms/businesslogic/datatype/DataTypeDefinition.cs
@@ -135,11 +135,16 @@ namespace umbraco.cms.businesslogic.datatype
             XmlElement prevalues = xd.CreateElement("PreValues");
             foreach (DictionaryEntry item in PreValues.GetPreValues(this.Id))
             {
-                XmlElement prevalue = xd.CreateElement("PreValue");
-                prevalue.Attributes.Append(xmlHelper.addAttribute(xd, "Id", ((PreValue)item.Value).Id.ToString()));
-                prevalue.Attributes.Append(xmlHelper.addAttribute(xd, "Value", ((PreValue)item.Value).Value));
+                var prevalue = (PreValue)item.Value;
+                var element = xd.CreateElement("PreValue");
+                element.Attributes.Append(xmlHelper.addAttribute(xd, "Id", prevalue.Id.ToString()));
 
-                prevalues.AppendChild(prevalue);
+                if (!string.IsNullOrWhiteSpace(prevalue.Alias))
+                    element.Attributes.Append(xmlHelper.addAttribute(xd, "Alias", prevalue.Alias));
+
+                element.Attributes.Append(xmlHelper.addAttribute(xd, "Value", prevalue.Value));
+
+                prevalues.AppendChild(element);
             }
 
             dt.AppendChild(prevalues);

--- a/src/umbraco.cms/businesslogic/datatype/PreValue.cs
+++ b/src/umbraco.cms/businesslogic/datatype/PreValue.cs
@@ -46,6 +46,21 @@ namespace umbraco.cms.businesslogic.datatype
         /// <summary>
         /// Initializes a new instance of the <see cref="PreValue"/> class.
         /// </summary>
+        /// <param name="Id">The unique identifier.</param>
+        /// <param name="SortOrder">The sort order.</param>
+        /// <param name="Value">The value.</param>
+        /// <param name="Alias">The alias.</param>
+        public PreValue(int Id, int SortOrder, string Value, string Alias)
+        {
+            _id = Id;
+            _sortOrder = SortOrder;
+            _value = Value;
+            _alias = Alias;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PreValue"/> class.
+        /// </summary>
         /// <param name="Id">The id.</param>
         public PreValue(int Id)
         {
@@ -92,7 +107,8 @@ namespace umbraco.cms.businesslogic.datatype
         private int _dataTypeId;
         private int? _id;
         private string _value;
-        private int _sortOrder; 
+        private int _sortOrder;
+        private string _alias;
         #endregion
 
         #region Public properties
@@ -134,7 +150,23 @@ namespace umbraco.cms.businesslogic.datatype
         {
             get { return _sortOrder; }
             set { _sortOrder = value; }
-        } 
+        }
+
+        /// <summary>
+        /// Gets or sets the alias.
+        /// </summary>
+        /// <value>The alias.</value>
+        public string Alias
+        {
+            get
+            {
+                if (_alias == null)
+                    _alias = string.Empty;
+
+                return _alias;
+            }
+            set { _alias = value; }
+        }
         #endregion
 
         #region Public methods
@@ -195,12 +227,13 @@ namespace umbraco.cms.businesslogic.datatype
         private void initialize()
         {
             IRecordsReader dr = SqlHelper.ExecuteReader(
-                 "Select id, sortorder, [value] from cmsDataTypePreValues where id = @id order by sortorder",
+                 "SELECT id, sortorder, [value], alias FROM cmsDataTypePreValues WHERE id = @id ORDER BY sortorder",
                  SqlHelper.CreateParameter("@id", Id));
             if (dr.Read())
             {
                 _sortOrder = dr.GetInt("sortorder");
                 _value = dr.GetString("value");
+                _alias = dr.GetString("alias");
             }
             dr.Close();
         } 

--- a/src/umbraco.cms/businesslogic/datatype/PreValues.cs
+++ b/src/umbraco.cms/businesslogic/datatype/PreValues.cs
@@ -30,13 +30,13 @@ namespace umbraco.cms.businesslogic.datatype
         {
             SortedList retval = new SortedList();
             IRecordsReader dr = SqlHelper.ExecuteReader(
-                "Select id, sortorder, [value] from cmsDataTypePreValues where DataTypeNodeId = @dataTypeId order by sortorder",
+                "SELECT id, sortorder, [value], alias FROM cmsDataTypePreValues WHERE DataTypeNodeId = @dataTypeId ORDER BY sortorder",
                 SqlHelper.CreateParameter("@dataTypeId", DataTypeId));
 
             int counter = 0;
             while (dr.Read())
             {
-                retval.Add(counter, new PreValue(dr.GetInt("id"), dr.GetInt("sortorder"), dr.GetString("value")));
+                retval.Add(counter, new PreValue(dr.GetInt("id"), dr.GetInt("sortorder"), dr.GetString("value"), dr.GetString("alias")));
                 counter++;
             }
             dr.Close();


### PR DESCRIPTION
Extends the `DataTypeDefinition` `.ToXml` method to include a prevalue's alias name for the package XML manifest.

Fixes [U4-3450](http://issues.umbraco.org/issue/U4-3450)