### PR TITLE
U4-6295 - Fix for BusinessLogic.Log.CleanLogs task error

### DIFF
--- a/src/umbraco.businesslogic/Log.cs
+++ b/src/umbraco.businesslogic/Log.cs
@@ -263,7 +263,7 @@ namespace umbraco.BusinessLogic
                     var formattedDate = oldestPermittedLogEntry.ToString("yyyy-MM-dd HH:mm:ss");
 
                     SqlHelper.ExecuteNonQuery("delete from umbracoLog where datestamp < @oldestPermittedLogEntry and logHeader in ('open','system')",
-                        SqlHelper.CreateParameter("@oldestPermittedLogEntry", formattedDate));
+                        SqlHelper.CreateParameter("@oldestPermittedLogEntry", oldestPermittedLogEntry));
 
                     LogHelper.Info<Log>(string.Format("Log scrubbed.  Removed all items older than {0}", formattedDate));
                 }


### PR DESCRIPTION
Passing directly the Datetime as SqlParameter let SqlClient take care of format conversion.
It does solve issue U4-6295.