### PR TITLE
Introduced alias for row configurations

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
@@ -10,6 +10,10 @@ ng-controller="Umbraco.PropertyEditors.GridPrevalueEditor.RowConfigController">
                 <input type="text" ng-model="currentRow.name" />
             </umb-control-group>
 
+            <umb-control-group label="Alias">
+                <input type="text" ng-model="currentRow.alias" />
+            </umb-control-group>
+
             <div class="uSky-templates-template"
                  style="margin: 0; width: 350px; position: relative;">
 


### PR DESCRIPTION
Document types, property editors and a lot of other types in Umbraco both have a name and an alias, where the name is only something visual, and the alias is something that can be used in the code. So why not use this for row configurations in the grid as well?

I think an alias for row configurations really makes sense, since there might be a reason for change the name of the row, whereas the alias could stay the same.

The label probably needs some localization, since I'm not sure how to do that.