### PR TITLE
U4-6061 - NodeCount for tags is not populated

### DIFF
--- a/src/Umbraco.Core/Models/TaggableObjectTypes.cs
+++ b/src/Umbraco.Core/Models/TaggableObjectTypes.cs
@@ -5,6 +5,7 @@
     /// </summary>
     public enum TaggableObjectTypes
     {
+        All,
         Content,
         Media,
         Member

--- a/src/Umbraco.Core/Persistence/Repositories/TagRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/TagRepository.cs
@@ -168,8 +168,6 @@ namespace Umbraco.Core.Persistence.Repositories
 
         public IEnumerable<TaggedEntity> GetTaggedEntitiesByTagGroup(TaggableObjectTypes objectType, string tagGroup)
         {
-            var nodeObjectType = GetNodeObjectType(objectType);
-
             var sql = new Sql()
                 .Select("cmsTagRelationship.nodeId, cmsPropertyType.Alias, cmsPropertyType.id as propertyTypeId, cmsTags.tag, cmsTags.id as tagId, cmsTags." + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group"))
                 .From<TagDto>()
@@ -181,8 +179,14 @@ namespace Umbraco.Core.Persistence.Repositories
                 .On<PropertyTypeDto, TagRelationshipDto>(left => left.Id, right => right.PropertyTypeId)
                 .InnerJoin<NodeDto>()
                 .On<NodeDto, ContentDto>(left => left.NodeId, right => right.NodeId)
-                .Where<NodeDto>(dto => dto.NodeObjectType == nodeObjectType)
                 .Where<TagDto>(dto => dto.Group == tagGroup);
+
+            if (objectType != TaggableObjectTypes.All)
+            {
+                var nodeObjectType = GetNodeObjectType(objectType);
+                sql = sql
+                    .Where<NodeDto>(dto => dto.NodeObjectType == nodeObjectType);
+            }
 
             return CreateTaggedEntityCollection(
                 ApplicationContext.Current.DatabaseContext.Database.Fetch<dynamic>(sql));
@@ -190,8 +194,6 @@ namespace Umbraco.Core.Persistence.Repositories
 
         public IEnumerable<TaggedEntity> GetTaggedEntitiesByTag(TaggableObjectTypes objectType, string tag, string tagGroup = null)
         {
-            var nodeObjectType = GetNodeObjectType(objectType);
-
             var sql = new Sql()
                 .Select("cmsTagRelationship.nodeId, cmsPropertyType.Alias, cmsPropertyType.id as propertyTypeId, cmsTags.tag, cmsTags.id as tagId, cmsTags." + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group"))
                 .From<TagDto>()
@@ -203,8 +205,14 @@ namespace Umbraco.Core.Persistence.Repositories
                 .On<PropertyTypeDto, TagRelationshipDto>(left => left.Id, right => right.PropertyTypeId)
                 .InnerJoin<NodeDto>()
                 .On<NodeDto, ContentDto>(left => left.NodeId, right => right.NodeId)
-                .Where<NodeDto>(dto => dto.NodeObjectType == nodeObjectType)
                 .Where<TagDto>(dto => dto.Tag == tag);
+
+            if (objectType != TaggableObjectTypes.All)
+            {
+                var nodeObjectType = GetNodeObjectType(objectType);
+                sql = sql
+                    .Where<NodeDto>(dto => dto.NodeObjectType == nodeObjectType);
+            }
 
             if (tagGroup.IsNullOrWhiteSpace() == false)
             {
@@ -233,8 +241,6 @@ namespace Umbraco.Core.Persistence.Repositories
 
         public IEnumerable<ITag> GetTagsForEntityType(TaggableObjectTypes objectType, string group = null)
         {
-            var nodeObjectType = GetNodeObjectType(objectType);
-
             var sql = GetTagsQuerySelect(true);
 
             sql = ApplyRelationshipJoinToTagsQuery(sql);
@@ -243,8 +249,14 @@ namespace Umbraco.Core.Persistence.Repositories
                 .InnerJoin<ContentDto>()
                 .On<ContentDto, TagRelationshipDto>(left => left.NodeId, right => right.NodeId)
                 .InnerJoin<NodeDto>()
-                .On<NodeDto, ContentDto>(left => left.NodeId, right => right.NodeId)
-                .Where<NodeDto>(dto => dto.NodeObjectType == nodeObjectType);
+                .On<NodeDto, ContentDto>(left => left.NodeId, right => right.NodeId);
+
+            if (objectType != TaggableObjectTypes.All)
+            {
+                var nodeObjectType = GetNodeObjectType(objectType);
+                sql = sql
+                    .Where<NodeDto>(dto => dto.NodeObjectType == nodeObjectType);
+            }
 
             sql = ApplyGroupFilterToTagsQuery(sql, group);
 

--- a/src/Umbraco.Core/Services/TagService.cs
+++ b/src/Umbraco.Core/Services/TagService.cs
@@ -133,14 +133,7 @@ namespace Umbraco.Core.Services
         {
             using (var repository = _repositoryFactory.CreateTagRepository(_uowProvider.GetUnitOfWork()))
             {
-                if (tagGroup.IsNullOrWhiteSpace())
-                {
-                    return repository.GetAll();
-                }
-
-                var query = Query<ITag>.Builder.Where(x => x.Group == tagGroup);
-                var definitions = repository.GetByQuery(query);
-                return definitions;
+                return repository.GetTagsForEntityType(TaggableObjectTypes.All, tagGroup);
             }  
         }
 

--- a/src/Umbraco.Tests/Persistence/Repositories/TagRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/TagRepositoryTest.cs
@@ -658,14 +658,20 @@ namespace Umbraco.Tests.Persistence.Repositories
                         new[]
                             {
                                 new Tag {Text = "tag1", Group = "test"},
-                                new Tag {Text = "tag2", Group = "test1"}
+                                new Tag {Text = "tag4", Group = "test1"}
                             }, false);
 
                     var result1 = repository.GetTagsForEntityType(TaggableObjectTypes.Content).ToArray();
                     var result2 = repository.GetTagsForEntityType(TaggableObjectTypes.Media).ToArray();
+                    var result3 = repository.GetTagsForEntityType(TaggableObjectTypes.All).ToArray();
 
                     Assert.AreEqual(3, result1.Count());
                     Assert.AreEqual(2, result2.Count());
+                    Assert.AreEqual(4, result3.Count());
+
+                    Assert.AreEqual(1, result1.Single(x => x.Text == "tag1").NodeCount);
+                    Assert.AreEqual(2, result3.Single(x => x.Text == "tag1").NodeCount);
+                    Assert.AreEqual(1, result3.Single(x => x.Text == "tag4").NodeCount);
 
                 }
             }


### PR DESCRIPTION
NodeCount was populated, but only for requests to get tags for content, media and members separately.  Retrieving for all tags across types didn't populate this property.

This PR amends that by using the same function for retrieval as the per type methods, but removing the filter by the type.