### PR TITLE
Make it possible to activate templates in rte

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -85,6 +85,9 @@ angular.module("umbraco")
                 style_formats: styleFormats
             };
 
+        if (tinyMceConfig.customConfig.templates) {
+            tinyMceConfig.customConfig.templates = JSON.parse(tinyMceConfig.customConfig.templates);
+        }
 
         if(tinyMceConfig.customConfig){
             angular.extend(baseLineConfigObj, tinyMceConfig.customConfig);


### PR DESCRIPTION
The above line of code makes it possible to add templates in tinymce using the /config/tinymceconfig.config file - relates to this feature request http://issues.umbraco.org/dashboard