### PR TITLE
macro name was not showing. The object targeting the selected macro w…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/insertmacro.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/insertmacro.html
@@ -28,7 +28,7 @@
 
             <div class="umb-pane" ng-switch-when="paramSelect">
 
-                <h5>{{$parent.$parent.selectedMacro.name}}</h5>
+                <h5>{{$parent.selectedMacro.name}}</h5>
 
                 <ul class="unstyled">
                     <li ng-repeat="param in $parent.macroParams">


### PR DESCRIPTION
The name of the macro when inserting it was not showing at the time of the wizard for the macro parameters. Only one level up was necessary to hit the {{$parent.selectedMacro.name}} in insertmacro.html