### PR TITLE
U4-5527: DefaultShortStringHelper ignores white space rule

### DIFF
--- a/src/Umbraco.Core/Strings/DefaultShortStringHelper.cs
+++ b/src/Umbraco.Core/Strings/DefaultShortStringHelper.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Core.Strings
         {
             foreach (var node in UmbracoConfig.For.UmbracoSettings().RequestHandler.CharCollection)
             {
-                if (node.Char.IsNullOrWhiteSpace() == false)
+                if(string.IsNullOrEmpty(node.Char) == false)
                     _urlReplaceCharacters[node.Char] = node.Replacement;
             }
         }


### PR DESCRIPTION
When using IsNullOrWhiteSpace the white space rule that will replace white spaces with dashes are ignored. This leads to unexpected behavior. Changed the code to use IsNullOrEmpty instead to match the behavior of the LegacyShortStringHelper.
