### PR TITLE
U4-6702: Fix incorect handling of wildcard domains when using UmbracoVirtualNodeHandler

### DIFF
--- a/src/Umbraco.Web/Routing/PublishedContentRequestEngine.cs
+++ b/src/Umbraco.Web/Routing/PublishedContentRequestEngine.cs
@@ -86,6 +86,9 @@ namespace Umbraco.Web.Routing
                 Thread.CurrentThread.CurrentUICulture = Thread.CurrentThread.CurrentCulture = _pcr.Culture;
 		    }
 
+            // handle wildcard domains
+            HandleWildcardDomains();
+
 			// trigger the Prepared event - at that point it is still possible to change about anything
             // even though the request might be flagged for redirection - we'll redirect _after_ the event
             //
@@ -357,9 +360,6 @@ namespace Umbraco.Web.Routing
 
 			// handle umbracoRedirect
 			FollowExternalRedirect();
-
-			// handle wildcard domains
-			HandleWildcardDomains();
 		}
 
 	    /// <summary>


### PR DESCRIPTION
As described in http://issues.umbraco.org/issue/U4-6702, this PR makes sure that HandleWildcardDomains is called in all cases, so that cultures are set correctly, even when using UmbracoVirtualNodeHandler.