### PR TITLE
U4-4241 UrlWithDomain() and UrlAbsolute() do not work

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -82,7 +82,7 @@ namespace Umbraco.Web
                         throw new InvalidOperationException("Cannot resolve a Url for a content item when UmbracoContext.Current is null.");
                     if (UmbracoContext.Current.UrlProvider == null)
                         throw new InvalidOperationException("Cannot resolve a Url for a content item when UmbracoContext.Current.UrlProvider is null.");
-                    return UmbracoContext.Current.UrlProvider.GetUrl(content.Id);
+                    return UmbracoContext.Current.UrlProvider.GetUrl(content.Id, absolute: true);
                 case PublishedItemType.Media:
                     throw new NotSupportedException("AbsoluteUrl is not supported for media types.");
                 default:


### PR DESCRIPTION
Fix for http://issues.umbraco.org/issue/U4-4241
UrlWithDomain() and UrlAbsolute() will now display full absolute url like http://localhost:43732/about , instead of /about
