### PR TITLE
U4-4080 Missing icons in context menu

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionDeleteRelationType.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionDeleteRelationType.cs
@@ -59,7 +59,7 @@ namespace umbraco.cms.presentation.developer.RelationTypes.TreeMenu
 		/// </summary>
 		public string Icon
 		{
-			get { return ".sprDelete"; } // .sprDelete refers to an existing sprite
+            get { return "delete"; } // .sprDelete refers to an existing sprite
 		}
 
 		/// <summary>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionDeleteRelationType.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionDeleteRelationType.cs
@@ -59,7 +59,7 @@ namespace umbraco.cms.presentation.developer.RelationTypes.TreeMenu
 		/// </summary>
 		public string Icon
 		{
-            get { return "delete"; } // .sprDelete refers to an existing sprite
+            get { return "delete"; } // delete refers to an existing sprite
 		}
 
 		/// <summary>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionNewRelationType.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionNewRelationType.cs
@@ -59,7 +59,7 @@ namespace umbraco.cms.presentation.developer.RelationTypes.TreeMenu
 		/// </summary>
 		public string Icon
 		{
-			get { return "add"; } // .sprNew refers to an existing sprite
+			get { return "add"; } // add refers to an existing sprite
 		}
 
 		/// <summary>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionNewRelationType.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionNewRelationType.cs
@@ -59,7 +59,7 @@ namespace umbraco.cms.presentation.developer.RelationTypes.TreeMenu
 		/// </summary>
 		public string Icon
 		{
-			get { return ".sprNew"; } // .sprNew refers to an existing sprite
+			get { return "add"; } // .sprNew refers to an existing sprite
 		}
 
 		/// <summary>


### PR DESCRIPTION
Updated the icons used, as they seems to have been removed in an earlier version. This is for the relation types area under developer

The Issue tracker also states that there shuold be one missing when selecting "Import document type" under document typs, but this isnt true for the current version