### PR TITLE
Fix for U4-5564

### DIFF
--- a/src/Umbraco.Core/Sync/ServerEnvironmentHelper.cs
+++ b/src/Umbraco.Core/Sync/ServerEnvironmentHelper.cs
@@ -24,8 +24,15 @@ namespace Umbraco.Core.Sync
 
             if (status == CurrentServerEnvironmentStatus.Single)
             {
-                //if it's a single install, then the base url has to be the first url registered
-                return string.Format("http://{0}", ApplicationContext.Current.OriginalRequestUrl);
+                //if it's a single install, then the base url has to be the first url registered. Use HTTP or HTTPS as appropriate.
+                if (GlobalSettings.UseSSL)
+                {
+                    return string.Format("https://{0}", ApplicationContext.Current.OriginalRequestUrl);
+                }
+                else
+                {
+                    return string.Format("http://{0}", ApplicationContext.Current.OriginalRequestUrl);
+                }
             }
 
             var servers = UmbracoSettings.DistributionServers;
@@ -33,8 +40,15 @@ namespace Umbraco.Core.Sync
             var nodes = servers.SelectNodes("./server");
             if (nodes == null)
             {
-                //cannot be determined, then the base url has to be the first url registered
-                return string.Format("http://{0}", ApplicationContext.Current.OriginalRequestUrl);
+                //cannot be determined, then the base url has to be the first url registered. Use HTTP or HTTPS as appropriate.
+                if (GlobalSettings.UseSSL)
+                {
+                    return string.Format("https://{0}", ApplicationContext.Current.OriginalRequestUrl);
+                }
+                else
+                {
+                    return string.Format("http://{0}", ApplicationContext.Current.OriginalRequestUrl);
+                }
             }
 
             var xmlNodes = nodes.Cast<XmlNode>().ToList();
@@ -61,8 +75,15 @@ namespace Umbraco.Core.Sync
                 }                
             }
 
-            //cannot be determined, then the base url has to be the first url registered
-            return string.Format("http://{0}", ApplicationContext.Current.OriginalRequestUrl);
+            //cannot be determined, then the base url has to be the first url registered. Use HTTP or HTTPS as appropriate.
+            if (GlobalSettings.UseSSL)
+            {
+                return string.Format("https://{0}", ApplicationContext.Current.OriginalRequestUrl);
+            }
+            else
+            {
+                return string.Format("http://{0}", ApplicationContext.Current.OriginalRequestUrl);
+            }
         }
 
         /// <summary>

--- a/src/Umbraco.Web/UmbracoModule.cs
+++ b/src/Umbraco.Web/UmbracoModule.cs
@@ -44,8 +44,16 @@ namespace Umbraco.Web
             //see: http://issues.umbraco.org/issue/U4-2059
             if (ApplicationContext.Current.OriginalRequestUrl.IsNullOrWhiteSpace())
             {
-                // the keepalive service will use that url
-                ApplicationContext.Current.OriginalRequestUrl = string.Format("{0}:{1}{2}", httpContext.Request.ServerVariables["SERVER_NAME"], httpContext.Request.ServerVariables["SERVER_PORT"], IOHelper.ResolveUrl(SystemDirectories.Umbraco));
+                // the keepalive service will use that url. Check if 443 should be used for HTTPS.
+                if (GlobalSettings.UseSSL)
+                {
+                    ApplicationContext.Current.OriginalRequestUrl = string.Format("{0}:{1}{2}", httpContext.Request.ServerVariables["SERVER_NAME"], 443, IOHelper.ResolveUrl(SystemDirectories.Umbraco));
+                }
+                else
+                {
+                    ApplicationContext.Current.OriginalRequestUrl = string.Format("{0}:{1}{2}", httpContext.Request.ServerVariables["SERVER_NAME"], httpContext.Request.ServerVariables["SERVER_PORT"], IOHelper.ResolveUrl(SystemDirectories.Umbraco));
+                }
+
                 LogHelper.Info<UmbracoModule>("Setting OriginalRequestUrl: " + ApplicationContext.Current.OriginalRequestUrl);
             }
 


### PR DESCRIPTION
If umbracoUseSSL is set to true, change makes GetCurrentServerUmbracoBaseUrl() return HTTPS URL. Also overrides ApplicationContext.Current.OriginalRequestUrl to use Port 443 instead of originally loaded port.
