### PR TITLE
Fixes: COU-191 Creating a revision gives a reference not set error (7.3)

### DIFF
--- a/src/Umbraco.Web/UI/LegacyDialogHandler.cs
+++ b/src/Umbraco.Web/UI/LegacyDialogHandler.cs
@@ -193,10 +193,18 @@ namespace Umbraco.Web.UI
             typeInstance.Alias = text;
 
             // check for returning url
-            var returnUrlTask = typeInstance as LegacyDialogTask;
-
-            returnUrlTask.AdditionalValues = additionalValues;
-
+            ITaskReturnUrl returnUrlTask = typeInstance as LegacyDialogTask;
+            if (returnUrlTask != null)
+            {
+                // if castable to LegacyDialogTask: add in additionalValues
+                ((LegacyDialogTask) returnUrlTask).AdditionalValues = additionalValues;
+            }
+            else
+            {
+                // otherwise cast to returnUrl interface
+                returnUrlTask = typeInstance as ITaskReturnUrl;
+            }
+            
             typeInstance.Save();
             
             return returnUrlTask != null


### PR DESCRIPTION
If the typeInstance could not be cast to LegacyDialogTask, trying to set additionalValues caused a null exception.
Inserted a null check and then cast to ITaskReturnUrl instead to get the returnUrl.