### PR TITLE
Fix for U4-7719

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -233,6 +233,10 @@ ul.color-picker li a  {
    left: 0;
  }
 
+ .umb-cropper img {
+   max-width: none;
+ }
+ 
  .umb-cropper .overlay, .umb-cropper-gravity .overlay {
   top: 0;
   left: 0;


### PR DESCRIPTION
Removes the `max-width` constraint that causes wrong aspect ratios inside the image-cropper.