### PR TITLE
Fixed: U4-4119 - Export ContentType fails for Generic Properties

### DIFF
--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -1631,7 +1631,7 @@ namespace Umbraco.Core.Services
             xml.Add(new XElement("Design", new XCData(template.Content)));
 
             var concreteTemplate = template as Template;
-            if (concreteTemplate != null)
+            if (concreteTemplate != null && concreteTemplate.MasterTemplateId != null)
             {
                 if (concreteTemplate.MasterTemplateId.IsValueCreated &&
                     concreteTemplate.MasterTemplateId.Value != default(int))


### PR DESCRIPTION
Adds Null checking for PropertyGroupID so that an exception is avoided when the propertyType is in the Generic Properties group (and has no PropertyGroupID has no value)
