### PR TITLE
U4-1029 Audit Trail dialog styles/formatting is broken, text overlaps

### DIFF
--- a/src/Umbraco.Web.UI/umbraco_client/Tree/menuIcons.css
+++ b/src/Umbraco.Web.UI/umbraco_client/Tree/menuIcons.css
@@ -1,12 +1,14 @@
 ﻿.menuSpr
 {
 	float: left;
+    min-width:17px;
+    background-repeat:no-repeat;
+    padding-top:3px;
 	background-image: url(sprites.png);
 	background-position: -7px -8px;	
 	margin-top: 1px;
-	width: 17px;
 	height: 16px;
-	margin: 1px 13px 1px 0px;
+	margin: 1px 1px 1px 0px;
 }
 
 .sprNew

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/viewAuditTrail.aspx
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/viewAuditTrail.aspx
@@ -22,7 +22,7 @@
                 <asp:TemplateColumn>
                   <HeaderTemplate>
                     <b>
-                      <%=umbraco.ui.Text("action")%>&nbsp;&nbsp;
+                      <%=umbraco.ui.Text("action")%>
                     </b>
                   </HeaderTemplate>
                   <ItemTemplate>


### PR DESCRIPTION
Altered the CSS so that the text doesn't overlap.
The same CSS class is responsible for the context menus, which seem fine after the change.