### PR TITLE
U4-5851

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Web.PropertyEditors
             [PreValueField("startNode", "Node type", "treesource")]
             public string StartNode { get; set; }
             
-            [PreValueField("filter", "Allow items of type", "textstring", Description = "Seperate with comma")]
+            [PreValueField("filter", "Allow items of type", "textstring", Description = "Separate with comma")]
             public string Filter { get; set; }
 
             [PreValueField("minNumber", "Minimum number of items", "number")]


### PR DESCRIPTION
Typo of 'seperate' when creating new MNTP data type : changed to 'separate'
