### PR TITLE
Fix for U4-6642

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
@@ -336,9 +336,11 @@ namespace Umbraco.Core.Persistence.Repositories
             //Logic for setting Path, Level and SortOrder
             var parent = Database.First<NodeDto>("WHERE id = @ParentId", new { ParentId = entity.ParentId });
             int level = parent.Level + 1;
-            int sortOrder =
-                Database.ExecuteScalar<int>("SELECT ISNULL( MAX(sortOrder) + 1 , 0) FROM umbracoNode WHERE parentID = @ParentId",
-                                                      new { ParentId = entity.ParentId });
+            var maxSortOrder =
+                    Database.ExecuteScalar<int>(
+                        "SELECT coalesce(max(sortOrder),0) FROM umbracoNode WHERE parentid = @ParentId AND nodeObjectType = @NodeObjectType",
+                        new { ParentId = entity.ParentId, NodeObjectType = NodeObjectTypeId });
+            var sortOrder = maxSortOrder + 1;
 
             //Create the (base) node data - umbracoNode
             var nodeDto = dto.ContentVersionDto.ContentDto.NodeDto;

--- a/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
@@ -337,8 +337,8 @@ namespace Umbraco.Core.Persistence.Repositories
             var parent = Database.First<NodeDto>("WHERE id = @ParentId", new { ParentId = entity.ParentId });
             int level = parent.Level + 1;
             int sortOrder =
-                Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoNode WHERE parentID = @ParentId AND nodeObjectType = @NodeObjectType",
-                                                      new { ParentId = entity.ParentId, NodeObjectType = NodeObjectTypeId });
+                Database.ExecuteScalar<int>("SELECT ISNULL( MAX(sortOrder) + 1 , 0) FROM umbracoNode WHERE parentID = @ParentId",
+                                                      new { ParentId = entity.ParentId });
 
             //Create the (base) node data - umbracoNode
             var nodeDto = dto.ContentVersionDto.ContentDto.NodeDto;


### PR DESCRIPTION
The sort order is unpredictable after deleting a node and adding a new node under the same parent.  This issue is described in U4-6642 (Sort order messing up after deleting a node)