### PR TITLE
Fixes: U4-6962 Public access in multiple levels is broken in 7.3

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/protectPage.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/protectPage.aspx.cs
@@ -79,7 +79,7 @@ namespace umbraco.presentation.umbraco.dialogs
 
             if (IsPostBack == false)
             {
-                if (Access.IsProtected(documentId, documentObject.Path) && Access.GetProtectionType(documentId) != ProtectionType.NotProtected)
+                if (Access.IsProtected(documentId) && Access.GetProtectionType(documentId) != ProtectionType.NotProtected)
                 {
                     bt_buttonRemoveProtection.Visible = true;
                     bt_buttonRemoveProtection.Attributes.Add("onClick", "return confirm('" + ui.Text("areyousure") + "')");
@@ -263,10 +263,11 @@ namespace umbraco.presentation.umbraco.dialogs
                 p_buttons.Visible = false;
                 pane_advanced.Visible = false;
                 pane_simple.Visible = false;
-                
                 var content = ApplicationContext.Current.Services.ContentService.GetById(pageId);
+                //reloads the current node in the tree
                 ClientTools.SyncTree(content.Path, true);
-
+                //reloads the current node's children in the tree
+                ClientTools.ReloadActionNode(false, true);
                 feedback.type = global::umbraco.uicontrols.Feedback.feedbacktype.success;
             }
         }
@@ -284,8 +285,10 @@ namespace umbraco.presentation.umbraco.dialogs
             feedback.Text = ui.Text("publicAccess", "paIsRemoved", new cms.businesslogic.CMSNode(pageId).Text) + "</p><p><a href='#' onclick='" + ClientTools.Scripts.CloseModalWindow() + "'>" + ui.Text("closeThisWindow") + "</a>";
 
             var content = ApplicationContext.Current.Services.ContentService.GetById(pageId);
+            //reloads the current node in the tree
             ClientTools.SyncTree(content.Path, true);
-
+            //reloads the current node's children in the tree
+            ClientTools.ReloadActionNode(false, true);
             feedback.type = global::umbraco.uicontrols.Feedback.feedbacktype.success;
         }
 

--- a/src/umbraco.cms/businesslogic/web/Access.cs
+++ b/src/umbraco.cms/businesslogic/web/Access.cs
@@ -213,7 +213,7 @@ namespace umbraco.cms.businesslogic.web
             var noAccessContent = ApplicationContext.Current.Services.ContentService.GetById(ErrorDocumentId);
             if (noAccessContent == null) throw new NullReferenceException("No content item found with id " + ErrorDocumentId);
 
-            var entry = ApplicationContext.Current.Services.PublicAccessService.GetEntryForContent(doc.ContentEntity);
+            var entry = ApplicationContext.Current.Services.PublicAccessService.GetEntryForContent(doc.ContentEntity.Id.ToString());
             if (entry != null)
             {
                 if (Simple)
@@ -418,6 +418,12 @@ namespace umbraco.cms.businesslogic.web
         public static bool IsProtected(int DocumentId, string Path)
         {
             return ApplicationContext.Current.Services.PublicAccessService.IsProtected(Path.EnsureEndsWith("," + DocumentId));             
+        }
+
+        //return the protection status of this exact document - not based on inheritance
+        public static bool IsProtected(int DocumentId)
+        {
+            return ApplicationContext.Current.Services.PublicAccessService.IsProtected(DocumentId.ToString());
         }
 
         public static int GetErrorPage(string Path)


### PR DESCRIPTION
Ensured the backoffice UI will look at protection for the specific node only (no inheritance) when specifying public access.
Added non-recursive method to Access class.
Fixed bug causing the tree (child nodes) not to update correctly after changing public access on nodes.