### PR TITLE
Fix for U4-5698 - EntityService.GetObjectType throws for deleted Id's

### DIFF
--- a/src/Umbraco.Core/Persistence/PetaPoco.cs
+++ b/src/Umbraco.Core/Persistence/PetaPoco.cs
@@ -563,12 +563,13 @@ namespace Umbraco.Core.Persistence
 						object val = cmd.ExecuteScalarWithRetry();
 						OnExecutedCommand(cmd);
 
-					    if (val == null && typeof(T) == typeof(Guid))
-					    {
-					        val = Guid.Empty;
-					    }
+                        if (val == null || val == DBNull.Value)
+                            return default(T);
 
-						return (T)Convert.ChangeType(val, typeof(T));
+                        Type t = typeof(T);
+                        Type u = Nullable.GetUnderlyingType(t);
+
+                        return (T)Convert.ChangeType(val, u ?? t);
 					}
 				}
 				finally


### PR DESCRIPTION
For example

```
var test = ApplicationContext.Current.Services.EntityService.GetObjectType(3333333);
```

This fix works but I suspect it has wider implications and there is probably a better method of handling it as I doubt we want to be modifying PetaPoco.cs, maybe even try/catch in the GetObjectType method, over to @Shandem  and @sitereactor....?
