### PR TITLE
Fix U4-6375, U4-5670

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/DataTypeDefinitionRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/DataTypeDefinitionRepository.cs
@@ -518,7 +518,11 @@ WHERE alias = @alias
 AND datatypeNodeId = @dtdid
 AND id <> @id",
                         new { id = entity.Id, alias = entity.Alias, dtdid = entity.DataType.Id });
-                if (exists > 0)
+
+
+                var excludedDataTypes = new string[] { "Umbraco.CheckBoxList", "Umbraco.DropDown", "Umbraco.DropDownMultiple", "Umbraco.DropdownlistMultiplePublishKeys", "Umbraco.DropdownlistPublishingKeys", "Umbraco.RadioButtonList" };
+
+                if (exists > 0 && excludedDataTypes.Contains(entity.DataType.PropertyEditorAlias) == false)
                 {
                     throw new DuplicateNameException("A pre value with the alias " + entity.Alias + " already exists for this data type");
                 }


### PR DESCRIPTION
Synopsis: There are six core data types broken due to how the multivalues controller interacts with the datatype API. If a user attempts to sort and save a previously saved prevalue configuration, an error occurs.

Note: This may get rejected due to the nature of the magic values, but I'm surprised it has yet to be resolved.

Issue reference here: http://issues.umbraco.org/issue/U4-6375 and here: http://issues.umbraco.org/issue/U4-5670

The six affected data types: "Umbraco.CheckBoxList", "Umbraco.DropDown", "Umbraco.DropDownMultiple", "Umbraco.DropdownlistMultiplePublishKeys", "Umbraco.DropdownlistPublishingKeys", "Umbraco.RadioButtonList"

This won't fix anyone borrowing the core multivalue prevalue editor for a custom editor, but it shouldn't break anything either; just fix the six broken ones.

A better solution might be to detect the prevalue editor in use, but I could not find that information from the given datatype object.

I won't be offended if this isn't a clean enough solution due to the magic values in string array :) 

The real crux of the problem is this query which assumes that the aliases won't change (which they normally don't):

https://github.com/umbraco/Umbraco-CMS/blob/a3d4ccc062b94859e446b1206bf21f334577a35c/src/Umbraco.Core/Persistence/Repositories/DataTypeDefinitionRepository.cs#L516-L519