### PR TITLE
U4-7503 Disable X-AspNetMvc-Version HTTP header

### DIFF
--- a/src/Umbraco.Web/UmbracoModule.cs
+++ b/src/Umbraco.Web/UmbracoModule.cs
@@ -490,6 +490,8 @@ namespace Umbraco.Web
                     httpContext.Response.Headers.Remove("Server");
                     //this doesn't normally work since IIS sets it but we'll keep it here anyways.
                     httpContext.Response.Headers.Remove("X-Powered-By");
+                    httpContext.Response.Headers.Remove("X-AspNet-Version");
+                    httpContext.Response.Headers.Remove("X-AspNetMvc-Version");
                 }
                 catch (PlatformNotSupportedException ex)
                 {

--- a/src/Umbraco.Web/WebBootManager.cs
+++ b/src/Umbraco.Web/WebBootManager.cs
@@ -145,6 +145,8 @@ namespace Umbraco.Web
             });
             ClientDependencySettings.Instance.MvcRendererCollection.Add(renderer);
             
+            // Disable the X-AspNetMvc-Version HTTP Header
+            MvcHandler.DisableMvcResponseHeader = true;
 
             InstallHelper insHelper = new InstallHelper(UmbracoContext.Current);
             insHelper.DeleteLegacyInstaller();


### PR DESCRIPTION
The X-AspNetMvc-Version HTTP header has reappeared since upgrading to MVC 5, so this PR removes it. I've also removed the X-AspNet-Version within the code as suggested by Sebastiaan.