### PR TITLE
U4-4071 Added the ability to allow pre tags within a package's readme

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Packages/installedPackage.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Packages/installedPackage.aspx.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Web;
 using System.Web.Security;
 using System.Web.UI;
@@ -46,7 +47,13 @@ namespace umbraco.presentation.developer.packages
                 lt_packagename.Text = _pack.Data.Name;
                 lt_packageVersion.Text = _pack.Data.Version;
                 lt_packageAuthor.Text = _pack.Data.Author;
-                lt_readme.Text = library.ReplaceLineBreaks( _pack.Data.Readme );
+
+                // Strip all tags except for pre tags
+                var strippedReadme = Regex.Replace(_pack.Data.Readme, @"</?(?(?=pre)notag|[a-zA-Z0-9]+)(?:\s[a-zA-Z0-9\-]+=?(?:(["",']?).*?\1?)?)*\s*/?>", string.Empty);
+
+                // Replace line breaks with a break tag except when inside a pre tag
+                var breakTag = bool.Parse(Umbraco.Core.Configuration.GlobalSettings.EditXhtmlMode) ? "<br/>\n" : "<br />\n";
+                lt_readme.Text = Regex.Replace(strippedReadme, "\n(?![^<]*</pre>)", breakTag);
 
                 bt_confirmUninstall.Attributes.Add("onClick", "jQuery('#buttons').hide(); jQuery('#loadingbar').show();; return true;");
 

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Packages/installer.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Packages/installer.aspx.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Web;
 using System.Web.SessionState;
@@ -190,7 +191,16 @@ namespace umbraco.presentation.developer.packages
             LabelLicense.Text = "<a href=\"" + _installer.LicenseUrl + "\" target=\"_blank\">" + _installer.License + "</a>";
 
             if (_installer.ReadMe != "")
-                readme.Text = "<div style=\"border: 1px solid #999; padding: 5px; overflow: auto; width: 370px; height: 160px;\">" + library.ReplaceLineBreaks(library.StripHtml(_installer.ReadMe)) + "</div>";
+            {
+                // Strip all tags except for pre tags
+                var strippedReadme = Regex.Replace(_installer.ReadMe, @"</?(?(?=pre)notag|[a-zA-Z0-9]+)(?:\s[a-zA-Z0-9\-]+=?(?:(["",']?).*?\1?)?)*\s*/?>", string.Empty);
+
+                // Replace line breaks with a break tag except when inside a pre tag
+                var breakTag = bool.Parse(Umbraco.Core.Configuration.GlobalSettings.EditXhtmlMode) ? "<br/>\n" : "<br />\n";
+                strippedReadme = Regex.Replace(strippedReadme, "\n(?![^<]*</pre>)", breakTag);
+
+                readme.Text = "<div style=\"border: 1px solid #999; padding: 5px; overflow: auto; width: 370px; height: 160px;\">" + strippedReadme + "</div>";
+            }
             else
                 readme.Text = "<span style=\"color: #999\">No information</span><br/>";
         }


### PR DESCRIPTION
This could be helpful for package developers to show example code snippets to end users. Currently it looks like all HTML tags are removed. To show code examples, package developers either have to link to external documentation or create a user control to show after a package's installation. The requested change allows package developers to input pre tags which can contain an encoded string to display to users installing a package.