### PR TITLE
U4-3691: Use empty alt text instead of 'Some description'

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -92,7 +92,7 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                             if (img) {
                                 var imagePropVal = imageHelper.getImagePropertyValue({ imageModel: img, scope: $scope });
                                 var data = {
-                                    alt: "Some description",
+                                    alt: "",
                                     src: (imagePropVal) ? imagePropVal : "nothing.jpg",
                                     id: '__mcenew'
                                 };


### PR DESCRIPTION
A temporary fix for http://issues.umbraco.org/issue/U4-3691 - use an empty alt text until editing can be implemented.
