### PR TITLE
Use new YouTube oembed https end-point (old http one redirects) and make...

### DIFF
--- a/src/Umbraco.Web.UI/config/EmbeddedMedia.Release.config
+++ b/src/Umbraco.Web.UI/config/EmbeddedMedia.Release.config
@@ -33,10 +33,11 @@
   <!-- Youtube Settings -->
   <provider name="Youtube" type="Umbraco.Web.Media.EmbedProviders.OEmbedVideo, umbraco">
     <urlShemeRegex><![CDATA[youtu(?:\.be|be\.com)/(?:(.*)v(/|=)|(.*/)?)([a-zA-Z0-9-_]+)]]></urlShemeRegex>
-    <apiEndpoint><![CDATA[http://www.youtube.com/oembed]]></apiEndpoint>
+    <apiEndpoint><![CDATA[https://www.youtube.com/oembed]]></apiEndpoint>
     <requestParams type="Umbraco.Web.Media.EmbedProviders.Settings.Dictionary, umbraco">
       <param name="iframe">1</param>
       <param name="format">xml</param>
+      <param name="scheme">https</param>
     </requestParams>
   </provider>
   <!-- StreamDotUmbracoDotCom -->

--- a/src/Umbraco.Web.UI/config/EmbeddedMedia.config
+++ b/src/Umbraco.Web.UI/config/EmbeddedMedia.config
@@ -33,10 +33,11 @@
   <!-- Youtube Settings -->
   <provider name="Youtube" type="Umbraco.Web.Media.EmbedProviders.OEmbedVideo, umbraco">
     <urlShemeRegex><![CDATA[youtu(?:\.be|be\.com)/(?:(.*)v(/|=)|(.*/)?)([a-zA-Z0-9-_]+)]]></urlShemeRegex>
-    <apiEndpoint><![CDATA[http://www.youtube.com/oembed]]></apiEndpoint>
+    <apiEndpoint><![CDATA[https://www.youtube.com/oembed]]></apiEndpoint>
     <requestParams type="Umbraco.Web.Media.EmbedProviders.Settings.Dictionary, umbraco">
       <param name="iframe">1</param>
       <param name="format">xml</param>
+      <param name="scheme">https</param>
     </requestParams>
   </provider>
   <!-- StreamDotUmbracoDotCom -->


### PR DESCRIPTION
... sure videos are embedded over https to allow for https Umbraco sites.

http://issues.umbraco.org/issue/U4-4785
