### PR TITLE
U4-6955: Issue with stripping modifiers with no trailing characters

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/config.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/config.controller.js
@@ -22,7 +22,10 @@ angular.module("umbraco")
                     } else {
                         return val.slice(paddArray[0].length, 0);
                     }
-                }else{
+                } else {
+                    if (paddArray[1].length === 0) {
+                        return val.slice(paddArray[0].length);
+                    }
                     return val.slice(paddArray[0].length, -paddArray[1].length); 
                 }
             }


### PR DESCRIPTION
When using a modifier with no trailing characters after the placeholder eg. setting a color style with #{0}.  The end selection is set to 0 resulting in the value also being stripped