### PR TITLE
Sperate image alt tag and title

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -144,7 +144,6 @@
     <key alias="sortDone">Sortorder is updated</key>
     <key alias="sortHelp">To sort the nodes, simply drag the nodes or click one of the column headers. You can select multiple nodes by holding the "shift" or "control" key while selecting</key>
     <key alias="statistics">Statistics</key>
-    <key alias="altText">Alt Text</key>
     <key alias="titleOptional">Title (optional)</key>
     <key alias="type">Type</key>
     <key alias="unPublish">Unpublish</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -144,6 +144,7 @@
     <key alias="sortDone">Sortorder is updated</key>
     <key alias="sortHelp">To sort the nodes, simply drag the nodes or click one of the column headers. You can select multiple nodes by holding the "shift" or "control" key while selecting</key>
     <key alias="statistics">Statistics</key>
+    <key alias="altText">Alt Text</key>
     <key alias="titleOptional">Title (optional)</key>
     <key alias="type">Type</key>
     <key alias="unPublish">Unpublish</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -128,6 +128,7 @@
     <key alias="sortDone">Sortorder is updated</key>
     <key alias="sortHelp">To sort the nodes, simply drag the nodes or click one of the column headers. You can select multiple nodes by holding the "shift" or "control" key while selecting</key>
     <key alias="statistics">Statistics</key>
+    <key alias="altText">Alt Text</key>
     <key alias="titleOptional">Title (optional)</key>
     <key alias="type">Type</key>
     <key alias="unPublish">Unpublish</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -128,7 +128,6 @@
     <key alias="sortDone">Sortorder is updated</key>
     <key alias="sortHelp">To sort the nodes, simply drag the nodes or click one of the column headers. You can select multiple nodes by holding the "shift" or "control" key while selecting</key>
     <key alias="statistics">Statistics</key>
-    <key alias="altText">Alt Text</key>
     <key alias="titleOptional">Title (optional)</key>
     <key alias="type">Type</key>
     <key alias="unPublish">Unpublish</key>

--- a/src/Umbraco.Web.UI/umbraco/controls/Images/ImageViewer.js
+++ b/src/Umbraco.Web.UI/umbraco/controls/Images/ImageViewer.js
@@ -77,7 +77,8 @@ Umbraco.Sys.registerNamespace("Umbraco.Controls");
                                 width: msg.d.width,
                                 height: msg.d.height,
                                 url: msg.d.url,
-                                alt: msg.d.alt
+                                alt: msg.d.alt,
+                                title: msg.d.title
                             };
                             //call the callback method
                             callback.call(_this, params);

--- a/src/Umbraco.Web.UI/umbraco/controls/Images/ImageViewer.js
+++ b/src/Umbraco.Web.UI/umbraco/controls/Images/ImageViewer.js
@@ -77,8 +77,7 @@ Umbraco.Sys.registerNamespace("Umbraco.Controls");
                                 width: msg.d.width,
                                 height: msg.d.height,
                                 url: msg.d.url,
-                                alt: msg.d.alt,
-                                title: msg.d.title
+                                alt: msg.d.alt
                             };
                             //call the callback method
                             callback.call(_this, params);

--- a/src/Umbraco.Web.UI/umbraco/plugins/tinymce3/insertImage.aspx
+++ b/src/Umbraco.Web.UI/umbraco/plugins/tinymce3/insertImage.aspx
@@ -69,7 +69,6 @@
             formObj.src.value = src;
 
             formObj.alt.value = alt;
-            formObj.title.value = "";
 
             var imageWidth = width;
             var imageHeight = height;
@@ -159,11 +158,8 @@
       <ui:PropertyPanel id="pp_src" runat="server" Text="Url">
           <input type="text" id="src" style="width: 300px"/>
       </ui:PropertyPanel>
-      <ui:PropertyPanel id="pp_alt" runat="server" Text="Alt Text">
-           <input type="text" id="alt" style="width: 300px"/>
-      </ui:PropertyPanel>
       <ui:PropertyPanel id="pp_title" runat="server" Text="Title">
-           <input type="text" id="title" style="width: 300px"/>
+           <input type="text" id="alt" style="width: 300px"/>
       </ui:PropertyPanel>
       <ui:PropertyPanel id="pp_dimensions" runat="server" Text="Dimensions">
             <asp:Literal ID="lt_widthLabel" runat="server" />:  <input name="width" type="text" id="width" value="" size="5" maxlength="5" class="size" onchange="changeDimensions('width');" />

--- a/src/Umbraco.Web.UI/umbraco/plugins/tinymce3/insertImage.aspx
+++ b/src/Umbraco.Web.UI/umbraco/plugins/tinymce3/insertImage.aspx
@@ -69,6 +69,7 @@
             formObj.src.value = src;
 
             formObj.alt.value = alt;
+            formObj.title.value = "";
 
             var imageWidth = width;
             var imageHeight = height;
@@ -158,8 +159,11 @@
       <ui:PropertyPanel id="pp_src" runat="server" Text="Url">
           <input type="text" id="src" style="width: 300px"/>
       </ui:PropertyPanel>
-      <ui:PropertyPanel id="pp_title" runat="server" Text="Title">
+      <ui:PropertyPanel id="pp_alt" runat="server" Text="Alt Text">
            <input type="text" id="alt" style="width: 300px"/>
+      </ui:PropertyPanel>
+      <ui:PropertyPanel id="pp_title" runat="server" Text="Title">
+           <input type="text" id="title" style="width: 300px"/>
       </ui:PropertyPanel>
       <ui:PropertyPanel id="pp_dimensions" runat="server" Text="Dimensions">
             <asp:Literal ID="lt_widthLabel" runat="server" />:  <input name="width" type="text" id="width" value="" size="5" maxlength="5" class="size" onchange="changeDimensions('width');" />

--- a/src/Umbraco.Web.UI/umbraco_client/tinymce3/plugins/umbracoimg/js/image.js
+++ b/src/Umbraco.Web.UI/umbraco_client/tinymce3/plugins/umbracoimg/js/image.js
@@ -18,6 +18,7 @@
             nl.width.value = dom.getAttrib(n, 'width');
             nl.height.value = dom.getAttrib(n, 'height');
             nl.alt.value = dom.getAttrib(n, 'alt');
+            nl.title.value = dom.getAttrib(n, 'title');
             nl.orgHeight.value = dom.getAttrib(n, 'rel').split(",")[1];
             nl.orgWidth.value = dom.getAttrib(n, 'rel').split(",")[0];
             
@@ -89,7 +90,7 @@
             width: nl.width.value,
             height: nl.height.value,
             alt: nl.alt.value,
-            title: nl.alt.value,
+            title: nl.title.value,
             rel: nl.orgWidth.value + ',' + nl.orgHeight.value
         });
 

--- a/src/Umbraco.Web.UI/umbraco_client/tinymce3/plugins/umbracoimg/js/image.js
+++ b/src/Umbraco.Web.UI/umbraco_client/tinymce3/plugins/umbracoimg/js/image.js
@@ -18,7 +18,6 @@
             nl.width.value = dom.getAttrib(n, 'width');
             nl.height.value = dom.getAttrib(n, 'height');
             nl.alt.value = dom.getAttrib(n, 'alt');
-            nl.title.value = dom.getAttrib(n, 'title');
             nl.orgHeight.value = dom.getAttrib(n, 'rel').split(",")[1];
             nl.orgWidth.value = dom.getAttrib(n, 'rel').split(",")[0];
             
@@ -90,7 +89,7 @@
             width: nl.width.value,
             height: nl.height.value,
             alt: nl.alt.value,
-            title: nl.title.value,
+            title: nl.alt.value,
             rel: nl.orgWidth.value + ',' + nl.orgHeight.value
         });
 

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx
@@ -69,7 +69,6 @@
             formObj.src.value = src;
 
             formObj.alt.value = alt;
-            formObj.title.value = "";
 
             var imageWidth = width;
             var imageHeight = height;
@@ -159,11 +158,8 @@
       <ui:PropertyPanel id="pp_src" runat="server" Text="Url">
           <input type="text" id="src" style="width: 300px"/>
       </ui:PropertyPanel>
-      <ui:PropertyPanel id="pp_alt" runat="server" Text="Alt Text">
-           <input type="text" id="alt" style="width: 300px"/>
-      </ui:PropertyPanel>
       <ui:PropertyPanel id="pp_title" runat="server" Text="Title">
-           <input type="text" id="title" style="width: 300px"/>
+           <input type="text" id="alt" style="width: 300px"/>
       </ui:PropertyPanel>
       <ui:PropertyPanel id="pp_dimensions" runat="server" Text="Dimensions">
             <asp:Literal ID="lt_widthLabel" runat="server" />:  <input name="width" type="text" id="width" value="" size="5" maxlength="5" class="size" onchange="changeDimensions('width');" />

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx
@@ -69,6 +69,7 @@
             formObj.src.value = src;
 
             formObj.alt.value = alt;
+            formObj.title.value = "";
 
             var imageWidth = width;
             var imageHeight = height;
@@ -158,8 +159,11 @@
       <ui:PropertyPanel id="pp_src" runat="server" Text="Url">
           <input type="text" id="src" style="width: 300px"/>
       </ui:PropertyPanel>
-      <ui:PropertyPanel id="pp_title" runat="server" Text="Title">
+      <ui:PropertyPanel id="pp_alt" runat="server" Text="Alt Text">
            <input type="text" id="alt" style="width: 300px"/>
+      </ui:PropertyPanel>
+      <ui:PropertyPanel id="pp_title" runat="server" Text="Title">
+           <input type="text" id="title" style="width: 300px"/>
       </ui:PropertyPanel>
       <ui:PropertyPanel id="pp_dimensions" runat="server" Text="Dimensions">
             <asp:Literal ID="lt_widthLabel" runat="server" />:  <input name="width" type="text" id="width" value="" size="5" maxlength="5" class="size" onchange="changeDimensions('width');" />

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx.cs
@@ -18,8 +18,7 @@ namespace umbraco.presentation.plugins.tinymce3
 			ClientLoader.DataBind();
 
             pp_src.Text = ui.Text("url");
-            pp_title.Text = ui.Text("titleOptional");
-            pp_alt.Text = ui.Text("altText");
+            pp_title.Text = ui.Text("name");
             pp_dimensions.Text = ui.Text("dimensions");
 
             pane_src.Style.Add("height", "105px");

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx.cs
@@ -18,7 +18,8 @@ namespace umbraco.presentation.plugins.tinymce3
 			ClientLoader.DataBind();
 
             pp_src.Text = ui.Text("url");
-            pp_title.Text = ui.Text("name");
+            pp_title.Text = ui.Text("titleOptional");
+            pp_alt.Text = ui.Text("altText");
             pp_dimensions.Text = ui.Text("dimensions");
 
             pane_src.Style.Add("height", "105px");

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx.designer.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx.designer.cs
@@ -118,7 +118,7 @@ namespace umbraco.presentation.plugins.tinymce3 {
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.ScriptManager ScriptManager1;
+        protected global::System.Web.UI.WebControls.ScriptManager ScriptManager1;
         
         /// <summary>
         /// pane_src control.
@@ -136,7 +136,7 @@ namespace umbraco.presentation.plugins.tinymce3 {
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::umbraco.controls.Images.ImageViewer ImageViewer;
+        protected global::System.Web.UI.UserControl ImageViewer;
         
         /// <summary>
         /// pp_src control.
@@ -146,6 +146,15 @@ namespace umbraco.presentation.plugins.tinymce3 {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::umbraco.uicontrols.PropertyPanel pp_src;
+        
+        /// <summary>
+        /// pp_alt control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::umbraco.uicontrols.PropertyPanel pp_alt;
         
         /// <summary>
         /// pp_title control.

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx.designer.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertImage.aspx.designer.cs
@@ -118,7 +118,7 @@ namespace umbraco.presentation.plugins.tinymce3 {
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.WebControls.ScriptManager ScriptManager1;
+        protected global::System.Web.UI.ScriptManager ScriptManager1;
         
         /// <summary>
         /// pane_src control.
@@ -136,7 +136,7 @@ namespace umbraco.presentation.plugins.tinymce3 {
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.UserControl ImageViewer;
+        protected global::umbraco.controls.Images.ImageViewer ImageViewer;
         
         /// <summary>
         /// pp_src control.
@@ -146,15 +146,6 @@ namespace umbraco.presentation.plugins.tinymce3 {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::umbraco.uicontrols.PropertyPanel pp_src;
-        
-        /// <summary>
-        /// pp_alt control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::umbraco.uicontrols.PropertyPanel pp_alt;
         
         /// <summary>
         /// pp_title control.


### PR DESCRIPTION
When using the TinyMCE interface to insert/edit images there is only one field for the image name witch sets both the title and meta text.  This is not logical though as there are many cases when users may want different meta text then hover/title text, or more likely not want any title text at all.  

This can technically be fixed by going into the html code of the resulting property and removing/changing the unwanted title attribute but this is efficient.  Also if the popup control is used again to adjust the text of the image the title take will again be updated/recreated.

This patch simply adds a separate text field for the image title that defaults to blank. (The alt still defaults to the  media node name like before.) Thus a user can set the title as desired of leave it blank if they don't want titles.

![screen shot 2013-12-18 at 12 31 19 pm](https://f.cloud.github.com/assets/458367/1775685/64d92c0c-680a-11e3-9e01-4d952c9093ea.png)
 