### PR TITLE
Partial Views and Partial View Macro's should allow for folder hierarchy (U4-5441)

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/create/PartialView.ascx
+++ b/src/Umbraco.Web.UI/Umbraco/create/PartialView.ascx
@@ -3,7 +3,7 @@
 <%@ Register TagPrefix="cc1" Namespace="umbraco.uicontrols" Assembly="controls" %>
 
 <cc1:Pane runat="server">
-    <cc1:PropertyPanel runat="server" Text="Filename (without .cshtml)">
+    <cc1:PropertyPanel runat="server" Text="Filename (without .cshtml, use / to make folders)">
         <asp:TextBox ID="FileName" runat="server" CssClass="bigInput input-large-type input-block-level"></asp:TextBox>
         <asp:RequiredFieldValidator ID="RequiredFieldValidator1" ErrorMessage="*" ControlToValidate="FileName" runat="server">*</asp:RequiredFieldValidator>
     </cc1:PropertyPanel>

--- a/src/Umbraco.Web.UI/Umbraco/create/PartialView.ascx.cs
+++ b/src/Umbraco.Web.UI/Umbraco/create/PartialView.ascx.cs
@@ -19,6 +19,10 @@ namespace Umbraco.Web.UI.Umbraco.Create
 			DataBind();
 
 		    LoadTemplates(PartialViewTemplate);
+
+            // Enable new contect item in folders to place items in that folder.
+            if (Request["nodeType"] == "partialViewsFolder")
+                FileName.Text = Request["nodeId"] + "/";
 		}
 
         private static void LoadTemplates(ListControl list)

--- a/src/Umbraco.Web.UI/umbraco/config/create/UI.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/create/UI.xml
@@ -330,7 +330,23 @@
       <delete assembly="umbraco" type="PartialViewTasks" />
     </tasks>
   </nodeType>
+  <nodeType alias="partialViewsFolder">
+    <header>Macro</header>
+    <usercontrol>/Create/PartialView.ascx</usercontrol>
+    <tasks>
+      <create assembly="umbraco" type="PartialViewTasks" />
+      <delete assembly="umbraco" type="PartialViewTasks" />
+    </tasks>
+  </nodeType>
   <nodeType alias="partialViewMacros">
+    <header>Macro</header>
+    <usercontrol>/Create/PartialViewMacro.ascx</usercontrol>
+    <tasks>
+      <create assembly="umbraco" type="PartialViewMacroTasks" />
+      <delete assembly="umbraco" type="PartialViewMacroTasks" />
+    </tasks>
+  </nodeType>
+  <nodeType alias="partialViewMacrosFolder">
     <header>Macro</header>
     <usercontrol>/Create/PartialViewMacro.ascx</usercontrol>
     <tasks>

--- a/src/Umbraco.Web.UI/umbraco/create/PartialViewMacro.ascx
+++ b/src/Umbraco.Web.UI/umbraco/create/PartialViewMacro.ascx
@@ -4,7 +4,7 @@
 <%@ Register TagPrefix="umb" Namespace="ClientDependency.Core.Controls" Assembly="ClientDependency.Core" %>
 
 <cc1:Pane runat="server">
-    <cc1:PropertyPanel runat="server" Text="Filename (without .cshtml)">
+    <cc1:PropertyPanel runat="server" Text="Filename (without .cshtml, use / to make folders)">
         <asp:TextBox ID="FileName" runat="server" CssClass="bigInput input-large-type input-block-level"></asp:TextBox>
         <asp:RequiredFieldValidator ID="RequiredFieldValidator2" ErrorMessage="*" ControlToValidate="FileName" runat="server">*</asp:RequiredFieldValidator>
     </cc1:PropertyPanel>

--- a/src/Umbraco.Web.UI/umbraco/create/PartialViewMacro.ascx.cs
+++ b/src/Umbraco.Web.UI/umbraco/create/PartialViewMacro.ascx.cs
@@ -19,6 +19,10 @@ namespace Umbraco.Web.UI.Umbraco.Create
             DataBind();
 
             LoadTemplates(PartialViewTemplate);
+
+            // Enable new contect item in folders to place items in that folder.
+            if (Request["nodeType"] == "partialViewMacrosFolder")
+                FileName.Text = Request["nodeId"] + "/";
         }
 
         private static void LoadTemplates(ListControl list)

--- a/src/Umbraco.Web.UI/umbraco/create/script.ascx
+++ b/src/Umbraco.Web.UI/umbraco/create/script.ascx
@@ -3,7 +3,7 @@
 
 <input type="hidden" name="nodeType" value="-1"/>
 <cc1:Pane runat="server">
-    <cc1:PropertyPanel runat="server" Text="Name">
+    <cc1:PropertyPanel runat="server" Text="Name (use / to make folders)">
         <asp:TextBox ID="rename" runat="server" CssClass="bigInput input-large-type input-block-level"></asp:TextBox>
         <asp:RequiredFieldValidator ID="RequiredFieldValidator1" ErrorMessage="*" ControlToValidate="rename" runat="server">*</asp:RequiredFieldValidator>
     </cc1:PropertyPanel>

--- a/src/Umbraco.Web.UI/umbraco/settings/views/EditView.aspx.cs
+++ b/src/Umbraco.Web.UI/umbraco/settings/views/EditView.aspx.cs
@@ -150,7 +150,10 @@ namespace Umbraco.Web.UI.Umbraco.Settings.Views
 			{
 				//we are editing a view (i.e. partial view)
 				OriginalFileName = HttpUtility.UrlDecode(Request.QueryString["file"]);
-                TemplateTreeSyncPath = "-1,init," + Path.GetFileName(OriginalFileName);
+
+                //TemplateTreeSyncPath = "-1,init," + Path.GetFileName(OriginalFileName);
+
+                TemplateTreeSyncPath = DeepLink.GetTreePathFromFilePath(OriginalFileName.TrimStart("MacroPartials/").TrimStart("Partials/"));
 			}
 			else
 			{

--- a/src/Umbraco.Web/Trees/PartialViewMacrosTree.cs
+++ b/src/Umbraco.Web/Trees/PartialViewMacrosTree.cs
@@ -31,7 +31,17 @@ namespace Umbraco.Web.Trees
 		                    UmbClientMgr.contentFrame('Settings/Views/EditView.aspx?treeType=partialViewMacros&file=MacroPartials%2f' + id);
 					    }
 		                ");
-		}
+
+		}/// <summary>
+		/// Ensures that no folders can be added
+		/// </summary>
+		/// <param name="xNode"></param>
+        protected override void OnRenderFolderNode(ref XmlTreeNode xNode)
+        {
+            base.OnRenderFolderNode(ref xNode);
+
+            xNode.NodeType = "partialViewMacrosFolder";
+        }
 
 		protected override void ChangeNodeAction(XmlTreeNode xNode)
 		{

--- a/src/Umbraco.Web/Trees/PartialViewsTree.cs
+++ b/src/Umbraco.Web/Trees/PartialViewsTree.cs
@@ -57,7 +57,11 @@ namespace Umbraco.Web.Trees
 		/// <param name="xNode"></param>
 		protected override void OnRenderFolderNode(ref XmlTreeNode xNode)
 		{
-			xNode = null;
+            // We should allow folder hierarchy for organization in large sites.
+            xNode.Action = "javascript:void(0);";
+            xNode.NodeType = "partialViewsFolder";
+            xNode.Menu = new List<IAction>(new IAction[] { ActionDelete.Instance, ContextMenuSeperator.Instance, ActionNew.Instance, ContextMenuSeperator.Instance, ActionRefresh.Instance });
+            
 		}
 
 		protected virtual void ChangeNodeAction(XmlTreeNode xNode)

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadScripts.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadScripts.cs
@@ -72,6 +72,7 @@ namespace umbraco
 
             xNode.Menu = new List<IAction>(new IAction[] { ActionDelete.Instance, ContextMenuSeperator.Instance, ActionNew.Instance, ContextMenuSeperator.Instance, ActionRefresh.Instance });
             xNode.NodeType = "scriptsFolder";
+            xNode.Action = "javascript:void(0);";
         }
 
         protected override void OnRenderFileNode(ref XmlTreeNode xNode)

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/script.ascx
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/script.ascx
@@ -3,7 +3,7 @@
 
 <input type="hidden" name="nodeType" value="-1"/>
 <cc1:Pane runat="server">
-    <cc1:PropertyPanel runat="server" Text="Name">
+    <cc1:PropertyPanel runat="server" Text="Name (use / to make folders)">
         <asp:TextBox ID="rename" runat="server" CssClass="bigInput input-large-type input-block-level"></asp:TextBox>
         <asp:RequiredFieldValidator ID="RequiredFieldValidator1" ErrorMessage="*" ControlToValidate="rename" runat="server">*</asp:RequiredFieldValidator>
     </cc1:PropertyPanel>

--- a/src/umbraco.cms/businesslogic/web/StyleSheet.cs
+++ b/src/umbraco.cms/businesslogic/web/StyleSheet.cs
@@ -254,7 +254,7 @@ namespace umbraco.cms.businesslogic.web
         {
             var e = new DeleteEventArgs();
             FireBeforeDelete(e);
-
+            
             if (!e.Cancel)
             {
                 File.Delete(IOHelper.MapPath(String.Format("{0}/{1}.css", SystemDirectories.Css, this.Text)));
@@ -272,6 +272,13 @@ namespace umbraco.cms.businesslogic.web
 
         public void saveCssToFile()
         {
+            if (this.Text.Contains('/'))
+            {
+                var dir = string.Format("{0}/{1}", IOHelper.MapPath(SystemDirectories.Css), this.Text.Substring(0, this.Text.LastIndexOf('/')));
+                if (!Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+            }
+
             using (StreamWriter SW = File.CreateText(IOHelper.MapPath(string.Format("{0}/{1}.css", SystemDirectories.Css, this.Text))))
             {
                 string tmpCss = this.Content ;


### PR DESCRIPTION
... for organization.  This changes makes them work much like the Scripts and css folders.

I didn't add a Type drop down like the scripts screen has.  This is unnecessary and cumbersome.  Instead it works like other screens and the user can generate a hierarchy in their files by adding /'s in the names.  This is how it works in Stylesheets works and its a lot cleaner.  I added a note of this to the creation dialogs as well.

For example create a view file with the name myFolder/myView and the system will take care of folder creation automatically.  There is also a delete option.

**Other errors fixed**
- Selecting a folder in the scripts lists was generating an error.
- Stylesheets would not create a new folder(but they wold make nested children in existing folders.
- Partial and Macro Views would not use the proper helpers for generating syncTree code.

![screen shot 2014-09-04 at 10 21 02 am](https://cloud.githubusercontent.com/assets/458367/4150562/bd843346-343e-11e4-8cde-d7e6f9c5c988.png)
