### PR TITLE
U4-3744: Make it possible to make individual selections while still selecting the entire text on first click

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/utill/selectOnFocus.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/utill/selectOnFocus.directive.js
@@ -3,19 +3,16 @@ angular.module("umbraco.directives")
     return function (scope, el, attrs) {
         $(el).bind("click", function () {
             var editmode = $(el).data("editmode");
-            if (editmode)
-            {
-                //Do nothing in this case
-            }
-            else {
-                //initial click
+            //If editmode is true a click is handled like a normal click
+            if (!editmode) {
+                //Initial click, select entire text
                 this.select();
                 //Set the edit mode so subsequent clicks work normally
                 $(el).data("editmode", true)
             }
         }).
         bind("blur", function () {
-            //reset on blur
+            //Reset on focus lost
             $(el).data("editmode", false);
         });
     };


### PR DESCRIPTION
This changes to "selectOnFocus" directive to allow for individual edits while still selecting the text on first click. On the first click, the text is selected and a flag set. On subsequent clicks the whole text is not selected if the flag is set. On loss of focus, the flag is cleared so the whole text will be selected again next time the box is clicked.
