### PR TITLE
U4-4028 Don't load the full images, but server side resized.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/help.html
@@ -37,7 +37,7 @@
 					<li class="span2" ng-repeat="video in videos">
 				    	<div class="thumbnail" style="margin-right: 20px">
 					    	<a target="_blank" href="{{video.link}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv" title="{{video.title}}">
-                                <img ng-src="{{video.thumbnail}}" alt="{{video.title}}">
+                                <img ng-src="{{video.thumbnail}}?width=120" alt="{{video.title}}">
 					    	</a>
 				    	</div>
 				    </li>


### PR DESCRIPTION
The images can be resized on the http://umbraco.tv/ website. For example: http://umbraco.tv/media/43191/intro.png?width=120.