### PR TITLE
U4-6657: Use flexbox for mediapicker search field and upload button 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -42,6 +42,23 @@
     bottom: 90px;
 }
 
+.umb-mediapicker-upload {
+    display: -ms-flexbox;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: flex;
+
+    .form-search {
+        -ms-flex: 1;
+        -webkit-flex: 1;
+        flex: 1;
+    }
+
+    .upload-button {
+        margin-left: 16px;
+    }
+}
+
 .umb-panel.editor-breadcrumb .umb-panel-body, .umb-panel.editor-breadcrumb .umb-bottom-bar {
     bottom: 31px !important;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.html
@@ -62,18 +62,16 @@
     <div class="umb-panel umb-dialogs-mediapicker browser" ng-hide="target" ng-style="{opacity: dropping == true ? '0.25' : '1.0'}">
         <div class="umb-panel-header">
 
-            <div class="umb-el-wrap umb-panel-buttons">
-                <div class="span5">
-                    <div class="form-search">
-                        <i class="icon-search"></i>
-                        <input type="text"
-                               ng-model="searchTerm"
-                               class="umb-search-field search-query"
-                               placeholder="Filter...">
-                    </div>
+            <div class="umb-el-wrap umb-panel-buttons umb-mediapicker-upload">
+                <div class="form-search">
+                    <i class="icon-search"></i>
+                    <input type="text"
+                            ng-model="searchTerm"
+                            class="umb-search-field search-query"
+                            placeholder="Filter...">
                 </div>
 
-                <div class="pull-right">
+                <div class="upload-button">
                     <span class="btn fileinput-button" ng-class="{disabled: disabled}">
                         <i class="icon-page-up"></i>
                         <input type="file" name="files[]" multiple ng-disabled="disabled" class="uploader">


### PR DESCRIPTION
Several languages have translations of the word "Upload" that are longer (German "Hochladen", Swedish "Ladda upp"). This causes the button to wrap around to the next line (as described in http://issues.umbraco.org/issue/U4-6657#).
This PR fixes this by using flexbox to have the search field resize dynamically to acommodate the upload button changing size, ensuring that they always stay on one line.
I have made minor alterations to the HTML structure to make it possible to use flexbox.
As far as I can tell, this is the first use of flexbox in Umbraco 7.3 (though 7.4 is supposed to use flexbox for the new media grid). I have included prefixes to make it work in older browsers.