### PR TITLE
U4-6969: Set proper culture for localizing property labels

### DIFF
--- a/src/Umbraco.Web/Editors/ContentControllerBase.cs
+++ b/src/Umbraco.Web/Editors/ContentControllerBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -28,7 +29,13 @@ namespace Umbraco.Web.Editors
         /// </summary>
         protected ContentControllerBase()
             : this(UmbracoContext.Current)
-        {            
+        {
+            var cultureInfo = Security.IsAuthenticated()
+                    ? Security.CurrentUser.GetUserCulture(Services.TextService)
+                    : CultureInfo.GetCultureInfo("en");
+
+            System.Threading.Thread.CurrentThread.CurrentUICulture = cultureInfo;
+            System.Threading.Thread.CurrentThread.CurrentCulture = cultureInfo;
         }
 
         /// <summary>
@@ -38,6 +45,12 @@ namespace Umbraco.Web.Editors
         protected ContentControllerBase(UmbracoContext umbracoContext)
             : base(umbracoContext)
         {
+            var cultureInfo = Security.IsAuthenticated()
+                       ? Security.CurrentUser.GetUserCulture(Services.TextService)
+                       : CultureInfo.GetCultureInfo("en");
+
+            System.Threading.Thread.CurrentThread.CurrentUICulture = cultureInfo;
+            System.Threading.Thread.CurrentThread.CurrentCulture = cultureInfo;
         }
 
         protected HttpResponseMessage HandleContentNotFound(object id, bool throwException = true)


### PR DESCRIPTION
Property Labels default to EN-us, because the CurrentUICulture is never set for backoffice requests. This PR sets the proper culture, allowing labels to show localized values again.
Issue here: http://issues.umbraco.org/issue/U4-6969