### PR TITLE
Fix for U4-4026 Inline styling affect header text

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/editLanguage.aspx
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/editLanguage.aspx
@@ -3,8 +3,7 @@
 
 <%@ Register TagPrefix="cc1" Namespace="umbraco.uicontrols" Assembly="controls" %>
 <asp:Content ContentPlaceHolderID="body" runat="server">
-    <cc1:UmbracoPanel ID="Panel1" runat="server" Width="608px" Height="336px" hasMenu="true"
-        Style="text-align: center">
+    <cc1:UmbracoPanel ID="Panel1" runat="server" Width="608px" Height="336px" hasMenu="true">
         <cc1:Pane ID="Pane7" runat="server">
             <cc1:PropertyPanel runat="server" ID="pp_language">
                 <asp:DropDownList ID="Cultures" runat="server">


### PR DESCRIPTION
Inline styling on container affect header text and dropdown with
text-align:center on language in settings section.
