### PR TITLE
Fixes: U4-2006 Domain.GetDomain(string DomainName) is case-sensitive

### DIFF
--- a/src/umbraco.cms/businesslogic/web/Domain.cs
+++ b/src/umbraco.cms/businesslogic/web/Domain.cs
@@ -177,7 +177,7 @@ namespace umbraco.cms.businesslogic.web
 
         public static Domain GetDomain(string DomainName)
         {
-        	return GetDomains().FirstOrDefault(d => d.Name == DomainName);
+            return GetDomains().FirstOrDefault(d => d.Name.InvariantEquals(DomainName));
         }
 
         public static int GetRootFromDomain(string DomainName)


### PR DESCRIPTION
Adds an invariant/case-insensitive check for getting the domain by hostname.

e.g. `Domain.GetDomain("localhost")` and `Domain.GetDomain("LocalHost")` return the same domain object.
