### PR TITLE
GetCurrentMember() method added to the MemberService.

### DIFF
--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -100,6 +100,12 @@ namespace Umbraco.Core.Services
         /// <returns><see cref="IMember"/></returns>
         IMember GetById(int id);
 
+		/// <summary>
+		/// Gets the current Member by the HttpContext User
+		/// </summary>
+		/// <returns><see cref="IMember"/></returns>
+		IMember GetCurrentMember();
+
         /// <summary>
         /// Gets all Members for the specified MemberType alias
         /// </summary>

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -167,6 +167,21 @@ namespace Umbraco.Core.Services
             }
         }
 
+		/// <summary>
+		/// Gets the current Member by the HttpContext User
+		/// </summary>
+		/// <returns><see cref="IMember"/></returns>
+		public IMember GetCurrentMember() {
+			if (System.Web.HttpContext.Current == null || System.Web.HttpContext.Current.User == null || System.Web.HttpContext.Current.User.Identity == null || string.IsNullOrEmpty(System.Web.HttpContext.Current.User.Identity.Name))
+				return null;
+			if (!System.Web.HttpContext.Current.Request.IsAuthenticated)
+				return null;
+			if (ApplicationContext.Current == null)
+				return null;
+
+			return GetByUsername(System.Web.HttpContext.Current.User.Identity.Name);
+		}
+
         /// <summary>
         /// Gets a Member by the unique key
         /// </summary>


### PR DESCRIPTION
It seems the MemberService was missing a method to simply get the currently logged in user (if any). This change adds this method.
