### PR TITLE
Fixing broken preview dialog U4-4977

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -14,7 +14,7 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
     $scope.nav = navigationService;
     $scope.currentSection = appState.getSectionState("currentSection");
     $scope.currentNode = null; //the editors affiliated node
-    
+
 
     //This sets up the action buttons based on what permissions the user has.
     //The allowedActions parameter contains a list of chars, each represents a button by permission so 
@@ -37,7 +37,7 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
                 }
             }
         }
-        
+
         //Now we need to make the drop down button list, this is also slightly tricky because:
         //We cannot have any buttons if there's no default button above.
         //We cannot have the unpublish button (Z) when there's no publish permission.    
@@ -57,7 +57,7 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
             //if we are not creating, then we should add unpublish too, 
             // so long as it's already published and if the user has access to publish
             if (!$routeParams.create) {
-                if (content.publishDate && _.contains(content.allowedActions,"U")) {
+                if (content.publishDate && _.contains(content.allowedActions, "U")) {
                     $scope.subButtons.push(createButtonDefinition("Z"));
                 }
             }
@@ -65,11 +65,11 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
 
         //We fetch all ancestors of the node to generate the footer breadcrump navigation
         if (!$routeParams.create) {
-        entityResource.getAncestors(content.id, "document")
-            .then(function(anc) {
-                anc.pop();
-                $scope.ancestors = anc; 
-            });
+            entityResource.getAncestors(content.id, "document")
+                .then(function (anc) {
+                    anc.pop();
+                    $scope.ancestors = anc;
+                });
         }
     }
 
@@ -117,9 +117,9 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
                 return null;
         }
     }
-    
+
     /** Syncs the content item to it's tree node - this occurs on first load and after saving */
-    function syncTreeNode(content, path, initialLoad) {        
+    function syncTreeNode(content, path, initialLoad) {
 
         //If this is a child of a list view then we can't actually sync the real tree
         if (!$scope.content.isChildOfListView) {
@@ -132,7 +132,7 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
             // from the server so that we can load in the actions menu.
             umbRequestHelper.resourcePromise(
                 $http.get(content.treeNodeUrl),
-                'Failed to retrieve data for child node ' + content.id).then(function(node) {
+                'Failed to retrieve data for child node ' + content.id).then(function (node) {
                     $scope.currentNode = node;
                 });
         }
@@ -165,9 +165,9 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
                     syncTreeNode($scope.content, data.path);
 
                     deferred.resolve(data);
-                    
+
                 }, function (err) {
-                    
+
                     contentEditingHelper.handleSaveError({
                         redirectOnFailure: true,
                         err: err,
@@ -191,10 +191,10 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
     if ($routeParams.create) {
         //we are creating so get an empty content item
         contentResource.getScaffold($routeParams.id, $routeParams.doctype)
-            .then(function(data) {
+            .then(function (data) {
                 $scope.loaded = true;
                 $scope.content = data;
-                
+
                 editorState.set($scope.content);
 
                 configureButtons($scope.content);
@@ -203,14 +203,14 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
     else {
         //we are editing so get the content item from the server
         contentResource.getById($routeParams.id)
-            .then(function(data) {
+            .then(function (data) {
                 $scope.loaded = true;
                 $scope.content = data;
-                
+
                 editorState.set($scope.content);
-                
+
                 configureButtons($scope.content);
-                
+
                 //in one particular special case, after we've created a new item we redirect back to the edit
                 // route but there might be server validation errors in the collection which we need to display
                 // after the redirect, so we will bind all subscriptions which will show the server validation errors
@@ -224,12 +224,12 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
 
 
     $scope.unPublish = function () {
-        
+
         if (formHelper.submitForm({ scope: $scope, statusMessage: "Unpublishing...", skipValidation: true })) {
 
             contentResource.unPublish($scope.content.id)
                 .then(function (data) {
-                    
+
                     formHelper.resetForm({ scope: $scope, notifications: data.notifications });
 
                     contentEditingHelper.handleSuccessfulSave({
@@ -246,36 +246,41 @@ function ContentEditController($scope, $routeParams, $q, $timeout, $window, appS
 
                 });
         }
-        
+
     };
 
-    $scope.sendToPublish = function() {
+    $scope.sendToPublish = function () {
         return performSave({ saveMethod: contentResource.sendToPublish, statusMessage: "Sending..." });
     };
 
-    $scope.saveAndPublish = function() {
-        return performSave({ saveMethod: contentResource.publish, statusMessage: "Publishing..." });        
+    $scope.saveAndPublish = function () {
+        return performSave({ saveMethod: contentResource.publish, statusMessage: "Publishing..." });
     };
 
     $scope.save = function () {
         return performSave({ saveMethod: contentResource.save, statusMessage: "Saving..." });
     };
 
-    $scope.preview = function(content){
+    $scope.preview = function (content) {
+        // Chromes popup blocker will kick in if a window is opened 
+        // outwith the initial scoped request. This trick will fix that.
+        var previewWindow = $window.open("/umbraco/views/content/umbpreview.html", "umbpreview");
         $scope.save().then(function (data) {
-            $window.open('dialogs/preview.aspx?id=' + data.id, 'umbpreview');
+            // Build the correct path so both /#/ and #/ work.
+            var redirect = Umbraco.Sys.ServerVariables.umbracoSettings.umbracoPath + '/dialogs/preview.aspx?id=' + data.id;
+            previewWindow.location.href = redirect;
         });
     };
-    
+
     /** this method is called for all action buttons and then we proxy based on the btn definition */
-    $scope.performAction = function(btn) {
+    $scope.performAction = function (btn) {
 
         if (!btn || !angular.isFunction(btn.handler)) {
             throw "btn.handler must be a function reference";
         }
-        
-        if(!$scope.busy){
-            btn.handler.apply(this);    
+
+        if (!$scope.busy) {
+            btn.handler.apply(this);
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/umbpreview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/umbpreview.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+    <title>Loading</title>
+    <link href="/umbraco/assets/css/umbraco.css" type="text/css" rel="stylesheet">
+</head>
+<body class="content-column-body">
+</body>
+</html>


### PR DESCRIPTION
Chrome won't all new window creation if the request is not made in the initial scoped click event.
This fix opens a new loading page on click and then redirects that page on the save callback.

Less changes were made than it looks like. I hit <kbd> ctrl- K,+ D </kbd> at some point whilst I was working on the file.
