### PR TITLE
Fixed login-view on mobile devices

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/login.less
@@ -24,7 +24,7 @@
 .login-overlay .form {
   display: block;
   padding-top: 100px;
-  padding-left: 165px;
+  padding-left: 21%;
   width: 370px;
   text-align: right
 }
@@ -44,4 +44,12 @@
     padding-left: 6px;
     margin-top: 10px;
     text-align: center;
+}
+
+@media (max-width: 767px) {
+  // Remove padding on login-form on smaller devices
+  .login-overlay .form {
+    padding-left: 2%!important;
+    width: 90%;
+  }
 }


### PR DESCRIPTION
On smaller screens the login-view was too far to the right.

Related issue: http://issues.umbraco.org/issue/U4-5020