### PR TITLE
Fix to :

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/developer/Packages/proxy.htm
+++ b/src/Umbraco.Web.UI/umbraco/developer/Packages/proxy.htm
@@ -7,15 +7,16 @@
 
     <script type="text/javascript">
         
-        //This is a genius way of parsing a uri
+        //This is a stupid way of parsing a uri
         //https://gist.github.com/jlong/2428561
 
         try {
+		
             var parser = document.createElement('a');
             parser.href = window.location.search.substring(1);
 
             // => "http:"
-            if (!parser.protocol || (parser.protocol.toLowerCase() != "http:" && parser.protocol.toLowerCase() != "https:")) {
+            if (parser.protocol && (parser.protocol.toLowerCase() != "http:" && parser.protocol.toLowerCase() != "https:")) {
                 throw "invalid protocol";
             };
 
@@ -27,13 +28,13 @@
             //parser.port;     // => "3000"
 
             // => "/pathname/"
-            if (!parser.pathname || ((parser.pathname.length - parser.pathname.indexOf("/developer/packages/installer.aspx")) != "/developer/packages/installer.aspx".length))
+            if (!parser.pathname || ((parser.pathname.length - parser.pathname.toLowerCase().indexOf("/developer/packages/installer.aspx")) != "/developer/packages/installer.aspx".length))
             {
                 throw "invalid pathname";
             }
             
             // => "?search=test"
-            if (!parser.search || parser.search.indexOf("?repoGuid") != 0) {
+            if (!parser.search || parser.search.toLowerCase().indexOf("?repoguid") != 0) {
                 throw "invalid search";
             }
             


### PR DESCRIPTION
http://issues.umbraco.org/issue/U4-5475
http://our.umbraco.org/forum/getting-started/installing-umbraco/56540-Could-not-install-packages
http://our.umbraco.org/forum/getting-started/installing-umbraco/57035-Installing-Package-Error-invalid-search
http://issues.umbraco.org/issue/U4-5571

Ecc...

This is only  a temporary workaround, because this is a stupid way of parsing a URI!!
1) It's not a real parsing, it uses browser DOM API with correlated compability problems (Invalid Protocol in Internet Explorer)
2) Check the validity of url clientside is useless...
