### PR TITLE
Removes NewGuid constraint on cmsPropertyType and fixes Key issue

### DIFF
--- a/src/Umbraco.Core/Models/Rdbms/PropertyTypeDto.cs
+++ b/src/Umbraco.Core/Models/Rdbms/PropertyTypeDto.cs
@@ -10,12 +10,6 @@ namespace Umbraco.Core.Models.Rdbms
     [ExplicitColumns]
     internal class PropertyTypeDto
     {
-        public PropertyTypeDto()
-        {
-            //by default always create a new guid
-            UniqueId = Guid.NewGuid();
-        }
-
         [Column("id")]
         [PrimaryKeyColumn(IdentitySeed = 50)]
         public int Id { get; set; }
@@ -62,7 +56,6 @@ namespace Umbraco.Core.Models.Rdbms
 
         [Column("UniqueID")]
         [NullSetting(NullSetting = NullSettings.NotNull)]
-        [Constraint(Default = SystemMethods.NewGuid)]
         [Index(IndexTypes.UniqueNonClustered, Name = "IX_cmsPropertyTypeUniqueID")]
         public Guid UniqueId { get; set; }
     }

--- a/src/Umbraco.Core/Persistence/Factories/PropertyGroupFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/PropertyGroupFactory.cs
@@ -129,11 +129,7 @@ namespace Umbraco.Core.Persistence.Factories
                 Name = propertyType.Name,
                 SortOrder = propertyType.SortOrder,
                 ValidationRegExp = propertyType.ValidationRegExp,
-                UniqueId = propertyType.HasIdentity
-                    ? propertyType.Key == Guid.Empty
-                        ? Guid.NewGuid()
-                        : propertyType.Key
-                    : Guid.NewGuid()
+                UniqueId = propertyType.Key == Guid.Empty ? Guid.NewGuid() : propertyType.Key
             };
 
             if (tabId != default(int))

--- a/src/Umbraco.Core/Persistence/Repositories/ContentTypeBaseRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentTypeBaseRepository.cs
@@ -454,6 +454,7 @@ AND umbracoNode.id <> @id",
                 propType.DataTypeDefinitionId = dto.DataTypeId;
                 propType.Description = dto.Description;
                 propType.Id = dto.Id;
+                propType.Key = dto.UniqueId;
                 propType.Name = dto.Name;
                 propType.Mandatory = dto.Mandatory;
                 propType.SortOrder = dto.SortOrder;

--- a/src/Umbraco.Tests/Services/Importing/PackageImportTests.cs
+++ b/src/Umbraco.Tests/Services/Importing/PackageImportTests.cs
@@ -75,6 +75,31 @@ namespace Umbraco.Tests.Services.Importing
         }
 
         [Test]
+        public void PackagingService_Can_Import_Inherited_ContentTypes_And_Verify_PropertyTypes_UniqueIds()
+        {
+            // Arrange
+            string strXml = ImportResources.InheritedDocTypes_Package;
+            var xml = XElement.Parse(strXml);
+            var dataTypeElement = xml.Descendants("DataTypes").First();
+            var templateElement = xml.Descendants("Templates").First();
+            var docTypeElement = xml.Descendants("DocumentTypes").First();
+            var packagingService = ServiceContext.PackagingService;
+
+            // Act
+            var dataTypes = packagingService.ImportDataTypeDefinitions(dataTypeElement);
+            var templates = packagingService.ImportTemplates(templateElement);
+            var contentTypes = packagingService.ImportContentTypes(docTypeElement);
+
+            // Assert
+            var mRBasePage = contentTypes.First(x => x.Alias == "MRBasePage");
+            foreach (var propertyType in mRBasePage.PropertyTypes)
+            {
+                var propertyTypeDto = this.DatabaseContext.Database.First<PropertyTypeDto>("WHERE id = @id", new { id = propertyType.Id });
+                Assert.AreEqual(propertyTypeDto.UniqueId, propertyType.Key);
+            }
+        }
+
+        [Test]
         public void PackagingService_Can_Import_Inherited_ContentTypes_And_Verify_PropertyGroups_And_PropertyTypes()
         {
             // Arrange


### PR DESCRIPTION
This removes the database constraint on the `UniqueID` column, so the guid can be controlled from code. Also fixes an issue where the UniqueId would be different in the database vs the `PropertyType.Key` property in a ContentTypes PropertyTypes collection. This was mostly apparent when installing a package, so a test has been added for that specific scenario.