### PR TITLE
Temp fix for U4-3691: Use blank alt value instead of 'Some description'

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -92,7 +92,7 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                             if (img) {
                                 var imagePropVal = imageHelper.getImagePropertyValue({ imageModel: img, scope: $scope });
                                 var data = {
-                                    alt: "Some description",
+                                    alt: "",
                                     src: (imagePropVal) ? imagePropVal : "nothing.jpg",
                                     id: '__mcenew'
                                 };


### PR DESCRIPTION
Use a blank alt value in the RTE instead of "Some description". This is a workaround, the real fix would be to allow entering a custom alt attribute and editing it later on.
