### PR TITLE
U4-5774: Add format parameter to GetCropUrl

### DIFF
--- a/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
@@ -226,7 +226,7 @@ namespace Umbraco.Web
             int? height = null,
             string imageCropperValue = null,
             string cropAlias = null,
-            string format = "jpg",
+            string format = null,
             int? quality = null,
             ImageCropMode? imageCropMode = null,
             ImageCropAnchor? imageCropAnchor = null,


### PR DESCRIPTION
This adds a `format` parameter to GetCropUrl to allow for changing the format. Photographs are by far the most frequent use case for the Image Cropper and those are much better compressed in JPEG.

**UPDATE**: I have revised this PR to provide no default value for the parameter and instead pull the image format from the umbracoExtension property when available. If it isn't, the existing behavior is used instead.

As the `format` parameter is optional, it is API compatible with v. 7.1.
This does not add a setting to change the default format, although that would probably be a good feature.
