### PR TITLE
U4-4629 - Detecting existing macros

### DIFF
--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -1196,6 +1196,10 @@ namespace Umbraco.Core.Services
 
             foreach (var macro in macros)
             {
+                var existing = _macroService.GetByAlias(macro.Alias);
+                if (existing != null)
+                    macro.Id = existing.Id;
+
                 _macroService.Save(macro, userId);
             }
 


### PR DESCRIPTION
By setting the ID of the macro the repository layer will update the existing instance rather than trying to create a new one, which would result in a duplicate alias and that violates a table index.
