### PR TITLE
Added recursive option to copy dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.copy.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.copy.controller.js
@@ -7,6 +7,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.CopyController",
 	        searchText = value + "...";
 	    });
 
+	    $scope.recursive = true;
 	    $scope.relateToOriginal = false;
 	    $scope.dialogTreeEventHandler = $({});
 	    $scope.busy = false;
@@ -95,7 +96,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.CopyController",
 	        $scope.busy = true;
 	        $scope.error = false;
 
-	        contentResource.copy({ parentId: $scope.target.id, id: node.id, relateToOriginal: $scope.relateToOriginal })
+	        contentResource.copy({ parentId: $scope.target.id, id: node.id, relateToOriginal: $scope.relateToOriginal, recursive: $scope.recursive })
                 .then(function (path) {
                     $scope.error = false;
                     $scope.success = true;

--- a/src/Umbraco.Web.UI.Client/src/views/content/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/copy.html
@@ -56,6 +56,12 @@
                     </umb-control-group>
                 </umb-pane>
 
+                <umb-pane>
+                    <umb-control-group label="Include descendants">
+                        <input type="checkbox" ng-model="$parent.$parent.recursive" />
+                    </umb-control-group>
+                </umb-pane>
+
             </div>
         </div>
     </div>

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -491,7 +491,7 @@ namespace Umbraco.Web.Editors
         {
             var toCopy = ValidateMoveOrCopy(copy);
 
-            var c = Services.ContentService.Copy(toCopy, copy.ParentId, copy.RelateToOriginal);
+            var c = Services.ContentService.Copy(toCopy, copy.ParentId, copy.RelateToOriginal, copy.Recursive);
 
             var response = Request.CreateResponse(HttpStatusCode.OK);
             response.Content = new StringContent(c.Path, Encoding.UTF8, "application/json");

--- a/src/Umbraco.Web/Models/ContentEditing/MoveOrCopy.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/MoveOrCopy.cs
@@ -33,6 +33,13 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "relateToOriginal", IsRequired = true)]
         [Required]
         public bool RelateToOriginal { get; set; }
+
+        /// <summary>
+        /// Boolean indicating whether copying the object should be recursive
+        /// </summary>
+        [DataMember(Name = "recursive", IsRequired = true)]
+        [Required]
+        public bool Recursive { get; set; }
     }
 
 }


### PR DESCRIPTION
Sometimes you only want to copy a single content item without including descendants.
This PR adds a new checkbox on the copy dialog to allow this.

Issue: http://issues.umbraco.org/issue/U4-7218