### PR TITLE
Hide loading bar if run into error

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
@@ -1,4 +1,3 @@
-
 /**
  * @ngdoc service
  * @name umbraco.services.treeService
@@ -182,7 +181,7 @@ function treeService($q, treeResource, iconHelper, notificationsService, $rootSc
                     $rootScope.$broadcast("treeNodeLoadError", {error: reason });
 
                     //stop show the loading indicator  
-                    node.loading = false;
+                    args.node.loading = false;
 
                     //tell notications about the error
                     notificationsService.error(reason);


### PR DESCRIPTION
Loading bar weren't hidden if this.getChildren can't fetch childrens.
