### PR TITLE
U4-5168 Media Items label says "Document Type" instead of  "Media Type"

### DIFF
--- a/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
@@ -2,10 +2,10 @@
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using Umbraco.Core.Dictionary;
 
 namespace Umbraco.Core.Services
 {
-
     /// <summary>
     /// Extension methods for ILocalizedTextService
     /// </summary>
@@ -60,6 +60,35 @@ namespace Umbraco.Core.Services
 
             return variables.Select((s, i) => new { index = i.ToString(CultureInfo.InvariantCulture), value = s })
                 .ToDictionary(keyvals => keyvals.index, keyvals => keyvals.value);
+        }
+
+        private static ICultureDictionary _cultureDictionary;
+
+        internal static string UmbracoDictionaryTranslate(this ILocalizedTextService manager, string text)
+        {
+            var cultureDictionary = CultureDictionary;
+            return UmbracoDictionaryTranslate(text, cultureDictionary);
+        }
+
+        private static string UmbracoDictionaryTranslate(string text, ICultureDictionary cultureDictionary)
+        {
+            if (text == null)
+                return null;
+
+            if (text.StartsWith("#") == false)
+                return text;
+
+            text = text.Substring(1);
+            return cultureDictionary[text].IfNullOrWhiteSpace(text);
+        }
+
+        private static ICultureDictionary CultureDictionary
+        {
+            get
+            {
+                return _cultureDictionary
+                    ?? (_cultureDictionary = CultureDictionaryFactoryResolver.Current.Factory.CreateDictionary());
+            }
         }
     }
 }

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -1,18 +1,14 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Web.Http;
 using AutoMapper;
-using Umbraco.Core;
-using Umbraco.Core.Dictionary;
 using Umbraco.Core.Models;
+using Umbraco.Web.Models;
 using Umbraco.Web.Models.ContentEditing;
-using Umbraco.Web.Models.Mapping;
 using Umbraco.Web.Mvc;
-using Umbraco.Web.WebApi;
-using System.Linq;
-using Umbraco.Web.WebApi.Filters;
 using Constants = Umbraco.Core.Constants;
-using Newtonsoft.Json;
+using Umbraco.Core.Services;
 
 namespace Umbraco.Web.Editors
 {
@@ -27,8 +23,6 @@ namespace Umbraco.Web.Editors
     [PluginController("UmbracoApi")]
     public class ContentTypeController : ContentTypeControllerBase
     {
-        private ICultureDictionary _cultureDictionary;
-
         /// <summary>
         /// Constructor
         /// </summary>
@@ -91,38 +85,13 @@ namespace Umbraco.Web.Editors
 
             var basics = types.Select(Mapper.Map<IContentType, ContentTypeBasic>).ToList();
 
+            var localizedTextService = Services.TextService;
             foreach (var basic in basics)
             {
-                basic.Name = TranslateItem(basic.Name);
-                basic.Description = TranslateItem(basic.Description);
+                basic.Name = localizedTextService.UmbracoDictionaryTranslate(basic.Name);
+                basic.Description = localizedTextService.UmbracoDictionaryTranslate(basic.Description);
             }
-
             return basics;
-        }
-
-        // TODO: This should really be centralized and used anywhere globalization applies.
-        internal string TranslateItem(string text)
-        {
-            if (text == null)
-            {
-                return null;
-            }
-
-            if (text.StartsWith("#") == false)
-                return text;
-
-            text = text.Substring(1);
-            return CultureDictionary[text].IfNullOrWhiteSpace(text);
-        }
-
-        private ICultureDictionary CultureDictionary
-        {
-            get
-            {
-                return
-                    _cultureDictionary ??
-                    (_cultureDictionary = CultureDictionaryFactoryResolver.Current.Factory.CreateDictionary());
-            }
         }
     }
 }

--- a/src/Umbraco.Web/Editors/MemberController.cs
+++ b/src/Umbraco.Web/Editors/MemberController.cs
@@ -135,7 +135,7 @@ namespace Umbraco.Web.Editors
                 ParentId = -1
             };
 
-            TabsAndPropertiesResolver.AddListView(display, "member", Services.DataTypeService);
+            TabsAndPropertiesResolver.AddListView(display, "member", Services.DataTypeService, Services.TextService);
 
             return display;
         }
@@ -343,12 +343,13 @@ namespace Umbraco.Web.Editors
             //lasty, if it is not valid, add the modelstate to the outgoing object and throw a 403
             HandleInvalidModelState(display);
 
+            var localizedTextService = Services.TextService;
             //put the correct msgs in 
             switch (contentItem.Action)
             {
                 case ContentSaveAction.Save:
                 case ContentSaveAction.SaveNew:
-                    display.AddSuccessNotification(ui.Text("speechBubbles", "editMemberSaved"), ui.Text("speechBubbles", "editMemberSaved"));
+                    display.AddSuccessNotification(localizedTextService.Localize("speechBubbles/editMemberSaved"), localizedTextService.Localize("speechBubbles/editMemberSaved"));
                     break;
             }
 

--- a/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Web;
 using AutoMapper;
 using Umbraco.Core;
-using Umbraco.Core.Dictionary;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
@@ -18,16 +15,19 @@ namespace Umbraco.Web.Models.Mapping
     /// Creates the tabs collection with properties assigned for display models
     /// </summary>
     internal class TabsAndPropertiesResolver : ValueResolver<IContentBase, IEnumerable<Tab<ContentPropertyDisplay>>>
-    {        
-        private ICultureDictionary _cultureDictionary;
+    {
+        private readonly ILocalizedTextService _localizedTextService;
         protected IEnumerable<string> IgnoreProperties { get; set; }
 
-        public TabsAndPropertiesResolver()
+        public TabsAndPropertiesResolver(ILocalizedTextService localizedTextService)
         {
+            if (localizedTextService == null) throw new ArgumentNullException("localizedTextService");
+            _localizedTextService = localizedTextService;
             IgnoreProperties = new List<string>();
         }
 
-        public TabsAndPropertiesResolver(IEnumerable<string> ignoreProperties)
+        public TabsAndPropertiesResolver(ILocalizedTextService localizedTextService, IEnumerable<string> ignoreProperties)
+            : this(localizedTextService)
         {         
             if (ignoreProperties == null) throw new ArgumentNullException("ignoreProperties");
             IgnoreProperties = ignoreProperties;
@@ -38,6 +38,7 @@ namespace Umbraco.Web.Models.Mapping
         /// </summary>
         /// <param name="content"></param>
         /// <param name="display"></param>
+        /// <param name="localizedTextService"></param>
         /// <param name="customProperties">
         /// Any additional custom properties to assign to the generic properties tab. 
         /// </param>
@@ -49,6 +50,7 @@ namespace Umbraco.Web.Models.Mapping
         public static void MapGenericProperties<TPersisted>(
             TPersisted content,
             ContentItemDisplayBase<ContentPropertyDisplay, TPersisted> display,
+            ILocalizedTextService localizedTextService,
             IEnumerable<ContentPropertyDisplay> customProperties = null,
             Action<List<ContentPropertyDisplay>> onGenericPropertiesMapped = null)
             where TPersisted : IContentBase
@@ -72,32 +74,25 @@ namespace Umbraco.Web.Models.Mapping
                 new ContentPropertyDisplay
                 {
                     Alias = string.Format("{0}creator", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
-                    Label = ui.Text("content", "createBy"),
-                    Description = ui.Text("content", "createByDesc"), //TODO: Localize this
+                    Label = localizedTextService.Localize("content/createBy"),
+                    Description = localizedTextService.Localize("content/createByDesc"),
                     Value = display.Owner.Name,
                     View = labelEditor
                 },
                 new ContentPropertyDisplay
                 {
                     Alias = string.Format("{0}createdate", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
-                    Label = ui.Text("content", "createDate"),
-                    Description = ui.Text("content", "createDateDesc"),
+                    Label = localizedTextService.Localize("content/createDate"),
+                    Description = localizedTextService.Localize("content/createDateDesc"),
                     Value = display.CreateDate.ToIsoString(),
                     View = labelEditor
                 },
                 new ContentPropertyDisplay
                 {
                     Alias = string.Format("{0}updatedate", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
-                    Label = ui.Text("content", "updateDate"),
-                    Description = ui.Text("content", "updateDateDesc"),
+                    Label = localizedTextService.Localize("content/updateDate"),
+                    Description = localizedTextService.Localize("content/updateDateDesc"),
                     Value = display.UpdateDate.ToIsoString(),
-                    View = labelEditor
-                },
-                new ContentPropertyDisplay
-                {
-                    Alias = string.Format("{0}doctype", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
-                    Label = ui.Text("content", "documentType"),
-                    Value = TranslateItem(display.ContentTypeName, CreateDictionary()),
                     View = labelEditor
                 }
             };
@@ -131,7 +126,7 @@ namespace Umbraco.Web.Models.Mapping
         /// <param name="display"></param>
         /// <param name="entityType">This must be either 'content' or 'media'</param>
         /// <param name="dataTypeService"></param>
-        internal static void AddListView<TPersisted>(TabbedContentItem<ContentPropertyDisplay, TPersisted> display, string entityType, IDataTypeService dataTypeService)
+        internal static void AddListView<TPersisted>(TabbedContentItem<ContentPropertyDisplay, TPersisted> display, string entityType, IDataTypeService dataTypeService, ILocalizedTextService localizedTextService)
              where TPersisted : IContentBase
         {
             int dtdId;
@@ -171,7 +166,7 @@ namespace Umbraco.Web.Models.Mapping
 
             var listViewTab = new Tab<ContentPropertyDisplay>();
             listViewTab.Alias = Constants.Conventions.PropertyGroups.ListViewGroupName;
-            listViewTab.Label = ui.Text("content", "childItems");
+            listViewTab.Label = localizedTextService.Localize("content/childItems");
             listViewTab.Id = 25;
             listViewTab.IsActive = true;
 
@@ -227,11 +222,12 @@ namespace Umbraco.Web.Models.Mapping
 
                 //then we'll just use the root group's data to make the composite tab
                 var rootGroup = propertyGroups.First(x => x.ParentId == null);
+                
                 aggregateTabs.Add(new Tab<ContentPropertyDisplay>
                     {
                         Id = rootGroup.Id,
                         Alias = rootGroup.Name,
-                        Label = TranslateItem(rootGroup.Name),
+                        Label = _localizedTextService.UmbracoDictionaryTranslate(rootGroup.Name),
                         Properties = aggregateProperties,
                         IsActive = false
                     });
@@ -248,7 +244,7 @@ namespace Umbraco.Web.Models.Mapping
             aggregateTabs.Add(new Tab<ContentPropertyDisplay>
                 {
                     Id = 0,
-                    Label = ui.Text("general", "properties"),
+                    Label = _localizedTextService.Localize("general/properties"),
                     Alias = "Generic properties",
                     Properties = genericproperties
                 });
@@ -264,45 +260,9 @@ namespace Umbraco.Web.Models.Mapping
             // Not sure whether it's a good idea to add this to the ContentPropertyDisplay mapper
             foreach (var prop in properties)
             {
-                prop.Label = TranslateItem(prop.Label);
-                prop.Description = TranslateItem(prop.Description);
+                prop.Label = _localizedTextService.UmbracoDictionaryTranslate(prop.Label);
+                prop.Description = _localizedTextService.UmbracoDictionaryTranslate(prop.Description);
             }
-        }
-
-        // TODO: This should really be centralized and used anywhere globalization applies.
-        internal string TranslateItem(string text)
-        {
-            var cultureDictionary = CultureDictionary;
-            return TranslateItem(text, cultureDictionary);
-        }
-
-        private static string TranslateItem(string text, ICultureDictionary cultureDictionary)
-        {
-            if (text == null)
-            {
-                return null;
-            }
-
-            if (text.StartsWith("#") == false)
-                return text;
-
-            text = text.Substring(1);
-            return cultureDictionary[text].IfNullOrWhiteSpace(text);
-        }
-
-        private ICultureDictionary CultureDictionary
-        {
-            get
-            {
-                return 
-                    _cultureDictionary ?? 
-                    (_cultureDictionary = CreateDictionary());
-            }
-        }
-
-        private static ICultureDictionary CreateDictionary()
-        {
-            return CultureDictionaryFactoryResolver.Current.Factory.CreateDictionary();
         }
     }
 }


### PR DESCRIPTION
Sounds so easy.. But it turned into Uncle Bob's boyscout rule (http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)

So: There was methods in several places to translate doctypes/properties/etc through the dictionary in Umbraco (anything that starts with "#"). I moved those methods to LocalizedTextServiceExtensions. 
Then I made sure the `ILocalizedTextService` was available everywhere where I touched some of the code to fix this issue and used `ILocalizedTextService` to remove all the `ui.Text` references.

Finally, to actually fix this issue: `TabsAndPropertiesResolver` is used by content, media and members and that's where it was hard coding "Document Type" as the label. I removed it there and added the property to the content,media and member modelmappers instead where they can be properly named.

I've tested: 

- content, media and members now have the correct label, fixing U4-5168
- all the changes from `ui.Text` to `localizedTextService.Localize` show the correct translations from our xml files
- did dictionary translations for: 
 - document type name 
 - document type description
 - property name
 - property description
 - template name

They all showed up properly translated throughout the backoffice using Umbraco's dictionary. 