### PR TITLE
Auto hide the 'Are you sure you want to delete' message on columns of a grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -123,7 +123,7 @@
                                                     <div class="cell-tools"
                                                          ng-class="{'with-prompt': control.deletePrompt}"
                                                          ng-animate="'fade'"
-                                                         ng-show="control && (currentControl == control)">
+                                                         ng-if="control && (currentControl == control)">
 
                                                         <!-- delete control -->
                                                         <div class="cell-tools-remove">
@@ -132,13 +132,13 @@
                                                                  ng-mouseover="setWarnhighlightControl(control)"
                                                                  ng-mouseleave="disableWarnhighlightControl(control)">
 
-                                                                <span class="prompt" ng-show="control.deletePrompt">
+                                                                <span class="prompt" ng-if="control.deletePrompt">
                                                                     <localize key="general_areyousure" />
                                                                     <a href ng-click="removeControl(area, $index)"><localize key="general_yes" /></a>
                                                                     <a href ng-click="clearPrompt(control, $event)"><localize key="general_no" /></a>
                                                                 </span>
 
-                                                                <i ng-show="!control.deletePrompt" class="icon icon-trash"></i>
+                                                                <i ng-if="!control.deletePrompt" class="icon icon-trash"></i>
                                                             </div>
                                                         </div>
 


### PR DESCRIPTION
Hide the 'Are you sure you want to delete' message on columns of a grid when mouse-leaving them just like it does on the similar message on the row level. This way they messages work the same for both rows and columns.

I have left the earlier change (the added 'no' button) as an additional means to hide the message.