### PR TITLE
U4-6412 - Ensures footer breadcrumb in content and media returned in correct order

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -37,7 +37,7 @@ function ContentEditController($scope, $rootScope, $routeParams, $q, $timeout, $
             if (content.parentId && content.parentId != -1) {
                 entityResource.getAncestors(content.id, "document")
                .then(function (anc) {
-                   $scope.ancestors = anc.reverse();
+                   $scope.ancestors = anc;
                });
             }
         }

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -71,7 +71,7 @@ function mediaEditController($scope, $routeParams, appState, mediaResource, enti
                     //We fetch all ancestors of the node to generate the footer breadcrump navigation
                     entityResource.getAncestors($routeParams.id, "media")
                         .then(function (anc) {
-                            $scope.ancestors = anc.reverse();
+                            $scope.ancestors = anc;
                         });
                 }
 

--- a/src/Umbraco.Web/Editors/EntityController.cs
+++ b/src/Umbraco.Web/Editors/EntityController.cs
@@ -557,6 +557,7 @@ namespace Umbraco.Web.Editors
 
                 return Services.EntityService.GetAll(objectType.Value, ids)
                     .WhereNotNull()
+                    .OrderBy(x => x.Level)
                     .Select(Mapper.Map<EntityBasic>);
             }
             //now we need to convert the unknown ones


### PR DESCRIPTION
By returning the ancestors in level order from the controller and then removing the reversing that was in place in the client-side code.