### PR TITLE
Optional custom row/control settings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/grid/grid.rte.directive.js
@@ -127,6 +127,9 @@ angular.module("umbraco.directives")
                                     //force overflow to hidden to prevent no needed scroll
                                     editor.getBody().style.overflow = "hidden";
 
+                                    //force transparent background
+                                    editor.getBody().style.background = "transparent";
+
                                     $timeout(function(){
                                         if(scope.value === null){
                                             editor.focus();

--- a/src/Umbraco.Web.UI.Client/src/common/services/grid.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/grid.service.js
@@ -1,10 +1,15 @@
 angular.module('umbraco.services')
 	.factory('gridService', function ($http, $q){
 
-		var configPath = "../config/grid.editors.config.js";
-        var service = {
+	    var configPath = "../config/grid.editors.config.js";
+	    var configSettingsPath = "../config/grid.settings.config.js";
+
+		var service = {
 			getGridEditors: function () {
 				return $http.get(configPath);
+			},
+			getGridSettings: function () {
+			    return $http.get(configSettingsPath);
 			}
 		};
 

--- a/src/Umbraco.Web.UI.Client/src/less/gridview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/gridview.less
@@ -184,7 +184,7 @@
 
 
 .usky-grid  .cell-tools-remove {
-    display:inline-block;
+    display: inline-block;
     position: absolute;
     top: 0px;
     right: 5px;
@@ -198,7 +198,7 @@
 }
 
 .usky-grid  .cell-tools-move {
-    display:inline-block;
+    display: inline-block;
     position: absolute;
     top: 40px;
     right: 5px;
@@ -206,6 +206,13 @@
     cursor: move
 }
 
+.usky-grid  .cell-tools-setting { 
+    display: inline-block;
+    position: absolute;
+    top: 80px;
+    right: 5px;
+    z-index: 500;
+}
 
 
 // CONTROL
@@ -255,8 +262,9 @@
 // CONTROL PLACEHOLDER
 // -------------------------
 .usky-grid  .usky-control-placeholder {
-    min-height: 50px;
+    padding-top: 20px !important;
     position: relative;
+    min-height: 78px;
     text-align: center;
     text-align: -moz-center;
     cursor: text;
@@ -285,7 +293,7 @@
     padding: 20px;
     padding-bottom: 30px;
     position: relative;
-    background-color: white;
+    background-color: rgba(255, 255, 255, 0.2);
     border: 4px dashed @grayLight;
     text-align: center;
     text-align: -moz-center;

--- a/src/Umbraco.Web.UI.Client/src/routes.js
+++ b/src/Umbraco.Web.UI.Client/src/routes.js
@@ -170,4 +170,6 @@ app.config(function ($routeProvider) {
 
         //$locationProvider.html5Mode(false).hashPrefix('!'); //turn html5 mode off
         // $locationProvider.html5Mode(true);         //turn html5 mode on
-});
+    }).config(function($controllerProvider) {
+        app.controllerProvider = $controllerProvider;
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -40,10 +40,11 @@
 
                     <!-- for each row in template section -->
                     <div ng-repeat="row in section.rows"
-                         class="usky-row"
+                         class="usky-row {{setSettingClasses(row)}}"
                          ng-mouseover="setCurrentRow(row)"
                          ng-mouseleave="disableCurrentRow()"
-                         ng-class="{'selectedControl':currentRow == row && currentControl === null}">
+                         ng-class="{'selectedControl':currentRow == row && currentControl === null}"
+                         ng-style="setSettingStyles(row)">
 
                         <!-- Row tool -->
                         <div class="row-tools" ng-animate="'fade'" ng-if="currentRow == row && currentControl === null">
@@ -71,11 +72,21 @@
                                     <i class="icon icon-navigation"></i>
                                 </div>
                             </div>
+
+                            <div ng-if="setting && setting.rowSetting" class="cell-tools-setting">
+                                <div class="iconBox"
+                                     ng-click="openSetting(row)"
+                                     ng-mouseover="setCurrentSettingRow(row)"
+                                     ng-mouseleave="disableCurrentSettingRow(row)">
+                                    <i class="icon icon-settings"></i>
+                                </div>
+                            </div>
+
                         </div>
 
                         <!-- row container -->
                         <div class="{{row.cssClass}} mainContainer usky-row-inner"
-                             ng-class="{last:$last,first:$first,warnhighlight:currentRemoveRow == row, infohighlight:currentMovedRow == row}">
+                             ng-class="{last:$last,first:$first,warnhighlight:currentRemoveRow == row, infohighlight:currentMovedRow == row || currentSettingRow == row}">
                             <div class="mainTb">
                                 <div class="tb">
                                     <div class="tr">
@@ -137,7 +148,8 @@
                                                  ng-mouseover="setCurrentControl(control)"
                                                  ng-mouseleave="disableCurrentControl(control)"
                                                  ng-animate="'fade'"
-                                                 class="usky-control">
+                                                 class="usky-control {{setSettingClasses(control)}}"
+                                                 ng-style="setSettingStyles(control)">
 
                                                 <!-- Filled cell tools -->
                                                 <div class="cell-tools"
@@ -169,10 +181,20 @@
                                                         </div>
                                                     </div>
 
+                                                    <!-- setting cell -->
+                                                    <div ng-if="setting && setting.controlSetting" class="cell-tools-setting">
+                                                        <div class="iconBox"
+                                                             ng-click="openSetting(control)"
+                                                             ng-mouseover="setCurrentSettingControl(control)"
+                                                             ng-mouseleave="disableCurrentSettingControl(control)">
+                                                            <i class="icon icon-settings"></i>
+                                                        </div>
+                                                    </div>
+
                                                 </div>
 
                                                 <div class="usky-control-inner" ng-class="{last:$last,
-                                                               infohighlight:currentMovedControl == control,
+                                                               infohighlight:currentMovedControl == control || currentSettingControl == control,
                                                                warnhighlight:currentRemoveControl == control,
                                                                selectedControl:currentControl == control}">
                                                     <!-- Redering the editor for specific control -->

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
@@ -301,4 +301,9 @@
                 <input type="text" class="" ng-model="model.value.columns" />
         </umb-control-group>
     </div>
+    <div style="max-width: 600px">
+        <umb-control-group label="Optional Settings" hide-label="false" description="Allow custom row/control settings. Configuration has to be placed in /config/grid.settings.config">
+            <input type="checkbox" class="" ng-model="model.value.optionalSetting" />
+        </umb-control-group>
+    </div>
 </div>


### PR DESCRIPTION
This pull request is a new feature for the Grid that allows it to be extended, adding custom settings for rows and controls.

How it works:
First, the user has to enable the option "Optional Settings" in the grid prevalues and then he has to define into the file grid.settings.config.js the paths of the views and controllers to be used as settings:

```
[{
    "rowSetting":{
        "view": "/scripts/gridRowSetting.html",
        "controller": "gridRowSettingController"
    },
    "controlSetting": {
        "view": "/scripts/gridControlSetting.html",
        "controller": "gridControlSettingController"
    },
    "assets": ["/css/gridSettingStyle.css"],
    "dependencies": ["/scripts/gridSettingController.js"]
}]
```

A new setting button will appear under the row/control move button. This button opens the Umbraco right panel with the setting view defined before. The values returned by this setting will be included into the row data (the setting object).

![1](https://cloud.githubusercontent.com/assets/1587387/4886218/827f6642-637a-11e4-9863-56af19d7f6ed.png)

![2](https://cloud.githubusercontent.com/assets/1587387/4886241/b4c6caaa-637a-11e4-90d4-e51005ca0c8d.png)

Comment: Maybe, it will be cleaner to put together all the grid config into a unique file: grid.settings.config.js and grid.editor.config.js
