### PR TITLE
U4-5764: Detailed Node Picker Info

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/umbbreadcrumbnav.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/umbbreadcrumbnav.directive.js
@@ -1,0 +1,52 @@
+﻿/**
+ * @ngdoc directive
+ * @name umbraco.directives.directive:umbBreadcrumbNav
+ * @function
+ * @description
+ * A breadcrumb navigation directive that shows linked ancestors.
+ * 
+ * @restrict E
+ */
+function breadcrumbNavDirective(entityResource, $compile) {
+
+    // Workaround since ng-if won't work at the root level of the directive.
+    function useEmptyMarkup(scope, element) {
+        var newElement = $compile("")(scope);
+        element.replaceWith(newElement);
+    }
+
+    return {
+        restrict: "E", // restrict to an element
+        replace: true,//TODO: Restore comment.
+        templateUrl: 'views/directives/umb-breadcrumb-nav.html',
+        scope: {
+            nodeId: '=',
+            kind: '=' // Kind can be "content" or "media".
+        },
+        link: function (scope, element, attrs, ctrl) {
+
+            // Fetch all ancestors.
+            var entityType = scope.kind === "content" ? "document" : "media";
+            if (scope.nodeId) {
+                entityResource
+                    .getAncestors(scope.nodeId, entityType)
+                    .then(function (anc) {
+                        if (anc && anc.length > 1) {
+                            scope.ancestors = anc;
+                        } else {
+                            useEmptyMarkup(scope, element);
+                        }
+                    });
+            } else {
+                useEmptyMarkup(scope, element);
+            }
+
+            // Set path for editing the entity.
+            scope.editBasePath = "#/" + scope.kind + "/" + scope.kind + "/edit/";
+
+        }
+    };
+
+}
+
+angular.module('umbraco.directives').directive("umbBreadcrumbNav", breadcrumbNavDirective);

--- a/src/Umbraco.Web.UI.Client/src/common/directives/umbbreadcrumbnav.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/umbbreadcrumbnav.directive.js
@@ -11,13 +11,27 @@ function breadcrumbNavDirective(entityResource, $compile) {
 
     // Workaround since ng-if won't work at the root level of the directive.
     function useEmptyMarkup(scope, element) {
-        var newElement = $compile("")(scope);
+        var newElement = $compile('')(scope);
         element.replaceWith(newElement);
     }
 
+    // Populates the ancestors of the node (inclusive of the node).
+    function populateAncestors(scope, entityType, element) {
+        entityResource
+            .getAncestors(scope.nodeId, entityType)
+            .then(function (anc) {
+                if (anc && anc.length > 1) {
+                    scope.ancestors = anc;
+                } else {
+                    useEmptyMarkup(scope, element);
+                }
+            });
+    }
+
+    // Return directive definition.
     return {
-        restrict: "E", // restrict to an element
-        replace: true,//TODO: Restore comment.
+        restrict: 'E', // restrict to an element
+        replace: true, // replace the html element with the template
         templateUrl: 'views/directives/umb-breadcrumb-nav.html',
         scope: {
             nodeId: '=',
@@ -26,27 +40,27 @@ function breadcrumbNavDirective(entityResource, $compile) {
         link: function (scope, element, attrs, ctrl) {
 
             // Fetch all ancestors.
-            var entityType = scope.kind === "content" ? "document" : "media";
+            var entityType = scope.kind === 'content' ? 'document' : 'media';
             if (scope.nodeId) {
-                entityResource
-                    .getAncestors(scope.nodeId, entityType)
-                    .then(function (anc) {
-                        if (anc && anc.length > 1) {
-                            scope.ancestors = anc;
-                        } else {
-                            useEmptyMarkup(scope, element);
-                        }
-                    });
+                populateAncestors(scope, entityType, element);
             } else {
-                useEmptyMarkup(scope, element);
+
+                // Wait until the node ID is present before searching for ancestors.
+                var unwatch = scope.$watch('nodeId', function (value) {
+                    if (value) {
+                        unwatch();
+                        populateAncestors(scope, entityType, element);
+                    }
+                });
+
             }
 
             // Set path for editing the entity.
-            scope.editBasePath = "#/" + scope.kind + "/" + scope.kind + "/edit/";
+            scope.editBasePath = '#/' + scope.kind + '/' + scope.kind + '/edit/';
 
         }
     };
 
 }
 
-angular.module('umbraco.directives').directive("umbBreadcrumbNav", breadcrumbNavDirective);
+angular.module('umbraco.directives').directive('umbBreadcrumbNav', breadcrumbNavDirective);

--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -41,6 +41,9 @@
 .umb-panel-body.with-footer {
     bottom: 90px;
 }
+.umb-panel-body.with-footer-and-breadcrumb {
+    bottom: 121px;
+}
 
 .umb-panel.editor-breadcrumb .umb-panel-body, .umb-panel.editor-breadcrumb .umb-bottom-bar {
     bottom: 31px !important;
@@ -143,6 +146,13 @@
     bottom: 0px;
     left: 0px;
     right: 0px;
+}
+
+// Adjust vertical layout to fit a breadcrumb in the footer.
+.umb-modal .umb-panel-footer.containing-breadcrumb .umb-panel-buttons {
+    // Forces the element to have a height.
+    overflow: hidden;
+    margin-bottom: 31px;
 }
 
 

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -40,8 +40,16 @@
   padding: 10px;
 }
 
-.umb-contentpicker small a {
+.umb-contentpicker small {
+
+  &:not(:last-child) {
+    padding-right: 3px;
+    border-right: 1px solid @grayMed;
+  }
+
+  a {
     color: @gray;
+  }
 }
 
 /* CODEMIRROR DATATYPE */

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -14,6 +14,7 @@
 @grayDarker:            #222;
 @grayDark:              #343434;
 @gray:                  #555;
+@grayMed:               #999;
 @grayLight:             #d9d9d9;
 @grayLighter:           #f8f8f8;
 @white:                 #fff; 

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/content/edit.controller.js
@@ -51,6 +51,12 @@ function ContentEditDialogController($scope, editorState, $routeParams, $q, $tim
         $scope.content.isDialogEditor = true;
 
         editorState.set($scope.content);
+
+        // Don't show the footer breadcrumb if this content is being created.
+        if (!$routeParams.create) {
+            $scope.showBreadcrumb = true;
+        }
+
     }
 
     //check if the entity is being passed in, otherwise load it from the server

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/content/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/content/edit.html
@@ -11,7 +11,7 @@
 			    ng-model="content.name"/>
 		</div>
 
-		<div class="umb-panel-body with-footer">
+		<div class="umb-panel-body with-footer-and-breadcrumb">
             <div id="tab{{tab.id}}" ng-repeat="tab in content.tabs">
                 <div class="umb-pane" ng-if="!tab.hide">
                     <h5>{{tab.label}}</h5>
@@ -24,7 +24,7 @@
 		</div>
 
 
-		<div class="umb-panel-footer" >
+		<div class="umb-panel-footer containing-breadcrumb">
 			<div class="umb-el-wrap umb-panel-buttons">
 		        <div class="btn-toolbar umb-btn-toolbar pull-right">
 		        	<a href ng-click="close()" class="btn btn-link">
@@ -55,6 +55,9 @@
 		        </div>
 
 		      </div>
+
+              <umb-breadcrumb-nav class="umb-panel-footer-nav nav nav-pills" node-id="content.id" kind="'content'" ng-if="showBreadcrumb"></umb-breadcrumb-nav>
+
 			</div>
 		</div>
 	</div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -32,15 +32,11 @@ function ContentEditController($scope, $rootScope, $routeParams, $q, $timeout, $
 
         editorState.set($scope.content);
 
-        //We fetch all ancestors of the node to generate the footer breadcrumb navigation
+        // Don't show the footer breadcrumb if this content is being created.
         if (!$routeParams.create) {
-            if (content.parentId && content.parentId != -1) {
-                entityResource.getAncestors(content.id, "document")
-               .then(function (anc) {
-                   $scope.ancestors = anc;
-               });
-            }
+            $scope.showBreadcrumb = true;
         }
+
     }
 
     /** Syncs the content item to it's tree node - this occurs on first load and after saving */

--- a/src/Umbraco.Web.UI.Client/src/views/content/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/edit.html
@@ -78,12 +78,7 @@
         </umb-tab-view>
 
 
-        <ul class="umb-panel-footer-nav nav nav-pills" ng-if="ancestors && ancestors.length > 0">
-            <li ng-repeat="ancestor in ancestors">
-                <a href="#/content/content/edit/{{ancestor.id}}">{{ancestor.name}}</a>
-            </li>
-            <li></li>
-        </ul>
+        <umb-breadcrumb-nav class="umb-panel-footer-nav nav nav-pills" node-id="content.id" kind="'content'" ng-if="showBreadcrumb"></umb-breadcrumb-nav>
 
     </umb-panel>
 </form>

--- a/src/Umbraco.Web.UI.Client/src/views/directives/umb-breadcrumb-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/directives/umb-breadcrumb-nav.html
@@ -1,0 +1,6 @@
+﻿<ul>
+    <li ng-repeat="ancestor in ancestors">
+        <a href="{{editBasePath}}{{ancestor.id}}">{{ancestor.name}}</a>
+    </li>
+    <li></li>
+</ul>

--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -54,11 +54,7 @@
             </umb-tab>
         </umb-tab-view>
 
-        <ul class="umb-panel-footer-nav nav nav-pills" ng-if="ancestors && ancestors.length > 0">
-            <li ng-repeat="ancestor in ancestors">
-                <a href="#/media/media/edit/{{ancestor.id}}">{{ancestor.name}}</a>
-            </li>
-            <li></li>
-        </ul>
+        <umb-breadcrumb-nav class="umb-panel-footer-nav nav nav-pills" node-id="content.id" kind="'media'"></umb-breadcrumb-nav>
+
     </umb-panel>
 </form>

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -66,14 +66,6 @@ function mediaEditController($scope, $routeParams, appState, mediaResource, enti
                 serverValidationManager.executeAndClearAllSubscriptions();
 
                 syncTreeNode($scope.content, data.path, true);
-               
-                if ($scope.content.parentId && $scope.content.parentId != -1) {
-                    //We fetch all ancestors of the node to generate the footer breadcrump navigation
-                    entityResource.getAncestors($routeParams.id, "media")
-                        .then(function (anc) {
-                            $scope.ancestors = anc;
-                        });
-                }
 
             });  
     }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -1,7 +1,7 @@
 //this controller simply tells the dialogs service to open a mediaPicker window
 //with a specified callback, this callback will receive an object with a selection on it
 
-function contentPickerController($scope, dialogService, entityResource, editorState, $log, iconHelper, $routeParams, fileManager, contentEditingHelper) {
+function contentPickerController($scope, dialogService, entityResource, editorState, $log, iconHelper, $routeParams, fileManager, contentEditingHelper, contentResource, navigationService) {
 
     function trim(str, chr) {
         var rgxtrim = (!chr) ? new RegExp('^\\s+|\\s+$', 'g') : new RegExp('^' + chr + '+|' + chr + '+$', 'g');
@@ -142,6 +142,17 @@ function contentPickerController($scope, dialogService, entityResource, editorSt
     $scope.remove = function (index) {
         $scope.renderModel.splice(index, 1);
     };
+
+    $scope.showNode = function (index) {
+        var item = $scope.renderModel[index];
+        var id = item.id;
+        contentResource
+            .getById(id)
+            .then(function (data) {
+                navigationService.syncTree({ tree: "content", path: data.path, forceReload: false, activate: true });
+                //TODO: Need to load node too: https://our.umbraco.org/forum/developers/api-questions/72584-programmatically-load-content-node-in-back-office
+            });
+    }
         
     $scope.add = function (item) {
         var currIds = _.map($scope.renderModel, function (i) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -1,7 +1,7 @@
 //this controller simply tells the dialogs service to open a mediaPicker window
 //with a specified callback, this callback will receive an object with a selection on it
 
-function contentPickerController($scope, dialogService, entityResource, editorState, $log, iconHelper, $routeParams, fileManager, contentEditingHelper, contentResource, navigationService) {
+function contentPickerController($location, $scope, dialogService, entityResource, editorState, $log, iconHelper, $routeParams, fileManager, contentEditingHelper, contentResource, navigationService) {
 
     function trim(str, chr) {
         var rgxtrim = (!chr) ? new RegExp('^\\s+|\\s+$', 'g') : new RegExp('^' + chr + '+|' + chr + '+$', 'g');
@@ -150,7 +150,8 @@ function contentPickerController($scope, dialogService, entityResource, editorSt
             .getById(id)
             .then(function (data) {
                 navigationService.syncTree({ tree: "content", path: data.path, forceReload: false, activate: true });
-                //TODO: Need to load node too: https://our.umbraco.org/forum/developers/api-questions/72584-programmatically-load-content-node-in-back-office
+                var routePath = "content/content/edit/" + id.toString();
+                $location.path(routePath).search("");
             });
     }
         

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -17,7 +17,7 @@
                 </a>
                 
                 <div ng-if="!dialogEditor">
-                    <small><a href ng-click="showNode($index)"><localize key="view">View</localize></a></small>
+                    <small><a href ng-click="showNode($index)"><localize key="open">Open</localize></a></small>
                     <small ng-if="model.config.showEditButton"><a href umb-launch-mini-editor="node"><localize key="edit">Edit</localize></a></small>
                 </div>
             </li>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -15,8 +15,10 @@
                     <i class="{{node.icon}} hover-hide"></i> 
                     {{node.name}}
                 </a>
-                <div ng-if="!dialogEditor && model.config.showEditButton">
-                    <small><a href umb-launch-mini-editor="node"><localize key="edit">Edit</localize></a></small>
+                
+                <div ng-if="!dialogEditor">
+                    <small><a href ng-click="showNode($index)"><localize key="view">View</localize></a></small>
+                    <small ng-if="model.config.showEditButton"><a href umb-launch-mini-editor="node"><localize key="edit">Edit</localize></a></small>
                 </div>
             </li>
         </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -16,8 +16,8 @@
                     {{node.name}}
                 </a>
                 
-                <div ng-if="!dialogEditor">
-                    <small><a href ng-click="showNode($index)"><localize key="open">Open</localize></a></small>
+                <div ng-if="!dialogEditor && (showOpenButton || model.config.showEditButton)">
+                    <small ng-if="showOpenButton"><a href ng-click="showNode($index)" title="{{node.namePath}}"><localize key="open">Open</localize></a></small>
                     <small ng-if="model.config.showEditButton"><a href umb-launch-mini-editor="node"><localize key="edit">Edit</localize></a></small>
                 </div>
             </li>


### PR DESCRIPTION
This request does a few things for http://issues.umbraco.org/issue/U4-5764:
* Adds an "Open" button below picked nodes. Hovering shows the node path. Clicking navigates to that node.

![hover](https://cloud.githubusercontent.com/assets/5933222/11024098/f72d450e-863d-11e5-82a6-82771a28eb72.png)
* Adds a breadcrumb to the content edit dialog (that is an existing feature that appears when you click the "Edit" button).

![dialog](https://cloud.githubusercontent.com/assets/5933222/11024102/06d365a6-863e-11e5-8ef6-7b20aa1b6c74.png)

Also, here are some more notes:
* This works for content nodes and media nodes (excepting an existing bug relating to the dialog not opening for media nodes). This does not affect picked members.
* I combined the breadcrumb code that was used in multiple places into a single directive.
* As was the case with the existing code, the breadcrumb in the dialog is hidden when a root-level node is being edited.