### PR TITLE
Fix for U4-5313 and U4-5330

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -33,8 +33,12 @@
     bottom: 90px;
 }
 
-.umb-panel.editor-breadcrumb .umb-panel-body, .umb-panel.editor-breadcrumb .umb-bottom-bar,{
-    bottom: 40px !Important;
+.umb-panel.editor-breadcrumb .umb-panel-body, .umb-panel.editor-breadcrumb .umb-bottom-bar {
+    bottom: 30px !Important;
+}
+
+.umb-tab-buttons.umb-bottom-bar {
+    bottom: 50px !Important;
 }
 
 .umb-panel-header .umb-headline, .umb-panel-header h1 {
@@ -159,6 +163,7 @@
     bottom: 0px;
     left: 100px;
     right: 20px;
+    z-index: 6010;
 };
 
 @media (min-width: 1101px) {


### PR DESCRIPTION
Make the bottom bar overlap the image cropper focal point and display
the scrollbar if there is overflow. I know the buttons are located a bit
(10px) closer to the top, but you can see the horizontal scrollbar then,
when there is one in e.g. a package. E.g. depending on the screen
resolution, I would in Matrix Property Editor (There is no spoon) prefer
the Umbracos editing section to scroll than add scroll inside the
property editor wrapper, because it give more editing space.
