### PR TITLE
Fix for U4-3831.  

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.controller.js
@@ -43,7 +43,7 @@
                 $scope.model.value.splice(idx, 1);               
             };
 
-            $scope.add = function () {
+            $scope.add = function ($event) {
                 if ($scope.newCaption == "") {
                     $scope.hasError = true;
                 } else {
@@ -79,6 +79,7 @@
                     $scope.newInternalName = '';
 
                 }
+                $event.preventDefault();
             };
 
             $scope.switch = function ($event) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.html
@@ -51,7 +51,6 @@
                     </td>
                 </tr>
                 <tr>
-                    <form ng-submit="add()">
                     <td><input type="text" ng-model="newCaption" placeholder="Enter a new caption" val-highlight="hasError"/></td>
                         <td>
                             <div ng-show="addExternal">
@@ -68,10 +67,9 @@
                     <td><input type="checkbox" ng-model="newNewWindow"/> </td>
                         <td>
                         <div class="btn-group">
-                            <input type="submit" class="btn btn-default" value="Add"/>
+                            <button class="btn btn-default" ng-click="add($event)">Add</button>
                         </div>
                     </td>
-                    </form>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
It appears the add button (`<input type="submit" />`) is submitting the entire page, rather than just calling `add()` on the containing form.  This makes it impossible to add items in some browsers.  This commit removes the containing form, changes the submit button to just a `<button />` and adds `ng-click` with `$event.preventDefault()` to prevent submitting the entire page.
