### PR TITLE
Update MembershipHelper.cs

### DIFF
--- a/src/Umbraco.Web/Security/MembershipHelper.cs
+++ b/src/Umbraco.Web/Security/MembershipHelper.cs
@@ -172,11 +172,14 @@ namespace Umbraco.Web.Security
                 if (status != MembershipCreateStatus.Success) return null;
             }
 
-            //Set member online
-            provider.GetUser(model.Username, true);
-
-            //Log them in
-            FormsAuthentication.SetAuthCookie(membershipUser.UserName, model.CreatePersistentLoginCookie);
+            if (logMemberIn)
+            {
+                //Set member online
+                provider.GetUser(model.Username, true);
+    
+                //Log them in
+                FormsAuthentication.SetAuthCookie(membershipUser.UserName, model.CreatePersistentLoginCookie);
+            }
 
             return membershipUser;
         }


### PR DESCRIPTION
The parameter "logMemberIn" wasn't used so setting "LoginOnSuccess" on the RegisterModel didn't have any effect. By checking the parameter you can disable automatically logging in the user after registration. If registration failed, it would have returned null in an earlier stage so it's safe to say registration succeeded at this point.
