### PR TITLE
Fix: U4-5180 Notifications email highlighting is incorrect. Ensured t…

### DIFF
--- a/src/Umbraco.Core/Services/NotificationService.cs
+++ b/src/Umbraco.Core/Services/NotificationService.cs
@@ -204,6 +204,8 @@ namespace Umbraco.Core.Services
             if (createSubject == null) throw new ArgumentNullException("createSubject");
             if (createBody == null) throw new ArgumentNullException("createBody");
 
+            allVersions = allVersions.OrderBy(x => x.UpdateDate).ToArray();
+
             int versionCount = (allVersions.Length > 1) ? (allVersions.Length - 2) : (allVersions.Length - 1);
             var oldDoc = _contentService.GetByVersion(allVersions[versionCount].Version);
 


### PR DESCRIPTION
…he versions of content used in comparison is sorted correctly so the highlighting is based on previous version and not the base version of the content.