### PR TITLE
Fix for U4-1076 Apostrophes in document type description are shown prece...

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/content.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/content.ascx.cs
@@ -43,7 +43,7 @@ namespace umbraco.cms.presentation.create.controls
                     if (string.IsNullOrEmpty(dt.Description) == false)
                         docDescription = dt.Description;
                     docDescription = "<strong>" + dt.Text + "</strong><br/>" + docDescription.Replace(Environment.NewLine, "<br />");
-                    docDescription = docDescription.Replace("'", "\\'");
+                    docDescription = docDescription.Replace("'", "\'");
 
                     var docImage = (dt.Thumbnail != "") ? dt.Thumbnail : "../nada.gif";
                     docImage = IOHelper.ResolveUrl( SystemDirectories.Umbraco ) + "/images/thumbnails/" + docImage;


### PR DESCRIPTION
...ded/escaped by a slash in the Create Node dialog
