### PR TITLE
Fix U4-5413 Makes the dictionary tree moveable

### DIFF
--- a/src/Umbraco.Core/Constants-Applications.cs
+++ b/src/Umbraco.Core/Constants-Applications.cs
@@ -66,7 +66,12 @@
             /// <summary>
             /// alias for the datatype tree.
             /// </summary>
-            public const string DataTypes = "datatype";
+			public const string DataTypes = "datatype";
+
+			/// <summary>
+			/// alias for the dictionary tree.
+			/// </summary>
+			public const string Dictionary = "dictionary";
 
             //TODO: Fill in the rest!
 

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadDictionary.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadDictionary.cs
@@ -29,7 +29,7 @@ using Umbraco.Core;
 
 namespace umbraco
 {
-    [Tree(Constants.Applications.Settings, "dictionary", "Dictionary", action: "openDictionary()", sortOrder: 3)]
+    [Tree(Constants.Applications.Settings, Constants.Trees.Dictionary, "Dictionary", action: "openDictionary()", sortOrder: 3)]
     public class loadDictionary : BaseTree
 	{
         public loadDictionary(string application) : base(application) { }

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/DictionaryItemList.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/DictionaryItemList.aspx.cs
@@ -8,13 +8,14 @@ using System.Web.UI;
 using System.Web.UI.WebControls;
 using System.Web.UI.WebControls.WebParts;
 using System.Web.UI.HtmlControls;
+using Umbraco.Core;
 
 namespace umbraco.presentation.settings {
     public partial class DictionaryItemList : BasePages.UmbracoEnsuredPage {
         public DictionaryItemList()
         {
-            CurrentApp = BusinessLogic.DefaultApps.settings.ToString();
-
+	        CurrentApp = ApplicationContext.Current.Services.ApplicationTreeService
+		        .GetByAlias(Constants.Trees.Dictionary).ApplicationAlias;
         }
 
         private cms.businesslogic.language.Language[] languages = cms.businesslogic.language.Language.getAll;

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/EditDictionaryItem.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/EditDictionaryItem.aspx.cs
@@ -9,6 +9,7 @@ using System.Web.UI;
 using System.Web.UI.WebControls;
 using System.Web.UI.HtmlControls;
 using umbraco.cms.presentation.Trees;
+using Umbraco.Core;
 using Umbraco.Core.IO;
 
 namespace umbraco.settings
@@ -20,7 +21,8 @@ namespace umbraco.settings
 	{
 	    public EditDictionaryItem()
 	    {
-            CurrentApp = BusinessLogic.DefaultApps.settings.ToString();
+			CurrentApp = ApplicationContext.Current.Services.ApplicationTreeService
+				.GetByAlias(Constants.Trees.Dictionary).ApplicationAlias;
 
 	    }
 		protected LiteralControl keyTxt = new LiteralControl();


### PR DESCRIPTION
Makes the dictionary tree moveable by looking up the application alias from the trees registration rather than hard coding to a specific section.
