### PR TITLE
U4-6696 - UmbracoHelper.GetPreValueAsString fires exception with inva…

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/DataTypeDefinitionRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/DataTypeDefinitionRepository.cs
@@ -283,15 +283,15 @@ AND umbracoNode.id <> @id",
         {
             //We need to see if we can find the cached PreValueCollection based on the cache key above
 
-            var regex = CacheKeys.DataTypePreValuesCacheKey + @"[\d]+-[,\d]*" + preValueId + @"[,\d$]*";
+            var regex = CacheKeys.DataTypePreValuesCacheKey + @"[-\d]+-([\d]*,)*" + preValueId + @"(?!\d)[,\d$]*";
 
             var cached = _cacheHelper.RuntimeCache.GetCacheItemsByKeyExpression<PreValueCollection>(regex);
             if (cached != null && cached.Any())
             {
                 //return from the cache
                 var collection = cached.First();
-                var preVal = collection.FormatAsDictionary().Single(x => x.Value.Id == preValueId);
-                return preVal.Value.Value;
+				var preVal = collection.FormatAsDictionary().Single(x => x.Value.Id == preValueId);
+				return preVal.Value.Value;
             }
 
             //go and find the data type id for the pre val id passed in


### PR DESCRIPTION
…lid integer

Fixes U4-6696

Short description:
The regex to get the cached prevalue wasn't matching the exact prevalue id, which caused some prevalues to never be fetched and would cause an exception.

Detailed description:
When a prevalue is requested, it would initially fetch it from the database and cache it in a cache item along with other associated prevalues for the datatype.
The key for the item would be UmbracoPreVal-87-21,33,48, where -87 is the datatype and 21,33,48 is the prevalue id's in the cache.

Example:
If I get a prevalue with an id of 33, it would cache it.  If I then request a prevalue with id 3, it would match UmbracoPreVal-87-21,33,48 because the regex would match the 3 in 33.  The code finds the cached item and calls .Single when the prevalue doesn't exist for 3, and will throw an exception.

To fix this, I refactored the regex to match the exact prevalue id.  So now only the cache item containing the prevalue would be returned and if not, it will proceed to the database as normal.