### PR TITLE
Package Service - Case Insensitive Macro parameters

### DIFF
--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -1219,7 +1219,7 @@ namespace Umbraco.Core.Services
                         sortOrder = int.Parse(sortOrderAttribute.Value);
                     }
 
-                    if (macro.Properties.Any(x => x.Alias == propertyAlias)) continue;
+                    if (macro.Properties.Any(x => string.Equals(x.Alias, propertyAlias, StringComparison.OrdinalIgnoreCase))) continue;
                     macro.Properties.Add(new MacroProperty(propertyAlias, propertyName, sortOrder, editorAlias));
                     sortOrder++;
                 }


### PR DESCRIPTION
Fixes a SQL Error you get if you try to import over an existing macro, but with different case for the parameter names. (see https://our.umbraco.org/projects/developer-tools/usync/usync/67822-usync-issue)

IF you import with diffrent cases you get a SQL Index error:
```
System.Data.SqlClient.SqlException (0x80131904): Cannot insert duplicate key row in object     'dbo.cmsMacroProperty' with unique index 'IX_cmsMacroProperty_Alias'. The duplicate key value is (33, rootContentNodeId). The statement has been terminated.
```
This fix just makes the test case Insensitive, it doesn't attempt to update the alias name, but that behaviour is consistent with the package service, which doesn't update existing macro values, it only writes new ones in. 

