### PR TITLE
Update Gravatar to use protocol relative URL

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/html/umbavatar.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/html/umbavatar.directive.js
@@ -17,7 +17,7 @@ function avatarDirective() {
 
             scope.$watch("hash", function (val) {
                 //set the gravatar url
-                scope.gravatar = "http://www.gravatar.com/avatar/" + val + "?s=40";
+                scope.gravatar = "//www.gravatar.com/avatar/" + val + "?s=40";
             });
             
         }


### PR DESCRIPTION
Stops warnings over SSL.
