### PR TITLE
Fixed bug U4-6004, MediaService.GetMediaByPath now returns IMedia for paths containing 'x' and '_'

### DIFF
--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -567,7 +567,8 @@ namespace Umbraco.Core.Services
         public IMedia GetMediaByPath(string mediaPath)
         {
             var umbracoFileValue = mediaPath;
-            var isResized = mediaPath.Contains("_") && mediaPath.Contains("x");
+            const string Pattern = ".*[_][0-9]+[x][0-9]+[.].*";
+            var isResized = Regex.IsMatch(mediaPath, Pattern);
 
             // If the image has been resized we strip the "_403x328" of the original "/media/1024/koala_403x328.jpg" url.
             if (isResized)


### PR DESCRIPTION
Issue U4-6004 here: http://issues.umbraco.org/issue/U4-6004

MediaService.GetMediaByPath checks for paths containing both 'x' and '_', and strips the path at the last '_'. I guess this is so that the method returns the original image rather than the resized copy. However, if any other media is uploaded which contains these two characters, the method fails to retrieve that media.

The only changes I've made have been to this method, which now makes another sql call with the original path if the stripped-down path returns null.
