### PR TITLE
U4-4400 Make upload new media item button bit clearer

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.html
@@ -63,6 +63,7 @@ data-file-upload="options" data-file-upload-progress="" data-ng-class="{'fileupl
 				    	<span class="btn fileinput-button" ng-class="{disabled: disabled}">
 				    	    <i class="icon-page-up"></i>
 				    	    <input type="file" name="files[]" multiple ng-disabled="disabled">
+				    	    <localize key="general_upload">Upload</localize>
 				    	</span>
 	        </div>
 


### PR DESCRIPTION
I'm reusing the "general_upload": "Upload" from the file "localization.mocks.js".