### PR TITLE
U4-5658 Dictionary tree JS: 'openDictionary' defined in Languages tree

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadDictionary.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadDictionary.cs
@@ -53,11 +53,13 @@ namespace umbraco
 		public override void RenderJS(ref StringBuilder Javascript)
         {
             Javascript.Append(
-                @"
+				@"
+			function openDictionary() {
+				UmbClientMgr.contentFrame('settings/DictionaryItemList.aspx');
+			}
 			function openDictionaryItem(id) {
 				UmbClientMgr.contentFrame('settings/editDictionaryItem.aspx?id=' + id);
-			}
-			");
+			}");
         }
 
         public override void Render(ref XmlTree tree)

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadLanguages.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadLanguages.cs
@@ -46,10 +46,6 @@ namespace umbraco
                 @"
 function openLanguage(id) {
 	UmbClientMgr.contentFrame('settings/editLanguage.aspx?id=' + id);
-}
-
-function openDictionary() {
-	UmbClientMgr.contentFrame('settings/DictionaryItemList.aspx');
 }");
         }
 


### PR DESCRIPTION
Fixes [U4-5658 - Dictionary tree JS: 'openDictionary' defined in Languages tree](http://issues.umbraco.org/issue/U4-5658)