### PR TITLE
U4-6773 create property - available properties are not sorted a-z

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentTypeControlNew.ascx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/controls/ContentTypeControlNew.ascx.cs
@@ -842,7 +842,7 @@ jQuery(document).ready(function() {{ refreshDropDowns(); }});
         {
             var tabs = _contentType.getVirtualTabs;
             var propertyTypeGroups = _contentType.PropertyTypeGroups.ToList();
-            var dtds = cms.businesslogic.datatype.DataTypeDefinition.GetAll();
+            var dtds = cms.businesslogic.datatype.DataTypeDefinition.GetAll().OrderBy(d => d.Text).ToArray();
 
             PropertyTypes.Controls.Clear();
 


### PR DESCRIPTION
Problem:
DataTypeDefinition.GetAll() returns data types unordered and is bound to the property type controls in ContentTypeControlNew.ascx.cs.

Solution:
I ordered the list after calling DataTypeDefinition.GetAll().