### PR TITLE
Providing the option to use absolute URLs in the Rich Text Editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -42,6 +42,7 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                        cfg.stylesheets = [];
                        cfg.dimensions = { height: 500 };
                        cfg.maxImageSize = 500;
+                      cfg.useAbsoluteUrls = false;
                 return cfg;
         },
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -119,7 +119,7 @@ angular.module("umbraco")
                     maxImageSize: editorConfig.maxImageSize,
                     toolbar: toolbar,
                     content_css: stylesheets.join(','),
-                    relative_urls: false,
+                    relative_urls: editorConfig.useAbsoluteUrls,
                     style_formats: styleFormats
                 };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -33,4 +33,8 @@
     <umb-control-group label="Maximum size for inserted images" description="0 to disable resizing">
         <input type="number" ng-model="model.value.maxImageSize" class="umb-editor-tiny" placeholder="Width/Height" /> Pixels
     </umb-control-group>
+
+    <umb-control-group label="Use absolute URLs" description="Tick to embed relative URLs">
+        <input type="checkbox" ng-model="model.value.useAbsoluteUrls" class="umb-editor-tiny" placeholder="UseAbsoluteUrls" /> Yes
+    </umb-control-group>
 </div>


### PR DESCRIPTION
Hi,

This change adds the ability to use absolute URLs in the Rich Text Editor.  This is required on a project of ours, where the emails have customisable content, and URLs within them must remain unchanged.

The value defaults to false, so will not affect existing behaviour.

Thanks,
Darren
