### PR TITLE
Use protocol relative gravatar url

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
@@ -90,7 +90,7 @@ function MainController($scope, $rootScope, $location, $routeParams, $timeout, $
                     $timeout(function () {
                         //this can be null if they time out
                         if ($scope.user && $scope.user.emailHash) {
-                            $scope.avatar = "http://www.gravatar.com/avatar/" + $scope.user.emailHash + ".jpg?s=64&d=mm";
+                            $scope.avatar = "//www.gravatar.com/avatar/" + $scope.user.emailHash + ".jpg?s=64&d=mm";
                         }
                     });
                     $("#avatar-img").fadeTo(1000, 1);


### PR DESCRIPTION
When serving the backoffice via https, the http:// gravatar url causes browser warnings
