### PR TITLE
Additional translations for members

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.controller.js
@@ -1,14 +1,21 @@
 angular.module("umbraco")
-    .controller("Umbraco.Dialogs.HelpController", function ($scope, $location, $routeParams, helpService, userService) {
+    .controller("Umbraco.Dialogs.HelpController", function ($scope, $location, $routeParams, helpService, userService, localizationService) {
         $scope.section = $routeParams.section;
         $scope.version = Umbraco.Sys.ServerVariables.application.version + " assembly: " + Umbraco.Sys.ServerVariables.application.assemblyVersion;
         
         if(!$scope.section){
-            $scope.section ="content";
+            $scope.section = "content";
         }
+
+        $scope.sectionName = $scope.section;
 
         var rq = {};
         rq.section = $scope.section;
+
+        //translate section name
+        localizationService.localize("sections_" + rq.section).then(function (value) {
+            $scope.sectionName = value;
+        });
         
         userService.getCurrentUser().then(function(user){
         	

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.html
@@ -7,7 +7,7 @@
 	<div class="umb-panel-body umb-scrollable">
 		<div class="tab-content umb-control-group">
 			<div class="umb-pane">
-				<h5><localize key="help_helpTopicsFor">Help topics for</localize>: {{section}}</h5>
+				<h5><localize key="help_helpTopicsFor">Help topics for</localize>: {{sectionName}}</h5>
 				<ul class="unstyled list-icons" ng-show="topics">
 					<li ng-repeat="topic in topics">
 				    	<i class="icon icon-help-alt"></i>
@@ -31,7 +31,7 @@
 			</div>
 
 			<div class="umb-pane">
-				<h5><localize key="help_videoChaptersFor">Video chapters for</localize>: {{section}}</h5>
+				<h5><localize key="help_videoChaptersFor">Video chapters for</localize>: {{sectionName}}</h5>
 
 				<ul class="thumbnails" ng-show="videos">
 					<li class="span2" ng-repeat="video in videos">

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.list.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.list.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the member list view
  */
-function MemberListController($scope, $routeParams, $location, $q, $window, appState, memberResource, entityResource, navigationService, notificationsService, angularHelper, serverValidationManager, contentEditingHelper, fileManager, formHelper, umbModelMapper, editorState) {
+function MemberListController($scope, $routeParams, $location, $q, $window, appState, memberResource, entityResource, navigationService, notificationsService, angularHelper, serverValidationManager, contentEditingHelper, fileManager, formHelper, umbModelMapper, editorState, localizationService) {
     
     //setup scope vars
     $scope.currentSection = appState.getSectionState("currentSection");
@@ -17,6 +17,13 @@ function MemberListController($scope, $routeParams, $location, $q, $window, appS
         .then(function (data) {
             $scope.loaded = true;
             $scope.content = data;
+
+            //translate "All Members"
+            if ($scope.content != null && $scope.content.name != null && $scope.content.name.replace(" ", "").toLowerCase() == "allmembers") {
+                localizationService.localize("member_allMembers").then(function (value) {
+                    $scope.content.name = value;
+                });
+            }
 
             editorState.set($scope.content);
 

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -918,9 +918,9 @@ Mange hilsner fra Umbraco robotten
     <key alias="searchAllChildren">Søg alle 'børn'</key>
     <key alias="startnode">Start node</key>
     <key alias="username">Navn</key>
-    <key alias="userPermissions">Bruger tilladelser</key>
+    <key alias="userPermissions">Brugertilladelser</key>
     <key alias="usertype">Brugertype</key>
-    <key alias="userTypes">Bruger typer</key>
+    <key alias="userTypes">Brugertyper</key>
     <key alias="writer">Forfatter</key>
     <key alias="translator">Oversætter</key>
     <key alias="yourProfile">Din profil</key>


### PR DESCRIPTION
Addtional translations for members, help dialog and a few updated in
da.xml

I have created an issue here: http://issues.umbraco.org/issue/U4-7008

![image](https://cloud.githubusercontent.com/assets/2919859/9428719/49dc6126-49b8-11e5-89e7-bc55bb142e4d.png)

![image](https://cloud.githubusercontent.com/assets/2919859/9428725/75ca144a-49b8-11e5-9300-4320767351f8.png)

I also noticed it is possible to translate the Member Type -> Member node by using a dictionary item. However it seems to effect Members -> Member node too .. it is probably the tree controller that doesn't handle dictionary item?
Also I couldn't find where the first node "Members" gets its name?

![image](https://cloud.githubusercontent.com/assets/2919859/9428743/d277a46e-49b8-11e5-8f70-1e6c39f1cb75.png)

Finally I think there is something wrong with the feed used in help dialog as it display the same video chapters for each section? E.g. in Members section I see the "Creating media" video chapter.