### PR TITLE
Fix of U4-2449 Change the default users language to en-us

### DIFF
--- a/src/Umbraco.Core/Persistence/Migrations/Initial/BaseDataCreation.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Initial/BaseDataCreation.cs
@@ -199,7 +199,7 @@ namespace Umbraco.Core.Persistence.Migrations.Initial
 
         private void CreateUmbracoLanguageData()
         {
-            _database.Insert("umbracoLanguage", "id", false, new LanguageDto { Id = 1, IsoCode = "en-US", CultureName = "en-US" });
+            _database.Insert("umbracoLanguage", "id", false, new LanguageDto { Id = 1, IsoCode = "en-US", CultureName = "en-GB" });
         }
 
         private void CreateCmsContentTypeAllowedContentTypeData()


### PR DESCRIPTION
...Instead I changed the created language to be en-GB since most 1. time installers are probably using the en-GB setting anyway. But now the created user and the created language match! :)