### PR TITLE
Fix for U4-5480 "Bad value for attribute rel on element img in Richtext ...

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
@@ -11,6 +11,10 @@ using Umbraco.Web.Templates;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
+    using System.Linq;
+
+    using HtmlAgilityPack;
+
     /// <summary>
 	/// A value converter for TinyMCE that will ensure any macro content is rendered properly even when 
 	/// used dynamically.
@@ -58,18 +62,60 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             return sb.ToString();
         }
 
-	    public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
-	    {
-	        if (source == null) return null;
-	        var sourceString = source.ToString();
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            var sourceString = source.ToString();
 
             // ensures string is parsed for {localLink} and urls are resolved correctly
             sourceString = TemplateUtilities.ParseInternalLinks(sourceString, preview);
-	        sourceString = TemplateUtilities.ResolveUrlsFromTextString(sourceString);
+            sourceString = TemplateUtilities.ResolveUrlsFromTextString(sourceString);
+
             // ensure string is parsed for macros and macros are executed correctly
             sourceString = RenderRteMacros(sourceString, preview);
 
-	        return sourceString;
-	    }
+            // find and remove the rel attributes used in the Umbraco UI from img tags
+            var doc = new HtmlDocument();
+            doc.LoadHtml(sourceString);
+
+            if (!doc.ParseErrors.Any() && doc.DocumentNode != null)
+            {
+                // Find all images with rel attribute
+                var imgNodes = doc.DocumentNode.SelectNodes("//img[@rel]");
+
+                if (imgNodes != null)
+                {
+                    var modified = false;
+
+                    foreach (var img in imgNodes)
+                    {
+                        var firstOrDefault = img.Attributes.FirstOrDefault(x => x.Name == "rel");
+                        if (firstOrDefault != null)
+                        {
+                            var rel = firstOrDefault.Value;
+
+                            // Check that the rel attribute is a integer before removing
+                            int nodeId;
+                            if (int.TryParse(rel, out nodeId))
+                            {
+                                img.Attributes.Remove("rel");
+                                modified = true;
+                            }
+                        }
+                    }
+
+                    if (modified)
+                    {
+                        return doc.DocumentNode.OuterHtml;
+                    }
+                }
+            }
+
+            return sourceString;
+        }
     }
 }


### PR DESCRIPTION
...editor" by removing the attributes in the RTE value converter so they don't render on the front end site but still exist in the Umbraco UI