### PR TITLE
U4-7612 Properties Pane is empty when trying to add a new Property to…

### DIFF
--- a/src/Umbraco.Web/Editors/DataTypeController.cs
+++ b/src/Umbraco.Web/Editors/DataTypeController.cs
@@ -299,14 +299,16 @@ namespace Umbraco.Web.Editors
         {
             var dataTypes = Services.DataTypeService
                      .GetAllDataTypeDefinitions()
-                     .Select(Mapper.Map<IDataTypeDefinition, DataTypeBasic>);
+                     .Select(Mapper.Map<IDataTypeDefinition, DataTypeBasic>)
+                     .ToArray();
 
             var propertyEditors = PropertyEditorResolver.Current.PropertyEditors.ToArray();
 
             foreach (var dataType in dataTypes)
             {
-                var propertyEditor = propertyEditors.Single(x => x.Alias == dataType.Alias);
-                dataType.HasPrevalues = propertyEditor.PreValueEditor.Fields.Any(); ;
+                var propertyEditor = propertyEditors.SingleOrDefault(x => x.Alias == dataType.Alias);
+                if(propertyEditor != null)
+                    dataType.HasPrevalues = propertyEditor.PreValueEditor.Fields.Any(); ;
             }
 
             var grouped = dataTypes


### PR DESCRIPTION
… a new or existing Document Type

Problem is that sometimes people remove plugins from their App_Plugins folder while there is still a datatype that refers to that plugin in that folder. The `GetGroupedDataTypes` method would assume that the plugin files were still on disk and start reading them. So by checking if they exist and then not reading them this error is fixed.

Also added `.ToArray()` as ReSharper complained about iterating the collection multiple times (tip: read what ReSharper tells you :) )