### PR TITLE
Add leave page validation for browser tab closing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
@@ -12,7 +12,7 @@
 * Another thing this directive does is to ensure that any .control-group that contains form elements that are invalid will
 * be marked with the 'error' css class. This ensures that labels included in that control group are styled correctly.
 **/
-function valFormManager(serverValidationManager, $rootScope, $log, $timeout, notificationsService, eventsService, $routeParams) {
+function valFormManager(serverValidationManager, $rootScope, $log, $timeout, notificationsService, eventsService, $routeParams, $window) {
     return {
         require: "form",
         restrict: "A",
@@ -96,11 +96,21 @@ function valFormManager(serverValidationManager, $rootScope, $log, $timeout, not
             });
             unsubscribe.push(locationEvent);
 
+            // leave page validation for tab closing (tested in Chrome, Firefox and IE)
+            var previousUnloadHandler = $window.onbeforeunload;
+            $window.onbeforeunload = confirmExit;
+            function confirmExit() {
+                if (formCtrl.$dirty) {
+                    return "You have unsaved changes";
+                }
+            }
             //Ensure to remove the event handler when this instance is destroyted
             scope.$on('$destroy', function() {
                 for (var u in unsubscribe) {
                     unsubscribe[u]();
                 }
+                // restore previous unload handler
+                $window.onbeforeunload = previousUnloadHandler;
             });
 
             $timeout(function(){


### PR DESCRIPTION
Those changes enable browser-level leave page validation to prevent data loss when user accidentally closes working browser tab.
