### PR TITLE
Null check to prevent object reference error with public properties on custom indexers

### DIFF
--- a/src/Umbraco.Web/WebServices/ExamineManagementApiController.cs
+++ b/src/Umbraco.Web/WebServices/ExamineManagementApiController.cs
@@ -258,9 +258,16 @@ namespace Umbraco.Web.WebServices
                 //ignore these properties
                                   .Where(x => new[] {"IndexerData", "Description", "WorkingFolder"}.InvariantContains(x.Name) == false)
                                   .OrderBy(x => x.Name);
+								  
             foreach (var p in props)
             {
-                indexerModel.ProviderProperties.Add(p.Name, p.GetValue(indexer, null).ToString());
+                var val = p.GetValue(indexer, null);
+                if (val == null)
+                {
+                    LogHelper.Warn<ExamineManagementApiController>("Property value was null when setting up property on indexer: " + indexer.Name + " property: " + p.Name);
+                    val = string.Empty;
+                }
+                indexerModel.ProviderProperties.Add(p.Name, val.ToString());
             }
 
             var luceneIndexer = indexer as LuceneIndexer;


### PR DESCRIPTION
The indexing api would break if an indexer was created with a public property defaulting to a null value. This would result in an object reference error in the admin system. Added null check and warning to the log.