### PR TITLE
Fix for U4-6395, U4-6117

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
+++ b/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
@@ -193,6 +193,7 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
     							});
 
     							selection.select(anchorElm);
+								editor.execCommand('mceEndTyping');
     						} else {
     							editor.execCommand('mceInsertLink', false, {
 									href: href,


### PR DESCRIPTION
After digging through everything, there is no listener in the RTE that runs `syncContent(editor)` in the main controller when just an attribute is changed.

By calling an `execCommand()` on the editor from the plugin, it triggers a `syncContent()` here: https://github.com/umbraco/Umbraco-CMS/blob/2834ccdc2b057619178b3df49aa05ae938faca15/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js#L207

Prior to this, the RTE is updated when a node is selected because it fires the `mceInsertLink` command.