### PR TITLE
ContentService - Replaced the hardcoded -1 and -20 values with Constants

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -407,7 +407,7 @@ namespace Umbraco.Core.Services
         {
             using (var repository = _repositoryFactory.CreateContentRepository(_uowProvider.GetUnitOfWork()))
             {
-                var query = Query<IContent>.Builder.Where(x => x.Level == level && !x.Path.StartsWith("-20"));
+                var query = Query<IContent>.Builder.Where(x => x.Level == level && !x.Path.StartsWith(Constants.System.RecycleBinContent.ToInvariantString()));
                 var contents = repository.GetByQuery(query);
 
                 return contents;
@@ -460,7 +460,7 @@ namespace Umbraco.Core.Services
         /// <returns>An Enumerable list of <see cref="IContent"/> objects</returns>
         public IEnumerable<IContent> GetAncestors(IContent content)
         {
-            var ids = content.Path.Split(',').Where(x => x != "-1" && x != content.Id.ToString(CultureInfo.InvariantCulture)).Select(int.Parse).ToArray();
+            var ids = content.Path.Split(',').Where(x => x != Constants.System.Root.ToInvariantString() && x != content.Id.ToString(CultureInfo.InvariantCulture)).Select(int.Parse).ToArray();
             if (ids.Any() == false)
                 return new List<IContent>();
 
@@ -506,8 +506,8 @@ namespace Umbraco.Core.Services
             {
                 
                 var query = Query<IContent>.Builder;
-                //if the id is -1, then just get all
-                if (id != -1)
+                //if the id is System Root, then just get all
+                if (id != Constants.System.Root)
                 {
                     query.Where(x => x.ParentId == id);
                 }
@@ -536,8 +536,8 @@ namespace Umbraco.Core.Services
             {
 
                 var query = Query<IContent>.Builder;
-                //if the id is -1, then just get all
-                if (id != -1)
+                //if the id is System Root, then just get all
+                if (id != Constants.System.Root)
                 {
                     query.Where(x => x.Path.SqlContains(string.Format(",{0},", id), TextColumnType.NVarchar));
                 }
@@ -614,7 +614,7 @@ namespace Umbraco.Core.Services
         /// <returns>Parent <see cref="IContent"/> object</returns>
         public IContent GetParent(IContent content)
         {
-            if (content.ParentId == -1 || content.ParentId == -20)
+            if (content.ParentId == Constants.System.Root || content.ParentId == Constants.System.RecycleBinContent)
                 return null;
 
             return GetById(content.ParentId);
@@ -639,7 +639,7 @@ namespace Umbraco.Core.Services
         {
             using (var repository = _repositoryFactory.CreateContentRepository(_uowProvider.GetUnitOfWork()))
             {
-                var query = Query<IContent>.Builder.Where(x => x.ParentId == -1);
+                var query = Query<IContent>.Builder.Where(x => x.ParentId == Constants.System.Root);
                 var contents = repository.GetByQuery(query);
 
                 return contents;
@@ -697,7 +697,7 @@ namespace Umbraco.Core.Services
         {
             using (var repository = _repositoryFactory.CreateContentRepository(_uowProvider.GetUnitOfWork()))
             {
-                var query = Query<IContent>.Builder.Where(x => x.Path.Contains("-20"));
+                var query = Query<IContent>.Builder.Where(x => x.Path.Contains(Constants.System.RecycleBinContent.ToInvariantString()));
                 var contents = repository.GetByQuery(query);
 
                 return contents;
@@ -960,7 +960,7 @@ namespace Umbraco.Core.Services
                 if (raiseEvents)
                     Saved.RaiseEvent(new SaveEventArgs<IContent>(asArray, false), this);
 
-                Audit.Add(AuditTypes.Save, "Bulk Save content performed by user", userId == -1 ? 0 : userId, -1);
+                Audit.Add(AuditTypes.Save, "Bulk Save content performed by user", userId == -1 ? 0 : userId, Constants.System.Root);
             }
         }
 
@@ -1004,7 +1004,7 @@ namespace Umbraco.Core.Services
 
                 Audit.Add(AuditTypes.Delete,
                           string.Format("Delete Content of Type {0} performed by user", contentTypeId),
-                          userId, -1);
+                          userId, Constants.System.Root);
             }
         }
 
@@ -1075,7 +1075,7 @@ namespace Umbraco.Core.Services
 
             DeletedVersions.RaiseEvent(new DeleteRevisionsEventArgs(id, false, dateToRetain: versionDate), this);
 
-            Audit.Add(AuditTypes.Delete, "Delete Content by version date performed by user", userId, -1);
+            Audit.Add(AuditTypes.Delete, "Delete Content by version date performed by user", userId, Constants.System.Root);
         }
 
         /// <summary>
@@ -1108,7 +1108,7 @@ namespace Umbraco.Core.Services
 
                 DeletedVersions.RaiseEvent(new DeleteRevisionsEventArgs(id, false, specificVersion: versionId), this);
 
-                Audit.Add(AuditTypes.Delete, "Delete Content by version performed by user", userId, -1);
+                Audit.Add(AuditTypes.Delete, "Delete Content by version performed by user", userId, Constants.System.Root);
             }
         }
 
@@ -1191,7 +1191,7 @@ namespace Umbraco.Core.Services
             using (new WriteLock(Locker))
             {
                 //This ensures that the correct method is called if this method is used to Move to recycle bin.
-                if (parentId == -20)
+                if (parentId == Constants.System.RecycleBinContent)
                 {
                     MoveToRecycleBin(content, userId);
                     return;
@@ -1251,7 +1251,7 @@ namespace Umbraco.Core.Services
 
                 
             }
-            Audit.Add(AuditTypes.Delete, "Empty Content Recycle Bin performed by user", 0, -20);
+            Audit.Add(AuditTypes.Delete, "Empty Content Recycle Bin performed by user", 0, Constants.System.RecycleBinContent);
         }
 
         /// <summary>
@@ -1486,7 +1486,7 @@ namespace Umbraco.Core.Services
                     contentTypeIds: contentTypeIds.Length == 0 ? null : contentTypeIds);
             }
 
-            Audit.Add(AuditTypes.Publish, "ContentService.RebuildXmlStructures completed, the xml has been regenerated in the database", 0, -1);
+            Audit.Add(AuditTypes.Publish, "ContentService.RebuildXmlStructures completed, the xml has been regenerated in the database", 0, Constants.System.Root);
 
         }
 
@@ -1518,9 +1518,9 @@ namespace Umbraco.Core.Services
             moveInfo.Add(new MoveEventInfo<IContent>(content, content.Path, parentId));
 
             content.WriterId = userId;
-            if (parentId == -1)
+            if (parentId == Constants.System.Root)
             {
-                content.Path = string.Concat("-1,", content.Id);
+                content.Path = string.Concat(Constants.System.Root, ",", content.Id);
                 content.Level = 1;
             }
             else
@@ -1609,7 +1609,7 @@ namespace Umbraco.Core.Services
                 var result = new List<Attempt<PublishStatus>>();
 
                 //Check if parent is published (although not if its a root node) - if parent isn't published this Content cannot be published
-                if (content.ParentId != -1 && content.ParentId != -20 && IsPublishable(content) == false)
+                if (content.ParentId != Constants.System.Root && content.ParentId != Constants.System.RecycleBinContent && IsPublishable(content) == false)
                 {
                     LogHelper.Info<ContentService>(
                         string.Format(
@@ -1862,11 +1862,11 @@ namespace Umbraco.Core.Services
             foreach (var id in ids)
             {
                 //If Id equals that of the recycle bin we return false because nothing in the bin can be published
-                if (id == -20)
+                if (id == Constants.System.RecycleBinContent)
                     return false;
 
                 //We don't check the System Root, so just continue
-                if (id == -1) continue;
+                if (id == Constants.System.Root) continue;
 
                 //If the current id equals that of the passed in content and if current shouldn't be checked we skip it.
                 if (checkCurrent == false && id == content.Id) continue;
@@ -1883,7 +1883,7 @@ namespace Umbraco.Core.Services
         private PublishStatusType CheckAndLogIsPublishable(IContent content)
         {
             //Check if parent is published (although not if its a root node) - if parent isn't published this Content cannot be published
-            if (content.ParentId != -1 && content.ParentId != -20 && IsPublishable(content) == false)
+            if (content.ParentId != Constants.System.Root && content.ParentId != Constants.System.RecycleBinContent && IsPublishable(content) == false)
             {
                 LogHelper.Info<ContentService>(
                     string.Format(


### PR DESCRIPTION
Whilst I was working on PR #610 (U4-337), I noticed the hardcoded values for `-1` and `-20`. I replaced them with references to the `Constants.System` values.

I haven't opened a corresponding ticket on the issue tracker, as it is only code housekeeping, but I can do if you want me to?