### PR TITLE
fix for: U4-4696. Macro personalized cache with custom membership provider not working

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/macro.cs
+++ b/src/Umbraco.Web/umbraco.presentation/macro.cs
@@ -216,8 +216,8 @@ namespace umbraco
 
             if (CacheByPersonalization)
             {
-                var currentMember = Member.GetCurrentMember();
-                id.AppendFormat("m{0}-", currentMember == null ? 0 : currentMember.Id);
+                int currentMember = Member.CurrentMemberId();
+                id.AppendFormat("m{0}-", currentMember);
             }
 
             foreach (var prop in model.Properties)
@@ -525,7 +525,7 @@ namespace umbraco
             if (Model.CacheDuration > 0)
             {
                 // do not add to cache if there's no member and it should cache by personalization
-                if (!Model.CacheByMember || (Model.CacheByMember && Member.GetCurrentMember() != null))
+                if (!Model.CacheByMember || (Model.CacheByMember && Member.IsLoggedOn()))
                 {
                     if (macroControl != null)
                     {


### PR DESCRIPTION
When using a custom membership provider, macro with "Cache Personalized enabled" is not working: the macro result is never added to the cache collection, and the macro is processed in each request.

This happens when on umbraco.AddMacroResultToCache() line 522 the "Member.GetCurrentMember()" method returns null since you are on a custom provider, the helper can't return a Member entity.

http://issues.umbraco.org/issue/U4-4696
