### PR TITLE
Adds browser refresh to uninstall

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -200,6 +200,10 @@ function umbTreeDirective($compile, $log, $q, $rootScope, treeService, notificat
                 //NOTE: loadChildren is ONLY used for legacy purposes, do not use this when syncing the tree as it will cause problems
                 // since there will be double request and event handling operations.
                 function loadActiveTree(treeAlias, loadChildren) {
+                    if (!treeAlias) {
+                        return;
+                    }
+
                     scope.activeTree = undefined;
 
                     function doLoad(tree) {

--- a/src/Umbraco.Web.UI/umbraco/developer/Packages/installedPackage.aspx
+++ b/src/Umbraco.Web.UI/umbraco/developer/Packages/installedPackage.aspx
@@ -148,10 +148,37 @@
                 </cc2:PropertyPanel>
             </cc2:Pane>
 
-            <cc2:Pane id="pane_uninstalled" runat="server" Visible="false">
-                <div style="margin: 10px;">
-                    <p><%= umbraco.ui.Text("packager", "packageUninstalledText") %></p>
+           <cc2:Pane id="pane_uninstalled" runat="server" Visible="false">
+
+                <div class="alert alert-block">
+                    Package uninstall in progress, please wait while the browser is reloaded...
                 </div>
+
+                <script type="text/javascript">
+                    
+                    //This is all a bit zany with double encoding because we have a URL in a hash (#) url part
+                    // but it works and maintains query strings
+
+                    var umbPath = "<%=umbraco.GlobalSettings.Path%>";
+                    setTimeout(function () {
+                        var mainWindow = UmbClientMgr.mainWindow();
+
+                        //kill the tree and template cache
+                        if (mainWindow.UmbClientMgr) {
+                            mainWindow.UmbClientMgr._packageInstalled();
+                        }
+
+                        var baseUrl = mainWindow.location.href.substr(0, mainWindow.location.href.indexOf("#/developer/framed/"));
+                        var framedUrl = baseUrl + "#/developer/framed/";
+                        var refreshUrl = framedUrl + encodeURIComponent(encodeURIComponent(umbPath + "/developer/packages/installer.aspx?installing=uninstalled"));
+
+                        var redirectUrl = umbPath + "/ClientRedirect.aspx?redirectUrl=" + refreshUrl;
+
+                        mainWindow.location.href = redirectUrl;
+                    }, 2000);
+                </script>
+
+
              </cc2:Pane>
     </cc2:Tabview>
 </asp:Content>

--- a/src/Umbraco.Web.UI/umbraco/developer/Packages/installer.aspx
+++ b/src/Umbraco.Web.UI/umbraco/developer/Packages/installer.aspx
@@ -294,6 +294,14 @@
             </cc1:PropertyPanel>
         </cc1:Pane>
 
+        <cc1:Pane ID="pane_uninstalled" runat="server" Text="Package has been uninstalled" Visible="false">
+            <cc1:PropertyPanel runat="server">
+               
+                <p><%= umbraco.ui.Text("packager", "packageUninstalledText") %></p>
+
+            </cc1:PropertyPanel>
+        </cc1:Pane>
+
         <cc1:Pane ID="pane_refresh" runat="server" Text="Browser is reloading" Visible="false">
             <cc1:PropertyPanel runat="server">
                 

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Packages/installedPackage.aspx
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Packages/installedPackage.aspx
@@ -31,9 +31,6 @@
     <cc2:Tabview ID="Panel1" Text="Installed package" runat="server" Width="496px" Height="584px">
 
 
-       
-
-
             <cc2:Pane ID="pane_meta" runat="server" Text="Package meta data">
 
                 <cc2:PropertyPanel ID="pp_name" runat="server">
@@ -145,12 +142,39 @@
                     </p>
                 </cc2:PropertyPanel>
             </cc2:Pane>
-
+            
             <cc2:Pane id="pane_uninstalled" runat="server" Visible="false">
-                <div style="margin: 10px;">
-                    <p><%= umbraco.ui.Text("packager", "packageUninstalledText") %></p>
+
+                <div class="alert alert-block">
+                    Please wait while the browser is reloaded...
                 </div>
+
+                <script type="text/javascript">
+                    
+                    //This is all a bit zany with double encoding because we have a URL in a hash (#) url part
+                    // but it works and maintains query strings
+
+                    var umbPath = "<%=GlobalSettings.Path%>";
+                    setTimeout(function () {
+                        var mainWindow = UmbClientMgr.mainWindow();
+
+                        //kill the tree and template cache
+                        if (mainWindow.UmbClientMgr) {
+                            mainWindow.UmbClientMgr._packageInstalled();
+                        }
+
+                        var baseUrl = mainWindow.location.href.substr(0, mainWindow.location.href.indexOf("#/developer/framed/"));
+                        var framedUrl = baseUrl + "#/developer/framed/";
+                        var refreshUrl = framedUrl + encodeURIComponent(encodeURIComponent(umbPath + "/developer/packages/installer.aspx?installing=uninstalled"));
+
+                        var redirectUrl = umbPath + "/ClientRedirect.aspx?redirectUrl=" + refreshUrl;
+
+                        mainWindow.location.href = redirectUrl;
+                    }, 2000);
+                </script>
+
+               
              </cc2:Pane>
-            </cc2:Pane>
+        </cc2:Pane>
     </cc2:Tabview>
 </asp:Content>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Packages/installer.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Packages/installer.aspx.cs
@@ -275,6 +275,9 @@ namespace umbraco.presentation.developer.packages
                 case "finished":
                     PerformFinishedAction(packageId, dir, Request.GetItemAsString("customUrl"));
                     break;
+                case "uninstalled":
+                    PerformUninstalledAction();
+                    break;
                 default:
                     break;
             }
@@ -301,6 +304,13 @@ namespace umbraco.presentation.developer.packages
             pane_success.Visible = true;
 
             PerformPostInstallCleanup(packageId, dir);
+        }
+
+        private void PerformUninstalledAction()
+        {
+            HideAllPanes();
+            Panel1.Text = "Package has been uninstalled";
+            pane_uninstalled.Visible = true;
         }
 
         /// <summary>
@@ -743,6 +753,9 @@ namespace umbraco.presentation.developer.packages
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::umbraco.uicontrols.Pane pane_installing;
+
+        protected global::umbraco.uicontrols.Pane pane_uninstalled;
+
 
         /// <summary>
         /// progBar2 control.


### PR DESCRIPTION
- InstalledPackage triggers a clientside refresh to installer.aspx - as
the installedpackage.aspx cannot be used for the last step since the
package is now gone
- installer.aspx displays the final uninstall message after browser
refreshing
- uses same clientside redirect as installs