### PR TITLE
U4-5439 - allowed for customised message when Saving or Publishing events are cancelled

### DIFF
--- a/src/Umbraco.Core/Events/CancellableEventArgs.cs
+++ b/src/Umbraco.Core/Events/CancellableEventArgs.cs
@@ -47,5 +47,7 @@ namespace Umbraco.Core.Events
 				_cancel = value;
 			}
 		}
+
+	    public string CustomMessage { get; set; }
 	}
 }

--- a/src/Umbraco.Core/Events/EventExtensions.cs
+++ b/src/Umbraco.Core/Events/EventExtensions.cs
@@ -7,7 +7,15 @@ namespace Umbraco.Core.Events
 	/// </summary>
 	public static class EventExtensions
 	{
-        public static bool IsRaisedEventCancelled<TSender, TArgs>(
+		/// <summary>
+		/// Raises the event and returns a boolean value indicating if the event was cancelled
+		/// </summary>
+		/// <typeparam name="TSender"></typeparam>
+		/// <typeparam name="TArgs"></typeparam>
+		/// <param name="eventHandler"></param>
+		/// <param name="args"></param>
+		/// <param name="sender"></param>
+		public static bool IsRaisedEventCancelled<TSender, TArgs>(
             this TypedEventHandler<TSender, TArgs> eventHandler,
             TArgs args,
             TSender sender)

--- a/src/Umbraco.Core/Events/EventExtensions.cs
+++ b/src/Umbraco.Core/Events/EventExtensions.cs
@@ -7,6 +7,18 @@ namespace Umbraco.Core.Events
 	/// </summary>
 	public static class EventExtensions
 	{
+        public static bool IsRaisedEventCancelled<TSender, TArgs>(
+            this TypedEventHandler<TSender, TArgs> eventHandler,
+            TArgs args,
+            TSender sender)
+            where TArgs : CancellableEventArgs
+        {
+            if (eventHandler != null)
+                eventHandler(sender, args);
+
+            return args.Cancel;
+        }
+
 		/// <summary>
 		/// Raises the event and returns a boolean value indicating if the event was cancelled
 		/// </summary>
@@ -15,17 +27,20 @@ namespace Umbraco.Core.Events
 		/// <param name="eventHandler"></param>
 		/// <param name="args"></param>
 		/// <param name="sender"></param>
+		/// <param name="customMessage"></param>
 		/// <returns></returns>
-		public static bool IsRaisedEventCancelled<TSender, TArgs>(
+        public static bool IsRaisedEventCancelled<TSender, TArgs>(
 			this TypedEventHandler<TSender, TArgs> eventHandler,
 			TArgs args,
-			TSender sender)
+			TSender sender, 
+            out string customMessage)
 			where TArgs : CancellableEventArgs
 		{
 			if (eventHandler != null)
 				eventHandler(sender, args);
 
-			return args.Cancel;
+		    customMessage = args.CustomMessage;
+            return args.Cancel;
 		}
 
 		/// <summary>

--- a/src/Umbraco.Core/Publishing/PublishStatus.cs
+++ b/src/Umbraco.Core/Publishing/PublishStatus.cs
@@ -21,6 +21,12 @@ namespace Umbraco.Core.Publishing
             StatusType = statusType;
         }
 
+        public PublishStatus(IContent content, PublishStatusType statusType, string customMessage)
+            : this(content, statusType)
+        {
+            CustomMessage = customMessage;
+        }
+
         /// <summary>
         /// Creates a successful publish status
         /// </summary>
@@ -36,5 +42,7 @@ namespace Umbraco.Core.Publishing
         /// Gets sets the invalid properties if the status failed due to validation.
         /// </summary>
         public IEnumerable<Property> InvalidProperties { get; set; }
+
+        public string CustomMessage { get; set; }
     }
 }

--- a/src/Umbraco.Core/Publishing/PublishingStrategy.cs
+++ b/src/Umbraco.Core/Publishing/PublishingStrategy.cs
@@ -21,11 +21,12 @@ namespace Umbraco.Core.Publishing
         /// <param name="userId">Id of the User issueing the publish operation</param>        
         internal Attempt<PublishStatus> PublishInternal(IContent content, int userId)
         {
-            if (Publishing.IsRaisedEventCancelled(new PublishEventArgs<IContent>(content), this))
+            string customMessage;
+            if (Publishing.IsRaisedEventCancelled(new PublishEventArgs<IContent>(content), this, out customMessage))
             {
                 LogHelper.Info<PublishingStrategy>(
                         string.Format("Content '{0}' with Id '{1}' will not be published, the event was cancelled.", content.Name, content.Id));
-                return Attempt<PublishStatus>.Fail(new PublishStatus(content, PublishStatusType.FailedCancelledByEvent));
+                return Attempt<PublishStatus>.Fail(new PublishStatus(content, PublishStatusType.FailedCancelledByEvent, customMessage));
             }
                 
 

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1760,8 +1760,9 @@ namespace Umbraco.Core.Services
                     var internalStrategy = (PublishingStrategy)_publishingStrategy;
                     //Publish and then update the database with new status
                     var publishResult = internalStrategy.PublishInternal(content, userId);
-                    //set the status type to the publish result
+                    //set the status type and message to the publish result
                     publishStatus.StatusType = publishResult.Result.StatusType;
+                    publishStatus.CustomMessage = publishResult.Result.CustomMessage;
                 }
 
                 //we are successfully published if our publishStatus is still Successful

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1729,9 +1729,12 @@ namespace Umbraco.Core.Services
         {
             if (raiseEvents)
             {
-                if (Saving.IsRaisedEventCancelled(new SaveEventArgs<IContent>(content), this))
+                string customMessage;
+                var isRaisedEventCancelled = Saving.IsRaisedEventCancelled(new SaveEventArgs<IContent>(content), this, out customMessage);
+
+                if (isRaisedEventCancelled)
                 {
-                    return Attempt.Fail(new PublishStatus(content, PublishStatusType.FailedCancelledByEvent));
+                    return Attempt.Fail(new PublishStatus(content, PublishStatusType.FailedCancelledByEvent, customMessage));
                 }
             }
 

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -260,7 +260,6 @@ namespace Umbraco.Web.Editors
                 publishStatus = Services.ContentService.SaveAndPublishWithStatus(contentItem.PersistedContent, Security.CurrentUser.Id);
             }
             
-
             //return the updated model
             var display = Mapper.Map<IContent, ContentItemDisplay>(contentItem.PersistedContent);
 
@@ -612,7 +611,9 @@ namespace Umbraco.Web.Editors
                 case PublishStatusType.FailedCancelledByEvent:
                     display.AddWarningNotification(
                         ui.Text("publish"),
-                        ui.Text("speechBubbles", "contentPublishedFailedByEvent"));
+                        string.IsNullOrEmpty(status.CustomMessage)
+                            ? ui.Text("speechBubbles", "contentPublishedFailedByEvent")
+                            : status.CustomMessage);
                     break;                
                 case PublishStatusType.FailedAwaitingRelease:
                     display.AddWarningNotification(


### PR DESCRIPTION
I've added a property to these EventArg classess where a custom message can be set like this:

    protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
    {
        ContentService.Saving += ContentService_Saving;
    }

    void ContentService_Saving(Core.Services.IContentService sender, Core.Events.SaveEventArgs<IContent> e)
    {
        e.Cancel = true;
        e.CustomMessage = "This is why save was cancelled";
    }

This then carries through to the UI and is displayed instead of the generic message about the operation being "cancelled by a 3rd party add-in".

Just to note I had a quick look at Deleting, Trashing and Moving as well - but although the events can be cancelled, the UI isn't consistently updated anyway (either with no response, or always a success one).  So that would be another issue.