### PR TITLE
Fix for JsSource on legacy trees not supporting virtual paths (~/) - U4-6346

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionDeleteRelationType.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionDeleteRelationType.cs
@@ -67,7 +67,7 @@ namespace umbraco.cms.presentation.developer.RelationTypes.TreeMenu
 		/// </summary>
 		public string JsSource
 		{
-			get { return "/umbraco/developer/RelationTypes/TreeMenu/ActionDeleteRelationType.js"; }
+			get { return "~/umbraco/developer/RelationTypes/TreeMenu/ActionDeleteRelationType.js"; }
 		}
 
 		/// <summary>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionNewRelationType.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionNewRelationType.cs
@@ -67,7 +67,7 @@ namespace umbraco.cms.presentation.developer.RelationTypes.TreeMenu
 		/// </summary>
 		public string JsSource
 		{
-			get { return "/umbraco/developer/RelationTypes/TreeMenu/ActionNewRelationType.js"; }
+			get { return "~/umbraco/developer/RelationTypes/TreeMenu/ActionNewRelationType.js"; }
 		}
 
 		/// <summary>

--- a/src/umbraco.cms/Actions/Action.cs
+++ b/src/umbraco.cms/Actions/Action.cs
@@ -13,6 +13,7 @@ using umbraco.cms.businesslogic.workflow;
 using umbraco.interfaces;
 using System.Text.RegularExpressions;
 using System.Linq;
+using Umbraco.Core.IO;
 using TypeFinder = Umbraco.Core.TypeFinder;
 
 namespace umbraco.BusinessLogic.Actions
@@ -89,7 +90,7 @@ namespace umbraco.BusinessLogic.Actions
         {
             return ActionsResolver.Current.Actions
                 .Where(x => !string.IsNullOrWhiteSpace(x.JsSource))
-                .Select(x => x.JsSource).ToList();
+                .Select(x => IOHelper.ResolveUrl(x.JsSource)).ToList();
             //return ActionJsReference;
         }
 


### PR DESCRIPTION
This is from a side-issue mentioned in [U4-6346](http://issues.umbraco.org/issue/U4-6346) - can create a new issue if needed.

When logging into the backoffice configured under a virtual directory, you receive two 404's on the below files.  This updates the legacy tree actions to support virtual directories to avoid these errors.