### PR TITLE
U4-5123 - Allow positioning of the 'Child Items' tab within the Tabs.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -57,6 +57,7 @@ function listViewController($rootScope, $scope, $routeParams, $injector, notific
     };
 
     $scope.options = {
+        displayAtTabNumber: $scope.model.config.displayAtTabNumber ? $scope.model.config.displayAtTabNumber : 1,
         pageSize: $scope.model.config.pageSize ? $scope.model.config.pageSize : 10,
         pageNumber: ($routeParams.page && Number($routeParams.page) != NaN && Number($routeParams.page) > 0) ? $routeParams.page : 1,
         filter: '',

--- a/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
@@ -119,9 +119,6 @@ namespace Umbraco.Web.Models.Mapping
 
             //re-assign
             genericProps.Properties = contentProps;
-
-           
-
         }
 
         /// <summary>
@@ -191,12 +188,38 @@ namespace Umbraco.Web.Models.Mapping
             });
             listViewTab.Properties = listViewProperties;
 
-            //Is there a better way?
-            var tabs = new List<Tab<ContentPropertyDisplay>>();
-            tabs.Add(listViewTab);
-            tabs.AddRange(display.Tabs);
-            display.Tabs = tabs;
+            SetChildItemsTabPosition(display, listViewConfig, listViewTab);
+        }
 
+        private static void SetChildItemsTabPosition<TPersisted>(TabbedContentItem<ContentPropertyDisplay, TPersisted> display, 
+                IDictionary<string, object> listViewConfig,
+                Tab<ContentPropertyDisplay> listViewTab) 
+            where TPersisted : IContentBase
+        {
+            // Find position of tab from config
+            var tabIndexForChildItems = 0;
+            if (listViewConfig["displayAtTabNumber"] != null && int.TryParse((string)listViewConfig["displayAtTabNumber"], out tabIndexForChildItems))
+            {
+                // Tab position is recorded 1-based but we insert into collection 0-based
+                tabIndexForChildItems--;
+
+                // Ensure within bounds
+                if (tabIndexForChildItems < 0)
+                {
+                    tabIndexForChildItems = 0;
+                }
+
+                if (tabIndexForChildItems > display.Tabs.Count())
+                {
+                    tabIndexForChildItems = display.Tabs.Count();
+                }
+            }
+
+            // Recreate tab list with child items tab at configured position
+            var tabs = new List<Tab<ContentPropertyDisplay>>();
+            tabs.AddRange(display.Tabs);
+            tabs.Insert(tabIndexForChildItems, listViewTab);
+            display.Tabs = tabs;
         }
 
         protected override IEnumerable<Tab<ContentPropertyDisplay>> ResolveCore(IContentBase content)

--- a/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Umbraco.Core;
-using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
@@ -24,6 +19,7 @@ namespace Umbraco.Web.PropertyEditors
                 return new Dictionary<string, object>
                 {
                     {"pageSize", "10"},
+                    {"displayAtTabNumber", "1"},
                     {"orderBy", "SortOrder"},
                     {"orderDirection", "asc"},
                     {
@@ -40,6 +36,8 @@ namespace Umbraco.Web.PropertyEditors
 
         internal class ListViewPreValueEditor : PreValueEditor
         {
+            [PreValueField("displayAtTabNumber", "Display At Tab Number", "number", Description = "Which tab position that the list of child items will be displayed")]
+            public int DisplayAtTabNumber { get; set; }
 
             [PreValueField("pageSize", "Page Size", "number", Description = "Number of items per page")]
             public int PageSize { get; set; }
@@ -55,7 +53,5 @@ namespace Umbraco.Web.PropertyEditors
                 Description = "The properties that will be displayed for each column")]
             public object IncludeProperties { get; set; }
         }
-
-
     }
 }


### PR DESCRIPTION
This PR allows the position of the list view child items tab within the tab list to be selected as part of the list view data type configuration.