### PR TITLE
Fixes: U4-3452 Update the MIT License URL (Packager)

### DIFF
--- a/src/umbraco.cms/businesslogic/Packager/data.cs
+++ b/src/umbraco.cms/businesslogic/Packager/data.cs
@@ -116,8 +116,8 @@ namespace umbraco.cms.businesslogic.packager
                 instance.Attributes.Append(xmlHelper.addAttribute(Source, "skinRepoGuid", ""));
 
                 XmlElement license = Source.CreateElement("license");
-                license.InnerText = "MIT license";
-                license.Attributes.Append(xmlHelper.addAttribute(Source, "url", "http://www.opensource.org/licenses/mit-license.php"));
+                license.InnerText = "MIT License";
+                license.Attributes.Append(xmlHelper.addAttribute(Source, "url", "http://opensource.org/licenses/MIT"));
                 instance.AppendChild(license);
 
                 XmlElement author = Source.CreateElement("author");


### PR DESCRIPTION
Updates the canonical URL for the MIT License...

From: http://opensource.org/licenses/mit-license.php
To: http://opensource.org/licenses/MIT
