### PR TITLE
Fix so Login screen now works correctly with Umbraco UI Localization settings.

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -480,14 +480,14 @@ However, Runway offers an easy foundation based on best practices to get you sta
     <key alias="renewSession">Renovar su sessión para guardar sus cambios</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Happy super Sunday</key>
-    <key alias="greeting1">Happy manic Monday </key>
-    <key alias="greeting2">Happy tubular Tuesday</key>
-    <key alias="greeting3">Happy wonderful Wednesday</key>
-    <key alias="greeting4">Happy thunderous Thursday</key>
-    <key alias="greeting5">Happy funky Friday</key>
-    <key alias="greeting6">Happy Caturday</key>
-    <key alias="instruction">Log in below</key>
+    <key alias="greeting0">Feliz Domingo</key>
+    <key alias="greeting1">Feliz Lunes</key>
+    <key alias="greeting2">Feliz Martes</key>
+    <key alias="greeting3">Feliz Miércoles</key>
+    <key alias="greeting4">Feliz Jueves</key>
+    <key alias="greeting5">Feliz Viernes</key>
+    <key alias="greeting6">Feliz Sábado</key>
+    <key alias="instruction">Introduce abajo</key>
     <key alias="timeout">Session timed out</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">umbraco.com</a></p> ]]></key>
     <key alias="topText">Bienvenido a umbraco, escribe tu nombre de usuario y clave en los campos de debajo:</key>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/js/language.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/js/language.aspx.cs
@@ -12,9 +12,18 @@ namespace umbraco.js
 		{
             Response.ContentType = "application/json";
             string lang = "en";
-            if(ValidateCurrentUser()){
+            var language = GlobalSettings.DefaultUILanguage;
+
+            if (language != string.Empty)
+            {
+                lang = language;
+            }
+
+            if (ValidateCurrentUser())
+            {
                 lang = UmbracoUser.Language;
             }
+
 
     	    XmlDocument all = ui.getLanguageFile(lang);
 


### PR DESCRIPTION
Fixed the issue that meant the Login screen was hard coded to always be in English, now it will respect the "umbracoDefaultUILanguage" setting in the web.config if set, this is now used by default unless a user has just logged out with a different language setting.

http://issues.umbraco.org/issue/U4-4585

Also added a couple more Spanish translations to the Language file.
