### PR TITLE
Adding extension methods to PartialViewMacroModel to allow: Model.GetParameterValue<DateTime>("datey")

### DIFF
--- a/src/Umbraco.Web/Models/PartialViewMacroModelExtensions.cs
+++ b/src/Umbraco.Web/Models/PartialViewMacroModelExtensions.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Web.Models
             return attempt.Success ? (T) attempt.Result : defaultValue;
         }
 
-        /// <summary>
+        /// <summary> 
         /// Attempt to get a Marco parameter from a PartialViewMacroModel
         /// </summary>
         /// <param name="partialViewMacroModel"></param>

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -353,6 +353,7 @@
     <Compile Include="Models\ImageCropData.cs" />
     <Compile Include="Models\ImageCropRatioMode.cs" />
     <Compile Include="Models\IRenderModel.cs" />
+    <Compile Include="Models\PartialViewMacroModelExtensions.cs" />
     <Compile Include="Models\PostRedirectModel.cs" />
     <Compile Include="Models\PublishedProperty.cs" />
     <Compile Include="Mvc\RedirectToUmbracoUrlResult.cs" />


### PR DESCRIPTION
Adding extension methods to PartialViewMacroModel to allow: Model.GetParameterValue<DateTime>("datey")

Model.GetParameterValue<int>("booly", 8) //optional default value if parsing can't happen
Model.GetParameterValue("booly",8) // can be used like this as type is implied by default value argument
