### PR TITLE
Fix U4-4797 by removing font settings from generic TinyMCE CSS

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/tinymce/skins/umbraco/content.min.css
+++ b/src/Umbraco.Web.UI.Client/lib/tinymce/skins/umbraco/content.min.css
@@ -1,7 +1,4 @@
 body.mce-content-body {
-    background-color: #fff;
-    font-family: Verdana,Arial,Helvetica,sans-serif;
-    font-size: 11px;
     scrollbar-3dlight-color: #f0f0ee;
     scrollbar-arrow-color: #676662;
     scrollbar-base-color: #f0f0ee;
@@ -10,11 +7,6 @@ body.mce-content-body {
     scrollbar-highlight-color: #f0f0ee;
     scrollbar-shadow-color: #f0f0ee;
     scrollbar-track-color: #f5f5f5;
-}
-
-td, th {
-    font-family: Verdana,Arial,Helvetica,sans-serif;
-    font-size: 11px;
 }
 
 .mce-object {


### PR DESCRIPTION
Predefined background color and font settings can interfere with user CSS-specified settings.  It's best to remove them from here and let users specify these settings on their own in their own stylesheets.
