### PR TITLE
Added support for HTML in property editor descriptions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/directives/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/directives/umb-property.html
@@ -7,7 +7,7 @@
             <div class="umb-el-wrap">
                 <label class="control-label" ng-hide="property.hideLabel" for="{{property.alias}}">
                     {{property.label}}
-                    <small>{{property.description}}</small>
+                    <small ng-bind-html-unsafe="property.description"></small>
                 </label>
 
                 <div class="controls controls-row" ng-transclude>


### PR DESCRIPTION
In Umbraco 6 it was possible to use raw HTML in the description of property editors. With Umbraco 7 and AngularJS this is no longer possible.

HTML in the descriptions should of course be used wisely, but it can help to highlight something of importance - eg. using the `<mark>` element, so I think this should be supported in Umbraco 7 as well.

![image](https://cloud.githubusercontent.com/assets/3634580/4498106/c26f08c0-4a75-11e4-805e-dcb1cf28e6e8.png)

Raw HTML can be inserted using the `ng-bind-html-unsafe` attribute/directive, which works fine in the version of Angular that Umbraco is currently using (1.1.5).

The directive has however been deprecated as of AngularJS 1.2, so it should be handled a little different if Umbraco upgrades to a more recent version of AngularJS. See some further information in this Stack Overflow thread: http://stackoverflow.com/questions/15754515/how-to-render-html-with-angular-templates
