### PR TITLE
U4-7557 Support folders for import/export, packaging

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/EntityContainerRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/EntityContainerRepository.cs
@@ -47,6 +47,14 @@ namespace Umbraco.Core.Persistence.Repositories
             return nodeDto == null ? null : CreateEntity(nodeDto);
         }
 
+        public EntityContainer Get(string name, int level, Guid umbracoObjectTypeId)
+        {
+            var sql = GetBaseQuery(false).Where("text=@name AND level=@level AND nodeObjectType=@umbracoObjectTypeId", new { name, level, umbracoObjectTypeId });
+
+            var nodeDto = Database.Fetch<NodeDto>(sql).FirstOrDefault();
+            return nodeDto == null ? null : CreateEntity(nodeDto);
+        }
+
         protected override IEnumerable<EntityContainer> PerformGetAll(params int[] ids)
         {
             throw new NotImplementedException();

--- a/src/Umbraco.Core/Persistence/Repositories/EntityContainerRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/EntityContainerRepository.cs
@@ -47,12 +47,10 @@ namespace Umbraco.Core.Persistence.Repositories
             return nodeDto == null ? null : CreateEntity(nodeDto);
         }
 
-        public EntityContainer Get(string name, int level, Guid umbracoObjectTypeId)
+        public IEnumerable<EntityContainer> Get(string name, int level, Guid umbracoObjectTypeId)
         {
             var sql = GetBaseQuery(false).Where("text=@name AND level=@level AND nodeObjectType=@umbracoObjectTypeId", new { name, level, umbracoObjectTypeId });
-
-            var nodeDto = Database.Fetch<NodeDto>(sql).FirstOrDefault();
-            return nodeDto == null ? null : CreateEntity(nodeDto);
+            return Database.Fetch<NodeDto>(sql).Select(CreateEntity);
         }
 
         protected override IEnumerable<EntityContainer> PerformGetAll(params int[] ids)

--- a/src/Umbraco.Core/Services/ContentTypeService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeService.cs
@@ -141,16 +141,26 @@ namespace Umbraco.Core.Services
             }
         }
 
+        public EntityContainer GetMediaTypeContainer(string name, int level)
+        {
+            var uow = UowProvider.GetUnitOfWork();
+            using (var repo = RepositoryFactory.CreateEntityContainerRepository(uow))
+            {
+                var container = repo.Get(name, level, Constants.ObjectTypes.MediaTypeContainerGuid);
+                return container;
+            }
+        }
+
         public EntityContainer GetContentTypeContainer(Guid containerId)
         {
             return GetContainer(containerId, Constants.ObjectTypes.DocumentTypeGuid);
         }
-
+        
         public EntityContainer GetMediaTypeContainer(Guid containerId)
         {
             return GetContainer(containerId, Constants.ObjectTypes.MediaTypeGuid);
         }
-
+        
         private EntityContainer GetContainer(Guid containerId, Guid containedObjectType)
         {
             var uow = UowProvider.GetUnitOfWork();
@@ -160,6 +170,16 @@ namespace Umbraco.Core.Services
                 return container != null && container.ContainedObjectType == containedObjectType
                     ? container
                     : null;
+            }
+        }
+
+        public EntityContainer GetContentTypeContainer(string name, int level)
+        {
+            var uow = UowProvider.GetUnitOfWork();
+            using (var repo = RepositoryFactory.CreateEntityContainerRepository(uow))
+            {
+                var container = repo.Get(name, level, Constants.ObjectTypes.DocumentTypeContainerGuid);
+                return container;
             }
         }
 

--- a/src/Umbraco.Core/Services/ContentTypeService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeService.cs
@@ -141,13 +141,12 @@ namespace Umbraco.Core.Services
             }
         }
 
-        public EntityContainer GetMediaTypeContainer(string name, int level)
+        public IEnumerable<EntityContainer> GetMediaTypeContainers(string name, int level)
         {
             var uow = UowProvider.GetUnitOfWork();
             using (var repo = RepositoryFactory.CreateEntityContainerRepository(uow))
             {
-                var container = repo.Get(name, level, Constants.ObjectTypes.MediaTypeContainerGuid);
-                return container;
+                return repo.Get(name, level, Constants.ObjectTypes.MediaTypeContainerGuid);
             }
         }
 
@@ -173,13 +172,12 @@ namespace Umbraco.Core.Services
             }
         }
 
-        public EntityContainer GetContentTypeContainer(string name, int level)
+        public IEnumerable<EntityContainer> GetContentTypeContainers(string name, int level)
         {
             var uow = UowProvider.GetUnitOfWork();
             using (var repo = RepositoryFactory.CreateEntityContainerRepository(uow))
             {
-                var container = repo.Get(name, level, Constants.ObjectTypes.DocumentTypeContainerGuid);
-                return container;
+                return repo.Get(name, level, Constants.ObjectTypes.DocumentTypeContainerGuid);
             }
         }
 

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -78,13 +78,12 @@ namespace Umbraco.Core.Services
             }
         }
 
-        public EntityContainer GetContainer(string name, int level)
+        public IEnumerable<EntityContainer> GetContainers(string name, int level)
         {
             var uow = UowProvider.GetUnitOfWork();
             using (var repo = RepositoryFactory.CreateEntityContainerRepository(uow))
             {
-                var container = repo.Get(name, level, Constants.ObjectTypes.DataTypeContainerGuid);
-                return container;
+                return repo.Get(name, level, Constants.ObjectTypes.DataTypeContainerGuid);
             }
         }
 

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -78,6 +78,16 @@ namespace Umbraco.Core.Services
             }
         }
 
+        public EntityContainer GetContainer(string name, int level)
+        {
+            var uow = UowProvider.GetUnitOfWork();
+            using (var repo = RepositoryFactory.CreateEntityContainerRepository(uow))
+            {
+                var container = repo.Get(name, level, Constants.ObjectTypes.DataTypeContainerGuid);
+                return container;
+            }
+        }
+
         public void SaveContainer(EntityContainer container, int userId = 0)
         {
             if (container.ContainedObjectType != Constants.ObjectTypes.DataTypeGuid) 

--- a/src/Umbraco.Core/Services/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/EntityXmlSerializer.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net.Http.Formatting;
 using System.Xml;
 using System.Xml.Linq;
 using Umbraco.Core.Configuration;
@@ -139,6 +141,18 @@ namespace Umbraco.Core.Services
         /// <returns><see cref="XElement"/> containing the xml representation of the IDataTypeDefinition object</returns>
         public XElement Serialize(IDataTypeService dataTypeService, IDataTypeDefinition dataTypeDefinition)
         {
+            return Serialize(dataTypeService, dataTypeDefinition, string.Empty);
+        }
+
+        /// <summary>
+        /// Exports an <see cref="IDataTypeDefinition"/> item to xml as an <see cref="XElement"/>
+        /// </summary>
+        /// <param name="dataTypeService"></param>
+        /// <param name="dataTypeDefinition">IDataTypeDefinition type to export</param>
+        /// <param name="folders">The path of folders for this data type separated by a backslash, for example: `SEO/Meta`</param>
+        /// <returns><see cref="XElement"/> containing the xml representation of the IDataTypeDefinition object</returns>
+        public XElement Serialize(IDataTypeService dataTypeService, IDataTypeDefinition dataTypeDefinition, string folders)
+        {
             var prevalues = new XElement("PreValues");
             var prevalueList = dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinition.Id)
                 .FormatAsDictionary();
@@ -161,6 +175,8 @@ namespace Umbraco.Core.Services
             xml.Add(new XAttribute("Id", dataTypeDefinition.PropertyEditorAlias));
             xml.Add(new XAttribute("Definition", dataTypeDefinition.Key));
             xml.Add(new XAttribute("DatabaseType", dataTypeDefinition.DatabaseType.ToString()));
+            if(string.IsNullOrWhiteSpace(folders) == false)
+                xml.Add(new XAttribute("Folders", folders));
 
             return xml;
         }
@@ -322,8 +338,9 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="dataTypeService"></param>
         /// <param name="contentType">Content type to export</param>
+        /// <param name="folders">The path of folders for this content type separated by a backslash, for example: `SEO/Meta`</param>
         /// <returns><see cref="XElement"/> containing the xml representation of the IContentType object</returns>
-        public XElement Serialize(IDataTypeService dataTypeService, IContentType contentType)
+        public XElement Serialize(IDataTypeService dataTypeService, IContentType contentType, string folders = "")
         {
             var info = new XElement("Info",
                                     new XElement("Name", contentType.Name),
@@ -397,11 +414,16 @@ namespace Umbraco.Core.Services
                 tabs.Add(tab);
             }
 
-            return new XElement("DocumentType",
-                                   info,
-                                   structure,
-                                   genericProperties,
-                                   tabs);
+            var xml = new XElement("DocumentType",
+                info,
+                structure,
+                genericProperties,
+                tabs);
+
+            if(string.IsNullOrWhiteSpace(folders) == false)
+                xml.Add(new XAttribute("Folders", folders));
+
+            return xml;
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Services/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/EntityXmlSerializer.cs
@@ -338,9 +338,20 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="dataTypeService"></param>
         /// <param name="contentType">Content type to export</param>
+        /// <returns><see cref="XElement"/> containing the xml representation of the IContentType object</returns>
+        public XElement Serialize(IDataTypeService dataTypeService, IContentType contentType)
+        {
+            return Serialize(dataTypeService, contentType, string.Empty);
+        }
+
+        /// <summary>
+        /// Exports an <see cref="IContentType"/> item to xml as an <see cref="XElement"/>
+        /// </summary>
+        /// <param name="dataTypeService"></param>
+        /// <param name="contentType">Content type to export</param>
         /// <param name="folders">The path of folders for this content type separated by a backslash, for example: `SEO/Meta`</param>
         /// <returns><see cref="XElement"/> containing the xml representation of the IContentType object</returns>
-        public XElement Serialize(IDataTypeService dataTypeService, IContentType contentType, string folders = "")
+        public XElement Serialize(IDataTypeService dataTypeService, IContentType contentType, string folders)
         {
             var info = new XElement("Info",
                                     new XElement("Name", contentType.Name),

--- a/src/Umbraco.Core/Services/IContentTypeService.cs
+++ b/src/Umbraco.Core/Services/IContentTypeService.cs
@@ -24,10 +24,10 @@ namespace Umbraco.Core.Services
         void SaveMediaTypeContainer(EntityContainer container, int userId = 0);
         EntityContainer GetContentTypeContainer(int containerId);
         EntityContainer GetContentTypeContainer(Guid containerId);
-        EntityContainer GetContentTypeContainer(string folderName, int level);
+        IEnumerable<EntityContainer> GetContentTypeContainers(string folderName, int level);
         EntityContainer GetMediaTypeContainer(int containerId);
         EntityContainer GetMediaTypeContainer(Guid containerId);
-        EntityContainer GetMediaTypeContainer(string folderName, int level);
+        IEnumerable<EntityContainer> GetMediaTypeContainers(string folderName, int level);
         void DeleteMediaTypeContainer(int folderId, int userId = 0);
         void DeleteContentTypeContainer(int containerId, int userId = 0);
 

--- a/src/Umbraco.Core/Services/IContentTypeService.cs
+++ b/src/Umbraco.Core/Services/IContentTypeService.cs
@@ -24,8 +24,10 @@ namespace Umbraco.Core.Services
         void SaveMediaTypeContainer(EntityContainer container, int userId = 0);
         EntityContainer GetContentTypeContainer(int containerId);
         EntityContainer GetContentTypeContainer(Guid containerId);
+        EntityContainer GetContentTypeContainer(string folderName, int level);
         EntityContainer GetMediaTypeContainer(int containerId);
         EntityContainer GetMediaTypeContainer(Guid containerId);
+        EntityContainer GetMediaTypeContainer(string folderName, int level);
         void DeleteMediaTypeContainer(int folderId, int userId = 0);
         void DeleteContentTypeContainer(int containerId, int userId = 0);
 

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -14,6 +14,7 @@ namespace Umbraco.Core.Services
         void SaveContainer(EntityContainer container, int userId = 0);
         EntityContainer GetContainer(int containerId);
         EntityContainer GetContainer(Guid containerId);
+        EntityContainer GetContainer(string folderName, int level);
         void DeleteContainer(int containerId, int userId = 0);
 
         /// <summary>

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Core.Services
         void SaveContainer(EntityContainer container, int userId = 0);
         EntityContainer GetContainer(int containerId);
         EntityContainer GetContainer(Guid containerId);
-        EntityContainer GetContainer(string folderName, int level);
+        IEnumerable<EntityContainer> GetContainers(string folderName, int level);
         void DeleteContainer(int containerId, int userId = 0);
 
         /// <summary>

--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -462,27 +462,25 @@ namespace Umbraco.Core.Services
                 var foldersAttribute = documentType.Attribute("Folders");
                 if (foldersAttribute != null)
                 {
-                    var containerId = 0;
                     var alias = documentType.Element("Info").Element("Alias").Value;
-
                     var folders = foldersAttribute.Value.Split('/');
                     var rootFolder = HttpUtility.UrlDecode(folders[0]);
                     var current = _contentTypeService.GetContentTypeContainer(rootFolder, 1);
 
-                    var rootFolderId = current != null
-                        ? current.Id
-                        : _contentTypeService.CreateContentTypeContainer(-1, rootFolder).Result;
+                    if (current == null)
+                    {
+                        var rootFolderId = _contentTypeService.CreateContentTypeContainer(-1, rootFolder).Result;
+                        current = _contentTypeService.GetContentTypeContainer(rootFolderId);
+                    }
 
-                    current = _contentTypeService.GetContentTypeContainer(rootFolderId);
+                    importedFolders.Add(alias, current.Id);
 
                     for (var i = 1; i < folders.Length; i++)
                     {
                         var folderName = HttpUtility.UrlDecode(folders[i]);
                         current = CreateContentTypeChildFolder(folderName, current);
-                        containerId = current.Id;
+                        importedFolders[alias] = current.Id;
                     }
-
-                    importedFolders.Add(alias, containerId);
                 }
             }
 
@@ -877,7 +875,7 @@ namespace Umbraco.Core.Services
 
                 var dataTypeDefinitionId = new Guid(dataTypeElement.Attribute("Definition").Value);
                 var databaseTypeAttribute = dataTypeElement.Attribute("DatabaseType");
-                
+
                 var parentId = -1;
                 if (importedFolders.ContainsKey(dataTypeDefinitionName))
                     parentId = importedFolders[dataTypeDefinitionName];
@@ -951,27 +949,25 @@ namespace Umbraco.Core.Services
                 var foldersAttribute = datatypeElement.Attribute("Folders");
                 if (foldersAttribute != null)
                 {
-                    var containerId = 0;
                     var name = datatypeElement.Attribute("Name").Value;
-
                     var folders = foldersAttribute.Value.Split('/');
                     var rootFolder = HttpUtility.UrlDecode(folders[0]);
                     var current = _dataTypeService.GetContainer(rootFolder, 1);
 
-                    var rootFolderId = current != null
-                        ? current.Id
-                        : _dataTypeService.CreateContainer(-1, rootFolder).Result;
+                    if (current == null)
+                    {
+                        var rootFolderId = _dataTypeService.CreateContainer(-1, rootFolder).Result;
+                        current = _dataTypeService.GetContainer(rootFolderId);
+                    }
 
-                    current = _dataTypeService.GetContainer(rootFolderId);
+                    importedFolders.Add(name, current.Id);
 
                     for (var i = 1; i < folders.Length; i++)
                     {
                         var folderName = HttpUtility.UrlDecode(folders[i]);
                         current = CreateDataTypeChildFolder(folderName, current);
-                        containerId = current.Id;
+                        importedFolders[name] = current.Id;
                     }
-
-                    importedFolders.Add(name, containerId);
                 }
             }
 

--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Web;
+using System.Web.UI.WebControls;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Newtonsoft.Json;
@@ -11,12 +13,14 @@ using Umbraco.Core.Events;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
+using Umbraco.Core.Models.EntityBase;
 using Umbraco.Core.Models.Rdbms;
 using Umbraco.Core.Packaging;
 using Umbraco.Core.Packaging.Models;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Querying;
 using Umbraco.Core.Persistence.UnitOfWork;
+using Content = Umbraco.Core.Models.Content;
 
 namespace Umbraco.Core.Services
 {
@@ -34,6 +38,7 @@ namespace Umbraco.Core.Services
         private readonly IDataTypeService _dataTypeService;
         private readonly IFileService _fileService;
         private readonly ILocalizationService _localizationService;
+        private readonly IEntityService _entityService;
         private readonly RepositoryFactory _repositoryFactory;
         private readonly IDatabaseUnitOfWorkProvider _uowProvider;
         private Dictionary<string, IContentType> _importedContentTypes;
@@ -50,6 +55,7 @@ namespace Umbraco.Core.Services
             IDataTypeService dataTypeService,
             IFileService fileService,
             ILocalizationService localizationService,
+            IEntityService entityService,
             IUserService userService,
             RepositoryFactory repositoryFactory,
             IDatabaseUnitOfWorkProvider uowProvider)
@@ -62,6 +68,7 @@ namespace Umbraco.Core.Services
             _dataTypeService = dataTypeService;
             _fileService = fileService;
             _localizationService = localizationService;
+            _entityService = entityService;
             _repositoryFactory = repositoryFactory;
             _uowProvider = uowProvider;
             _userService = userService;
@@ -344,6 +351,9 @@ namespace Umbraco.Core.Services
             //Otherwise something like uSync won't work.
             var fields = new List<TopologicalSorter.DependencyField<XElement>>();
             var isSingleDocTypeImport = unsortedDocumentTypes.Count == 1;
+
+            var importedFolders = CreateContentTypeFolderStructure(unsortedDocumentTypes);
+
             if (isSingleDocTypeImport == false)
             {
                 //NOTE Here we sort the doctype XElements based on dependencies
@@ -404,6 +414,15 @@ namespace Umbraco.Core.Services
                 }
             }
 
+            foreach (var contentType in _importedContentTypes)
+            {
+                var ct = contentType.Value;
+                if (importedFolders.ContainsKey(ct.Alias))
+                {
+                    ct.ParentId = importedFolders[ct.Alias];
+                }
+            }
+
             //Save the newly created/updated IContentType objects
             var list = _importedContentTypes.Select(x => x.Value).ToList();
             _contentTypeService.Save(list, userId);
@@ -433,6 +452,52 @@ namespace Umbraco.Core.Services
                 ImportedContentType.RaiseEvent(new ImportEventArgs<IContentType>(list, element, false), this);
 
             return list;
+        }
+
+        private Dictionary<string, int> CreateContentTypeFolderStructure(IEnumerable<XElement> unsortedDocumentTypes)
+        {
+            var importedFolders = new Dictionary<string, int>();
+            foreach (var documentType in unsortedDocumentTypes)
+            {
+                var foldersAttribute = documentType.Attribute("Folders");
+                if (foldersAttribute != null)
+                {
+                    var containerId = 0;
+                    var alias = documentType.Element("Info").Element("Alias").Value;
+
+                    var folders = foldersAttribute.Value.Split('/');
+                    var rootFolder = HttpUtility.UrlDecode(folders[0]);
+                    var current = _contentTypeService.GetContentTypeContainer(rootFolder, 1);
+
+                    var rootFolderId = current != null
+                        ? current.Id
+                        : _contentTypeService.CreateContentTypeContainer(-1, rootFolder).Result;
+
+                    current = _contentTypeService.GetContentTypeContainer(rootFolderId);
+
+                    for (var i = 1; i < folders.Length; i++)
+                    {
+                        var folderName = HttpUtility.UrlDecode(folders[i]);
+                        current = CreateContentTypeChildFolder(folderName, current);
+                        containerId = current.Id;
+                    }
+
+                    importedFolders.Add(alias, containerId);
+                }
+            }
+
+            return importedFolders;
+        }
+
+        private EntityContainer CreateContentTypeChildFolder(string folderName, IUmbracoEntity current)
+        {
+            var children = _entityService.GetChildren(current.Id).ToArray();
+            var found = children.Any(x => x.Name.InvariantEquals(folderName));
+            var containerId = found
+                ? children.Single(x => x.Name.InvariantEquals(folderName)).Id
+                : _contentTypeService.CreateContentTypeContainer(current.Id, folderName).Result;
+
+            return _contentTypeService.GetContentTypeContainer(containerId);
         }
 
         private IContentType CreateContentTypeFromXml(XElement documentType)
@@ -657,13 +722,13 @@ namespace Umbraco.Core.Services
                 if (sortOrderElement != null)
                     int.TryParse(sortOrderElement.Value, out sortOrder);
                 var propertyType = new PropertyType(dataTypeDefinition, property.Element("Alias").Value)
-                                       {
-                                           Name = property.Element("Name").Value,
-                                           Description = property.Element("Description") != null ? property.Element("Description").Value : null,
-                                           Mandatory = property.Element("Mandatory") != null ? property.Element("Mandatory").Value.ToLowerInvariant().Equals("true") : false,
-                                           ValidationRegExp = property.Element("Validation") != null ? property.Element("Validation").Value : null,
-                                           SortOrder = sortOrder
-                                       };
+                {
+                    Name = property.Element("Name").Value,
+                    Description = property.Element("Description") != null ? property.Element("Description").Value : null,
+                    Mandatory = property.Element("Mandatory") != null ? property.Element("Mandatory").Value.ToLowerInvariant().Equals("true") : false,
+                    ValidationRegExp = property.Element("Validation") != null ? property.Element("Validation").Value : null,
+                    SortOrder = sortOrder
+                };
 
                 var tab = property.Element("Tab").Value;
                 if (string.IsNullOrEmpty(tab))
@@ -801,6 +866,8 @@ namespace Umbraco.Core.Services
                                        ? (from doc in element.Elements("DataType") select doc).ToList()
                                        : new List<XElement> { element };
 
+            var importedFolders = CreateDataTypeFolderStructure(dataTypeElements);
+
             foreach (var dataTypeElement in dataTypeElements)
             {
                 var dataTypeDefinitionName = dataTypeElement.Attribute("Name").Value;
@@ -810,6 +877,10 @@ namespace Umbraco.Core.Services
 
                 var dataTypeDefinitionId = new Guid(dataTypeElement.Attribute("Definition").Value);
                 var databaseTypeAttribute = dataTypeElement.Attribute("DatabaseType");
+                
+                var parentId = -1;
+                if (importedFolders.ContainsKey(dataTypeDefinitionName))
+                    parentId = importedFolders[dataTypeDefinitionName];
 
                 var definition = _dataTypeService.GetDataTypeDefinitionById(dataTypeDefinitionId);
                 //If the datatypedefinition doesn't already exist we create a new new according to the one in the package xml
@@ -823,11 +894,12 @@ namespace Umbraco.Core.Services
                     if (legacyPropertyEditorId != Guid.Empty)
                     {
                         var dataTypeDefinition = new DataTypeDefinition(-1, legacyPropertyEditorId)
-                            {
-                                Key = dataTypeDefinitionId,
-                                Name = dataTypeDefinitionName,
-                                DatabaseType = databaseType
-                            };
+                        {
+                            Key = dataTypeDefinitionId,
+                            Name = dataTypeDefinitionName,
+                            DatabaseType = databaseType,
+                            ParentId = parentId
+                        };
                         dataTypes.Add(dataTypeDefinitionName, dataTypeDefinition);
                     }
                     else
@@ -837,11 +909,17 @@ namespace Umbraco.Core.Services
                         {
                             Key = dataTypeDefinitionId,
                             Name = dataTypeDefinitionName,
-                            DatabaseType = databaseType
+                            DatabaseType = databaseType,
+                            ParentId = parentId
                         };
                         dataTypes.Add(dataTypeDefinitionName, dataTypeDefinition);
                     }
 
+                }
+                else
+                {
+                    definition.ParentId = parentId;
+                    _dataTypeService.Save(definition, userId);
                 }
             }
 
@@ -863,6 +941,52 @@ namespace Umbraco.Core.Services
                 ImportedDataType.RaiseEvent(new ImportEventArgs<IDataTypeDefinition>(list, element, false), this);
 
             return list;
+        }
+
+        private Dictionary<string, int> CreateDataTypeFolderStructure(IEnumerable<XElement> datatypeElements)
+        {
+            var importedFolders = new Dictionary<string, int>();
+            foreach (var datatypeElement in datatypeElements)
+            {
+                var foldersAttribute = datatypeElement.Attribute("Folders");
+                if (foldersAttribute != null)
+                {
+                    var containerId = 0;
+                    var name = datatypeElement.Attribute("Name").Value;
+
+                    var folders = foldersAttribute.Value.Split('/');
+                    var rootFolder = HttpUtility.UrlDecode(folders[0]);
+                    var current = _dataTypeService.GetContainer(rootFolder, 1);
+
+                    var rootFolderId = current != null
+                        ? current.Id
+                        : _dataTypeService.CreateContainer(-1, rootFolder).Result;
+
+                    current = _dataTypeService.GetContainer(rootFolderId);
+
+                    for (var i = 1; i < folders.Length; i++)
+                    {
+                        var folderName = HttpUtility.UrlDecode(folders[i]);
+                        current = CreateDataTypeChildFolder(folderName, current);
+                        containerId = current.Id;
+                    }
+
+                    importedFolders.Add(name, containerId);
+                }
+            }
+
+            return importedFolders;
+        }
+
+        private EntityContainer CreateDataTypeChildFolder(string folderName, IUmbracoEntity current)
+        {
+            var children = _entityService.GetChildren(current.Id).ToArray();
+            var found = children.Any(x => x.Name.InvariantEquals(folderName));
+            var containerId = found
+                ? children.Single(x => x.Name.InvariantEquals(folderName)).Id
+                : _dataTypeService.CreateContainer(current.Id, folderName).Result;
+
+            return _dataTypeService.GetContainer(containerId);
         }
 
         private void SavePrevaluesFromXml(List<IDataTypeDefinition> dataTypes, IEnumerable<XElement> dataTypeElements)
@@ -1104,9 +1228,9 @@ namespace Umbraco.Core.Services
                 if (existingLanguage == null)
                 {
                     var langauge = new Language(isoCode)
-                                   {
-                                       CultureName = languageElement.Attribute("FriendlyName").Value
-                                   };
+                    {
+                        CultureName = languageElement.Attribute("FriendlyName").Value
+                    };
                     _localizationService.Save(langauge);
                     list.Add(langauge);
                 }
@@ -1388,11 +1512,11 @@ namespace Umbraco.Core.Services
                 }
 
                 var field = new TopologicalSorter.DependencyField<XElement>
-                                {
-                                    Alias = elementCopy.Element("Alias").Value,
-                                    Item = new Lazy<XElement>(() => elementCopy),
-                                    DependsOn = dependencies.ToArray()
-                                };
+                {
+                    Alias = elementCopy.Element("Alias").Value,
+                    Item = new Lazy<XElement>(() => elementCopy),
+                    DependsOn = dependencies.ToArray()
+                };
 
                 fields.Add(field);
             }

--- a/src/Umbraco.Core/Services/ServiceContext.cs
+++ b/src/Umbraco.Core/Services/ServiceContext.cs
@@ -279,14 +279,14 @@ namespace Umbraco.Core.Services
             if (_localizationService == null)
                 _localizationService = new Lazy<ILocalizationService>(() => new LocalizationService(provider, repositoryFactory, logger, eventMessagesFactory));
 
-            if (_packagingService == null)
-                _packagingService = new Lazy<IPackagingService>(() => new PackagingService(logger, _contentService.Value, _contentTypeService.Value, _mediaService.Value, _macroService.Value, _dataTypeService.Value, _fileService.Value, _localizationService.Value, _userService.Value, repositoryFactory, provider));
-
             if (_entityService == null)
                 _entityService = new Lazy<IEntityService>(() => new EntityService(
-                    provider, repositoryFactory, logger, eventMessagesFactory, 
+                    provider, repositoryFactory, logger, eventMessagesFactory,
                     _contentService.Value, _contentTypeService.Value, _mediaService.Value, _dataTypeService.Value, _memberService.Value, _memberTypeService.Value,
                     cache.RuntimeCache));
+            
+            if (_packagingService == null)
+                _packagingService = new Lazy<IPackagingService>(() => new PackagingService(logger, _contentService.Value, _contentTypeService.Value, _mediaService.Value, _macroService.Value, _dataTypeService.Value, _fileService.Value, _localizationService.Value, _entityService.Value, _userService.Value, repositoryFactory, provider));
 
             if (_relationService == null)
                 _relationService = new Lazy<IRelationService>(() => new RelationService(provider, repositoryFactory, logger, eventMessagesFactory, _entityService.Value));

--- a/src/Umbraco.Tests/Mvc/UmbracoViewPageTests.cs
+++ b/src/Umbraco.Tests/Mvc/UmbracoViewPageTests.cs
@@ -393,6 +393,7 @@ namespace Umbraco.Tests.Mvc
                     new Mock<IDataTypeService>().Object,
                     new Mock<IFileService>().Object,
                     new Mock<ILocalizationService>().Object,
+                    new Mock<IEntityService>().Object,
                     new Mock<IUserService>().Object,
                     new RepositoryFactory(CacheHelper.CreateDisabledCacheHelper(), logger, Mock.Of<ISqlSyntaxProvider>(), umbracoSettings),
                     new Mock<IDatabaseUnitOfWorkProvider>().Object),

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/exportDocumenttype.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/exportDocumenttype.aspx.cs
@@ -32,45 +32,42 @@ namespace umbraco.presentation.dialogs
 			int documentTypeId = int.Parse(helper.Request("nodeID"));
 			if (documentTypeId > 0) 
 			{
-				cms.businesslogic.web.DocumentType dt = new cms.businesslogic.web.DocumentType(documentTypeId);
-				if (dt != null)
-				{
-				    var folderNames = string.Empty;
-				    if (dt.Level != 1)
-				    {
-				        var folders = new List<string>();
+				var dt = new cms.businesslogic.web.DocumentType(documentTypeId);
+                var folderNames = string.Empty;
+                if (dt.Level != 1)
+                {
+                    var folders = new List<string>();
 
-				        var current = dt.Parent;
-				        while (current.Level >= 1)
-				        {
-				            if (current.nodeObjectType == Constants.ObjectTypes.DocumentTypeContainerGuid)
-				                folders.Add(HttpUtility.UrlEncode(current.Text));
+                    var current = dt.Parent;
+                    while (current.Level >= 1)
+                    {
+                        if (current.nodeObjectType == Constants.ObjectTypes.DocumentTypeContainerGuid)
+                            folders.Add(HttpUtility.UrlEncode(current.Text));
 
-				            if (current.Level == 1)
-				                break;
-				            current = current.Parent;
-				        }
-
-                        folderNames = string.Join("/", folders.ToArray().Reverse());
+                        if (current.Level == 1)
+                            break;
+                        current = current.Parent;
                     }
 
-                    Response.AddHeader("Content-Disposition", "attachment;filename=" + dt.Alias + ".udt");
-					Response.ContentType = "application/octet-stream";
+                    folderNames = string.Join("/", folders.ToArray().Reverse());
+                }
 
-					XmlDocument doc = new XmlDocument();
-					doc.AppendChild(dt.ToXml(doc, folderNames));
+                Response.AddHeader("Content-Disposition", "attachment;filename=" + dt.Alias + ".udt");
+                Response.ContentType = "application/octet-stream";
+
+                XmlDocument doc = new XmlDocument();
+                doc.AppendChild(dt.ToXml(doc, folderNames));
 
 
-					XmlWriterSettings writerSettings = new XmlWriterSettings();
-					writerSettings.Indent = true;
+                XmlWriterSettings writerSettings = new XmlWriterSettings();
+                writerSettings.Indent = true;
 
-					XmlWriter xmlWriter = XmlWriter.Create(Response.OutputStream, writerSettings);
-					doc.Save(xmlWriter);
+                XmlWriter xmlWriter = XmlWriter.Create(Response.OutputStream, writerSettings);
+                doc.Save(xmlWriter);
 
-					//Response.Write(editDataType.ToXml(new XmlDocument()).OuterXml);
-				}
-			}
-		}
+                //Response.Write(editDataType.ToXml(new XmlDocument()).OuterXml);
+            }
+        }
 
 		#region Web Form Designer generated code
 		override protected void OnInit(EventArgs e)

--- a/src/umbraco.cms/businesslogic/datatype/DataTypeDefinition.cs
+++ b/src/umbraco.cms/businesslogic/datatype/DataTypeDefinition.cs
@@ -142,11 +142,16 @@ namespace umbraco.cms.businesslogic.datatype
 
         public XmlElement ToXml(XmlDocument xd)
         {
-            var serializer = new EntityXmlSerializer();
-            var xml = serializer.Serialize(ApplicationContext.Current.Services.DataTypeService, DataTypeItem);
-            return (XmlElement)xml.GetXmlNode(xd);
-
+            return ToXml(xd, string.Empty);
         }
+
+        public XmlElement ToXml(XmlDocument xd, string folders)
+        {
+            var serializer = new EntityXmlSerializer();
+            var xml = serializer.Serialize(ApplicationContext.Current.Services.DataTypeService, DataTypeItem, folders);
+            return (XmlElement)xml.GetXmlNode(xd);
+        }
+
         #endregion
 
         #region Static methods

--- a/src/umbraco.cms/businesslogic/web/DocumentType.cs
+++ b/src/umbraco.cms/businesslogic/web/DocumentType.cs
@@ -474,13 +474,18 @@ namespace umbraco.cms.businesslogic.web
 
         public XmlElement ToXml(XmlDocument xd)
         {
+            return ToXml(xd, string.Empty);
+        }
+
+        public XmlElement ToXml(XmlDocument xd, string folders)
+        {
             var exporter = new EntityXmlSerializer();
-            var xml = exporter.Serialize(ApplicationContext.Current.Services.DataTypeService, ContentType);
+            var xml = exporter.Serialize(ApplicationContext.Current.Services.DataTypeService, ContentType, folders);
 
             //convert the Linq to Xml structure to the old .net xml structure
             var xNode = xml.GetXmlNode();
             var doc = (XmlElement)xd.ImportNode(xNode, true);
-            return doc;
+            return doc;   
         }
 
         [Obsolete("Obsolete, Use SetDefaultTemplate(null) on Umbraco.Core.Models.ContentType", false)]
@@ -538,7 +543,10 @@ namespace umbraco.cms.businesslogic.web
         protected override void setupNode()
         {
             var contentType = ApplicationContext.Current.Services.ContentTypeService.GetContentType(Id);
-            SetupNode(contentType);
+            
+            // If it's null, it's probably a folder
+            if (contentType != null)
+                SetupNode(contentType);
         }
 
         #endregion


### PR DESCRIPTION
The only thing that we support in the current version of the packager is ContentTypes and DataTypes, so I've limited this to those two. 

I've maintained backwards compatibility by making a few overloads on the `.ToXml` / `Serialize` methods.

Tested with content/datatypes in the following structures:

- Content/DataType name

===

- Folder
 - Content/DataType name

===

- Folder
 - SubFolder
   - Content/DataType name

===

So: 0, 1 and 2 levels.

In the xml there's a new optional `Folders` attribute on `<DocumentType/>` and on `<DataType/>`. The attribute can look like this for example: `<DocumentType Folders="test/hello%2fworld" />` and would result in a structure like so:

- test
 - hello/world
   - ContentType name


The folders are separated by a `/` and UrlEncoded in the XML so that when people type an actual `/` in their folder name it doesn't mess up the folder structure.