### PR TITLE
U4-6111 Fixed Bootstrap3.cshtml exception

### DIFF
--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3.cshtml
@@ -6,7 +6,7 @@
     Razor helpers located at the bottom of this file
 *@
 
-@if (Model != null && Model.sections != null)
+@if (Model != null && Model.GetType() == typeof(JObject) && Model.sections != null)
 {
     var oneColumn = ((System.Collections.ICollection)Model.sections).Count == 1;
     


### PR DESCRIPTION
An exception could be thrown when no data was available due to the model being an empty string ("").
Issue report: http://issues.umbraco.org/issue/U4-6111