### PR TITLE
Added configurable settings to the ListView data type to control the def...

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -1,4 +1,4 @@
-function listViewController($rootScope, $scope, $routeParams, $injector, notificationsService, iconHelper, dialogService) {
+function listViewController($rootScope, $scope, $routeParams, $injector, notificationsService, iconHelper, dialogService, editorState) {
 
     //this is a quick check to see if we're in create mode, if so just exit - we cannot show children for content 
     // that isn't created yet, if we continue this will use the parent id in the route params which isn't what
@@ -30,11 +30,11 @@ function listViewController($rootScope, $scope, $routeParams, $injector, notific
     };
 
     $scope.options = {
-        pageSize: 10,
+        pageSize: $scope.model.config.pageSize ? $scope.model.config.pageSize : 10,
         pageNumber: 1,
         filter: '',
-        orderBy: 'UpdateDate',
-        orderDirection: "desc"
+        orderBy: $scope.model.config.orderBy ? $scope.model.config.orderBy : 'UpdateDate',
+        orderDirection: $scope.model.config.orderDirection ? $scope.model.config.orderDirection : "desc"
     };
 
 
@@ -80,7 +80,7 @@ function listViewController($rootScope, $scope, $routeParams, $injector, notific
         contentResource.getChildren(id, $scope.options).then(function (data) {
 
             $scope.listViewResultSet = data;
-            $scope.pagination = [];            
+            $scope.pagination = [];
 
             for (var i = $scope.listViewResultSet.totalPages - 1; i >= 0; i--) {
                 $scope.pagination[i] = { index: i, name: i + 1 };
@@ -239,6 +239,18 @@ function listViewController($rootScope, $scope, $routeParams, $injector, notific
     if ($routeParams.id) {
         $scope.pagination = new Array(10);
         $scope.listViewAllowedTypes = contentTypeResource.getAllowedTypes($routeParams.id);
+        $scope.includeProperties = $scope.model.config.includeProperties ? _.map($scope.model.config.includeProperties, function (i) {
+            if (!i.label)
+                i.label = i.value.replace(/([A-Z]?[a-z]+)/g, '$1 ').trim(' ');
+            if (typeof (i.isProperty) == "undefined")
+                i.isProperty = !i.value.match("contentTypeAlias|createDate|icon|owner|published|sortOrder|updateDat|updator");
+            if (!i.isProperty && !i.sortBy)
+                i.sortBy = i.value.substring(0, 1).toUpperCase() + i.value.slice(1);
+            // TODO: Add sort logic for custom properties.
+            //else if (!i.sortBy)
+            //        ;
+            return i;
+        }) : {};
         $scope.reloadView($routeParams.id);
 
         $scope.contentId = $routeParams.id;
@@ -247,5 +259,6 @@ function listViewController($rootScope, $scope, $routeParams, $injector, notific
     }
 
 }
+
 
 angular.module("umbraco").controller("Umbraco.PropertyEditors.ListViewController", listViewController);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -55,6 +55,12 @@
                     <td><a href="#" ng-click="sort('Owner')" prevent-default>
                         <localize key="content_updatedBy">Updated by</localize>
                         <i class="icon-sort"></i></a></td>
+                    <td ng-repeat="property in includeProperties">
+                        <a href="#" ng-click="sort('{{property.sortBy}}')" prevent-default ng-hide="!property.sortBy">
+                        {{property.label}}
+                        <i class="icon-sort"></i></a>
+                        <span ng-hide="property.sortBy">{{property.label}}</span>
+                    </td>
                     <td>
                         <form class="pull-right" novalidate>
                             <i class="icon-search"></i>
@@ -91,6 +97,13 @@
                     <td>
                         {{result.owner.name}}
                         <!--<span class="label">Admin</span>-->
+                    </td>
+                    <td ng-repeat="property in includeProperties">
+                        {{result[property.value]}}
+
+                        <div ng-repeat="props in result.properties | filter: { alias: property.value }">
+                            {{props.value}}
+                        </div>
                     </td>
                     <td></td>
                 </tr>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/orderDirection.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/orderDirection.prevalues.html
@@ -1,0 +1,12 @@
+﻿<div>
+    <label class="radio">
+        <input type="radio" name="orderDirection" value="asc" ng-model="model.value" />
+        Ascending <code>[a-z]</code>
+    </label>
+    <label class="radio">
+        <input type="radio" name="orderDirection" value="desc" ng-model="model.value" />
+        Descending <code>[z-a]</code>
+    </label>
+    
+    <span class="help-inline" val-msg-for="orderDirection" val-toggle-msg="required">Required</span>
+</div>

--- a/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
@@ -11,7 +11,37 @@ namespace Umbraco.Web.PropertyEditors
     [PropertyEditor(Constants.PropertyEditors.ListViewAlias, "List view", "listview", HideLabel = true)]
     public class ListViewPropertyEditor : PropertyEditor
     {
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new ListViewPreValueEditor();
+        }
 
+        public override IDictionary<string, object> DefaultPreValues
+        {
+            get {
+                return new Dictionary<string, object>
+                {
+                    {"pageSize", "10"},
+                    {"orderBy", "SortOrder"},
+                    {"orderDirection", "asc"}
+                };
+            }
+        }
+
+        internal class ListViewPreValueEditor : PreValueEditor
+        {
+            [PreValueField("pageSize", "Page Size", "number", Description = "Number of items per page")]
+            public int PageSize { get; set; }
+
+            [PreValueField("orderBy", "Order By", "textstring", Description = "SortOrder, Name, UpdateDate, CreateDate, ContentTypeAlias, UpdateDate, Updator or Owner")]
+            public int OrderBy { get; set; }
+
+            [PreValueField("orderDirection", "Order By", "views/propertyeditors/listview/orderDirection.prevalues.html")]
+            public int OrderDirection { get; set; }
+
+            [PreValueField("includeProperties", "Include Properties", "multivalues", Description = "Extra properties by name or custom properties by alias to include")]
+            public int IncludeProperties { get; set; }
+        }
 
 
     }


### PR DESCRIPTION
...ault sorting and page sizes.  This won't affect normal nodes with Enable list view views but instead a custom property of the ListView type can be created and added to a content type.  Doing this will allow defaults to be changed.  Alternately these additional settings could be added to the content type screen directly along with the Enable list view option but I didn't ant to get into chaining that.

The view will look for and configure itself if any of these options are set.

Limitations:
- The sort and filter interface from angularJs can''t sort or filter on custom properties.  In fact the filter only works on name were as any base property can be sorted on.  As such custom fields switch off the sort link.
