### PR TITLE
Fix U4-5301: Update node name when updating XML cache (revised)

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/content.cs
+++ b/src/Umbraco.Web/umbraco.presentation/content.cs
@@ -402,6 +402,11 @@ namespace umbraco
                                      ? xmlContentCopy.DocumentElement
                                      : xmlContentCopy.GetElementById(parentId.ToString());
 
+            // TODO: Update with new schema!
+            var xpath = UmbracoConfig.For.UmbracoSettings().Content.UseLegacyXmlSchema
+                            ? "./node"
+                            : "./* [@id]";
+
             if (parentNode != null)
             {
                 if (currentNode == null)
@@ -413,6 +418,14 @@ namespace umbraco
                 {
                     //check the current parent id
                     var currParentId = currentNode.AttributeValue<int>("parentID");
+
+                    
+
+                    //copy over children
+                    foreach (XmlNode child in currentNode.SelectNodes(xpath))
+                    {
+                        docNode.AppendChild(child);
+                    }
 
                     //First, check if we're moving the node
                     if (currParentId != docNode.AttributeValue<int>("parentID"))
@@ -431,10 +444,7 @@ namespace umbraco
                     currentNode = docNode;
                 }
 
-                // TODO: Update with new schema!
-                var xpath = UmbracoConfig.For.UmbracoSettings().Content.UseLegacyXmlSchema
-                                ? "./node"
-                                : "./* [@id]";
+                
 
                 var childNodes = parentNode.SelectNodes(xpath);
 


### PR DESCRIPTION
When using the new XML schema, the content type alias is the node name itself. When updating the XML cache this is not accounted for, resulting in a Republish entire site being required.
This fixes the issue by eliminating the tedious copying of attributes and child elements from the new to the old node and instead uses the new node directly.
One question: What should be done with the TransferValuesFromDocumentXmlToPublishedXml method? It is no longer used in Umbraco, so it could just be removed. But the method is public, so there might be compatibility concerns (although I highly doubt that anyone else would use that method)
