### PR TITLE
Allows for a build version to be in web.config

### DIFF
--- a/src/Umbraco.Core/ApplicationContext.cs
+++ b/src/Umbraco.Core/ApplicationContext.cs
@@ -175,7 +175,9 @@ namespace Umbraco.Core
 				try
 				{
 					string configStatus = ConfigurationStatus;
-					string currentVersion = UmbracoVersion.Current.ToString(3);
+                    string currentVersion = string.Format("{0}.{1}.{2}", UmbracoVersion.Current.Major, UmbracoVersion.Current.Minor, UmbracoVersion.Current.Build);
+				    if (UmbracoVersion.CurrentComment != string.Empty)
+				        currentVersion = string.Format("{0}.{1}", currentVersion, UmbracoVersion.CurrentComment);
 
 
 					if (currentVersion != configStatus)

--- a/src/Umbraco.Web/Install/Controllers/InstallController.cs
+++ b/src/Umbraco.Web/Install/Controllers/InstallController.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Web.Mvc;
 using Umbraco.Core;
 using Umbraco.Core.Configuration;
@@ -22,34 +18,47 @@ namespace Umbraco.Web.Install.Controllers
     {
         private readonly UmbracoContext _umbracoContext;
 
-		public InstallController()
-			: this(UmbracoContext.Current)
-		{
-			
-		}
+        public InstallController()
+            : this(UmbracoContext.Current)
+        {
+
+        }
 
         public InstallController(UmbracoContext umbracoContext)
-		{
-			_umbracoContext = umbracoContext;
-		}
+        {
+            _umbracoContext = umbracoContext;
+        }
 
 
         [HttpGet]
         public ActionResult Index()
         {
-            //if this is not an upgrade we will log in with the default user.
+            // If this is not an upgrade we will log in with the default user.
             // It's not considered an upgrade if the ConfigurationStatus is missing or empty or if the db is not configured.
-            if (string.IsNullOrWhiteSpace(GlobalSettings.ConfigurationStatus) == false
+            var configuredVersion = GlobalSettings.ConfigurationStatus;
+
+            if (string.IsNullOrWhiteSpace(configuredVersion) == false
                 && ApplicationContext.Current.DatabaseContext.IsDatabaseConfigured)
             {
+                var semVerVersion = string.Empty;
+
+                // There may be a versionComment
+                var versionParts = configuredVersion.Split('.');
+                if (versionParts.Length >= 3)
+                    semVerVersion = string.Format("{0}.{1}.{2}", versionParts[0], versionParts[1], versionParts[2]);
+
+                var versionComment = string.Empty;
+                if (versionParts.Length == 4)
+                    versionComment = versionParts[3];
+
                 Version current;
-                if (Version.TryParse(GlobalSettings.ConfigurationStatus, out current))
+                if (Version.TryParse(semVerVersion, out current))
                 {
                     //check if we are on the current version, and not let the installer execute
-                    if (current == UmbracoVersion.Current)
+                    if (current == UmbracoVersion.Current && string.IsNullOrWhiteSpace(versionComment) == false && UmbracoVersion.CurrentComment == versionComment)
                     {
                         return Redirect(SystemDirectories.Umbraco.EnsureEndsWith('/'));
-                    }    
+                    }
                 }
 
                 var result = _umbracoContext.Security.ValidateCurrentUser(false);
@@ -57,14 +66,14 @@ namespace Umbraco.Web.Install.Controllers
                 switch (result)
                 {
                     case ValidateRequestAttempt.FailedNoPrivileges:
-                    case ValidateRequestAttempt.FailedNoContextId: 
-                        return Redirect(SystemDirectories.Umbraco + "/AuthorizeUpgrade?redir=" + Server.UrlEncode(Request.RawUrl));                        
+                    case ValidateRequestAttempt.FailedNoContextId:
+                        return Redirect(SystemDirectories.Umbraco + "/AuthorizeUpgrade?redir=" + Server.UrlEncode(Request.RawUrl));
                 }
-            }            
+            }
 
             //gen the install base url
             ViewBag.InstallApiBaseUrl = Url.GetUmbracoApiService("GetSetup", "InstallApi", "UmbracoInstall").TrimEnd("GetSetup");
-            
+
             //get the base umbraco folder
             ViewBag.UmbracoBaseFolder = IOHelper.ResolveUrl(SystemDirectories.Umbraco);
 
@@ -74,6 +83,5 @@ namespace Umbraco.Web.Install.Controllers
             //always ensure full path (see NOTE in the class remarks)
             return View(GlobalSettings.Path.EnsureEndsWith('/') + "install/views/index.cshtml");
         }
-
     }
 }

--- a/src/Umbraco.Web/Install/InstallSteps/SetUmbracoVersionStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/SetUmbracoVersionStep.cs
@@ -34,7 +34,10 @@ namespace Umbraco.Web.Install.InstallSteps
             DistributedCache.Instance.RefreshAllPageCache();
 
             // Update configurationStatus
-            GlobalSettings.ConfigurationStatus = UmbracoVersion.Current.ToString(3);
+            var semVerVersion = string.Format("{0}.{1}.{2}", UmbracoVersion.Current.Major, UmbracoVersion.Current.Minor, UmbracoVersion.Current.Build);
+            GlobalSettings.ConfigurationStatus = semVerVersion;
+            if (UmbracoVersion.CurrentComment != string.Empty)
+                GlobalSettings.ConfigurationStatus = string.Format("{0}.{1}", semVerVersion, UmbracoVersion.CurrentComment);
 
             // Update ClientDependency version
             var clientDependencyConfig = new ClientDependencyConfiguration();


### PR DESCRIPTION
So that we can detect the exact build from web.config and set new ones when appropriate.

Currently we want to use this for UaaS to easily upgrades between builds (we detect the currently running version by looking in the web.config, which didn't have the ability to have build numbers in it yet).
It's also very useful for the core as it can be expanded in the future to make migrations more granular (think: upgrading from alpha to beta).

These changes have been tested by changing the version in both the web.config and the UmbracoVersion.cs to have a comment (`7.2.2.beta`, `7.2.2.build12`, etc), not have a comment (`7.2.2`), have an empty comment (`7.2.2.` - note the period after the last "2") and have multiple comments. (`7.2.2.build1239.build123`). The upgrade installer handles all these correctly and can move between any type of version just fine.

Currently in this PR there's a bit too much string parsing involved for my liking and I'm looking for feedback on making this better. One option I've thought about so far is to make our own Version class but I'm not entirely  sure how far reaching that would turn out to be. There will also be people who are already expecting System.Version to come back from UmbracoVersion so we'd have to find a way to make that at least backwards compatible. Thoughts?