### PR TITLE
CropUrl should be formatted with InvariantCulture.

### DIFF
--- a/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
@@ -97,17 +97,17 @@ namespace Umbraco.Web
                     if (crop != null && crop.Coordinates != null)
                     {
                         imageResizerUrl.Append("?crop=");
-                        imageResizerUrl.Append(crop.Coordinates.X1).Append(",");
-                        imageResizerUrl.Append(crop.Coordinates.Y1).Append(",");
-                        imageResizerUrl.Append(crop.Coordinates.X2).Append(",");
-                        imageResizerUrl.Append(crop.Coordinates.Y2);
+			            imageResizerUrl.Append(crop.Coordinates.X1.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(",");
+            			imageResizerUrl.Append(crop.Coordinates.Y1.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(",");
+			            imageResizerUrl.Append(crop.Coordinates.X2.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(",");
+            			imageResizerUrl.Append(crop.Coordinates.Y2.ToString(System.Globalization.CultureInfo.InvariantCulture));
                         imageResizerUrl.Append("&cropmode=percentage");
                     }
                     else
                     {
                         if (cropDataSet.HasFocalPoint())
                         {
-                            imageResizerUrl.Append("?center=" + cropDataSet.FocalPoint.Top + "," + cropDataSet.FocalPoint.Left);
+                            imageResizerUrl.Append("?center=" + cropDataSet.FocalPoint.Top.ToString(System.Globalization.CultureInfo.InvariantCulture) + "," + cropDataSet.FocalPoint.Left.ToString(System.Globalization.CultureInfo.InvariantCulture));
                             imageResizerUrl.Append("&mode=crop");
                         }
                         else


### PR DESCRIPTION
When "Culture and Hostnames" is set to "nl", the crop url contains commas where it should contain dots. As a result the cropper just wont work.

E.g.:
language = nl –> /media/1015/kantoor.jpg?crop=0,50926279359747528,0,44275147434918666,0,10902867903402354,0,37051178879082175&cropmode=percentage&width=775&height=284&rnd=635310800525781037

language = inherit –> /media/1015/kantoor.jpg?crop=0.50926279359747528,0.44275147434918666,0.10902867903402354,0.37051178879082175&cropmode=percentage&width=775&height=284&rnd=635310801460824519
