### PR TITLE
Setting UMB_CONTEXT with Domain "FALSE"

### DIFF
--- a/src/Umbraco.Web/Security/Identity/GetUserSecondsMiddleWare.cs
+++ b/src/Umbraco.Web/Security/Identity/GetUserSecondsMiddleWare.cs
@@ -83,7 +83,7 @@ namespace Umbraco.Web.Security.Identity
                             var cookieOptions = new CookieOptions
                             {
                                 Path = "/",
-                                Domain = _authOptions.CookieDomain,
+                                Domain = _authOptions.CookieDomain ?? "FALSE",
                                 Expires = DateTime.Now.AddMinutes(_authOptions.LoginTimeoutMinutes),
                                 HttpOnly = true,
                                 Secure = _authOptions.CookieSecure == CookieSecureOption.Always


### PR DESCRIPTION
I kept getting logged out running in Visual Studio, then noticed it was because I was losing my UMB_CONTEXT cookie.  The reason for this is a failed attempt for the server to re-set it.  This change allows the re-set to succeed (for Chrome 45)

Running Umbraco on localhost, Chrome does not handle received 'Set Cookie's with no domain.  "FALSE" works as noted here:  http://stackoverflow.com/questions/1134290/cookies-on-localhost-with-explicit-domain