### PR TITLE
Fix U4-6655:  RTE Macro not rendering in backoffice when "macroAlias" is not first attribute

### DIFF
--- a/src/Umbraco.Core/Macros/MacroTagParser.cs
+++ b/src/Umbraco.Core/Macros/MacroTagParser.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Core.Macros
 	internal class MacroTagParser
 	{
         private static readonly Regex MacroRteContent = new Regex(@"(<!--\s*?)(<\?UMBRACO_MACRO.*?/>)(\s*?-->)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        private static readonly Regex MacroPersistedFormat = new Regex(@"(<\?UMBRACO_MACRO macroAlias=[""']([^""\'\n\r]+?)[""'].+?)(?:/>|>.*?</\?UMBRACO_MACRO>)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        private static readonly Regex MacroPersistedFormat = new Regex(@"(<\?UMBRACO_MACRO (?:.+)?macroAlias=[""']([^""\'\n\r]+?)[""'].+?)(?:/>|>.*?</\?UMBRACO_MACRO>)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
 	    /// <summary>
 	    /// This formats the persisted string to something useful for the rte so that the macro renders properly since we 

--- a/src/Umbraco.Tests/Macros/MacroParserTests.cs
+++ b/src/Umbraco.Tests/Macros/MacroParserTests.cs
@@ -110,6 +110,29 @@ namespace Umbraco.Tests.Macros
         }
 
         [Test]
+        public void Format_RTE_Data_For_Editor_With_Params_When_MacroAlias_Not_First()
+        {
+            var content = @"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<?UMBRACO_MACRO test1=""value1"" test2=""value2"" macroAlias=""Map"" />
+<p>asdfasdf</p>";
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+
+//            Assert.AreEqual(@"<p>asdfasdf</p>
+//<p>asdfsadf</p>
+//<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+//<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+//<ins>Macro alias: <strong>Map</strong></ins></div>
+//<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+            Assert.AreEqual(@"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
+<!-- <?UMBRACO_MACRO test1=""value1"" test2=""value2"" macroAlias=""Map"" /> -->
+<ins>Macro alias: <strong>Map</strong></ins></div>
+<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [Test]
         public void Format_RTE_Data_For_Editor_With_Params_Closing_Tag()
         {
             var content = @"<p>asdfasdf</p>

--- a/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
@@ -15,7 +15,7 @@ function macroService() {
             
             //This regex will match an alias of anything except characters that are quotes or new lines (for legacy reasons, when new macros are created
             // their aliases are cleaned an invalid chars are stripped)
-            var expression = /(<\?UMBRACO_MACRO macroAlias=["']([^\"\'\n\r]+?)["'][\s\S]+?)(\/>|>.*?<\/\?UMBRACO_MACRO>)/i;
+            var expression = /(<\?UMBRACO_MACRO (?:.+)?macroAlias=["']([^\"\'\n\r]+?)["'][\s\S]+?)(\/>|>.*?<\/\?UMBRACO_MACRO>)/i;
             var match = expression.exec(syntax);
             if (!match || match.length < 3) {
                 return null;

--- a/src/Umbraco.Web.UI.Client/test/unit/common/services/macro-service.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/services/macro-service.spec.js
@@ -40,6 +40,18 @@ describe('macro service tests', function () {
             expect(result.macroParamsDictionary.test2).toBe("hello");
         });
 
+        it('can parse syntax for macros when macroAlias is not the first parameter', function () {
+
+            var result = macroService.parseMacroSyntax("<?UMBRACO_MACRO test=\"asdf\" test2='hello' macroAlias='Map.Test' />");
+
+            expect(result).not.toBeNull();
+            expect(result.macroAlias).toBe("Map.Test");
+            expect(result.macroParamsDictionary.test).not.toBeUndefined();
+            expect(result.macroParamsDictionary.test).toBe("asdf");
+            expect(result.macroParamsDictionary.test2).not.toBeUndefined();
+            expect(result.macroParamsDictionary.test2).toBe("hello");
+        });
+
         it('can parse syntax for macros with aliases containing whitespace and other chars', function () {
 
             var result = macroService.parseMacroSyntax("<?UMBRACO_MACRO macroAlias='Map Test [Hello\\World]' test=\"asdf\" test2='hello' />");


### PR DESCRIPTION
See [U4-6655](http://issues.umbraco.org/issue/U4-6655)