### PR TITLE
Fix for:U4-6294: Added title tag with property editor name in the cell in the grid layout

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -117,7 +117,7 @@
                                                      ng-mouseover="setCurrentControl(control)"
                                                      ng-mouseleave="disableCurrentControl(control)"
                                                      ng-animate="'fade'"
-                                                     class="usky-control">
+                                                     class="usky-control" title="{{control.editor.name}}">
 
                                                     <!-- Filled cell tools -->
                                                     <div class="cell-tools"


### PR DESCRIPTION
Added title tag so it possible to see which property editor that is use in the cell in the grid layout