### PR TITLE
Fixed: U4-7175 Discard changes overlay sometimes breaks the url

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
@@ -30,7 +30,6 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
                 formHelper.resetForm({ scope: $scope });
 
                 var section = appState.getSectionState("currentSection");
-
                 $location.path("/" + section + "/documenttypes/list/" + folderId);
 
             }, function(err) {
@@ -43,14 +42,14 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
     $scope.createDocType = function() {
         $location.search('create', null);
         $location.search('notemplate', null);
-        $location.path("/settings/documenttypes/edit/" + node.id).search("create", true);
+        $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true");
         navigationService.hideMenu();
     }
 
     $scope.createComponent = function() {
       $location.search('create', null);
       $location.search('notemplate', null);
-      $location.path("/settings/documenttypes/edit/" + node.id).search("create", true).search("notemplate", true);
+      $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true").search("notemplate", "true");
       navigationService.hideMenu();
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/create.controller.js
@@ -1,12 +1,12 @@
 /**
  * @ngdoc controller
- * @name Umbraco.Editors.MediaType.CreateController
+ * @name Umbraco.Editors.MemberType.CreateController
  * @function
  *
  * @description
- * The controller for the media type creation dialog
+ * The controller for the member type creation dialog
  */
-function MediaTypesCreateController($scope, $location, navigationService, mediaTypeResource, formHelper, appState) {
+function MemberTypesCreateController($scope, $location, navigationService, memberTypeResource, formHelper, appState) {
 
     $scope.model = {
         folderName: "",
@@ -21,11 +21,11 @@ function MediaTypesCreateController($scope, $location, navigationService, mediaT
 
     $scope.createFolder = function () {
         if (formHelper.submitForm({ scope: $scope, formCtrl: this.createFolderForm, statusMessage: "Creating folder..." })) {
-            mediaTypeResource.createFolder(node.id, $scope.model.folderName).then(function (folderId) {
+            memberTypeResource.createFolder(node.id, $scope.model.folderName).then(function (folderId) {
 
                 navigationService.hideMenu();
                 var currPath = node.path ? node.path : "-1";
-                navigationService.syncTree({ tree: "mediatypes", path: currPath + "," + folderId, forceReload: true, activate: true });
+                navigationService.syncTree({ tree: "membertypes", path: currPath + "," + folderId, forceReload: true, activate: true });
 
                 formHelper.resetForm({ scope: $scope });
 
@@ -38,11 +38,11 @@ function MediaTypesCreateController($scope, $location, navigationService, mediaT
         };
     }
 
-    $scope.createMediaType = function() {
+    $scope.createMemberType = function() {
         $location.search('create', null);
-        $location.path("/settings/mediatypes/edit/" + node.id).search("create", "true");
+        $location.path("/settings/membertypes/edit/" + node.id).search("create", "true");
         navigationService.hideMenu();
     }
 }
 
-angular.module('umbraco').controller("Umbraco.Editors.MediaTypes.CreateController", MediaTypesCreateController);
+angular.module('umbraco').controller("Umbraco.Editors.MemberTypes.CreateController", MemberTypesCreateController);

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/create.html
@@ -1,0 +1,51 @@
+<div class="umbracoDialog umb-dialog-body with-footer" ng-controller="Umbraco.Editors.MemberTypes.CreateController">
+
+    <div class="umb-pane" ng-if="!model.creatingFolder">
+        <h5><localize key="create_createUnder">Create a type under</localize> {{currentNode.name}}</h5>
+
+        <ul class="umb-actions umb-actions-child">
+            <li>
+                <a href="" ng-click="showCreateFolder()">
+
+                    <i class="large icon-folder"></i>
+
+                    <span class="menu-label">
+                        Folder
+                    </span>
+                </a>
+            </li>
+            <li>
+                <a href="" ng-click="createMemberType()">
+
+                    <i class="large icon-item-arrangement"></i>
+
+                    <span class="menu-label">
+                        <localize key="general_new">New</localize>&nbsp;
+                        <localize key="content_memberType">Member type</localize>
+                    </span>
+
+                </a>
+            </li>
+        </ul>
+    </div>
+
+    <div class="umb-pane" ng-if="model.creatingFolder">
+        <form novalidate name="createFolderForm"
+              ng-submit="createFolder()"
+              val-form-manager>
+
+            <umb-control-group label="Enter a folder name" hide-label="false">
+                <input type="text" name="folderName" ng-model="model.folderName" class="umb-textstring textstring input-block-level" required />
+            </umb-control-group>
+
+            <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>
+        </form>
+    </div>
+
+</div>
+
+<div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-if="!model.creatingFolder">
+    <button class="btn" ng-click="nav.hideDialog(true)">
+        <localize key="buttons_somethingElse">Do something else</localize>
+    </button>
+</div>


### PR DESCRIPTION
Updates content/media/member types dialogs
to correctly set ?create to "true" instead of true (string instead of bool) - there is a bug in the way angular parses these urls so url?create becomes url?create=undefined which means the opposite in our checks. - which is why it breaks