### PR TITLE
If no doctypes exist then hide Master Doc Type dropdown

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/create/nodeType.ascx
+++ b/src/Umbraco.Web.UI/umbraco/create/nodeType.ascx
@@ -2,7 +2,7 @@
 <%@ Register TagPrefix="cc1" Namespace="umbraco.uicontrols" Assembly="controls" %>
 
 <cc1:Pane runat="server">
-    <cc1:PropertyPanel runat="server" text="Master Document Type">
+    <cc1:PropertyPanel runat="server" text="Master Document Type" ID="pp_mastertypes">
         <asp:ListBox id="masterType" Runat="server" cssClass="bigInput input-large-type input-block-level" Rows="1" SelectionMode="Single"></asp:ListBox>
         <asp:Literal ID="masterTypePreDefined" runat="server" Visible="false"></asp:Literal>
     </cc1:PropertyPanel>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/nodeType.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/nodeType.ascx.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using Umbraco.Core;
 using Umbraco.Web.UI;
 using Umbraco.Web;
@@ -38,6 +39,11 @@ namespace umbraco.cms.presentation.create.controls
                         //                    if (dt.MasterContentType == 0)
                         masterType.Items.Add(new ListItem(dt.Text, dt.Id.ToString(CultureInfo.InvariantCulture)));
                     }
+
+                    if (masterType.Items.Count == 1)
+                    {
+                        pp_mastertypes.Visible = false;
+                    }
                 }
                 else
                 {
@@ -70,6 +76,9 @@ namespace umbraco.cms.presentation.create.controls
 
                 // check master type
                 string masterTypeVal = String.IsNullOrEmpty(Request.GetItemAsString("nodeId")) || Request.GetItemAsString("nodeId") == "init" ? masterType.SelectedValue : Request.GetItemAsString("nodeId");
+
+                // set master type to none if no master type was selected, or the drop down was hidden because there were no doctypes available
+			    masterTypeVal = string.IsNullOrEmpty(masterTypeVal) ? "0" : masterTypeVal;
 
                 var returnUrl = LegacyDialogHandler.Create(
                     new HttpContextWrapper(Context),

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/nodeType.ascx.designer.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/nodeType.ascx.designer.cs
@@ -38,6 +38,8 @@ namespace umbraco.cms.presentation.create.controls {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::umbraco.uicontrols.PropertyPanel pp_name;
+
+        protected global::umbraco.uicontrols.PropertyPanel pp_mastertypes;
         
         /// <summary>
         /// rename control.


### PR DESCRIPTION
Fixes U4-4347
