### PR TITLE
Remove unnecessary ToLowerInvariant call from PreviewMode

### DIFF
--- a/src/Umbraco.Web/Mvc/UmbracoViewPageOfTModel.cs
+++ b/src/Umbraco.Web/Mvc/UmbracoViewPageOfTModel.cs
@@ -238,7 +238,7 @@ namespace Umbraco.Web.Mvc
             {
                 if (UmbracoContext.Current.IsDebug || UmbracoContext.Current.InPreviewMode)
                 {
-                    var text = value.ToString().ToLowerInvariant();
+                    var text = value.ToString();
                     var pos = text.IndexOf("</body>", StringComparison.InvariantCultureIgnoreCase);
 
                     if (pos > -1)


### PR DESCRIPTION
Text was being set lowercase and then injected with the preview badge markup. This meant that things such as script tags were being lowercased, breaking the javascript.