### PR TITLE
Update Field() methods in UmbracoHelper

### DIFF
--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -317,7 +317,7 @@ namespace Umbraco.Web
             bool formatAsDateWithTime = false,
             string formatAsDateWithTimeSeparator = "")
 		{			
-            return _componentRenderer.Field(AssignedContentItem, fieldAlias, altFieldAlias,
+            return UmbracoComponentRenderer.Field(AssignedContentItem, fieldAlias, altFieldAlias,
                 altText, insertBefore, insertAfter, recursive, convertLineBreaks, removeParagraphTags,
                 casing, encoding, formatAsDate, formatAsDateWithTime, formatAsDateWithTimeSeparator);
 		}
@@ -350,7 +350,7 @@ namespace Umbraco.Web
             bool formatAsDateWithTime = false,
             string formatAsDateWithTimeSeparator = "")
 		{
-            return _componentRenderer.Field(currentPage, fieldAlias, altFieldAlias,
+            return UmbracoComponentRenderer.Field(currentPage, fieldAlias, altFieldAlias,
                 altText, insertBefore, insertAfter, recursive, convertLineBreaks, removeParagraphTags,
                 casing, encoding, formatAsDate, formatAsDateWithTime, formatAsDateWithTimeSeparator);
 		}


### PR DESCRIPTION
Update Field() methods in UmbracoHelper to use the existing lazy
instantiation of ComponentRenderer to fix a problem where
_componentRenderer is not provided by the default constructor.