### PR TITLE
Remove Content Service Setter case sensitivity

### DIFF
--- a/src/Umbraco.Core/Models/ContentBase.cs
+++ b/src/Umbraco.Core/Models/ContentBase.cs
@@ -436,7 +436,7 @@ namespace Umbraco.Core.Models
                 return;
             }
 
-            var propertyType = PropertyTypes.FirstOrDefault(x => x.Alias == propertyTypeAlias);
+            var propertyType = PropertyTypes.FirstOrDefault(x => x.Alias.InvariantEquals(propertyTypeAlias));
             if (propertyType == null)
             {
                 throw new Exception(String.Format("No PropertyType exists with the supplied alias: {0}", propertyTypeAlias));

--- a/src/Umbraco.Core/Models/PropertyCollection.cs
+++ b/src/Umbraco.Core/Models/PropertyCollection.cs
@@ -21,7 +21,9 @@ namespace Umbraco.Core.Models
         internal Func<Property, bool> ValidateAdd { get; set; }
 
         internal PropertyCollection()
-        {}
+            : base(StringComparer.InvariantCultureIgnoreCase)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyCollection"/> class with a delegate responsible for validating the addition of <see cref="Property"/> instances.
@@ -29,11 +31,13 @@ namespace Umbraco.Core.Models
         /// <param name="validationCallback">The validation callback.</param>
         /// <remarks></remarks>
         internal PropertyCollection(Func<Property, bool> validationCallback)
+            : this()
         {
             ValidateAdd = validationCallback;
         }
 
         public PropertyCollection(IEnumerable<Property> properties)
+            : this()
         {
             Reset(properties);
         }
@@ -113,14 +117,14 @@ namespace Umbraco.Core.Models
         /// <remarks></remarks>
         public new bool Contains(string propertyTypeAlias)
         {
-            return this.Any(x => x.Alias == propertyTypeAlias);
+            return base.Contains(propertyTypeAlias);
         }
 
         public int IndexOfKey(string key)
         {
             for (var i = 0; i < this.Count; i++)
             {
-                if (this[i].Alias == key)
+                if (this[i].Alias.InvariantEquals(key))
                 {
                     return i;
                 }
@@ -145,7 +149,7 @@ namespace Umbraco.Core.Models
         {
             get
             {
-                return this.FirstOrDefault(x => x.Alias == propertyType.Alias);
+                return this.FirstOrDefault(x => x.Alias.InvariantEquals(propertyType.Alias));
             }
         }
 
@@ -165,7 +169,7 @@ namespace Umbraco.Core.Models
         /// <param name="propertyTypes">List of PropertyType</param>
         protected internal void EnsurePropertyTypes(IEnumerable<PropertyType> propertyTypes)
         {
-            if(/*!this.Any() &&*/ propertyTypes != null)
+            if (/*!this.Any() &&*/ propertyTypes != null)
             {
                 foreach (var propertyType in propertyTypes)
                 {
@@ -180,7 +184,7 @@ namespace Umbraco.Core.Models
         /// <param name="propertyTypes">List of PropertyType</param>
         protected internal void EnsureCleanPropertyTypes(IEnumerable<PropertyType> propertyTypes)
         {
-            if(propertyTypes != null)
+            if (propertyTypes != null)
             {
                 //Remove PropertyTypes that doesn't exist in the list of new PropertyTypes
                 var aliases = this.Select(p => p.Alias).Except(propertyTypes.Select(x => x.Alias)).ToList();


### PR DESCRIPTION
As per conversations on the Google group.

This makes checks for property alias case insensitive using invariant culture so that behaviour matches that of the `IPublishedContent` getters.