### PR TITLE
U4-6236 - umbraco 7 macro parameters saving "null"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/umbeditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/umbeditor.directive.js
@@ -28,6 +28,10 @@ angular.module("umbraco.directives")
                 }
 
                 scope.propertyEditorView = umbPropEditorHelper.getViewPath(scope.model.view, scope.isPreValue);
+				
+				 if(scope.model.view == 'textbox'){
+                    scope.model.value = scope.model.value || '';
+                }
             }
         };
     });


### PR DESCRIPTION
Text editor should have a value of blank instead of "null" if it doesn't
contain anything