### PR TITLE
Prevented "no starter kit" link from hiding the content area after click

### DIFF
--- a/src/Umbraco.Web.UI/install/steps/Skinning/loadStarterKits.ascx
+++ b/src/Umbraco.Web.UI/install/steps/Skinning/loadStarterKits.ascx
@@ -60,7 +60,7 @@
         <FooterTemplate>
 
             <li class="add-thanks">
-                <asp:LinkButton runat="server" class="single-tab declineStarterKits" ID="declineStarterKits" OnClientClick="return confirm('Are you sure you do not want to install a starter kit?');" OnClick="NextStep">
+                <asp:LinkButton runat="server" class="declineStarterKits" ID="declineStarterKits" OnClientClick="return confirm('Are you sure you do not want to install a starter kit?');" OnClick="NextStep">
             <img class="zoom-img" src="<%# umbraco.GlobalSettings.ClientPath + "/installer/images/btn-no-thanks.png" %>" alt="image description" width="150" height="204">
                 </asp:LinkButton>
 


### PR DESCRIPTION
It would do one of two things:
- Redirect to another page, no need to hide content area.
- cancel - definately shouldn't hide content area.