### PR TITLE
U4-5221 - Ensured multi-value data type prevalues are rendered sorted according to defined sort order

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/DataTypeDefinitionRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/DataTypeDefinitionRepository.cs
@@ -426,7 +426,7 @@ AND umbracoNode.id <> @id",
         {
             //go get the data
             var dtos = Database.Fetch<DataTypePreValueDto>("WHERE datatypeNodeId = @Id", new { Id = dataTypeId });
-            var list = dtos.Select(x => new Tuple<PreValue, string, int>(new PreValue(x.Id, x.Value), x.Alias, x.SortOrder)).ToList();
+            var list = dtos.Select(x => new Tuple<PreValue, string, int>(new PreValue(x.Id, x.Value, x.SortOrder), x.Alias, x.SortOrder)).ToList();
             var collection = PreValueConverter.ConvertToPreValuesCollection(list);
 
             //now create the cache key, this needs to include all pre-value ids so that we can use this cached item in the GetPreValuesAsString method


### PR DESCRIPTION
The issue here was that although the sort order was being persisted correctly to the database, in the mapping operation for retrieving it it was getting lost, so all sort orders were 0.
