### PR TITLE
Fixes U4-6579 error deleting media item in umbraco 7

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
@@ -31,7 +31,13 @@ function MediaDeleteController($scope, mediaResource, treeService, navigationSer
             
             //if the current edited item is the same one as we're deleting, we need to navigate elsewhere
             if (editorState.current && editorState.current.id == $scope.currentNode.id) {
-                $location.path("/media/media/edit/" + $scope.currentNode.parentId);
+
+            	//If the deleted item lived at the root then just redirect back to the root, otherwise redirect to the item's parent
+            	var location = "/media";
+            	if ($scope.currentNode.parentId != -1)
+            		location = "/media/media/edit/" + $scope.currentNode.parentId;
+
+                $location.path(location);
             }
 
             navigationService.hideMenu();


### PR DESCRIPTION
Checks if media item being deleted was at the root then redirects to the root, otherwise redirects to parent item.