### PR TITLE
Fix for issue U4-4826

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/umbtree.directive.js
@@ -204,7 +204,7 @@ function umbTreeDirective($compile, $log, $q, $rootScope, treeService, notificat
                     }
                     else {
                         scope.eventhandler.one("treeLoaded", function(e, args) {
-                            doLoad(args.tree);
+                            doLoad(args.tree.root);
                         });
                     }
                 }


### PR DESCRIPTION
When editing an existing link in tinymce the following error is thrown:
Could not find the tree content, activeTree has not been set 

This is caused by passing a wrong value as parameter to the doLoad method in the loadActiveTree function.
