### PR TITLE
deploy-29 - Sanitize UniqueId

### DIFF
--- a/src/Umbraco.Core/Models/Content.cs
+++ b/src/Umbraco.Core/Models/Content.cs
@@ -341,18 +341,6 @@ namespace Umbraco.Core.Models
         }
         
         /// <summary>
-        /// Method to call when Entity is being saved
-        /// </summary>
-        /// <remarks>Created date is set and a Unique key is assigned</remarks>
-        internal override void AddingEntity()
-        {
-            base.AddingEntity();
-
-            if(Key == Guid.Empty)
-                Key = Guid.NewGuid();
-        }
-
-        /// <summary>
         /// Method to call when Entity is being updated
         /// </summary>
         /// <remarks>Modified Date is set and a new Version guid is set</remarks>

--- a/src/Umbraco.Core/Models/ContentType.cs
+++ b/src/Umbraco.Core/Models/ContentType.cs
@@ -138,19 +138,6 @@ namespace Umbraco.Core.Models
         }
 
         /// <summary>
-        /// Method to call when Entity is being saved
-        /// </summary>
-        /// <remarks>Created date is set and a Unique key is assigned</remarks>
-        internal override void AddingEntity()
-        {
-            base.AddingEntity();
-
-            if (Key == Guid.Empty)
-                Key = Guid.NewGuid();
-        }
-
-
-        /// <summary>
         /// Creates a deep clone of the current entity with its identity/alias and it's property identities reset
         /// </summary>
         /// <returns></returns>

--- a/src/Umbraco.Core/Models/ContentTypeBase.cs
+++ b/src/Umbraco.Core/Models/ContentTypeBase.cs
@@ -452,11 +452,6 @@ namespace Umbraco.Core.Models
         /// <returns>Returns <c>True</c> if PropertyType was added, otherwise <c>False</c></returns>
         public bool AddPropertyType(PropertyType propertyType)
         {
-            if (propertyType.HasIdentity == false)
-            {
-                propertyType.Key = Guid.NewGuid();
-            }
-
             if (PropertyTypeExists(propertyType.Alias) == false)
             {
                 _propertyTypes.Add(propertyType);                

--- a/src/Umbraco.Core/Models/ContentTypeCompositionBase.cs
+++ b/src/Umbraco.Core/Models/ContentTypeCompositionBase.cs
@@ -210,9 +210,6 @@ namespace Umbraco.Core.Models
         /// <returns>Returns <c>True</c> if PropertyType was added, otherwise <c>False</c></returns>
         public override bool AddPropertyType(PropertyType propertyType, string propertyGroupName)
         {
-            if (propertyType.HasIdentity == false)
-                propertyType.Key = Guid.NewGuid();
-
             // ensure no duplicate alias - over all composition properties
             if (PropertyTypeExists(propertyType.Alias))
                 return false;

--- a/src/Umbraco.Core/Models/DataTypeDefinition.cs
+++ b/src/Umbraco.Core/Models/DataTypeDefinition.cs
@@ -265,13 +265,5 @@ namespace Umbraco.Core.Models
         {
             get { return _additionalData; }
         }
-
-        internal override void AddingEntity()
-        {
-            base.AddingEntity();
-
-            if(Key == default(Guid))
-                Key = Guid.NewGuid();
-        }
     }
 }

--- a/src/Umbraco.Core/Models/DictionaryItem.cs
+++ b/src/Umbraco.Core/Models/DictionaryItem.cs
@@ -98,16 +98,5 @@ namespace Umbraco.Core.Models
                         enumerable => enumerable.GetHashCode()));
             }
         }
-
-        /// <summary>
-        /// Method to call before inserting a new entity in the db
-        /// </summary>
-        internal override void AddingEntity()
-        {
-            base.AddingEntity();
-
-            Key = Guid.NewGuid();            
-        }
-        
     }
 }

--- a/src/Umbraco.Core/Models/EntityBase/Entity.cs
+++ b/src/Umbraco.Core/Models/EntityBase/Entity.cs
@@ -62,9 +62,9 @@ namespace Umbraco.Core.Models.EntityBase
         {
             get
             {
+                // if an entity does NOT have a UniqueId yet, assign one now
                 if (_key == Guid.Empty)
-                    return _id.ToGuid();
-
+                    _key = Guid.NewGuid();
                 return _key;
             }
             set
@@ -136,6 +136,7 @@ namespace Umbraco.Core.Models.EntityBase
         {
             _hasIdentity = false;
             _id = default(int);
+            _key = Guid.Empty;
         }
 
         /// <summary>
@@ -242,6 +243,7 @@ namespace Umbraco.Core.Models.EntityBase
         {
             //Memberwise clone on Entity will work since it doesn't have any deep elements
             // for any sub class this will work for standard properties as well that aren't complex object's themselves.
+            var ignored = this.Key; // ensure that 'this' has a key, before cloning
             var clone = (Entity)MemberwiseClone();
             //ensure the clone has it's own dictionaries
             clone.ResetChangeTrackingCollections();

--- a/src/Umbraco.Core/Models/Media.cs
+++ b/src/Umbraco.Core/Models/Media.cs
@@ -118,17 +118,5 @@ namespace Umbraco.Core.Models
             //The Media Recycle Bin Id is -21 so we correct that here
             ParentId = parentId == -20 ? -21 : parentId;
         }
-
-        /// <summary>
-        /// Method to call when Entity is being saved
-        /// </summary>
-        /// <remarks>Created date is set and a Unique key is assigned</remarks>
-        internal override void AddingEntity()
-        {
-            base.AddingEntity();
-
-            if (Key == Guid.Empty)
-                Key = Guid.NewGuid();
-        }
     }
 }

--- a/src/Umbraco.Core/Models/MediaType.cs
+++ b/src/Umbraco.Core/Models/MediaType.cs
@@ -38,26 +38,5 @@ namespace Umbraco.Core.Models
             : base(parent, alias)
         {
         }
-
-        /// <summary>
-        /// Method to call when Entity is being saved
-        /// </summary>
-        /// <remarks>Created date is set and a Unique key is assigned</remarks>
-        internal override void AddingEntity()
-        {
-            base.AddingEntity();
-
-            if (Key == Guid.Empty)
-                Key = Guid.NewGuid();
-        }
-
-        /// <summary>
-        /// Method to call when Entity is being updated
-        /// </summary>
-        /// <remarks>Modified Date is set and a new Version guid is set</remarks>
-        internal override void UpdatingEntity()
-        {
-            base.UpdatingEntity();
-        }
     }
 }

--- a/src/Umbraco.Core/Models/Member.cs
+++ b/src/Umbraco.Core/Models/Member.cs
@@ -509,11 +509,8 @@ namespace Umbraco.Core.Models
         {
             base.AddingEntity();
 
-            if (Key == Guid.Empty)
-            {
-                Key = Guid.NewGuid();
+            if (ProviderUserKey == null)
                 ProviderUserKey = Key;
-            }
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Models/MemberGroup.cs
+++ b/src/Umbraco.Core/Models/MemberGroup.cs
@@ -60,17 +60,5 @@ namespace Umbraco.Core.Models
         }
 
         public IDictionary<string, object> AdditionalData { get; private set; }
-
-        /// <summary>
-        /// Method to call when Entity is being saved
-        /// </summary>
-        /// <remarks>Created date is set and a Unique key is assigned</remarks>
-        internal override void AddingEntity()
-        {
-            base.AddingEntity();
-
-            if (Key == Guid.Empty)
-                Key = Guid.NewGuid();
-        }
     }
 }

--- a/src/Umbraco.Core/Models/MemberType.cs
+++ b/src/Umbraco.Core/Models/MemberType.cs
@@ -131,26 +131,5 @@ namespace Umbraco.Core.Models
                 MemberTypePropertyTypes.Add(propertyTypeAlias, tuple);
             }
         }
-
-        /// <summary>
-        /// Method to call when Entity is being saved
-        /// </summary>
-        /// <remarks>Created date is set and a Unique key is assigned</remarks>
-        internal override void AddingEntity()
-        {
-            base.AddingEntity();
-
-            if (Key == Guid.Empty)
-                Key = Guid.NewGuid();
-        }
-
-        /// <summary>
-        /// Method to call when Entity is being updated
-        /// </summary>
-        /// <remarks>Modified Date is set and a new Version guid is set</remarks>
-        internal override void UpdatingEntity()
-        {
-            base.UpdatingEntity();
-        }
     }
 }

--- a/src/Umbraco.Core/Models/PublicAccessEntry.cs
+++ b/src/Umbraco.Core/Models/PublicAccessEntry.cs
@@ -108,18 +108,6 @@ namespace Umbraco.Core.Models
             }
         }
 
-        /// <summary>
-        /// Method to call on entity saved when first added
-        /// </summary>
-        internal override void AddingEntity()
-        {
-            if (Key == default(Guid))
-            {
-                Key = Guid.NewGuid();
-            }
-            base.AddingEntity();
-        }
-
         [DataMember]
         public int LoginNodeId
         {

--- a/src/Umbraco.Core/Models/PublicAccessRule.cs
+++ b/src/Umbraco.Core/Models/PublicAccessRule.cs
@@ -28,18 +28,6 @@ namespace Umbraco.Core.Models
        
         public Guid AccessEntryId { get; internal set; }
 
-        /// <summary>
-        /// Method to call on entity saved when first added
-        /// </summary>
-        internal override void AddingEntity()
-        {
-            if (Key == default(Guid))
-            {                
-                Key = Guid.NewGuid();       
-            }
-            base.AddingEntity();
-        }
-
         public string RuleValue
         {
             get { return _ruleValue; }

--- a/src/Umbraco.Core/Models/Rdbms/NodeDto.cs
+++ b/src/Umbraco.Core/Models/Rdbms/NodeDto.cs
@@ -10,12 +10,6 @@ namespace Umbraco.Core.Models.Rdbms
     [ExplicitColumns]
     internal class NodeDto
     {
-        public NodeDto()
-        {
-            //By default, always generate a new guid
-            UniqueId = Guid.NewGuid();
-        }
-
         public const int NodeIdSeed = 1050;
 
         [Column("id")]

--- a/src/Umbraco.Core/Models/Rdbms/PropertyTypeDto.cs
+++ b/src/Umbraco.Core/Models/Rdbms/PropertyTypeDto.cs
@@ -10,12 +10,6 @@ namespace Umbraco.Core.Models.Rdbms
     [ExplicitColumns]
     internal class PropertyTypeDto
     {
-        public PropertyTypeDto()
-        {
-            //by default always create a new guid
-            UniqueId = Guid.NewGuid();
-        }
-
         [Column("id")]
         [PrimaryKeyColumn(IdentitySeed = 50)]
         public int Id { get; set; }

--- a/src/Umbraco.Core/Models/Rdbms/PropertyTypeGroupDto.cs
+++ b/src/Umbraco.Core/Models/Rdbms/PropertyTypeGroupDto.cs
@@ -11,12 +11,6 @@ namespace Umbraco.Core.Models.Rdbms
     [ExplicitColumns]
     internal class PropertyTypeGroupDto
     {
-        public PropertyTypeGroupDto()
-        {
-            //by default always create a new guid
-            UniqueId = Guid.NewGuid();
-        }
-
         [Column("id")]
         [PrimaryKeyColumn(IdentitySeed = 12)]
         public int Id { get; set; }

--- a/src/Umbraco.Core/Models/Template.cs
+++ b/src/Umbraco.Core/Models/Template.cs
@@ -118,18 +118,6 @@ namespace Umbraco.Core.Models
             return ApplicationContext.Current.Services.FileService.DetermineTemplateRenderingEngine(this);
         }
 
-        /// <summary>
-        /// Method to call when Entity is being saved
-        /// </summary>
-        /// <remarks>Created date is set and a Unique key is assigned</remarks>
-        internal override void AddingEntity()
-        {
-            base.AddingEntity();
-
-            if (Key == Guid.Empty)
-                Key = Guid.NewGuid();
-        }
-
         public void SetMasterTemplate(ITemplate masterTemplate)
         {
             if (masterTemplate == null)

--- a/src/Umbraco.Core/Persistence/Factories/PropertyGroupFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/PropertyGroupFactory.cs
@@ -99,9 +99,7 @@ namespace Umbraco.Core.Persistence.Factories
                                  ContentTypeNodeId = _contentTypeId,
                                  SortOrder = propertyGroup.SortOrder,
                                  Text = propertyGroup.Name,
-                                 UniqueId = propertyGroup.Key == Guid.Empty
-                                    ? Guid.NewGuid()
-                                    : propertyGroup.Key
+                                 UniqueId = propertyGroup.Key
                              };
 
             if (propertyGroup.HasIdentity)
@@ -124,9 +122,7 @@ namespace Umbraco.Core.Persistence.Factories
                 Name = propertyType.Name,
                 SortOrder = propertyType.SortOrder,
                 ValidationRegExp = propertyType.ValidationRegExp,
-                UniqueId = propertyType.Key == Guid.Empty
-                    ? Guid.NewGuid()
-                    : propertyType.Key
+                UniqueId = propertyType.Key
             };
 
             if (tabId != default(int))

--- a/src/Umbraco.Core/Persistence/Repositories/ContentTypeBaseRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentTypeBaseRepository.cs
@@ -466,6 +466,7 @@ AND umbracoNode.id <> @id",
                 propType.DataTypeDefinitionId = dto.DataTypeId;
                 propType.Description = dto.Description;
                 propType.Id = dto.Id;
+                propType.Key = dto.UniqueId;
                 propType.Name = dto.Name;
                 propType.Mandatory = dto.Mandatory;
                 propType.SortOrder = dto.SortOrder;

--- a/src/Umbraco.Core/Persistence/Repositories/EntityContainerRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/EntityContainerRepository.cs
@@ -180,11 +180,9 @@ namespace Umbraco.Core.Persistence.Repositories
                 Path = path,
                 SortOrder = 0,
                 Text = entity.Name,
-                UserId = entity.CreatorId
+                UserId = entity.CreatorId,
+                UniqueId = entity.Key
             };
-
-            if (entity.Key != default(Guid))
-                nodeDto.UniqueId = entity.Key;
 
             // insert, get the id, update the path with the id
             var id = Convert.ToInt32(Database.Insert(nodeDto));
@@ -193,7 +191,6 @@ namespace Umbraco.Core.Persistence.Repositories
 
             // refresh the entity
             entity.Id = id;
-            entity.Key = nodeDto.UniqueId;
             entity.Path = nodeDto.Path;
             entity.Level = nodeDto.Level;
             entity.SortOrder = 0;

--- a/src/Umbraco.Tests/Persistence/Querying/ContentTypeSqlMappingTests.cs
+++ b/src/Umbraco.Tests/Persistence/Querying/ContentTypeSqlMappingTests.cs
@@ -151,10 +151,10 @@ namespace Umbraco.Tests.Persistence.Querying
                 DatabaseContext.Database.Execute(new Sql(string.Format("SET IDENTITY_INSERT {0} OFF ", SqlSyntaxContext.SqlSyntaxProvider.GetQuotedTableName("cmsContentType"))));
 
                 DatabaseContext.Database.Execute(new Sql(string.Format("SET IDENTITY_INSERT {0} ON ", SqlSyntaxContext.SqlSyntaxProvider.GetQuotedTableName("cmsPropertyTypeGroup"))));
-                DatabaseContext.Database.Insert("cmsPropertyTypeGroup", "id", false, new PropertyTypeGroupDto { Id = 77776, ContentTypeNodeId = 99999, Text = "Group1", SortOrder = 1 });
-                DatabaseContext.Database.Insert("cmsPropertyTypeGroup", "id", false, new PropertyTypeGroupDto { Id = 77777, ContentTypeNodeId = 99999, Text = "Group2", SortOrder = 2 });
-                DatabaseContext.Database.Insert("cmsPropertyTypeGroup", "id", false, new PropertyTypeGroupDto { Id = 77778, ContentTypeNodeId = 99999, Text = "Group3", SortOrder = 3 });
-                DatabaseContext.Database.Insert("cmsPropertyTypeGroup", "id", false, new PropertyTypeGroupDto { Id = 77779, ContentTypeNodeId = 99999, Text = "Group4", SortOrder = 4 });
+                DatabaseContext.Database.Insert("cmsPropertyTypeGroup", "id", false, new PropertyTypeGroupDto { Id = 77776, UniqueId = 77776.ToGuid(), ContentTypeNodeId = 99999, Text = "Group1", SortOrder = 1 });
+                DatabaseContext.Database.Insert("cmsPropertyTypeGroup", "id", false, new PropertyTypeGroupDto { Id = 77777, UniqueId = 77777.ToGuid(), ContentTypeNodeId = 99999, Text = "Group2", SortOrder = 2 });
+                DatabaseContext.Database.Insert("cmsPropertyTypeGroup", "id", false, new PropertyTypeGroupDto { Id = 77778, UniqueId = 77778.ToGuid(), ContentTypeNodeId = 99999, Text = "Group3", SortOrder = 3 });
+                DatabaseContext.Database.Insert("cmsPropertyTypeGroup", "id", false, new PropertyTypeGroupDto { Id = 77779, UniqueId = 77779.ToGuid(), ContentTypeNodeId = 99999, Text = "Group4", SortOrder = 4 });
                 DatabaseContext.Database.Execute(new Sql(string.Format("SET IDENTITY_INSERT {0} OFF ", SqlSyntaxContext.SqlSyntaxProvider.GetQuotedTableName("cmsPropertyTypeGroup"))));
 
                 DatabaseContext.Database.Execute(new Sql(string.Format("SET IDENTITY_INSERT {0} ON ", SqlSyntaxContext.SqlSyntaxProvider.GetQuotedTableName("cmsPropertyType"))));

--- a/src/Umbraco.Tests/Services/Importing/PackageImportTests.cs
+++ b/src/Umbraco.Tests/Services/Importing/PackageImportTests.cs
@@ -78,7 +78,7 @@ namespace Umbraco.Tests.Services.Importing
         public void PackagingService_Can_Import_Inherited_ContentTypes_And_Verify_PropertyTypes_UniqueIds()
         {
             // Arrange
-            string strXml = ImportResources.InheritedDocTypes_Package;
+            var strXml = ImportResources.InheritedDocTypes_Package;
             var xml = XElement.Parse(strXml);
             var dataTypeElement = xml.Descendants("DataTypes").First();
             var templateElement = xml.Descendants("Templates").First();


### PR DESCRIPTION
Merges work done for Deploy:

http://issues.umbraco.org/issue/deploy-29
Refactor Entity so that every entity always have a non-empty Key. Remove all the tests that we had, checking for empty Key value and setting a non-empty value, as this is not needed anymore. Cleanup and bugfix things related to Key and UniqueId management (cloning, resetting identity...).

Test: create entities such as content types, property groups and property types, templates, anything that is an entity. Do all sorts of CRUD operation on them in the backend. Should work and maintain consistent UniqueId values in the database. No more property types with ever-changing keys, etc.