### PR TITLE
U4-6724 Moving content with JSON Tags add extra characters

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
@@ -395,7 +395,7 @@ ON cmsPropertyType.dataTypeId = cmsDataTypePreValues.datatypeNodeId", docSql.Arg
             // below if any property requires tag support
             var allPreValues = new Lazy<IEnumerable<DataTypePreValueDto>>(() =>
             {
-                var preValsSql = new Sql(@"SELECT a.id as preValId, a.value, a.sortorder, a.alias, a.datatypeNodeId
+                var preValsSql = new Sql(@"SELECT a.id, a.value, a.sortorder, a.alias, a.datatypeNodeId
 FROM cmsDataTypePreValues a
 WHERE EXISTS(
     SELECT DISTINCT b.id as preValIdInner

--- a/src/Umbraco.Core/PropertyEditors/TagPropertyDefinition.cs
+++ b/src/Umbraco.Core/PropertyEditors/TagPropertyDefinition.cs
@@ -31,7 +31,10 @@ namespace Umbraco.Core.PropertyEditors
             Delimiter = tagsAttribute.Delimiter;
             ReplaceTags = tagsAttribute.ReplaceTags;
             TagGroup = tagsAttribute.TagGroup;
-            StorageType = TagCacheStorageType.Csv;
+
+            var preValues = propertySaving.PreValues.PreValuesAsDictionary;
+            StorageType =  preValues.ContainsKey("storageType") && preValues["storageType"].Value == TagCacheStorageType.Json.ToString() ? 
+                TagCacheStorageType.Json : TagCacheStorageType.Csv;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes U4-6724

Problem:
The TagPropertyDefinition class that provides the tag definition on how to parse the tag is always in CSV modes.  This affects the way the TagExtractor parses the value - which is causing this issue.  It causes it to split by comma instead of treating it as Json.

There was also an additional issue when prevalues were retrieved for the tag property type, line 456 in VersionableRepositoryBase.  Distinct was being called, which meant 'storageType' wasn't being returned and only 'group' was being returned.  Shortly after this, the TagExtractor is called with the prevalues attached to the ContentPropertyData.

Solution:
I fixed the line retrieving prevalues on line 456 so all prevalues are retrieved.
I have also updated the TagPropertyDefinition to check the 'storageType' prevalue and check if it is set to be JSON and set the TagCacheStorageType accordingly.