### PR TITLE
Added a default value to the Umbaco.TrueFalse datatype.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
@@ -2,7 +2,7 @@ function booleanEditorController($scope, $rootScope, assetsService) {
 
     function setupViewModel() {
         $scope.renderModel = {
-            value: false
+            value: $scope.model.config.default || false
         };
         if ($scope.model && $scope.model.value && ($scope.model.value.toString() === "1" || angular.lowercase($scope.model.value) === "true")) {
             $scope.renderModel.value = true;

--- a/src/Umbraco.Web/PropertyEditors/TrueFalsePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalsePropertyEditor.cs
@@ -6,5 +6,15 @@ namespace Umbraco.Web.PropertyEditors
     [PropertyEditor(Constants.PropertyEditors.TrueFalseAlias, "True/False", "INT", "boolean", IsParameterEditor = true)]
     public class TrueFalsePropertyEditor : PropertyEditor
     {
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new TrueFalsePreValueEditor();
+        }
+
+        internal class TrueFalsePreValueEditor : PreValueEditor
+        {
+            [PreValueField("default", "Default Value", "boolean")]
+            public string Default { get; set; }
+        }
     }
 }


### PR DESCRIPTION
This is a quick and simple addition to the built in TrueFalse property adding a "Default Value" checkbox so that developers can easily add checkboxes that default to checked.