### PR TITLE
Update web.config with .woff mime support

### DIFF
--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -193,6 +193,8 @@
       <mimeMap fileExtension=".air" mimeType="application/vnd.adobe.air-application-installer-package+zip" />
       <remove fileExtension=".svg" />
       <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+      <remove fileExtension=".woff"/>
+      <mimeMap fileExtension=".woff" mimeType="application/x-font-woff" />
     </staticContent>
 
     <!-- Ensure the powered by header is not returned -->


### PR DESCRIPTION
Bootstrap icons aren't visible on clients that are using the .woff variant because the mimetype isn't available/correct. You can verify this by looking at the error in the developer tools inside the browser.

Updated the web.config and added .woff mimetype to the staticContent section of system.webServer.
