### PR TITLE
Check for any media types before Mapping Properties

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/ContentTypeBaseRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentTypeBaseRepository.cs
@@ -574,7 +574,10 @@ AND umbracoNode.id <> @id",
                 var mediaTypes = MapMediaTypes(mediaTypeIds, db, sqlSyntax, out allParentMediaTypeIds)
                     .ToArray();
 
-                MapContentTypeChildren(mediaTypes, db, sqlSyntax, contentTypeRepository, allParentMediaTypeIds);
+                if (mediaTypes.Any())
+                {
+                    MapContentTypeChildren(mediaTypes, db, sqlSyntax, contentTypeRepository, allParentMediaTypeIds);
+                }
 
                 return mediaTypes;
             }


### PR DESCRIPTION
Fixes error when calling ContentTypeService.GetMediaType(guid).([Issue U4-7108](http://issues.umbraco.org/issue/U4-7108))

if mediatype with specified guid does not exist - you get a sql error

Server Error in '/' Application.

Incorrect syntax near ')'. 
  Description: An unhandled exception occurred during the execution of the current web request. Please review the stack trace for more information about the error and where it originated in the code. 

 Exception Details: System.Data.SqlClient.SqlException: Incorrect syntax near ')'.

Source Error: 


 An unhandled exception was generated during the execution of the current web request. Information regarding the origin and location of the exception can be identified using the exception stack trace below.  

```
Stack Trace: 
[SqlException (0x80131904): Incorrect syntax near ')'.]
   System.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction) +408
   System.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, Boolean callerHasConnectionLock, Boolean asyncClose) +768
   System.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady) +4489
   System.Data.SqlClient.SqlDataReader.TryConsumeMetaData() +117
   System.Data.SqlClient.SqlDataReader.get_MetaData() +126
   System.Data.SqlClient.SqlCommand.FinishExecuteReader(SqlDataReader ds, RunBehavior runBehavior, String resetOptionsString) +522
   System.Data.SqlClient.SqlCommand.RunExecuteReaderTds(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, Boolean async, Int32 timeout, Task& task, Boolean asyncWrite, SqlDataReader ds) +3117
   System.Data.SqlClient.SqlCommand.RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, String method, TaskCompletionSource`1 completion, Int32 timeout, Task& task, Boolean asyncWrite) +536
   System.Data.SqlClient.SqlCommand.RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, String method) +104
   System.Data.SqlClient.SqlCommand.ExecuteReader(CommandBehavior behavior, String method) +1113
   System.Data.SqlClient.SqlCommand.ExecuteReader(CommandBehavior behavior, String method) +1785
   System.Data.SqlClient.SqlCommand.ExecuteDbDataReader(CommandBehavior behavior) +183
   StackExchange.Profiling.Data.ProfiledDbCommand.ExecuteDbDataReader(CommandBehavior behavior) in c:\Code\github\SamSaffron\MiniProfiler\StackExchange.Profiling\Data\ProfiledDbCommand.cs:235
   System.Data.Common.DbCommand.System.Data.IDbCommand.ExecuteReader() +17
   Umbraco.Core.Persistence.<Query>d__7`1.MoveNext() +897
   System.Collections.Generic.List`1..ctor(IEnumerable`1 collection) +536
   System.Linq.Enumerable.ToList(IEnumerable`1 source) +76
   Umbraco.Core.Persistence.Repositories.ContentTypeQueryMapper.MapGroupsAndProperties(Int32[] contentTypeIds, Database db, ISqlSyntaxProvider sqlSyntax, IDictionary`2& allPropertyTypeCollection, IDictionary`2& allPropertyGroupCollection) +744
   Umbraco.Core.Persistence.Repositories.ContentTypeQueryMapper.MapContentTypeChildren(IContentTypeComposition[] contentTypes, Database db, ISqlSyntaxProvider sqlSyntax, TRepo contentTypeRepository, IDictionary`2 allParentContentTypeIds) +260
   Umbraco.Core.Persistence.Repositories.MediaTypeRepository.PerformGet(Guid id) +182
   Umbraco.Core.Persistence.Repositories.GuidReadOnlyContentTypeBaseRepository.PerformGet(Guid id) +41
   Umbraco.Core.Persistence.Repositories.RepositoryBase`2.Get(TId id) +258
   Umbraco.Core.Persistence.Repositories.ContentTypeBaseRepository`1.Get(Guid id) +38
   Umbraco.Core.Services.ContentTypeService.GetMediaType(Guid id) +117
```

This pr just adds the same .Any() check to GetMediaTypes that exists in GetContentTypes in the same class.