### PR TITLE
Fix content-edit-view on mobile devices

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -794,3 +794,17 @@ legend + .control-group {
     position: relative;
     z-index: 1000;
 }
+
+
+
+@media (max-width: 767px) {
+
+  // Labels on own row
+  .form-horizontal .control-label {
+    width: 100%;
+  }
+  .form-horizontal .controls {
+    margin-left: 0;
+  }
+
+}

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -146,7 +146,7 @@ h5{
 
 .controls-row {
   padding-top: 5px;
-  margin-left: 240px !important;
+  margin-left: 240px;
 }
 .controls-row label {
   display: inline-block


### PR DESCRIPTION
The content editing view did not work at all on small screens. The label
took to much space, leaving the controller with almost none. Now the
label and the controller get its own row on smaller screens. Much
cleaner look and you can acctually edit a page on a small screen. Note:
Grids still don't work well.

Related issue: http://issues.umbraco.org/issue/U4-6633