### PR TITLE
Grid editor, set max items for row cells

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
@@ -48,6 +48,10 @@ ng-controller="Umbraco.PropertyEditors.GridPrevalueEditor.RowConfigController">
                     </div>
                 </umb-control-group>
 
+                <umb-control-group label="@grid_maxItems" description="@grid_maxItemsDescription">
+                    <input type="text" ng-model="currentCell.maxItems" />
+                </umb-control-group>
+
 
                 <umb-control-group hide-label="true">
                     <ul class="unstyled">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -190,7 +190,7 @@
                                                      ng-if="!currentToolsControl"
                                                      ng-animate="'fade'">
 
-                                                    <a class="iconBox" href ng-click="addItemOverlay($event, area, 0, area.$uniqueId);">
+                                                    <a class="iconBox" href ng-show="area.maxItems == '' || area.maxItems == -1 || area.maxItems > area.controls.length" ng-click="addItemOverlay($event, area, 0, area.$uniqueId);">
                                                         <i class=" icon icon-add"></i>
                                                     </a>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
@@ -66,7 +66,7 @@
                                     ng-repeat="area in layout.areas | filter:zeroWidthFilter"
                                     ng-style="{width: percentage(area.grid) + '%'}">
 
-                                    <div class="preview-cell"></div>
+                                    <div class="preview-cell"><p style="font-size:6px; line-height:8px; text-align: center" ng-show="area.maxItems > 0">{{area.maxItems}}</p></div>
                                 </div>
                             </div>
                         </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -642,6 +642,9 @@ Mange hilsner fra Umbraco robotten
 
     <key alias="allowAllEditors">Tillad alle editorer</key>
     <key alias="allowAllRowConfigurations">Tillad alle rækkekonfigurationer</key>
+
+    <key alias="maxItems">Maksimalt emner</key>
+    <key alias="maxItemsDescription">Efterlad blank eller sat til -1 ubegrænset for</key>
   </area>
   <area alias="rollback">
     <key alias="currentVersion">Nuværende version</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -879,6 +879,9 @@ To manage your website, simply open the Umbraco back office and start adding con
 
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+  
+    <key alias="maxItems">Maximum items</key>
+    <key alias="maxItemsDescription">Leave blank or set to -1 for unlimited</key>
   </area>
 
   <area alias="templateEditor">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -883,6 +883,9 @@ To manage your website, simply open the Umbraco back office and start adding con
 
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+    
+    <key alias="maxItems">Maximum items</key>
+    <key alias="maxItemsDescription">Leave blank or set to -1 for unlimited</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternative field</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -744,6 +744,9 @@
 
     <key alias="allowAllEditors">Permitir todos los controles de edición</key>
     <key alias="allowAllRowConfigurations">Permitir todas las configuraciones de fila</key>
+
+    <key alias="maxItems">Artículos máximos</key>
+    <key alias="maxItemsDescription">Dejar en blanco o se establece en -1 para ilimitada</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Campo opcional</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -817,6 +817,9 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
 
 		<key alias="allowAllEditors">Alle editors toelaten</key>
 		<key alias="allowAllRowConfigurations">Alle rijconfiguraties toelaten</key>
+
+    <key alias="maxItems">Maximale artikelen</key>
+    <key alias="maxItemsDescription">Laat dit leeg of is ingesteld op -1 voor onbeperkt</key>
 	</area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternatief veld</key>


### PR DESCRIPTION
Add the ability to limit the number of items that can be inserted into a row cell in the grid editor.
- Adds the Maximum items field in the row configuration, if set to nothing or -1 will allow the unlimited items
- The preview in the prevalue editor now shows a small number in the grid cell preview to show how many items the cell has been set to.
- The grid property editor view has been updated to show and hide the (+) button depending whether the cell has passed the limit or not.
- Dictionary keys have been added to language files that have grid items in them. da, en, en_us, es, nl
