### PR TITLE
6.2.0  package service fixes

### DIFF
--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -733,7 +733,7 @@ namespace Umbraco.Core.Services
             var dataTypes = new Dictionary<string, IDataTypeDefinition>();
             var dataTypeElements = name.Equals("DataTypes")
                                        ? (from doc in element.Elements("DataType") select doc).ToList()
-                                       : new List<XElement> { element.Element("DataType") };
+                                       : new List<XElement> { element };
 
             foreach (var dataTypeElement in dataTypeElements)
             {


### PR DESCRIPTION
Fixes to the Packaging Service for Exporting of ContentTypes (U4-4119) and when importing single DocTypes - these are the relevant fixes for 6.2 from the pull request for v7.1.0 (https://github.com/umbraco/Umbraco-CMS/pull/287) 
