### PR TITLE
U4-4507 - Make expand arrow in sections as a toggle

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/umbsections.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/umbsections.directive.js
@@ -22,6 +22,9 @@ function sectionsDirective($timeout, $window, navigationService, treeService, se
                 if (scope.showTray) {
                     return 'slide';
                 }
+                else if (scope.showTray === false) {
+                    return 'slide';
+                }
                 else {
                     return '';
                 }
@@ -83,6 +86,13 @@ function sectionsDirective($timeout, $window, navigationService, treeService, se
 			};
 
 			scope.sectionClick = function (section) {
+			    if (navigationService.userDialog) {
+			        navigationService.userDialog.close();
+			    }
+			    if (navigationService.helpDialog) {
+			        navigationService.helpDialog.close();
+			    }
+			    
 			    navigationService.hideSearch();
 			    navigationService.showTree(section.alias);
 			    $location.path("/" + section.alias);
@@ -92,8 +102,20 @@ function sectionsDirective($timeout, $window, navigationService, treeService, se
 				navigationService.reloadSection(section.alias);
 			};
 
-			scope.trayClick = function(){
-				navigationService.showTray();
+			scope.trayClick = function () {
+                // close dialogs
+			    if (navigationService.userDialog) {
+			        navigationService.userDialog.close();
+			    }
+			    if (navigationService.helpDialog) {
+			        navigationService.helpDialog.close();
+			    }
+
+			    if (appState.getGlobalState("showTray") === true) {
+			        navigationService.hideTray();
+			    } else {
+			        navigationService.showTray();
+			    }
 			};
             
 			loadSections();

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -513,23 +513,26 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
          * Opens the user dialog, next to the sections navigation
          * template is located in views/common/dialogs/user.html
          */
-        showUserDialog: function() {
+        showUserDialog: function () {
+            // hide tray and close help dialog
+            if (service.helpDialog) {
+                service.helpDialog.close();
+            }
+            service.hideTray();
 
-            if(userDialog){
-                userDialog.close();
-                userDialog = null;
+            if (service.userDialog) {
+                service.userDialog.close();
+                service.userDialog = undefined;
             }
 
-            userDialog = dialogService.open(
-                {
-                    template: "views/common/dialogs/user.html",
-                    modalClass: "umb-modal-left",
-                    show: true
-                });
-        
-            
+            service.userDialog = dialogService.open(
+            {
+                template: "views/common/dialogs/user.html",
+                modalClass: "umb-modal-left",
+                show: true
+            });
 
-            return userDialog;
+            return service.userDialog;
         },
 
         /**
@@ -541,7 +544,13 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
          * Opens the user dialog, next to the sections navigation
          * template is located in views/common/dialogs/user.html
          */
-        showHelpDialog: function() {
+        showHelpDialog: function () {
+            // hide tray and close user dialog
+            service.hideTray();
+            if (service.userDialog) {
+                service.userDialog.close();
+            }
+
             if(service.helpDialog){
                 service.helpDialog.close();
                 service.helpDialog = undefined;

--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -43,6 +43,7 @@ ul.sections li a {
 	width: 100%;
 	height: 100%;
 	margin: 0 0 0 -4px;
+    cursor: pointer; // make sure IE10 displays pointer cursor for expand and help sections. 
 }
 
 ul.sections a span {

--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -7,6 +7,7 @@ ul.sections {
 	background: @blackLight;
 	height: 100%;
 	width: 80px;
+    border-right: 1px solid @grayDark;
 }
 
 ul.sections li {
@@ -63,7 +64,7 @@ ul.sections:hover a span {
 // -------------------------
 
 ul.sections li.avatar {
-	height: 69px;
+	height: 67px;
 	padding: 30px 0 2px 0;
 	text-align: center;
 	margin: 0 0 0 -4px;
@@ -116,7 +117,38 @@ ul.sections li.help a {
 // -------------------------
 li.expand a, li.expand{border: none !Important;}
 
+li.expand {
+
+    &.open > a > i.icon {
+        -webkit-transition: all 1s !important;
+        -o-transition: all 1s !important;
+        -moz-transition: all 1s !important;
+        transition: all 1s !important;
+        
+        &:before {
+            -ms-transform: rotate(180deg) !important; /* IE 9 */
+            -webkit-transform: rotate(180deg) !important; /* Chrome, Safari, Opera */
+            -o-transform: rotate(180deg) !important;
+            -moz-transform: rotate(180deg) !important;
+            transform: rotate(180deg) !important;
+        }
+    }
+}
+
 ul.sections-tray {
-	padding-top: 102px;
+	padding-top: 99px;
 	width: 80px;
+
+    & > li:first-child > a {
+        border-top: 1px solid #343434;
+    }
+
+    & > li {
+        // 5px (instead of 4px) because of vertical border
+        border-left-width: 5px;
+        
+        &.current, &:hover {
+            border-left-width: 5px;
+        }
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.controller.js
@@ -36,10 +36,6 @@ angular.module("umbraco")
 
     	    helpService.findVideos(rq).then(function(videos){
     	        $scope.videos = videos;
-
-    	        angular.forEach($scope.videos, function (obj) {
-    	            obj.thumbnail = obj.thumbnail.replace(/(\.[\w\d_-]+)$/i, '_thumb$1');
-    	        });
     	    });
 
         });

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.controller.js
@@ -35,7 +35,11 @@ angular.module("umbraco")
     	    });
 
     	    helpService.findVideos(rq).then(function(videos){
-    	    	$scope.videos = videos;
+    	        $scope.videos = videos;
+
+    	        angular.forEach($scope.videos, function (obj) {
+    	            obj.thumbnail = obj.thumbnail.replace(/(\.[\w\d_-]+)$/i, '_thumb$1');
+    	        });
     	    });
 
         });

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.html
@@ -37,7 +37,7 @@
 					<li class="span2" ng-repeat="video in videos">
 				    	<div class="thumbnail" style="margin-right: 20px">
 					    	<a target="_blank" href="{{video.link}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv" title="{{video.title}}">
-					    		<img ng-src="{{video.thumbnail}}"  alt="{{video.title}}">
+                                <img ng-src="{{video.thumbnail}}" alt="{{video.title}}">
 					    	</a>
 				    	</div>
 				    </li>

--- a/src/Umbraco.Web.UI.Client/src/views/directives/umb-sections.html
+++ b/src/Umbraco.Web.UI.Client/src/views/directives/umb-sections.html
@@ -16,7 +16,7 @@
                 </a>
             </li>
             
-            <li class="expand" ng-show="needTray">
+            <li class="expand" ng-class="{ 'open': showTray === true }" ng-show="needTray">
                 <a href ng-click="trayClick()">
                     <i class="icon icon-arrow-right"></i>
                 </a>


### PR DESCRIPTION
I have made some suggestions, so the right arrow act as a toggle button,
so you easily can collapse the extra overflow-sections. Furthermore I
have made some changes, so when you click userDialog or helpDialog other
open dialogs close and also sections. When you click a section or expand
it also close dialogs, so you don't have to close those dialogs first.
http://issues.umbraco.org/issue/U4-4507

In the top of the sections, just below the avatar, I made sure that the horizontal line follow the line across to the tree area and editing area, and I added some additional borders to seperate the different sections.

I like the effect that the arrow just rotate, but I have added some comments in the code if you rather want to switch to a left arrow icon without the rotate effekt.
On smaller screen resolutions the tree menu is hidden, so when your cursor leave the sections the the tray is closed - can the tray be closed when you click outside the sections e.g. in the tree area or editing area? The user dialog and help dialog are closed when you click these areas.

Finally I also made a change to use small versions of thumbnails in help panel: http://issues.umbraco.org/issue/U4-4028

Instead of displaying large image like this: http://umbraco.tv/media/88895/settings-and-styles.jpg, why not use the _thumb http://umbraco.tv/media/88895/settings-and-styles_thumb.jpg. This thumb has a width of 100px and the thumbnails are anyway scaled to a width of 90px. However it seems that not all these video thumbnails have a _thumb image generated? And if the large images not are used inside Umbraco, it would be better to only request the _thumb image e.g. 100x56px instead of requesting images with a image size of 1280x720px.
