### PR TITLE
U4-4418 - fix issue with tab sorting

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/controls/ContentTypeControlNew.ascx
+++ b/src/Umbraco.Web.UI/umbraco/controls/ContentTypeControlNew.ascx
@@ -25,18 +25,18 @@
     
   <cc2:Pane ID="Pane1" runat="server" Width="216" Height="80">
     <asp:DataGrid ID="dgTabs" Width="100%" runat="server" CellPadding="2" HeaderStyle-CssClass="propertyHeader"
-      ItemStyle-CssClass="propertyContent" GridLines="None" OnItemCommand="dgTabs_ItemCommand"
+      ItemStyle-CssClass="propertyContent" GridLines="None" OnItemCommand="dgTabs_ItemCommand" OnPreRender="dgTabs_PreRender"
       HeaderStyle-Font-Bold="True" AutoGenerateColumns="False" CssClass="tabs-table">
       <Columns>
         <asp:BoundColumn DataField="id" Visible="False"></asp:BoundColumn>
         <asp:TemplateColumn HeaderText="Name & sort order">
           <ItemTemplate>
-            <i class="icon-navigation handle"></i>
+            <i class="icon-navigation handle" style="display:inline-block; margin-top:5px;"></i>
             <asp:TextBox ID="txtTab" runat="server" Value='<%#DataBinder.Eval(Container.DataItem,"name")%>'></asp:TextBox>
             <asp:TextBox ID="txtSortOrder" runat="server" CssClass="sort-order" style="width:40px;background-color:#f2f2f2;" Value='<%#DataBinder.Eval(Container.DataItem,"order") %>'></asp:TextBox>
+            <asp:Button ID="btnDelete" runat="server" Text="Delete" CommandName="Delete" CssClass="btn btn-small btn-danger" />
           </ItemTemplate>
         </asp:TemplateColumn>
-        <asp:ButtonColumn ButtonType="PushButton" Text="Delete" CommandName="Delete"></asp:ButtonColumn>
       </Columns>
     </asp:DataGrid>
     <p style="text-align: center;">

--- a/src/Umbraco.Web.UI/umbraco/controls/ContentTypeControlNew.ascx
+++ b/src/Umbraco.Web.UI/umbraco/controls/ContentTypeControlNew.ascx
@@ -25,7 +25,7 @@
     
   <cc2:Pane ID="Pane1" runat="server" Width="216" Height="80">
     <asp:DataGrid ID="dgTabs" Width="100%" runat="server" CellPadding="2" HeaderStyle-CssClass="propertyHeader"
-      ItemStyle-CssClass="propertyContent" GridLines="None" OnItemCommand="dgTabs_ItemCommand" OnPreRender="dgTabs_PreRender"
+      ItemStyle-CssClass="propertyContent" GridLines="None" OnItemCommand="dgTabs_ItemCommand" OnItemDataBound="dgTabs_ItemDataBound" OnPreRender="dgTabs_PreRender"
       HeaderStyle-Font-Bold="True" AutoGenerateColumns="False" CssClass="tabs-table">
       <Columns>
         <asp:BoundColumn DataField="id" Visible="False"></asp:BoundColumn>

--- a/src/Umbraco.Web.UI/umbraco/controls/ContentTypeControlNew.ascx.cs
+++ b/src/Umbraco.Web.UI/umbraco/controls/ContentTypeControlNew.ascx.cs
@@ -43,6 +43,17 @@ namespace Umbraco.Web.UI.Umbraco.Controls
                     table.Rows[table.Rows.Count - 1].TableSection = TableRowSection.TableFooter;
             }
         }
-      
+
+        protected void dgTabs_ItemDataBound(object sender, DataGridItemEventArgs e)
+        {
+            Table table = dgTabs.Controls[0] as Table;
+            if (table != null && table.Rows.Count > 0)
+            {
+                if (dgTabs.ShowHeader)
+                    table.Rows[0].TableSection = TableRowSection.TableHeader;
+                if (dgTabs.ShowFooter)
+                    table.Rows[table.Rows.Count - 1].TableSection = TableRowSection.TableFooter;
+            }
+        }
     }
 }

--- a/src/Umbraco.Web.UI/umbraco/controls/ContentTypeControlNew.ascx.cs
+++ b/src/Umbraco.Web.UI/umbraco/controls/ContentTypeControlNew.ascx.cs
@@ -28,6 +28,21 @@ namespace Umbraco.Web.UI.Umbraco.Controls
             DataTypeControllerUrl = Url.GetUmbracoApiServiceBaseUrl<DataTypeController>(x => x.GetById(0));
             ContentTypeControllerUrl = Url.GetUmbracoApiServiceBaseUrl<ContentTypeController>(x => x.GetAssignedListViewDataType(0));
         }
+
+        protected void dgTabs_PreRender(object sender, EventArgs e)
+        {
+            dgTabs.UseAccessibleHeader = true; //to make sure we render th, not td
+
+            Table table = dgTabs.Controls[0] as Table;
+            if (table != null && table.Rows.Count > 0)
+            {
+                // here we render <thead> and <tfoot>
+                if (dgTabs.ShowHeader) 
+                    table.Rows[0].TableSection = TableRowSection.TableHeader;
+                if (dgTabs.ShowFooter)
+                    table.Rows[table.Rows.Count - 1].TableSection = TableRowSection.TableFooter;
+            }
+        }
       
     }
 }


### PR DESCRIPTION
Fixed issue with tab sorting, where you are able to drag the rows above
the table header. Ensured that ```<thead>``` / ```<th>``` is added, so the class
"ui-sortable" is added to ```<tbody>``` and only ```<tbody>``` will be the
drag-area.
I also added styling for delete button so it's more consistent with
other "delete"-buttons, e.g. for in settings for dropdown lists,
checkbox lists and radionbutton lists. Furthermore the delete-button is
moved inside the ItemTemplate, so the classes easily could be added to
the button and also make the button stay close to the fields.

It also fix the same issue for tabs in media types and member types.

![2015-01-19_21-53-11](https://cloud.githubusercontent.com/assets/2919859/5807651/a0c20cf8-a025-11e4-8f29-e96942389e81.jpg)
