### PR TITLE
Fix for U4-5657 List view typo: "There are no items show in the list."

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -130,7 +130,7 @@
     <key alias="itemChanged">This item has been changed after publication</key>
     <key alias="itemNotPublished">This item is not published</key>
     <key alias="lastPublished">Last published</key>
-    <key alias="listViewNoItems" version="7.1.5">There are no items show in the list.</key>
+    <key alias="listViewNoItems" version="7.1.5">There are no items to show in the list.</key>
     <key alias="mediatype">Media Type</key>
     <key alias="mediaLinks">Link to media item(s)</key>
     <key alias="membergroup">Member Group</key>


### PR DESCRIPTION
Simple spelling mistake
