### PR TITLE
Fix broken path

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -90,7 +90,7 @@
     //tell the assetsService to load the bootstrap slider
     //libs from the plugin folder
     assetsService
-        .loadJs("lib/slider/bootstrap-slider.js")
+        .loadJs("lib/slider/js/bootstrap-slider.js")
         .then(function () {
 
             createSlider();


### PR DESCRIPTION
Fixes http://issues.umbraco.org/issue/U4-3354

The slider path is missing the /js in the path.
