### PR TITLE
Fix the media picker not rendering when a media item has no image

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
@@ -109,7 +109,7 @@ angular.module('umbraco')
             //NOTE: The 'entity' can be either a normal media entity or an "entity" returned from the entityResource
             // they contain different data structures so if we need to query against it we need to be aware of this.
             mediaHelper.registerFileResolver("Umbraco.ImageCropper", function (property, entity, thumbnail) {
-                if (property.value.src) {
+                if (property.value && property.value.src) {
 
                     if (thumbnail === true) {
                         return property.value.src + "?width=500&mode=max";


### PR DESCRIPTION
Reproduction steps:

1. Add a Media Picker property to a document type
2. Create an image media item with an image
3. Create a content entity, select the media item and save
4. Remove the image from the media item
5. The media picker no longer renders on the content entity in Umbraco