### PR TITLE
Additional Content Sensitive Edit Links

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Macros/editMacro.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Macros/editMacro.aspx.cs
@@ -14,6 +14,8 @@ using umbraco.uicontrols;
 using umbraco.DataLayer;
 using umbraco.cms.presentation.Trees;
 using umbraco.cms.businesslogic.macro;
+using System.Text;
+using Umbraco.Core;
 
 namespace umbraco.cms.presentation.developer
 {
@@ -128,6 +130,49 @@ namespace umbraco.cms.presentation.developer
 							"&macroID=" + Request.QueryString["macroID"] + "&type=" + macroType.Text +
 								"', 'Browse Properties', true, 500, 475); return false\" class=\"guiInputButton\"><img src=\"../../images/editor/propertiesNew.gif\" align=\"absmiddle\" style=\"width: 18px; height: 17px; padding-right: 5px;\"/> Browse properties</button>"));
 			}
+
+            StringBuilder scriptCode = new StringBuilder();
+
+            #region Content Edit Link
+            if (!String.IsNullOrEmpty(m_macro.ScriptingFile) && !m_macro.ScriptingFile.StartsWith(SystemDirectories.MvcViews))
+            {
+                HyperLink documentTypeLink = new HyperLink();
+                documentTypeLink.NavigateUrl = "javascript:openDLRScript('" + m_macro.ScriptingFile + "');";
+                documentTypeLink.Text = "Edit Script";
+                documentTypeLink.Style.Add(HtmlTextWriterStyle.PaddingLeft, "10px");
+
+                macroName.Parent.Controls.Add(documentTypeLink);
+
+                new umbraco.loadPython(Constants.Applications.Developer).RenderJS(ref scriptCode);
+            }
+
+            if (!String.IsNullOrEmpty(m_macro.Xslt))
+            {
+                HyperLink documentTypeLink = new HyperLink();
+                documentTypeLink.NavigateUrl = "javascript:openXslt('" + m_macro.Xslt + "');";
+                documentTypeLink.Text = "Edit Xslt";
+                documentTypeLink.Style.Add(HtmlTextWriterStyle.PaddingLeft, "10px");
+
+                macroName.Parent.Controls.Add(documentTypeLink);
+
+                new umbraco.loadXslt(Constants.Applications.Developer).RenderJS(ref scriptCode);
+            }
+
+            if (!String.IsNullOrEmpty(m_macro.ScriptingFile) && m_macro.ScriptingFile.StartsWith(SystemDirectories.MvcViews))
+            {
+                HyperLink documentTypeLink = new HyperLink();
+                documentTypeLink.NavigateUrl = "javascript:openMacroPartialView('" + m_macro.ScriptingFile.Replace(SystemDirectories.MvcViews + "/MacroPartials/", "") + "');";
+                documentTypeLink.Text = "Edit Partial View";
+                documentTypeLink.Style.Add(HtmlTextWriterStyle.PaddingLeft, "10px");
+
+                macroName.Parent.Controls.Add(documentTypeLink);
+
+                new Umbraco.Web.Trees.PartialViewMacrosTree(Constants.Applications.Developer).RenderJS(ref scriptCode);
+            }
+            #endregion
+
+            // Add applicable scripts to page.
+            ClientScript.RegisterClientScriptBlock(this.GetType(), "EditLinkScripts", scriptCode.ToString(), true);
 		}
 
 		/// <summary>
@@ -359,6 +404,7 @@ namespace umbraco.cms.presentation.developer
 			save2.ImageUrl = SystemDirectories.Umbraco + "/images/editor/save.gif";
 
 			base.OnInit(e);
+
 		}
 
 		/// <summary>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Python/editPython.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Python/editPython.aspx.cs
@@ -18,6 +18,9 @@ using umbraco.cms.businesslogic.macro;
 using umbraco.cms.presentation.Trees;
 using umbraco.cms.helpers;
 using umbraco.uicontrols;
+using System.Text;
+using System.Linq;
+using Umbraco.Core;
 
 namespace umbraco.cms.presentation.developer
 {
@@ -69,6 +72,8 @@ namespace umbraco.cms.presentation.developer
         {
             base.OnInit(e);
 
+            StringBuilder scriptCode = new StringBuilder();
+
             SaveButton = UmbracoPanel1.Menu.NewIcon();
             SaveButton.ImageURL = SystemDirectories.Umbraco + "/images/editor/save.gif";
             SaveButton.AltText = "Save scripting File";
@@ -90,6 +95,25 @@ namespace umbraco.cms.presentation.developer
             S = SR.ReadToEnd();
             SR.Close();
             pythonSource.Text = S;
+
+            #region Macro Edit Link
+            // Lookup the pages content type and add a link to edit it directly.
+            Macro macro = Macro.GetAll().FirstOrDefault(s => s.ScriptingFile == Request.QueryString["file"]);
+            if (macro != null)
+            {
+                HyperLink macroLink = new HyperLink();
+                macroLink.NavigateUrl = "javascript:openMacro(" + macro.Id + ");";
+                macroLink.Text = "Edit Macro";
+                macroLink.Style.Add(HtmlTextWriterStyle.PaddingLeft, "10px");
+
+                pp_filename.Controls.Add(macroLink);
+
+                new umbraco.loadMacros(Constants.Applications.Developer).RenderJS(ref scriptCode);
+            }
+            #endregion
+
+            if (!String.IsNullOrEmpty(scriptCode.ToString()))
+                ClientScript.RegisterClientScriptBlock(this.GetType(), "EditLinkScripts", scriptCode.ToString(), true);
         }
 
         protected override void OnPreRender(EventArgs e)

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Xslt/editXslt.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Xslt/editXslt.aspx.cs
@@ -13,6 +13,10 @@ using umbraco.uicontrols;
 using System.Net;
 using umbraco.cms.presentation.Trees;
 using umbraco.cms.helpers;
+using System.Text;
+using umbraco.cms.businesslogic.macro;
+using System.Linq;
+using Umbraco.Core;
 
 namespace umbraco.cms.presentation.developer
 {
@@ -46,8 +50,10 @@ namespace umbraco.cms.presentation.developer
 		}
 
 		protected override void OnInit(EventArgs e)
-		{			
-			base.OnInit(e);
+		{
+            base.OnInit(e);
+
+            StringBuilder scriptCode = new StringBuilder();
             
             SaveButton = UmbracoPanel1.Menu.NewIcon();
             SaveButton.ImageURL = SystemDirectories.Umbraco + "/images/editor/save.gif";
@@ -115,6 +121,26 @@ namespace umbraco.cms.presentation.developer
 			SR.Close();
 
 			editorSource.Text = S;
+
+
+            #region Macro Edit Link
+            // Lookup the pages content type and add a link to edit it directly.
+            Macro macro = Macro.GetAll().FirstOrDefault(s => s.ScriptingFile == Request.QueryString["file"]);
+            if (macro != null)
+            {
+                HyperLink macroLink = new HyperLink();
+                macroLink.NavigateUrl = "javascript:openMacro(" + macro.Id + ");";
+                macroLink.Text = "Edit Macro";
+                macroLink.Style.Add(HtmlTextWriterStyle.PaddingLeft, "10px");
+
+                pp_filename.Controls.Add(macroLink);
+
+                new umbraco.loadMacros(Constants.Applications.Developer).RenderJS(ref scriptCode);
+            }
+            #endregion
+
+            if (!String.IsNullOrEmpty(scriptCode.ToString()))
+                ClientScript.RegisterClientScriptBlock(this.GetType(), "EditLinkScripts", scriptCode.ToString(), true);
 		}
 
 


### PR DESCRIPTION
This patch adds a few edit links into Content, Media, and Macro related editor to more easily navigate between related items.  For example if a editor is editing a document and notices a type in a property or needs to add a property; they have to navigate over to settings and find the appropriate content type to edit(witch could be many steps down a hierarchy tree).  This the minor change going to the Properties tab will reveal a Edit Content Type button that will go directly to the settings tab, locate the documents content type, and open it for editing.  Assuming you have access to it of course.

The following logical QuickLinks are added
Edit Content Type from Document
Edit Template from Document
Edit Media Type from Media
Edit Macro from Script File, Xslt File, or Partial Macro View.
Edit Script File, Xslt File, or Partial Macro View from Macro.

![screen shot 2014-04-14 at 4 11 05 pm](https://cloud.githubusercontent.com/assets/458367/2700263/f064dd9a-c410-11e3-88b3-d0272e5a7c6f.png)

(I had original created this as a custom package but in reality this is such a minor change and is such a huge time saver, that it really should just be included in the UI by default.  