### PR TITLE
As discussed in cg15 Grid workshop

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -850,7 +850,7 @@ To manage your website, simply open the Umbraco back office and start adding con
 
   <area alias="grid">
     <key alias="insertControl">Insert control</key>
-    <key alias="addRows">Choose a layout for the page</key>
+    <key alias="addRows">Choose a layout for this section</key>
     <key alias="addElement"><![CDATA[To start, click the <i class="icon icon-add blue"></i> below and add your first element]]></key>
 
     <key alias="clickToEmbed">Click to embed</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -850,7 +850,7 @@ To manage your website, simply open the Umbraco back office and start adding con
   </area>
   <area alias="grid">
     <key alias="insertControl">Insert control</key>
-    <key alias="addRows">Choose a layout for the page</key>
+    <key alias="addRows">Choose a layout for this section</key>
     <key alias="addElement"><![CDATA[To start, click the <i class="icon icon-add blue"></i> below and add your first element]]></key>
 
     <key alias="clickToEmbed">Click to embed</key>


### PR DESCRIPTION
If you use more than one grid datatype in one doctype, the editors are shown the text 'Choose a layout for the page' more than once. By showing 'Choose a layout for this section', the text is in line with the documentation