### PR TITLE
U4-6184 - Incorrect page served when request includes port number

### DIFF
--- a/src/Umbraco.Web/Routing/DomainHelper.cs
+++ b/src/Umbraco.Web/Routing/DomainHelper.cs
@@ -157,6 +157,16 @@ namespace Umbraco.Web.Routing
                 var currentWithSlash = current.EndPathWithSlash();
                 domainAndUri = domainsAndUris
                     .FirstOrDefault(d => d.Uri.EndPathWithSlash().IsBaseOf(currentWithSlash));
+
+                // try removing the port number from Uri and then try to match it.
+                // e.g. request: http://website.com:443/ maps to http://website.com/
+                if (domainAndUri == null)
+                {
+                    currentWithSlash = new Uri(currentWithSlash.GetComponents(UriComponents.AbsoluteUri & ~UriComponents.Port, UriFormat.UriEscaped));
+                    domainAndUri = domainsAndUris
+                        .FirstOrDefault(d => d.Uri.EndPathWithSlash().IsBaseOf(currentWithSlash));
+                }
+
                 if (domainAndUri != null) return domainAndUri;
 
                 // if none matches, then try to run the filter to pick a domain


### PR DESCRIPTION
The following code change will allow a domain to be discovered when the incoming URL contains a port number and in turn serve the correct page from the correct website.
In situations where Umbraco resides on a web server behind a load balanced server and  pages are requested by URLs such as 'http://www.website.com:443/contact' this request will map to the website with a host name 'www.website.com'