### PR TITLE
Support virtual paths when defining PropertyEditors via Attributes (U4-5128)

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/PropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyEditor.cs
@@ -114,7 +114,7 @@ namespace Umbraco.Core.PropertyEditors
                 throw new NotImplementedException("This method must be implemented if a view is not explicitly set");
             }
 
-            editor.View = _attribute.EditorView;
+            editor.View = _attribute.EditorView.StartsWith("~/") ? IOHelper.ResolveUrl(_attribute.EditorView) : _attribute.EditorView;
             editor.ValueType = _attribute.ValueType;
             editor.HideLabel = _attribute.HideLabel;
             return editor;


### PR DESCRIPTION
Previously you were not able to have your view start with `~/` when registering PropertyEditors through Attributes.  It worked fine when defining via `package.manifest`, but the [code to handle that](https://github.com/imulus/Umbraco-CMS/blob/a23fb7bc741df76376b640a4db5abe2fb92991fe/src/Umbraco.Core/PropertyEditors/PropertyEditor.cs#L102-L105) was not running for those defined via Attributes.

Fixes [U4-5128](http://issues.umbraco.org/issue/U4-5128)
