### PR TITLE
Publicise methods and subclasses in MediaCacheRefresher

### DIFF
--- a/src/Umbraco.Web/Cache/MediaCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/MediaCacheRefresher.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Web.Cache
         /// </summary>
         /// <param name="json"></param>
         /// <returns></returns>
-        internal static JsonPayload[] DeserializeFromJsonPayload(string json)
+        public static JsonPayload[] DeserializeFromJsonPayload(string json)
         {
             var serializer = new JavaScriptSerializer();
             var jsonObject = serializer.Deserialize<JsonPayload[]>(json);
@@ -99,14 +99,14 @@ namespace Umbraco.Web.Cache
 
         #region Sub classes
 
-        internal enum OperationType
+        public enum OperationType
         {
             Saved,
             Trashed,
             Deleted
         }
 
-        internal class JsonPayload
+        public class JsonPayload
         {
             public string Path { get; set; }
             public int Id { get; set; }


### PR DESCRIPTION
Make DeserializeFromJsonPayload in MediaCacheRefresher and associated sub classes public so that it's possible to easily retrieve the data in custom code

Would make it possible to do something like this:

                case MessageType.RefreshByJson:
                    var jsonPayloads = MediaCacheRefresher.DeserializeFromJsonPayload((string)e.MessageObject);
                    
                    foreach (var payload in jsonPayloads)
                    {
                        this.Refresh(new UmbracoHelper(UmbracoContext.Current).TypedMedia(payload.Id));   
                    }

                    break;