### PR TITLE
U4-7508 - IsChildOfListView should be populated for Media items

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
@@ -84,6 +84,33 @@ namespace Umbraco.Web.Models.Mapping
 
         private static void AfterMap(IMedia media, MediaItemDisplay display, IDataTypeService dataTypeService)
         {
+			// Adapted from ContentModelMapper
+			//map the IsChildOfListView (this is actually if it is a descendant of a list view!)
+            //TODO: Fix this shorthand .Ancestors() lookup, at least have an overload to use the current
+            if (media.HasIdentity)
+            {
+                var ancesctorListView = media.Ancestors().FirstOrDefault(x => x.ContentType.IsContainer);
+                display.IsChildOfListView = ancesctorListView != null;
+            }
+            else
+            {
+                //it's new so it doesn't have a path, so we need to look this up by it's parent + ancestors
+                var parent = media.Parent();
+                if (parent == null)
+                {
+                    display.IsChildOfListView = false;
+                }
+                else if (parent.ContentType.IsContainer)
+                {
+                    display.IsChildOfListView = true;
+                }
+                else
+                {
+                    var ancesctorListView = parent.Ancestors().FirstOrDefault(x => x.ContentType.IsContainer);
+                    display.IsChildOfListView = ancesctorListView != null;
+                }
+            }
+			
             //map the tree node url
             if (HttpContext.Current != null)
             {


### PR DESCRIPTION
IsChildOfListView  on MediaItemDisplay was not being populated properly which results in that the Actions menu is not shown for Media items that are under list view.

This fix adapts the same logic used to populate the IsChildOfListView property for Content items.