### PR TITLE
Fixes: U4-7246 Integer datatype PropertyEditor is missing ValueType d…

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/IntegerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/IntegerPropertyEditor.cs
@@ -1,9 +1,10 @@
+using System;
 using Umbraco.Core;
 using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.IntegerAlias, "Numeric", "integer", IsParameterEditor = true)]
+    [PropertyEditor(Constants.PropertyEditors.IntegerAlias, "Numeric", "integer", IsParameterEditor = true, ValueType = "integer")]
     public class IntegerPropertyEditor : PropertyEditor
     {
         /// <summary>


### PR DESCRIPTION
…efinition

Ensured IntegerPropertyEditor stores its value in the dataInt column in cmsPropertyData.