### PR TITLE
Changing MasterTemplateId to public

### DIFF
--- a/src/Umbraco.Core/Models/ITemplate.cs
+++ b/src/Umbraco.Core/Models/ITemplate.cs
@@ -10,5 +10,11 @@
         /// </summary>
         /// <returns><see cref="RenderingEngine"/></returns>
         RenderingEngine GetTypeOfRenderingEngine();
+
+        /// <summary>
+        /// Set the mastertemplate
+        /// </summary>
+        /// <param name="masterTemplate"></param>
+        void SetMasterTemplate(ITemplate masterTemplate);
     }
 }

--- a/src/Umbraco.Core/Models/Template.cs
+++ b/src/Umbraco.Core/Models/Template.cs
@@ -96,7 +96,7 @@ namespace Umbraco.Core.Models
         }
         
         [DataMember]
-        public Lazy<int> MasterTemplateId { get; set; }
+        internal Lazy<int> MasterTemplateId { get; set; }
 
         [DataMember]
         internal string MasterTemplateAlias
@@ -182,6 +182,12 @@ namespace Umbraco.Core.Models
 
             if (Key == Guid.Empty)
                 Key = Guid.NewGuid();
+        }
+
+
+        public void SetMasterTemplate(ITemplate masterTemplate)
+        {
+            MasterTemplateId = new Lazy<int>(() => {return masterTemplate.Id});
         }
     }
 }


### PR DESCRIPTION
When you create a Template in code, I think there is no way to define a masterTemplate. If MasterTempateId were to be public it could be done.
