### PR TITLE
U4-5129 Removed .css extension from node name if provided

### DIFF
--- a/src/umbraco.cms/businesslogic/web/StyleSheet.cs
+++ b/src/umbraco.cms/businesslogic/web/StyleSheet.cs
@@ -174,6 +174,13 @@ namespace umbraco.cms.businesslogic.web
 
         public static StyleSheet MakeNew(BusinessLogic.User user, string Text, string FileName, string Content)
         {
+            // Remove .css extension from stylesheet if created with it, to avoid duplicating the extension 
+            // as it is added anyway to the file name, and also to prevent clashes with nodes created as e.g.
+            // 'style' and 'style.css' (U4-5129)
+            if (Text.ToLowerInvariant().EndsWith(".css"))
+            {
+                Text = Text.Substring(0, Text.Length - ".css".Length);
+            }
 
             // Create the umbraco node
             var newNode = CMSNode.MakeNew(-1, ModuleObjectType, user.Id, 1, Text, Guid.NewGuid());


### PR DESCRIPTION
When creating stylesheets, if you provide a .css extension this causes various issues as outlined in http://issues.umbraco.org/issue/U4-5129 - the file on disk has a double extension, and it gets duplicated in the node tree (one with the extension and one without).  To avoid this, this pull request simply strips off the .css.
