### PR TITLE
U4-7324 Member Picker search results doesn't show correct icons

### DIFF
--- a/src/Umbraco.Core/Services/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/EntityXmlSerializer.cs
@@ -100,6 +100,8 @@ namespace Umbraco.Core.Services
 
             xml.Add(new XAttribute("loginName", member.Username));
             xml.Add(new XAttribute("email", member.Email));
+            
+            xml.Add(new XAttribute("icon", member.ContentType.Icon));
 
             return xml;
         }

--- a/src/UmbracoExamine/UmbracoMemberIndexer.cs
+++ b/src/UmbracoExamine/UmbracoMemberIndexer.cs
@@ -207,6 +207,9 @@ namespace UmbracoExamine
                 if (e.Fields.ContainsKey("_searchEmail") == false)
                     e.Fields.Add("_searchEmail", e.Node.Attribute("email").Value.Replace(".", " ").Replace("@", " "));
             }
+            
+            if (e.Fields.ContainsKey(IconFieldName) == false)
+                e.Fields.Add(IconFieldName, (string)e.Node.Attribute("icon"));
         }
 
         private static XElement GetMemberItem(int nodeId)


### PR DESCRIPTION
Fix includes changes to EntityXMLSerializer.cs to map Member.ContentType.Icon, and UmbracoMemberIndexer.cs to map 'icon' to '__Icon' fields