### PR TITLE
U4-7561 Backoffice Media Section should provide information on physic…

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -168,6 +168,7 @@
   <area alias="media">
     <key alias="clickToUpload">Click to upload</key>
     <key alias="dropFilesHere">Drop your files here...</key>
+	<key alias="urls">Link to media</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -168,6 +168,7 @@
   <area alias="media">
     <key alias="clickToUpload">Click to upload</key>
     <key alias="dropFilesHere">Drop your files here...</key>
+	<key alias="urls">Link to media</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
@@ -136,13 +136,13 @@ namespace Umbraco.Web.Models.Mapping
                 }
             };
 
-            if (media.Properties.FirstOrDefault(x => x.Alias == "umbracoFile") != null)
+            if (media.Properties.FirstOrDefault(x => x.Alias == Constants.Conventions.Media.File) != null)
             {
                 var helper = new UmbracoHelper(UmbracoContext.Current);
                 var mediaItem = helper.TypedMedia(media.Id);
                 if (mediaItem != null)
                 {
-                    var crop = mediaItem.GetCropUrl("umbracoFile", string.Empty);
+                    var crop = mediaItem.GetCropUrl(Constants.Conventions.Media.File, string.Empty);
                     if (string.IsNullOrWhiteSpace(crop) == false)
                     {
                         var link = new ContentPropertyDisplay

--- a/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
@@ -9,6 +9,7 @@ using System.Web.Routing;
 using AutoMapper;
 using umbraco;
 using Umbraco.Core;
+using Umbraco.Core.Configuration;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Mapping;
 using Umbraco.Core.PropertyEditors;
@@ -142,15 +143,23 @@ namespace Umbraco.Web.Models.Mapping
                 var mediaItem = helper.TypedMedia(media.Id);
                 if (mediaItem != null)
                 {
-                    var crop = mediaItem.GetCropUrl(Constants.Conventions.Media.File, string.Empty);
-                    if (string.IsNullOrWhiteSpace(crop) == false)
+                    var crops = new List<string>();
+                    var autoFillProperties = UmbracoConfig.For.UmbracoSettings().Content.ImageAutoFillProperties;
+                    foreach (var field in autoFillProperties)
+                    {
+                        var crop = mediaItem.GetCropUrl(field.Alias, string.Empty);
+                        if (string.IsNullOrWhiteSpace(crop) == false)
+                            crops.Add(crop.Split('?')[0]);
+                    }
+                    
+                    if (crops.Any())
                     {
                         var link = new ContentPropertyDisplay
                         {
                             Alias = string.Format("{0}urls", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
                             Label = localizedText.Localize("media/urls"),
                             // don't add the querystring, split on the "?" will also work if there is no "?"
-                            Value = crop.Split('?')[0],
+                            Value = string.Join(",", crops),
                             View = "urllist"
                         };
 

--- a/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
@@ -136,6 +136,29 @@ namespace Umbraco.Web.Models.Mapping
                 }
             };
 
+            if (media.Properties.FirstOrDefault(x => x.Alias == "umbracoFile") != null)
+            {
+                var helper = new UmbracoHelper(UmbracoContext.Current);
+                var mediaItem = helper.TypedMedia(media.Id);
+                if (mediaItem != null)
+                {
+                    var crop = mediaItem.GetCropUrl("umbracoFile", string.Empty);
+                    if (string.IsNullOrWhiteSpace(crop) == false)
+                    {
+                        var link = new ContentPropertyDisplay
+                        {
+                            Alias = string.Format("{0}urls", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
+                            Label = localizedText.Localize("media/urls"),
+                            // don't add the querystring, split on the "?" will also work if there is no "?"
+                            Value = crop.Split('?')[0],
+                            View = "urllist"
+                        };
+
+                        genericProperties.Add(link);
+                    }
+                }
+            }
+
             TabsAndPropertiesResolver.MapGenericProperties(media, display, localizedText, genericProperties);
         }
 

--- a/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
@@ -137,21 +137,21 @@ namespace Umbraco.Web.Models.Mapping
                 }
             };
 
-            if (media.Properties.FirstOrDefault(x => x.Alias == Constants.Conventions.Media.File) != null)
+            var helper = new UmbracoHelper(UmbracoContext.Current);
+            var mediaItem = helper.TypedMedia(media.Id);
+            if (mediaItem != null)
             {
-                var helper = new UmbracoHelper(UmbracoContext.Current);
-                var mediaItem = helper.TypedMedia(media.Id);
-                if (mediaItem != null)
+                var crops = new List<string>();
+                var autoFillProperties = UmbracoConfig.For.UmbracoSettings().Content.ImageAutoFillProperties.ToArray();
+                if (autoFillProperties.Any())
                 {
-                    var crops = new List<string>();
-                    var autoFillProperties = UmbracoConfig.For.UmbracoSettings().Content.ImageAutoFillProperties;
                     foreach (var field in autoFillProperties)
                     {
                         var crop = mediaItem.GetCropUrl(field.Alias, string.Empty);
                         if (string.IsNullOrWhiteSpace(crop) == false)
                             crops.Add(crop.Split('?')[0]);
                     }
-                    
+
                     if (crops.Any())
                     {
                         var link = new ContentPropertyDisplay


### PR DESCRIPTION
…al location of files

This works for all media types that have a property with alias `umbracoFile` and if the value stored in that is either a string (upload field) or a cropper. The `GetCropUrl` method will detect the difference and give a url back. 