### PR TITLE
U4-7360 - Toggle password in login screen

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/login.less
@@ -30,6 +30,37 @@
     text-align: right;
 }
 
+.login-overlay .form .control-group {
+    position: relative;
+}
+
+.login-overlay .form .control-group .showhide-password {
+    position: absolute;
+    right: 0;
+    color: #ccc;
+    padding: 5px 10px;
+    font-size: 18px;
+    text-decoration: none;
+}
+
+.login-overlay .form .control-group .showhide-password > [class^="icon-"],
+.login-overlay .form .control-group .showhide-password > [class*=" icon-"] {
+    display: inline-block;
+    height: 18px;
+    width: 18px;
+}
+
+.login-overlay .form .control-group input.password.has-password {
+    padding-right: 36px;
+    width: 240px;
+}
+
+.login-overlay .form .control-group input.password:focus + .showhide-password,
+.login-overlay .form .control-group input.password + .showhide-password:hover {
+    color: #555;
+}
+    
+
 .login-overlay h1 {
     display: block;
     text-align: right;

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.controller.js
@@ -18,11 +18,11 @@
 
         $scope.errorMsg = "";
 
-        localizationService.localize("general_showPassword").then(function (label) {
+        localizationService.localize("login_showPassword").then(function (label) {
             $scope.showPasswordText = label;
         });
 
-        localizationService.localize("general_hidePassword").then(function (label) {
+        localizationService.localize("login_hidePassword").then(function (label) {
             $scope.hidePasswordText = label;
         });
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.controller.js
@@ -18,6 +18,13 @@
 
         $scope.errorMsg = "";
 
+        // hide password as default
+        $scope.showpassword = false;
+        // Hide & show password function
+        $scope.showHidePassword = function () {
+            $scope.showpassword = $scope.showpassword == false ? true : false;
+        };
+
         $scope.externalLoginFormAction = Umbraco.Sys.ServerVariables.umbracoUrls.externalLoginsUrl;
         $scope.externalLoginProviders = externalLoginInfo.providers;
         $scope.externalLoginInfo = externalLoginInfo;

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.controller.js
@@ -1,5 +1,5 @@
 ﻿angular.module("umbraco").controller("Umbraco.Dialogs.LoginController",
-    function ($scope, localizationService, userService, externalLoginInfo) {
+    function ($scope, $timeout, localizationService, userService, externalLoginInfo) {
 
         /**
          * @ngdoc function
@@ -18,11 +18,26 @@
 
         $scope.errorMsg = "";
 
+        localizationService.localize("general_showPassword").then(function (label) {
+            $scope.showPasswordText = label;
+        });
+
+        localizationService.localize("general_hidePassword").then(function (label) {
+            $scope.hidePasswordText = label;
+        });
+
         // hide password as default
         $scope.showpassword = false;
+
+        // ensure title is binded on init
+        $timeout(function () {
+            $scope.showHidePasswordTitle = $scope.showpassword == false ? $scope.showPasswordText : $scope.hidePasswordText;
+        }, 0);
+
         // Hide & show password function
         $scope.showHidePassword = function () {
             $scope.showpassword = $scope.showpassword == false ? true : false;
+            $scope.showHidePasswordTitle = $scope.showpassword == false ? $scope.showPasswordText : $scope.hidePasswordText;
         };
 
         $scope.externalLoginFormAction = Umbraco.Sys.ServerVariables.umbracoUrls.externalLoginsUrl;

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
@@ -40,7 +40,10 @@
                 </div>
 
                 <div class="control-group" ng-class="{error: loginForm.password.$invalid}">
-                    <input type="password" ng-model="password" name="password" class="input-xlarge" localize="placeholder" placeholder="@placeholders_password" autocomplete="off" />
+                    <input type="{{showpassword ? 'text' : 'password'}}" ng-model="password" name="password" class="input-xlarge password" ng-class="{'has-password': password.length > 0}" localize="placeholder" placeholder="@placeholders_password" autocomplete="off" />
+                    <a href="#" class="showhide-password" ng-show="password.length > 0" ng-click="showHidePassword()" prevent-default>
+                        <i ng-class="{'icon-eye': !showpassword, 'icon-eye-off': showpassword}"></i>
+                    </a>
                 </div>
 
                 <button type="submit" class="btn" val-trigger-change="#login .form input"><localize key="general_login">Login</localize></button>

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
@@ -41,7 +41,7 @@
 
                 <div class="control-group" ng-class="{error: loginForm.password.$invalid}">
                     <input type="{{showpassword ? 'text' : 'password'}}" ng-model="password" name="password" class="input-xlarge password" ng-class="{'has-password': password.length > 0}" localize="placeholder" placeholder="@placeholders_password" autocomplete="off" />
-                    <a href="#" class="showhide-password" ng-show="password.length > 0" ng-click="showHidePassword()" prevent-default>
+                    <a href="#" class="showhide-password" ng-show="password.length > 0" ng-click="showHidePassword()" ng-attr-title="{{showHidePasswordTitle}}" prevent-default>
                         <i ng-class="{'icon-eye': !showpassword, 'icon-eye-off': showpassword}"></i>
                     </a>
                 </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -357,8 +357,6 @@
     <key alias="login">Login</key>
     <key alias="logoff">Log af</key>
     <key alias="logout">Log ud</key>
-    <key alias="showPassword">Vis kodeord</key>
-    <key alias="hidePassword">Skjul kodeord</key>
     <key alias="macro">Makro</key>
     <key alias="move">Flyt</key>
     <key alias="more">Mere</key>
@@ -492,7 +490,6 @@
     <key alias="renewSession">Forny for at gemme dine ændringer</key>
   </area>
   <area alias="login">
-
     <key alias="greeting0">Så er det søndag!</key>  
     <key alias="greeting1">Smil, det er mandag!</key>
     <key alias="greeting2">Hurra, det er tirsdag!</key>
@@ -500,12 +497,10 @@
     <key alias="greeting4">Glædelig torsdag!</key>
     <key alias="greeting5">Endelig fredag!</key>
     <key alias="greeting6">Glædelig lørdag</key>
-    
-
     <key alias="instruction">indtast brugernavn og kodeord</key>
     <key alias="timeout">Din session er udløbet</key>
-
-
+    <key alias="showPassword">Vis kodeord</key>
+    <key alias="hidePassword">Skjul kodeord</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">umbraco.com</a></p> ]]></key>
   </area>
   <area alias="main">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -357,6 +357,8 @@
     <key alias="login">Login</key>
     <key alias="logoff">Log af</key>
     <key alias="logout">Log ud</key>
+    <key alias="showPassword">Vis kodeord</key>
+    <key alias="hidePassword">Skjul kodeord</key>
     <key alias="macro">Makro</key>
     <key alias="move">Flyt</key>
     <key alias="more">Mere</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -358,8 +358,6 @@
     <key alias="login">Anmelden</key>
     <key alias="logoff">Abmelden</key>
     <key alias="logout">Abmelden</key>
-    <key alias="showPassword">Passwort anzeigen</key>
-    <key alias="hidePassword">Passwort ausblenden</key>
     <key alias="macro">Makro</key>
     <key alias="move">Verschieben</key>
     <key alias="more">Mehr</key>
@@ -533,7 +531,9 @@ Wenn Sie sich für Runway entscheiden, können Sie optional Blöcke nutzen, die 
     <key alias="greeting6">Wunderbaren sonnigen Samstag</key>
     <key alias="instruction">Hier anmelden:</key>
     <key alias="timeout">Die Sitzung ist abgelaufen</key>
-	<key alias="bottomText">&lt;p style="text-align:right;"&gt;&amp;copy; 2001 - %0% &lt;br /&gt;&lt;a href="http://umbraco.com" style="text-decoration: none" target="_blank"&gt;umbraco.org&lt;/a&gt;&lt;/p&gt; </key>
+    <key alias="showPassword">Passwort anzeigen</key>
+    <key alias="hidePassword">Passwort ausblenden</key>
+    <key alias="bottomText">&lt;p style="text-align:right;"&gt;&amp;copy; 2001 - %0% &lt;br /&gt;&lt;a href="http://umbraco.com" style="text-decoration: none" target="_blank"&gt;umbraco.org&lt;/a&gt;&lt;/p&gt; </key>
   </area>
   <area alias="main">
     <key alias="dashboard">Armaturenbrett</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -358,6 +358,8 @@
     <key alias="login">Anmelden</key>
     <key alias="logoff">Abmelden</key>
     <key alias="logout">Abmelden</key>
+    <key alias="showPassword">Passwort anzeigen</key>
+    <key alias="hidePassword">Passwort ausblenden</key>
     <key alias="macro">Makro</key>
     <key alias="move">Verschieben</key>
     <key alias="more">Mehr</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -366,8 +366,6 @@
     <key alias="login">Login</key>
     <key alias="logoff">Log off</key>
     <key alias="logout">Logout</key>
-    <key alias="showPassword">Show password</key>
-    <key alias="hidePassword">Hide password</key>
     <key alias="macro">Macro</key>
     <key alias="move">Move</key>
     <key alias="more">More</key>
@@ -563,6 +561,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="greeting6">Happy Caturday</key>
     <key alias="instruction">Log in below</key>
     <key alias="timeout">Session timed out</key>
+    <key alias="showPassword">Show password</key>
+    <key alias="hidePassword">Hide password</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">Umbraco.com</a></p> ]]></key>
   </area>
   <area alias="main">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -366,6 +366,8 @@
     <key alias="login">Login</key>
     <key alias="logoff">Log off</key>
     <key alias="logout">Logout</key>
+    <key alias="showPassword">Show password</key>
+    <key alias="hidePassword">Hide password</key>
     <key alias="macro">Macro</key>
     <key alias="move">Move</key>
     <key alias="more">More</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -367,8 +367,6 @@
     <key alias="login">Login</key>
     <key alias="logoff">Log off</key>
     <key alias="logout">Logout</key>
-    <key alias="showPassword">Show password</key>
-    <key alias="hidePassword">Hide password</key>
     <key alias="macro">Macro</key>
     <key alias="move">Move</key>
     <key alias="more">More</key>
@@ -564,6 +562,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="greeting6">Happy Caturday</key>
     <key alias="instruction">Log in below</key>
     <key alias="timeout">Session timed out</key>
+    <key alias="showPassword">Show password</key>
+    <key alias="hidePassword">Hide password</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">Umbraco.com</a></p> ]]></key>  
   </area>
   <area alias="main">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -367,6 +367,8 @@
     <key alias="login">Login</key>
     <key alias="logoff">Log off</key>
     <key alias="logout">Logout</key>
+    <key alias="showPassword">Show password</key>
+    <key alias="hidePassword">Hide password</key>
     <key alias="macro">Macro</key>
     <key alias="move">Move</key>
     <key alias="more">More</key>


### PR DESCRIPTION
Add an icon to toggle the password visibility (show/hide) in login screen.
http://issues.umbraco.org/issue/U4-7360

Umbraco 7 includes the font icons from http://hlvticons.ch/ .. however it only include an "eye" icon, not and "eye-off", like in the font set here http://zavoloklom.github.io/material-design-iconic-font/icons.html that I have used for the package https://our.umbraco.org/projects/backoffice-extensions/material-design-icon-pack/) or "eye-close" included in font awesome http://fortawesome.github.io/Font-Awesome/3.2.1/icon/eye-close/

Maybe the creators from http://hlvticons.ch/ can add a similar one to their font set, so it can be included in the Umbraco 7 core font set?

![image](https://cloud.githubusercontent.com/assets/2919859/11020943/0bd093ce-8631-11e5-8d28-9eb0439cdc1c.png)

So that is why the icon is missing for now when I click "show password".
![image](https://cloud.githubusercontent.com/assets/2919859/11020948/2ea76454-8631-11e5-827b-7a2d541abc88.png)
