### PR TITLE
parseMacroSyntax accepts other characters than a-z

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
@@ -12,8 +12,8 @@ function macroService() {
        
         /** parses the special macro syntax like <?UMBRACO_MACRO macroAlias="Map" /> and returns an object with the macro alias and it's parameters */
         parseMacroSyntax: function (syntax) {
-
-            var expression = /(<\?UMBRACO_MACRO macroAlias=["']([\w\.]+?)["'][\s\S]+?)(\/>|>.*?<\/\?UMBRACO_MACRO>)/i;
+            
+            var expression = /(<\?UMBRACO_MACRO macroAlias=["']([\s\S.]+?)["'][\s\S]+?)(\/>|>.*?<\/\?UMBRACO_MACRO>)/i;
             var match = expression.exec(syntax);
             if (!match || match.length < 3) {
                 return null;


### PR DESCRIPTION
I had problems with parseMacroSyntax when `syntax` included Swedish characters. Now it works with other characters than a-z as well.