### PR TITLE
Fix unable to login to backoffice when using virtual directory - U4-6346

### DIFF
--- a/src/Umbraco.Core/UriExtensions.cs
+++ b/src/Umbraco.Core/UriExtensions.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Core
             var urlPath = fullUrlPath.TrimStart(appPath).EnsureStartsWith('/');
             
             //check if this is in the umbraco back office
-            var isUmbracoPath = urlPath.InvariantStartsWith(GlobalSettings.Path.EnsureStartsWith('/'));
+            var isUmbracoPath = urlPath.InvariantStartsWith(GlobalSettings.Path.EnsureStartsWith('/').TrimStart(appPath.EnsureStartsWith('/')).EnsureStartsWith('/'));
             //if not, then def not back office
             if (isUmbracoPath == false) return false;
 


### PR DESCRIPTION
See [U4-6346](http://issues.umbraco.org/issue/U4-6346)

When logging into the backoffice under a virtual directory, a 401 is returned from subsequent backoffice API calls.  It appears to be because `IsBackOfficeRequest` is returning `false` for these URLs.

I updated `IsBackOfficeRequest` so that it works properly in virtual directories and normal configurations.

**Note regarding testing**
The existing tests say that this should work already, but I found an inconsistency - in the tests, `GlobalSettings.Path` is `/umbraco`, but in runtime under a virtual directory, it's `/myvdir/umbraco`.  I'd like to get the tests updated too, but not sure the best way to approach this difference.  Let me know if you have any advice and I'm glad to give it a try.

Crude mockup showing the testing issue:
![testing-inconsistency](https://cloud.githubusercontent.com/assets/1396376/8292259/9d7e7bd0-18fc-11e5-819b-524fd66b99aa.png)
