### PR TITLE
Nested Properties List

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -414,6 +414,11 @@ namespace Umbraco.Core
             /// Alias for the email address property editor
             /// </summary>
             public const string EmailAddressAlias = "Umbraco.EmailAddress";
+
+            /// <summary>
+            /// Alias for the email address property editor
+            /// </summary>
+            public const string NestedPropertiesListAlias = "Umbraco.NestedPropertiesList";
         }
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/datatype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/datatype.resource.js
@@ -84,6 +84,16 @@ function dataTypeResource($q, $http, umbDataFormatter, umbRequestHelper) {
                'Failed to retrieve data');
         },
 
+        getAllPropertyEditors: function () {
+
+            return umbRequestHelper.resourcePromise(
+               $http.get(
+                   umbRequestHelper.getApiUrl(
+                       "dataTypeApiBaseUrl",
+                       "GetAllPropertyEditors")),
+               'Failed to retrieve data');
+        },
+
         /**
          * @ngdoc method
          * @name umbraco.resources.contentResource#getScaffold

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/fields.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/fields.prevalues.controller.js
@@ -1,34 +1,66 @@
 ﻿angular.module("umbraco").controller("Umbraco.PrevalueEditors.NestedPropertyController",
-    function ($scope, entityResource) {
+function ($scope, entityResource) {
 
-        if (!$scope.model.value) {
-            $scope.model.value = [];
-        }
+    if (!$scope.model.value) {
+        $scope.model.value = [];
+    }
 
-        $scope.add = function () {
-            $scope.model.value.push({ alias: '', title: '', descriptoin: '', datatype: 'textstring', required: false });
-        };
+    $scope.add = function () {
+        $scope.model.value.push({ alias: '', title: '', descriptoin: '', datatype: 'textstring', required: false });
+    };
 
-        $scope.remove = function (index) {
-            var remainder = [];
-            for (var x = 0; x < $scope.model.value.length; x++) {
-                if (x !== index) {
-                    remainder.push($scope.model.value[x]);
-                }
+    $scope.remove = function (index) {
+        var remainder = [];
+        for (var x = 0; x < $scope.model.value.length; x++) {
+            if (x !== index) {
+                remainder.push($scope.model.value[x]);
             }
-            $scope.model.value = remainder;
-        };
+        }
+        $scope.model.value = remainder;
+    };
 
-        var setAliasDebounce = _.debounce(function (index) {
-            $scope.model.value[index].alias = $scope.model.value[index].label.substring(0, 1).toLowerCase() + $scope.model.value[index].label.replace(/\s+/, '').slice(1);
-        }, 500);
+    var setAliasDebounce = _.debounce(function (index) {
+        $scope.model.value[index].alias = $scope.model.value[index].label.substring(0, 1).toLowerCase() + $scope.model.value[index].label.replace(/\s+/, '').slice(1);
+    }, 500);
 
-        $scope.setAlias = function (index) {
-            setAliasDebounce(index);
+    $scope.setAlias = function (index) {
+        setAliasDebounce(index);
+    }
+
+    entityResource.getAll("Datatype").then(function (data) {
+        $scope.datatypes = data;
+    });
+
+    $scope.sortableOptions = {
+        axis: 'y',
+        containment: 'parent',
+        cursor: 'move',
+        items: '> div.control-group',
+        tolerance: 'pointer',
+        update: function (e, ui) {
+            // Get the new and old index for the moved element (using the text as the identifier, so 
+            // we'd have a problem if two prevalues were the same, but that would be unlikely)
+            var newIndex = ui.item.index();
+            var movedPrevalueText = $('input[type="text"][ng-model="item.alias"]', ui.item).val();
+            var originalIndex = getElementIndexByPrevalueText(movedPrevalueText);
+
+            // Move the element in the model
+            if (originalIndex > -1) {
+                var movedElement = $scope.model.value[originalIndex];
+                $scope.model.value.splice(originalIndex, 1);
+                $scope.model.value.splice(newIndex, 0, movedElement);
+            }
+        }
+    };
+
+    
+    function getElementIndexByPrevalueText(value) {
+        for (var i = 0; i < $scope.model.value.length; i++) {
+            if ($scope.model.value[i].alias === value) {
+                return i;
+            }
         }
 
-        entityResource.getAll("Datatype").then(function (data) {
-            $scope.datatypes = data;
-        });
-
-    });
+        return -1;
+    }
+});

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/fields.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/fields.prevalues.controller.js
@@ -1,0 +1,34 @@
+﻿angular.module("umbraco").controller("Umbraco.PrevalueEditors.NestedPropertyController",
+    function ($scope, entityResource) {
+
+        if (!$scope.model.value) {
+            $scope.model.value = [];
+        }
+
+        $scope.add = function () {
+            $scope.model.value.push({ alias: '', title: '', descriptoin: '', datatype: 'textstring', required: false });
+        };
+
+        $scope.remove = function (index) {
+            var remainder = [];
+            for (var x = 0; x < $scope.model.value.length; x++) {
+                if (x !== index) {
+                    remainder.push($scope.model.value[x]);
+                }
+            }
+            $scope.model.value = remainder;
+        };
+
+        var setAliasDebounce = _.debounce(function (index) {
+            $scope.model.value[index].alias = $scope.model.value[index].label.substring(0, 1).toLowerCase() + $scope.model.value[index].label.replace(/\s+/, '').slice(1);
+        }, 500);
+
+        $scope.setAlias = function (index) {
+            setAliasDebounce(index);
+        }
+
+        entityResource.getAll("Datatype").then(function (data) {
+            $scope.datatypes = data;
+        });
+
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/fields.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/fields.prevalues.controller.js
@@ -1,12 +1,14 @@
 ﻿angular.module("umbraco").controller("Umbraco.PrevalueEditors.NestedPropertyController",
-function ($scope, entityResource) {
+function ($scope, entityResource, angularHelper) {
 
     if (!$scope.model.value) {
         $scope.model.value = [];
     }
 
     $scope.add = function () {
-        $scope.model.value.push({ alias: '', title: '', descriptoin: '', datatype: 'textstring', required: false });
+        $scope.model.value.push({ alias: '', title: '', descriptoin: '', datatype: 'textstring', required: false, showsummary: false });
+        var currForm = angularHelper.getCurrentForm($scope);
+        currForm.$setDirty();
     };
 
     $scope.remove = function (index) {
@@ -17,11 +19,14 @@ function ($scope, entityResource) {
             }
         }
         $scope.model.value = remainder;
+        var currForm = angularHelper.getCurrentForm($scope);
+        currForm.$setDirty();
     };
 
     var setAliasDebounce = _.debounce(function (index) {
-        $scope.model.value[index].alias = $scope.model.value[index].label.substring(0, 1).toLowerCase() + $scope.model.value[index].label.replace(/\s+/, '').slice(1);
-    }, 500);
+        if ($scope.model.value[index].label)
+            $scope.model.value[index].alias = $scope.model.value[index].label.substring(0, 1).toLowerCase() + $scope.model.value[index].label.replace(/\s+/, '').slice(1);
+    }, 50);
 
     $scope.setAlias = function (index) {
         setAliasDebounce(index);
@@ -50,10 +55,13 @@ function ($scope, entityResource) {
                 $scope.model.value.splice(originalIndex, 1);
                 $scope.model.value.splice(newIndex, 0, movedElement);
             }
+
+            var currForm = angularHelper.getCurrentForm($scope);
+            currForm.$setDirty();
         }
     };
 
-    
+
     function getElementIndexByPrevalueText(value) {
         for (var i = 0; i < $scope.model.value.length; i++) {
             if ($scope.model.value[i].alias === value) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/fields.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/fields.prevalues.html
@@ -1,0 +1,34 @@
+﻿<div class="umb-editor" ng-controller="Umbraco.PrevalueEditors.NestedPropertyController">
+    <div ui-sortable="sortableOptions">
+        <div class="control-group" ng-repeat="item in model.value">
+            <i class="icon icon-navigation handle"></i>&nbsp;
+            <a prevent-default href="" title="Remove this property"
+                ng-show="model.value.length > 1"
+                ng-click="remove($index)">
+                <i class="icon icon-remove"></i>
+            </a>
+            <umb-control-group label="Name" alias="">
+                <input type="text" ng-model="item.label" val-server="item_{{$index}}" required ng-change="setAlias($index)" />
+            </umb-control-group>
+            <umb-control-group label="Alias" alias="">
+                <input type="text" ng-model="item.alias" val-server="item_{{$index}}" required  />
+            </umb-control-group>
+            <umb-control-group label="Type" alias="">
+                <select ng-model="item.datatype" val-server="item_{{$index}}" required ng-options="item.id as item.name for item in datatypes"></select>
+            </umb-control-group>
+            <umb-control-group label="Mandatory" alias="">
+                <input type="checkbox" ng-model="item.required" val-server="item_{{$index}}" /><br />
+            </umb-control-group>
+            <umb-control-group label="Description" alias="">
+                <textarea ng-model="item.description" val-server="item_{{$index}}" />
+            </umb-control-group>
+            
+        </div>
+    </div>
+    <div class="control-group">
+        <a prevent-default href="" title="Add another proprety"
+            ng-click="add()">
+            <i class="icon icon-add"></i>
+        </a>
+    </div>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/fields.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/fields.prevalues.html
@@ -1,28 +1,50 @@
 ﻿<div class="umb-editor" ng-controller="Umbraco.PrevalueEditors.NestedPropertyController">
     <div ui-sortable="sortableOptions">
-        <div class="control-group" ng-repeat="item in model.value">
-            <i class="icon icon-navigation handle"></i>&nbsp;
-            <a prevent-default href="" title="Remove this property"
+        <div class="control-group" ng-repeat="item in model.value" ng-init="expand=item.alias==''">
+            <ng-form name="keyvalueForm">
+            <p>
+                <i class="icon icon-navigation handle"></i>
+                
+                <a prevent-default href="" title="Remove this property" class="pull-right"
                 ng-show="model.value.length > 1"
                 ng-click="remove($index)">
-                <i class="icon icon-remove"></i>
-            </a>
+                <i class="icon icon icon-delete"></i>
+                </a>
+                <a prevent-default href="" ng-click="expand=!expand" ng-show="!expand"><span ng-bind="item.label"></span> (<span ng-bind="item.alias"></span>), Type: <span ng-bind="(datatypes | filter:{id:item.datatype})[0].name"></span><span ng-show="item.required">, Required</span>
+                    <i class="icon icon-navigation-down pull-right"></i>
+
+                </a>
+                <a prevent-default href="" ng-click="!item.alias || (expand=!expand)" ng-disabled="!item.alias" ng-show="expand">Edit "<span ng-bind="item.label"></span><span ng-show="!item.label">Add New Property</span>" 
+                    <i class="icon icon-navigation-up pull-right"></i>
+                </a>
+            </p>
+          
+            <div ng-show="expand">
             <umb-control-group label="Name" alias="">
-                <input type="text" ng-model="item.label" val-server="item_{{$index}}" required ng-change="setAlias($index)" />
+                <input type="text" ng-model="item.label" name="label" val-server="item_{{$index}}" required ng-change="setAlias($index)" />
+                <span class="help-inline" val-msg-for="label" val-toggle-msg="required">Required</span>
             </umb-control-group>
             <umb-control-group label="Alias" alias="">
-                <input type="text" ng-model="item.alias" val-server="item_{{$index}}" required  />
+                <input type="text" ng-model="item.alias" name="alias" val-server="item_{{$index}}" required  val-regex="^[a-zA-Z0-9]*$"  />
+                <span class="help-inline" val-msg-for="alias" val-toggle-msg="required">Required</span>
+                <span class="help-inline" val-msg-for="alias" val-toggle-msg="valRegex">The value entered is not valid alias</span>
             </umb-control-group>
             <umb-control-group label="Type" alias="">
-                <select ng-model="item.datatype" val-server="item_{{$index}}" required ng-options="item.id as item.name for item in datatypes"></select>
+                <select ng-model="item.datatype" name="datatype" val-server="item_{{$index}}" required val-regex="^[-0-9]*$" ng-options="item.id as item.name for item in datatypes">
+                </select>
+                <span class="help-inline" val-msg-for="datatype" val-toggle-msg="required">Required</span>
             </umb-control-group>
             <umb-control-group label="Mandatory" alias="">
                 <input type="checkbox" ng-model="item.required" val-server="item_{{$index}}" /><br />
             </umb-control-group>
+            <umb-control-group label="Show in Summary" alias="">
+                <input type="checkbox" ng-model="item.showsummary" val-server="item_{{$index}}" /><br />
+            </umb-control-group>
             <umb-control-group label="Description" alias="">
                 <textarea ng-model="item.description" val-server="item_{{$index}}" />
             </umb-control-group>
-            
+                </ng-form>
+            </div>
         </div>
     </div>
     <div class="control-group">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.controller.js
@@ -108,30 +108,20 @@
         writeValue();
     });
 
-    /*$scope.sortableOptions = {
+    $scope.sortableOptions = {
         axis: 'y',
         containment: 'parent',
         cursor: 'move',
         items: '> div.control-group',
         tolerance: 'pointer',
         update: function (e, ui) {
-            // Get the new and old index for the moved element (using the text as the identifier, so 
-            // we'd have a problem if two prevalues were the same, but that would be unlikely)
-            var newIndex = ui.item.index();
-            var movedPrevalueText = $('input[type="text"][ng-model="item.alias"]', ui.item).val();
-            var originalIndex = getElementIndexByPrevalueText(movedPrevalueText);
-
-            // Move the element in the model
-            if (originalIndex > -1) {
-                var movedElement = $scope.model.value[originalIndex];
-                $scope.model.value.splice(originalIndex, 1);
-                $scope.model.value.splice(newIndex, 0, movedElement);
-            }
+            var currForm = angularHelper.getCurrentForm($scope);
+            currForm.$setDirty();
         }
     };
 
 
-    function getElementIndexByPrevalueText(value) {
+    /*function getElementIndexByPrevalueText(value) {
         for (var i = 0; i < $scope.model.value.length; i++) {
             if ($scope.model.value[i].alias === value) {
                 return i;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.controller.js
@@ -1,0 +1,90 @@
+﻿function NestedPropertiesListController($scope, $q, dataTypeResource) {
+
+    if (!$scope.model.value) {
+        $scope.model.value = [];
+    }
+
+    $scope.model.value = [{ fieldName: "test", optionalField: 1070 }];
+
+    //add any fields that there isn't values for
+    if ($scope.model.config.min > 0) {
+        for (var i = 0; i < $scope.model.config.min; i++) {
+            if ((i + 1) > $scope.model.value.length) {
+                $scope.model.value.push({ });
+            }
+        }
+    }
+
+    $scope.add = function () {
+        if ($scope.model.config.max <= 0 || $scope.model.value.length < $scope.model.config.max) {
+            $scope.model.value.push({ });
+        }
+    };
+
+    $scope.remove = function (index) {
+        var remainder = [];
+        for (var x = 0; x < $scope.model.value.length; x++) {
+            if (x !== index) {
+                remainder.push($scope.model.value[x]);
+            }
+        }
+        $scope.model.value = remainder;
+    };
+
+    
+    var await = [];
+
+    var dataTypes = [];
+    $scope.properties = [];
+
+    dataTypeResource.getAllPropertyEditors().then(function (propertyEditors) {
+        //await.push(dataTypeResource.getAll().then(function (data) {
+        //      _.each(dataTypes, function(data) {
+        //          dataTypes[data.id] = data;
+        //      });
+        //}));
+        
+        _.each(_.unique(_.map($scope.model.config.items, function (i) { return i.datatype })), function (id) {
+            await.push(dataTypeResource.getById(id)
+                .then(function (data) {
+                    dataTypes[id] = data;
+                }));
+        });
+
+        // Wait for all property types to be read.  This should be quicker then using the sommented out getAll above.
+        $q.all(await).then(function () {
+            $scope.value = _.map($scope.model.value, function (value) {
+                return _.map($scope.model.config.items, function (property) {
+                    var datatype = dataTypes[property.datatype];
+                    var propertyeditor = _.filter(propertyEditors, function (dt) {
+                        if (dt.alias == datatype.selectedEditor)
+                            return this;
+                    }).pop();
+
+                    var fakeItem = _.clone(property);
+
+                    fakeItem.view = propertyeditor.view;
+                    fakeItem.hideLabel = propertyeditor.hideLabel;
+
+                    fakeItem.config = _.reduce(datatype.preValues, function (o, v, i) {
+                        o[v.key] = v.value;
+                        return o;
+                    }, {});
+
+                    fakeItem.validation = { mandatory: property.required, pattern: property.pattern };
+                    fakeItem.value = value[property.alias];
+                    return fakeItem;
+                });
+            });
+
+        });
+    });
+
+
+    $scope.$on("formSubmitting", function (ev, args) {
+        //$scope.model.value; $scope.value
+    });
+    
+}
+
+angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedPropertiesListController", NestedPropertiesListController);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.controller.js
@@ -4,24 +4,25 @@
         $scope.model.value = [];
     }
 
-    $scope.model.value = [{ fieldName: "test", optionalField: 1070 }];
-
     //add any fields that there isn't values for
     if ($scope.model.config.min > 0) {
         for (var i = 0; i < $scope.model.config.min; i++) {
             if ((i + 1) > $scope.model.value.length) {
-                $scope.model.value.push({ });
+                $scope.model.value.push({});
             }
         }
     }
 
     $scope.add = function () {
         if ($scope.model.config.max <= 0 || $scope.model.value.length < $scope.model.config.max) {
-            $scope.model.value.push({ });
+            writeValue();
+            $scope.model.value.push({});
+            syncValue();
         }
     };
 
     $scope.remove = function (index) {
+        writeValue();
         var remainder = [];
         for (var x = 0; x < $scope.model.value.length; x++) {
             if (x !== index) {
@@ -29,21 +30,59 @@
             }
         }
         $scope.model.value = remainder;
+        syncValue();
     };
 
-    
-    var await = [];
 
+    var await = [];
     var dataTypes = [];
+    var propertyEditors;
     $scope.properties = [];
 
-    dataTypeResource.getAllPropertyEditors().then(function (propertyEditors) {
+    function syncValue() {
+        $scope.value = _.map($scope.model.value, function (value) {
+            return _.map($scope.model.config.items, function (property) {
+                var datatype = dataTypes[property.datatype];
+                var propertyeditor = _.filter(propertyEditors, function (dt) {
+                    if (dt.alias == datatype.selectedEditor)
+                        return this;
+                }).pop();
+
+                var fakeItem = _.clone(property);
+
+                fakeItem.view = propertyeditor.view;
+                fakeItem.hideLabel = propertyeditor.hideLabel;
+
+                fakeItem.config = _.reduce(datatype.preValues, function (o, v, i) {
+                    o[v.key] = v.value;
+                    return o;
+                }, {});
+
+                fakeItem.validation = { mandatory: property.required, pattern: property.pattern };
+                fakeItem.value = value[property.alias];
+                return fakeItem;
+            });
+        });
+    }
+
+    function writeValue() {
+        console.log($scope.value);
+        console.log($scope.model.value);
+        $scope.model.value = _.map($scope.value, function (value) {
+            return _.reduce(value, function (o, v, i) {
+                o[v.alias] = v.value;
+                return o;
+            }, {});
+        });
+    }
+
+    dataTypeResource.getAllPropertyEditors().then(function (data) {
         //await.push(dataTypeResource.getAll().then(function (data) {
         //      _.each(dataTypes, function(data) {
         //          dataTypes[data.id] = data;
         //      });
         //}));
-        
+
         _.each(_.unique(_.map($scope.model.config.items, function (i) { return i.datatype })), function (id) {
             await.push(dataTypeResource.getById(id)
                 .then(function (data) {
@@ -51,40 +90,52 @@
                 }));
         });
 
+        propertyEditors = data;
+
         // Wait for all property types to be read.  This should be quicker then using the sommented out getAll above.
         $q.all(await).then(function () {
-            $scope.value = _.map($scope.model.value, function (value) {
-                return _.map($scope.model.config.items, function (property) {
-                    var datatype = dataTypes[property.datatype];
-                    var propertyeditor = _.filter(propertyEditors, function (dt) {
-                        if (dt.alias == datatype.selectedEditor)
-                            return this;
-                    }).pop();
-
-                    var fakeItem = _.clone(property);
-
-                    fakeItem.view = propertyeditor.view;
-                    fakeItem.hideLabel = propertyeditor.hideLabel;
-
-                    fakeItem.config = _.reduce(datatype.preValues, function (o, v, i) {
-                        o[v.key] = v.value;
-                        return o;
-                    }, {});
-
-                    fakeItem.validation = { mandatory: property.required, pattern: property.pattern };
-                    fakeItem.value = value[property.alias];
-                    return fakeItem;
-                });
-            });
+            syncValue();
 
         });
     });
 
 
     $scope.$on("formSubmitting", function (ev, args) {
-        //$scope.model.value; $scope.value
+        writeValue();
     });
-    
+
+    /*$scope.sortableOptions = {
+        axis: 'y',
+        containment: 'parent',
+        cursor: 'move',
+        items: '> div.control-group',
+        tolerance: 'pointer',
+        update: function (e, ui) {
+            // Get the new and old index for the moved element (using the text as the identifier, so 
+            // we'd have a problem if two prevalues were the same, but that would be unlikely)
+            var newIndex = ui.item.index();
+            var movedPrevalueText = $('input[type="text"][ng-model="item.alias"]', ui.item).val();
+            var originalIndex = getElementIndexByPrevalueText(movedPrevalueText);
+
+            // Move the element in the model
+            if (originalIndex > -1) {
+                var movedElement = $scope.model.value[originalIndex];
+                $scope.model.value.splice(originalIndex, 1);
+                $scope.model.value.splice(newIndex, 0, movedElement);
+            }
+        }
+    };
+
+
+    function getElementIndexByPrevalueText(value) {
+        for (var i = 0; i < $scope.model.value.length; i++) {
+            if ($scope.model.value[i].alias === value) {
+                return i;
+            }
+        }
+
+        return -1;
+    }*/
 }
 
 angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedPropertiesListController", NestedPropertiesListController);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.controller.js
@@ -1,4 +1,4 @@
-﻿function NestedPropertiesListController($scope, $q, dataTypeResource) {
+﻿function NestedPropertiesListController($scope, $q, dataTypeResource, angularHelper) {
 
     if (!$scope.model.value) {
         $scope.model.value = [];
@@ -18,6 +18,9 @@
             writeValue();
             $scope.model.value.push({});
             syncValue();
+
+            var currForm = angularHelper.getCurrentForm($scope);
+            currForm.$setDirty();
         }
     };
 
@@ -31,6 +34,9 @@
         }
         $scope.model.value = remainder;
         syncValue();
+
+        var currForm = angularHelper.getCurrentForm($scope);
+        currForm.$setDirty();
     };
 
 
@@ -66,8 +72,6 @@
     }
 
     function writeValue() {
-        console.log($scope.value);
-        console.log($scope.model.value);
         $scope.model.value = _.map($scope.value, function (value) {
             return _.reduce(value, function (o, v, i) {
                 o[v.alias] = v.value;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.html
@@ -1,0 +1,25 @@
+﻿<div ng-controller="Umbraco.PropertyEditors.NestedPropertiesListController" class="umb-editor umb-nestedpropertieslist">
+    <div ui-sortable ng-model="value">
+    <div class="control-group" ng-repeat="item in value">
+    			<i class="icon icon-navigation handle"></i>
+       
+        <umb-property 
+            property="property"
+            ng-repeat="property in item">
+            <umb-editor model="property" ></umb-editor>
+        </umb-property>
+        
+        <a prevent-default href="" title="Remove this item"
+            ng-show="value.length > model.config.min"
+            ng-click="remove($index)">
+            <i class="icon icon-remove"></i>
+        </a>
+    </div>
+	</div>
+
+    <a prevent-default href="" title="Add another item"
+        ng-show="model.config.max <= 0 || value.length < model.config.max"
+        ng-click="add()">
+        <i class="icon icon-add"></i>
+    </a>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.html
@@ -1,22 +1,39 @@
 ﻿<div ng-controller="Umbraco.PropertyEditors.NestedPropertiesListController" class="umb-editor umb-nestedpropertieslist">
-    <div ui-sortable ng-model="value">
-    <div class="control-group" ng-repeat="item in value">
+   <div ui-sortable ng-model="value">
+    <div class="control-group" ng-repeat="item in value" ng-init="expand=false">
+        <ng-form name="keyvalueForm">
+            <p>
     			<i class="icon icon-navigation handle"></i>
-       
-        <umb-property 
-            property="property"
-            ng-repeat="property in item">
-            <umb-editor model="property" ></umb-editor>
-        </umb-property>
-        
-        <a prevent-default href="" title="Remove this item"
-            ng-show="value.length > model.config.min"
-            ng-click="remove($index)">
-            <i class="icon icon-remove"></i>
-        </a>
+
+                <a prevent-default href="" title="Remove this item" class="pull-right"
+                    ng-show="value.length > model.config.min"
+                    ng-click="remove($index)">
+                <i class="icon icon icon-delete"></i>
+                </a>
+                <a prevent-default href="" ng-click="expand=!expand" ng-show="!expand">
+                    <span ng-repeat="property in item | filter:{showsummary: true}">
+                        <span ng-bind="property.label"></span>: <span ng-bind="property.value"></span><span ng-show="!$last">, </span>
+                    </span>
+                    
+                    <i class="icon icon-navigation-down pull-right"></i>
+
+                </a>
+                <a prevent-default href="" ng-click="!item || (expand=!expand)" ng-disabled="!item" ng-show="expand">
+                    Edit "<span ng-bind="item.label"></span><span ng-show="!item.label">Add New Item</span>" 
+                    <i class="icon icon-navigation-up pull-right"></i>
+                </a>
+            </p>
+          
+            <div ng-show="expand">
+                <umb-property 
+                    property="property"
+                    ng-repeat="property in item">
+                    <umb-editor model="property" ></umb-editor>
+                </umb-property>
+            </div>
+        </ng-form>
     </div>
 	</div>
-
     <a prevent-default href="" title="Add another item"
         ng-show="model.config.max <= 0 || value.length < model.config.max"
         ng-click="add()">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedpropertieslist/nestedpropertieslist.html
@@ -1,5 +1,5 @@
 ﻿<div ng-controller="Umbraco.PropertyEditors.NestedPropertiesListController" class="umb-editor umb-nestedpropertieslist">
-   <div ui-sortable ng-model="value">
+   <div ui-sortable="sortableOptions" ng-model="value">
     <div class="control-group" ng-repeat="item in value" ng-init="expand=false">
         <ng-form name="keyvalueForm">
             <p>

--- a/src/Umbraco.Web/Editors/DataTypeController.cs
+++ b/src/Umbraco.Web/Editors/DataTypeController.cs
@@ -59,6 +59,23 @@ namespace Umbraco.Web.Editors
             return Mapper.Map<IDataTypeDefinition, DataTypeDisplay>(dataType);
         }
 
+        public IEnumerable<DataTypeDisplay> GetAll()
+        {
+            var dataType = Services.DataTypeService.GetAllDataTypeDefinitions();
+            if (dataType == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+            return dataType
+                .Select(s => Mapper.Map<IDataTypeDefinition, DataTypeDisplay>(s));
+        }
+        
+        public IEnumerable<ContentPropertyDisplay> GetAllPropertyEditors()
+        {
+            return PropertyEditorResolver.Current.PropertyEditors
+                .Select(s => Mapper.Map<PropertyEditor, ContentPropertyDisplay>(s));
+        }
+
         /// <summary>
         /// Deletes a data type wth a given ID
         /// </summary>

--- a/src/Umbraco.Web/Models/Mapping/DataTypeModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/DataTypeModelMapper.cs
@@ -39,6 +39,10 @@ namespace Umbraco.Web.Models.Mapping
                 .ForMember(x => x.Alias, expression => expression.Ignore())
                 .ForMember(x => x.IsSystemDataType, expression => expression.MapFrom(definition => systemIds.Contains(definition.Id)));
 
+            config.CreateMap<PropertyEditor, ContentPropertyDisplay>()
+                .ForMember(x => x.View, expression => expression.MapFrom(definition => definition.ValueEditor.View))
+                .ForMember(x => x.Editor, expression => expression.MapFrom(definition => definition.Name));
+
             config.CreateMap<IDataTypeDefinition, DataTypeDisplay>()
                 .ForMember(display => display.AvailableEditors, expression => expression.ResolveUsing<AvailablePropertyEditorsResolver>())
                 .ForMember(display => display.PreValues, expression => expression.ResolveUsing(

--- a/src/Umbraco.Web/PropertyEditors/NestedPropertiesListPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedPropertiesListPropertyEditor.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.PropertyEditors;
+using umbraco;
+
+namespace Umbraco.Web.PropertyEditors
+{
+    /// <summary>
+    /// Pre-value editor used to create a list of items
+    /// </summary>
+    /// <remarks>
+    /// This pre-value editor is shared with editors like drop down, checkbox list, etc....
+    /// </remarks>
+    [PropertyEditor(Constants.PropertyEditors.NestedPropertiesListAlias, "Nested Properties List", "nestedpropertieslist", ValueType="JSON")]
+    public class NestedPropertiesListPropertyEditor : PropertyEditor
+    {
+
+        /// <summary>
+        /// Return a custom pre-value editor
+        /// </summary>
+        /// <returns></returns>
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new NestedPropertiesListPreValueEditor();
+        }
+
+        internal class NestedPropertiesListPreValueEditor : PreValueEditor
+        {
+
+            public NestedPropertiesListPreValueEditor()
+            {
+                Fields.AddRange(CreatePreValueFields());
+            }
+
+            /// <summary>
+            /// Creates the pre-value fields
+            /// </summary>
+            /// <returns></returns>
+            protected List<PreValueField> CreatePreValueFields()
+            {
+                return new List<PreValueField>
+                    {
+                        //create the fields
+                        new PreValueField(new IntegerValidator())
+                        {
+                            Description = "Enter the minimum amount of items to be displayed",
+                            Key = "min",
+                            View = "requiredfield",
+                            Name = "Minimum"
+                        },
+                        new PreValueField(new IntegerValidator())
+                        {
+                            Description = "Enter the maximum amount of items to be displayed, enter 0 for unlimited",
+                            Key = "max",
+                            View = "requiredfield",
+                            Name = "Maximum"
+                        },
+                        new PreValueField(new EnsureUniqueValuesValidator())
+                            {
+                                Description = "Add and remove values for the list",
+                                //we're going to call this 'items' because we are going to override the 
+                                //serialization of the pre-values to ensure that each one gets saved with it's own key 
+                                //(new db row per pre-value, thus to maintain backwards compatibility)
+
+                                //It's also important to note that by default the dropdown angular controller is expecting the 
+                                // config options to come in with a property called 'items'
+                                Key = "items",
+                                Name = ui.Text("editdatatype", "addPrevalue"),
+                                View = "views/propertyeditors/nestedpropertieslist/fields.prevalues.html"
+                            }                   
+                    };
+            } 
+            /*
+            /// <summary>
+            /// The editor is expecting a json array for a field with a key named "items" so we need to format the persisted values
+            /// to this format to be used in the editor.
+            /// </summary>
+            /// <param name="defaultPreVals"></param>
+            /// <param name="persistedPreVals"></param>
+            /// <returns></returns>
+            public override IDictionary<string, object> ConvertDbToEditor(IDictionary<string, object> defaultPreVals, PreValueCollection persistedPreVals)
+            {
+                var dictionary = persistedPreVals.FormatAsDictionary();
+                var arrayOfVals = dictionary.Select(item => item.Value)
+                    //ensure they are sorted - though this isn't too important because in json in may not maintain
+                    // the sorted order and the js has to sort anyways.
+                    .OrderBy(x => x.SortOrder)
+                    .ToList();
+          
+                //the items list will be a dictionary of it's id -> value we need to use the id for persistence for backwards compatibility
+                return new Dictionary<string, object> {{"items", arrayOfVals.ToDictionary(x => x.Id, x => PreValueAsDictionary(x))}};
+            }
+
+            /// <summary>
+            /// Formats the prevalue as a dictionary (as we need to return not just the value, but also the sort-order, to the client)
+            /// </summary>
+            /// <param name="preValue">The prevalue to format</param>
+            /// <returns>Dictionary object containing the prevalue formatted with the field names as keys and the value of those fields as the values</returns>
+            private IDictionary<string, object> PreValueAsDictionary(PreValue preValue)
+            {
+                return new Dictionary<string, object>() { { "value", preValue.Value }, {"sortOrder", preValue.SortOrder } };
+            }
+
+            /// <summary>
+            /// Need to format the delimited posted string to individual values
+            /// </summary>
+            /// <param name="editorValue"></param>
+            /// <param name="currentValue"></param>
+            /// <returns>
+            /// A string/string dictionary since all values that need to be persisted in the database are strings.
+            /// </returns>
+            /// <remarks>
+            /// This is mostly because we want to maintain compatibility with v6 drop down property editors that store their prevalues in different db rows.
+            /// </remarks>
+            public override IDictionary<string, PreValue> ConvertEditorToDb(IDictionary<string, object> editorValue, PreValueCollection currentValue)
+            {
+                var val = editorValue["items"] as JArray;
+                var result = new Dictionary<string, PreValue>();
+            
+                if (val == null)
+                {
+                    return result;
+                }
+
+                try
+                {
+                    var index = 0;
+
+                    //get all values in the array that are not empty 
+                    foreach (var item in val.OfType<JObject>()
+                        .Where(jItem => jItem["value"] != null)
+                        .Select(jItem => new
+                            {
+                                idAsString = jItem["id"] == null ? "0" : jItem["id"].ToString(), 
+                                valAsString = jItem["value"].ToString()
+                            })
+                        .Where(x => x.valAsString.IsNullOrWhiteSpace() == false))
+                    {
+                        var id = 0;
+                        int.TryParse(item.idAsString, out id);
+                        result.Add(index.ToInvariantString(), new PreValue(id, item.valAsString));
+                        index++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.Error<ValueListPreValueEditor>("Could not deserialize the posted value: " + val, ex);                
+                }
+
+                return result;
+            }*/
+
+            /// <summary>
+            /// A custom validator to ensure that all values in the list are unique
+            /// </summary>
+            internal class EnsureUniqueValuesValidator : IPropertyValidator
+            {
+                public IEnumerable<ValidationResult> Validate(object value, PreValueCollection preValues, PropertyEditor editor)
+                {
+                    var json = value as JArray;
+                    if (json == null) yield break;
+
+                    //get all values in the array that are not empty (we'll remove empty values when persisting anyways)
+                    var groupedValues = json.OfType<JObject>()
+                                            .Where(jItem => jItem["value"] != null)
+                                            .Select((jItem, index) => new { value = jItem["value"].ToString(), index = index })
+                                            .Where(asString => asString.value.IsNullOrWhiteSpace() == false)
+                                            .GroupBy(x => x.value);
+
+                    foreach (var g in groupedValues.Where(g => g.Count() > 1))
+                    {
+                        yield return new ValidationResult("The value " + g.Last().value + " must be unique", new[]
+                            {
+                                //we'll make the server field the index number of the value so it can be wired up to the view
+                                "item_" + g.Last().index.ToInvariantString()
+                            });
+                    }
+
+
+                }
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -451,6 +451,7 @@
     <Compile Include="Mvc\RedirectToUmbracoUrlResult.cs" />
     <Compile Include="PropertyEditors\GridPropertyEditor.cs" />
     <Compile Include="Mvc\UmbracoVirtualNodeByIdRouteHandler.cs" />
+    <Compile Include="PropertyEditors\NestedPropertiesListPropertyEditor.cs" />
     <Compile Include="PropertyEditors\ValueConverters\MacroContainerValueConverter.cs" />
     <Compile Include="PropertyEditors\TagsDataController.cs" />
     <Compile Include="PublishedCache\MemberPublishedContent.cs" />


### PR DESCRIPTION
Per http://issues.umbraco.org/issue/U4-7389

This is a custom Property Editor that allows developers to create Data Types that allow a nested list of other data types.  That is one can create a Authors data type for example that when added to a document asks for a Name, Email, and Title.  The lists of member properties is configured in the Data Type and can be as many or few as desired and each has it's own title, alias, required, and data type from those available in the system.  In addition the configuration can support adding a single item with nested details or adding items to a list.  Ie a list of Authors all configured and hosted in the single property.  

Much of the same logic as indicated above can be done with normal document types, structure rules, and  Enable List View options using node traversing to accomplish similar results.  This method has some district differences though including:
*All the configuration is stored in one property and can be read in as a single JSON object.
*The configuration can be fully updated all in one screen without having to do many page loads adding and removing nodes.
*One page can have multiple data types with different configurations, where as if the same configuration is stored as nodes and Enable List View is used there is then only one list for all node types and documents as well.  (Unless even more hierarchy and additional documents are created.)
*None of the items/content will generate url's or cause conflicts.
*Will work on documents, media, or and custom trees.

![document](https://cloud.githubusercontent.com/assets/458367/11102532/11368a9c-888b-11e5-8740-cdf1a2ab54b4.png)
![property](https://cloud.githubusercontent.com/assets/458367/11102533/11378410-888b-11e5-903d-e18d6c61e76a.png)
