### PR TITLE
Fixes U4-6340 : Partial view macro with parameters not working in RTE and Grid (backend)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/macro.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/macro.resource.js
@@ -45,28 +45,14 @@ function macroResource($q, $http, umbRequestHelper) {
          */
         getMacroResultAsHtmlForEditor: function (macroAlias, pageId, macroParamDictionary) {
 
-            //need to format the query string for the custom dictionary
             var query = "macroAlias=" + macroAlias + "&pageId=" + pageId;
-            var macroParams = {};
-            if (macroParamDictionary) {
-                _.each(macroParamDictionary, function (val, key) {
-                    //check for null
-                    val = val ? val : "";
-                    //need to detect if the val is a string or an object
-                    if (!angular.isString(val)) {
-                        //if it's not a string we'll send it through the json serializer
-                        val = angular.toJson(val);
-                    }
-                    macroParams[key] = val;
-                });
-            }
 
             return umbRequestHelper.resourcePromise(
                $http.post(
                    umbRequestHelper.getApiUrl(
                        "macroApiBaseUrl",
                        "GetMacroResultAsHtmlForEditor",
-                       query), JSON.stringify(macroParams)),
+                       query), JSON.stringify(macroParamDictionary)),
                'Failed to retrieve macro result for macro with alias  ' + macroAlias);
         }
     };

--- a/src/Umbraco.Web.UI.Client/src/common/resources/macro.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/macro.resource.js
@@ -51,7 +51,7 @@ function macroResource($q, $http, umbRequestHelper) {
                $http.post(
                    umbRequestHelper.getApiUrl(
                        "macroApiBaseUrl",
-                       "GetMacroResultAsHtmlForEditor",
+                       "GetMacroResultAsHtmlForEditorUsingHttpPost",
                        query), JSON.stringify(macroParamDictionary)),
                'Failed to retrieve macro result for macro with alias  ' + macroAlias);
         }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/macro.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/macro.resource.js
@@ -36,7 +36,7 @@ function macroResource($q, $http, umbRequestHelper) {
          * @methodOf umbraco.resources.macroResource
          *
          * @description
-         * Gets the result of a macro as html to display in the rich text editor
+         * Gets the result of a macro as html to display in the rich text editor or in the Grid
          *
          * @param {int} macroId The macro id to get parameters for
          * @param {int} pageId The current page id
@@ -47,37 +47,28 @@ function macroResource($q, $http, umbRequestHelper) {
 
             //need to format the query string for the custom dictionary
             var query = "macroAlias=" + macroAlias + "&pageId=" + pageId;
+            var macroParams = {};
             if (macroParamDictionary) {
-                var counter = 0;
                 _.each(macroParamDictionary, function (val, key) {
                     //check for null
                     val = val ? val : "";
                     //need to detect if the val is a string or an object
                     if (!angular.isString(val)) {
                         //if it's not a string we'll send it through the json serializer
-                        var json = angular.toJson(val);
-                        //then we need to url encode it so that it's safe
-                        val = encodeURIComponent(json);
+                        val = angular.toJson(val);
                     }
-                    else {
-                        //we still need to encode the string, it could contain line breaks, etc...
-                        val = encodeURIComponent(val);
-                    }
-
-                    query += "&macroParams[" + counter + "].key=" + key + "&macroParams[" + counter + "].value=" + val;
-                    counter++;
+                    macroParams[key] = val;
                 });
             }
 
             return umbRequestHelper.resourcePromise(
-               $http.get(
+               $http.post(
                    umbRequestHelper.getApiUrl(
                        "macroApiBaseUrl",
                        "GetMacroResultAsHtmlForEditor",
-                       query)),
+                       query), JSON.stringify(macroParams)),
                'Failed to retrieve macro result for macro with alias  ' + macroAlias);
         }
-            
     };
 }
 

--- a/src/Umbraco.Web/Editors/MacroController.cs
+++ b/src/Umbraco.Web/Editors/MacroController.cs
@@ -49,7 +49,9 @@ namespace Umbraco.Web.Editors
         /// 
         /// </param>
         /// <returns></returns>
-        public HttpResponseMessage GetMacroResultAsHtmlForEditor(string macroAlias, int pageId, [FromUri]IDictionary<string, object> macroParams)
+        [HttpPost]
+        [HttpGet]
+        public HttpResponseMessage GetMacroResultAsHtmlForEditor(string macroAlias, int pageId, [FromBody]IDictionary<string, object> macroParams)
         {
             // note - here we should be using the cache, provided that the preview content is in the cache...
 

--- a/src/Umbraco.Web/Editors/MacroController.cs
+++ b/src/Umbraco.Web/Editors/MacroController.cs
@@ -52,51 +52,7 @@ namespace Umbraco.Web.Editors
         [HttpGet]
         public HttpResponseMessage GetMacroResultAsHtmlForEditor(string macroAlias, int pageId, [FromUri] IDictionary<string, object> macroParams)
         {
-            // note - here we should be using the cache, provided that the preview content is in the cache...
-
-            var doc = Services.ContentService.GetById(pageId);
-            if (doc == null)
-            {
-                throw new HttpResponseException(HttpStatusCode.NotFound);
-            }
-
-            //need to get a legacy macro object - eventually we'll have a new format but nto yet
-            var macro = new macro(macroAlias);
-            if (macro == null)
-            {
-                throw new HttpResponseException(HttpStatusCode.NotFound);
-            }
-
-            //if it isn't supposed to be rendered in the editor then return an empty string
-            if (macro.DontRenderInEditor)
-            {
-                var response = Request.CreateResponse();
-                //need to create a specific content result formatted as html since this controller has been configured
-                //with only json formatters.
-                response.Content = new StringContent(string.Empty, Encoding.UTF8, "text/html");
-
-                return response;
-            }
-
-            //because macro's are filled with insane legacy bits and pieces we need all sorts of wierdness to make them render.
-            //the 'easiest' way might be to create an IPublishedContent manually and populate the legacy 'page' object with that
-            //and then set the legacy parameters.
-
-            var legacyPage = new global::umbraco.page(doc);
-            UmbracoContext.HttpContext.Items["pageID"] = doc.Id;
-            UmbracoContext.HttpContext.Items["pageElements"] = legacyPage.Elements;
-            UmbracoContext.HttpContext.Items[global::Umbraco.Core.Constants.Conventions.Url.AltTemplate] = null;
-
-            var renderer = new UmbracoComponentRenderer(UmbracoContext);
-
-            var result = Request.CreateResponse();
-            //need to create a specific content result formatted as html since this controller has been configured
-            //with only json formatters.
-            result.Content = new StringContent(
-                renderer.RenderMacro(macro, macroParams, legacyPage).ToString(),
-                Encoding.UTF8,
-                "text/html");
-            return result;
+            return GetMacroResultAsHtml(macroAlias, pageId, macroParams);
         }
 
         /// <summary>
@@ -110,6 +66,11 @@ namespace Umbraco.Web.Editors
         /// <returns></returns>
         [HttpPost]
         public HttpResponseMessage GetMacroResultAsHtmlForEditorUsingHttpPost(string macroAlias, int pageId, [FromBody]IDictionary<string, object> macroParams)
+        {
+            return GetMacroResultAsHtml(macroAlias, pageId, macroParams);
+        }
+
+        private HttpResponseMessage GetMacroResultAsHtml(string macroAlias, int pageId, IDictionary<string, object> macroParams)
         {
             // note - here we should be using the cache, provided that the preview content is in the cache...
 


### PR DESCRIPTION
(See my comment here for full description: http://issues.umbraco.org/issue/U4-6340#comment=67-24142)

This fix uses POST instead of GET to render the macros in RTE or Grid (backend) The problem with previous version was that it used querystring to pass the macro parameters. When the length exceeds the maxQueryStringLength (default: 2048) it returns a 404.15 status code. 
