### PR TITLE
Fixes issue U4-2760, sorting installed packages

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadPackages.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadPackages.cs
@@ -55,7 +55,7 @@ namespace umbraco
                         .OrderByDescending(x => Version.TryParse(x.Data.Version, out v) ? v : new Version())
                         .GroupBy(x => x.Data.Name)
                         .Select(x => x.First())
-                        .OrderBy(x => x.Data.Id);
+                        .OrderBy(x => x.Data.Name);
                     foreach (var p in uniquePackages)
                     {
                         var xNode = XmlTreeNode.Create(this);


### PR DESCRIPTION
Makes the installed packages list by name in alphabetical order to make it easier to see what's installed.

http://issues.umbraco.org/issue/U4-2760
