### PR TITLE
Cache not refreshed when importing hierarchial dictionary items using old Dictionary.Import

### DIFF
--- a/src/umbraco.cms/businesslogic/Dictionary.cs
+++ b/src/umbraco.cms/businesslogic/Dictionary.cs
@@ -481,6 +481,8 @@ namespace umbraco.cms.businesslogic
                             
                             item.setValue(defaultValue);
 
+                            DictionaryItems.TryAdd(dr.GetString("key"), item);
+
                             item.OnNew(EventArgs.Empty);
 
                             return item.id;


### PR DESCRIPTION
USync still uses this and crashes when trying to import a child.
Is fixedand more when https://github.com/umbraco/Umbraco-CMS/pull/127 is pulled, but need this for now and until USync is changed to use PackagingService.Import.
Ain't bothering with tests, I've sweared and debugged all day, and this fixes it. :)

Sorry about commit comment, very delayed and frustrated atm.