### PR TITLE
Don't ensure App_Code

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/EnsureSystemPathsApplicationStartupHandler.cs
+++ b/src/Umbraco.Web/umbraco.presentation/EnsureSystemPathsApplicationStartupHandler.cs
@@ -16,7 +16,6 @@ namespace umbraco.presentation
         {
             base.ApplicationInitialized(umbracoApplication, applicationContext);
 
-            EnsurePathExists("~/App_Code");
             EnsurePathExists("~/App_Data");
             EnsurePathExists(SystemDirectories.AppPlugins);
             EnsurePathExists(SystemDirectories.Css);


### PR DESCRIPTION
We'd really like to precompile webs, you can't when App_Code is created every recycle.

I guess there's some obscure usecase where the system need the folder in place, so I assume this won't get pulled right away, BUT:
Nothing changed when I set up a new site without that folder or the EnsureFolder("App_Code") in place.
Nor did stuff like xslt templates break.
IMHO, people who use App_Code and/or use functionality within Umbraco that requires it to be there can just go ahead and create it manually.