### PR TITLE
Fixes VS14 build. 

### DIFF
--- a/src/SQLCE4Umbraco/SqlCEHelper.cs
+++ b/src/SQLCE4Umbraco/SqlCEHelper.cs
@@ -229,5 +229,17 @@ namespace SqlCE4Umbraco
             return new SqlCeDataReaderHelper(SqlCeApplicationBlock.ExecuteReader(ConnectionString, CommandType.Text,
                                                             commandText, parameters));
         }
+
+
+        internal IRecordsReader ExecuteReader(string commandText)
+        {
+            return ExecuteReader(commandText, new SqlCEParameter(string.Empty, string.Empty));
+        }
+
+
+        internal int ExecuteNonQuery(string commandText)
+        {
+            return ExecuteNonQuery(commandText, new SqlCEParameter(string.Empty, string.Empty));
+        }
     }
 }

--- a/src/umbraco.datalayer/Properties/AssemblyInfo.cs
+++ b/src/umbraco.datalayer/Properties/AssemblyInfo.cs
@@ -25,5 +25,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6210756f-436d-4536-bad3-d7b000e1694f")]
-
-[assembly: InternalsVisibleTo("SqlCE4Umbraco")]

--- a/src/umbraco.datalayer/SqlHelper.cs
+++ b/src/umbraco.datalayer/SqlHelper.cs
@@ -234,12 +234,7 @@ namespace umbraco.DataLayer
                 throw new SqlHelperException("ExecuteNonQuery", commandText, parameters, e);
             }
         }
-
-        internal int ExecuteNonQuery(string commandText)
-        {
-            return ExecuteNonQuery(commandText, new P[0]);
-        }
-
+        
         /// <summary>
         /// Executes a command and returns a records reader containing the results.
         /// </summary>
@@ -263,12 +258,7 @@ namespace umbraco.DataLayer
                 throw new SqlHelperException("ExecuteReader", commandText, parameters, e);
             }
         }
-
-        internal IRecordsReader ExecuteReader(string commandText)
-        {
-            return ExecuteReader(commandText, new P[0]);
-        }
-
+        
         /// <summary>
         /// Executes a command that returns an XML value.
         /// </summary>


### PR DESCRIPTION
SqlCEHelper.cs - the compiler in Vs14 doesn't like that we're callng `public IRecordsReader ExecuteReader(string commandText, params IParameter[] parameters)` like this: `ExecuteNonQuery("alter table [" + table + "] drop constraint [" + constraint + "]");`

Added two internal method overloads that just send an empty parameter array instead.
