### PR TITLE
Property editor fixes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -6,7 +6,7 @@ angular.module('umbraco')
 	function($scope, dialogService, entityResource, editorState, $log, iconHelper, $routeParams){
 	    $scope.renderModel = [];
 	    $scope.ids = $scope.model.value ? $scope.model.value.split(',') : [];
-        
+
 	    //configuration
 	    $scope.cfg = {
 	        multiPicker: "0",
@@ -16,7 +16,7 @@ angular.module('umbraco')
 	        startNode: {
 				query: "",
 	            type: "content",
-	            id: -1
+	            id: $scope.model.config.startNodeId ? $scope.model.config.startNodeId : -1 // get start node for simple Content Picker
 	        }
 	    };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
@@ -1,8 +1,8 @@
 ﻿<div class="umb-editor">
-    <input name="integerField" type="number" class="umb-editor umb-number"
+    <input name="integerField" type="number" class="umb-editor umb-number "
         ng-model="model.value"
         val-server="value"
-        fix-number />
+        fix-number min="{{model.config.min}}" max="{{model.config.max}}" step="{{model.config.step}}" />
     
     <span class="help-inline" val-msg-for="integerField" val-toggle-msg="number">Not a number</span>
     <span class="help-inline" val-msg-for="integerField" val-toggle-msg="valServer">{{propertyForm.requiredField.errorMsg}}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
@@ -17,22 +17,25 @@ function ($scope, assetsService, dialogService, $log, imageHelper) {
             "lib/markdown/markdown.editor.js"
         ])
 		.then(function () {
+            
+		    // we need a short delay to wait for the textbox to appear.
+		    setTimeout(function() {
+		        //this function will execute when all dependencies have loaded
+		        var converter2 = new Markdown.Converter();
+		        var editor2 = new Markdown.Editor(converter2, "-" + $scope.model.alias);
+		        editor2.run();
 
-		    //this function will execute when all dependencies have loaded
-		    var converter2 = new Markdown.Converter();
-		    var editor2 = new Markdown.Editor(converter2, "-" + $scope.model.alias);
-		    editor2.run();
+		        //subscribe to the image dialog clicks
+		        editor2.hooks.set("insertImageDialog", function (callback) {
 
-		    //subscribe to the image dialog clicks
-		    editor2.hooks.set("insertImageDialog", function (callback) {
+		            dialogService.mediaPicker({ callback: function (data) {
+					    callback(data.url);
+		        	    }
+		            });
 
-		        dialogService.mediaPicker({ callback: function (data) {
-					callback(data.url);
-		        	}
+		            return true; // tell the editor that we'll take care of getting the image url
 		        });
-
-		        return true; // tell the editor that we'll take care of getting the image url
-		    });
+		    }, 200);
 
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
@@ -1,13 +1,15 @@
 ﻿<div class="umb-editor umb-multiple-textbox" ng-controller="Umbraco.PropertyEditors.MultipleTextBoxController">
 
+    <div ui-sortable ng-model="model.value">
     <div class="control-group" ng-repeat="item in model.value">
+    			<i class="icon icon-navigation handle"></i>
         <input type="text" name="item_{{$index}}" ng-model="item.value" />
         <a prevent-default href="" title="Remove this text box"
             ng-show="model.value.length > model.config.min"
             ng-click="remove($index)">
             <i class="icon icon-remove"></i>
         </a>
-    </div>
+    </div></div>
     <a prevent-default href="" title="Add another text box"
         ng-show="model.config.max <= 0 || model.value.length < model.config.max"
         ng-click="add()">

--- a/src/Umbraco.Web/PropertyEditors/ContentPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ContentPickerPropertyEditor.cs
@@ -6,5 +6,15 @@ namespace Umbraco.Web.PropertyEditors
     [PropertyEditor(Constants.PropertyEditors.ContentPickerAlias, "Content Picker", "INT", "contentpicker", IsParameterEditor = true)]
     public class ContentPickerPropertyEditor : PropertyEditor
     {
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new ContentPickerPreValueEditor();
+        }
+
+        internal class ContentPickerPreValueEditor : PreValueEditor
+        {
+            [PreValueField("startNodeId", "Start node", "treepicker")]
+            public int StartNodeId { get; set; }
+        }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/IntegerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/IntegerPropertyEditor.cs
@@ -16,6 +16,42 @@ namespace Umbraco.Web.PropertyEditors
             editor.Validators.Add(new IntegerValidator());
             return editor;
         }
+        
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new IntegerPreValueEditor();
+        }
 
+        /// <summary>
+        /// A custom pre-value editor class to deal with the legacy way that the pre-value data is stored.
+        /// </summary>
+        internal class IntegerPreValueEditor : PreValueEditor
+        {
+            public IntegerPreValueEditor()
+            {
+                //create the fields
+                Fields.Add(new PreValueField(new IntegerValidator())
+                {
+                    Description = "Enter the minimum amount of number to be entered",
+                    Key = "min",
+                    View = "number",
+                    Name = "Minimum"
+                });
+                Fields.Add(new PreValueField(new IntegerValidator())
+                {
+                    Description = "Enter the intervals amount between each step of number to be entered",
+                    Key = "step",
+                    View = "number",
+                    Name = "Step Size"
+                });
+                Fields.Add(new PreValueField(new IntegerValidator())
+                {
+                    Description = "Enter the maximum amount of number to be entered",
+                    Key = "max",
+                    View = "number",
+                    Name = "Maximum"
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
This contains some fixes and improvements for the built in property editors including:
- Multi Textbox list items should be sortable in the content section.
- Markdown editor needs a delay to ensure text boxes are processed by the Dom first.
- Numeric should allow for setting min, max, and step by values.
- The simple Content Picker should let the developer set a start node like the media picker and multi node pickers do. 

