### PR TITLE
Optional stylesheet link that can be used for improve the macros' displa...

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/grid/grid.rte.directive.js
@@ -127,6 +127,9 @@ angular.module("umbraco.directives")
                                     //force overflow to hidden to prevent no needed scroll
                                     editor.getBody().style.overflow = "hidden";
 
+                                    //force transparent background
+                                    editor.getBody().style.background = "transparent";
+
                                     $timeout(function(){
                                         if(scope.value === null){
                                             editor.focus();

--- a/src/Umbraco.Web.UI.Client/src/common/services/grid.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/grid.service.js
@@ -1,10 +1,15 @@
 angular.module('umbraco.services')
 	.factory('gridService', function ($http, $q){
 
-		var configPath = "../config/grid.editors.config.js";
-        var service = {
+	    var configPath = "../config/grid.editors.config.js";
+	    var configSettingsPath = "../config/grid.settings.config.js";
+
+		var service = {
 			getGridEditors: function () {
 				return $http.get(configPath);
+			},
+			getGridSettings: function () {
+			    return $http.get(configSettingsPath);
 			}
 		};
 

--- a/src/Umbraco.Web.UI.Client/src/less/gridview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/gridview.less
@@ -184,7 +184,7 @@
 
 
 .usky-grid  .cell-tools-remove {
-    display:inline-block;
+    display: inline-block;
     position: absolute;
     top: 0px;
     right: 5px;
@@ -198,7 +198,7 @@
 }
 
 .usky-grid  .cell-tools-move {
-    display:inline-block;
+    display: inline-block;
     position: absolute;
     top: 40px;
     right: 5px;
@@ -206,6 +206,13 @@
     cursor: move
 }
 
+.usky-grid  .cell-tools-setting { 
+    display: inline-block;
+    position: absolute;
+    top: 80px;
+    right: 5px;
+    z-index: 500;
+}
 
 
 // CONTROL
@@ -255,8 +262,9 @@
 // CONTROL PLACEHOLDER
 // -------------------------
 .usky-grid  .usky-control-placeholder {
-    min-height: 50px;
+    padding-top: 20px !important;
     position: relative;
+    min-height: 78px;
     text-align: center;
     text-align: -moz-center;
     cursor: text;
@@ -285,7 +293,7 @@
     padding: 20px;
     padding-bottom: 30px;
     position: relative;
-    background-color: white;
+    background-color: rgba(255, 255, 255, 0.2);
     border: 4px dashed @grayLight;
     text-align: center;
     text-align: -moz-center;

--- a/src/Umbraco.Web.UI.Client/src/routes.js
+++ b/src/Umbraco.Web.UI.Client/src/routes.js
@@ -170,4 +170,6 @@ app.config(function ($routeProvider) {
 
         //$locationProvider.html5Mode(false).hashPrefix('!'); //turn html5 mode off
         // $locationProvider.html5Mode(true);         //turn html5 mode on
-});
+    }).config(function($controllerProvider) {
+        app.controllerProvider = $controllerProvider;
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -200,6 +200,14 @@ angular.module("umbraco")
             $scope.currentMovedRow = null;
         };
 
+        $scope.setCurrentSettingRow = function (Row) {
+            $scope.currentSettingRow = Row;
+        };
+
+        $scope.disableCurrentSettingRow = function (Row) {
+            $scope.currentSettingRow = null;
+        };
+
         $scope.getAllowedLayouts = function(column){
             var layouts = $scope.model.config.items.layouts;
 
@@ -236,7 +244,6 @@ angular.module("umbraco")
             }
         };
 
-
         // *********************************************
         // Cell management functions
         // *********************************************
@@ -257,9 +264,6 @@ angular.module("umbraco")
                 return "icon-layout";
             }
         };
-
-
-
 
         // *********************************************
         // Control management functions
@@ -296,6 +300,14 @@ angular.module("umbraco")
 
         $scope.disableCurrentMovedControl = function (Control) {
             $scope.currentMovedControl = null;
+        };
+
+        $scope.setCurrentSettingControl = function (Control) {
+            $scope.currentSettingControl = Control;
+        };
+
+        $scope.disableCurrentSettingControl = function (Control) {
+            $scope.currentSettingControl = null;
         };
 
         $scope.setUniqueId = function (cell, index) {
@@ -348,13 +360,6 @@ angular.module("umbraco")
         $scope.percentage = function(spans){
             return ((spans/12)*100).toFixed(1);
         };
-
-
-
-
-
-
-
 
         // *********************************************
         // INITIALISATION
@@ -475,12 +480,88 @@ angular.module("umbraco")
                 //set a no disposable unique ID (util for row styling)
                 original.id = !row.id ? $scope.setUniqueId() : row.id;
 
+                //set optional setting if it exists
+                if (row.setting) original.setting = row.setting;
+
                 return original;
             }
 
         };
 
+        // *********************************************
+        // -- optional row/cell settings --
+        // Feature that allows to extend the grid with 
+        // additional custom row/cell settings
+        // *********************************************
 
+        /* init setting */
+        $scope.initSetting = function () {
+
+            if ($scope.model.config.items.optionalSetting) {
+
+                gridService.getGridSettings().then(function (response) {
+
+                    if (response.data && response.data.length > 0) {
+
+                        $scope.setting = response.data[0];
+
+                        // Load dependencies and register row setting controller
+                        if ($scope.setting.dependencies) {
+                            assetsService.load($scope.setting.dependencies).then(function () {
+                                if ($scope.setting.rowSetting && $scope.setting.rowSetting.controller) {
+                                    var rowSettingController = eval($scope.setting.rowSetting.controller)
+                                    if (rowSettingController) {
+                                        app.controllerProvider.register($scope.setting.rowSetting.controller, rowSettingController);
+                                    }
+                                }
+                                if ($scope.setting.controlSetting && $scope.setting.controlSetting.controller) {
+                                    var controlSettingController = eval($scope.setting.controlSetting.controller)
+                                    if (controlSettingController) {
+                                        app.controllerProvider.register($scope.setting.controlSetting.controller, controlSettingController);
+                                    }
+                                }
+                            });
+                        }
+
+                        // Load assets
+                        if ($scope.setting.assets) {
+                            assetsService.loadCss($scope.setting.assets);
+                        }
+
+                    }
+                })
+
+            }
+
+        }
+
+        /* Open optional row setting panel */
+        $scope.openSetting = function (item) {
+            if ($scope.setting && $scope.setting.rowSetting) {
+                var dialog = dialogService.open({
+                    template: $scope.setting.rowSetting.view,
+                    show: true,
+                    dialogData: item.setting ? item.setting : undefined,
+                    callback: function (data) {
+                        item.setting = data ? data : undefined;
+                    }
+                });
+            }
+        }
+
+        /* Optional style that can be added to the item by setting.styles */
+        $scope.setSettingStyles = function (item) {
+            if (item.setting && item.setting.styles) {
+                return item.setting.styles;
+            }
+        }
+
+        /* Optional classes that can be added to the item by setting.classes */
+        $scope.setSettingClasses = function (item) {
+            if (item.setting && item.setting.classes) {
+                return item.setting.classes;
+            }
+        }
 
         // *********************************************
         // Init control
@@ -501,9 +582,11 @@ angular.module("umbraco")
             }
         };
 
-
         gridService.getGridEditors().then(function(response){
             $scope.availableEditors = response.data;
+
+            // Init optional row setting
+            $scope.initSetting();
 
             $scope.contentReady = true;
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -40,10 +40,11 @@
 
                     <!-- for each row in template section -->
                     <div ng-repeat="row in section.rows"
-                         class="usky-row"
+                         class="usky-row {{setSettingClasses(row)}}"
                          ng-mouseover="setCurrentRow(row)"
                          ng-mouseleave="disableCurrentRow()"
-                         ng-class="{'selectedControl':currentRow == row && currentControl === null}">
+                         ng-class="{'selectedControl':currentRow == row && currentControl === null}"
+                         ng-style="setSettingStyles(row)">
 
                         <!-- Row tool -->
                         <div class="row-tools" ng-animate="'fade'" ng-if="currentRow == row && currentControl === null">
@@ -71,11 +72,21 @@
                                     <i class="icon icon-navigation"></i>
                                 </div>
                             </div>
+
+                            <div ng-if="setting && setting.rowSetting" class="cell-tools-setting">
+                                <div class="iconBox"
+                                     ng-click="openSetting(row)"
+                                     ng-mouseover="setCurrentSettingRow(row)"
+                                     ng-mouseleave="disableCurrentSettingRow(row)">
+                                    <i class="icon icon-settings"></i>
+                                </div>
+                            </div>
+
                         </div>
 
                         <!-- row container -->
                         <div class="{{row.cssClass}} mainContainer usky-row-inner"
-                             ng-class="{last:$last,first:$first,warnhighlight:currentRemoveRow == row, infohighlight:currentMovedRow == row}">
+                             ng-class="{last:$last,first:$first,warnhighlight:currentRemoveRow == row, infohighlight:currentMovedRow == row || currentSettingRow == row}">
                             <div class="mainTb">
                                 <div class="tb">
                                     <div class="tr">
@@ -137,7 +148,8 @@
                                                  ng-mouseover="setCurrentControl(control)"
                                                  ng-mouseleave="disableCurrentControl(control)"
                                                  ng-animate="'fade'"
-                                                 class="usky-control">
+                                                 class="usky-control {{setSettingClasses(control)}}"
+                                                 ng-style="setSettingStyles(control)">
 
                                                 <!-- Filled cell tools -->
                                                 <div class="cell-tools"
@@ -169,10 +181,20 @@
                                                         </div>
                                                     </div>
 
+                                                    <!-- setting cell -->
+                                                    <div ng-if="setting && setting.controlSetting" class="cell-tools-setting">
+                                                        <div class="iconBox"
+                                                             ng-click="openSetting(control)"
+                                                             ng-mouseover="setCurrentSettingControl(control)"
+                                                             ng-mouseleave="disableCurrentSettingControl(control)">
+                                                            <i class="icon icon-settings"></i>
+                                                        </div>
+                                                    </div>
+
                                                 </div>
 
                                                 <div class="usky-control-inner" ng-class="{last:$last,
-                                                               infohighlight:currentMovedControl == control,
+                                                               infohighlight:currentMovedControl == control || currentSettingControl == control,
                                                                warnhighlight:currentRemoveControl == control,
                                                                selectedControl:currentControl == control}">
                                                     <!-- Redering the editor for specific control -->

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
@@ -301,4 +301,9 @@
                 <input type="text" class="" ng-model="model.value.columns" />
         </umb-control-group>
     </div>
+    <div style="max-width: 600px">
+        <umb-control-group label="Optional Settings" hide-label="false" description="Allow custom row/control settings. Configuration has to be placed in /config/grid.settings.config">
+            <input type="checkbox" class="" ng-model="model.value.optionalSetting" />
+        </umb-control-group>
+    </div>
 </div>


### PR DESCRIPTION
Basically I added an optional stylesheet link into the grid prevalues that can be used to improve the macros' display into the grid. This way, the editor can have a nicer preview of the macro and its content.
![capture2](https://cloud.githubusercontent.com/assets/1587387/4865328/448de484-6123-11e4-8d4d-33fe594bed4a.PNG)
![capture](https://cloud.githubusercontent.com/assets/1587387/4865335/51de46f6-6123-11e4-9a7e-0d83c1be68a0.PNG)
