### PR TITLE
Package Installer - Moving content.setValue back out of PropertyType if block (back to v7.1.4 pos)

### DIFF
--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -259,10 +259,9 @@ namespace Umbraco.Core.Services
                             propertyValue = string.Join(",", propertyValueList.ToArray());
 
                         }
-
-                        //set property value
-                        content.SetValue(propertyTypeAlias, propertyValue);        
                     }
+                    //set property value
+                    content.SetValue(propertyTypeAlias, propertyValue);
                 }
             }
 


### PR DESCRIPTION
In CreateContentFromXML the code checks first for a valid PropertyTypeA|ias, and also gets the PropertyType from the associated contentType

the second check it done for 'edge case' Check-box imports, but always returns null if the specific property is an inherited one (i.e. defined on a parent ContentType) 

between v7.1.4 and v7.1.6 the content.setValue was moved inside the if ( propertyType == null ) block - as a result content inl inherited properties is not set during import. (see - http://issues.umbraco.org/issue/U4-5437) 

Moving content.SetValue back outside of the block - will reinstate the import of inherited items - and shouldn't cause any issues at it uses propertyTypeAlias not propertyType 
