### PR TITLE
Markdown property should store to text not varchar.

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/MarkdownPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MarkdownPropertyEditor.cs
@@ -3,7 +3,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.MarkdownEditorAlias, "Markdown editor", "markdowneditor")]
+    [PropertyEditor(Constants.PropertyEditors.MarkdownEditorAlias, "Markdown editor", "markdowneditor", ValueType = "TEXT")]
     public class MarkdownPropertyEditor : PropertyEditor
     {
         protected override PreValueEditor CreatePreValueEditor()


### PR DESCRIPTION
The markdown property type is currently posting into the dataNvarchar field of the property.  This should be going into dataNtext as is is a text editor akin to the rich text editor and can logical contain any amount of data.
