### PR TITLE
U4-4432 - Expose Mandatory setting in ContentProperty

### DIFF
--- a/src/Umbraco.Web/Models/ContentEditing/ContentPropertyDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentPropertyDisplay.cs
@@ -31,5 +31,8 @@ namespace Umbraco.Web.Models.ContentEditing
 
         [DataMember(Name = "hideLabel")]
         public bool HideLabel { get; set; }
+
+        [DataMember(Name = "mandatory")]
+        public bool Mandatory { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/Mapping/ContentPropertyDisplayConverter.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentPropertyDisplayConverter.cs
@@ -35,6 +35,7 @@ namespace Umbraco.Web.Models.Mapping
             display.Description = originalProp.PropertyType.Description;
             display.Label = originalProp.PropertyType.Name;
             display.HideLabel = valEditor.HideLabel;
+            display.Mandatory = originalProp.PropertyType.Mandatory;
             
             if (display.PropertyEditor == null)
             {


### PR DESCRIPTION
It might be useful for a PropertyEditor to know whether it's marked as Mandatory or not.

This exposes the "Mandatory" setting in the `ContentPropertyDisplay`, which already exposes the other similar settings (Alias, Description, etc)

A `PropertyEditor` can then determine whether it's required like so:

```
if ($scope.model.mandatory)
```
