### PR TITLE
U4 6297

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -273,6 +273,36 @@ angular.module("umbraco")
                 });
 
         };
+        
+        
+        // *********************************************
+        // Control management functions
+        // *********************************************
+
+        $scope.editControlSettings = function (control) {
+
+            var obj = $scope.model.config;
+            obj.items.config = control.editor.config.settings;
+
+            dialogService.open(
+            {
+                template: "views/propertyeditors/grid/dialogs/config.html",
+                gridItem: { "config": (control.value ? control.value.settings : null) },
+                itemType: null,
+                config: obj,
+                callback: function (data) {
+                    if (angular.isObject(control.value))
+                        control.value.settings = data.config;
+                    else {
+                        control.value = {
+                            "settings": data.config
+                        };
+                    }
+                    //console.log(control.value);
+                    //console.log(control.value.settings);
+                }
+            });
+        };
 
         // *********************************************
         // Area management functions

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -291,15 +291,7 @@ angular.module("umbraco")
                 itemType: null,
                 config: obj,
                 callback: function (data) {
-                    if (angular.isObject(control.value))
-                        control.value.settings = data.config;
-                    else {
-                        control.value = {
-                            "settings": data.config
-                        };
-                    }
-                    //console.log(control.value);
-                    //console.log(control.value.settings);
+                    control.settings = data.config;
                 }
             });
         };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -164,7 +164,7 @@
                                                         </div>
                                                         
                                                         <!-- control setting area -->
-                                                        <div class="cell-tools-edit" ng-if="control.editor.config && control.editor.config.settings">
+                                                        <div class="cell-tools-edit" ng-style="hasSettings && $first && {'top': '99px'}" ng-if="control.editor.config && control.editor.config.settings">
                                                             <a class="iconBox"
                                                                ng-click="editControlSettings(control)"
                                                                href>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -162,6 +162,15 @@
                                                                 <i class="icon icon-settings"></i>
                                                             </a>
                                                         </div>
+                                                        
+                                                        <!-- control setting area -->
+                                                        <div class="cell-tools-edit" ng-if="control.editor.config && control.editor.config.settings">
+                                                            <a class="iconBox"
+                                                               ng-click="editControlSettings(control)"
+                                                               href>
+                                                                <i class="icon icon-hammer"></i>
+                                                            </a>
+                                                        </div>
 
                                                     </div>
 


### PR DESCRIPTION
As per comments in U4-6297.  

To use this merge:

add expected config.settings in your grid.editors.config.js file as follows:
{
    "name": "RWC Headline",
    "alias": "rwc-headline",
    "view": "/app_plugins/rwc.grid.headline/editor.html",
    "render": "/app_plugins/rwc.grid.headline/editor.cshtml",
    "icon": "icon-coin",
    "config": {
        "settings": [
                {
                    "label": "Hide Background?",
                    "description": "Check if you want to hide the gray'ish background color for the header",
                    "key": "hideBackground",
                    "view": "boolean"
                }
        ]
    }
}

It results in anew icon next to your control that will show the "settings editor" for whatever you have defined in config.settings above - therefore a very quick way to put together some custom ui on a control.

Then in your view you can use:
control.value.settings.hideBackground

Then in your render you can use:
Model.value.settings.hideBackground