### PR TITLE
U4 4652 - Decimal property editor

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -159,6 +159,11 @@ namespace Umbraco.Core
             public const string IntegerAlias = "Umbraco.Integer";
 
             /// <summary>
+            /// Alias for the Decimal datatype.
+            /// </summary>
+            public const string DecimalAlias = "Umbraco.Decimal";
+
+            /// <summary>
             /// Alias for the listview datatype.
             /// </summary>
             public const string ListViewAlias = "Umbraco.ListView";

--- a/src/Umbraco.Core/CoreBootManager.cs
+++ b/src/Umbraco.Core/CoreBootManager.cs
@@ -431,6 +431,7 @@ namespace Umbraco.Core
                     new Lazy<Type>(() => typeof (DelimitedManifestValueValidator)),
                     new Lazy<Type>(() => typeof (EmailValidator)),
                     new Lazy<Type>(() => typeof (IntegerValidator)),
+                    new Lazy<Type>(() => typeof (DecimalValidator)),
                 });
 
             //by default we'll use the db server registrar unless the developer has the legacy

--- a/src/Umbraco.Core/Models/DataTypeDatabaseType.cs
+++ b/src/Umbraco.Core/Models/DataTypeDatabaseType.cs
@@ -21,6 +21,8 @@ namespace Umbraco.Core.Models
         [EnumMember]
         Integer,
         [EnumMember]
-        Date
+        Date,
+        [EnumMember]
+        Decimal
     }
 }

--- a/src/Umbraco.Core/Models/PropertyType.cs
+++ b/src/Umbraco.Core/Models/PropertyType.cs
@@ -401,6 +401,9 @@ namespace Umbraco.Core.Models
                 if (DataTypeDatabaseType == DataTypeDatabaseType.Integer && type == typeof(int))
                     return true;
 
+                if (DataTypeDatabaseType == DataTypeDatabaseType.Decimal && type == typeof(decimal))
+                    return true;
+
                 if (DataTypeDatabaseType == DataTypeDatabaseType.Date && type == typeof(DateTime))
                     return true;
 

--- a/src/Umbraco.Core/Models/Rdbms/PropertyDataDto.cs
+++ b/src/Umbraco.Core/Models/Rdbms/PropertyDataDto.cs
@@ -33,6 +33,10 @@ namespace Umbraco.Core.Models.Rdbms
         [NullSetting(NullSetting = NullSettings.Null)]
         public int? Integer { get; set; }
 
+        [Column("dataDecimal")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public decimal? Decimal { get; set; }
+
         [Column("dataDate")]
         [NullSetting(NullSetting = NullSettings.Null)]
         public DateTime? Date { get; set; }
@@ -55,22 +59,27 @@ namespace Umbraco.Core.Models.Rdbms
         {
             get
             {
-                if(Integer.HasValue)
+                if (Integer.HasValue)
                 {
                     return Integer.Value;
                 }
+
+                if (Decimal.HasValue)
+                {
+                    return Decimal.Value;
+                }
                 
-                if(Date.HasValue)
+                if (Date.HasValue)
                 {
                     return Date.Value;
                 }
                 
-                if(string.IsNullOrEmpty(VarChar) == false)
+                if (string.IsNullOrEmpty(VarChar) == false)
                 {
                     return VarChar;
                 }
 
-                if(string.IsNullOrEmpty(Text) == false)
+                if (string.IsNullOrEmpty(Text) == false)
                 {
                     return Text;
                 }

--- a/src/Umbraco.Core/Persistence/Factories/PropertyFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/PropertyFactory.cs
@@ -63,7 +63,9 @@ namespace Umbraco.Core.Persistence.Factories
 
                 //Check if property has an Id and set it, so that it can be updated if it already exists
                 if (property.HasIdentity)
+                {
                     dto.Id = property.Id;
+                }
 
                 if (property.DataTypeDatabaseType == DataTypeDatabaseType.Integer)
                 {
@@ -82,11 +84,21 @@ namespace Umbraco.Core.Persistence.Factories
                         }
                     }
                 }
+                else if (property.DataTypeDatabaseType == DataTypeDatabaseType.Decimal && property.Value != null)
+                {
+                    decimal val;
+                    if (decimal.TryParse(property.Value.ToString(), out val))
+                    {
+                        dto.Decimal = val;
+                    }
+                }
                 else if (property.DataTypeDatabaseType == DataTypeDatabaseType.Date && property.Value != null && string.IsNullOrWhiteSpace(property.Value.ToString()) == false)
                 {
                     DateTime date;
-                    if(DateTime.TryParse(property.Value.ToString(), out date))
+                    if (DateTime.TryParse(property.Value.ToString(), out date))
+                    {
                         dto.Date = date;
+                    }
                 }
                 else if (property.DataTypeDatabaseType == DataTypeDatabaseType.Ntext && property.Value != null)
                 {

--- a/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenFourZero/AddDataDecimalColumn.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenFourZero/AddDataDecimalColumn.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenFourZero
+{
+    [Migration("7.4.0", 1, GlobalSettings.UmbracoMigrationName)]
+    public class AddDataDecimalColumn : MigrationBase
+    {
+        public AddDataDecimalColumn(ISqlSyntaxProvider sqlSyntax, ILogger logger)
+            : base(sqlSyntax, logger)
+        {
+        }
+
+        public override void Up()
+        {
+            //Don't exeucte if the column is already there
+            var columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToArray();
+
+            if (columns.Any(x => x.TableName.InvariantEquals("cmsPropertyData") && x.ColumnName.InvariantEquals("dataDecimal")) == false)
+                Create.Column("dataDecimal").OnTable("cmsPropertyData").AsDecimal(18, 9).Nullable();
+        }
+
+        public override void Down()
+        {
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/DecimalValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalValidator.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Umbraco.Core.Models;
+
+namespace Umbraco.Core.PropertyEditors
+{
+    /// <summary>
+    /// A validator that validates that the value is a valid decimal
+    /// </summary>
+    [ValueValidator("Decimal")]
+    internal sealed class DecimalValidator : ManifestValueValidator, IPropertyValidator
+    {
+        public override IEnumerable<ValidationResult> Validate(object value, string config, PreValueCollection preValues, PropertyEditor editor)
+        {
+            if (value != null && value.ToString() != string.Empty)
+            {
+                var result = value.TryConvertTo<decimal>();
+                if (result.Success == false)
+                {
+                    yield return new ValidationResult("The value " + value + " is not a valid decimal", new[] { "value" });
+                }
+            }
+        }
+
+        public IEnumerable<ValidationResult> Validate(object value, PreValueCollection preValues, PropertyEditor editor)
+        {
+            return Validate(value, "", preValues, editor);
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/PropertyValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueEditor.cs
@@ -133,6 +133,8 @@ namespace Umbraco.Core.PropertyEditors
                 case "INT":
                 case "INTEGER":
                     return DataTypeDatabaseType.Integer;
+                case "DECIMAL":
+                    return DataTypeDatabaseType.Decimal;
                 case "STRING":
                     return DataTypeDatabaseType.Nvarchar;
                 case "TEXT":
@@ -201,6 +203,11 @@ namespace Umbraco.Core.PropertyEditors
                     return result.Success && result.Result != null
                         ? Attempt<object>.Succeed((int)(long)result.Result) 
                         : result;
+
+                case DataTypeDatabaseType.Decimal:
+                    //ensure these are nullable so we can return a null if required
+                    valueType = typeof(decimal?);
+                    break;
 
                 case DataTypeDatabaseType.Date:
                     //ensure these are nullable so we can return a null if required
@@ -283,6 +290,7 @@ namespace Umbraco.Core.PropertyEditors
                     }
                     return property.Value.ToString();
                 case DataTypeDatabaseType.Integer:
+                case DataTypeDatabaseType.Decimal:
                     //we can just ToString() any of these types
                     return property.Value.ToString();
                 case DataTypeDatabaseType.Date:
@@ -325,6 +333,7 @@ namespace Umbraco.Core.PropertyEditors
             {
                 case DataTypeDatabaseType.Date:
                 case DataTypeDatabaseType.Integer:
+                case DataTypeDatabaseType.Decimal:
                     return new XText(ConvertDbToString(property, propertyType, dataTypeService));                    
                 case DataTypeDatabaseType.Nvarchar:
                 case DataTypeDatabaseType.Ntext:
@@ -354,6 +363,7 @@ namespace Umbraco.Core.PropertyEditors
                     property.Value.ToXmlString<string>();
                     return property.Value.ToXmlString<string>();
                 case DataTypeDatabaseType.Integer:
+                case DataTypeDatabaseType.Decimal:
                     return property.Value.ToXmlString(property.Value.GetType());                
                 case DataTypeDatabaseType.Date:
                     //treat dates differently, output the format as xml format

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/DecimalValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/DecimalValueConverter.cs
@@ -1,0 +1,31 @@
+﻿using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Core.PropertyEditors.ValueConverters
+{
+    [PropertyValueType(typeof(decimal))]
+    [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]
+    public class DecimalValueConverter : PropertyValueConverterBase
+    {
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return Constants.PropertyEditors.DecimalAlias.Equals(propertyType.PropertyEditorAlias);
+        }
+
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source == null) return 0M;
+
+            // in XML a decimal is a string
+            var sourceString = source as string;
+            if (sourceString != null)
+            {
+                decimal d;
+                return (decimal.TryParse(sourceString, out d)) ? d : 0M;
+            }
+
+            // in the database an a decimal is an a decimal 
+            // default value is zero
+            return (source is decimal) ? source : 0M;
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -404,6 +404,7 @@
     <Compile Include="Persistence\Mappers\AccessMapper.cs" />
     <Compile Include="Persistence\Mappers\DomainMapper.cs" />
     <Compile Include="Persistence\Mappers\MigrationEntryMapper.cs" />
+    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenFourZero\AddDataDecimalColumn.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenThreeZero\AddExternalLoginsTable.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenThreeZero\AddForeignKeysForLanguageAndDictionaryTables.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenThreeZero\AddServerRegistrationColumnsAndLock.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -455,7 +455,9 @@
     <Compile Include="Persistence\Repositories\RepositoryCacheOptions.cs" />
     <Compile Include="Persistence\Repositories\TaskRepository.cs" />
     <Compile Include="Persistence\Repositories\TaskTypeRepository.cs" />
+    <Compile Include="PropertyEditors\DecimalValidator.cs" />
     <Compile Include="PropertyEditors\ValueConverters\GridValueConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\DecimalValueConverter.cs" />
     <Compile Include="Publishing\UnPublishedStatusType.cs" />
     <Compile Include="Publishing\UnPublishStatus.cs" />
     <Compile Include="Security\BackOfficeClaimsIdentityFactory.cs" />

--- a/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueEditorTests.cs
+++ b/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueEditorTests.cs
@@ -5,12 +5,29 @@ using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
+using Umbraco.Core.ObjectResolution;
+using Umbraco.Core.Strings;
+using Umbraco.Tests.TestHelpers;
 
 namespace Umbraco.Tests.PropertyEditors
 {
     [TestFixture]
     public class PropertyEditorValueEditorTests
     {
+        [SetUp]
+        public virtual void TestSetup()
+        {
+            ShortStringHelperResolver.Current = new ShortStringHelperResolver(new DefaultShortStringHelper(SettingsForTests.GetDefault()));
+            Resolution.Freeze();
+        }
+
+        [TearDown]
+        public virtual void TestTearDown()
+        {
+            ResolverCollection.ResetAll();
+            Resolution.Reset();
+        }
+
         [TestCase("{prop1: 'val1', prop2: 'val2'}", true)]
         [TestCase("{1,2,3,4}", false)]
         [TestCase("[1,2,3,4]", true)]
@@ -46,6 +63,47 @@ namespace Umbraco.Tests.PropertyEditors
             Assert.AreEqual(expected, result.Result);
         }
 
+        // The following decimal tests have not been added as [TestCase]s
+        // as the decimal type cannot be used as an attribute parameter
+        [Test]
+        public void Value_Editor_Can_Convert_To_Decimal_Clr_Type()
+        {
+            var valueEditor = new PropertyValueEditor
+            {
+                ValueType = "DECIMAL"
+            };
+
+            var result = valueEditor.TryConvertValueToCrlType("12.34");
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(12.34M, result.Result);
+        }
+
+        [Test]
+        public void Value_Editor_Can_Convert_To_Decimal_Clr_Type_With_Other_Separator()
+        {
+            var valueEditor = new PropertyValueEditor
+            {
+                ValueType = "DECIMAL"
+            };
+
+            var result = valueEditor.TryConvertValueToCrlType("12,34");
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(12.34M, result.Result);
+        }
+
+        [Test]
+        public void Value_Editor_Can_Convert_To_Decimal_Clr_Type_With_Empty_String()
+        {
+            var valueEditor = new PropertyValueEditor
+            {
+                ValueType = "DECIMAL"
+            };
+
+            var result = valueEditor.TryConvertValueToCrlType(string.Empty);
+            Assert.IsTrue(result.Success);
+            Assert.IsNull(result.Result);
+        }
+        
         [Test]
         public void Value_Editor_Can_Convert_To_Date_Clr_Type()
         {
@@ -76,6 +134,35 @@ namespace Umbraco.Tests.PropertyEditors
 
             var result = valueEditor.ConvertDbToEditor(prop, prop.PropertyType, new Mock<IDataTypeService>().Object);
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Value_Editor_Can_Serialize_Decimal_Value()
+        {
+            var value = 12.34M;
+            var valueEditor = new PropertyValueEditor
+                {
+                    ValueType = "DECIMAL"
+                };
+
+            var prop = new Property(1, Guid.NewGuid(), new PropertyType("test", DataTypeDatabaseType.Decimal), value);
+
+            var result = valueEditor.ConvertDbToEditor(prop, prop.PropertyType, new Mock<IDataTypeService>().Object);
+            Assert.AreEqual("12.34", result);
+        }
+
+        [Test]
+        public void Value_Editor_Can_Serialize_Decimal_Value_With_Empty_String()
+        {
+            var valueEditor = new PropertyValueEditor
+                {
+                    ValueType = "DECIMAL"
+                };
+
+            var prop = new Property(1, Guid.NewGuid(), new PropertyType("test", DataTypeDatabaseType.Decimal), string.Empty);
+
+            var result = valueEditor.ConvertDbToEditor(prop, prop.PropertyType, new Mock<IDataTypeService>().Object);
+            Assert.AreEqual(string.Empty, result);
         }
 
         [Test]

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/decimal.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/decimal.html
@@ -1,0 +1,11 @@
+<div>
+    <input name="decimalField" class="umb-editor umb-number" 
+           type="number" 
+           ng-model="model.value"
+           val-server="value"
+           fix-number />
+
+    <span class="help-inline" val-msg-for="decimalField" val-toggle-msg="number">Not a number</span>
+    <span class="help-inline" val-msg-for="decimalField" val-toggle-msg="valServer">{{propertyForm.requiredField.errorMsg}}</span>
+    
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/number.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/number.html
@@ -3,7 +3,7 @@
            type="number" 
            ng-model="model.value"
            val-server="value"
-            fix-number />
+           fix-number />
 
     <span class="help-inline" val-msg-for="numberField" val-toggle-msg="number">Not a number</span>
     <span class="help-inline" val-msg-for="numberField" val-toggle-msg="valServer">{{propertyForm.requiredField.errorMsg}}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
@@ -1,8 +1,11 @@
 ﻿<div class="umb-editor">
-    <input name="decimalField" type="number" class="umb-editor umb-number"
-        ng-model="model.value"
-        val-server="value"
-        fix-number min="{{model.config.min}}" max="{{model.config.max}}" step="{{model.config.step}}" />
+    <input name="decimalField" 
+           type="number"
+           pattern="[0-9]+([,\.][0-9]+)?"
+           class="umb-editor umb-number"
+           ng-model="model.value"
+           val-server="value"
+           fix-number min="{{model.config.min}}" max="{{model.config.max}}" step="{{model.config.step}}" />
     
     <span class="help-inline" val-msg-for="decimalField" val-toggle-msg="number">Not a number</span>
     <span class="help-inline" val-msg-for="decimalField" val-toggle-msg="valServer">{{propertyForm.requiredField.errorMsg}}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
@@ -1,0 +1,9 @@
+﻿<div class="umb-editor">
+    <input name="decimalField" type="number" class="umb-editor umb-number"
+        ng-model="model.value"
+        val-server="value"
+        fix-number min="{{model.config.min}}" max="{{model.config.max}}" step="{{model.config.step}}" />
+    
+    <span class="help-inline" val-msg-for="decimalField" val-toggle-msg="number">Not a number</span>
+    <span class="help-inline" val-msg-for="decimalField" val-toggle-msg="valServer">{{propertyForm.requiredField.errorMsg}}</span>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
@@ -6,5 +6,4 @@
     
     <span class="help-inline" val-msg-for="integerField" val-toggle-msg="number">Not a number</span>
     <span class="help-inline" val-msg-for="integerField" val-toggle-msg="valServer">{{propertyForm.requiredField.errorMsg}}</span>
-    
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
@@ -1,8 +1,11 @@
 ﻿<div class="umb-editor">
-    <input name="integerField" type="number" class="umb-editor umb-number "
-        ng-model="model.value"
-        val-server="value"
-        fix-number min="{{model.config.min}}" max="{{model.config.max}}" step="{{model.config.step}}" />
+    <input name="integerField"
+           type="number"
+           pattern="[0-9]*"
+           class="umb-editor umb-number "
+           ng-model="model.value"
+           val-server="value"
+           fix-number min="{{model.config.min}}" max="{{model.config.max}}" step="{{model.config.step}}" />
     
     <span class="help-inline" val-msg-for="integerField" val-toggle-msg="number">Not a number</span>
     <span class="help-inline" val-msg-for="integerField" val-toggle-msg="valServer">{{propertyForm.requiredField.errorMsg}}</span>

--- a/src/Umbraco.Web/PropertyEditors/DecimalPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DecimalPropertyEditor.cs
@@ -1,0 +1,57 @@
+using Umbraco.Core;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Web.PropertyEditors
+{
+    [PropertyEditor(Constants.PropertyEditors.DecimalAlias, "Decimal", "decimal", "decimal", IsParameterEditor = true)]
+    public class DecimalPropertyEditor : PropertyEditor
+    {
+        /// <summary>
+        /// Overridden to ensure that the value is validated
+        /// </summary>
+        /// <returns></returns>
+        protected override PropertyValueEditor CreateValueEditor()
+        {
+            var editor = base.CreateValueEditor();
+            editor.Validators.Add(new DecimalValidator());
+            return editor;
+        }
+        
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new DecimalPreValueEditor();
+        }
+
+        /// <summary>
+        /// A custom pre-value editor class to deal with the legacy way that the pre-value data is stored.
+        /// </summary>
+        internal class DecimalPreValueEditor : PreValueEditor
+        {
+            public DecimalPreValueEditor()
+            {
+                //create the fields
+                Fields.Add(new PreValueField(new DecimalValidator())
+                {
+                    Description = "Enter the minimum amount of number to be entered",
+                    Key = "min",
+                    View = "decimal",
+                    Name = "Minimum"
+                });
+                Fields.Add(new PreValueField(new DecimalValidator())
+                {
+                    Description = "Enter the intervals amount between each step of number to be entered",
+                    Key = "step",
+                    View = "decimal",
+                    Name = "Step Size"
+                });
+                Fields.Add(new PreValueField(new DecimalValidator())
+                {
+                    Description = "Enter the maximum amount of number to be entered",
+                    Key = "max",
+                    View = "decimal",
+                    Name = "Maximum"
+                });
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -305,6 +305,7 @@
     <Compile Include="Models\ContentEditing\SimpleNotificationModel.cs" />
     <Compile Include="Models\PublishedContentWithKeyBase.cs" />
     <Compile Include="PropertyEditors\DatePreValueEditor.cs" />
+    <Compile Include="PropertyEditors\DecimalPropertyEditor.cs" />
     <Compile Include="RequestLifespanMessagesFactory.cs" />
     <Compile Include="Scheduling\LatchedBackgroundTaskBase.cs" />
     <Compile Include="Security\Identity\ExternalSignInAutoLinkOptions.cs" />


### PR DESCRIPTION
Looking at this one is seemed an oversight probably from a long time back that numeric data is saved into an int field.  This PR adds a new column called `dataDecimal` to `cmsPropertyData` and a property editor for a "Decimal" type - so things like currencies or other decimal values can be stored without using a text string (and not then being able to use `<input type="number" />` for entry.

On the assumption it would need to at least wait for the next minor version, I've created a migration for 7.4 for the following SQL:

```
ALTER TABLE dbo.cmsPropertyData ADD
	dataDecimal decimal(18, 9) NULL
GO
```