### PR TITLE
Fix for  U4-3529  Ysod editing Partial View

### DIFF
--- a/src/Umbraco.Web/UI/Controls/InsertMacroSplitButton.cs
+++ b/src/Umbraco.Web/UI/Controls/InsertMacroSplitButton.cs
@@ -137,7 +137,7 @@ namespace Umbraco.Web.UI.Controls
 
 		private bool DoesMacroHaveParameters(int macroId)
 		{
-			return ApplicationContext.DatabaseContext.Database.ExecuteScalar<int>(string.Format("select 1 from cmsMacroProperty where macro = {0}", macroId)) == 1;
+            return ApplicationContext.DatabaseContext.Database.ExecuteScalar<int>(string.Format("SELECT COUNT(*) from cmsMacroProperty where macro = {0}", macroId)) > 0;
 		}
 	}
 }


### PR DESCRIPTION
Fix for http://issues.umbraco.org/issue/U4-3529 Select 1 will return null which can't be converted to a type in PetaPoco. Select Count(*) will always return a result so when count is greater than 0 we have parameters
