### PR TITLE
Overflow auto instead of visible

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/dashboard/UserControlProxy.aspx
+++ b/src/Umbraco.Web.UI/Umbraco/dashboard/UserControlProxy.aspx
@@ -20,7 +20,7 @@
     <umb:JsInclude ID="JsInclude2" runat="server" FilePath="ui/default.js" PathNameAlias="UmbracoClient" Priority="5" />
 
 </head>
-<body style="overflow: scroll">
+<body style="overflow: auto">
     <form id="form1" runat="server">
     <div>
             <asp:PlaceHolder ID="container" runat="server" />    


### PR DESCRIPTION
I don't know why it's 'visible' at the moment, because scrollbars will always be visible at the moment, instead of just when it's needed.
