### PR TITLE
Fixes U4-7249 Insert Macro split button, when selecting a macro that …

### DIFF
--- a/src/Umbraco.Web.UI/umbraco_client/Editors/EditTemplate.js
+++ b/src/Umbraco.Web.UI/umbraco_client/Editors/EditTemplate.js
@@ -9,12 +9,12 @@
         _openMacroModal: function(alias) {
             
             var self = this;
-
+           
             UmbClientMgr.openAngularModalWindow({
                 template: "views/common/dialogs/insertmacro.html",
                 dialogData: {
                     renderingEngine: "WebForms",
-                    selectedAlias: alias
+                    macroData: { macroAlias: alias }
                 },
                 callback: function(data) {
                     UmbEditor.Insert(data.syntax, '', self._opts.editorClientId);

--- a/src/Umbraco.Web.UI/umbraco_client/Editors/EditView.js
+++ b/src/Umbraco.Web.UI/umbraco_client/Editors/EditView.js
@@ -41,12 +41,12 @@
             /// <summary>callback used to display the modal dialog to insert a macro with parameters</summary>
             
             var self = this;
-
+           
             UmbClientMgr.openAngularModalWindow({
                 template: "views/common/dialogs/insertmacro.html",
                 dialogData: {
                     renderingEngine: "Mvc",
-                    selectedAlias: alias
+                    macroData: {macroAlias: alias}
                 },
                 callback: function (data) {
                     UmbEditor.Insert(data.syntax, '', self._opts.codeEditorElementId);


### PR DESCRIPTION
…has parameters the dialog should immediately show those