### PR TITLE
Fix backoffice breaking when Actions use code in JsSource - U4-6843

### DIFF
--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -715,7 +715,7 @@ namespace Umbraco.Web.Editors
                     if (isValid)
                     {
                         //it is a valid URL add to Url list
-                        urlList.Add(IOHelper.ResolveUrl(jsFile));
+                        urlList.Add(jsFile.StartsWith("~/") ? IOHelper.ResolveUrl(jsFile) : jsFile);
                     }
                 }
                 else

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -715,7 +715,7 @@ namespace Umbraco.Web.Editors
                     if (isValid)
                     {
                         //it is a valid URL add to Url list
-                        urlList.Add(jsFile);
+                        urlList.Add(IOHelper.ResolveUrl(jsFile));
                     }
                 }
                 else

--- a/src/umbraco.cms/Actions/Action.cs
+++ b/src/umbraco.cms/Actions/Action.cs
@@ -90,7 +90,7 @@ namespace umbraco.BusinessLogic.Actions
         {
             return ActionsResolver.Current.Actions
                 .Where(x => !string.IsNullOrWhiteSpace(x.JsSource))
-                .Select(x => IOHelper.ResolveUrl(x.JsSource)).ToList();
+                .Select(x => x.JsSource).ToList();
             //return ActionJsReference;
         }
 


### PR DESCRIPTION
This reverts/refactors this pull request: https://github.com/umbraco/Umbraco-CMS/pull/722/files

Since JsSource can be used for a file path or actual javascript, we can't use IOHelper.ResolveUrl here.  Instead we're moving it to the GetLegacyActionJs() method, which already handles deciding if it's a code or a URL.

:poop: