### PR TITLE
Add "config" support to the macro grid property editor item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/macro.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/macro.controller.js
@@ -8,7 +8,10 @@ angular.module("umbraco")
             dialogService.macroPicker({
                 dialogData: {
                     richTextEditor: true,  
-                    macroData: $scope.control.value
+                    macroData: $scope.control.value || {
+                        macroAlias: $scope.control.editor.config && $scope.control.editor.config.macroAlias
+                          ? $scope.control.editor.config.macroAlias : ""
+                    }
                 },
                 callback: function (data) {
                     $scope.control.value = {


### PR DESCRIPTION
Edited the Umbraco.PropertyEditors.Grid.MacroController to allow the use of a config object in the grid.editors.config.js to define a single MacroAlias that that instance can use. What this then does is allows macros to be defined individually within the "insert control" dialog of the grid along with a nice name and icon, rather than having to go via the generic macro grid item.

![capture2](https://cloud.githubusercontent.com/assets/527305/5899802/d211e8a4-a558-11e4-9336-a5713be98305.PNG)

![capture1](https://cloud.githubusercontent.com/assets/527305/5899807/eefe3e54-a558-11e4-95f9-aca26f7e514c.png)


