### PR TITLE
Update macroResultWrapper.aspx.cs

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/macroResultWrapper.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/macroResultWrapper.aspx.cs
@@ -28,7 +28,7 @@ namespace umbraco.presentation
             Guid pageVersion = new Guid(helper.Request("umbVersionId"));
 
             System.Web.HttpContext.Current.Items["macrosAdded"] = 0;
-            System.Web.HttpContext.Current.Items["pageID"] = pageID.ToString();
+            System.Web.HttpContext.Current.Items["pageID"] = pageID;
 
             // Collect attributes
             Hashtable attributes = new Hashtable();


### PR DESCRIPTION
In the Node.cs file, Node.GetCurrent() tries to cast this as an int and fails.
