### PR TITLE
Fix for U4-5236

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -248,6 +248,10 @@ div.not-allowed > i.icon,div.not-allowed > a{
 	cursor: not-allowed;
 }
 
+// override small icon color
+.umb-tree li.current > div:before {
+	color: @blueLight;
+}
 
 // Tree context menu
 // -------------------------

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -23,6 +23,7 @@
 // -------------------------
 @blue:                  #2e8aea;
 @blueDark:              #0064cd;
+@blueLight:             #add8e6;
 @green:                 #46a546;
 @red:                   #9d261d;
 @yellow:                #ffc40d;


### PR DESCRIPTION
Changed the color of the small icon next to the tree icon, when the node
is selected. I have created a new variable for a lighter blue color. It
just need to have a bigger contrast to the color blue: #2e8aea.
And the current colors for turquoise (listview) and green (has
unpublished version) just haven't a big enough contrast to the blue
color. Maybe also for red too (but more clear). I just choose the
lightblue to make it consistency and a little difference to the white
tree icon, but #fff might also work or a very dark color.