### PR TITLE
Alphabetised the locales list in the treeview

### DIFF
--- a/src/umbraco.cms/businesslogic/language/Language.cs
+++ b/src/umbraco.cms/businesslogic/language/Language.cs
@@ -42,7 +42,7 @@ namespace umbraco.cms.businesslogic.language
             get { return Application.SqlHelper; }
         }
 
-        protected internal const string m_SQLOptimizedGetAll = @"select * from umbracoLanguage";
+        protected internal const string m_SQLOptimizedGetAll = @"SELECT * FROM umbracoLanguage ORDER BY languageISOCode ASC";
 
         #endregion
         


### PR DESCRIPTION
Single-line edit to alphabetise the locales list by [IETF tag](https://en.wikipedia.org/wiki/IETF_language_tag) (so by [ISO 639-1 α2 code](https://en.wikipedia.org/wiki/ISO_639-1)), to make the list easier to read.

It would be better to sort these by [Culture name](http://msdn.microsoft.com/en-gb/library/ee825488%28v=cs.20%29.aspx), but that wouldn't be a single-line edit, so would introduce a [slightly] greater overhead. Also, the table `umbracoLanguage` is already indexed on the column `languageISOCode`, so the overhead of this edit on the SQL server should be minimal.
