### PR TITLE
U4-5461 - Further amends to date picker behaviour

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -8,7 +8,6 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
         pickDate: true,
         pickTime: true,
         pick12HourFormat: false,
-        autoclose: true,
         format: "yyyy-MM-dd hh:mm:ss"
     };
 


### PR DESCRIPTION
Following up on issues found with previous pull request #491 that was accepted.

Removed close of date/time picker on date selection when set up with time picker.
Close picker in either form when you on click on document behind the picker.  I've used a jquery document click event for the latter, which perhaps isn't the most angular way, but works for what's needed here - as otherwise the time version can't be closed.
