### PR TITLE
This commit fixes U4-1115

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/users/EditUser.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/users/EditUser.aspx.cs
@@ -365,7 +365,7 @@ namespace umbraco.cms.presentation.user
                 Application[] uapps = u.Applications;
                 foreach (Application app in BusinessLogic.Application.getAll())
                 {
-                    if (CurrentUser.IsRoot() || currentUserApps.Contains(";" + app.alias + ";"))
+                    if (CurrentUser.IsAdmin() || currentUserApps.Contains(";" + app.alias + ";"))
                     {
                         ListItem li = new ListItem(ui.Text("sections", app.alias), app.alias);
                         if (!IsPostBack) foreach (Application tmp in uapps) if (app.alias == tmp.alias) li.Selected = true;


### PR DESCRIPTION
by allowing other backend admin users than the root user, the possibility of allowing access to not used sections.

Right now the EditUser.aspx.cs codebehind only lists out sections the currently logged in user already has access to, unless the currently logged in user is the "root user", ie. the user with Id = 0

NOTE: This fixes an issue in edituser that exists in legacy usercontrol code, since this is still used for editing users, if there's work being done on porting user editing to the "Belle" model, this change is not relevant.

TESTING: As far as I can tell there's not really extensive testing regarding user handling, so I didn't bother adding testing for this change. I tested it on a live environment exhibiting the behavior described in [U4-1115](http://issues.umbraco.org/issue/U4-1115#comment=67-6143), where it solved the problem described. Other than that testing consisted of logging in as different types of users, and checking that the EditUser view works as expected.
