### PR TITLE
Fix for U4-5145

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -1,13 +1,14 @@
 ﻿angular.module("umbraco").controller("Umbraco.PrevalueEditors.MultiColorPickerController",
     function ($scope, $timeout, assetsService, angularHelper, $element) {
         //NOTE: We need to make each color an object, not just a string because you cannot 2-way bind to a primitive.
-
-        $scope.newColor = "";
+        var defaultColor = "000000";
+        
+        $scope.newColor = defaultColor;
         $scope.hasError = false;
 
         assetsService.load([
             //"lib/spectrum/tinycolor.js",
-            "lib/spectrum/spectrum.js"			
+            "lib/spectrum/spectrum.js"          
         ]).then(function () {
             var elem = $element.find("input");
             elem.spectrum({
@@ -67,7 +68,10 @@
                 });
                 if (!exists) {
                     $scope.model.value.push({ value: $scope.newColor });
-                    $scope.newColor = "";
+                    //$scope.newColor = defaultColor;
+                    // set colorpicker to default color
+                    //var elem = $element.find("input");
+                    //elem.spectrum("set", $scope.newColor);
                     $scope.hasError = false;
                     return;
                 }


### PR DESCRIPTION
Changes to not reset the color each time a color is added (keep the last
added color). Preferable if e.g. you want to add some colors close to
each other in the color spectrum.
If there is a reason to reset the color to default color (black) after
adding each color, the spectrum color picker should also change color -
then enable line 71 + 73-74 which use the set method.
