### PR TITLE
Fixes: U4-7220 Upgrading 4.9.0 to 7.3.0 fails due to missing UniqueID…

### DIFF
--- a/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSixZeroOne/UpdatePropertyTypesAndGroups.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSixZeroOne/UpdatePropertyTypesAndGroups.cs
@@ -28,37 +28,38 @@ namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSixZeroOne
         {
             if (database != null)
             {
-                //Fetch all PropertyTypes that belongs to a PropertyTypeGroup                
+				//Fetch all PropertyTypes that belongs to a PropertyTypeGroup                
                 //NOTE: We are writing the full query because we've added a column to the PropertyTypeDto in later versions so one of the columns
                 // won't exist yet
-                var propertyTypes = database.Fetch<PropertyTypeDto>("SELECT * FROM cmsPropertyType WHERE propertyTypeGroupId > 0");
+				//NOTE: We're using dynamic to avoid having this migration fail due to the UniqueId column added in 7.3 (this column is not added
+				// in the table yet and will make the mapping of done by Fetch fail when the actual type is used here).
+                var propertyTypes = database.Fetch<dynamic>("SELECT * FROM cmsPropertyType WHERE propertyTypeGroupId > 0");
 
                 var propertyGroups = database.Fetch<PropertyTypeGroupDto>("WHERE id > 0");
 
                 foreach (var propertyType in propertyTypes)
                 {
                     //Get the PropertyTypeGroup that the current PropertyType references
-                    var parentPropertyTypeGroup = propertyGroups.FirstOrDefault(x => x.Id == propertyType.PropertyTypeGroupId);
+                    var parentPropertyTypeGroup = propertyGroups.FirstOrDefault(x => x.Id == propertyType.propertyTypeGroupId);
                     if (parentPropertyTypeGroup != null)
                     {
                         //If the ContentType is the same on the PropertyType and the PropertyTypeGroup the group is valid and we skip to the next
-                        if (parentPropertyTypeGroup.ContentTypeNodeId == propertyType.ContentTypeId) continue;
+                        if (parentPropertyTypeGroup.ContentTypeNodeId == propertyType.contentTypeId) continue;
 
                         //Check if the 'new' PropertyTypeGroup has already been created
                         var existingPropertyTypeGroup =
                             propertyGroups.FirstOrDefault(
                                 x =>
                                 x.ParentGroupId == parentPropertyTypeGroup.Id && x.Text == parentPropertyTypeGroup.Text &&
-                                x.ContentTypeNodeId == propertyType.ContentTypeId);
+                                x.ContentTypeNodeId == propertyType.contentTypeId);
 
                         //This should ensure that we don't create duplicate groups for a single ContentType
                         if (existingPropertyTypeGroup == null)
                         {
-
                             //Create a new PropertyTypeGroup that references the parent group that the PropertyType was referencing pre-6.0.1
                             var propertyGroup = new PropertyTypeGroupDto
                                                     {
-                                                        ContentTypeNodeId = propertyType.ContentTypeId,
+                                                        ContentTypeNodeId = propertyType.contentTypeId,
                                                         ParentGroupId = parentPropertyTypeGroup.Id,
                                                         Text = parentPropertyTypeGroup.Text,
                                                         SortOrder = parentPropertyTypeGroup.SortOrder
@@ -69,19 +70,18 @@ namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSixZeroOne
                             propertyGroup.Id = id;
                             propertyGroups.Add(propertyGroup);
                             //Update the reference to the new PropertyTypeGroup on the current PropertyType
-                            propertyType.PropertyTypeGroupId = id;
-                            database.Update(propertyType);
+                            propertyType.propertyTypeGroupId = id;
+							database.Update("cmsPropertyType", "id", propertyType);
                         }
                         else
                         {
-                            //Update the reference to the existing PropertyTypeGroup on the current PropertyType
-                            propertyType.PropertyTypeGroupId = existingPropertyTypeGroup.Id;
-                            database.Update(propertyType);
+							//Update the reference to the existing PropertyTypeGroup on the current PropertyType
+							propertyType.propertyTypeGroupId = existingPropertyTypeGroup.Id;
+							database.Update("cmsPropertyType", "id", propertyType);
                         }
                     }
                 }
             }
-
             return string.Empty;
         }
     }


### PR DESCRIPTION
… field on cmsPropertyType table

Migration happening in 6.0.2 failing due to use of a PropertyTypeDto type where we have added UniqueId in 7.3.0.