### PR TITLE
U4-5386 Filter out items with type for the Media Picker data type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js
@@ -9,7 +9,7 @@ angular.module("umbraco")
             $scope.showDetails = dialogOptions.showDetails;
             $scope.multiPicker = (dialogOptions.multiPicker && dialogOptions.multiPicker !== "0") ? true : false;
             $scope.startNodeId = dialogOptions.startNodeId ? dialogOptions.startNodeId : -1;
-
+            $scope.filter = dialogOptions.filter ? dialogOptions.filter : [];
 
             $scope.options = {
                 url: umbRequestHelper.getApiUrl("mediaApiBaseUrl", "PostAddFile"),
@@ -69,6 +69,24 @@ angular.module("umbraco")
                     .then(function(data) {
                         $scope.searchTerm = "";
                         $scope.images = data.items ? data.items : [];
+
+                        // Hide types not in the filter list
+                        if ($scope.filter.length > 0) {
+                            angular.forEach(data.items, function (item, index) {
+
+                                // If item is a folder, always show but disable select if 
+                                // not in the filter list
+                                if (item.contentTypeAlias == "Folder") {
+                                    if ($scope.filter.indexOf("Folder") == -1) {
+                                        item.hideSelect = true;
+                                    }
+                                } else {
+                                    if ($scope.filter.indexOf(item.contentTypeAlias) == -1) {
+                                        item.hide = true;
+                                    }
+                                }
+                            });
+                        }
                     });
 
                 $scope.options.formData.currentFolder = folder.id;
@@ -85,6 +103,13 @@ angular.module("umbraco")
                 if (image.isFolder && !select) {
                     $scope.gotoFolder(image);
                 }else{
+
+                    if ($scope.filter.length > 0) {
+                        if ($scope.filter.indexOf(image.contentTypeAlias) == -1) {
+                            return;
+                        }
+                    }
+
                     eventsService.emit("dialogs.mediaPicker.select", image);
                     
                     //we have 3 options add to collection (if multi) show details, or submit it right back to the callback

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js
@@ -104,12 +104,6 @@ angular.module("umbraco")
                     $scope.gotoFolder(image);
                 }else{
 
-                    if ($scope.filter.length > 0) {
-                        if ($scope.filter.indexOf(image.contentTypeAlias) == -1) {
-                            return;
-                        }
-                    }
-
                     eventsService.emit("dialogs.mediaPicker.select", image);
                     
                     //we have 3 options add to collection (if multi) show details, or submit it right back to the callback

--- a/src/Umbraco.Web.UI.Client/src/views/directives/html/umb-photo-folder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/directives/html/umb-photo-folder.html
@@ -2,6 +2,7 @@
     <div class="picrow" ng-repeat="row in rows">
 
         <div class="pic"
+            ng-show="!img.hide"
             ng-class="img.cssclass"
             ng-style="img.style" ng-repeat="img in row.images">
 
@@ -17,10 +18,10 @@
                 <div ng-if="img.thumbnail" class="umb-photo" ng-style="img.thumbStyle" alt="{{img.name}}"></div>
             </a>
 
-            <a href ng-click="clickHandler(img, $event, true)" 
-                ng-if="img.isFolder" class="selector-overlay">
+            <a href ng-click="clickHandler(img, $event, true)"
+               ng-if="img.isFolder && !img.hideSelect" class="selector-overlay">
                 <localize key="buttons_select">Select</localize>
-			</a>
+            </a>
         </div>
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -9,6 +9,8 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
         if (!$scope.model.config.startNodeId)
              $scope.model.config.startNodeId = -1;
 
+        if ($scope.model.config.filter)
+            $scope.model.config.filterArray = $scope.model.config.filter.split(',');
          
         function setupViewModel() {
             $scope.images = [];
@@ -54,8 +56,10 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
         };
 
         $scope.add = function() {
+
             dialogService.mediaPicker({
                 startNodeId: $scope.model.config.startNodeId,
+                filter: $scope.model.config.filterArray,
                 multiPicker: multiPicker,
                 callback: function(data) {
                     

--- a/src/Umbraco.Web/PropertyEditors/MediaPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPickerPropertyEditor.cs
@@ -45,6 +45,9 @@ namespace Umbraco.Web.PropertyEditors
         {
             [PreValueField("startNodeId", "Start node", "mediapicker")]
             public int StartNodeId { get; set; }
+
+            [PreValueField("filter", "Allow items of type", "textstring", Description = "Seperate with comma")]
+            public string Filter { get; set; }
         }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MultipleMediaPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultipleMediaPickerPropertyEditor.cs
@@ -23,7 +23,10 @@ namespace Umbraco.Web.PropertyEditors
             public bool MultiPicker { get; set; }
 
             [PreValueField("startNodeId", "Start node", "mediapicker")]
- 			public int StartNodeId { get; set; }
+            public int StartNodeId { get; set; }
+
+            [PreValueField("filter", "Allow items of type", "textstring", Description = "Seperate with comma")]
+            public string Filter { get; set; }
         }
     }
 }


### PR DESCRIPTION
It would be helpful if a developer could specify a list of media types to filter out when an editor is selecting from the media picker. For example, if a developer wants to make sure an image is only selected and not a folder. This pull requests adds a pre value field to the Media Picker and Multi Media Picker so that a developer can add a comma separated list of Media Types to filter by when displaying the Media Picker.