### PR TITLE
U4 4198

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.controller.js
@@ -38,7 +38,12 @@
             $scope.cancelEdit = function(idx) {
                 $scope.model.value[idx].edit = false;
             };
-            
+
+            $scope.saveEdit = function (idx) {
+                $scope.model.value[idx].title = $scope.model.value[idx].caption;
+                $scope.model.value[idx].edit = false;
+            };
+
             $scope.delete = function (idx) {               
                 $scope.model.value.splice(idx, 1);               
             };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.html
@@ -15,6 +15,7 @@
                 <td style="word-wrap:break-word; word-break: break-all">
                     <span ng-show="!link.edit">{{link.caption}}</span>
                     <input type="text" ng-model="link.caption" ng-show="link.edit" />
+                    <input type="hidden" ng-model="link.title" value="{{link.caption}}" />
                 </td>
                 <td style="word-wrap:break-word; word-break: break-all">
                     <div ng-show="!link.edit">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.html
@@ -15,7 +15,6 @@
                 <td style="word-wrap:break-word; word-break: break-all">
                     <span ng-show="!link.edit">{{link.caption}}</span>
                     <input type="text" ng-model="link.caption" ng-show="link.edit" />
-                    <input type="hidden" ng-model="link.title" value="{{link.caption}}" />
                 </td>
                 <td style="word-wrap:break-word; word-break: break-all">
                     <div ng-show="!link.edit">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.html
@@ -47,7 +47,7 @@
                     </div>
                     <div class="btn-group" ng-show="link.edit">
                         <button type="button" class="btn btn-default" ng-click="cancelEdit($index)"><localize key="cancel">Cancel</localize></button>
-                        <button type="button" class="btn btn-default" ng-click="cancelEdit($index)"><localize key="buttons_save">Save</localize></button>
+                        <button type="button" class="btn btn-default" ng-click="saveEdit($index)"><localize key="buttons_save">Save</localize></button>
                     </div>
 
                 </td>


### PR DESCRIPTION
I have added a save event to ensure that the title property is correctly updated when a related link is edited.
This does fix the bug however why the title property is still in place is up for debate I guess.