### PR TITLE
fix for issue U4-4707 - When a mediaitem is selected in the linkpicker, the id is not returned

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
+++ b/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
@@ -181,7 +181,6 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
 			currentTarget: currentTarget,
             callback: function (data) {
                 if (data) {
-                    console.log(data);
                     var href = data.url;
                     
                     function insertLink() {

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
@@ -26,13 +26,16 @@ angular.module("umbraco").controller("Umbraco.Dialogs.LinkPickerController",
 		}
 	}
 
-	$scope.switchToMediaPicker = function(){
-		dialogService.mediaPicker({callback: function(media){
-					$scope.target.id = media.id;
-		            $scope.target.isMedia = true;
-					$scope.target.name = media.name;
-					$scope.target.url = mediaHelper.resolveFile(media);
-				}});
+	$scope.switchToMediaPicker = function () {
+	    dialogService.mediaPicker(
+            {
+                callback: function (media) {
+                    $scope.target.id = media.id;
+                    $scope.target.isMedia = true;
+                    $scope.target.name = media.name;
+                    $scope.target.url = mediaHelper.resolveFile(media);
+                }
+            });
 	};
 
 
@@ -75,5 +78,8 @@ angular.module("umbraco").controller("Umbraco.Dialogs.LinkPickerController",
 		    }
 		}
 
+		if (!angular.isUndefined($scope.target.isMedia)) {
+		    delete $scope.target.isMedia;
+		}
 	});
 });


### PR DESCRIPTION
Currently the id is implicitly set to undefined when a media is selected - that makes the linkpicker unusable in situations where you'd want a id for your selected media in the linkpicker.
