### PR TITLE
Fix Typo's build-in and seperate (U4-5559)

### DIFF
--- a/src/Umbraco.Core/Media/Exif/ExifFileTypeDescriptor.cs
+++ b/src/Umbraco.Core/Media/Exif/ExifFileTypeDescriptor.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Core.Media.Exif
     }
 
     /// <summary>
-    /// Expands ExifProperty objects contained in an ExifFile as seperate properties.
+    /// Expands ExifProperty objects contained in an ExifFile as separate properties.
     /// </summary>
     internal sealed class ExifFileTypeDescriptor : CustomTypeDescriptor
     {

--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -1220,7 +1220,7 @@ namespace Umbraco.Core
         // other helpers may not. DefaultShortStringHelper produces better, but non-compatible, results.
 
         /// <summary>
-        /// Splits a Pascal cased string into a phrase seperated by spaces.
+        /// Splits a Pascal cased string into a phrase separated by spaces.
         /// </summary>
         /// <param name="phrase">The text to split.</param>
         /// <returns>The splitted text.</returns>

--- a/src/Umbraco.Tests/Configurations/UmbracoSettings/umbracoSettings.config
+++ b/src/Umbraco.Tests/Configurations/UmbracoSettings/umbracoSettings.config
@@ -243,7 +243,7 @@
       @trySkipIisCustomErrors
         Tries to skip IIS custom errors.
         Starting with IIS 7.5, this must be set to true for Umbraco 404 pages to show. Else, IIS will take
-        over and render its build-in error page. See MS doc for HttpResponseBase.TrySkipIisCustomErrors.
+        over and render its built-in error page. See MS doc for HttpResponseBase.TrySkipIisCustomErrors.
         The default value is false, for backward compatibility reasons, which means that IIS _will_ take
         over, and _prevent_ Umbraco 404 pages to show.
       @internalRedirectPreservesTemplate

--- a/src/Umbraco.Web.UI.Client/docs/src/tutorials/Adding-Configuration-To-Property-Editor.ngdoc
+++ b/src/Umbraco.Web.UI.Client/docs/src/tutorials/Adding-Configuration-To-Property-Editor.ngdoc
@@ -32,7 +32,7 @@ So to add configuration options to our markdown editor, open the package.manifes
 		]
 	}
 
-**Remember to: ** seperate the editor element and prevalue editor definition with a comma, or you will get a json error. 
+**Remember to: ** separate the editor element and prevalue editor definition with a comma, or you will get a json error. 
 
 So what did we just add? We added a prevalue editor, with a `fields` collection. This collection contains infomation about the UI we will render on the data type configuration for this editor. 
 

--- a/src/Umbraco.Web.UI.Client/docs/src/tutorials/Building.ngdoc
+++ b/src/Umbraco.Web.UI.Client/docs/src/tutorials/Building.ngdoc
@@ -90,7 +90,7 @@ Before running build.bat, then the latest UI files will be included.
 
 
 ##Conclusion
-Having Umbraco 7 UI as a seperate project does indeed give us a bit more complexity when building and running from visual studio, since 2 build systems are in play: grunt and msbuild. 
+Having Umbraco 7 UI as a separate project does indeed give us a bit more complexity when building and running from visual studio, since 2 build systems are in play: grunt and msbuild. 
 
 However, the alternative would be to shove everything into the msbuil process, making the entire thing inaccesible to a large number of frontend developers and with a clunkier and less uptodate system.
 

--- a/src/Umbraco.Web.UI.Client/src/app.dev.js
+++ b/src/Umbraco.Web.UI.Client/src/app.dev.js
@@ -12,7 +12,7 @@ var app = angular.module('umbraco', [
     'tmh.dynamicLocale'
 ]);
 
-/* For Angular 1.2: we need to load in Route, animate and touch seperately
+/* For Angular 1.2: we need to load in Route, animate and touch separately
 	    'ngRoute',
 	    'ngAnimate',
 	    'ngTouch'

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -507,7 +507,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
          *
          * @description
          * Saves changes made to a content item to its current version, if the content item is new, the isNew paramater must be passed to force creation
-         * if the content item needs to have files attached, they must be provided as the files param and passed seperately 
+         * if the content item needs to have files attached, they must be provided as the files param and passed separately 
          * 
          * 
          * ##usage
@@ -540,7 +540,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
          *
          * @description
          * Saves and publishes changes made to a content item to a new version, if the content item is new, the isNew paramater must be passed to force creation
-         * if the content item needs to have files attached, they must be provided as the files param and passed seperately 
+         * if the content item needs to have files attached, they must be provided as the files param and passed separately 
          * 
          * 
          * ##usage

--- a/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
@@ -336,7 +336,7 @@ function mediaResource($q, $http, umbDataFormatter, umbRequestHelper) {
          *
          * @description
          * Saves changes made to a media item, if the media item is new, the isNew paramater must be passed to force creation
-         * if the media item needs to have files attached, they must be provided as the files param and passed seperately 
+         * if the media item needs to have files attached, they must be provided as the files param and passed separately 
          * 
          * 
          * ##usage

--- a/src/Umbraco.Web.UI.Client/src/common/resources/member.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/member.resource.js
@@ -203,7 +203,7 @@ function memberResource($q, $http, umbDataFormatter, umbRequestHelper) {
          *
          * @description
          * Saves changes made to a member, if the member is new, the isNew paramater must be passed to force creation
-         * if the member needs to have files attached, they must be provided as the files param and passed seperately 
+         * if the member needs to have files attached, they must be provided as the files param and passed separately 
          * 
          * 
          * ##usage

--- a/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
@@ -348,7 +348,7 @@ function umbModelMapper() {
          * @param {String} source.name The node name
          * @param {String} source.icon The models icon as a css class (.icon-doc)
          * @param {Number} source.parentId The parentID, if no parent, set to -1
-         * @param {path} source.path comma-seperated string of ancestor IDs (-1,1234,1782,1234)
+         * @param {path} source.path comma-separated string of ancestor IDs (-1,1234,1782,1234)
          */
 
         /** This converts the source model to a basic entity model, it will throw an exception if there isn't enough data to create the model */

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -38,7 +38,7 @@
     /** This creates the slider with the model values - it's called on startup and if the model value changes */
     function createSlider() {
 
-        //the value that we'll give the slider - if it's a range, we store our value as a comma seperated val but this slider expects an array
+        //the value that we'll give the slider - if it's a range, we store our value as a comma separated val but this slider expects an array
         var sliderVal = null;
 
         //configure the model value based on if range is enabled or not
@@ -121,7 +121,7 @@
 
         });
 
-    //load the seperate css for the editor to avoid it blocking our js loading
+    //load the separate css for the editor to avoid it blocking our js loading
     assetsService.loadCss("lib/slider/slider.css");
 
 }

--- a/src/Umbraco.Web.UI.Client/test/config/app.unit.js
+++ b/src/Umbraco.Web.UI.Client/test/config/app.unit.js
@@ -8,6 +8,6 @@ var app = angular.module('umbraco', [
     'ngCookies'
 ]);
 
-/* For Angular 1.2: we need to load in Routing seperately
+/* For Angular 1.2: we need to load in Routing separately
 	    'ngRoute'
 */

--- a/src/Umbraco.Web.UI/config/umbracoSettings.Release.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.Release.config
@@ -130,7 +130,7 @@
       @trySkipIisCustomErrors
         Tries to skip IIS custom errors.
         Starting with IIS 7.5, this must be set to true for Umbraco 404 pages to show. Else, IIS will take
-        over and render its build-in error page. See MS doc for HttpResponseBase.TrySkipIisCustomErrors.
+        over and render its built-in error page. See MS doc for HttpResponseBase.TrySkipIisCustomErrors.
         The default value is false, for backward compatibility reasons, which means that IIS _will_ take
         over, and _prevent_ Umbraco 404 pages to show.
       @internalRedirectPreservesTemplate

--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -259,7 +259,7 @@
       @trySkipIisCustomErrors
         Tries to skip IIS custom errors.
         Starting with IIS 7.5, this must be set to true for Umbraco 404 pages to show. Else, IIS will take
-        over and render its build-in error page. See MS doc for HttpResponseBase.TrySkipIisCustomErrors.
+        over and render its built-in error page. See MS doc for HttpResponseBase.TrySkipIisCustomErrors.
         The default value is false, for backward compatibility reasons, which means that IIS _will_ take
         over, and _prevent_ Umbraco 404 pages to show.
       @internalRedirectPreservesTemplate

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/TreeDefinitionCollection.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/TreeDefinitionCollection.cs
@@ -70,7 +70,7 @@ namespace umbraco.cms.presentation.Trees
             var foundTree = this.Find(
                delegate(TreeDefinition t)
                {
-                   // zb-00002 #29929 : use IsAssignableFrom instead of Equal, otherwise you can't override build-in
+                   // zb-00002 #29929 : use IsAssignableFrom instead of Equal, otherwise you can't override built-in
                    // trees because for ex. PermissionEditor.aspx.cs OnInit calls FindTree<loadContent>()
                    return typeof(T).IsAssignableFrom(t.TreeType);
                }

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/MemberGroupTasks.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/MemberGroupTasks.cs
@@ -21,7 +21,7 @@ namespace umbraco
 
         public override bool PerformDelete()
         {
-            // only build-in roles can be deleted
+            // only built-in roles can be deleted
             if (Member.IsUsingUmbracoRoles())
             {
                 MemberGroup.GetByName(Alias).delete();

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery.cs
@@ -121,7 +121,7 @@ namespace umbraco
 		/// <summary>
 		/// build a string array from a csv
 		/// </summary>
-		/// <param name="csv">string of comma seperated values</param>
+		/// <param name="csv">string of comma separated values</param>
 		/// <returns>An array of node ids as string.</returns>
 		public static string[] GetCsvIds(string csv)
 		{

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/users/NodePermissions.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/users/NodePermissions.ascx.cs
@@ -61,7 +61,7 @@ namespace umbraco.cms.presentation.user
         }
 
         /// <summary>
-        /// The JavaScript method to call when a node is checked. The method will receive a comma seperated list of node IDs that are checked.
+        /// The JavaScript method to call when a node is checked. The method will receive a comma separated list of node IDs that are checked.
         /// </summary>
         public string OnClientItemChecked
         {

--- a/src/umbraco.businesslogic/UmbracoSettings.cs
+++ b/src/umbraco.businesslogic/UmbracoSettings.cs
@@ -451,7 +451,7 @@ namespace umbraco
 
         /// <summary>
         /// Gets all repositories registered, and returns them as XmlNodes, containing name, alias and webservice url.
-        /// These repositories are used by the build-in package installer and uninstaller to install new packages and check for updates.
+        /// These repositories are used by the built-in package installer and uninstaller to install new packages and check for updates.
         /// All repositories should have a unique alias.
         /// All packages installed from a repository gets the repository alias included in the install information
         /// </summary>

--- a/src/umbraco.cms/businesslogic/datatype/DefaultPreValueEditor.cs
+++ b/src/umbraco.cms/businesslogic/datatype/DefaultPreValueEditor.cs
@@ -37,7 +37,7 @@ namespace umbraco.cms.businesslogic.datatype
         }
 
         /// <summary>
-        /// The default editor for editing the build-in pre values in umbraco
+        /// The default editor for editing the built-in pre values in umbraco
         /// </summary>
         /// <param name="DataType">The DataType to be parsed</param>
         /// <param name="DisplayTextBox">Whether to use the default text box</param>

--- a/src/umbraco.editorControls/DefaultPrevalueEditor.cs
+++ b/src/umbraco.editorControls/DefaultPrevalueEditor.cs
@@ -29,7 +29,7 @@ namespace umbraco.editorControls
         }
 
         /// <summary>
-        /// The default editor for editing the build-in pre values in umbraco
+        /// The default editor for editing the built-in pre values in umbraco
         /// </summary>
         /// <param name="DataType">The DataType to be parsed</param>
         /// <param name="DisplayTextBox">Whether to use the default text box</param>

--- a/src/umbraco.editorControls/MultiNodeTreePicker/MNTPResources.Designer.cs
+++ b/src/umbraco.editorControls/MultiNodeTreePicker/MNTPResources.Designer.cs
@@ -118,7 +118,7 @@ namespace umbraco.editorControls.MultiNodeTreePicker
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You can specify to store the data in Umbraco as comma seperated or as XML. By default it is stored as XML which makes it easier to use the saved value in XSLT, however, storing it as comma seperated makes it easier to work with the data using the API such as Node factory..
+        ///   Looks up a localized string similar to You can specify to store the data in Umbraco as comma separated or as XML. By default it is stored as XML which makes it easier to use the saved value in XSLT, however, storing it as comma separated makes it easier to work with the data using the API such as Node factory..
         /// </summary>
         public static string Desc_StoreAsComma {
             get {

--- a/src/umbraco.editorControls/MultiNodeTreePicker/MNTPResources.resx
+++ b/src/umbraco.editorControls/MultiNodeTreePicker/MNTPResources.resx
@@ -136,7 +136,7 @@
     <value>Define the starting node that should be rendered for the picker. This will ensure that the correct security measures are in place by checking the defined start node ID for the user accessing the picker. In some cases, if the user is not able to view the node, then the picker will render an error message.</value>
   </data>
   <data name="Desc_StoreAsComma" xml:space="preserve">
-    <value>You can specify to store the data in Umbraco as comma seperated or as XML. By default it is stored as XML which makes it easier to use the saved value in XSLT, however, storing it as comma seperated makes it easier to work with the data using the API such as Node factory.</value>
+    <value>You can specify to store the data in Umbraco as comma separated or as XML. By default it is stored as XML which makes it easier to use the saved value in XSLT, however, storing it as comma separated makes it easier to work with the data using the API such as Node factory.</value>
   </data>
   <data name="Desc_XPathExpression" xml:space="preserve">
     <value>This XPath expression is used to select a starting node and depends on the XPath expression type chosen (global or from current). &lt;u&gt;IMPORTANT&lt;/u&gt;: This XPath expression should be written to match &lt;b&gt;ONE&lt;/b&gt; node, if the expression matches more than one node, then the first node matched will be used as the start node.</value>

--- a/src/umbraco.editorControls/MultiNodeTreePicker/MNTP_DataType.cs
+++ b/src/umbraco.editorControls/MultiNodeTreePicker/MNTP_DataType.cs
@@ -77,7 +77,7 @@ namespace umbraco.editorControls.MultiNodeTreePicker
         }
 
         /// <summary>
-        /// Value indicating whether to store as comma seperated or Xml
+        /// Value indicating whether to store as comma separated or Xml
         /// </summary>
         public bool StoreAsCommaDelimited
         {

--- a/src/umbraco.editorControls/macrocontainer/PrevalueEditor.cs
+++ b/src/umbraco.editorControls/macrocontainer/PrevalueEditor.cs
@@ -121,7 +121,7 @@ namespace umbraco.editorControls.macrocontainer
 
         #region Methods
         /// <summary>
-        /// Returns the selected Macro's in a comma seperated string
+        /// Returns the selected Macro's in a comma separated string
         /// </summary>
         private string GetSelectedMacosFromCheckList()
         {

--- a/src/umbraco.editorControls/umbraco.editorControls.csproj
+++ b/src/umbraco.editorControls/umbraco.editorControls.csproj
@@ -437,7 +437,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>MediaChooserScripts.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Include="MultiNodeTreePicker\MNTPResources.resx" />
+    <EmbeddedResource Include="MultiNodeTreePicker\MNTPResources.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="textfield\textFieldDataEditor.resx">
       <DependentUpon>textFieldDataEditor.cs</DependentUpon>
       <SubType>Designer</SubType>


### PR DESCRIPTION
According to the issuetracker build-in should be replaced by built-in and seperate should be replaced by separate.  