### PR TITLE
Added check for possible Null Reference Exception when rendering a grid textstring

### DIFF
--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/TextString.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/TextString.cshtml
@@ -6,7 +6,11 @@
     string markup = Model.editor.config.markup.ToString();
 
     markup = markup.Replace("#value#", Model.value.ToString());
-    markup = markup.Replace("#style#", Model.editor.config.style.ToString());
+    
+    if (Model.editor.config.style != null)
+    {
+        markup = markup.Replace("#style#", Model.editor.config.style.ToString());
+    }
 
     <text>
         @Html.Raw(markup)


### PR DESCRIPTION
Noticed this issue when I created a simple <p>#value#</p> grid editor which didn't provide any style data.
