### PR TITLE
Fix U4-6687: Can't add multiple instances of a macro in RTE in 7.2.6 …

### DIFF
--- a/src/Umbraco.Core/Macros/MacroTagParser.cs
+++ b/src/Umbraco.Core/Macros/MacroTagParser.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Core.Macros
 	internal class MacroTagParser
 	{
         private static readonly Regex MacroRteContent = new Regex(@"(<!--\s*?)(<\?UMBRACO_MACRO.*?/>)(\s*?-->)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        private static readonly Regex MacroPersistedFormat = new Regex(@"(<\?UMBRACO_MACRO (?:.+)?macroAlias=[""']([^""\'\n\r]+?)[""'].+?)(?:/>|>.*?</\?UMBRACO_MACRO>)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        private static readonly Regex MacroPersistedFormat = new Regex(@"(<\?UMBRACO_MACRO (?:.+?)?macroAlias=[""']([^""\'\n\r]+?)[""'].+?)(?:/>|>.*?</\?UMBRACO_MACRO>)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
 	    /// <summary>
 	    /// This formats the persisted string to something useful for the rte so that the macro renders properly since we 

--- a/src/Umbraco.Core/Macros/MacroTagParser.cs
+++ b/src/Umbraco.Core/Macros/MacroTagParser.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Core.Macros
 	internal class MacroTagParser
 	{
         private static readonly Regex MacroRteContent = new Regex(@"(<!--\s*?)(<\?UMBRACO_MACRO.*?/>)(\s*?-->)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        private static readonly Regex MacroPersistedFormat = new Regex(@"(<\?UMBRACO_MACRO (?:.+?)?macroAlias=[""']([^""\'\n\r]+?)[""'].+?)(?:/>|>.*?</\?UMBRACO_MACRO>)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        private static readonly Regex MacroPersistedFormat = new Regex(@"(<\?UMBRACO_MACRO(?:.+?)?macroAlias=[""']([^""\'\n\r]+?)[""'].+?)(?:/>|>.*?</\?UMBRACO_MACRO>)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
 	    /// <summary>
 	    /// This formats the persisted string to something useful for the rte so that the macro renders properly since we 

--- a/src/Umbraco.Tests/Macros/MacroParserTests.cs
+++ b/src/Umbraco.Tests/Macros/MacroParserTests.cs
@@ -133,6 +133,74 @@ namespace Umbraco.Tests.Macros
         }
 
         [Test]
+        public void Format_RTE_Data_For_Editor_With_Params_When_MacroAlias_Is_First()
+        {
+
+            var content = @"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" />
+<p>asdfasdf</p>";
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+
+            //            Assert.AreEqual(@"<p>asdfasdf</p>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+            Assert.AreEqual(@"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
+<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+<ins>Macro alias: <strong>Map</strong></ins></div>
+<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [Test]
+        public void Format_RTE_Data_For_Editor_With_Params_When_Multiple_Macros()
+        {
+            var content = @"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<?UMBRACO_MACRO test1=""value1"" test2=""value2"" macroAlias=""Map"" />
+<p>asdfsadf</p>
+<?UMBRACO_MACRO test1=""value1"" macroAlias=""Map"" test2=""value2"" />
+<p>asdfsadf</p>
+<?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" />
+<p>asdfasdf</p>";
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+
+            //            Assert.AreEqual(@"<p>asdfasdf</p>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO test1=""value1"" test2=""value2"" macroAlias=""Map"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO test1=""value1"" macroAlias=""Map"" test2=""value2"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+
+            Assert.AreEqual(@"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
+<!-- <?UMBRACO_MACRO test1=""value1"" test2=""value2"" macroAlias=""Map"" /> -->
+<ins>Macro alias: <strong>Map</strong></ins></div>
+<p>asdfsadf</p>
+<div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
+<!-- <?UMBRACO_MACRO test1=""value1"" macroAlias=""Map"" test2=""value2"" /> -->
+<ins>Macro alias: <strong>Map</strong></ins></div>
+<p>asdfsadf</p>
+<div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
+<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+<ins>Macro alias: <strong>Map</strong></ins></div>
+<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [Test]
         public void Format_RTE_Data_For_Editor_With_Params_Closing_Tag()
         {
             var content = @"<p>asdfasdf</p>

--- a/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
@@ -15,7 +15,7 @@ function macroService() {
             
             //This regex will match an alias of anything except characters that are quotes or new lines (for legacy reasons, when new macros are created
             // their aliases are cleaned an invalid chars are stripped)
-            var expression = /(<\?UMBRACO_MACRO (?:.+)?macroAlias=["']([^\"\'\n\r]+?)["'][\s\S]+?)(\/>|>.*?<\/\?UMBRACO_MACRO>)/i;
+            var expression = /(<\?UMBRACO_MACRO (?:.+?)?macroAlias=["']([^\"\'\n\r]+?)["'][\s\S]+?)(\/>|>.*?<\/\?UMBRACO_MACRO>)/i;
             var match = expression.exec(syntax);
             if (!match || match.length < 3) {
                 return null;

--- a/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
@@ -15,7 +15,7 @@ function macroService() {
             
             //This regex will match an alias of anything except characters that are quotes or new lines (for legacy reasons, when new macros are created
             // their aliases are cleaned an invalid chars are stripped)
-            var expression = /(<\?UMBRACO_MACRO (?:.+?)?macroAlias=["']([^\"\'\n\r]+?)["'][\s\S]+?)(\/>|>.*?<\/\?UMBRACO_MACRO>)/i;
+            var expression = /(<\?UMBRACO_MACRO(?:.+?)?macroAlias=["']([^\"\'\n\r]+?)["'][\s\S]+?)(\/>|>.*?<\/\?UMBRACO_MACRO>)/i;
             var match = expression.exec(syntax);
             if (!match || match.length < 3) {
                 return null;


### PR DESCRIPTION
…without ruining RTE formatting

We found that the MacroTagParser.cs was being greedy and matching all UMBRACO_MACRO tags instead of getting them individually.

macro.service.js was updated for posterity purposes to match the regex in the .cs side, but testing showed that it was functioning as expected without this change.