### PR TITLE
Close user dialog on logout

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/user.controller.js
@@ -25,7 +25,9 @@ angular.module("umbraco")
                 $scope.close();
             });
 
+
             //perform the path change, if it is successful then the promise will resolve otherwise it will fail
+            $scope.close();
             $location.path("/logout");
         };
 


### PR DESCRIPTION
Currently when logging out of the back office, then logging back in with a different user, the new user still see's the old users dialog, with name, and recent history. Calling close() fixes the issue.
