### PR TITLE
Fixes issue U4-2757 where generic properties are not ordered correctly.

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentControl.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentControl.cs
@@ -178,7 +178,7 @@ namespace umbraco.controls
 
             //if the property is not in a tab, add it to the general tab
             var props = _content.GenericProperties;
-            foreach (Property p in props)
+            foreach (Property p in props.OrderBy(x => x.PropertyType.SortOrder))
             {
                 if (inTab[p.PropertyType.Id.ToString()] == null)
                     AddControlNew(p, tpProp, ui.Text("general", "properties", null));


### PR DESCRIPTION
All normal properties are ordered by the sort order defined in the DocType. The generic properties were not being ordered so always come out in the order that they were entered. This pull request fixes this so they now sort properly.

Fixes U4-2757: http://issues.umbraco.org/issue/U4-2757
