### PR TITLE
7.1.0 image cropper - helpers fix up

### DIFF
--- a/src/Umbraco.Web/ImageCropperBaseExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperBaseExtensions.cs
@@ -49,23 +49,6 @@ namespace Umbraco.Web
             return imageCrops;
         }
 
-
-
-        internal static bool HasPropertyAndValue(this IPublishedContent publishedContent, string propertyAlias)
-        {              
-            if (propertyAlias != null && publishedContent.HasProperty(propertyAlias)
-                && publishedContent.HasValue(propertyAlias))
-            {
-                var propertyAliasValue = publishedContent.GetPropertyValue<string>(propertyAlias);
-                if (propertyAliasValue.DetectIsJson() && propertyAliasValue.Length <= 2)
-                {
-                    return false;
-                }
-                return true;
-            }           
-            return false;
-        }
-
         internal static bool HasPropertyAndValueAndCrop(this IPublishedContent publishedContent, string propertyAlias, string cropAlias)
         {
             if (propertyAlias != null && publishedContent.HasProperty(propertyAlias)
@@ -80,7 +63,7 @@ namespace Umbraco.Web
                 if (allTheCrops != null && allTheCrops.Crops.Any())
                 {
                     var crop = cropAlias != null
-                                    ? allTheCrops.Crops.First(x => x.Alias ==cropAlias)
+                                    ? allTheCrops.Crops.First(x => x.Alias.ToLowerInvariant() == cropAlias.ToLowerInvariant())
                                     : allTheCrops.Crops.First();
                     if (crop != null)
                     {

--- a/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
@@ -73,13 +73,12 @@ namespace Umbraco.Web
             if (!string.IsNullOrEmpty(imageUrl))
             {
                 var imageResizerUrl = new StringBuilder();
-               // imageResizerUrl.Append(imageUrl);
 
                 if (!string.IsNullOrEmpty(imageCropperValue) && imageCropperValue.DetectIsJson())
                 {
                     var cropDataSet = imageCropperValue.SerializeToCropDataSet();
                     imageResizerUrl.Append(cropDataSet.Src);
-                    var crop = cropDataSet.Crops.FirstOrDefault(x => x.Alias == cropAlias);
+                    var crop = cropDataSet.Crops.FirstOrDefault(x => cropAlias != null && x.Alias.ToLowerInvariant() == cropAlias.ToLowerInvariant());
                     if (crop != null && crop.Coordinates != null)
                     {
                         imageResizerUrl.Append("?crop=");


### PR DESCRIPTION
Removing my old v7.0.3 media cache crash workaround code and also fixing the overloaded GetCropUrl method as it doesn't work
