### PR TITLE
Alphabetised the locales list in the treeview

### DIFF
--- a/src/umbraco.cms/businesslogic/language/Language.cs
+++ b/src/umbraco.cms/businesslogic/language/Language.cs
@@ -41,9 +41,6 @@ namespace umbraco.cms.businesslogic.language
         {
             get { return Application.SqlHelper; }
         }
-
-        protected internal const string m_SQLOptimizedGetAll = @"SELECT * FROM umbracoLanguage ORDER BY languageISOCode ASC";
-
         #endregion
         
         #region Constructors
@@ -91,10 +88,12 @@ namespace umbraco.cms.businesslogic.language
                         SqlHelper.CreateParameter("@CultureCode", cultureCode));
 
                     //get it's id
-                    var newId = SqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM umbracoLanguage WHERE languageISOCode=@cultureCode", SqlHelper.CreateParameter("@cultureCode", cultureCode));
+                    var newId = SqlHelper.ExecuteScalar<int>(
+                        "SELECT MAX(id) FROM umbracoLanguage WHERE languageISOCode = @cultureCode",
+                        SqlHelper.CreateParameter("@cultureCode", cultureCode));
 
                     //load it and raise events
-                    using (var dr = SqlHelper.ExecuteReader(string.Format("{0} where id = {1}", m_SQLOptimizedGetAll, newId)))
+                    using (var dr = SqlHelper.ExecuteReader(string.Format("SELECT * FROM umbracoLanguage where id = {0} ORDER BY languageISOCode ASC", newId)))
                     {
                         while (dr.Read())
                         {
@@ -135,7 +134,7 @@ namespace umbraco.cms.businesslogic.language
                 () =>
                     {
                         var languages = new List<Language>();
-                        using (var dr = SqlHelper.ExecuteReader(m_SQLOptimizedGetAll))
+                        using (var dr = SqlHelper.ExecuteReader("SELECT * FROM umbracoLanguage ORDER BY languageISOCode ASC"))
                         {
                             while (dr.Read())
                             {

--- a/src/umbraco.cms/businesslogic/language/Language.cs
+++ b/src/umbraco.cms/businesslogic/language/Language.cs
@@ -42,7 +42,7 @@ namespace umbraco.cms.businesslogic.language
             get { return Application.SqlHelper; }
         }
 
-        protected internal const string m_SQLOptimizedGetAll = @"select * from umbracoLanguage";
+        protected internal const string m_SQLOptimizedGetAll = @"SELECT * FROM umbracoLanguage ORDER BY languageISOCode ASC";
 
         #endregion
         


### PR DESCRIPTION
Single-line edit to alphabetise the locales list by [IETF tag](https://en.wikipedia.org/wiki/IETF_language_tag) (so by [ISO 639-1 α2 code](https://en.wikipedia.org/wiki/ISO_639-1)), to make the list easier to read.

It would be better to sort these by [Culture name](http://msdn.microsoft.com/en-gb/library/ee825488(v=cs.20).aspx), but that wouldn't be a single-line edit, so would introduce a [slightly] greater overhead. Also, the table `umbracoLanguage` is already indexed on the column `languageISOCode`, so the overhead of this edit on the SQL server should be minimal.