### PR TITLE
Issue U4-5231 - Created an interface based on the LogService to replace LogHelper

### DIFF
--- a/src/Umbraco.Core/Logging/LogHelper.cs
+++ b/src/Umbraco.Core/Logging/LogHelper.cs
@@ -9,6 +9,7 @@ namespace Umbraco.Core.Logging
 	///<summary>
 	/// Used for logging
 	///</summary>
+    [Obsolete("Use UmbracoContext.Current.Application.Services.LoggingService instead")]
 	public static class LogHelper
 	{
 		///<summary>

--- a/src/Umbraco.Core/Services/ILoggingService.cs
+++ b/src/Umbraco.Core/Services/ILoggingService.cs
@@ -7,34 +7,17 @@ namespace Umbraco.Core.Services
     /// </summary>
     public interface ILoggingService
     {
-        void Error<T>(string message, Exception exception);
         void Error(Type callingType, string message, Exception exception);
         void Warn(Type callingType, string message, params Func<object>[] formatItems);
-        void Warn(Type callingType, string message, bool showHttpTrace, params Func<object>[] formatItems);
+       
         void WarnWithException(Type callingType, string message, Exception e, params Func<object>[] formatItems);
-        void WarnWithException(Type callingType, string message, bool showHttpTrace, Exception e, params Func<object>[] formatItems);
-
-        void Warn<T>(string message, params Func<object>[] formatItems);
-        void Warn<T>(string message, bool showHttpTrace, params Func<object>[] formatItems);
-        void WarnWithException<T>(string message, Exception e, params Func<object>[] formatItems);
-        void WarnWithException<T>(string message, bool showHttpTrace, Exception e, params Func<object>[] formatItems);
-
-        void Info<T>(Func<string> generateMessage);
 
         void Info(Type callingType, Func<string> generateMessage);
 
         void Info(Type type, string generateMessageFormat, params Func<object>[] formatItems);
 
-        void Info<T>(string generateMessageFormat, params Func<object>[] formatItems);
-
-        void Debug<T>(Func<string> generateMessage);
-
         void Debug(Type callingType, Func<string> generateMessage);
 
         void Debug(Type type, string generateMessageFormat, params Func<object>[] formatItems);
-
-        void Debug<T>(string generateMessageFormat, params Func<object>[] formatItems);
-
-        void Debug<T>(string generateMessageFormat, bool showHttpTrace, params Func<object>[] formatItems);
     }
 }

--- a/src/Umbraco.Core/Services/ILoggingService.cs
+++ b/src/Umbraco.Core/Services/ILoggingService.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Umbraco.Core.Services
+{
+    /// <summary>
+    /// Interface for logging service.
+    /// </summary>
+    public interface ILoggingService
+    {
+        void Error<T>(string message, Exception exception);
+        void Error(Type callingType, string message, Exception exception);
+        void Warn(Type callingType, string message, params Func<object>[] formatItems);
+        void Warn(Type callingType, string message, bool showHttpTrace, params Func<object>[] formatItems);
+        void WarnWithException(Type callingType, string message, Exception e, params Func<object>[] formatItems);
+        void WarnWithException(Type callingType, string message, bool showHttpTrace, Exception e, params Func<object>[] formatItems);
+
+        void Warn<T>(string message, params Func<object>[] formatItems);
+        void Warn<T>(string message, bool showHttpTrace, params Func<object>[] formatItems);
+        void WarnWithException<T>(string message, Exception e, params Func<object>[] formatItems);
+        void WarnWithException<T>(string message, bool showHttpTrace, Exception e, params Func<object>[] formatItems);
+
+        void Info<T>(Func<string> generateMessage);
+
+        void Info(Type callingType, Func<string> generateMessage);
+
+        void Info(Type type, string generateMessageFormat, params Func<object>[] formatItems);
+
+        void Info<T>(string generateMessageFormat, params Func<object>[] formatItems);
+
+        void Debug<T>(Func<string> generateMessage);
+
+        void Debug(Type callingType, Func<string> generateMessage);
+
+        void Debug(Type type, string generateMessageFormat, params Func<object>[] formatItems);
+
+        void Debug<T>(string generateMessageFormat, params Func<object>[] formatItems);
+
+        void Debug<T>(string generateMessageFormat, bool showHttpTrace, params Func<object>[] formatItems);
+    }
+}

--- a/src/Umbraco.Core/Services/LoggingService.cs
+++ b/src/Umbraco.Core/Services/LoggingService.cs
@@ -1,0 +1,267 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Web;
+using log4net;
+
+namespace Umbraco.Core.Services
+{
+    ///<summary>
+	/// Used for logging
+	///</summary>
+    public class LoggingService : ILoggingService
+	{
+		///<summary>
+		/// Returns a logger for the type specified
+		///</summary>
+		///<typeparam name="T"></typeparam>
+		///<returns></returns>
+		internal ILog LoggerFor<T>()
+		{
+			return LogManager.GetLogger(typeof(T));
+		}
+
+		/// <summary>
+		/// Returns a logger for the object's type
+		/// </summary>
+		/// <param name="getTypeFromInstance"></param>
+		/// <returns></returns>
+		internal ILog LoggerFor(object getTypeFromInstance)
+		{
+			if (getTypeFromInstance == null) throw new ArgumentNullException("getTypeFromInstance");
+			
+			return LogManager.GetLogger(getTypeFromInstance.GetType());
+		}
+
+		/// <summary>
+		/// Useful if the logger itself is running on another thread
+		/// </summary>
+		/// <param name="generateMessageFormat"></param>
+		/// <returns></returns>
+		private string PrefixThreadId(string generateMessageFormat)
+		{
+			return "[Thread " + Thread.CurrentThread.ManagedThreadId + "] " + generateMessageFormat;
+		}
+
+		#region Error
+		/// <summary>
+		/// Adds an error log
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="message"></param>
+		/// <param name="exception"></param>
+		public void Error<T>(string message, Exception exception)
+		{
+			Error(typeof (T), message, exception);
+		}
+
+		public void Error(Type callingType, string message, Exception exception)
+		{
+			var logger = LogManager.GetLogger(callingType);
+			if (logger != null)
+				logger.Error(PrefixThreadId(message), exception);
+		}
+
+		#endregion
+
+		#region Warn		
+
+		public void Warn(Type callingType, string message, params Func<object>[] formatItems)
+		{
+			var logger = LogManager.GetLogger(callingType);
+			if (logger == null || !logger.IsWarnEnabled) return;
+			logger.WarnFormat(PrefixThreadId(message), formatItems.Select(x => x.Invoke()).ToArray());
+		}
+
+		public void Warn(Type callingType, string message, bool showHttpTrace, params Func<object>[] formatItems)
+		{
+			Mandate.ParameterNotNull(callingType, "callingType");
+			Mandate.ParameterNotNullOrEmpty(message, "message");
+
+			if (showHttpTrace && HttpContext.Current != null)
+			{
+				HttpContext.Current.Trace.Warn(callingType.Name, string.Format(message, formatItems.Select(x => x.Invoke()).ToArray()));
+			}	
+
+			var logger = LogManager.GetLogger(callingType);
+			if (logger == null || !logger.IsWarnEnabled) return;
+			logger.WarnFormat(PrefixThreadId(message), formatItems.Select(x => x.Invoke()).ToArray());
+
+		}
+
+		public void WarnWithException(Type callingType, string message, Exception e, params Func<object>[] formatItems)
+		{
+			WarnWithException(callingType, message, false, e, formatItems);
+		}
+
+		public void WarnWithException(Type callingType, string message, bool showHttpTrace, Exception e, params Func<object>[] formatItems)
+		{
+			Mandate.ParameterNotNull(e, "e");
+			Mandate.ParameterNotNull(callingType, "callingType");
+			Mandate.ParameterNotNullOrEmpty(message, "message");
+
+			if (showHttpTrace && HttpContext.Current != null)
+			{
+				HttpContext.Current.Trace.Warn(
+					callingType.Name,
+					string.Format(message, formatItems.Select(x => x.Invoke()).ToArray()), 
+					e);
+			}
+
+			var logger = LogManager.GetLogger(callingType);
+			if (logger == null || !logger.IsWarnEnabled) return;
+			var executedParams = formatItems.Select(x => x.Invoke()).ToArray();
+			logger.WarnFormat(PrefixThreadId(message) + ". Exception: " + e, executedParams);				
+		} 
+
+		/// <summary>
+		/// Adds a warn log
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="message"></param>
+		/// <param name="formatItems"></param>
+		public void Warn<T>(string message, params Func<object>[] formatItems)
+		{
+			Warn(typeof(T), message, formatItems);
+		}
+
+		public void Warn<T>(string message, bool showHttpTrace, params Func<object>[] formatItems)
+		{
+			Warn(typeof(T), message, showHttpTrace, formatItems);
+		}
+
+		public void WarnWithException<T>(string message, Exception e, params Func<object>[] formatItems)
+		{
+			WarnWithException(typeof(T), message, e, formatItems);
+		}
+		public void WarnWithException<T>(string message, bool showHttpTrace, Exception e, params Func<object>[] formatItems)
+		{
+			WarnWithException(typeof(T), message, showHttpTrace, e, formatItems);
+		} 
+
+		#endregion
+
+		#region Info
+		/// <summary>
+		/// Traces a message, only generating the message if tracing is actually enabled. Use this method to avoid calling any long-running methods such as "ToDebugString" if logging is disabled.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="generateMessage">The delegate to generate a message.</param>
+		/// <remarks></remarks>
+		public void Info<T>(Func<string> generateMessage)
+		{
+			Info(typeof(T), generateMessage);
+		}
+
+		/// <summary>
+		/// Traces if tracing is enabled.
+		/// </summary>
+		/// <param name="callingType"></param>
+		/// <param name="generateMessage"></param>
+		public void Info(Type callingType, Func<string> generateMessage)
+		{
+			var logger = LogManager.GetLogger(callingType);
+			if (logger == null || !logger.IsInfoEnabled) return;
+			logger.Info(PrefixThreadId(generateMessage.Invoke()));
+		}
+
+		/// <summary>
+		/// Traces if tracing is enabled.
+		/// </summary>
+		/// <param name="type">The type for the logging namespace.</param>
+		/// <param name="generateMessageFormat">The message format.</param>
+		/// <param name="formatItems">The format items.</param>
+		public void Info(Type type, string generateMessageFormat, params Func<object>[] formatItems)
+		{
+			var logger = LogManager.GetLogger(type);
+			if (logger == null || !logger.IsInfoEnabled) return;
+			var executedParams = formatItems.Select(x => x.Invoke()).ToArray();
+			logger.InfoFormat(PrefixThreadId(generateMessageFormat), executedParams);
+		}
+
+		/// <summary>
+		/// Traces a message, only generating the message if tracing is actually enabled. Use this method to avoid calling any long-running methods such as "ToDebugString" if logging is disabled.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="generateMessageFormat">The generate message format.</param>
+		/// <param name="formatItems">The format items.</param>
+		/// <remarks></remarks>
+		public void Info<T>(string generateMessageFormat, params Func<object>[] formatItems)
+		{
+			Info(typeof(T), generateMessageFormat, formatItems);
+		} 
+		#endregion
+
+		#region Debug
+		/// <summary>
+		/// Debugs a message, only generating the message if tracing is actually enabled. Use this method to avoid calling any long-running methods such as "ToDebugString" if logging is disabled.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="generateMessage">The delegate to generate a message.</param>
+		/// <remarks></remarks>
+		public void Debug<T>(Func<string> generateMessage)
+		{
+			Debug(typeof(T), generateMessage);
+		}
+
+		/// <summary>
+		/// Debugs if tracing is enabled.
+		/// </summary>
+		/// <param name="callingType"></param>
+		/// <param name="generateMessage"></param>
+		public void Debug(Type callingType, Func<string> generateMessage)
+		{
+			var logger = LogManager.GetLogger(callingType);
+			if (logger == null || !logger.IsDebugEnabled) return;
+			logger.Debug(PrefixThreadId(generateMessage.Invoke()));
+		}
+
+		/// <summary>
+		/// Debugs if tracing is enabled.
+		/// </summary>
+		/// <param name="type">The type for the logging namespace.</param>
+		/// <param name="generateMessageFormat">The message format.</param>
+		/// <param name="formatItems">The format items.</param>
+		public void Debug(Type type, string generateMessageFormat, params Func<object>[] formatItems)
+		{
+			var logger = LogManager.GetLogger(type);
+			if (logger == null || !logger.IsDebugEnabled) return;
+			var executedParams = formatItems.Select(x => x.Invoke()).ToArray();
+			logger.DebugFormat(PrefixThreadId(generateMessageFormat), executedParams);
+		}
+
+		/// <summary>
+		/// Debugs a message, only generating the message if debug is actually enabled. Use this method to avoid calling any long-running methods such as "ToDebugString" if logging is disabled.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="generateMessageFormat">The generate message format.</param>
+		/// <param name="formatItems">The format items.</param>
+		/// <remarks></remarks>
+		public void Debug<T>(string generateMessageFormat, params Func<object>[] formatItems)
+		{
+			Debug(typeof(T), generateMessageFormat, formatItems);
+		}
+
+		/// <summary>
+		/// Debugs a message and also writes to the TraceContext specified, useful for when you would like the debug
+		/// output also displayed in the Http trace output.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="generateMessageFormat"></param>
+		/// <param name="showHttpTrace"></param>
+		/// <param name="formatItems"></param>
+		public void Debug<T>(string generateMessageFormat, bool showHttpTrace, params Func<object>[] formatItems)
+		{
+			if (showHttpTrace && HttpContext.Current != null)
+			{
+				HttpContext.Current.Trace.Write(
+					typeof(T).Name,
+					string.Format(generateMessageFormat, formatItems.Select(x => x()).ToArray()));	
+			}			
+			Debug(typeof(T), generateMessageFormat, formatItems);
+		}
+
+		#endregion
+		
+	}
+}

--- a/src/Umbraco.Core/Services/LoggingService.cs
+++ b/src/Umbraco.Core/Services/LoggingService.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Core.Services
 			return "[Thread " + Thread.CurrentThread.ManagedThreadId + "] " + generateMessageFormat;
 		}
 
-		#region Error
+
 		/// <summary>
 		/// Adds an error log
 		/// </summary>
@@ -62,9 +62,7 @@ namespace Umbraco.Core.Services
 				logger.Error(PrefixThreadId(message), exception);
 		}
 
-		#endregion
 
-		#region Warn		
 
 		public void Warn(Type callingType, string message, params Func<object>[] formatItems)
 		{
@@ -139,9 +137,9 @@ namespace Umbraco.Core.Services
 			WarnWithException(typeof(T), message, showHttpTrace, e, formatItems);
 		} 
 
-		#endregion
+		
 
-		#region Info
+
 		/// <summary>
 		/// Traces a message, only generating the message if tracing is actually enabled. Use this method to avoid calling any long-running methods such as "ToDebugString" if logging is disabled.
 		/// </summary>
@@ -190,9 +188,10 @@ namespace Umbraco.Core.Services
 		{
 			Info(typeof(T), generateMessageFormat, formatItems);
 		} 
-		#endregion
+	
 
-		#region Debug
+
+
 		/// <summary>
 		/// Debugs a message, only generating the message if tracing is actually enabled. Use this method to avoid calling any long-running methods such as "ToDebugString" if logging is disabled.
 		/// </summary>
@@ -261,7 +260,5 @@ namespace Umbraco.Core.Services
 			Debug(typeof(T), generateMessageFormat, formatItems);
 		}
 
-		#endregion
-		
 	}
 }

--- a/src/Umbraco.Core/Services/ServiceContext.cs
+++ b/src/Umbraco.Core/Services/ServiceContext.cs
@@ -1,4 +1,5 @@
 using System;
+using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.UnitOfWork;
 using Umbraco.Core.Publishing;
@@ -12,6 +13,7 @@ namespace Umbraco.Core.Services
     /// </summary>
     public class ServiceContext
     {
+        private Lazy<ILoggingService> _loggingService;
         private Lazy<ITagService> _tagService;
         private Lazy<IContentService> _contentService;
         private Lazy<IUserService> _userService;
@@ -52,6 +54,7 @@ namespace Umbraco.Core.Services
         /// <param name="treeService"></param>
         /// <param name="tagService"></param>
         /// <param name="notificationService"></param>
+        /// <param name="loggingService"></param>
         public ServiceContext(
             IContentService contentService, 
             IMediaService mediaService, 
@@ -69,7 +72,7 @@ namespace Umbraco.Core.Services
             ISectionService sectionService,
             IApplicationTreeService treeService,
             ITagService tagService,
-            INotificationService notificationService)
+            INotificationService notificationService, ILoggingService loggingService)
         {
             _tagService = new Lazy<ITagService>(() => tagService);     
             _contentService = new Lazy<IContentService>(() => contentService);        
@@ -88,7 +91,7 @@ namespace Umbraco.Core.Services
             _memberService = new Lazy<IMemberService>(() => memberService);
             _userService = new Lazy<IUserService>(() => userService);
             _notificationService = new Lazy<INotificationService>(() => notificationService);
-
+            _loggingService = new Lazy<ILoggingService>(() => loggingService);
         }
 
         /// <summary>
@@ -174,6 +177,10 @@ namespace Umbraco.Core.Services
                 _tagService = new Lazy<ITagService>(() => new TagService(provider, repositoryFactory.Value));
             if (_memberGroupService == null)
                 _memberGroupService = new Lazy<IMemberGroupService>(() => new MemberGroupService(provider, repositoryFactory.Value));
+
+
+            if (_loggingService== null)
+                _loggingService = new Lazy<ILoggingService>(() => new LoggingService());
             
         }
 
@@ -328,6 +335,13 @@ namespace Umbraco.Core.Services
         {
             get { return _memberGroupService.Value; }
         }
-        
+
+        /// <summary>
+        /// Gets the LoggingService
+        /// </summary>
+        public ILoggingService LoggingService
+        {
+            get { return _loggingService.Value; }
+        }
     }
 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -106,7 +106,7 @@
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.30506.0\lib\net40\System.Web.Razor.dll</HintPath>
-    </Reference>    
+    </Reference>
     <Reference Include="System.Web.Services, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
@@ -315,6 +315,8 @@
     <Compile Include="IDisposeOnRequestEnd.cs" />
     <Compile Include="IO\ResizedImage.cs" />
     <Compile Include="IO\UmbracoMediaFile.cs" />
+    <Compile Include="Services\ILoggingService.cs" />
+    <Compile Include="Services\LoggingService.cs" />
     <Compile Include="Macros\XsltExtension.cs" />
     <Compile Include="Macros\XsltExtensionAttribute.cs" />
     <Compile Include="Macros\XsltExtensionsResolver.cs" />

--- a/src/Umbraco.Tests/MockTests.cs
+++ b/src/Umbraco.Tests/MockTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Web;
 using NUnit.Framework;
 using Umbraco.Core;
+using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.UnitOfWork;
 using Umbraco.Core.Services;
@@ -56,7 +57,7 @@ namespace Umbraco.Tests
             new Mock<ISectionService>().Object,
                 new Mock<IApplicationTreeService>().Object,
                 new Mock<ITagService>().Object,
-                new Mock<INotificationService>().Object);
+                new Mock<INotificationService>().Object, new Mock<ILoggingService>().Object);
             Assert.Pass();
         }
 
@@ -101,7 +102,7 @@ namespace Umbraco.Tests
                     new Mock<ISectionService>().Object,
                     new Mock<IApplicationTreeService>().Object,
                     new Mock<ITagService>().Object,
-                    new Mock<INotificationService>().Object),
+                    new Mock<INotificationService>().Object, new Mock<ILoggingService>().Object),
                 CacheHelper.CreateDisabledCacheHelper());
             
             Assert.Pass();


### PR DESCRIPTION
Created an interface based on the LogHelper, and created a service, exposed through Application.Services. Made LogHelper obsolete.

http://issues.umbraco.org/issue/U4-5231

Assisted by @cloud46limited

