### PR TITLE
[WIP] U4-5683 - Angular-ify the Dictionary tree & editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/dictionary.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/dictionary.resource.js
@@ -1,0 +1,58 @@
+function dictionaryResource($q, $http, umbDataFormatter, umbRequestHelper) {
+
+    return {
+
+        getById: function (id) {
+            return umbRequestHelper.resourcePromise(
+               $http.get(
+                   umbRequestHelper.getApiUrl(
+                       "dictionaryApiBaseUrl",
+                       "GetById",
+                       [{ id: id }])),
+               'Failed to retrieve data for dictionary item id ' + id);
+        },
+
+        getAll: function () {
+            return umbRequestHelper.resourcePromise(
+               $http.get(
+                   umbRequestHelper.getApiUrl(
+                       "dictionaryApiBaseUrl",
+                       "GetAll")),
+               'Failed to retrieve data');
+        },
+
+        getScaffold: function () {
+            return umbRequestHelper.resourcePromise(
+               $http.get(
+                   umbRequestHelper.getApiUrl(
+                       "dictionaryApiBaseUrl",
+                       "GetEmpty")),
+               'Failed to retrieve data for empty dictionary item');
+        },
+
+        deleteById: function (id) {
+            return umbRequestHelper.resourcePromise(
+                $http.post(
+                    umbRequestHelper.getApiUrl(
+                        "dictionaryApiBaseUrl",
+                        "DeleteById",
+                        [{ id: id }])),
+                'Failed to delete dictionary item ' + id);
+        },
+
+        save: function (dicationaryItem, translations, isNew) {
+
+            var saveModel = umbDataFormatter.formatDictionaryItemPostData(dicationaryItem, translations, "save" + (isNew ? "New" : ""));
+
+            return umbRequestHelper.resourcePromise(
+                 $http.post(
+                    umbRequestHelper.getApiUrl(
+                        "dictionaryApiBaseUrl",
+                        "PostSave"),
+                        saveModel),
+                'Failed to save data for dicationary item id ' + dicationaryItem.id);
+        }
+    };
+}
+
+angular.module('umbraco.resources').factory('dictionaryResource', dictionaryResource);

--- a/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
@@ -503,6 +503,25 @@ function umbDataFormatter() {
             return saveModel;
         },
 
+        /** formats the display model used to display the dictionary item to the model used to save the dictionary item */
+        formatDictionaryItemPostData: function (displayModel, translations, action) {
+            var saveModel = {
+                parentId: displayModel.parentId,
+                id: displayModel.id,
+                name: displayModel.name,
+                action: action,
+                translations: []
+            };
+            for (var i = 0; i < translations.length; i++) {
+
+                saveModel.translations.push({
+                    language: translations[i].language,
+                    value: translations[i].value
+                });
+            }
+            return saveModel;
+        },
+
         /** formats the display model used to display the member to the model used to save the member */
         formatMemberPostData: function(displayModel, action) {
             //this is basically the same as for media but we need to explicitly add the username,email, password to the save model

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.edit.controller.js
@@ -1,0 +1,95 @@
+/**
+ * @ngdoc controller
+ * @name Umbraco.Editors.Dictionary.EditController
+ * @function
+ * 
+ * @description
+ * The controller for the dictionary editor
+ */
+function DictionaryEditController($scope, $routeParams, appState, navigationService, dictionaryResource, serverValidationManager, contentEditingHelper, formHelper, editorState) {
+
+    //setup scope vars    
+    $scope.currentSection = appState.getSectionState("currentSection");
+    $scope.currentNode = null; //the editors affiliated node
+
+    if ($routeParams.create) {
+        //we are creating so get an empty dictionary item
+        dictionaryResource.getScaffold()
+            .then(function(data) {
+                $scope.loaded = true;
+                $scope.content = data;
+
+                console.info(data);
+
+                //set a shared state
+                editorState.set($scope.content);
+            });
+    }
+    else {
+        //we are editing so get the dictionary item from the server
+        dictionaryResource.getById($routeParams.id)
+            .then(function (data) {
+                $scope.loaded = true;
+                $scope.content = data;
+
+                console.info(data);
+                // TODO: [LK] Implement a callback (to populate the translations?)
+
+                //share state
+                editorState.set($scope.content);
+
+                //in one particular special case, after we've created a new item we redirect back to the edit
+                // route but there might be server validation errors in the collection which we need to display
+                // after the redirect, so we will bind all subscriptions which will show the server validation errors
+                // if there are any and then clear them so the collection no longer persists them.
+                serverValidationManager.executeAndClearAllSubscriptions();
+                
+                navigationService.syncTree({ tree: "dictionary", path: [String(data.id)] }).then(function (syncArgs) {
+                    $scope.currentNode = syncArgs.node;
+                });
+            });
+    }
+
+    $scope.save = function() {
+
+        if (formHelper.submitForm({ scope: $scope, statusMessage: "Saving..." })) {
+
+            dictionaryResource.save($scope.content, $scope.translations, $routeParams.create)
+                .then(function(data) {
+
+                    formHelper.resetForm({ scope: $scope, notifications: data.notifications });
+
+                    contentEditingHelper.handleSuccessfulSave({
+                        scope: $scope,
+                        savedContent: data,
+                        rebindCallback: function() {
+                             // TODO: [LK] Implement a callback (to populate the translations?)
+                        }
+                    });
+
+                    //share state
+                    editorState.set($scope.content);
+
+                    navigationService.syncTree({ tree: "dictionary", path: [String(data.id)], forceReload: true }).then(function (syncArgs) {
+                        $scope.currentNode = syncArgs.node;
+                    });
+                    
+                }, function(err) {
+
+                    //NOTE: in the case of data type values we are setting the orig/new props 
+                    // to be the same thing since that only really matters for content/media.
+                    contentEditingHelper.handleSaveError({
+                        redirectOnFailure: false,
+                        err: err
+                    });
+                    
+                    //share state
+                    editorState.set($scope.content);
+                });
+        }
+
+    };
+
+}
+
+angular.module("umbraco").controller("Umbraco.Editors.Dictionary.EditController", DictionaryEditController);

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.list.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.list.controller.js
@@ -1,0 +1,15 @@
+/**
+ * @ngdoc controller
+ * @name Umbraco.Editors.Dictionary.ListController
+ * @function
+ * 
+ * @description
+ * The controller for listing dictionary items
+ */
+function DictionaryListController($scope, localizationService) {
+
+	// do something
+
+}
+
+angular.module("umbraco").controller("Umbraco.Editors.Dictionary.ListController", DictionaryListController);

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/edit.html
@@ -1,0 +1,50 @@
+<form novalidate name="contentForm" 
+      ng-controller="Umbraco.Editors.Dictionary.EditController"
+      ng-show="loaded" 
+      ng-submit="save()"
+      val-form-manager>
+    <umb-panel>
+
+        <umb-header>
+
+            <div class="span7">
+                <umb-content-name
+                    placeholder="@placeholders_entername"
+                    ng-model="content.name"/>
+            </div>
+
+            <div class="span5">
+                <div class="btn-toolbar pull-right umb-btn-toolbar">
+                    <umb-options-menu ng-show="currentNode"
+                        current-node="currentNode"
+                        current-section="{{currentSection}}">
+                    </umb-options-menu>
+                </div>
+            </div>
+        </umb-header>
+        
+        <div class="umb-panel-body umb-scrollable row-fluid">
+            <div class="tab-content form-horizontal" style="padding-bottom: 90px">
+                <div class="umb-pane">
+
+
+					<p><localize key="dictionaryItem_description">description</localize></p>
+
+
+					<!--display the translations here-->
+
+
+                    <div class="umb-tab-buttons" detect-fold>
+                        <div class="btn-group">
+                            <button type="submit" data-hotkey="ctrl+s" class="btn btn-success">
+                                <localize key="buttons_save">Save</localize>
+                            </button>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+
+    </umb-panel>
+</form>

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
@@ -1,0 +1,14 @@
+<umb-panel ng-controller="Umbraco.Editors.Dictionary.ListController">
+	<umb-header>
+		<div class="umb-headline-editor-wrapper span12">
+			<h1><localize key="treeHeaders_dictionary">Dictionary</localize></h1>
+		</div>
+	</umb-header>
+	<umb-tab-view>
+		<umb-tab id="tabRecycleBin" rel="RecycleBin">
+			<umb-pane>
+				<h1>Hello World</h1>
+			</umb-pane>
+		</umb-tab>
+	</umb-tab-view>
+</umb-panel>

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -177,6 +177,10 @@ namespace Umbraco.Web.Editors
                                         controller => controller.GetDashboard(null))
                                 },
                                 {
+                                    "dictionaryApiBaseUrl", Url.GetUmbracoApiServiceBaseUrl<DictionaryController>(
+                                        controller => controller.GetById(0))
+                                },
+                                {
                                     "logApiBaseUrl", Url.GetUmbracoApiServiceBaseUrl<LogController>(
                                         controller => controller.GetEntityLog(0))
                                 },

--- a/src/Umbraco.Web/Editors/DictionaryController.cs
+++ b/src/Umbraco.Web/Editors/DictionaryController.cs
@@ -1,0 +1,93 @@
+﻿using System.Data;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using AutoMapper;
+using Umbraco.Core.Models;
+using Umbraco.Web.Models.ContentEditing;
+using Umbraco.Web.Mvc;
+using Umbraco.Web.WebApi.Filters;
+using Constants = Umbraco.Core.Constants;
+using Umbraco.Web.WebApi;
+using umbraco;
+using System.Collections.Generic;
+
+namespace Umbraco.Web.Editors
+{
+	/// <summary>
+	/// The API controller used for editing dictionary items
+	/// </summary>
+	[PluginController("UmbracoApi")]
+	[UmbracoTreeAuthorize(Constants.Trees.Dictionary)]
+	public class DictionaryController : UmbracoAuthorizedJsonController
+	{
+		[HttpDelete]
+		[HttpPost]
+		public HttpResponseMessage DeleteById(int id)
+		{
+			var foundType = Services.LocalizationService.GetDictionaryItemById(id);
+
+			if (foundType == null)
+			{
+				throw new HttpResponseException(HttpStatusCode.NotFound);
+			}
+
+			Services.LocalizationService.Delete(foundType, Security.CurrentUser.Id);
+
+			return Request.CreateResponse(HttpStatusCode.OK);
+		}
+
+		public IEnumerable<DictionaryItemDisplay> GetAll()
+		{
+			var dictionaryItems = Services.LocalizationService.GetRootDictionaryItems();
+
+			if (dictionaryItems == null)
+			{
+				throw new HttpResponseException(HttpStatusCode.NotFound);
+			}
+
+			return dictionaryItems
+				.Select(x => Mapper.Map<IDictionaryItem, DictionaryItemDisplay>(x));
+		}
+
+		public DictionaryItemDisplay GetById(int id)
+		{
+			var dictionaryItem = Services.LocalizationService.GetDictionaryItemById(id);
+
+			if (dictionaryItem == null)
+			{
+				throw new HttpResponseException(HttpStatusCode.NotFound);
+			}
+
+			return Mapper.Map<IDictionaryItem, DictionaryItemDisplay>(dictionaryItem);
+		}
+
+		public DictionaryItemDisplay GetEmpty()
+		{
+			var item = new DictionaryItem("");
+			return Mapper.Map<IDictionaryItem, DictionaryItemDisplay>(item);
+		}
+
+		public DictionaryItemDisplay PostSave(DictionaryItemSave dictionaryItem)
+		{
+			var currentValue = Services.LocalizationService.GetDictionaryItemById(dictionaryItem.PersistedDictionaryItem.Id);
+
+			try
+			{
+				Services.LocalizationService.Save(currentValue, Security.CurrentUser.Id);
+			}
+			catch (DuplicateNameException ex)
+			{
+				ModelState.AddModelError("Name", ex.Message);
+				throw new HttpResponseException(Request.CreateValidationErrorResponse(ModelState));
+			}
+
+			var display = Mapper.Map<IDictionaryItem, DictionaryItemDisplay>(dictionaryItem.PersistedDictionaryItem);
+
+			display.AddSuccessNotification(ui.Text("speechBubbles", "dictionaryItemSaved"), "");
+
+			return display;
+		}
+	}
+}

--- a/src/Umbraco.Web/Models/ContentEditing/DictionaryItemDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/DictionaryItemDisplay.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Umbraco.Web.Models.ContentEditing
+{
+	[DataContract(Name = "dictionaryItem", Namespace = "")]
+	public class DictionaryItemDisplay : EntityBasic, INotificationModel
+	{
+		public DictionaryItemDisplay()
+		{
+			Notifications = new List<Notification>();
+		}
+
+		[DataMember(Name = "parentGuid")]
+		public Guid ParentGuid { get; set; }
+
+		[DataMember(Name = "translations")]
+		public IEnumerable<DictionaryTranslationDisplay> Translations { get; set; }
+
+		[DataMember(Name = "notifications")]
+		public List<Notification> Notifications { get; private set; }
+	}
+}

--- a/src/Umbraco.Web/Models/ContentEditing/DictionaryItemSave.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/DictionaryItemSave.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Umbraco.Core.Models;
+
+namespace Umbraco.Web.Models.ContentEditing
+{
+	[DataContract(Name = "dictionaryItem", Namespace = "")]
+	public class DictionaryItemSave : EntityBasic
+	{
+		[DataMember(Name = "action", IsRequired = true)]
+		[Required]
+		public ContentSaveAction Action { get; set; }
+
+		[DataMember(Name = "parentId")]
+		public Guid ParentId { get; set; }
+
+		[DataMember(Name = "itemKey")]
+		public string ItemKey { get; set; }
+
+		[DataMember(Name = "translations")]
+		public IEnumerable<DictionaryTranslationDisplay> Translations { get; set; }
+
+		[JsonIgnore]
+		internal IDictionaryItem PersistedDictionaryItem { get; set; }
+	}
+}

--- a/src/Umbraco.Web/Models/ContentEditing/DictionaryTranslationDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/DictionaryTranslationDisplay.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.Serialization;
+
+namespace Umbraco.Web.Models.ContentEditing
+{
+	[DataContract(Name = "translation", Namespace = "")]
+	public class DictionaryTranslationDisplay
+	{
+		[DataMember(Name = "language", IsRequired = true)]
+		public string Language { get; set; }
+
+		[DataMember(Name = "value", IsRequired = true)]
+		public object Value { get; set; }
+	}
+}

--- a/src/Umbraco.Web/Models/Mapping/DictionaryModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/DictionaryModelMapper.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using AutoMapper;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.Mapping;
+using Umbraco.Core.Services;
+using Umbraco.Web.Models.ContentEditing;
+
+namespace Umbraco.Web.Models.Mapping
+{
+	internal class DictionaryModelMapper : MapperConfiguration
+	{
+		public override void ConfigureMappings(IConfiguration config, ApplicationContext applicationContext)
+		{
+			var lazyLocalizationService = new Lazy<ILocalizationService>(() => applicationContext.Services.LocalizationService);
+
+			config.CreateMap<IDictionaryItem, DictionaryItemDisplay>()
+				.ForMember(x => x.Name, expression => expression.MapFrom(definition => definition.ItemKey))
+				.ForMember(x => x.ParentGuid, expression => expression.MapFrom(definition => definition.ParentId))
+				.ForMember(x => x.ParentId, expression => expression.MapFrom(definition => -1))
+				.ForMember(x => x.Translations, expression => expression.MapFrom(definition => definition.Translations))
+				.ForMember(x => x.Notifications, expression => expression.Ignore())
+				.ForMember(x => x.Icon, expression => expression.Ignore())
+				.ForMember(x => x.Alias, expression => expression.Ignore());
+		}
+	}
+}

--- a/src/Umbraco.Web/Trees/DictionaryTreeController.cs
+++ b/src/Umbraco.Web/Trees/DictionaryTreeController.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Formatting;
+using umbraco;
+using umbraco.BusinessLogic.Actions;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Web.Models.Trees;
+using Umbraco.Web.Mvc;
+using Umbraco.Web.WebApi.Filters;
+using Constants = Umbraco.Core.Constants;
+
+namespace Umbraco.Web.Trees
+{
+	[UmbracoTreeAuthorize(Constants.Applications.Settings, Constants.Trees.Dictionary)]
+	[LegacyBaseTree(typeof(loadDictionary))]
+	[Tree(Constants.Applications.Settings, Constants.Trees.Dictionary, "Dictionary")]
+	[PluginController("UmbracoTrees")]
+	[CoreTree]
+	public class DictionaryTreeController : TreeController
+	{
+		protected override TreeNode CreateRootNode(FormDataCollection queryStrings)
+		{
+			var root = base.CreateRootNode(queryStrings);
+
+			root.RoutePath = string.Join("/", root.RoutePath, Constants.Trees.Dictionary, "list");
+
+			return root;
+		}
+
+		protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
+		{
+			var collection = new TreeNodeCollection();
+
+			collection.AddRange(
+				GetDictionaryItems(id)
+				.OrderBy(x => x.Id)
+				.Select(x => CreateTreeNode(id, queryStrings, x)));
+
+			return collection;
+		}
+
+		private IEnumerable<IDictionaryItem> GetDictionaryItems(string id)
+		{
+			int dictionaryId;
+			if (int.TryParse(id, out dictionaryId) && dictionaryId > Constants.System.Root)
+			{
+				var dictionaryItem = Services.LocalizationService.GetDictionaryItemById(dictionaryId);
+
+				if (dictionaryItem != null)
+					return Services.LocalizationService.GetDictionaryItemChildren(dictionaryItem.Key);
+			}
+
+			return Services.LocalizationService.GetRootDictionaryItems();
+		}
+
+		private TreeNode CreateTreeNode(string id, FormDataCollection queryStrings, IDictionaryItem dictionaryItem)
+		{
+			var hasChildren = Services.LocalizationService.GetDictionaryItemChildren(dictionaryItem.Key).Any();
+
+			var node = CreateTreeNode(
+				dictionaryItem.Id.ToInvariantString(),
+				id,
+				queryStrings,
+				dictionaryItem.ItemKey,
+				"icon-book-alt",
+				hasChildren);
+
+			return node;
+		}
+
+		protected override MenuItemCollection GetMenuForNode(string id, FormDataCollection queryStrings)
+		{
+			var menu = new MenuItemCollection();
+
+			menu.Items.Add<CreateChildEntity, ActionNew>(ui.Text("actions", ActionNew.Instance.Alias));
+
+			if (id != Constants.System.Root.ToInvariantString())
+			{
+				menu.Items.Add<ActionDelete>(ui.Text("actions", ActionDelete.Instance.Alias));
+			}
+
+			menu.Items.Add<RefreshNode, ActionRefresh>(ui.Text("actions", ActionRefresh.Instance.Alias), true);
+
+			return menu;
+		}
+	}
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -501,6 +501,7 @@
     <Compile Include="TagQuery.cs" />
     <Compile Include="Trees\CoreTreeAttribute.cs" />
     <Compile Include="Trees\DataTypeTreeController.cs" />
+    <Compile Include="Trees\DictionaryTreeController.cs" />
     <Compile Include="Trees\FileSystemTreeController.cs" />
     <Compile Include="Trees\LegacyBaseTreeAttribute.cs" />
     <Compile Include="Trees\MemberTreeController.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -304,6 +304,7 @@
     <Compile Include="Editors\DashboardSecurity.cs" />
     <Compile Include="Editors\DataTypeController.cs" />
     <Compile Include="Editors\DataTypeValidateAttribute.cs" />
+    <Compile Include="Editors\DictionaryController.cs" />
     <Compile Include="Editors\EntityControllerActionSelector.cs" />
     <Compile Include="Editors\EntityControllerConfigurationAttribute.cs" />
     <Compile Include="Editors\ImagesController.cs" />
@@ -311,6 +312,9 @@
     <Compile Include="Editors\CanvasDesignerController.cs" />
     <Compile Include="Editors\UserController.cs" />
     <Compile Include="GridTemplateExtensions.cs" />
+    <Compile Include="Models\ContentEditing\DictionaryItemDisplay.cs" />
+    <Compile Include="Models\ContentEditing\DictionaryItemSave.cs" />
+    <Compile Include="Models\ContentEditing\DictionaryTranslationDisplay.cs" />
     <Compile Include="Models\PackageInstallModel.cs" />
     <Compile Include="Models\ContentEditing\DataTypeBasic.cs" />
     <Compile Include="Models\ContentEditing\MemberBasic.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -315,6 +315,7 @@
     <Compile Include="Models\ContentEditing\DictionaryItemDisplay.cs" />
     <Compile Include="Models\ContentEditing\DictionaryItemSave.cs" />
     <Compile Include="Models\ContentEditing\DictionaryTranslationDisplay.cs" />
+    <Compile Include="Models\Mapping\DictionaryModelMapper.cs" />
     <Compile Include="Models\PackageInstallModel.cs" />
     <Compile Include="Models\ContentEditing\DataTypeBasic.cs" />
     <Compile Include="Models\ContentEditing\MemberBasic.cs" />

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadDictionary.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadDictionary.cs
@@ -29,7 +29,8 @@ using Umbraco.Core;
 
 namespace umbraco
 {
-    [Tree(Constants.Applications.Settings, Constants.Trees.Dictionary, "Dictionary", action: "openDictionary()", sortOrder: 3)]
+    [Obsolete("This is no longer used and will be removed from the codebase in the future")]
+    //[Tree(Constants.Applications.Settings, Constants.Trees.Dictionary, "Dictionary", action: "openDictionary()", sortOrder: 3)]
     public class loadDictionary : BaseTree
 	{
         public loadDictionary(string application) : base(application) { }


### PR DESCRIPTION
Closed PR #514, opened new PR as rebased on `master-v7` - as per new branching structure.

> _WORK IN PROGRESS_

Started work on migrating the legacy Dictionary tree and editor over to Angular.

I have opened this pull-request to start a dialogue with the core team about its development and progress.

_Task list:_
- [x] _Tree_ - Web API controller
- [x] _Tree_ - Angular resources
- [x] _Tree_ - Depreciate legacy tree
- [ ] _Editor_ - List view (Angular template + controller)
- [ ] _Editor_ - Edit view (Angular template + controller)
- [ ] _Editor_ - Model mapping (AutoMapper configuration)

[Ticket opened on issue tracker: #U4-5683](http://issues.umbraco.org/issue/U4-5683)
