### PR TITLE
Added code to clear the Partial View cache on file changes.

### DIFF
--- a/src/Umbraco.Web/CacheHelperExtensions.cs
+++ b/src/Umbraco.Web/CacheHelperExtensions.cs
@@ -28,7 +28,8 @@ namespace Umbraco.Web
 		{
             protected override void ApplicationInitialized(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
 			{
-                if (applicationContext != null)
+                // Only run in 
+                if (applicationContext != null && SystemUtilities.GetCurrentTrustLevel() == AspNetHostingPermissionLevel.Unrestricted)
 				{
 					//bind to events to clear the cache, after publish, after media save and after member save
 


### PR DESCRIPTION
This is a very simple fix to clear out the cache for Partial Views when their source files are edited.
Currently they clear properly when content is changed, but not when the source code itself is changed. 
(This is only relevant when using @Html.CachedPartial calls.)