### PR TITLE
Fixes: U4-3736 Unit test Can_Get_File_Dates() now testing correctly.

### DIFF
--- a/src/Umbraco.Tests/IO/AbstractFileSystemTests.cs
+++ b/src/Umbraco.Tests/IO/AbstractFileSystemTests.cs
@@ -122,11 +122,11 @@ namespace Umbraco.Tests.IO
 
             Assert.AreEqual(DateTime.Today.Year, created.Year);
             Assert.AreEqual(DateTime.Today.Month, created.Month);
-            Assert.AreEqual(DateTime.Today.Date, created.Date);
+            Assert.AreEqual(DateTime.UtcNow.Date, created.Date);
 
             Assert.AreEqual(DateTime.Today.Year, modified.Year);
             Assert.AreEqual(DateTime.Today.Month, modified.Month);
-            Assert.AreEqual(DateTime.Today.Date, modified.Date);
+            Assert.AreEqual(DateTime.UtcNow.Date, modified.Date);
 
             _fileSystem.DeleteFile("test.txt");
         }


### PR DESCRIPTION
Hi Umbraco-Core

I've submitted a minor bug (#U4-3736) in one of the unit tests in Umbraco-cms, to issues.umbraco.org  :

"Can_Get_File_Dates() fails when run on non-UTC machine, due to mismatch between .NET's generic DateTime.Today function - returning local time - and Umbraco's PhysicalFileSystem.GetCreated(string path) which returns UTC time.

So on a UTC+4 locale, the test will fail for 4 hours after midnight, every day.

Fix: If PhysicalFileSystem.GetCreated(string path) is intended to return time in UTC format the unit test needs to be changed."

I've also corrected the issue, by correcting the test. This of course assumes that the intention of GetCreated to return the date as UTC.

I'd like to contribute further to Umbraco by doing bug fixes. Do I need anything special(account, etc.) for that?

Best Regards,
Anders
