### PR TITLE
CopyUmbracoFilesToWebRoot assumes packages loacation

### DIFF
--- a/build/NuSpecs/build/UmbracoCms.props
+++ b/build/NuSpecs/build/UmbracoCms.props
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+ <PropertyGroup>
+    <UmbracoVersion>7.1.2</UmbracoVersion>
+  </PropertyGroup>
   <PropertyGroup>
     <CopyAllFilesToSingleFolderForPackageDependsOn>
       AddUmbracoFilesToOutput;

--- a/build/NuSpecs/build/UmbracoCms.targets
+++ b/build/NuSpecs/build/UmbracoCms.targets
@@ -1,11 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <UmbracoVersion>7.1.2</UmbracoVersion>
-  </PropertyGroup>
   <Target Name="CopyUmbracoFilesToWebRoot" BeforeTargets="AfterBuild">
     <PropertyGroup>
-      <UmbracoFilesFolder>..\packages\UmbracoCms.$(UmbracoVersion)\UmbracoFiles\</UmbracoFilesFolder>
+      <UmbracoFilesFolder>$(MSBuildThisFileDirectory)..\UmbracoFiles\</UmbracoFilesFolder>
     </PropertyGroup>
     <ItemGroup>
       <UmbracoFiles Include="$(UmbracoFilesFolder)**\*" />


### PR DESCRIPTION
CopyUmbracoFilesToWebRoot assumes packages folder is always one dir up from
project file which is not always the case.

I have changed to use MSBuildThisFileDirectory which makes the path
relative the the UmbracoCms.targets file.
MSBuildThisFileDirectory is supported from MSBuild 4 but as ToolsVersion is
already set to 4.0 that should not be a problem.

UmbracoVersion property is no longer required but removing it may break
external target files depending on it. Have moved it to props file as this
makes it more reliable for external targets files.
