### PR TITLE
Fix changes in user section labels

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -863,7 +863,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="editors">Redaktør</key>
     <key alias="excerptField">Uddragsfelt</key>
     <key alias="language">Sprog</key>
-    <key alias="loginname">Login</key>
+    <key alias="loginname">Brugernavn</key>
     <key alias="mediastartnode">Startnode i mediearkivet</key>
     <key alias="modules">Moduler</key>
     <key alias="noConsole">Deaktivér adgang til Umbraco</key>
@@ -881,12 +881,11 @@ Mange hilsner fra Umbraco robotten
     <key alias="permissionSelectPages">Vælg sider for at ændre deres rettigheder</key>
     <key alias="searchAllChildren">Søg alle 'børn'</key>
     <key alias="startnode">Start node</key>
-    <key alias="username">Brugernavn</key>
+    <key alias="username">Navn</key>
     <key alias="userPermissions">Bruger tilladelser</key>
     <key alias="usertype">Brugertype</key>
     <key alias="userTypes">Bruger typer</key>
     <key alias="writer">Forfatter</key>
-
     <key alias="yourProfile">Din profil</key>
     <key alias="yourHistory">Din historik</key>
     <key alias="sessionExpires">Session udløber</key>


### PR DESCRIPTION
Fixed translation in da.xml according to change in en.xml  from 7.2.4 to
7.2.5 and to be consistent in the UI.
http://issues.umbraco.org/issue/U4-6629

However I find it a bit confusing with the changes in the language files and the labels doesn't match the keys anymore.

E.g in en.xml 

Before:
```
<key alias="loginname">Login</key>
<key alias="username">Username</key>
```

After:
```
<key alias="loginname">Username</key>
<key alias="username">Name</key>
```

I think it would make more sense to update the keys in the views (or old .aspx files) and have keys like this:
```
<key alias="loginname">Name</key>
<key alias="username">Username</key>
```
or name it **name** instead of **loginname**

and then update the view files with the right key.