### PR TITLE
Fixed bug in U4-6593 - After sort, reset the TinyMCE editors with previous settings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -129,6 +129,9 @@ angular.module("umbraco")
             },
 
             start: function (e, ui) {
+                // reset dragged RTE settings in case a RTE isn't dragged
+                draggedRteSettings = undefined;
+
                 ui.item.find('.mceNoEditor').each(function () {
                     notIncludedRte = [];
 
@@ -148,12 +151,14 @@ angular.module("umbraco")
                     }
                 });
                 $timeout(function () {
-                    // reconstruct the dragged RTE
-                    tinyMCE.init(draggedRteSettings);
+                    // reconstruct the dragged RTE (could be undefined when dragging something else than RTE)
+                    if (draggedRteSettings !== undefined) {
+                        tinyMCE.init(draggedRteSettings);
+                    }
 
                     _.forEach(notIncludedRte, function (id) {
                         // reset all the other RTEs
-                        if (id != draggedRteSettings.id) {
+                        if (draggedRteSettings === undefined || id != draggedRteSettings.id) {
                             var rteSettings = _.findWhere(tinyMCE.editors, { id: id }).settings;
                             tinyMCE.execCommand('mceRemoveEditor', false, id);
                             tinyMCE.init(rteSettings);


### PR DESCRIPTION
There was a bug in this PR when something else than RTE was dragged. In that case, upon drop, an exception would be thrown (tinyMCE.init(draggedRteSettings); was called with undefined).

The fix tests for draggedRteSettings !== undefined and if false, does not reinitialize the dragged RTE. Furthermore, it also resets draggedRteSettings upon drag start in case a RTE isn't dragged.