### PR TITLE
Returning root element instead of document node from JsonToXml()

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/library.cs
+++ b/src/Umbraco.Web/umbraco.presentation/library.cs
@@ -256,7 +256,7 @@ namespace umbraco
             catch (Exception ex)
             {
                 var xd = new XmlDocument();
-                xd.LoadXml(string.Format("<error>Could not convert json to xml. Error: {0}</error>", ex));
+                xd.LoadXml(string.Format("<error>Could not convert JSON to XML. Error: {0}</error>", ex));
                 return xd.CreateNavigator().Select("/error");
             }
         }


### PR DESCRIPTION
As discussed in the issue [U4-3581](http://issues.umbraco.org/issue/U4-3581) it's better to return the actual element instead of the document node.

I am not able to run the tests, but as far as I can see, they should pass because of the way the C# objects handle this - otherwise we'll have to get someone like @leekelleher to have a quick look at them :-)
