### PR TITLE
U4-7601 - filter nodes based on composition

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web.Caching;
-using System.Web.UI;
 using Umbraco.Core.Cache;
 
 namespace Umbraco.Core.Models.PublishedContent
@@ -27,6 +24,7 @@ namespace Umbraco.Core.Models.PublishedContent
         {
             Id = contentType.Id;
             Alias = contentType.Alias;
+            CompositionAliases = contentType.CompositionAliases();
             _propertyTypes = contentType.CompositionPropertyTypes
                 .Select(x => new PublishedPropertyType(this, x))
                 .ToArray();
@@ -34,10 +32,11 @@ namespace Umbraco.Core.Models.PublishedContent
         }
 
         // internal so it can be used for unit tests
-        internal PublishedContentType(int id, string alias, IEnumerable<PublishedPropertyType> propertyTypes)
+        internal PublishedContentType(int id, string alias, IEnumerable<string> compositionAliases, IEnumerable<PublishedPropertyType> propertyTypes)
         {
             Id = id;
             Alias = alias;
+            CompositionAliases = compositionAliases;
             _propertyTypes = propertyTypes.ToArray();
             foreach (var propertyType in _propertyTypes)
                 propertyType.ContentType = this;
@@ -45,8 +44,8 @@ namespace Umbraco.Core.Models.PublishedContent
         }
 
         // create detached content type - ie does not match anything in the DB
-        internal PublishedContentType(string alias, IEnumerable<PublishedPropertyType> propertyTypes)
-            : this (0, alias, propertyTypes)
+        internal PublishedContentType(string alias, IEnumerable<string> compositionAliases, IEnumerable<PublishedPropertyType> propertyTypes)
+            : this(0, alias, compositionAliases, propertyTypes)
         { }
 
         private void InitializeIndexes()
@@ -63,6 +62,7 @@ namespace Umbraco.Core.Models.PublishedContent
 
         public int Id { get; private set; }
         public string Alias { get; private set; }
+        public IEnumerable<string> CompositionAliases { get; private set; }
 
         #endregion
 

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentMoreTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentMoreTests.cs
@@ -234,9 +234,9 @@ namespace Umbraco.Tests.PublishedContent
                         new PublishedPropertyType("prop1", 1, "?"), 
                     };
 
-            var contentType1 = new PublishedContentType(1, "ContentType1", props);
-            var contentType2 = new PublishedContentType(2, "ContentType2", props);
-            var contentType2s = new PublishedContentType(3, "ContentType2Sub", props);
+            var contentType1 = new PublishedContentType(1, "ContentType1", Enumerable.Empty<string>(), props);
+            var contentType2 = new PublishedContentType(2, "ContentType2", Enumerable.Empty<string>(), props);
+            var contentType2s = new PublishedContentType(3, "ContentType2Sub", Enumerable.Empty<string>(), props);
 
             cache.Add(new SolidPublishedContent(contentType1)
                 {

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTestElements.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTestElements.cs
@@ -355,7 +355,11 @@ namespace Umbraco.Tests.PublishedContent
         private static readonly PublishedPropertyType Default = new PublishedPropertyType("*", 0, "?");
 
         public AutoPublishedContentType(int id, string alias, IEnumerable<PublishedPropertyType> propertyTypes)
-            : base(id, alias, propertyTypes)
+            : base(id, alias, Enumerable.Empty<string>(), propertyTypes)
+        { }
+
+        public AutoPublishedContentType(int id, string alias, IEnumerable<string> compositionAliases, IEnumerable<PublishedPropertyType> propertyTypes)
+            : base(id, alias, compositionAliases, propertyTypes)
         { }
 
         public override PublishedPropertyType GetPropertyType(string alias)

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -50,7 +50,8 @@ namespace Umbraco.Tests.PublishedContent
                     new PublishedPropertyType("content", 0, Constants.PropertyEditors.TinyMCEAlias), 
                     new PublishedPropertyType("testRecursive", 0, "?"), 
                 };
-            var type = new AutoPublishedContentType(0, "anything", propertyTypes);
+            var compositionAliases = new[] {"MyCompositionAlias"};
+            var type = new AutoPublishedContentType(0, "anything", compositionAliases, propertyTypes);
             PublishedContentType.GetPublishedContentTypeCallback = (alias) => type;
         }
 
@@ -468,6 +469,16 @@ namespace Umbraco.Tests.PublishedContent
 			Assert.IsNull(doc.FirstChild<IPublishedContent>());
 		}
 
+        [Test]
+        public void IsComposedOf()
+        {
+            var doc = GetNode(1173);
+
+            var isComposedOf = doc.IsComposedOf("MyCompositionAlias");
+
+            Assert.IsTrue(isComposedOf);
+        }
+
 		[Test]
 		public void HasProperty()
 		{
@@ -475,8 +486,7 @@ namespace Umbraco.Tests.PublishedContent
 
 			var hasProp = doc.HasProperty(Constants.Conventions.Content.UrlAlias);
 
-			Assert.AreEqual(true, (bool)hasProp);
-
+            Assert.IsTrue(hasProp);
 		}
 
 		[Test]

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -410,7 +410,9 @@
     <Compile Include="PublishedContent\PublishedContentDataTableTests.cs" />
     <Compile Include="PublishedContent\PublishedContentTestBase.cs" />
     <Compile Include="PublishedContent\PublishedContentTestElements.cs" />
-    <Compile Include="PublishedContent\PublishedContentTests.cs" />
+    <Compile Include="PublishedContent\PublishedContentTests.cs">
+      <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="PublishedContent\PublishedMediaTests.cs" />
     <Compile Include="HashCodeCombinerTests.cs" />
     <Compile Include="Mvc\HtmlHelperExtensionMethodsTests.cs" />

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -116,6 +116,21 @@ namespace Umbraco.Web
 
         #endregion
 
+        #region IsComposedOf
+
+        /// <summary>
+        /// Gets a value indicating whether the content is of a content type composed of the given alias
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="alias">The content type alias.</param>
+        /// <returns>A value indicating whether the content is of a content type composed of a content type identified by the alias.</returns>
+        public static bool IsComposedOf(this IPublishedContent content, string alias)
+        {
+            return content.ContentType.CompositionAliases.Contains(alias);
+        }
+
+        #endregion
+
         #region HasProperty
 
         /// <summary>


### PR DESCRIPTION
This PR creates an extension method on IPublishedContent that allows you to filter nodes based on what document types they are composed of, in the following way:

```
<ul>
@foreach(var c in
    Umbraco.TypedContentAtRoot().First().Children
	    .Where(x => x.IsComposedOf("Seo")))
{
	<li>@c.Name</li>
}
</ul>
```