### PR TITLE
Fixes: U4-6193 Inserting an image into grid layout ignores alternativ…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
@@ -14,7 +14,8 @@ angular.module("umbraco")
                     $scope.control.value = {
                         focalPoint: data.focalPoint,
                         id: data.id,
-                        image: data.image
+                        image: data.image,
+                        altText: data.altText
                     };
 
                     $scope.setUrl();

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/Media.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/Media.cshtml
@@ -14,7 +14,7 @@
         }
     }
     
-    <img src="@url" alt="@Model.value.caption">
+    <img src="@url" alt="@Model.value.altText">
     
     if (Model.value.caption != null)
     {


### PR DESCRIPTION
…e text

AltText is used for alt tag instead of caption text which is used below the media.
Ensured the altText set in the dialog is saved to the value object.