### PR TITLE
Prevent NullReferenceException

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/TreeRequestParams.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/TreeRequestParams.cs
@@ -88,10 +88,12 @@ namespace umbraco.cms.presentation.Trees
 		{
 			get
 			{
-				string val = (m_params.ContainsKey("id") ? m_params["id"] : "");
-				int sNodeID;
-				if (int.TryParse(HttpContext.Current.Request.QueryString["id"], out sNodeID))
-					return sNodeID;
+				if(m_params.ContainsKey("id"))
+                {
+				    int sNodeID;
+				    if (int.TryParse(m_params["id"], out sNodeID))
+					    return sNodeID;
+                }
 				return -1;
 			}
 		}


### PR DESCRIPTION
The variable val was not referenced later in the function and caused a
NullReferenceException.

http://issues.umbraco.org/issue/U4-4091
