### PR TITLE
Fix error U4-3876

### DIFF
--- a/src/Umbraco.Web/Strategies/Migrations/ClearMediaXmlCacheForDeletedItemsAfterUpgrade.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/ClearMediaXmlCacheForDeletedItemsAfterUpgrade.cs
@@ -29,12 +29,11 @@ namespace Umbraco.Web.Strategies.Migrations
 
             if (e.ConfiguredVersion <= target70)
             {
-                
 
-                var sql = @"DELETE FROM cmsContentXml WHERE nodeId IN
-    (SELECT DISTINCT cmsContentXml.nodeId FROM cmsContentXml 
-        INNER JOIN umbracoNode ON cmsContentXml.nodeId = umbracoNode.id
-        WHERE nodeObjectType = 'B796F64C-1F99-4FFB-B886-4BF4BC011A9C' AND " + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("path") + " like '%-21%')";
+
+                var sql = @"DELETE cmsContentXml.* FROM cmsContentXml
+INNER JOIN umbracoNode ON cmsContentXml.nodeId = umbracoNode.id
+        WHERE nodeObjectType = 'B796F64C-1F99-4FFB-B886-4BF4BC011A9C' AND " + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("path") + " like '%-21%'";
 
                 var count = e.MigrationContext.Database.Execute(sql);
 


### PR DESCRIPTION
MySQL has limitations on using subselects to determine records to delete.  This was causing problems when clearing the XML cache.  This fix restructures the query to fix U4-3876.

This fix has been tested on MySQL.  I don't have a MSSQL instance to test it, but I don't think it should break things there.
