### PR TITLE
Fixes: U4-7630 Cannot save a document type when it has a date picker …

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbdisableformvalidation.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbdisableformvalidation.directive.js
@@ -1,0 +1,20 @@
+(function() {
+  'use strict';
+
+  function UmbDisableFormValidation() {
+
+      var directive = {
+          restrict: 'A',
+          require: '?form',
+          link: function (scope, elm, attrs, ctrl) {
+              //override the $setValidity function of the form to disable validation
+              ctrl.$setValidity = function () { };
+          }
+      };
+
+    return directive;
+  }
+
+  angular.module('umbraco.directives').directive('umbDisableFormValidation', UmbDisableFormValidation);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -279,6 +279,10 @@ input.umb-group-builder__group-sort-value {
   cursor: auto;
 }
 
+.umb-group-builder__property-preview .help-inline {
+    display:none !important;
+}
+
 .umb-group-builder__property-preview-overlay {
   position: absolute;
   top: 0;

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-editor.html
@@ -1,1 +1,1 @@
-<div ng-include="propertyEditorView"></div>
+<ng-form name="propertyEditor" ng-include="propertyEditorView" umb-disable-form-validation></ng-form>

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-editor.html
@@ -1,1 +1,2 @@
-<ng-form name="propertyEditor" ng-include="propertyEditorView" umb-disable-form-validation></ng-form>
+
+    <div ng-include="propertyEditorView"></div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -171,7 +171,12 @@
                                     <span ng-if="property.dataTypeName == undefined">Preview</span>
                                 </span>
 
-                                <umb-property-editor model="property" ng-if="property.view !== undefined"></umb-property-editor>
+                                <ng-form name="propertyEditorPreviewForm" umb-disable-form-validation>
+                                    <umb-property-editor
+                                        ng-if="property.view !== undefined"
+                                        model="property">
+                                    </umb-property-editor>
+                                </ng-form>
 
                             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
@@ -1,2 +1,3 @@
-﻿<textarea ng-model="model.value" id="{{model.alias}}" name="textarea" rows="10" class="umb-editor umb-textarea textstring" val-server="value"></textarea>
+﻿<textarea ng-model="model.value" id="{{model.alias}}" name="textarea" rows="10" class="umb-editor umb-textarea textstring" val-server="value" ng-required="model.validation.mandatory"></textarea>
+<span class="help-inline" val-msg-for="textarea" val-toggle-msg="required">Required</span>
 <span class="help-inline" val-msg-for="textarea" val-toggle-msg="valServer"></span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
@@ -2,6 +2,8 @@
     <input type="text" name="textbox" ng-model="model.value" id="{{model.alias}}"
            class="umb-editor umb-textstring textstring"
            val-server="value"
+           ng-required="model.validation.mandatory"
            ng-trim="false" />
     <span class="help-inline" val-msg-for="textbox" val-toggle-msg="valServer"></span>
+    <span class="help-inline" val-msg-for="textbox" val-toggle-msg="required">Required</span>
 </div>


### PR DESCRIPTION
…required property with the new property type editor in 7.4

Directive for disabling validation on forms.
Passing on required validation from settings to textarea and textbox.
Wrapping property editor preview in disabled validation form.