### PR TITLE
Fix for U4-6276 - Keep headline at same position

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/modals.less
+++ b/src/Umbraco.Web.UI.Client/src/less/modals.less
@@ -63,6 +63,7 @@
 
 .umb-modal-left .umb-panel-header .umb-headline, .umb-modal-left .umb-panel-header h1 {
   width: auto;
+  padding-left: 0;
 }
 
 /* umb.dialog is used for the dialogs on the conent tree*/

--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -92,7 +92,7 @@
   margin: -6px 0 0 0;
   padding: 0 0 2px 0;
   border-radius: 0;
-  line-height: 1em;
+  line-height: normal;
   border: 1px solid transparent;
   color: @black;
   letter-spacing: -0.01em

--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -48,6 +48,7 @@
   background: none;
   margin: 15px 0 0 20px;
   padding: 3px 5px;
+  line-height: 1.4;
   height: auto;
   width: 100%;
   border: 1px solid @grayLighter;


### PR DESCRIPTION
I made a small change to make sure the headline is in same position
regardless it is editable or readonly.

Nothing fancy, just a small adjustment to the line height seems to keep the "readonly" headline closer to the header and same position.

![2015-02-15_22-06-11](https://cloud.githubusercontent.com/assets/2919859/6205060/583eef86-b561-11e4-8d51-dc72f9b69afc.jpg)

![2015-02-15_22-12-13](https://cloud.githubusercontent.com/assets/2919859/6205062/5b057f78-b561-11e4-976d-fe35704034a6.jpg)
