### PR TITLE
SqlHelper Refactoring

### DIFF
--- a/src/Umbraco.Web/UI/Controls/InsertMacroSplitButton.cs
+++ b/src/Umbraco.Web/UI/Controls/InsertMacroSplitButton.cs
@@ -71,7 +71,7 @@ namespace Umbraco.Web.UI.Controls
 			var divMacroItemContainer = new TagBuilder("div");
 			divMacroItemContainer.Attributes.Add("style", "width: 285px;display:none;");
 			divMacroItemContainer.Attributes.Add("class", "sbMenu");
-			var macros = ApplicationContext.DatabaseContext.Database.Query<MacroDto>("select id, macroAlias, macroName from cmsMacro order by macroName");
+			var macros = ApplicationContext.DatabaseContext.Database.Fetch<MacroDto>("select id, macroAlias, macroName from cmsMacro order by macroName");
 			foreach (var macro in macros)
 			{
 				var divMacro = new TagBuilder("div");


### PR DESCRIPTION
Fixed potential DbReaderException
- Use Fetch<T> instead of Query<T> because we create another DbReader inside the loop with DoesMacroHaveParameters().
