### PR TITLE
Fix U4-4779: Media Picker not working as single picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -4,7 +4,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
     function($rootScope, $scope, dialogService, mediaResource, mediaHelper, $timeout) {
 
         //check the pre-values for multi-picker
-        var multiPicker = $scope.model.config.multiPicker !== '0' ? true : false;
+        var multiPicker = $scope.model.config.multiPicker && $scope.model.config.multiPicker !== '0' ? true : false;
 
         if (!$scope.model.config.startNodeId)
              $scope.model.config.startNodeId = -1;


### PR DESCRIPTION
If you create a new Media Picker and leave "Multi Picker" unchecked, it still allows you to pick multiple items.

This is because `multiPicker` is `null` but the code only checks for a [specific condition](https://github.com/umbraco/Umbraco-CMS/blob/7.1.2/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js#L7).

This pull request updates the condition to be inline with the way it's done in the [dialog](https://github.com/umbraco/Umbraco-CMS/blob/7.1.2/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js#L10) and should fix the issue.
