### PR TITLE
Support generic CultureInfo as language culture

### DIFF
--- a/src/Umbraco.Core/Models/Language.cs
+++ b/src/Umbraco.Core/Models/Language.cs
@@ -64,7 +64,7 @@ namespace Umbraco.Core.Models
         [IgnoreDataMember]
         public CultureInfo CultureInfo
         {
-            get { return CultureInfo.CreateSpecificCulture(IsoCode); }
+            get { return CultureInfo.GetCultureInfo(IsoCode); }
         }
     }
 }


### PR DESCRIPTION
The CreateSpecificCulture messes up for us. We're using English as main culture for an international site, that also has sites for English (US), English (GB) etc.
Need to support generic. Old "business" version "did it right".