### PR TITLE
Resolved U4-5193 and U4-6051

### DIFF
--- a/src/umbraco.cms/businesslogic/web/Access.cs
+++ b/src/umbraco.cms/businesslogic/web/Access.cs
@@ -518,7 +518,7 @@ namespace umbraco.cms.businesslogic.web
 
                 if (member != null)
                 {
-                    foreach (string role in Roles.GetRolesForUser())
+                    foreach (string role in Roles.GetRolesForUser(member.UserName))
                     {
                         if (currentNode.SelectSingleNode("./group [@id='" + role + "']") != null)
                         {


### PR DESCRIPTION
Fixed: U4-5193 HasAccess override method name error  
Fixed: U4-6051 HasAccces method tests the roles of the wrong user  
