### PR TITLE
Hoover a property in backend to get its alias

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/directives/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/directives/umb-property.html
@@ -5,7 +5,7 @@
             <val-property-msg property="property"></val-property-msg>
             
             <div class="umb-el-wrap">
-                <label class="control-label" ng-hide="property.hideLabel" for="{{property.alias}}">
+                <label class="control-label" ng-hide="property.hideLabel" for="{{property.alias}}" title="{{property.alias}}">
                     {{property.label}}
                     <small ng-bind-html="property.description"></small>
                 </label>


### PR DESCRIPTION
I always forget the alias of my properties, so I have to go Settings>Document types>find the doctype>find the property...
Adding a title-attr so you just can hoover a property name to see what alias it has!