### PR TITLE
U4-4249 - PetaPocoExtensions CreateTable doesn't recreate the table

### DIFF
--- a/src/Umbraco.Core/Persistence/PetaPocoExtensions.cs
+++ b/src/Umbraco.Core/Persistence/PetaPocoExtensions.cs
@@ -221,6 +221,7 @@ namespace Umbraco.Core.Persistence
             if (overwrite && tableExist)
             {
                 db.DropTable(tableName);
+                tableExist = false;
             }
 
             if (tableExist == false)


### PR DESCRIPTION
Amends `PetaPocoExtensions.CreateTable`, so if `overwrite` is enabled, the table is dropped, then recreated.

http://issues.umbraco.org/issue/U4-4249

Previously when the table was dropped, the value for `tableExist` would still be `true`, and was not recreated.
