### PR TITLE
Resolves bugs #U4-5944 & #U4-5568

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/util/fixnumber.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/util/fixnumber.directive.js
@@ -24,6 +24,7 @@ function fixNumber($parse) {
 
             //always return an int to the model
             ctrl.$parsers.push(function (value) {
+            	if (value === 0) return 0;
                 return parseFloat(value || '', 10);
             });
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -111,7 +111,7 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                                 if (img) {
 
                                     var data = {
-                                        alt: img.altText,
+                                        alt: img.altText || "",
                                         src: (img.url) ? img.url : "nothing.jpg",
                                         rel: img.id,
                                         id: '__mcenew'


### PR DESCRIPTION
This change resolves an issue with the media picker / RTE where an image inserted with no alt title provided is inserted with it equal to "undefined". 
See: http://issues.umbraco.org/issue/U4-5944

This change now also includes an update to the FixNumber directive to allow the number '0' to be entered. 
See: http://issues.umbraco.org/issue/U4-5568