### PR TITLE
Remove MVC dependencies from Umbraco.Core (moved to Umbraco.Web where necessary)

### DIFF
--- a/src/Umbraco.Core/DictionaryExtensions.cs
+++ b/src/Umbraco.Core/DictionaryExtensions.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
-using System.Web.Mvc;
 using System.Web;
 
 namespace Umbraco.Core
@@ -135,20 +134,6 @@ namespace Umbraco.Core
 			return n;
 		}
 
-		/// <summary>
-		/// Converts a dictionary to a FormCollection
-		/// </summary>
-		/// <param name="d"></param>
-		/// <returns></returns>
-		public static FormCollection ToFormCollection(this IDictionary<string, object> d)
-		{
-			var n = new FormCollection();
-			foreach (var i in d)
-			{
-				n.Add(i.Key, Convert.ToString(i.Value));
-			}
-			return n;
-		}
 
 	    /// <summary>
 	    /// Merges all key/values from the sources dictionaries into the destination dictionary

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -54,10 +54,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\log4net-mediumtrust.2.0.0\lib\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
     <Reference Include="MiniProfiler, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b44f9351044011a3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\MiniProfiler.2.1.0\lib\net40\MiniProfiler.dll</HintPath>
@@ -95,32 +91,8 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.Helpers.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.30506.0\lib\net40\System.Web.Mvc.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.30506.0\lib\net40\System.Web.Razor.dll</HintPath>
-    </Reference>
     <Reference Include="System.Web.Services, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -902,8 +874,6 @@
     <Compile Include="Profiling\LogProfiler.cs" />
     <Compile Include="Profiling\ProfilerExtensions.cs" />
     <Compile Include="Profiling\ProfilerResolver.cs" />
-    <Compile Include="Profiling\ProfilingView.cs" />
-    <Compile Include="Profiling\ProfilingViewEngine.cs" />
     <Compile Include="Profiling\WebProfiler.cs" />
     <Compile Include="PropertyEditors\DelimitedManifestValueValidator.cs" />
     <Compile Include="PropertyEditors\IntegerValidator.cs" />
@@ -1210,7 +1180,6 @@
     <Compile Include="StringExtensions.cs" />
     <Compile Include="UriExtensions.cs" />
     <Compile Include="SystemUtilities.cs" />
-    <Compile Include="UrlHelperExtensions.cs" />
     <Compile Include="WriteLock.cs" />
     <Compile Include="XmlExtensions.cs" />
     <Compile Include="XmlHelper.cs" />

--- a/src/Umbraco.Core/UmbracoApplicationBase.cs
+++ b/src/Umbraco.Core/UmbracoApplicationBase.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Web;
 using System.Web.Hosting;
-using System.Web.Mvc;
-using StackExchange.Profiling;
-using Umbraco.Core.Configuration;
 using Umbraco.Core.Logging;
 using Umbraco.Core.ObjectResolution;
 
@@ -33,8 +30,6 @@ namespace Umbraco.Core
         /// </summary>
         internal void StartApplication(object sender, EventArgs e)
         {
-            //don't output the MVC version header (security)
-            MvcHandler.DisableMvcResponseHeader = true;
 
             //boot up the application
             GetBootManager()

--- a/src/Umbraco.Core/UriExtensions.cs
+++ b/src/Umbraco.Core/UriExtensions.cs
@@ -1,9 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Web;
-using System.Web.Mvc;
-using System.Web.Routing;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.IO;
 

--- a/src/Umbraco.Core/packages.config
+++ b/src/Umbraco.Core/packages.config
@@ -3,14 +3,10 @@
   <package id="AutoMapper" version="3.0.0" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
   <package id="log4net-mediumtrust" version="2.0.0" targetFramework="net40" />
-  <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net40" />
-  <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebApi.Client" version="4.0.30506.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net45" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
   <package id="MiniProfiler" version="2.1.0" targetFramework="net45" />
   <package id="MySql.Data" version="6.6.5" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />

--- a/src/Umbraco.Web/Mvc/ProfilingView.cs
+++ b/src/Umbraco.Web/Mvc/ProfilingView.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Web.Mvc;
 
 namespace Umbraco.Core.Profiling

--- a/src/Umbraco.Web/Mvc/ProfilingViewEngine.cs
+++ b/src/Umbraco.Web/Mvc/ProfilingViewEngine.cs
@@ -1,4 +1,4 @@
-﻿using System.Web.Mvc;
+using System.Web.Mvc;
 
 namespace Umbraco.Core.Profiling
 {

--- a/src/Umbraco.Web/Mvc/QueryStringFilterAttribute.cs
+++ b/src/Umbraco.Web/Mvc/QueryStringFilterAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web.Mvc;
 using Umbraco.Core;
@@ -30,12 +31,28 @@ namespace Umbraco.Web.Mvc
         {
             var nonNullKeys = filterContext.HttpContext.Request.QueryString.AllKeys.Where(x => !string.IsNullOrEmpty(x));
             var vals = nonNullKeys.ToDictionary(q => q, q => (object)filterContext.HttpContext.Request.QueryString[q]);
-            var qs = vals.ToFormCollection();
+            var qs = ToFormCollection(vals);
 
             filterContext.ActionParameters[ParameterName] = qs;
 
             base.OnActionExecuting(filterContext);
         }
+
+        /// <summary>
+        /// Converts a dictionary to a FormCollection
+        /// </summary>
+        /// <param name="d"></param>
+        /// <returns></returns>
+        public static FormCollection ToFormCollection(IDictionary<string, object> d)
+        {
+            var n = new FormCollection();
+            foreach (var i in d)
+            {
+                n.Add(i.Key, Convert.ToString(i.Value));
+            }
+            return n;
+        }
+
     }
 
 }

--- a/src/Umbraco.Web/Mvc/UrlHelperExtensions.cs
+++ b/src/Umbraco.Web/Mvc/UrlHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -274,6 +274,9 @@
     <Compile Include="Mvc\DisableClientCacheAttribute.cs" />
     <Compile Include="Mvc\MvcVersionCheck.cs" />
     <Compile Include="Mvc\ReflectedFixedRazorViewEngine.cs" />
+    <Compile Include="Mvc\ProfilingView.cs" />
+    <Compile Include="Mvc\ProfilingViewEngine.cs" />
+    <Compile Include="Mvc\UrlHelperExtensions.cs" />	
     <Compile Include="Scheduling\BackgroundTaskRunner.cs" />
     <Compile Include="BatchedServerMessenger.cs" />
     <Compile Include="CacheHelperExtensions.cs" />


### PR DESCRIPTION
This removes the dependency from Umbraco.Core on the MVC hosting library.  This sounds like a generally good idea anyway, but I have included an explanation of my specific scenario in case you want to know more.

This allows my readonly REST API wrapper for Umbraco to be hosted anywhere - including in different versions of MVC and on Mono.  I still run the main Umbraco website production build for content editing, but this separate service extracts the data from UmbracoDB directly.  This separate service runs in a docker container within ASP.NET 5 (currently vNext) as an ApiController, but I can also run it on windows and on older versions of ASP.NET. 

I tried to avoid making any change to the Umbraco code base, as maintaining my own branch is too much effort in the long term.  Unfortunately the traditional mechanism to write Umbraco API services just was not possible in my scenario.  I also considered a few other options:
  -  network access from my new service to the main umbraco website
  -  separate app domain to host the umbraco and its own MVC library.

Here are the commit notes:
note:MvcHandler.DisableMvcResponseHeader = true was removed from UmbracoApplicationBase.StartApplication.
This was the only breaking change, it can be put back in at a higher level if necessary.