### PR TITLE
U4-5344 - Clear previous version after changing node document type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/mocks/services/localization.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/services/localization.mocks.js
@@ -92,6 +92,7 @@ angular.module('umbraco.mocks').
                   "buttons_tableInsert": "Insert table",
                   "changeDocType_changeDocTypeInstruction": "To change the document type for the selected content, first select from the list of valid types for this location.",
                   "changeDocType_changeDocTypeInstruction2": "Then confirm and/or amend the mapping of properties from the current type to the new, and click Save.",
+                  "changeDocType_changeDocTypeInstruction3": "Please note that following this operation all previous versions of the content will be deleted. Rollback to versions using the previous document type will not be possible.",
                   "changeDocType_contentRepublished": "The content has been re-published.",
                   "changeDocType_currentProperty": "Current Property",
                   "changeDocType_currentType": "Current type",

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -96,6 +96,7 @@
   <area alias="changeDocType">
     <key alias="changeDocTypeInstruction">To change the document type for the selected content, first select from the list of valid types for this location.</key>
     <key alias="changeDocTypeInstruction2">Then confirm and/or amend the mapping of properties from the current type to the new, and click Save.</key>
+    <key alias="changeDocTypeInstruction3">Please note that following this operation all previous versions of the content will be deleted. Rollback to versions using the previous document type will not be possible.</key>
     <key alias="contentRepublished">The content has been re-published.</key>
     <key alias="currentProperty">Current Property</key>
     <key alias="currentType">Current type</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -99,6 +99,7 @@
   <area alias="changeDocType">
     <key alias="changeDocTypeInstruction">To change the document type for the selected content, first select from the list of valid types for this location.</key>
     <key alias="changeDocTypeInstruction2">Then confirm and/or amend the mapping of properties from the current type to the new, and click Save.</key>
+    <key alias="changeDocTypeInstruction3">Please note that following this operation all previous versions of the content will be deleted. Rollback to versions using the previous document type will not be possible.</key>
     <key alias="contentRepublished">The content has been re-published.</key>
     <key alias="currentProperty">Current Property</key>
     <key alias="currentType">Current type</key>

--- a/src/Umbraco.Web.UI/umbraco/dialogs/ChangeDocType.aspx
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/ChangeDocType.aspx
@@ -110,7 +110,9 @@
     </asp:PlaceHolder>
 
     <asp:PlaceHolder ID="SaveAndCancelPlaceholder" runat="server">
-        <br />
+        <p class="help">
+            <%= umbraco.ui.Text("changeDocType", "changeDocTypeInstruction3") %>            
+        </p>
         <p>
             <asp:PlaceHolder ID="SavePlaceholder" runat="server">        
                 <asp:Button ID="ValidateAndSave" runat="server" OnClick="ValidateAndSave_Click" />


### PR DESCRIPTION
As per the related issue, it doesn't make much sense to keep previous versions and allow rollback if the document type as changed.  Hence this PR which deletes the previous versions, and displays an on-screen warning indicating that this will occur.
