### PR TITLE
U4-6856 - fixed issue that prevents username update...

### DIFF
--- a/src/Umbraco.Web/Editors/MemberController.cs
+++ b/src/Umbraco.Web/Editors/MemberController.cs
@@ -385,6 +385,7 @@ namespace Umbraco.Web.Editors
             }
 
             var shouldReFetchMember = false;
+            var providedUserName = contentItem.PersistedContent.Username;
 
             //Update the membership user if it has changed
             try
@@ -444,7 +445,9 @@ namespace Umbraco.Web.Editors
                 if (shouldReFetchMember)
                 {
                     RefetchMemberData(contentItem, LookupType.ByKey);
+                    RestoreProvidedUserName(contentItem, providedUserName);
                 }
+
                 return null;
             }
 
@@ -456,6 +459,7 @@ namespace Umbraco.Web.Editors
                 if (shouldReFetchMember)
                 {
                     RefetchMemberData(contentItem, LookupType.ByKey);
+                    RestoreProvidedUserName(contentItem, providedUserName);
                 }
 
                 //even if we weren't resetting this, it is the correct value (null), otherwise if we were resetting then it will contain the new pword
@@ -466,7 +470,6 @@ namespace Umbraco.Web.Editors
             ModelState.AddPropertyError(
                 passwordChangeResult.Result.ChangeError,
                 string.Format("{0}password", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
-
 
             return null;
         }
@@ -526,6 +529,17 @@ namespace Umbraco.Web.Editors
                     p.TagSupport.Tags = valueMapped.TagSupport.Tags;
                 }
             }            
+        }
+
+        /// <summary>
+        /// Following a refresh of member data called during an update if the membership provider has changed some underlying data, 
+        /// we don't want to lose the provided, and potentiallly changed, username
+        /// </summary>
+        /// <param name="contentItem"></param>
+        /// <param name="providedUserName"></param>
+        private static void RestoreProvidedUserName(MemberSave contentItem, string providedUserName)
+        {
+            contentItem.PersistedContent.Username = providedUserName;
         }
 
         /// <summary>


### PR DESCRIPTION
…if other core membership provider properties are updated at the same time (such as the email address).