### PR TITLE
U4-5602 Dropdown List data type now shows an empty option after a page is saved

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdown/dropdown.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdown/dropdown.html
@@ -4,7 +4,8 @@
             class="umb-editor umb-dropdown"
             ng-switch-default
             ng-model="model.value"
-            ng-options="item.id as item.value for item in model.config.items">        
+            ng-options="item.id as item.value for item in model.config.items">
+        <option></option>
     </select>
     
     <!--NOTE: This ng-switch is required because ng-multiple doesn't actually support dynamic bindings with multi-select lists -->


### PR DESCRIPTION
I created a new data type using the Dropdown List property editor. I added 6 options. When used on a document type, if an instance of the document type has not been saved before, an empty option appears first in the list. When a value has been selected and saved, the drop down list does not display an empty option. Therefore, making it unable to reset the property's value to null.

Screencast available at https://www.screenr.com/SG4N demonstrating a clean install and how to recreate the issue.

This pull requests adds a default option to the drop down property editor.
