### PR TITLE
Fixes U4-6700

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/directives/umb-sections.html
+++ b/src/Umbraco.Web.UI.Client/src/views/directives/umb-sections.html
@@ -31,7 +31,7 @@
         </ul>
     </div>
 
-    <div id="applications-tray" ng-show="showTray" ng-animate="trayAnimation()">
+    <div id="applications-tray" ng-show="showTray" ng-animate="trayAnimation()" style="display: none;">
         <ul class="sections sections-tray">
             <li ng-repeat="section in sections | limitTo: overflowingSections" ng-class="{current: section.alias == currentSection}">
                 <a href="#/{{section.alias}}"


### PR DESCRIPTION
#applications-tray should be hidden as default, if there is too many sections to fit an arrow appear that when clicked toggles #applications-tray.