### PR TITLE
DistributedCache - don't serialize payload on local node

### DIFF
--- a/src/Umbraco.Core/Cache/IPayloadCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/IPayloadCacheRefresher.cs
@@ -1,0 +1,16 @@
+﻿using umbraco.interfaces;
+
+namespace Umbraco.Core.Cache
+{
+    /// <summary>
+    /// A cache refresher that supports refreshing cache based on a custom payload
+    /// </summary>
+    interface IPayloadCacheRefresher : ICacheRefresher
+    {
+        /// <summary>
+        /// Refreshes, clears, etc... any cache based on the information provided in the payload
+        /// </summary>
+        /// <param name="payload"></param>
+        void Refresh(object payload);
+    }
+}

--- a/src/Umbraco.Core/Cache/IPayloadCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/IPayloadCacheRefresher.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Core.Cache
     /// <summary>
     /// A cache refresher that supports refreshing cache based on a custom payload
     /// </summary>
-    interface IPayloadCacheRefresher : ICacheRefresher
+    interface IPayloadCacheRefresher : IJsonCacheRefresher
     {
         /// <summary>
         /// Refreshes, clears, etc... any cache based on the information provided in the payload

--- a/src/Umbraco.Core/Cache/JsonCacheRefresherBase.cs
+++ b/src/Umbraco.Core/Cache/JsonCacheRefresherBase.cs
@@ -4,17 +4,16 @@ using umbraco.interfaces;
 namespace Umbraco.Core.Cache
 {
     /// <summary>
-    /// A base class for json cache refreshers that ensures the correct events are raised when 
-    /// cache refreshing occurs.
+    /// Provides a base class for "json" cache refreshers.
     /// </summary>
-    /// <typeparam name="TInstanceType">The real cache refresher type, this is used for raising strongly typed events</typeparam>
-    public abstract class JsonCacheRefresherBase<TInstanceType> : CacheRefresherBase<TInstanceType>, IJsonCacheRefresher 
-        where TInstanceType : ICacheRefresher
+    /// <typeparam name="TInstance">The actual cache refresher type.</typeparam>
+    /// <remarks>Ensures that the correct events are raised when cache refreshing occurs.</remarks>
+    public abstract class JsonCacheRefresherBase<TInstance> : CacheRefresherBase<TInstance>, IJsonCacheRefresher
+        where TInstance : ICacheRefresher
     {        
-
-        public virtual void Refresh(string jsonPayload)
+        public virtual void Refresh(string json)
         {            
-            OnCacheUpdated(Instance, new CacheRefresherEventArgs(jsonPayload, MessageType.RefreshByJson));
+            OnCacheUpdated(Instance, new CacheRefresherEventArgs(json, MessageType.RefreshByJson));
         }
     }
 }

--- a/src/Umbraco.Core/Cache/PayloadCacheRefresherBase.cs
+++ b/src/Umbraco.Core/Cache/PayloadCacheRefresherBase.cs
@@ -1,0 +1,27 @@
+﻿using Umbraco.Core.Sync;
+using umbraco.interfaces;
+
+namespace Umbraco.Core.Cache
+{
+    /// <summary>
+    /// Provides a base class for "payload" cache refreshers.
+    /// </summary>
+    /// <typeparam name="TInstance">The actual cache refresher type.</typeparam>
+    /// <remarks>Ensures that the correct events are raised when cache refreshing occurs.</remarks>
+    public abstract class PayloadCacheRefresherBase<TInstance> : JsonCacheRefresherBase<TInstance>, IPayloadCacheRefresher
+        where TInstance : ICacheRefresher
+    {
+        protected abstract object Deserialize(string json);
+
+        public override void Refresh(string json)
+        {
+            var payload = Deserialize(json);
+            Refresh(payload);
+        }
+
+        public virtual void Refresh(object payload)
+        {
+            OnCacheUpdated(Instance, new CacheRefresherEventArgs(payload, MessageType.RefreshByPayload));
+        }
+    }
+}

--- a/src/Umbraco.Core/Sync/IServerMessenger.cs
+++ b/src/Umbraco.Core/Sync/IServerMessenger.cs
@@ -10,15 +10,13 @@ namespace Umbraco.Core.Sync
     /// <remarks>Also ensures that the notification is processed on the local environment.</remarks>
     public interface IServerMessenger
     {
-        // TODO
-        // everything we do "by JSON" means that data is serialized then deserialized on the local server
-        // we should stop using this, and instead use Notify() with an actual object that can be passed
-        // around locally, and serialized for remote messaging - but that would break backward compat ;-(
-        //
-        // and then ServerMessengerBase must be able to handle Notify(), and all messengers too
-        // and then ICacheRefresher (or INotifiableCacheRefresher?) must be able to handle it too
-        //
-        // >> v8
+        /// <summary>
+        /// Notifies the distributed cache, for a specified <see cref="ICacheRefresher"/>.
+        /// </summary>
+        /// <param name="servers">The servers that compose the load balanced environment.</param>
+        /// <param name="refresher">The ICacheRefresher.</param>
+        /// <param name="payload">The notification content.</param>
+        void PerformRefresh(IEnumerable<IServerAddress> servers, ICacheRefresher refresher, object payload);
 
         /// <summary>
         /// Notifies the distributed cache, for a specified <see cref="ICacheRefresher"/>.
@@ -27,15 +25,6 @@ namespace Umbraco.Core.Sync
         /// <param name="refresher">The ICacheRefresher.</param>
         /// <param name="jsonPayload">The notification content.</param>
         void PerformRefresh(IEnumerable<IServerAddress> servers, ICacheRefresher refresher, string jsonPayload);
-
-        ///// <summary>
-        ///// Notifies the distributed cache, for a specified <see cref="ICacheRefresher"/>.
-        ///// </summary>
-        ///// <param name="servers">The servers that compose the load balanced environment.</param>
-        ///// <param name="refresher">The ICacheRefresher.</param>
-        ///// <param name="payload">The notification content.</param>
-        ///// <param name="serializer">A custom Json serializer.</param>
-        //void Notify(IEnumerable<IServerAddress> servers, ICacheRefresher refresher, object payload, Func<object, string> serializer = null);
 
         /// <summary>
         /// Notifies the distributed cache of specifieds item invalidation, for a specified <see cref="ICacheRefresher"/>.

--- a/src/Umbraco.Core/Sync/MessageType.cs
+++ b/src/Umbraco.Core/Sync/MessageType.cs
@@ -10,6 +10,7 @@
         RefreshByJson,
         RemoveById,
         RefreshByInstance,
-        RemoveByInstance
+        RemoveByInstance,
+        RefreshByPayload
     }
 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Cache\CacheRefresherEventArgs.cs" />
     <Compile Include="Cache\DictionaryCacheProviderBase.cs" />
     <Compile Include="Cache\HttpRequestCacheProvider.cs" />
+    <Compile Include="Cache\IPayloadCacheRefresher.cs" />
     <Compile Include="Cache\ObjectCacheRuntimeCacheProvider.cs" />
     <Compile Include="Cache\IRuntimeCacheProvider.cs" />
     <Compile Include="Cache\HttpRuntimeCacheProvider.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Cache\IJsonCacheRefresher.cs" />
     <Compile Include="Cache\JsonCacheRefresherBase.cs" />
     <Compile Include="Cache\NullCacheProvider.cs" />
+    <Compile Include="Cache\PayloadCacheRefresherBase.cs" />
     <Compile Include="Cache\StaticCacheProvider.cs" />
     <Compile Include="Cache\TypedCacheRefresherBase.cs" />
     <Compile Include="CodeAnnotations\FriendlyNameAttribute.cs" />

--- a/src/Umbraco.Tests/DistributedCache/DistributedCacheTests.cs
+++ b/src/Umbraco.Tests/DistributedCache/DistributedCacheTests.cs
@@ -140,6 +140,10 @@ namespace Umbraco.Tests.DistributedCache
             public List<string> PayloadsRefreshed = new List<string>(); 
             public int CountOfFullRefreshes = 0;
 
+            public void PerformRefresh(IEnumerable<IServerAddress> servers, ICacheRefresher refresher, object payload)
+            {
+                // doing nothing
+            }
 
             public void PerformRefresh(IEnumerable<IServerAddress> servers, ICacheRefresher refresher, string jsonPayload)
             {

--- a/src/Umbraco.Web/Cache/DistributedCache.cs
+++ b/src/Umbraco.Web/Cache/DistributedCache.cs
@@ -145,6 +145,16 @@ namespace Umbraco.Web.Cache
                 id);
         }
 
+        public void RefreshByPayload(Guid factoryGuid, object payload)
+        {
+            if (factoryGuid == Guid.Empty || payload == null) return;
+
+            ServerMessengerResolver.Current.Messenger.PerformRefresh(
+                ServerRegistrarResolver.Current.Registrar.Registrations,
+                GetRefresherById(factoryGuid),
+                payload);
+        }
+
         /// <summary>
         /// Notifies the distributed cache, for a specified <see cref="ICacheRefresher"/>.
         /// </summary>


### PR DESCRIPTION
Some cache refresher are going the RefreshByJson way (vs eg RefreshById or RefreshByInstance) because we want to carry more infos (such as, refreshing a content that impacts only that content, or its entire branch). Json implies serialization and de-serialization, which is required in a distributed scenario to send messages to the other nodes -- but is a useless overhead on the local node.

That PR makes it possible to RefreshByPayload() cache refreshers that are IPayloadCacheRefresher. The local node will directly receive the non-serialized payload, while the remote nodes will be refreshed by Json (so obviously being IPayloadCacheRefresher implies being IJsonCacheRefresher).