### PR TITLE
Fixes: U4-7560 Default member properties should not be editable

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -440,7 +440,7 @@
 
       scope.editPropertyTypeSettings = function(property, group) {
 
-        if (!property.inherited) {
+        if (!property.inherited && !property.locked) {
 
           scope.propertySettingsDialogModel = {};
           scope.propertySettingsDialogModel.title = "Property settings";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -190,6 +190,16 @@ input.umb-group-builder__group-sort-value {
   border: transparent;
 }
 
+.umb-group-builder__property.-locked {
+  border: transparent;
+  background: #FDFDFD;
+  animation: fadeIn 0.5s;
+}
+
+.umb-group-builder__property.-locked:hover {
+  border: transparent;
+}
+
 .umb-group-builder__property.-sortable,
 .umb-group-builder__property.-sortable-locked {
     min-height: 35px;
@@ -336,6 +346,18 @@ input.umb-group-builder__group-sort-value {
   padding: 0 10px 0 5px;
   top: 0;
 }
+
+.umb-group-builder__property-locked-label {
+  font-size: 11px;
+  background-color: #E9E9E9;
+  margin-left: 5px;
+  position: absolute;
+  right: 0;
+  z-index: 100;
+  padding: 0 10px 0 5px;
+  top: 0;
+}
+
 
 /* ---------- PLACEHOLDER BOX ---------- */
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -93,7 +93,7 @@
 
                 <ul class="umb-group-builder__properties" ui-sortable="sortableOptionsProperty" ng-model="tab.properties">
 
-                    <li ng-class="{'umb-group-builder__property-sortable': sortingMode && !property.inherited}" ng-repeat="property in tab.properties">
+                    <li ng-class="{'umb-group-builder__property-sortable': sortingMode && !property.inherited && !property.locked}" ng-repeat="property in tab.properties">
 
                         <!-- Init property / Property placeholder / add new property -->
                         <a href="" class="umb-group-builder__property -placeholder" ng-if="property.propertyState=='init' && !sortingMode" ng-class="{'-placeholder': property.propertyState=='init'}" hotkey="alt+shift+p" ng-click="addProperty(property, tab)" focus-when="{{property.focus}}">
@@ -116,7 +116,7 @@
 
                         </a>
 
-                        <div class="umb-group-builder__property" ng-if="property.propertyState!=='init'" ng-class="{'-active': property.dialogIsOpen, '-active': property.propertyState=='active', '-inherited': property.inherited, 'umb-group-builder__property-handle -sortable': sortingMode && !property.inherited, '-sortable-locked': sortingMode && property.inherited}">
+                        <div class="umb-group-builder__property" ng-if="property.propertyState!=='init'" ng-class="{'-active': property.dialogIsOpen, '-active': property.propertyState=='active', '-inherited': property.inherited, '-locked': property.locked, 'umb-group-builder__property-handle -sortable': sortingMode && !property.inherited && !property.locked, '-sortable-locked': sortingMode && (property.inherited || property.locked)}">
 
                             <!-- property meta text -->
                             <div class="umb-group-builder__property-meta" ng-class="{'-full-width': sortingMode}">
@@ -125,11 +125,15 @@
                                     <i class="icon icon-merge"></i> Inherited from {{property.contentTypeName}}
                                 </div>
 
+                                <div class="umb-group-builder__property-locked-label" ng-if="property.locked">
+                                    <i class="icon icon-lock"></i> Locked
+                                </div>
+
                                 <ng-form name="propertyTypeForm">
                                     <div class="control-group -no-margin" ng-if="!sortingMode">
 
-                                        <div class="umb-group-builder__property-meta-alias" ng-if="property.inherited">{{ property.alias }}</div>
-                                        <umb-locked-field ng-if="!property.inherited"
+                                        <div class="umb-group-builder__property-meta-alias" ng-if="property.inherited || property.locked">{{ property.alias }}</div>
+                                        <umb-locked-field ng-if="!property.inherited && !property.locked"
                                                           locked="locked"
                                                           ng-model="property.alias"
                                                           placeholder-text="'Alias...'"
@@ -137,7 +141,7 @@
                                         </umb-locked-field>
 
                                         <div class="umb-group-builder__property-meta-label">
-                                            <textarea placeholder="Label..." ng-model="property.label" ng-disabled="property.inherited"
+                                            <textarea placeholder="Label..." ng-model="property.label" ng-disabled="property.inherited || property.locked"
                                                       name="groupName"
                                                       umb-auto-resize
                                                       required
@@ -148,13 +152,13 @@
                                         </div>
 
                                         <div class="umb-group-builder__property-meta-description">
-                                            <textarea ng-model="property.description" placeholder="Enter your description..." ng-disabled="property.inherited" umb-auto-resize></textarea>
+                                            <textarea ng-model="property.description" placeholder="Enter your description..." ng-disabled="property.inherited || property.locked" umb-auto-resize></textarea>
                                         </div>
                                     </div>
                                 </ng-form>
 
                                 <div ng-if="sortingMode">
-                                    <i class="icon icon-navigation" ng-if="!property.inherited"></i>
+                                    <i class="icon icon-navigation" ng-if="!property.inherited && !property.locked"></i>
                                     <span class="umb-group-builder__property-meta-label">{{ property.label }}</span>
                                     <span class="umb-group-builder__property-meta-alias">({{ property.alias }})</span>
                                 </div>
@@ -162,7 +166,7 @@
                             </div>
 
 
-                            <div tabindex="-1" class="umb-group-builder__property-preview" ng-click="editPropertyTypeSettings(property, tab)" ng-if="!sortingMode" ng-class="{'-not-clickable': !sortingMode && property.inherited}">
+                            <div tabindex="-1" class="umb-group-builder__property-preview" ng-click="editPropertyTypeSettings(property, tab)" ng-if="!sortingMode" ng-class="{'-not-clickable': !sortingMode && (property.inherited || property.locked)}">
 
                                 <span class="umb-group-builder__property-preview-overlay"></span>
 
@@ -183,7 +187,7 @@
                             <!-- row tools -->
                             <div class="umb-group-builder__property-actions" ng-if="!sortingMode">
 
-                                <div ng-if="!property.inherited">
+                                <div ng-if="!property.inherited && !property.locked">
 
                                     <!-- settings for property -->
                                     <div class="umb-group-builder__property-action" ng-click="editPropertyTypeSettings(property, tab)">

--- a/src/Umbraco.Web/Models/ContentEditing/PropertyTypeDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/PropertyTypeDisplay.cs
@@ -1,16 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Umbraco.Web.Models.ContentEditing
 {
     [DataContract(Name = "propertyType")]
     public class PropertyTypeDisplay : PropertyTypeBasic
-    {  
+    {
         [DataMember(Name = "editor")]
         [ReadOnly(true)]
         public string Editor { get; set; }
@@ -23,6 +19,15 @@ namespace Umbraco.Web.Models.ContentEditing
         [ReadOnly(true)]
         public IDictionary<string, object> Config { get; set; }
         
+        /// <summary>
+        /// Gets a value indicating whether this property should be locked when editing.
+        /// </summary>
+        /// <remarks>This is used for built in properties like the default MemberType
+        /// properties that should not be editable from the backoffice.</remarks>
+        [DataMember(Name = "locked")]
+        [ReadOnly(true)]
+        public bool Locked { get; set; }
+
         //SD: Seems strange that this is needed
         [DataMember(Name = "contentTypeId")]
         [ReadOnly(true)]

--- a/src/Umbraco.Web/Models/Mapping/ContentTypeModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeModelMapper.cs
@@ -230,7 +230,8 @@ namespace Umbraco.Web.Models.Mapping
                 .ForMember(g => g.View, expression => expression.Ignore())
                 .ForMember(g => g.Config, expression => expression.Ignore())
                 .ForMember(g => g.ContentTypeId, expression => expression.Ignore())
-                .ForMember(g => g.ContentTypeName, expression => expression.Ignore());
+                .ForMember(g => g.ContentTypeName, expression => expression.Ignore())
+                .ForMember(g => g.Locked, exp => exp.Ignore());
 
             #endregion
 

--- a/src/Umbraco.Web/Models/Mapping/PropertyTypeGroupResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/PropertyTypeGroupResolver.cs
@@ -117,6 +117,19 @@ namespace Umbraco.Web.Models.Mapping
                 groups.Add(genericTab);
             }
 
+            // handle locked properties
+            var lockedPropertyAliases = new List<string>();
+            // add built-in member property aliases to list of aliases to be locked
+            foreach (var propertyAlias in Constants.Conventions.Member.GetStandardPropertyTypeStubs().Keys)
+            {
+                lockedPropertyAliases.Add(propertyAlias);
+            }
+            // lock properties by aliases
+            foreach (var property in groups.SelectMany(x => x.Properties))
+            {
+                property.Locked = lockedPropertyAliases.Contains(property.Alias);
+            }
+
             // now merge tabs based on names
             // as for one name, we might have one local tab, plus some inherited tabs
             var groupsGroupsByName = groups.GroupBy(x => x.Name).ToArray();


### PR DESCRIPTION
Added locked property to content type properties by alias.
Ensured built in member properties are locked in the editor.
Content type editor changes for supporting locked properties.