### PR TITLE
Quick stab at testing a method from BackofficeController for U4-6843

### DIFF
--- a/src/Umbraco.Tests/Controllers/BackOfficeControllerUnitTests.cs
+++ b/src/Umbraco.Tests/Controllers/BackOfficeControllerUnitTests.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Umbraco.Web.Editors;
+
+namespace Umbraco.Tests.Controllers
+{
+    [TestFixture]
+    public class BackOfficeControllerUnitTests
+    {
+        public static object[] TestLegacyJsActionPaths = new object[] {
+            new string[]
+            {
+                "alert('hello');",
+                "function test() { window.location = 'http://www.google.com'; }",
+                "function openCourierSecurity(userid){ UmbClientMgr.contentFrame('page?userid=123); }",
+                @"function openRepository(repo, folder){ UmbClientMgr.contentFrame('page?repo=repo&folder=folder); }
+                  function openTransfer(revision, repo, folder){ UmbClientMgr.contentFrame('page?revision=revision&repo=repo&folder=folder); }",
+                "umbraco/js/test.js",
+                "/umbraco/js/test.js",
+                "~/umbraco/js/test.js"
+            }
+        };
+
+
+        [TestCaseSource("TestLegacyJsActionPaths")]
+        public void Separates_Legacy_JsActions_By_Block_Or_Url(object[] jsActions)
+        {
+            var jsBlocks =
+                BackOfficeController.GetLegacyActionJsForActions(BackOfficeController.LegacyJsActionType.JsBlock,
+                    jsActions.Select(n => n.ToString()));
+
+            var jsUrls =
+                BackOfficeController.GetLegacyActionJsForActions(BackOfficeController.LegacyJsActionType.JsUrl,
+                    jsActions.Select(n => n.ToString()));
+
+            Assert.That(jsBlocks.Count() == 4);
+            Assert.That(jsUrls.Count() == 3);
+            Assert.That(!jsUrls.Last().StartsWith("~/"));
+        }
+    }
+}

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -177,6 +177,7 @@
     <Compile Include="AttemptTests.cs" />
     <Compile Include="Cache\CacheRefresherTests.cs" />
     <Compile Include="Cache\DeepCloneRuntimeCacheProviderTests.cs" />
+    <Compile Include="Controllers\BackOfficeControllerUnitTests.cs" />
     <Compile Include="Logging\AsyncRollingFileAppenderTest.cs" />
     <Compile Include="Logging\DebugAppender.cs" />
     <Compile Include="Logging\ParallelForwarderTest.cs" />

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -685,19 +685,16 @@ namespace Umbraco.Web.Editors
             return JavaScript(result);
         }
 
-        /// <summary>
-        /// Renders out all JavaScript references that have bee declared in IActions
-        /// </summary>
-        private static IEnumerable<string> GetLegacyActionJs(LegacyJsActionType type)
+        internal static IEnumerable<string> GetLegacyActionJsForActions(LegacyJsActionType type, IEnumerable<string> values)
         {
             var blockList = new List<string>();
             var urlList = new List<string>();
-            foreach (var jsFile in global::umbraco.BusinessLogic.Actions.Action.GetJavaScriptFileReferences())
+            foreach (var jsFile in values)
             {
                 //validate that this is a url, if it is not, we'll assume that it is a text block and render it as a text
                 //block instead.
                 var isValid = true;
-                
+
                 if (Uri.IsWellFormedUriString(jsFile, UriKind.RelativeOrAbsolute))
                 {
                     //ok it validates, but so does alert('hello'); ! so we need to do more checks
@@ -726,7 +723,7 @@ namespace Umbraco.Web.Editors
                 if (isValid == false)
                 {
                     //it isn't a valid URL, must be a js block
-                    blockList.Add(jsFile);                     
+                    blockList.Add(jsFile);
                 }
             }
 
@@ -740,8 +737,16 @@ namespace Umbraco.Web.Editors
 
             return blockList;
         }
-        
-        private enum LegacyJsActionType
+
+        /// <summary>
+        /// Renders out all JavaScript references that have bee declared in IActions
+        /// </summary>
+        private static IEnumerable<string> GetLegacyActionJs(LegacyJsActionType type)
+        {
+            return GetLegacyActionJsForActions(type, global::umbraco.BusinessLogic.Actions.Action.GetJavaScriptFileReferences());
+        }
+
+        internal enum LegacyJsActionType
         {
             JsBlock,
             JsUrl


### PR DESCRIPTION
* Move GetLegacyActionJs logic into an internal static method so we can test
* Change LegacyJsActionType to internal for testing
* Add tests to verify method can determine between js paths and js blocks, so as not to pass js code into IOHelper.ResolveUrl