### PR TITLE
This is a simple key/value property editor that is configured at the document...

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -227,6 +227,11 @@ namespace Umbraco.Core
             public const string MultipleTextstringAlias = "Umbraco.MultipleTextstring";
 
             /// <summary>
+            /// Alias for the Key/Value List datatype.
+            /// </summary>
+            public const string KeyValueListAlias = "Umbraco.KeyValueList";
+
+            /// <summary>
             /// Guid for the No edit datatype.
             /// </summary>
             [Obsolete("GUIDs are no longer used to reference Property Editors, use the Alias constant instead. This will be removed in future versions")]

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/ensureUnique.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/ensureUnique.js
@@ -1,0 +1,40 @@
+﻿/**
+ * Validate that input items in a ng-repeate have a unique value. 
+ * Eg: <div ui-sortable ng-model="myValueList">
+ *  <div class="control-group" ng-repeat="item in myValueList">
+ *      <input type="text" name="key" ng-model="item.key" placeholder="key" ng-required="true" ensure-unique="myValueList" />
+ *      <span class="help-inline" val-msg-for="key" val-toggle-msg="unique">Duplicate</span>
+ *    </ng-form>
+ *  </div>
+ *
+ * This is sued for example in the keyValue list to ensure that each key is unique.
+ */
+
+angular.module('umbraco.directives').directive('ensureUnique', function () {
+    return {
+        require: 'ngModel',
+        link: function (scope, element, attrs, ngModel) {
+            element.bind('blur', function (e, f) {
+                if (!ngModel || !element.val())
+                    ngModel.$setValidity('unique', true);
+                else {
+
+                    var currentValue = element.val();
+                    var childAttr = attrs.ngModel.split(/\./).pop();
+                    if (_.filter(scope.$parent.$eval(attrs.ensureUnique),
+                        function (item) {
+                            return item[childAttr] == currentValue;
+                    }).length > 1)
+                        ngModel.$setValidity('unique', false);
+                    else
+                        ngModel.$setValidity('unique', true);
+                }
+
+                // Update sibbling values affected by this change.
+                if (e.originalEvent && e.originalEvent.type == 'blur')
+                    $(this).parents("[ng-repeat]:first").siblings().find("[ng-model='" + attrs.ngModel + "']").blur();
+
+            });
+        }
+    }
+});

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -492,3 +492,10 @@ ul.color-picker li a  {
 .umb-tags .tag i{padding: 2px;}
 .umb-tags input{border: none; background: white}
 
+
+//
+// keyvaluelist
+// --------------------------------------------------
+.umb-keyvalue-list .control-group > * {
+vertical-align: baseline;
+}

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.controller.js
@@ -1,7 +1,7 @@
 ﻿function KeyValueListController($scope) {
 
     if (!$scope.model.value) {
-        $scope.model.value = { asd: "AS" };
+        $scope.model.value = {  };
     }
     $scope.value = _.map($scope.model.value, function (v, k) {
         return { key: k, value: v };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.controller.js
@@ -1,0 +1,43 @@
+﻿function KeyValueListController($scope) {
+
+    if (!$scope.model.value) {
+        $scope.model.value = { asd: "AS" };
+    }
+    $scope.value = _.map($scope.model.value, function (v, k) {
+        return { key: k, value: v };
+    });
+
+    //add any fields that there isn't values for
+    if ($scope.model.config.min > 0) {
+        for (var i = 0; i < $scope.model.config.min; i++) {
+            if ((i + 1) > $scope.value.length) {
+                $scope.value.push({ key: '', value: '' });
+            }
+        }
+    }
+
+    $scope.add = function () {
+        if ($scope.model.config.max <= 0 || $scope.value.length < $scope.model.config.max) {
+            $scope.value.push({ key: '', value: '' });
+        }
+    };
+
+    $scope.remove = function (index) {
+        var remainder = [];
+        for (var x = 0; x < $scope.value.length; x++) {
+            if (x !== index) {
+                remainder.push($scope.value[x]);
+            }
+        }
+        $scope.value = remainder;
+    };
+
+    $scope.$on("formSubmitting", function (ev, args) {
+        $scope.model.value = _.reduce($scope.value, function (o, v, i) {
+            o[v.key] = v.value;
+            return o;
+        }, {});
+    });
+}
+
+angular.module("umbraco").controller("Umbraco.PropertyEditors.KeyValueListController", KeyValueListController);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.controller.js
@@ -1,4 +1,4 @@
-﻿function KeyValueListController($scope) {
+﻿function KeyValueListController($scope, angularHelper) {
 
     if (!$scope.model.value) {
         $scope.model.value = {  };
@@ -19,6 +19,9 @@
     $scope.add = function () {
         if ($scope.model.config.max <= 0 || $scope.value.length < $scope.model.config.max) {
             $scope.value.push({ key: '', value: '' });
+
+            var currForm = angularHelper.getCurrentForm($scope);
+            currForm.$setDirty();
         }
     };
 
@@ -30,6 +33,9 @@
             }
         }
         $scope.value = remainder;
+
+        var currForm = angularHelper.getCurrentForm($scope);
+        currForm.$setDirty();
     };
 
     $scope.$on("formSubmitting", function (ev, args) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.html
@@ -8,7 +8,7 @@
         <a prevent-default href="" title="Remove this text box"
             ng-show="value.length > model.config.min"
             ng-click="remove($index)">
-            <i class="icon icon-remove"></i>
+            <i class="icon icon-delete"></i>
         </a>
         <span class="help-inline" val-msg-for="key" val-toggle-msg="unique">Duplicate</span>
         <span class="help-inline" val-msg-for="key" val-toggle-msg="required">Required</span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.html
@@ -2,13 +2,17 @@
 
     <div ui-sortable ng-model="value">
     <div class="control-group" ng-repeat="item in value">
+        <ng-form name="keyvalueForm">
     			<i class="icon icon-navigation handle"></i>
-        <input type="text" name="item_{{$index}}" ng-model="item.key" placeholder="key" ng-required="true" /><span> =&gt; </span><input type="text" name="item_{{$index}}_label" ng-model="item.value" placeholder="label" />
+        <input type="text" name="key" ng-model="item.key" placeholder="key" ng-required="true" ensure-unique="value" /><span> =&gt; </span><input type="text" name="label" ng-model="item.value" placeholder="label" />
         <a prevent-default href="" title="Remove this text box"
             ng-show="value.length > model.config.min"
             ng-click="remove($index)">
             <i class="icon icon-remove"></i>
         </a>
+        <span class="help-inline" val-msg-for="key" val-toggle-msg="unique">Duplicate</span>
+        <span class="help-inline" val-msg-for="key" val-toggle-msg="required">Required</span>
+        </ng-form>
     </div>
 	</div>
     <a prevent-default href="" title="Add another text box"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.html
@@ -4,7 +4,7 @@
     <div class="control-group" ng-repeat="item in value">
         <ng-form name="keyvalueForm">
     			<i class="icon icon-navigation handle"></i>
-        <input type="text" name="key" ng-model="item.key" placeholder="key" ng-required="true" ensure-unique="value" /><span> =&gt; </span><input type="text" name="label" ng-model="item.value" placeholder="label" />
+        <input type="text" name="key" ng-model="item.key" placeholder="key" ng-required="true" ensure-unique="value" /><span class="icon icon-right-double-arrow"></span><input type="text" name="label" ng-model="item.value" placeholder="label" />
         <a prevent-default href="" title="Remove this text box"
             ng-show="value.length > model.config.min"
             ng-click="remove($index)">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/keyvaluelist/keyvaluelist.html
@@ -1,0 +1,20 @@
+﻿<div class="umb-editor umb-keyvalue-list" ng-controller="Umbraco.PropertyEditors.KeyValueListController">
+
+    <div ui-sortable ng-model="value">
+    <div class="control-group" ng-repeat="item in value">
+    			<i class="icon icon-navigation handle"></i>
+        <input type="text" name="item_{{$index}}" ng-model="item.key" placeholder="key" ng-required="true" /><span> =&gt; </span><input type="text" name="item_{{$index}}_label" ng-model="item.value" placeholder="label" />
+        <a prevent-default href="" title="Remove this text box"
+            ng-show="value.length > model.config.min"
+            ng-click="remove($index)">
+            <i class="icon icon-remove"></i>
+        </a>
+    </div>
+	</div>
+    <a prevent-default href="" title="Add another text box"
+        ng-show="model.config.max <= 0 || value.length < model.config.max"
+        ng-click="add()">
+        <i class="icon icon-add"></i>
+    </a>
+    
+</div>

--- a/src/Umbraco.Web/PropertyEditors/KeyValuePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/KeyValuePropertyEditor.cs
@@ -14,7 +14,7 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.KeyValueListAlias, "Key/Value List", "keyvaluelist", ValueType = "TEXT")]
+    [PropertyEditor(Constants.PropertyEditors.KeyValueListAlias, "Key/Value List", "keyvaluelist", ValueType = "JSON")]
     public class KeyValuePropertyEditor : PropertyEditor
     {
         protected override PreValueEditor CreatePreValueEditor()

--- a/src/Umbraco.Web/PropertyEditors/KeyValuePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/KeyValuePropertyEditor.cs
@@ -1,0 +1,51 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.Editors;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Web.PropertyEditors
+{
+    [PropertyEditor(Constants.PropertyEditors.KeyValueListAlias, "Key/Value List", "keyvaluelist", ValueType = "TEXT")]
+    public class KeyValuePropertyEditor : PropertyEditor
+    {
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new KeyValuePreValueEditor();
+        }
+
+        /// <summary>
+        /// A custom pre-value editor class to deal with the legacy way that the pre-value data is stored.
+        /// </summary>
+        internal class KeyValuePreValueEditor : PreValueEditor
+        {
+            public KeyValuePreValueEditor()
+            {
+                //create the fields
+                Fields.Add(new PreValueField(new IntegerValidator())
+                {
+                    Description = "Enter the minimum amount of text boxes to be displayed",
+                    Key = "min",
+                    View = "requiredfield",
+                    Name = "Minimum"
+                });
+                Fields.Add(new PreValueField(new IntegerValidator())
+                {
+                    Description = "Enter the maximum amount of text boxes to be displayed, enter 0 for unlimited",
+                    Key = "max",
+                    View = "requiredfield",
+                    Name = "Maximum"
+                });
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
 level as opposed to the data type level.  Currently you can make variable size lists in Umbraco with he multi-textbox control but the only allows for one field and gets really tacky if you try to store more complex logic in it.  This is a variation on that with two controls.  Additional the data is stored as a dictionary for simple enumeration and lookups.

Eg to consume the list in Javascript you can simply do the following: console.log(@Html.Raw(CurrentPage.test));
Object {item: "my Item", "item 2": "Another Item"}

Or in .Net:
@using Newtonsoft.Json
@using Newtonsoft.Json.Linq
var data = JsonConvert.DeserializeObject<JObject>(CurrentPage.test); @data.item
@data["item 2"]

![screen shot 2014-09-10 at 4 00 43 pm](https://cloud.githubusercontent.com/assets/458367/4224666/1829e1f0-3927-11e4-98ba-5be713bc7fcf.png)