### PR TITLE
U4-4051 - Remember latest folder in media archive / select media

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js
@@ -27,7 +27,7 @@ angular.module("umbraco")
 
             //preload selected item
             $scope.target = undefined;
-            if(dialogOptions.currentTarget){
+            if(dialogOptions.currentTarget) {
                 $scope.target = dialogOptions.currentTarget;
             }
 
@@ -150,11 +150,24 @@ angular.module("umbraco")
 
                 $scope.target = undefined;
             };
+            
+            if (!$scope.target) {
 
-           
+                // Check start node is in the path of the requested node to open on (if passed).  It might not be if there are multiple media pickers
+                // with different start nodes.  If it's not, we'll reset to present from the start node.
+                if (dialogOptions.openAtNodeId && dialogOptions.openAtNodeId !== $scope.startNodeId) {
+                    entityResource.getById(dialogOptions.openAtNodeId, "media")
+                        .then(function (openAtNode) {
+                            var openAtNodeId = $scope.startNodeId;
+                            if (openAtNode.path.split(',').indexOf($scope.startNodeId)) {
+                                openAtNodeId = openAtNode.id;
+                            }
 
-            //default root item
-            if(!$scope.target){
-                $scope.gotoFolder({ id: $scope.startNodeId, name: "Media", icon: "icon-folder" });  
+                            $scope.gotoFolder({ id: openAtNodeId, name: "Media", icon: "icon-folder" });
+                        });
+                } else {
+                    $scope.gotoFolder({ id: $scope.startNodeId, name: "Media", icon: "icon-folder" });
+                }
+
             }
         });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -11,12 +11,10 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                 $scope.model.config.startNodeId = userData.startMediaId;
             });
         }
-            
-
          
         function setupViewModel() {
             $scope.images = [];
-            $scope.ids = []; 
+            $scope.ids = [];
 
             if ($scope.model.value) {
                 var ids = $scope.model.value.split(',');
@@ -40,7 +38,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                             }
 
                             $scope.images.push(media);
-                            $scope.ids.push(media.id);   
+                            $scope.ids.push(media.id);
                         }
                     });
 
@@ -60,6 +58,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
         $scope.add = function() {
             dialogService.mediaPicker({
                 startNodeId: $scope.model.config.startNodeId,
+                openAtNodeId: $rootScope.lastPickedMediaParentId ? $rootScope.lastPickedMediaParentId : $scope.model.config.startNodeId,
                 multiPicker: multiPicker,
                 callback: function(data) {
                     
@@ -76,6 +75,8 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
 
                         $scope.images.push(media);
                         $scope.ids.push(media.id);
+
+                        $rootScope.lastPickedMediaParentId = media.parentId;
                     });
 
                     $scope.sync();


### PR DESCRIPTION
I've done this by tracking the parent of the last picked media item in rootScope and presenting that as the default in subsequent openings of the media picker.  There's a check to ensure the node requested to open at has the configured start node in the path (as it could be it's not if there's different start nodes configured on different media pickers).