### PR TITLE
Fix for U4-5397

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -377,6 +377,14 @@ div.not-allowed > i.icon,div.not-allowed > a{
 // Loading Animation 
 // ------------------------
 
+div.umb-loader-wrapper {
+overflow:hidden;
+position:absolute;
+left:0;
+right:0;
+margin: 10px 0;
+}
+
 .umb-tree li div.l{
 width:100%;
 height:1px;

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.html
@@ -98,8 +98,10 @@ data-file-upload="options" data-file-upload-progress="" data-ng-class="{'fileupl
 	</div>
 
 	<div class="umb-panel-body with-footer">
-        <div style="height: 10px; margin: 10px 0px 10px 0px" class="umb-loader" 
-        	ng-hide="active() == 0"></div>
+		<div class="umb-loader-wrapper" style="position:relative; margin: 0px -20px;">
+	        <div style="height: 10px; margin: 10px 0px 10px 0px" class="umb-loader" 
+	        	ng-hide="active() == 0"></div>
+        </div>
 
         <umb-photo-folder 
         	min-height="75" 

--- a/src/Umbraco.Web.UI/umbraco/developer/Packages/installedPackage.aspx
+++ b/src/Umbraco.Web.UI/umbraco/developer/Packages/installedPackage.aspx
@@ -142,7 +142,7 @@
                     <p>
                         <asp:Button ID="bt_confirmUninstall" OnClick="confirmUnInstall" OnClientClick="$('#loadingbar').show()" Text="Confirm uninstall" CssClass="btn btn-primary" runat="server" />
                         <div id="loadingbar" style="display: none">
-                            <div style="overflow: hidden; margin-left: -100%; margin-right: -20px;">
+                            <div class="umb-loader-wrapper">
                                 <cc2:ProgressBar ID="progbar" runat="server" Title="Please wait..." />
                             </div>
                         </div>

--- a/src/Umbraco.Web.UI/umbraco/developer/Packages/installer.aspx
+++ b/src/Umbraco.Web.UI/umbraco/developer/Packages/installer.aspx
@@ -74,8 +74,10 @@
             <cc1:PropertyPanel runat="server" Text="&nbsp;">
                 <asp:Button ID="ButtonLoadPackage" runat="server" Enabled="false" Text="Load Package"
                     OnClick="uploadFile"></asp:Button>
-                <div id="loadingbar" style="display: none; overflow: hidden; margin-left: -100%; margin-right: -20px;">
-                    <cc1:ProgressBar ID="progbar1" runat="server" Title="Please wait..." />
+                <div id="loadingbar" style="display: none;">
+                    <div class="umb-loader-wrapper">
+                        <cc1:ProgressBar ID="progbar1" runat="server" Title="Please wait..." />
+                    </div>
                 </div>
             </cc1:PropertyPanel>
         </cc1:Pane>
@@ -253,7 +255,7 @@
                 <cc1:PropertyPanel runat="server" Text=" ">
                     <br />
                     <div id="installingMessage" style="display: none;">
-                        <div style="overflow: hidden; margin-left: -100%; margin-right: -20px;">
+                        <div class="umb-loader-wrapper">
                             <cc1:ProgressBar runat="server" ID="_progbar1" />
                         </div>
                         <em>Installing package, please wait...</em><br /><br />

--- a/src/Umbraco.Web.UI/umbraco/dialogs/republish.aspx
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/republish.aspx
@@ -24,7 +24,9 @@
     </div>     
       
     <div id="progress" style="visibility: hidden;">
-		<cc1:ProgressBar ID="progbar" runat="server" Title="Please wait..." />
+      <div class="umb-loader-wrapper">
+		    <cc1:ProgressBar ID="progbar" runat="server" Title="Please wait..." />
+      </div>
     </div>
       
     </asp:Panel>

--- a/src/Umbraco.Web.UI/umbraco/dialogs/sort.aspx
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/sort.aspx
@@ -19,12 +19,14 @@
     <div class="umb-dialog-body">
         <cc1:Pane runat="server">
 
-          <div id="loading" style="display: none;">
+          <div id="loading" style="display: none; margin-bottom: 10px;">
                 <div class="notice">
                     <p><%= umbraco.ui.Text("sort", "sortPleaseWait") %></p>
                 </div>
                 <br />
-                <cc1:ProgressBar ID="prog1" runat="server" Title="sorting.." />
+                <div class="umb-loader-wrapper">
+                    <cc1:ProgressBar ID="prog1" runat="server" Title="sorting.." />
+                </div>
             </div>
 
             <div id="sortingDone" style="display: none;" class="success">


### PR DESCRIPTION
Since the default header in editing section have been given styling to
look more as an editing field, it seems to have affected the sidebar
headers too (h1), because these also is located inside parent elements
with a umb-panel-header class.

I also added a tiny, tiny change to U4-5313 as the bottom bar seems to
overlap the border. The breadcrumb at bottom have a height of 30 px in
umb-panel-footer-nav and a top border on 1 px. So it seems right with
the change from 30px to 31px from bottom.
