### PR TITLE
Removed capitalize from headings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/modals.less
+++ b/src/Umbraco.Web.UI.Client/src/less/modals.less
@@ -20,7 +20,6 @@
   font-size: @fontSizeLarge;
   font-weight: 400;
   padding-top: 10px !important;
-  text-transform: capitalize !important;
 }
 
 .umb-modalcolumn-body {


### PR DESCRIPTION
To avoid uppercase on first letter in every word for headings (in modals
for example).

Issue: http://issues.umbraco.org/issue/U4-6699