### PR TITLE
U4-6034 Fixed issue with tab renames losing properties

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentTypeControlNew.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentTypeControlNew.ascx.cs
@@ -394,9 +394,12 @@ namespace umbraco.controls
                     var tabs = SaveTabs();
                     foreach (var tab in tabs)
                     {
-                        if (_contentType.ContentTypeItem.PropertyGroups.Contains(tab.Item2))
-                        {
-                            _contentType.ContentTypeItem.PropertyGroups[tab.Item2].SortOrder = tab.Item3;
+                        var propertyGroup = _contentType.ContentTypeItem.PropertyGroups
+                            .SingleOrDefault(x => x.Id == tab.Item1);
+                        if (propertyGroup != null)
+                        {                            
+                            propertyGroup.Name = tab.Item2;
+                            propertyGroup.SortOrder = tab.Item3;
                         }
                         else
                         {


### PR DESCRIPTION
By ensuring look-up to identify existing tabs uses Id rather than Name property - at least for the following scenario:

- Create "Doc Type A", and one tab "Tab 1" and one property to that tab
- Create "Doc Type B" that inherits from "Doc Type A", add one tab "Tab 2" and one property to that tab
- Also add one property on "Doc Type B" to "Tab 1" and save
- Rename "Tab 2" on "Doc Type B" to "Tab 3" and observe that the property you added on this tab is gone

With the code in this PR in place the rename occurs and the property remains on the tab