### PR TITLE
U4-4145: DateTime property values not valid when republishing node

### DIFF
--- a/src/Umbraco.Core/ObjectExtensions.cs
+++ b/src/Umbraco.Core/ObjectExtensions.cs
@@ -526,7 +526,7 @@ namespace Umbraco.Core
 			if (type == typeof(bool)) return XmlConvert.ToString((bool)value);
 			if (type == typeof(byte)) return XmlConvert.ToString((byte)value);
 			if (type == typeof(char)) return XmlConvert.ToString((char)value);
-			if (type == typeof(DateTime)) return XmlConvert.ToString((DateTime)value, XmlDateTimeSerializationMode.RoundtripKind);
+			if (type == typeof(DateTime)) return XmlConvert.ToString((DateTime)value, XmlDateTimeSerializationMode.Unspecified);
 			if (type == typeof(DateTimeOffset)) return XmlConvert.ToString((DateTimeOffset)value);
 			if (type == typeof(decimal)) return XmlConvert.ToString((decimal)value);
 			if (type == typeof(double)) return XmlConvert.ToString((double)value);


### PR DESCRIPTION
When republishing a content node (including children), any properties of the type 'Date' will be formatted in the Umbraco XML as UTC date, in the format of '2014-01-26T00:00:00Z'. This value is not properly parsed when using the GetPropertyValue<DateTime>("alias") method.
When publishing a single page, this problem does not exists.

Reason for this is as follows: when publishing a single page, the DateTime is parsed from the posted contents of the HTTP request. This will result in a DateTime of kind 'Unspecified'. When using the XmlConvert.ToString method, this will result in a string of '2014-01-26T00:00:00'.
When republishing an entire node, the DateTime values are retrieved from the database, whereby the DateTime values are of the kind 'UTC'. When using the XmlConvert.ToString method, UTC datetimes are postfixed with an 'Z' resulting in a string representation of '2014-01-26T00:00:00Z'. This value cannot be parsed properly within the GetPropertyValue<DateTime>() method, resulting in a DateTime.Min value as the response.
