### PR TITLE
U4-4680 - ensured base type properties always display before inherited type ones when both on the same tab.

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
@@ -157,8 +157,12 @@ namespace Umbraco.Web.Models.Mapping
             {
                 var aggregateProperties = new List<ContentPropertyDisplay>();
                 
-                //add the properties from each composite property group
-                foreach (var current in propertyGroups)
+                // Add the properties from each composite property group
+                // - order by Id to ensure the base type properties come before the inherited ones
+                //   and thus always appear first in the list of properties for editing (given the 
+                //   inherited type must have been created after the base one, it will have a higher Id
+                //   value)
+                foreach (var current in propertyGroups.OrderBy(x => x.Id))
                 {
                     var propsForGroup = content.GetPropertiesForGroup(current)
                         .Where(x => IgnoreProperties.Contains(x.Alias) == false); //don't include ignored props


### PR DESCRIPTION
This PR contains a small amend to ensure that if you have properties on a tab from a base and inherited type, the base type ones come first.  From memory this was previously the case, but I've found an example in 7.1.1 where this was reversed.  This amend just ensures the order they are added follows the document type inheritance order.