### PR TITLE
U4-6986 PublishedContentExtensions.FirstChild() throws exception

### DIFF
--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -455,6 +455,20 @@ namespace Umbraco.Tests.PublishedContent
 		}
 
 		[Test]
+		public void FirstChild()
+		{
+			var doc = GetNode(1173); // has child nodes
+			Assert.IsNotNull(doc.FirstChild());
+			Assert.IsNotNull(doc.FirstChild(x => true));
+			Assert.IsNotNull(doc.FirstChild<IPublishedContent>());
+
+			doc = GetNode(1175); // does not have child nodes
+			Assert.IsNull(doc.FirstChild());
+			Assert.IsNull(doc.FirstChild(x => true));
+			Assert.IsNull(doc.FirstChild<IPublishedContent>());
+		}
+
+		[Test]
 		public void HasProperty()
 		{
 			var doc = GetNode(1173);

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1734,7 +1734,7 @@ namespace Umbraco.Web
 
         public static IPublishedContent FirstChild(this IPublishedContent content)
         {
-            return content.Children().First();
+            return content.Children().FirstOrDefault();
         }
 
         public static IPublishedContent FirstChild(this IPublishedContent content, Func<IPublishedContent, bool> predicate)


### PR DESCRIPTION
Changes the return value to use `.FirstOrDefault()` instead of `.First()`.
Includes unit-test.