### PR TITLE
Adding method for copying on IContentService without copying children

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1339,6 +1339,21 @@ namespace Umbraco.Core.Services
         /// <returns>The newly created <see cref="IContent"/> object</returns>
         public IContent Copy(IContent content, int parentId, bool relateToOriginal, int userId = 0)
         {
+            return Copy(content, parentId, relateToOriginal, true, userId);
+        }
+
+        /// <summary>
+        /// Copies an <see cref="IContent"/> object by creating a new Content object of the same type and copies all data from the current 
+        /// to the new copy which is returned.
+        /// </summary>
+        /// <param name="content">The <see cref="IContent"/> to copy</param>
+        /// <param name="parentId">Id of the Content's new Parent</param>
+        /// <param name="relateToOriginal">Boolean indicating whether the copy should be related to the original</param>
+        /// <param name="recursive">Boolean indicating whether to copy children too or not</param>
+        /// <param name="userId">Optional Id of the User copying the Content</param>
+        /// <returns>The newly created <see cref="IContent"/> object</returns>
+        public IContent Copy(IContent content, int parentId, bool relateToOriginal, bool recursive, int userId = 0)
+        {
             //TODO: This all needs to be managed correctly so that the logic is submitted in one
             // transaction, the CRUD needs to be moved to the repo
 
@@ -1380,13 +1395,16 @@ namespace Umbraco.Core.Services
                     }
                 }
 
-                //Look for children and copy those as well
-                var children = GetChildren(content.Id);
-                foreach (var child in children)
+                if (recursive)
                 {
-                    //TODO: This shouldn't recurse back to this method, it should be done in a private method
-                    // that doesn't have a nested lock and so we can perform the entire operation in one commit.
-                    Copy(child, copy.Id, relateToOriginal, userId);
+                //Look for children and copy those as well
+                    var children = GetChildren(content.Id);
+                    foreach (var child in children)
+                    {
+                        //TODO: This shouldn't recurse back to this method, it should be done in a private method
+                        // that doesn't have a nested lock and so we can perform the entire operation in one commit.
+                        Copy(child, copy.Id, relateToOriginal, userId);
+                    }
                 }
 
                 Copied.RaiseEvent(new CopyEventArgs<IContent>(content, copy, false, parentId, relateToOriginal), this);

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -431,6 +431,18 @@ namespace Umbraco.Core.Services
         IContent Copy(IContent content, int parentId, bool relateToOriginal, int userId = 0);
 
         /// <summary>
+        /// Copies an <see cref="IContent"/> object by creating a new Content object of the same type and copies all data from the current 
+        /// to the new copy which is returned.
+        /// </summary>
+        /// <param name="content">The <see cref="IContent"/> to copy</param>
+        /// <param name="parentId">Id of the Content's new Parent</param>
+        /// <param name="relateToOriginal">Boolean indicating whether the copy should be related to the original</param>
+		/// <param name="recursive">Boolean indicating whether to copy children too or not</param>
+        /// <param name="userId">Optional Id of the User copying the Content</param>
+        /// <returns>The newly created <see cref="IContent"/> object</returns>
+        IContent Copy(IContent content, int parentId, bool relateToOriginal, bool recursive, int userId = 0);
+
+        /// <summary>
         /// Checks if the passed in <see cref="IContent"/> can be published based on the anscestors publish state.
         /// </summary>
         /// <param name="content"><see cref="IContent"/> to check if anscestors are published</param>


### PR DESCRIPTION
Adding the option to copy ONLY the given content, without any children.

New Copy method created on ContentService, with an additional argument, for whether or not to copy recursively.