### PR TITLE
Fix Null Prevalue Values on Export of DataTypes

### DIFF
--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -801,7 +801,7 @@ namespace Umbraco.Core.Services
             {
                 var prevalue = new XElement("PreValue");
                 prevalue.Add(new XAttribute("Id", pv.Value.Id));
-                prevalue.Add(new XAttribute("Value", pv.Value.Value));
+                prevalue.Add(new XAttribute("Value", pv.Value.Value == null ? "" : pv.Value.Value));
                 prevalue.Add(new XAttribute("Alias", pv.Key));
                 prevalue.Add(new XAttribute("SortOrder", sort));
                 prevalues.Add(prevalue);


### PR DESCRIPTION
Exporting a DataType that has a Numeric pre-value that has no value
causes an Exception - 

```
System.ArgumentNullException: Value cannot be null.
Parameter name: value
   at System.Xml.Linq.XAttribute..ctor(XName name, Object value)
   at Umbraco.Core.Services.PackagingService.Export(IDataTypeDefinition dataTypeDefinition, Boolean raiseEvents)
   at jumps.umbraco.usync.SyncDataType.SaveToDisk(IDataTypeDefinition item)
```

added null checking to pre value.value
