### PR TITLE
Update package.json for v7.1.2

### DIFF
--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -1,8 +1,8 @@
 {
   "author": "Umbraco HQ",
   "name": "umbraco",
-  "homepage": "https://github.com/umbraco/umbraco-cms/tree/7.0.0",
-  "version": "7.0.0-Beta",
+  "homepage": "https://github.com/umbraco/umbraco-cms/tree/7.1.2",
+  "version": "7.1.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:umbraco/umbraco-cms.git"
@@ -13,7 +13,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/umbraco/Umbraco-CMS/blob/7.0.0/docs/License.txt"
+      "url": "https://github.com/umbraco/Umbraco-CMS/blob/7.1.2/docs/License.txt"
     }
   ],
   "engines": {


### PR DESCRIPTION
I have been helping peeps with broken NuGet upgrades today and checking the build date on the /umbraco/js/ files is a really helpful way of seeing what's gone wrong.  However it's also confusing that they still say v7.0.0-beta.  Not sure if the update of package.json could be automated for each new release branch as that would be ideal!
