### PR TITLE
U4-6582: Added data-rel attribute linking to node id in tinymce

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
+++ b/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
@@ -189,7 +189,7 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
     								href: href,
     								title: data.name, 
     								target: data.target ? data.target : null,
-    								rel: data.rel ? data.rel : null
+    								'data-rel': data.id ? data.id : null          // dataRel wasn't interpretted correctly, so needed the to use string literal 'data-rel'
     							});
 
     							selection.select(anchorElm);
@@ -199,7 +199,7 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
 									href: href,
 									title: data.name, 
 									target: data.target ? data.target : null,
-									rel: data.rel ? data.rel : null
+									'data-rel': data.id ? data.id : null          // dataRel wasn't interpretted correctly, so needed the to use string literal 'data-rel'
 								});
     						}
     				}

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -114,6 +114,7 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                                         alt: img.altText || "",
                                         src: (img.url) ? img.url : "nothing.jpg",
                                         rel: img.id,
+                                        'data-rel': img.id,           // dataRel wasn't interpretted correctly, so needed the to use string literal 'data-rel'
                                         id: '__mcenew'
                                     };
 

--- a/src/Umbraco.Web.UI/config/tinyMceConfig.config
+++ b/src/Umbraco.Web.UI/config/tinyMceConfig.config
@@ -215,10 +215,10 @@
     <plugin loadOnFrontend="true">lists</plugin>
   </plugins>
   <validElements>
-    <![CDATA[+a[id|style|rel|rev|charset|hreflang|dir|lang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|onclick|
+    <![CDATA[+a[id|style|rel|data-rel|rev|charset|hreflang|dir|lang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|onclick|
 ondblclick|onmousedown|onmouseup|onmouseover|onmousemove|onmouseout|onkeypress|onkeydown|onkeyup],-strong/-b[class|style],-em/-i[class|style],
 -strike[class|style],-u[class|style],#p[id|style|dir|class|align],-ol[class|reversed|start|style|type],-ul[class|style],-li[class|style],br[class],
-img[id|dir|lang|longdesc|usemap|style|class|src|onmouseover|onmouseout|border|alt=|title|hspace|vspace|width|height|align|umbracoorgwidth|umbracoorgheight|onresize|onresizestart|onresizeend|rel],
+img[id|dir|lang|longdesc|usemap|style|class|src|onmouseover|onmouseout|border|alt=|title|hspace|vspace|width|height|align|umbracoorgwidth|umbracoorgheight|onresize|onresizestart|onresizeend|rel|data-rel],
 -sub[style|class],-sup[style|class],-blockquote[dir|style|class],-table[border=0|cellspacing|cellpadding|width|height|class|align|summary|style|dir|id|lang|bgcolor|background|bordercolor],
 -tr[id|lang|dir|class|rowspan|width|height|align|valign|style|bgcolor|background|bordercolor],tbody[id|class],
 thead[id|class],tfoot[id|class],#td[id|lang|dir|class|colspan|rowspan|width|height|align|valign|style|bgcolor|background|bordercolor|scope],


### PR DESCRIPTION
I added the data-rel attribute to RTE img tags and to a tags that link to media. I also added data-rel as an allowed attribute to the tinymce validElements. This is the link to the umbraco issue:

http://issues.umbraco.org/issue/U4-6582