### PR TITLE
Update PublishedContentExtensions.cs

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -990,6 +990,16 @@ namespace Umbraco.Web
 		{
 			return content.Next(0);
 		}
+
+		public static IPublishedContent Next(this IPublishedContent current, Func<IPublishedContent, bool> func) {
+			IPublishedContent next = current.Next();
+			while (next != null) {
+				if (func(next)) return next;
+				next = next.Next();
+			}
+			return null;
+		}
+
 		public static IPublishedContent Next(this IPublishedContent content, int number)
 		{
             var ownersList = content.GetOwnersList();
@@ -1022,6 +1032,16 @@ namespace Umbraco.Web
 		{
 			return content.Previous(0);
 		}
+
+		public static IPublishedContent Previous(this IPublishedContent current, Func<IPublishedContent, bool> func) {
+			IPublishedContent prev = current.Previous();
+			while (prev != null) {
+				if (func(prev)) return prev;
+				prev = prev.Previous();
+			}
+			return null;
+		}
+
 		public static IPublishedContent Previous(this IPublishedContent content, int number)
 		{
             var ownersList = content.GetOwnersList();


### PR DESCRIPTION
Added overloaded extension methods for Next() and Previous() to take a delegate (eg. lambda expression) as a second parameter. The methods are based on this thread by Jeavon Leopold: http://our.umbraco.org/forum/developers/razor/46832-Filtered-Next()-and-Previous()-v7-UmbracoHelperMVC

The code is tested in 7.0.0, but since it only relies on the existing Next() and Previous() methods, it should work in 6.1.x and 7.0.1 as well.
