### PR TITLE
U4-5012 Moved preview step for RTE embed dialog to a button press

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/rteembed.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/rteembed.controller.js
@@ -12,9 +12,9 @@
     var origWidth = 500;
     var origHeight = 300;
     
-    $scope.showPreview = function(){
+    $scope.showPreview = function() {
 
-        if ($scope.form.url != "") {
+        if ($scope.form.url) {
             $scope.form.show = true;
             $scope.form.preview = "<div class=\"umb-loader\" style=\"height: 10px; margin: 10px 0px;\"></div>";
             $scope.form.info = "";
@@ -28,7 +28,7 @@
                     switch (data.Status) {
                         case 0:
                             //not supported
-                            $scope.form.info = "Not Supported";
+                            $scope.form.info = "Not supported";
                             break;
                         case 1:
                             //error
@@ -41,13 +41,16 @@
                             break;
                     }
                 })
-                .error(function() {
+                .error(function () {
+                    $scope.form.supportsDimensions = false;
                     $scope.form.preview = "";
                     $scope.form.info = "Computer says no";
                 });
-
+        } else {
+            $scope.form.supportsDimensions = false;
+            $scope.form.preview = "";
+            $scope.form.info = "Please enter a URL";
         }
-
     };
 
     $scope.changeSize = function (type) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/rteembed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/rteembed.html
@@ -3,7 +3,8 @@
          <div class="umb-panel-body no-header with-footer">
             <umb-pane>
                 <umb-control-group label="Url">
-                    <input id="url" class="umb-editor input-block-level" type="text" ng-model="form.url" ng-change="showPreview()" required/>
+                    <input id="url" class="umb-editor input-block-level" type="text" ng-model="form.url" ng-keyup="$event.keyCode == 13 ? showPreview() : null" required />
+                    <input type="button" ng-click="showPreview()" class="btn" value="Retrieve" />
                 </umb-control-group>
 
                 <div ng-show="form.supportsDimensions">    


### PR DESCRIPTION
This PR fixes the issues described in issue U4-5012 by moving the preview step to a button (or return key) press rather than firing off the request to embed on every key press.
