### PR TITLE
U4-6044 - prevent search engines from indexing login page

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/umbraco/Views/Default.cshtml
@@ -20,6 +20,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="robots" content="noindex, nofollow">
 
     <title ng-bind="$root.locationTitle">Umbraco</title>
     


### PR DESCRIPTION
Added noindex, nofollow to default page to discourage search engines from indexing the back-office
