### PR TITLE
U4-7032 7.3.0 Custom backoffice login provider requires simpler implementation extensibility

### DIFF
--- a/src/Umbraco.Core/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Core/Security/BackOfficeUserManager.cs
@@ -201,12 +201,17 @@ namespace Umbraco.Core.Security
         /// </remarks>
         public async override Task<bool> CheckPasswordAsync(T user, string password)
         {
-            if (BackOfficeUserPasswordChecker == null)
+            if (BackOfficeUserPasswordChecker != null)
             {
-                //use the default behavior
-                return await base.CheckPasswordAsync(user, password);
+                var result = await BackOfficeUserPasswordChecker.CheckPasswordAsync(user, password);
+                //if the result indicates to not fallback to the default, then return true if the credentials are valid
+                if (result != BackOfficeUserPasswordCheckerResult.FallbackToDefaultChecker)
+                {
+                    return result == BackOfficeUserPasswordCheckerResult.ValidCredentials;
+                }
             }
-            return await BackOfficeUserPasswordChecker.CheckPasswordAsync(user, password);
+            //use the default behavior
+            return await base.CheckPasswordAsync(user, password);
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Core/Security/BackOfficeUserManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Web.Security;
 using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Identity.Owin;
@@ -9,8 +10,6 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Core.Security
 {
-    
-
     /// <summary>
     /// Default back office user manager
     /// </summary>
@@ -21,6 +20,18 @@ namespace Umbraco.Core.Security
         {
         }
 
+        public BackOfficeUserManager(
+            IUserStore<BackOfficeIdentityUser, int> store,
+            IdentityFactoryOptions<BackOfficeUserManager> options,
+            MembershipProviderBase membershipProvider)
+            : base(store)
+        {
+            if (options == null) throw new ArgumentNullException("options");
+            var manager = new BackOfficeUserManager(store);
+            InitUserManager(manager, membershipProvider, options);
+        }
+
+        #region Static Create methods
         /// <summary>
         /// Creates a BackOfficeUserManager instance with all default options and the default BackOfficeUserManager 
         /// </summary>
@@ -40,8 +51,8 @@ namespace Umbraco.Core.Security
             if (externalLoginService == null) throw new ArgumentNullException("externalLoginService");
 
             var manager = new BackOfficeUserManager(new BackOfficeUserStore(userService, externalLoginService, membershipProvider));
-
-            return InitUserManager(manager, membershipProvider, options);
+            manager.InitUserManager(manager, membershipProvider, options);
+            return manager;
         }
 
         /// <summary>
@@ -56,13 +67,10 @@ namespace Umbraco.Core.Security
            BackOfficeUserStore customUserStore,
            MembershipProviderBase membershipProvider)
         {
-            if (options == null) throw new ArgumentNullException("options");
-            if (customUserStore == null) throw new ArgumentNullException("customUserStore");
-
-            var manager = new BackOfficeUserManager(customUserStore);
-
-            return InitUserManager(manager, membershipProvider, options);
-        }
+            var manager = new BackOfficeUserManager(customUserStore, options, membershipProvider);
+            return manager;
+        } 
+        #endregion
 
         /// <summary>
         /// Initializes the user manager with the correct options
@@ -71,7 +79,7 @@ namespace Umbraco.Core.Security
         /// <param name="membershipProvider"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        private static BackOfficeUserManager InitUserManager(BackOfficeUserManager manager, MembershipProviderBase membershipProvider, IdentityFactoryOptions<BackOfficeUserManager> options)
+        protected void InitUserManager(BackOfficeUserManager manager, MembershipProviderBase membershipProvider, IdentityFactoryOptions<BackOfficeUserManager> options)
         {
             // Configure validation logic for usernames
             manager.UserValidator = new UserValidator<BackOfficeIdentityUser, int>(manager)
@@ -125,10 +133,10 @@ namespace Umbraco.Core.Security
             //});
 
             //manager.EmailService = new EmailService();
-            //manager.SmsService = new SmsService();
-
-            return manager;
+            //manager.SmsService = new SmsService();            
         }
+
+        
     }
 
     /// <summary>
@@ -171,5 +179,39 @@ namespace Umbraco.Core.Security
         }
         #endregion
 
+        /// <summary>
+        /// Logic used to validate a username and password
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="password"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// By default this uses the standard ASP.Net Identity approach which is:
+        /// * Get password store
+        /// * Call VerifyPasswordAsync with the password store + user + password
+        /// * Uses the PasswordHasher.VerifyHashedPassword to compare the stored password
+        /// 
+        /// In some cases people want simple custom control over the username/password check, for simplicity
+        /// sake, developers would like the users to simply validate against an LDAP directory but the user
+        /// data remains stored inside of Umbraco. 
+        /// See: http://issues.umbraco.org/issue/U4-7032 for the use cases.
+        /// 
+        /// We've allowed this check to be overridden with a simple callback so that developers don't actually
+        /// have to implement/override this class.
+        /// </remarks>
+        public async override Task<bool> CheckPasswordAsync(T user, string password)
+        {
+            if (BackOfficeUserPasswordChecker == null)
+            {
+                //use the default behavior
+                return await base.CheckPasswordAsync(user, password);
+            }
+            return await BackOfficeUserPasswordChecker.CheckPasswordAsync(user, password);
+        }
+
+        /// <summary>
+        /// Gets/sets the default back office user password checker
+        /// </summary>
+        public IBackOfficeUserPasswordChecker BackOfficeUserPasswordChecker { get; set; }
     }
 }

--- a/src/Umbraco.Core/Security/BackOfficeUserPasswordCheckerResult.cs
+++ b/src/Umbraco.Core/Security/BackOfficeUserPasswordCheckerResult.cs
@@ -1,0 +1,12 @@
+namespace Umbraco.Core.Security
+{
+    /// <summary>
+    /// The result returned from the IBackOfficeUserPasswordChecker
+    /// </summary>
+    public enum BackOfficeUserPasswordCheckerResult
+    {
+        ValidCredentials,
+        InvalidCredentials,
+        FallbackToDefaultChecker
+    }
+}

--- a/src/Umbraco.Core/Security/IBackOfficeUserPasswordChecker.cs
+++ b/src/Umbraco.Core/Security/IBackOfficeUserPasswordChecker.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using Umbraco.Core.Models.Identity;
+
+namespace Umbraco.Core.Security
+{
+    /// <summary>
+    /// Used by the BackOfficeUserManager to check the username/password which allows for developers to more easily 
+    /// set the logic for this procedure.
+    /// </summary>
+    public interface IBackOfficeUserPasswordChecker
+    {
+        Task<bool> CheckPasswordAsync(BackOfficeIdentityUser user, string password);
+    }
+}

--- a/src/Umbraco.Core/Security/IBackOfficeUserPasswordChecker.cs
+++ b/src/Umbraco.Core/Security/IBackOfficeUserPasswordChecker.cs
@@ -9,6 +9,6 @@ namespace Umbraco.Core.Security
     /// </summary>
     public interface IBackOfficeUserPasswordChecker
     {
-        Task<bool> CheckPasswordAsync(BackOfficeIdentityUser user, string password);
+        Task<BackOfficeUserPasswordCheckerResult> CheckPasswordAsync(BackOfficeIdentityUser user, string password);
     }
 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -462,6 +462,7 @@
     <Compile Include="Security\BackOfficeCookieAuthenticationProvider.cs" />
     <Compile Include="Security\BackOfficeSignInManager.cs" />
     <Compile Include="Security\BackOfficeUserManager.cs" />
+    <Compile Include="Security\BackOfficeUserPasswordCheckerResult.cs" />
     <Compile Include="Security\BackOfficeUserStore.cs" />
     <Compile Include="Security\IBackOfficeUserPasswordChecker.cs" />
     <Compile Include="Security\MembershipPasswordHasher.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -463,6 +463,7 @@
     <Compile Include="Security\BackOfficeSignInManager.cs" />
     <Compile Include="Security\BackOfficeUserManager.cs" />
     <Compile Include="Security\BackOfficeUserStore.cs" />
+    <Compile Include="Security\IBackOfficeUserPasswordChecker.cs" />
     <Compile Include="Security\MembershipPasswordHasher.cs" />
     <Compile Include="SemVersionExtensions.cs" />
     <Compile Include="ServiceProviderExtensions.cs" />


### PR DESCRIPTION
adds a ctor to the BackOfficeUserManager to allow better inheritance so that all settings are initialized by default, changes init method to be protected so other devs can use it. Adds a new property for devs to use to more easily extend the logic to just validate the username/password.