### PR TITLE
Fixes U4-6135 (node name disappears in certain situations when tree is synched 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/umbtreeitem.directive.js
@@ -88,6 +88,10 @@ angular.module("umbraco.directives")
 
                 element.find("a:first").html(node.name);
 
+                if (!node.menuUrl) {
+                    element.find("a.umb-options").remove();
+                }
+
                 if (node.style) {
                     element.find("i:first").attr("style", node.style);
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/umbtreeitem.directive.js
@@ -88,10 +88,6 @@ angular.module("umbraco.directives")
 
                 element.find("a:first").html(node.name);
 
-                if (!node.menuUrl) {
-                    element.find("a:last").remove();
-                }
-
                 if (node.style) {
                     element.find("i:first").attr("style", node.style);
                 }


### PR DESCRIPTION
Removed code in tree synchronisation that removes anchor tag containing node name for certain nodes.  This was coded to occur when the node's menuUrl property hadn't been set, however don't think that should be happening as the anchor tag contains the node name.

For reference the code was added in [this commit](https://github.com/umbraco/Umbraco-CMS/commit/7a7f31b7a6baa554fdafc39ff52f3f37c220e2ac) so the context for what I've removed can be reviewed.