### PR TITLE
MarkdownEditor fix and ValueConverter

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
@@ -1,5 +1,5 @@
 //inject umbracos assetsServce and dialog service
-function MarkdownEditorController($scope, assetsService, dialogService, $timeout) {
+function MarkdownEditorController($scope, assetsService, dialogService, angularHelper, $timeout) {
 
     //tell the assets service to load the markdown.editor libs from the markdown editors
     //plugin folder
@@ -17,29 +17,31 @@ function MarkdownEditorController($scope, assetsService, dialogService, $timeout
         .then(function () {
 
             // we need a short delay to wait for the textbox to appear.
-            setTimeout(function () {
-                //this function will execute when all dependencies have loaded
-                // but in the case that they've been previously loaded, we can only 
-                // init the md editor after this digest because the DOM needs to be ready first
-                // so run the init on a timeout
-                $timeout(function () {
-                    var converter2 = new Markdown.Converter();
-                    var editor2 = new Markdown.Editor(converter2, "-" + $scope.model.alias);
-                    editor2.run();
+            //this function will execute when all dependencies have loaded
+            // but in the case that they've been previously loaded, we can only 
+            // init the md editor after this digest because the DOM needs to be ready first
+            // so run the init on a timeout
+            $timeout(function () {
+                var converter2 = new Markdown.Converter();
+                var editor2 = new Markdown.Editor(converter2, "-" + $scope.model.alias);
+                editor2.run();
 
-                    //subscribe to the image dialog clicks
-                    editor2.hooks.set("insertImageDialog", function (callback) {
+                //subscribe to the image dialog clicks
+                editor2.hooks.set("insertImageDialog", function (callback) {
 
-                        dialogService.mediaPicker({
-                            callback: function (data) {
-                                callback(data.image);
-                            }
-                        });
-
-                        return true; // tell the editor that we'll take care of getting the image url
+                    dialogService.mediaPicker({
+                        callback: function (data) {
+                            callback(data.image);
+                        }
                     });
-                }, 200);
-            });
+
+                    return true; // tell the editor that we'll take care of getting the image url
+                });
+
+                editor2.hooks.set("onPreviewRefresh", function () {
+                    angularHelper.getCurrentForm($scope).$setDirty();
+                });
+            }, 200);
 
             //load the seperat css for the editor to avoid it blocking our js loading TEMP HACK
             assetsService.loadCss("lib/markdown/markdown.css");

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
@@ -1,5 +1,5 @@
 //inject umbracos assetsServce and dialog service
-function MarkdownEditorController($scope, assetsService, dialogService, angularHelper, $timeout) {
+function MarkdownEditorController($scope, $element, assetsService, dialogService, angularHelper, $timeout) {
 
     //tell the assets service to load the markdown.editor libs from the markdown editors
     //plugin folder
@@ -40,6 +40,10 @@ function MarkdownEditorController($scope, assetsService, dialogService, angularH
 
                 editor2.hooks.set("onPreviewRefresh", function () {
                     angularHelper.getCurrentForm($scope).$setDirty();
+                    // We must manually update the model as there is no way to hook into the markdown editor events without editing that code.
+                    $scope.$apply(function () {
+                        $scope.model.value = $("textarea", $element).val();
+                    });
                 });
             }, 200);
 

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MarkdownSharp;
+using System;
 using System.Web;
 using Umbraco.Core;
 using Umbraco.Core.Models.PublishedContent;
@@ -31,8 +32,11 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
         public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
         {
+            // Convert markup to html for frontend rendering.
+            Markdown mark = new Markdown();
+
             // source should come from ConvertSource and be a string (or null) already
-            return new HtmlString(source == null ? string.Empty : (string)source);
+            return new HtmlString(source == null ? string.Empty : mark.Transform((string)source));
         }
 
         public override object ConvertSourceToXPath(PublishedPropertyType propertyType, object source, bool preview)

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -132,6 +132,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Lucene.Net.2.9.4.1\lib\net40\Lucene.Net.dll</HintPath>
     </Reference>
+    <Reference Include="MarkdownSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdown.1.14.4\lib\net45\MarkdownSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>

--- a/src/Umbraco.Web/packages.config
+++ b/src/Umbraco.Web/packages.config
@@ -6,6 +6,7 @@
   <package id="Examine" version="0.1.68.0" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net45" />
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net45" />
+  <package id="Markdown" version="1.14.4" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Owin" version="2.2.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />


### PR DESCRIPTION
Quick fix for http://issues.umbraco.org/issue/U4-7524.  

### Fix for editing
This properly sets the form dirt and manually updates the model when changes are detected to fix:
-  Unsaved changes warning not appearing.
-  Changes done with buttons not updating model and being saved.
- Changed done with keyboard shortcuts not updating model and being saved.

### Fix for rendering
I also add a reference to the Markdown library and added code to the MarkdownEditorValueConverter to automatically process and render HTML on templates and user code instead of returning the raw markup.

Both of these will return processed HtmlString not the raw markup.
```
@CurrentPage.markup
@Umbraco.Field("markup")
```

The raw markup can still be manually retrieved with the following in templates and user code.
```
@{
var rawMarkup = Model.Content.GetPropertyValue<string>("markup");
}
@rawMarkup
```

### Other Fixes
Also removed duplicate timeout checks.