### PR TITLE
Name of Media items easyer to read

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -355,7 +355,7 @@ ul.color-picker li a  {
   vertical-align: center;
   font-size: 12px;
   background: @grayLighter;
-  color: @grayLight;
+  color: @black;
   text-decoration: none;
 }
 


### PR DESCRIPTION
The contrast between the text color and background was to low. The text
color has to be darker - black would be the right one.
