### PR TITLE
Temp pvs studio

### DIFF
--- a/src/Umbraco.Core/Media/Exif/ExifPropertyCollection.cs
+++ b/src/Umbraco.Core/Media/Exif/ExifPropertyCollection.cs
@@ -75,7 +75,7 @@ namespace Umbraco.Core.Media.Exif
 		{
 			if (items.ContainsKey (key))
 				items.Remove (key);
-			if (key == ExifTag.WindowsTitle || key == ExifTag.WindowsTitle || key == ExifTag.WindowsComment || key == ExifTag.WindowsAuthor || key == ExifTag.WindowsKeywords || key == ExifTag.WindowsSubject) {
+			if (key == ExifTag.WindowsTitle || key == ExifTag.WindowsComment || key == ExifTag.WindowsAuthor || key == ExifTag.WindowsKeywords || key == ExifTag.WindowsSubject) {
 				items.Add (key, new WindowsByteString (key, value));
 			} else {
 				items.Add (key, new ExifAscii (key, value, parent.Encoding));

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -111,7 +111,7 @@ namespace Umbraco.Core.Services
 
             member.RawPasswordValue = result.RawPasswordValue;
             member.LastPasswordChangeDate = result.LastPasswordChangeDate;
-            member.UpdateDate = member.UpdateDate;
+            member.UpdateDate = result.UpdateDate;
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -266,7 +266,7 @@ namespace Umbraco.Core.Services
                 //should never be null but it could have been deleted by another thread.
                 user.RawPasswordValue = result.RawPasswordValue;
                 user.LastPasswordChangeDate = result.LastPasswordChangeDate;
-                user.UpdateDate = user.UpdateDate;
+                user.UpdateDate = result.UpdateDate;
             }
         }
 

--- a/src/Umbraco.Tests/UriExtensionsTests.cs
+++ b/src/Umbraco.Tests/UriExtensionsTests.cs
@@ -141,7 +141,7 @@ namespace Umbraco.Tests
         public void GetAbsolutePathDecoded(string input, string expected)
         {
             var source = new Uri(input, UriKind.RelativeOrAbsolute);
-            var output = source.GetSafeAbsolutePathDecoded();
+            var output = source.GetAbsolutePathDecoded();
             Assert.AreEqual(expected, output);
         }
 

--- a/src/Umbraco.Web/Models/ImageCropDataSet.cs
+++ b/src/Umbraco.Web/Models/ImageCropDataSet.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Web.Models
 
         public bool HasFocalPoint()
         {
-            return FocalPoint != null && FocalPoint.Top != 0.5m && FocalPoint.Top != 0.5m;
+            return FocalPoint != null && FocalPoint.Left != 0.5m && FocalPoint.Top != 0.5m;
         }
 
         public bool HasCrop(string alias)

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/BaseTree.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/BaseTree.cs
@@ -500,7 +500,7 @@ namespace umbraco.cms.presentation.Trees
         /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
         protected virtual void OnBeforeNodeRender(ref XmlTree sender, ref XmlTreeNode node, EventArgs e)
         {
-            if (node != null && node != null)
+            if (sender != null && node != null)
             {
                 if (BeforeNodeRender != null)
                     BeforeNodeRender(ref sender, ref node, e);    

--- a/src/umbraco.editorControls/tinyMCE3/TinyMCE.cs
+++ b/src/umbraco.editorControls/tinyMCE3/TinyMCE.cs
@@ -164,13 +164,8 @@ namespace umbraco.editorControls.tinyMCE3
                                     foreach (StylesheetProperty p in s.Properties)
                                     {
                                         if (styles != string.Empty)
-                                        {
                                             styles += ";";
-                                        }
-                                        if (p.Alias.StartsWith("."))
-                                            styles += p.Text + "=" + p.Alias;
-                                        else
-                                            styles += p.Text + "=" + p.Alias;
+                                        styles += p.Text + "=" + p.Alias;
                                     }
 
                                     cssFiles += ",";


### PR DESCRIPTION
See http://www.viva64.com/en/b/0357/#ID0EWKAE

Code sample No.3 seems to be indeed superfluous code, removed the double check

Code sample No.4 leads to some code that's commented with: 
> // check db field type being saved to and store prevalue id as an int or a string - note can never save a prevalue id to a date field ! 

So no action is required here, the date field cannot be used.

Code sample No.5 - no idea what the intention was here, don't think it matters, just removed the `if` check.

Code sample No.8 - the code is super old and only used for macroscripts as far as I can tell, don't care about this.

Code sample No.9 - really not sure what the intention was here, it could help with syncing the tree, but in my tests there was no difference, dropped the recommendation.