### PR TITLE
HtmlAgilityPack binding redirect

### DIFF
--- a/src/Umbraco.Web.UI/web.Template.Debug.config
+++ b/src/Umbraco.Web.UI/web.Template.Debug.config
@@ -169,7 +169,7 @@
 												 xdt:Locator="Condition(_defaultNamespace:assemblyIdentity[@name='HtmlAgilityPack']])" />
       <dependentAssembly xdt:Transform="Insert">
         <assemblyIdentity name="HtmlAgilityPack" publicKeyToken="bd319b19eaf3b43a" culture="neutral" />
-        <bindingRedirect oldVersion="1.4.5.0-1.4.6.0" newVersion="1.4.6.0" />
+        <bindingRedirect oldVersion="1.4.5.0-1.4.9.0" newVersion="1.4.9.0" />
       </dependentAssembly>
 
       <dependentAssembly  xdt:Transform="Remove"

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -250,7 +250,7 @@
       <!-- Ensure correct version of HtmlAgilityPack -->
       <dependentAssembly>
         <assemblyIdentity name="HtmlAgilityPack" publicKeyToken="bd319b19eaf3b43a" culture="neutral" />
-        <bindingRedirect oldVersion="1.4.5.0-1.4.6.0" newVersion="1.4.6.0" />
+        <bindingRedirect oldVersion="1.4.5.0-1.4.9.0" newVersion="1.4.9.0" />
       </dependentAssembly>
 
       <dependentAssembly>


### PR DESCRIPTION
For v7.3 the referenced version of the HtmlAgilityPack is 1.4.9.0, however the binding redirect in the web.config still refers to 1.4.6.0. When you're trying to install packages that have been built against an earlier version, it breaks with a 'Could not load file or assembly' error.

This pull request updates the version number to match the referenced DLL.
