### PR TITLE
RTE composite block and class formatting

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -78,6 +78,16 @@ angular.module("umbraco")
                             r.inline = "span";
                             r.attributes = { id: rule.selector.substring(1) };
                         }
+                        else if (rule.selector[0] != "." && rule.selector.indexOf(".") > -1) {
+                            var split = rule.selector.split(".");
+                            r.block = split[0];
+                            r.classes = rule.selector.substring(rule.selector.indexOf(".") + 1);
+                        }
+                        else if (rule.selector[0] != "#" && rule.selector.indexOf("#") > -1) {
+                            var split = rule.selector.split("#");
+                            r.block = split[0];
+                            r.classes = rule.selector.substring(rule.selector.indexOf("#") + 1);
+                        }
                         else {
                             r.block = rule.selector;
                         }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -81,7 +81,7 @@ angular.module("umbraco")
                         else if (rule.selector[0] != "." && rule.selector.indexOf(".") > -1) {
                             var split = rule.selector.split(".");
                             r.block = split[0];
-                            r.classes = rule.selector.substring(rule.selector.indexOf(".") + 1);
+                            r.classes = rule.selector.substring(rule.selector.indexOf(".") + 1).replace(".", " ");
                         }
                         else if (rule.selector[0] != "#" && rule.selector.indexOf("#") > -1) {
                             var split = rule.selector.split("#");


### PR DESCRIPTION
Added `block.class` and `block#id` formatting to the Rich Text Editor.

Example use include following formats:
`p.lead` -> `<p class="lead">`
`p.lead.text` -> `<p class="lead text">`
`h1#title` `<h1 id="title">`

Without this only `p` or `.lead` will work, not composites.