### PR TITLE
Update booting.aspx

### DIFF
--- a/src/Umbraco.Web.UI/config/splashes/booting.aspx
+++ b/src/Umbraco.Web.UI/config/splashes/booting.aspx
@@ -2,7 +2,7 @@
 
 <%
     // NH: Adds this inline check to avoid a simple codebehind file in the legacy project!
-    if (!umbraco.cms.helpers.url.ValidateProxyUrl(Request["url"], Request.Url.AbsoluteUri))
+    if (Request["url"].ToLower().Contains("booting.aspx") || !umbraco.cms.helpers.url.ValidateProxyUrl(Request["url"], Request.Url.AbsoluteUri))
     {
         throw new ArgumentException("Can't redirect to the requested url - it's not local or an approved proxy url",
                                     "url");


### PR DESCRIPTION
Throw the exception immediately if the parameter is not there or empty.

If the parameter is not there it's defaulted to the current url, and this will redirect to itself and create an endless loop here.
