### PR TITLE
U4-7297 - fixes <hr/>-button in tinymce

### DIFF
--- a/src/Umbraco.Web.UI/config/tinyMceConfig.Release.config
+++ b/src/Umbraco.Web.UI/config/tinyMceConfig.Release.config
@@ -213,6 +213,7 @@
         <plugin loadOnFrontend="true">charmap</plugin>
         <plugin loadOnFrontend="true">table</plugin>
     <plugin loadOnFrontend="true">lists</plugin>
+        <plugin loadOnFrontend="true">hr</plugin>
     </plugins>
     <validElements>
       <![CDATA[+a[id|style|rel|data-id|rev|charset|hreflang|dir|lang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|onclick|

--- a/src/Umbraco.Web.UI/config/tinyMceConfig.config
+++ b/src/Umbraco.Web.UI/config/tinyMceConfig.config
@@ -213,6 +213,7 @@
     <plugin loadOnFrontend="true">charmap</plugin>
     <plugin loadOnFrontend="true">table</plugin>
     <plugin loadOnFrontend="true">lists</plugin>
+    <plugin loadOnFrontend="true">hr</plugin>
   </plugins>
   <validElements>
     <![CDATA[+a[id|style|rel|data-id|rev|charset|hreflang|dir|lang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|onclick|


### PR DESCRIPTION
http://issues.umbraco.org/issue/U4-7297 - the horizontal rule button was not showing up when ticking the checkbox in the tinymce datatype. Adding the plugin in the config file seems to fix this issue. 