### PR TITLE
Changed the surrounding quotes for Grid custom settings/styles to be double quotes

### DIFF
--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap2.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap2.cshtml
@@ -65,7 +65,7 @@
 
         if(cfg != null)
             foreach (JProperty property in cfg.Properties()) {
-                attrs.Add(property.Name + "='" + property.Value.ToString() + "'");
+                attrs.Add(property.Name + "=\"" + property.Value.ToString() + "\"");
             }
                 
         JObject style = contentItem.styles;
@@ -76,7 +76,7 @@
             cssVals.Add(property.Name + ":" + property.Value.ToString() + ";");
 
         if (cssVals.Any())
-            attrs.Add("style='" + string.Join(" ", cssVals) + "'");
+            attrs.Add("style=\"" + string.Join(" ", cssVals) + "\"");
         }
             
         return new MvcHtmlString(string.Join(" ", attrs));

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3.cshtml
@@ -65,7 +65,7 @@
 
         if(cfg != null)
             foreach (JProperty property in cfg.Properties()) {
-                attrs.Add(property.Name + "='" + property.Value.ToString() + "'");
+                attrs.Add(property.Name + "=\"" + property.Value.ToString() + "\"");
             }
                 
         JObject style = contentItem.styles;
@@ -76,7 +76,7 @@
             cssVals.Add(property.Name + ":" + property.Value.ToString() + ";");
 
         if (cssVals.Any())
-            attrs.Add("style='" + string.Join(" ", cssVals) + "'");
+            attrs.Add("style=\"" + string.Join(" ", cssVals) + "\"");
         }
             
         return new MvcHtmlString(string.Join(" ", attrs));


### PR DESCRIPTION
Changed the surrounding quotes for settings/styles from single quotes to double quotes to allow for single quotes to work in the settings/styles json config modifier property output rendering.

Basically, I had an issue where the output was truncated because of the single quotes. Changing to double quotes fixed it.