### PR TITLE
Maintains tab sort order for doc type imports/exports.

### DIFF
--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -586,9 +586,18 @@ namespace Umbraco.Core.Services
             {
                 var id = tab.Element("Id").Value;//Do we need to use this for tracking?
                 var caption = tab.Element("Caption").Value;
+
                 if (contentType.PropertyGroups.Contains(caption) == false)
                 {
                     contentType.AddPropertyGroup(caption);
+
+                    int sortOrder;
+                    if(tab.Element("SortOrder") != null && 
+                        int.TryParse(tab.Element("SortOrder").Value, out sortOrder))
+                    {
+                        // Override the sort order with the imported value
+                        contentType.PropertyGroups[caption].SortOrder = sortOrder;
+                    }
                 }
             }
         }

--- a/src/umbraco.cms/businesslogic/web/DocumentType.cs
+++ b/src/umbraco.cms/businesslogic/web/DocumentType.cs
@@ -547,6 +547,7 @@ namespace umbraco.cms.businesslogic.web
                     var tabx = xd.CreateElement("Tab");
                     tabx.AppendChild(XmlHelper.AddTextNode(xd, "Id", propertyTypeGroup.Id.ToString()));
                     tabx.AppendChild(XmlHelper.AddTextNode(xd, "Caption", propertyTypeGroup.Name));
+                    tabx.AppendChild(XmlHelper.AddTextNode(xd, "SortOrder", propertyTypeGroup.SortOrder.ToString()));
                     tabs.AppendChild(tabx);
                 }
             }


### PR DESCRIPTION
Added SortOrder to XML for document types (used by export)
Added ability for doctype importer to set the sort order if a sort order element is available
