### PR TITLE
U4-1083 Document type alias can be created the same.

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/dialogs/MoveOrCopy.aspx.designer.cs
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/MoveOrCopy.aspx.designer.cs
@@ -11,5 +11,23 @@ namespace Umbraco.Web.UI.Umbraco.Dialogs {
     
     
     public partial class MoveOrCopy {
+        
+        /// <summary>
+        /// CustomValidation1 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CustomValidator CustomValidation1;
+        
+        /// <summary>
+        /// CustomValidation2 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CustomValidator CustomValidation2;
     }
 }

--- a/src/Umbraco.Web.UI/umbraco/dialogs/moveOrCopy.aspx
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/moveOrCopy.aspx
@@ -1,4 +1,5 @@
 <%@ Page Language="c#" CodeBehind="moveOrCopy.aspx.cs" MasterPageFile="../masterpages/umbracoDialog.Master" AutoEventWireup="True" Inherits="Umbraco.Web.UI.Umbraco.Dialogs.MoveOrCopy" %>
+
 <%@ Register TagPrefix="umb" Namespace="ClientDependency.Core.Controls" Assembly="ClientDependency.Core" %>
 <%@ Register TagPrefix="cc1" Namespace="umbraco.uicontrols" Assembly="controls" %>
 <%@ Register Src="../controls/Tree/TreeControl.ascx" TagName="TreeControl" TagPrefix="umbraco" %>
@@ -7,60 +8,55 @@
 
 	<script type="text/javascript">
 
-			function dialogHandler(id) {
-				document.getElementById("copyTo").value = id;
-				document.getElementById("<%= ok.ClientID %>").disabled = false;
-				
+		function dialogHandler(id) {
+			document.getElementById("copyTo").value = id;
+			document.getElementById("<%= ok.ClientID %>").disabled = false;
+
 				// Get node name by xmlrequest
 				if (id > 0)
-						umbraco.presentation.webservices.CMSNode.GetNodeName('<%=umbraco.BasePages.BasePage.umbracoUserContextID%>', id, updateName);
-				else{
+					umbraco.presentation.webservices.CMSNode.GetNodeName('<%=umbraco.BasePages.BasePage.umbracoUserContextID%>', id, updateName);
+				else {
 					//document.getElementById("pageNameContent").innerHTML = "'<strong><%=umbraco.ui.Text(umbraco.helper.Request("app"))%></strong>' <%= umbraco.ui.Text("moveOrCopy","nodeSelected") %>";
-			    
+
 					jQuery("#pageNameContent").html("<strong><%=umbraco.ui.Text(umbraco.helper.Request("app"))%></strong> <%= umbraco.ui.Text("moveOrCopy","nodeSelected") %>");
-					jQuery("#pageNameHolder").attr("class","success");
-			  }
+					jQuery("#pageNameHolder").attr("class", "success");
+				}
 			}
-			
-            var actionIsValid = true;
+
+			var actionIsValid = true;
 
 			function updateName(result) {
-                if(actionIsValid)
-                {
-				    jQuery("#pageNameContent").html("'<strong>" + result + "</strong>' <%= umbraco.ui.Text("moveOrCopy","nodeSelected") %>");
-				    jQuery("#pageNameHolder").attr("class","success");
+				if (actionIsValid) {
+					jQuery("#pageNameContent").html("'<strong>" + result + "</strong>' <%= umbraco.ui.Text("moveOrCopy","nodeSelected") %>");
+                	jQuery("#pageNameHolder").attr("class", "success");
                 }
 			}
 
-           
-            function notValid()
-            {
-                jQuery("#pageNameHolder").attr("class", "error");
-                jQuery("#pageNameContent").html("<%= umbraco.ui.Text("moveOrCopy","notValid") %>");
+
+			function notValid() {
+				jQuery("#pageNameHolder").attr("class", "error");
+				jQuery("#pageNameContent").html("<%= umbraco.ui.Text("moveOrCopy","notValid") %>");
                 actionIsValid = false;
-            }
-	
+			}
+
 	</script>
 
-	
+
 
 	<style type="text/css">
-		.propertyItemheader
-		{
-			width: 180px !important;
-		}
+		.propertyItemheader { width: 180px !important; }
 	</style>
 </asp:Content>
 <asp:Content ContentPlaceHolderID="body" runat="server">
-	<umb:JsInclude ID="JsInclude1" runat="server" FilePath="js/umbracoCheckKeys.js" PathNameAlias="UmbracoRoot"/>
-	
+	<umb:JsInclude ID="JsInclude1" runat="server" FilePath="js/umbracoCheckKeys.js" PathNameAlias="UmbracoRoot" />
+
 	<input type="hidden" id="copyTo" name="copyTo" />
 	<cc1:Feedback ID="feedback" runat="server" />
 	<cc1:Pane ID="pane_form" runat="server" Visible="false">
-		<cc1:PropertyPanel runat="server" Style="overflow: auto; height: 220px;position: relative;">
+		<cc1:PropertyPanel runat="server" Style="overflow: auto; height: 220px; position: relative;">
 			<umbraco:TreeControl runat="server" ID="JTree" App='<%#umbraco.helper.Request("app") %>'
-                IsDialog="true" DialogMode="id" ShowContextMenu="false" FunctionToCall="dialogHandler"
-                Height="200"></umbraco:TreeControl>
+				IsDialog="true" DialogMode="id" ShowContextMenu="false" FunctionToCall="dialogHandler"
+				Height="200"></umbraco:TreeControl>
 		</cc1:PropertyPanel>
 		<cc1:PropertyPanel runat="server" ID="pp_relate" Text="relateToOriginal">
 			<asp:CheckBox runat="server" ID="RelateDocuments" Checked="false" />
@@ -69,7 +65,8 @@
 	<asp:PlaceHolder ID="pane_form_notice" runat="server" Visible="false">
 		<div class="notice" id="pageNameHolder" style="margin-top: 10px;">
 			<p id="pageNameContent">
-				<%= umbraco.ui.Text("moveOrCopy","noNodeSelected") %></p>
+				<%= umbraco.ui.Text("moveOrCopy","noNodeSelected") %>
+			</p>
 		</div>
 	</asp:PlaceHolder>
 	<cc1:Pane ID="pane_settings" runat="server" Visible="false">
@@ -81,11 +78,13 @@
 		</cc1:PropertyPanel>
 	</cc1:Pane>
 	<asp:Panel ID="panel_buttons" runat="server">
-		<p>
+		<div>
+			<asp:CustomValidator ID="CustomValidation1" ErrorMessage="* A document type with this name/alias already exists" OnServerValidate="validationDoctypeName" ControlToValidate="rename" ForeColor="red" runat="server" />
+			<asp:CustomValidator ID="CustomValidation2" ErrorMessage="<br/>* The name of the document type will result in an invalid alias" OnServerValidate="validationDoctypeAlias" ControlToValidate="rename" ForeColor="red" runat="server" />
 			<asp:Button ID="ok" runat="server" CssClass="guiInputButton" OnClick="HandleMoveOrCopy"></asp:Button>
 			&nbsp; <em>
 				<%=umbraco.ui.Text("general", "or", this.getUser())%></em> &nbsp; <a href="#" style="color: blue" onclick="UmbClientMgr.closeModalWindow()">
 					<%=umbraco.ui.Text("general", "cancel", this.getUser())%></a>
-		</p>
+		</div>
 	</asp:Panel>
 </asp:Content>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/nodeType.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/nodeType.ascx.cs
@@ -10,7 +10,7 @@ namespace umbraco.cms.presentation.create.controls
 	using System.Web.UI.HtmlControls;
 	using umbraco.cms.helpers;
 	using umbraco.BasePages;
-    using umbraco.cms.businesslogic.web;
+	using umbraco.cms.businesslogic.web;
 
 	/// <summary>
 	///		Summary description for nodeType.
@@ -22,54 +22,62 @@ namespace umbraco.cms.presentation.create.controls
 		protected void Page_Load(object sender, System.EventArgs e)
 		{
 			sbmt.Text = ui.Text("create");
-            if (!IsPostBack)
-            {
-                string nodeId = umbraco.helper.Request("nodeId");
-                if (String.IsNullOrEmpty(nodeId) || nodeId == "init")
-                {
-                    masterType.Attributes.Add("style", "width: 350px;");
-                    masterType.Items.Add(new ListItem(ui.Text("none") + "...", "0"));
-                    foreach (cms.businesslogic.web.DocumentType dt in cms.businesslogic.web.DocumentType.GetAllAsList())
-                    {
-                        //                    if (dt.MasterContentType == 0)
-                        masterType.Items.Add(new ListItem(dt.Text, dt.Id.ToString()));
-                    }
-                }
-                else
-                {
-                    // there's already a master doctype defined
-                    masterType.Visible = false;
-                    masterTypePreDefined.Visible = true;
-                    masterTypePreDefined.Text = "<h3>" + new DocumentType(int.Parse(nodeId)).Text + "</h3>";
-                }
-            }
+			if (!IsPostBack)
+			{
+				string nodeId = umbraco.helper.Request("nodeId");
+				if (String.IsNullOrEmpty(nodeId) || nodeId == "init")
+				{
+					masterType.Attributes.Add("style", "width: 350px;");
+					masterType.Items.Add(new ListItem(ui.Text("none") + "...", "0"));
+					foreach (cms.businesslogic.web.DocumentType dt in cms.businesslogic.web.DocumentType.GetAllAsList())
+					{
+						//                    if (dt.MasterContentType == 0)
+						masterType.Items.Add(new ListItem(dt.Text, dt.Id.ToString()));
+					}
+				}
+				else
+				{
+					// there's already a master doctype defined
+					masterType.Visible = false;
+					masterTypePreDefined.Visible = true;
+					masterTypePreDefined.Text = "<h3>" + new DocumentType(int.Parse(nodeId)).Text + "</h3>";
+				}
+			}
 		}
 
-        protected void validationDoctypeName(object sender, ServerValidateEventArgs e) {
-            if (DocumentType.GetByAlias(rename.Text) != null)
-                e.IsValid = false;
-        }
+		protected void validationDoctypeName(object sender, ServerValidateEventArgs e)
+		{
+			if (DocumentType.GetByAlias(rename.Text) != null)
+			{
+				e.IsValid = false;
+			}
+			else
+			{
+				if (DocumentType.GetByAlias(rename.Text.ToSafeAlias()) != null)
+					e.IsValid = false;
+			}
+		}
 
-        protected void validationDoctypeAlias(object sender, ServerValidateEventArgs e)
-        {
-            if (string.IsNullOrEmpty(rename.Text.ToSafeAlias()))
-                e.IsValid = false;
-        }
+		protected void validationDoctypeAlias(object sender, ServerValidateEventArgs e)
+		{
+			if (string.IsNullOrEmpty(rename.Text.ToSafeAlias()))
+				e.IsValid = false;
+		}
 
 		protected void sbmt_Click(object sender, System.EventArgs e)
 		{
-			if (Page.IsValid) 
+			if (Page.IsValid)
 			{
 				int createTemplateVal = 0;
-			    if (createTemplate.Checked)
+				if (createTemplate.Checked)
 					createTemplateVal = 1;
 
-                // check master type
-                string masterTypeVal = String.IsNullOrEmpty(umbraco.helper.Request("nodeId")) || umbraco.helper.Request("nodeId") == "init" ? masterType.SelectedValue : umbraco.helper.Request("nodeId");
+				// check master type
+				string masterTypeVal = String.IsNullOrEmpty(umbraco.helper.Request("nodeId")) || umbraco.helper.Request("nodeId") == "init" ? masterType.SelectedValue : umbraco.helper.Request("nodeId");
 
 				string returnUrl = umbraco.presentation.create.dialogHandler_temp.Create(
 					umbraco.helper.Request("nodeType"),
-                    int.Parse(masterTypeVal),
+					int.Parse(masterTypeVal),
 					createTemplateVal,
 					rename.Text);
 
@@ -79,7 +87,7 @@ namespace umbraco.cms.presentation.create.controls
 					.CloseModalWindow();
 
 			}
-		
+
 		}
 		#region Web Form Designer generated code
 		override protected void OnInit(EventArgs e)
@@ -90,7 +98,7 @@ namespace umbraco.cms.presentation.create.controls
 			InitializeComponent();
 			base.OnInit(e);
 		}
-		
+
 		/// <summary>
 		///		Required method for Designer support - do not modify
 		///		the contents of this method with the code editor.

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/nodeType.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/nodeType.ascx.cs
@@ -53,7 +53,7 @@ namespace umbraco.cms.presentation.create.controls
 			}
 			else
 			{
-				if (DocumentType.GetByAlias(rename.Text.ToSafeAlias()) != null)
+				if (DocumentType.GetByAlias(alias) != null)
 					e.IsValid = false;
 			}
 		}

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/moveOrCopy.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/moveOrCopy.aspx.cs
@@ -1,438 +1,457 @@
 ﻿using System;
-using System.Collections;
+using System.Linq;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-using System.Xml;
+using umbraco.BasePages;
+using umbraco.cms.businesslogic.web;
+using umbraco.cms.presentation.user;
+using umbraco.interfaces;
 using Umbraco.Core;
 using Umbraco.Core.IO;
 using Umbraco.Core.Models;
-using umbraco.BasePages;
-using umbraco.cms.businesslogic.web;
-using umbraco.presentation;
-using System.Linq;
-using umbraco.cms.businesslogic;
-using umbraco.cms.presentation.user;
-using umbraco.interfaces;
 using Umbraco.Web;
-using Umbraco.Core;
 
 namespace umbraco.dialogs
 {
-    /// <summary>
-    /// Summary description for moveOrCopy.
-    /// </summary>
-    public partial class moveOrCopy : UmbracoEnsuredPage
-    {
+	/// <summary>
+	/// Summary description for moveOrCopy.
+	/// </summary>
+	public partial class moveOrCopy : UmbracoEnsuredPage
+	{
 
-        protected override void OnInit(EventArgs e)
-        {
-            CurrentApp = Request["app"];
+		protected override void OnInit(EventArgs e)
+		{
+			CurrentApp = Request["app"];
 
-            base.OnInit(e);
-        }
+			base.OnInit(e);
+		}
 
-        protected void Page_Load(object sender, EventArgs e)
-        {
-            JTree.DataBind();
+		protected void Page_Load(object sender, EventArgs e)
+		{
+			JTree.DataBind();
 
-            // Put user code to initialize the page here
-            if (IsPostBack == false)
-            {
-                pp_relate.Text = ui.Text("moveOrCopy", "relateToOriginal");
+			// Put user code to initialize the page here
+			if (IsPostBack == false)
+			{
+				pp_relate.Text = ui.Text("moveOrCopy", "relateToOriginal");
 
-                //Document Type copy Hack...                
+				//Document Type copy Hack...                
 
-                if (CurrentApp == Constants.Applications.Settings)
-                {
-                    pane_form.Visible = false;
-                    pane_form_notice.Visible = false;
-                    pane_settings.Visible = true;
+				if (CurrentApp == Constants.Applications.Settings)
+				{
+					pane_form.Visible = false;
+					pane_form_notice.Visible = false;
+					pane_settings.Visible = true;
 
-                    ok.Text = ui.Text("general", "ok", UmbracoUser);
-                    ok.Attributes.Add("style", "width: 60px");
+					ok.Text = ui.Text("general", "ok", UmbracoUser);
+					ok.Attributes.Add("style", "width: 60px");
 
-                    var documentType = new DocumentType(int.Parse(Request.GetItemAsString("id")));
+					var documentType = new DocumentType(int.Parse(Request.GetItemAsString("id")));
 
-                    //Load master types... 
-                    masterType.Attributes.Add("style", "width: 350px;");
-                    masterType.Items.Add(new ListItem(ui.Text("none") + "...", "0"));
-                    foreach (var docT in DocumentType.GetAllAsList())
-                    {
-                        masterType.Items.Add(new ListItem(docT.Text, docT.Id.ToString()));
-                    }
+					//Load master types... 
+					masterType.Attributes.Add("style", "width: 350px;");
+					masterType.Items.Add(new ListItem(ui.Text("none") + "...", "0"));
+					foreach (var docT in DocumentType.GetAllAsList())
+					{
+						masterType.Items.Add(new ListItem(docT.Text, docT.Id.ToString()));
+					}
 
-                    masterType.SelectedValue = documentType.MasterContentType.ToString();
+					masterType.SelectedValue = documentType.MasterContentType.ToString();
 
-                    rename.Text = documentType.Text + " (copy)";
-                    pane_settings.Text = "Make a copy of the document type '" + documentType.Text + "' and save it under a new name";
+					rename.Text = documentType.Text + " (copy)";
+					pane_settings.Text = "Make a copy of the document type '" + documentType.Text + "' and save it under a new name";
 
-                }
-                else
-                {
-                    pane_form.Visible = true;
-                    pane_form_notice.Visible = true;
+				}
+				else
+				{
+					pane_form.Visible = true;
+					pane_form_notice.Visible = true;
 
-                    pane_settings.Visible = false;
+					pane_settings.Visible = false;
 
-                    // Caption and properies on BUTTON
-                    ok.Text = ui.Text("general", "ok", UmbracoUser);
-                    ok.Attributes.Add("style", "width: 60px");
-                    ok.Attributes.Add("disabled", "true");
+					// Caption and properies on BUTTON
+					ok.Text = ui.Text("general", "ok", UmbracoUser);
+					ok.Attributes.Add("style", "width: 60px");
+					ok.Attributes.Add("disabled", "true");
 
-                    IContentBase currContent;
-                    if (CurrentApp == "content")
-                    {
-                        currContent = Services.ContentService.GetById(Request.GetItemAs<int>("id"));
-                    }
-                    else
-                    {
-                        currContent = Services.MediaService.GetById(Request.GetItemAs<int>("id"));
-                    }
+					IContentBase currContent;
+					if (CurrentApp == "content")
+					{
+						currContent = Services.ContentService.GetById(Request.GetItemAs<int>("id"));
+					}
+					else
+					{
+						currContent = Services.MediaService.GetById(Request.GetItemAs<int>("id"));
+					}
 
-                    var validAction = true;
-                    if (CurrentApp == Constants.Applications.Content && Umbraco.Core.Models.ContentExtensions.HasChildren(currContent, Services))
-                    {
-                        validAction = ValidAction(currContent, Request.GetItemAsString("mode") == "cut" ? 'M' : 'O');
-                    }
+					var validAction = true;
+					if (CurrentApp == Constants.Applications.Content && Umbraco.Core.Models.ContentExtensions.HasChildren(currContent, Services))
+					{
+						validAction = ValidAction(currContent, Request.GetItemAsString("mode") == "cut" ? 'M' : 'O');
+					}
 
-                    if (Request.GetItemAsString("mode") == "cut")
-                    {
-                        pane_form.Text = ui.Text("moveOrCopy", "moveTo", currContent.Name, UmbracoUser);
-                        pp_relate.Visible = false;
-                    }
-                    else
-                    {
-                        pane_form.Text = ui.Text("moveOrCopy", "copyTo", currContent.Name, UmbracoUser);
-                        pp_relate.Visible = true;
-                    }
+					if (Request.GetItemAsString("mode") == "cut")
+					{
+						pane_form.Text = ui.Text("moveOrCopy", "moveTo", currContent.Name, UmbracoUser);
+						pp_relate.Visible = false;
+					}
+					else
+					{
+						pane_form.Text = ui.Text("moveOrCopy", "copyTo", currContent.Name, UmbracoUser);
+						pp_relate.Visible = true;
+					}
 
-                    if (validAction == false)
-                    {
-                        panel_buttons.Visible = false;
-                        ScriptManager.RegisterStartupScript(this, GetType(), "notvalid", "notValid();", true);
-                    }
-                }
-            }
+					if (validAction == false)
+					{
+						panel_buttons.Visible = false;
+						ScriptManager.RegisterStartupScript(this, GetType(), "notvalid", "notValid();", true);
+					}
+				}
+			}
 
-        }
+		}
 
-        private bool ValidAction(IContentBase cmsNode, char actionLetter)
-        {
-            var currentAction = BusinessLogic.Actions.Action.GetPermissionAssignable().First(a => a.Letter == actionLetter);
-            return CheckPermissions(cmsNode, currentAction);
-        }
+		private bool ValidAction(IContentBase cmsNode, char actionLetter)
+		{
+			var currentAction = BusinessLogic.Actions.Action.GetPermissionAssignable().First(a => a.Letter == actionLetter);
+			return CheckPermissions(cmsNode, currentAction);
+		}
 
-        /// <summary>
-        /// Checks if the current user has permissions to execute this action against this node
-        /// </summary>
-        /// <param name="node"></param>
-        /// <param name="currentAction"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// This used to do a recursive check for all descendent nodes but this is not required and is a massive CPU hog.
-        /// See: http://issues.umbraco.org/issue/U4-2632, https://groups.google.com/forum/?fromgroups=#!topic/umbraco-dev/L1D4LwVSP2Y
-        /// </remarks>
-        private bool CheckPermissions(IContentBase node, IAction currentAction)
-        {
-            var currUserPermissions = new UserPermissions(CurrentUser);
-            var lstCurrUserActions = currUserPermissions.GetExistingNodePermission(node.Id);
+		/// <summary>
+		/// Checks if the current user has permissions to execute this action against this node
+		/// </summary>
+		/// <param name="node"></param>
+		/// <param name="currentAction"></param>
+		/// <returns></returns>
+		/// <remarks>
+		/// This used to do a recursive check for all descendent nodes but this is not required and is a massive CPU hog.
+		/// See: http://issues.umbraco.org/issue/U4-2632, https://groups.google.com/forum/?fromgroups=#!topic/umbraco-dev/L1D4LwVSP2Y
+		/// </remarks>
+		private bool CheckPermissions(IContentBase node, IAction currentAction)
+		{
+			var currUserPermissions = new UserPermissions(CurrentUser);
+			var lstCurrUserActions = currUserPermissions.GetExistingNodePermission(node.Id);
 
-            return lstCurrUserActions.Contains(currentAction);
-        }
+			return lstCurrUserActions.Contains(currentAction);
+		}
 
-        private void HandleDocumentTypeCopy()
-        {
-            var contentTypeService = ApplicationContext.Current.Services.ContentTypeService;
-            var contentType = contentTypeService.GetContentType(
-                int.Parse(Request.GetItemAsString("id")));
+		private void HandleDocumentTypeCopy()
+		{
+			if (Page.IsValid)
+			{
+				var contentTypeService = ApplicationContext.Current.Services.ContentTypeService;
+				var contentType = contentTypeService.GetContentType(
+					int.Parse(Request.GetItemAsString("id")));
 
-            var alias = rename.Text.Replace("'", "''");
-            var clone = ((Umbraco.Core.Models.ContentType) contentType).Clone(alias);
-            contentTypeService.Save(clone);
+				var name = rename.Text.Replace("'", "''");
+				var clone = ((Umbraco.Core.Models.ContentType)contentType).Clone(name);
+				clone.Name = name;
+				contentTypeService.Save(clone);
 
-            var returnUrl = string.Format("{0}/settings/editNodeTypeNew.aspx?id={1}", SystemDirectories.Umbraco, clone.Id);
+				var returnUrl = string.Format("{0}/settings/editNodeTypeNew.aspx?id={1}", SystemDirectories.Umbraco, clone.Id);
 
-            pane_settings.Visible = false;
-            panel_buttons.Visible = false;
+				pane_settings.Visible = false;
+				panel_buttons.Visible = false;
 
-            feedback.Text = "Document type copied";
-            feedback.type = uicontrols.Feedback.feedbacktype.success;
+				feedback.Text = "Document type copied";
+				feedback.type = uicontrols.Feedback.feedbacktype.success;
 
-            ClientTools.ChangeContentFrameUrl(returnUrl);
-        }
+				ClientTools.ChangeContentFrameUrl(returnUrl);
+			}
+		}
 
-        public void HandleMoveOrCopy(object sender, EventArgs e)
-        {
-            if (CurrentApp == Constants.Applications.Settings)
-                HandleDocumentTypeCopy();
-            else
-                HandleDocumentMoveOrCopy();
-        }
+		public void HandleMoveOrCopy(object sender, EventArgs e)
+		{
+			if (CurrentApp == Constants.Applications.Settings)
+				HandleDocumentTypeCopy();
+			else
+				HandleDocumentMoveOrCopy();
+		}
 
-        protected override void OnPreRender(EventArgs e)
-        {
-            base.OnPreRender(e);
-            ScriptManager.GetCurrent(Page).Services.Add(new ServiceReference("../webservices/cmsnode.asmx"));
-            ScriptManager.GetCurrent(Page).Services.Add(new ServiceReference("../webservices/legacyAjaxCalls.asmx"));
-        }
+		protected override void OnPreRender(EventArgs e)
+		{
+			base.OnPreRender(e);
+			ScriptManager.GetCurrent(Page).Services.Add(new ServiceReference("../webservices/cmsnode.asmx"));
+			ScriptManager.GetCurrent(Page).Services.Add(new ServiceReference("../webservices/legacyAjaxCalls.asmx"));
+		}
 
-        private void HandleDocumentMoveOrCopy()
-        {
-            if (Request.GetItemAsString("copyTo") != "" && Request.GetItemAsString("id") != "")
-            {
-                // Check if the current node is allowed at new position
-                var nodeAllowed = false;
+		protected void validationDoctypeName(object sender, ServerValidateEventArgs e)
+		{
+			if (DocumentType.GetByAlias(rename.Text) != null)
+			{
+				e.IsValid = false;
+			}
+			else
+			{
+				if (DocumentType.GetByAlias(rename.Text.ToSafeAlias()) != null)
+					e.IsValid = false;
+			}
+		}
 
-                IContentBase currContent;
-                IContentBase parentContent = null;
-                IContentTypeBase parentContentType = null;
-                if (CurrentApp == "content")
-                {
-                    currContent = Services.ContentService.GetById(Request.GetItemAs<int>("id"));
-                    if (Request.GetItemAs<int>("copyTo") != -1)
-                    {
-                        parentContent = Services.ContentService.GetById(Request.GetItemAs<int>("copyTo"));
-                        if (parentContent != null)
-                        {
-                            parentContentType = Services.ContentTypeService.GetContentType(parentContent.ContentTypeId);
-                        }   
-                    }    
-                }
-                else
-                {
-                    currContent = Services.MediaService.GetById(Request.GetItemAs<int>("id"));
-                    if (Request.GetItemAs<int>("copyTo") != -1)
-                    {
-                        parentContent = Services.MediaService.GetById(Request.GetItemAs<int>("copyTo"));
-                        if (parentContent != null)
-                        {
-                            parentContentType = Services.ContentTypeService.GetMediaType(parentContent.ContentTypeId);
-                        }
-                    }                    
-                }
+		protected void validationDoctypeAlias(object sender, ServerValidateEventArgs e)
+		{
+			if (string.IsNullOrEmpty(rename.Text.ToSafeAlias()))
+				e.IsValid = false;
+		}
 
-                // Check on contenttypes
-                if (parentContentType == null)
-                {
-                    //check if this is allowed at root
-                    IContentTypeBase currContentType;
-                    if (CurrentApp == "content")
-                    {
-                        currContentType = Services.ContentTypeService.GetContentType(currContent.ContentTypeId);
-                    }
-                    else
-                    {
-                        currContentType = Services.ContentTypeService.GetMediaType(currContent.ContentTypeId);
-                    }
-                    nodeAllowed = currContentType.AllowedAsRoot;
-                    if (!nodeAllowed)
-                    {
-                        feedback.Text = ui.Text("moveOrCopy", "notAllowedAtRoot", UmbracoUser);
-                        feedback.type = uicontrols.Feedback.feedbacktype.error;
-                    }
-                }
-                else
-                {
-                    var allowedChildContentTypeIds = parentContentType.AllowedContentTypes.Select(x => x.Id).ToArray();
-                    if (allowedChildContentTypeIds.Any(x => x.Value == currContent.ContentTypeId))
-                    {
-                        nodeAllowed = true;
-                    }
 
-                    if (nodeAllowed == false)
-                    {
-                        feedback.Text = ui.Text("moveOrCopy", "notAllowedByContentType", UmbracoUser);
-                        feedback.type = uicontrols.Feedback.feedbacktype.error;
-                    }
-                    else
-                    {
-                        // Check on paths
-                        if ((string.Format(",{0},", parentContent.Path)).IndexOf(string.Format(",{0},", currContent.Id)) > -1)
-                        {
-                            nodeAllowed = false;
-                            feedback.Text = ui.Text("moveOrCopy", "notAllowedByPath", UmbracoUser);
-                            feedback.type = uicontrols.Feedback.feedbacktype.error;
-                        }
-                    }
-                }
+		private void HandleDocumentMoveOrCopy()
+		{
+			if (Request.GetItemAsString("copyTo") != "" && Request.GetItemAsString("id") != "")
+			{
+				// Check if the current node is allowed at new position
+				var nodeAllowed = false;
 
-                if (nodeAllowed)
-                {
-                    pane_form.Visible = false;
-                    pane_form_notice.Visible = false;
-                    panel_buttons.Visible = false;
+				IContentBase currContent;
+				IContentBase parentContent = null;
+				IContentTypeBase parentContentType = null;
+				if (CurrentApp == "content")
+				{
+					currContent = Services.ContentService.GetById(Request.GetItemAs<int>("id"));
+					if (Request.GetItemAs<int>("copyTo") != -1)
+					{
+						parentContent = Services.ContentService.GetById(Request.GetItemAs<int>("copyTo"));
+						if (parentContent != null)
+						{
+							parentContentType = Services.ContentTypeService.GetContentType(parentContent.ContentTypeId);
+						}
+					}
+				}
+				else
+				{
+					currContent = Services.MediaService.GetById(Request.GetItemAs<int>("id"));
+					if (Request.GetItemAs<int>("copyTo") != -1)
+					{
+						parentContent = Services.MediaService.GetById(Request.GetItemAs<int>("copyTo"));
+						if (parentContent != null)
+						{
+							parentContentType = Services.ContentTypeService.GetMediaType(parentContent.ContentTypeId);
+						}
+					}
+				}
 
-                    var newNodeCaption = parentContent == null 
-                        ? ui.Text(CurrentApp) 
-                        : parentContent.Name;
+				// Check on contenttypes
+				if (parentContentType == null)
+				{
+					//check if this is allowed at root
+					IContentTypeBase currContentType;
+					if (CurrentApp == "content")
+					{
+						currContentType = Services.ContentTypeService.GetContentType(currContent.ContentTypeId);
+					}
+					else
+					{
+						currContentType = Services.ContentTypeService.GetMediaType(currContent.ContentTypeId);
+					}
+					nodeAllowed = currContentType.AllowedAsRoot;
+					if (!nodeAllowed)
+					{
+						feedback.Text = ui.Text("moveOrCopy", "notAllowedAtRoot", UmbracoUser);
+						feedback.type = uicontrols.Feedback.feedbacktype.error;
+					}
+				}
+				else
+				{
+					var allowedChildContentTypeIds = parentContentType.AllowedContentTypes.Select(x => x.Id).ToArray();
+					if (allowedChildContentTypeIds.Any(x => x.Value == currContent.ContentTypeId))
+					{
+						nodeAllowed = true;
+					}
 
-                    string[] nodes = { currContent.Name, newNodeCaption };
+					if (nodeAllowed == false)
+					{
+						feedback.Text = ui.Text("moveOrCopy", "notAllowedByContentType", UmbracoUser);
+						feedback.type = uicontrols.Feedback.feedbacktype.error;
+					}
+					else
+					{
+						// Check on paths
+						if ((string.Format(",{0},", parentContent.Path)).IndexOf(string.Format(",{0},", currContent.Id)) > -1)
+						{
+							nodeAllowed = false;
+							feedback.Text = ui.Text("moveOrCopy", "notAllowedByPath", UmbracoUser);
+							feedback.type = uicontrols.Feedback.feedbacktype.error;
+						}
+					}
+				}
 
-                    if (Request["mode"] == "cut")
-                    {
-                        if (CurrentApp == Constants.Applications.Content)
-                        {
-                            //Backwards comp. change, so old events are fired #U4-2731
-                            var doc = new Document(currContent as IContent);
-                            doc.Move(Request.GetItemAs<int>("copyTo"));
-                        }
-                        else
-                        {
-                            //Backwards comp. change, so old events are fired #U4-2731
-                            var media = new umbraco.cms.businesslogic.media.Media(currContent as IMedia);
-                            media.Move(Request.GetItemAs<int>("copyTo"));
-                            library.ClearLibraryCacheForMedia(currContent.Id);
-                        }
+				if (nodeAllowed)
+				{
+					pane_form.Visible = false;
+					pane_form_notice.Visible = false;
+					panel_buttons.Visible = false;
 
-                        feedback.Text = ui.Text("moveOrCopy", "moveDone", nodes, UmbracoUser) + "</p><p><a href='#' onclick='" + ClientTools.Scripts.CloseModalWindow() + "'>" + ui.Text("closeThisWindow") + "</a>";
-                        feedback.type = uicontrols.Feedback.feedbacktype.success;
+					var newNodeCaption = parentContent == null
+						? ui.Text(CurrentApp)
+						: parentContent.Name;
 
-                        // refresh tree
-                        ClientTools.MoveNode(currContent.Id.ToString(), currContent.Path);
-                    }
-                    else
-                    {
-                        //NOTE: We ONLY support Copy on content not media for some reason.
+					string[] nodes = { currContent.Name, newNodeCaption };
 
-                        //Backwards comp. change, so old events are fired #U4-2731
-                        var newContent = new Document(currContent as IContent);
-                        newContent.Copy(Request.GetItemAs<int>("copyTo"), getUser(), RelateDocuments.Checked);
-                        
-                        feedback.Text = ui.Text("moveOrCopy", "copyDone", nodes, getUser()) + "</p><p><a href='#' onclick='" + ClientTools.Scripts.CloseModalWindow() + "'>" + ui.Text("closeThisWindow") + "</a>";
-                        feedback.type = uicontrols.Feedback.feedbacktype.success;
+					if (Request["mode"] == "cut")
+					{
+						if (CurrentApp == Constants.Applications.Content)
+						{
+							//Backwards comp. change, so old events are fired #U4-2731
+							var doc = new Document(currContent as IContent);
+							doc.Move(Request.GetItemAs<int>("copyTo"));
+						}
+						else
+						{
+							//Backwards comp. change, so old events are fired #U4-2731
+							var media = new umbraco.cms.businesslogic.media.Media(currContent as IMedia);
+							media.Move(Request.GetItemAs<int>("copyTo"));
+							library.ClearLibraryCacheForMedia(currContent.Id);
+						}
 
-                        // refresh tree
-                        ClientTools.CopyNode(currContent.Id.ToString(), newContent.Path);
-                    }
-                }
-            }
-        }
+						feedback.Text = ui.Text("moveOrCopy", "moveDone", nodes, UmbracoUser) + "</p><p><a href='#' onclick='" + ClientTools.Scripts.CloseModalWindow() + "'>" + ui.Text("closeThisWindow") + "</a>";
+						feedback.type = uicontrols.Feedback.feedbacktype.success;
 
-        /// <summary>
-        /// JsInclude1 control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::ClientDependency.Core.Controls.JsInclude JsInclude1;
+						// refresh tree
+						ClientTools.MoveNode(currContent.Id.ToString(), currContent.Path);
+					}
+					else
+					{
+						//NOTE: We ONLY support Copy on content not media for some reason.
 
-        /// <summary>
-        /// feedback control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::umbraco.uicontrols.Feedback feedback;
+						//Backwards comp. change, so old events are fired #U4-2731
+						var newContent = new Document(currContent as IContent);
+						newContent.Copy(Request.GetItemAs<int>("copyTo"), getUser(), RelateDocuments.Checked);
 
-        /// <summary>
-        /// pane_form control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::umbraco.uicontrols.Pane pane_form;
+						feedback.Text = ui.Text("moveOrCopy", "copyDone", nodes, getUser()) + "</p><p><a href='#' onclick='" + ClientTools.Scripts.CloseModalWindow() + "'>" + ui.Text("closeThisWindow") + "</a>";
+						feedback.type = uicontrols.Feedback.feedbacktype.success;
 
-        /// <summary>
-        /// JTree control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::umbraco.controls.Tree.TreeControl JTree;
+						// refresh tree
+						ClientTools.CopyNode(currContent.Id.ToString(), newContent.Path);
+					}
+				}
+			}
+		}
 
-        /// <summary>
-        /// pp_relate control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::umbraco.uicontrols.PropertyPanel pp_relate;
+		/// <summary>
+		/// JsInclude1 control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::ClientDependency.Core.Controls.JsInclude JsInclude1;
 
-        /// <summary>
-        /// RelateDocuments control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.CheckBox RelateDocuments;
+		/// <summary>
+		/// feedback control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::umbraco.uicontrols.Feedback feedback;
 
-        /// <summary>
-        /// pane_form_notice control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.PlaceHolder pane_form_notice;
+		/// <summary>
+		/// pane_form control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::umbraco.uicontrols.Pane pane_form;
 
-        /// <summary>
-        /// pane_settings control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::umbraco.uicontrols.Pane pane_settings;
+		/// <summary>
+		/// JTree control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::umbraco.controls.Tree.TreeControl JTree;
 
-        /// <summary>
-        /// PropertyPanel1 control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::umbraco.uicontrols.PropertyPanel PropertyPanel1;
+		/// <summary>
+		/// pp_relate control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::umbraco.uicontrols.PropertyPanel pp_relate;
 
-        /// <summary>
-        /// masterType control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.ListBox masterType;
+		/// <summary>
+		/// RelateDocuments control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::System.Web.UI.WebControls.CheckBox RelateDocuments;
 
-        /// <summary>
-        /// rename control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.TextBox rename;
+		/// <summary>
+		/// pane_form_notice control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::System.Web.UI.WebControls.PlaceHolder pane_form_notice;
 
-        /// <summary>
-        /// RequiredFieldValidator1 control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.RequiredFieldValidator RequiredFieldValidator1;
+		/// <summary>
+		/// pane_settings control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::umbraco.uicontrols.Pane pane_settings;
 
-        /// <summary>
-        /// panel_buttons control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.Panel panel_buttons;
+		/// <summary>
+		/// PropertyPanel1 control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::umbraco.uicontrols.PropertyPanel PropertyPanel1;
 
-        /// <summary>
-        /// ok control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.Button ok;
+		/// <summary>
+		/// masterType control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::System.Web.UI.WebControls.ListBox masterType;
 
-    }
+		/// <summary>
+		/// rename control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::System.Web.UI.WebControls.TextBox rename;
+
+		/// <summary>
+		/// RequiredFieldValidator1 control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::System.Web.UI.WebControls.RequiredFieldValidator RequiredFieldValidator1;
+
+		/// <summary>
+		/// panel_buttons control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::System.Web.UI.WebControls.Panel panel_buttons;
+
+		/// <summary>
+		/// ok control.
+		/// </summary>
+		/// <remarks>
+		/// Auto-generated field.
+		/// To modify move field declaration from designer file to code-behind file.
+		/// </remarks>
+		protected global::System.Web.UI.WebControls.Button ok;
+
+	}
 }


### PR DESCRIPTION
I have fixed this by amending the validation function.
I also spotted the same bug when copying a document type. I fixed this one by adding the validation controls to it's page and adding it's corresponding validation methods. I also wrapped a Page.IsValid to the function that copies the document type.
I also spotted that the copied document type's name is not change so I fixed this too.

PLEASE NOTE that most of the line changes shown are due to visual studio formatting the page. (tabs instead of spaces etc.)