### PR TITLE
U4-4532: Make RTE handle inserting ImageCropper images correctly

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
@@ -58,12 +58,18 @@ function mediaHelper(umbRequestHelper) {
 
             var mediaVal;
 
-            //our default images might store one or many images (as csv)
-            var split = imageProp.value.split(',');
-            var self = this;
-            mediaVal = _.map(split, function (item) {
-                return { file: item, isImage: self.detectIfImageByExtension(item) };
-            });
+            if (typeof imageProp.value == "string") {
+                //our default images might store one or many images (as csv)
+                var split = imageProp.value.split(',');
+                var self = this;
+                mediaVal = _.map(split, function (item) {
+                    return { file: item, isImage: self.detectIfImageByExtension(item) };
+                });
+            }
+            else if (imageProp.value.src) {
+                //Handle imagecropper items
+                mediaVal = [{ file: imageProp.value.src, isImage: this.detectIfImageByExtension(imageProp.value.src) }];
+            }
 
             //for now we'll just return the first image in the collection.
             //TODO: we should enable returning many to be displayed in the picker if the uploader supports many.


### PR DESCRIPTION
This makes the RTE handle inserting images where the media type has an ImageCropper instead of an Upload field. This uses the default uncropped image, as, judging from the comments, there seem to be plans to implement choosing between multiple photos at later date.
