### PR TITLE
Fix for U4-3953 (modified)

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/developer/Packages/installedPackage.aspx
+++ b/src/Umbraco.Web.UI/umbraco/developer/Packages/installedPackage.aspx
@@ -141,8 +141,10 @@
                 <cc2:PropertyPanel ID="pp_confirm" runat="server" Text="&nbsp;">
                     <p>
                         <asp:Button ID="bt_confirmUninstall" OnClick="confirmUnInstall" OnClientClick="$('#loadingbar').show()" Text="Confirm uninstall" CssClass="btn btn-primary" runat="server" />
-                        <div style="display: none" id="loadingbar">
-                            <cc2:ProgressBar ID="progbar" runat="server" Title="Please wait..." />    
+                        <div id="loadingbar" style="display: none">
+                            <div style="overflow: hidden; margin-left: -100%; margin-right: -20px;">
+                                <cc2:ProgressBar ID="progbar" runat="server" Title="Please wait..." />
+                            </div>
                         </div>
                     </p>
                 </cc2:PropertyPanel>

--- a/src/Umbraco.Web.UI/umbraco/developer/Packages/installer.aspx
+++ b/src/Umbraco.Web.UI/umbraco/developer/Packages/installer.aspx
@@ -74,9 +74,9 @@
             <cc1:PropertyPanel runat="server" Text="&nbsp;">
                 <asp:Button ID="ButtonLoadPackage" runat="server" Enabled="false" Text="Load Package"
                     OnClick="uploadFile"></asp:Button>
-                <span id="loadingbar" style="display: none;">
+                <div id="loadingbar" style="display: none; overflow: hidden; margin-left: -100%; margin-right: -20px;">
                     <cc1:ProgressBar ID="progbar1" runat="server" Title="Please wait..." />
-                </span>
+                </div>
             </cc1:PropertyPanel>
         </cc1:Pane>
         <cc1:Pane ID="pane_authenticate" runat="server" Visible="false" Text="Repository authentication">
@@ -98,16 +98,17 @@
         </cc1:Pane>
 
         <asp:Panel ID="pane_acceptLicense" runat="server" Visible="false">
-            <br />
-            <div class="alert alert-warning">
-                <p>
-                    <strong>Please note:</strong> Installing a package containing several items and
-                    files can take some time. Do not refresh the page or navigate away before, the installer
-                    notifies you the install is completed.
-                </p>
-            </div>
-
+            
             <cc1:Pane ID="pane_acceptLicenseInner" runat="server">
+                
+                <div class="alert alert-warning">
+                    <p>
+                        <strong>Please note:</strong> Installing a package containing several items and
+                        files can take some time. Do not refresh the page or navigate away before, the installer
+                        notifies you the install is completed.
+                    </p>
+                </div>
+
                 <cc1:PropertyPanel ID="PropertyPanel3" runat="server" Text="Name">
                     <asp:Label ID="LabelName" runat="server" /></cc1:PropertyPanel>
                 <cc1:PropertyPanel ID="PropertyPanel5" runat="server" Text="Author">
@@ -251,10 +252,11 @@
 
                 <cc1:PropertyPanel runat="server" Text=" ">
                     <br />
-                    <div style="display: none;" id="installingMessage">
-                        <cc1:ProgressBar runat="server" ID="_progbar1" />
-                        <br />
-                        <em>&nbsp; &nbsp;Installing package, please wait...</em><br />
+                    <div id="installingMessage" style="display: none;">
+                        <div style="overflow: hidden; margin-left: -100%; margin-right: -20px;">
+                            <cc1:ProgressBar runat="server" ID="_progbar1" />
+                        </div>
+                        <em>Installing package, please wait...</em><br /><br />
                     </div>
                     <asp:Button ID="ButtonInstall" runat="server" Text="Install Package" CssClass="btn btn-primary" Enabled="False"
                         OnClick="startInstall"></asp:Button>


### PR DESCRIPTION
I overlooked the installing message, so here the message is still
visible below the progressbar. Furthermore the same is fixed for the
uninstalling progressbar, which I didn't noticed previously.

Previously pull request was this one: https://github.com/umbraco/Umbraco-CMS/pull/420
