### PR TITLE
U4-7400 - Datepicker is not updating scope model value in time for 3r…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -44,6 +44,7 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
                 $scope.datePickerForm.datepicker.$setValidity("pickerError", true);
                 $scope.hasDatetimePickerValue = true;
                 $scope.datetimePickerValue = e.date.format($scope.model.config.format);
+                $scope.model.value = $scope.datetimePickerValue;
             }
             else {
                 $scope.hasDatetimePickerValue = false;


### PR DESCRIPTION
…d party plugins

Force set scope model value when the datetime changes, rather than just on formsubmit. This means that 3rd party plugins (such as grids) can use this editor.