### PR TITLE
Fix pickers in IE9+

### DIFF
--- a/src/Umbraco.Web.UI/umbraco_client/modal/modal.js
+++ b/src/Umbraco.Web.UI/umbraco_client/modal/modal.js
@@ -235,6 +235,11 @@ Umbraco.Sys.registerNamespace("Umbraco.Controls");
                 this._rVal = rVal;
                 top.focus();
                 this._obj.jqmHide(); //do the hiding, this will call the onHide handler
+                //fixes issue with IE9+ and pickers
+                if ($("#right").length)
+	        {
+	            $("#right").contents().find("body").focus();
+	        }
             },
             _close: function() {
                 /// <summary>Finalizes the objects counter and instance manager</summary>


### PR DESCRIPTION
This is a simple fix for the issue with content/media pickers causing text fields/areas to become locked in IE9+ on Umbraco 4.7 - 6.2.