### PR TITLE
Changed minimum bootstrap column span from 2 to 1 in the grid view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.controller.js
@@ -193,11 +193,11 @@ angular.module("umbraco")
             utillities
         *****************/
         $scope.scaleUp = function(section, max){
-           var add = (max > 2) ? 2 : max;
+           var add = (max > 1) ? 1 : max;
            section.grid = section.grid+add;
         };
         $scope.scaleDown = function(section){
-           var remove = (section.grid > 2) ? 2 : section.grid;
+           var remove = (section.grid > 1) ? 1 : section.grid;
            section.grid = section.grid-remove;
         };    
         $scope.toggleCollection = function(collection){


### PR DESCRIPTION
Was using the new Grid in a new project.

And the people entering content, needed to have som columns that did span an un even number of bootstrap columns, in order to do a layout of 3/3/3/3.

This is my first try to do a github pull request, so i hope i am doing it correctly.
