### PR TITLE
fix /{localLink:ID}

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
+++ b/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
@@ -209,7 +209,7 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
 
     				//if we have an id, it must be a locallink:id
     				if(data.id){
-    					href = "{localLink:" + data.id + "}";
+    					href = "/{localLink:" + data.id + "}";
     					insertLink();
     					return;
     				}


### PR DESCRIPTION
Small fix to ensures it set the href to /{localLink:ID} instead of /umbraco/{localLink:ID}
