### PR TITLE
Fixes U4-7424 : Edit and localize error message when a macro partial view fails to render

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -301,6 +301,7 @@
     <key alias="codemirroriewarning">NOTE! Even though CodeMirror is enabled by configuration, it is disabled in Internet Explorer because it's not stable enough.</key>
     <key alias="contentTypeAliasAndNameNotNull">Please fill both alias and name on the new property type!</key>
     <key alias="filePermissionsError">There is a problem with read/write access to a specific file or folder</key>
+    <key alias="macroErrorLoadingPartialView">Error loading Partial View script (file: %0%)</key>
     <key alias="missingTitle">Please enter a title</key>
     <key alias="missingType">Please choose a type</key>
     <key alias="pictureResizeBiggerThanOrg">You're about to make the picture larger than the original size. Are you sure that you want to proceed?</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -302,6 +302,7 @@
     <key alias="codemirroriewarning">NOTE! Even though CodeMirror is enabled by configuration, it is disabled in Internet Explorer because it's not stable enough.</key>
     <key alias="contentTypeAliasAndNameNotNull">Please fill both alias and name on the new property type!</key>
     <key alias="filePermissionsError">There is a problem with read/write access to a specific file or folder</key>
+    <key alias="macroErrorLoadingPartialView">Error loading Partial View script (file: %0%)</key>
     <key alias="missingTitle">Please enter a title</key>
     <key alias="missingType">Please choose a type</key>
     <key alias="pictureResizeBiggerThanOrg">You're about to make the picture larger than the original size. Are you sure that you want to proceed?</key>

--- a/src/Umbraco.Web/umbraco.presentation/macro.cs
+++ b/src/Umbraco.Web/umbraco.presentation/macro.cs
@@ -24,6 +24,7 @@ using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Macros;
 using Umbraco.Core.Models;
+using Umbraco.Core.Services;
 using Umbraco.Core.Xml.XPath;
 using Umbraco.Core.Profiling;
 using umbraco.interfaces;
@@ -322,7 +323,13 @@ namespace umbraco
                                                 Exception = e,
                                                 Behaviour = UmbracoConfig.For.UmbracoSettings().Content.MacroErrorBehaviour
                                             };
-                                    return GetControlForErrorBehavior("Error loading Partial View script (file: " + ScriptFile + ")", macroErrorEventArgs);
+
+                                    var errorMessage = ApplicationContext.Current.Services.TextService.Localize("errors/macroErrorLoadingPartialView",new[]{ScriptFile});
+                                    if (errorMessage.Equals("[macroErrorLoadingPartialView]")) // This check can be removed when key is added to every language file
+                                    {
+                                        errorMessage = "Error loading Partial View script (file: " + ScriptFile + ")";
+                                    }
+                                    return GetControlForErrorBehavior(errorMessage, macroErrorEventArgs);
                                 };
 
                             using (DisposableTimer.DebugDuration<macro>("Executing Partial View: " + Model.TypeName))


### PR DESCRIPTION
Add the possibilty to change the error message when a macro partial view
fails to render.