### PR TITLE
Fixed: U4-6054 "Unit test 'Umbraco.Tests.IO.AbstractFileSystemTests.Can_...

### DIFF
--- a/src/Umbraco.Core/IO/FileSystemExtensions.cs
+++ b/src/Umbraco.Core/IO/FileSystemExtensions.cs
@@ -7,13 +7,22 @@ namespace Umbraco.Core.IO
     {
 		public static long GetSize(this IFileSystem fs, string path)
         {
-            using (var s = fs.OpenFile(path))
-            {
-                var size = s.Length;
-                s.Close();
-
-                return size;    
-            }
+			 using (var ms = new MemoryStream())
+			 {
+				 using (var sr = new StreamReader(ms))
+				 {
+					 using (Stream file = fs.OpenFile(path))
+					 {
+						 var bytes = new byte[file.Length];
+						 file.Read(bytes, 0, (int) file.Length);
+						 ms.Write(bytes, 0, (int) file.Length);
+						 file.Close();
+						 ms.Position = 0;
+						 string str = sr.ReadToEnd();
+						 return str.Length;
+					 }
+				 }
+			 }
         }
 
         public static void CopyFile(this IFileSystem fs, string path, string newPath)


### PR DESCRIPTION
...Get_Size()' fails" by looking at the size of the string not the file which can vary - possibly dependent on encoding.

Fixed by making the FileSystemExtensions.GetSize() method parse the FileStream to a MemoryStream and finally a string, then returning the length of that.