### PR TITLE
U4-7760 - prevents deletion of content types that are in use as a composition

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1232,7 +1232,9 @@ namespace Umbraco.Core.Services
                 using (var uow = UowProvider.GetUnitOfWork())
                 {
                     var repository = RepositoryFactory.CreateContentRepository(uow);
-                    //NOTE What about content that has the contenttype as part of its composition?
+                    //NOTE: Q. What about content that has the contenttype as part of its composition?
+                    //      A. This is OK as there shouldn't be any - we prevent deletion of a document type if used in a composition
+                    //         until all document types that use it are themselves deleted
                     var query = Query<IContent>.Builder.Where(x => x.ContentTypeId == contentTypeId);
                     var contents = repository.GetByQuery(query).ToArray();
 

--- a/src/Umbraco.Core/Services/ContentTypeService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeService.cs
@@ -651,6 +651,15 @@ namespace Umbraco.Core.Services
 	        if (DeletingContentType.IsRaisedEventCancelled(new DeleteEventArgs<IContentType>(contentType), this)) 
 				return;
 
+            // Check to see if the document type being deleted is used in a composition.  If so, prevent the deletion to avoid
+            // a potentially dangerous and expensive operation that deletes more content than expected.  The user will need
+            // to delete all types that use this type as a composition first.
+            // The UI should prevent access to deleting types used in composition so in normal back-office used this exception won't be thrown.
+            if (IsTypeUsedAsComposition(contentType))
+            {
+                throw new InvalidOperationException("Document type cannot be deleted as it is used as a composition in one or more other types");
+            }
+
             using (new WriteLock(Locker))
             {
                 _contentService.DeleteContentOfType(contentType.Id);
@@ -1109,6 +1118,12 @@ namespace Umbraco.Core.Services
 
             }
             return dtd.ToString();
+        }
+
+        private bool IsTypeUsedAsComposition(IContentType contentType)
+        {
+            return GetAllContentTypes()
+                .Any(x => x.ContentTypeComposition.Any(y => y.Id == contentType.Id));
         }
 
         private void Audit(AuditType type, string message, int userId, int objectId)

--- a/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
@@ -50,7 +50,6 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
                'Failed to retrieve data for content type id ' + contentTypeId);
         },
 
-
         /**
          * @ngdoc method
          * @name umbraco.resources.contentTypeResource#getAllowedTypes
@@ -66,7 +65,7 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
          *        $scope.type = type;
          *    });
          * </pre>
-         * @param {Int} contentTypeId id of the content item to retrive allowed child types for
+         * @param {Int} contentTypeId id of the content item to retrieve allowed child types for
          * @returns {Promise} resourcePromise object.
          *
          */
@@ -81,6 +80,34 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
                'Failed to retrieve data for content id ' + contentTypeId);
         },
 
+        /**
+         * @ngdoc method
+         * @name umbraco.resources.contentTypeResource#getTypesUsingComposite
+         * @methodOf umbraco.resources.contentTypeResource
+         *
+         * @description
+         * Returns a list of types that have the passed types as a composite
+         *
+         * ##usage
+         * <pre>
+         * contentTypeResource.getTypesUsingComposite(1234)
+         *    .then(function(array) {
+         *        $scope.type = type;
+         *    });
+         * </pre>
+         * @param {Int} contentTypeId id of the content item to retrieve composed types for
+         * @returns {Promise} resourcePromise object.
+         *
+         */
+        getTypesUsingComposite: function (contentTypeId) {
+            return umbRequestHelper.resourcePromise(
+               $http.get(
+                   umbRequestHelper.getApiUrl(
+                       "contentTypeApiBaseUrl",
+                       "GetTypesUsingComposite",
+                       [{ contentTypeId: contentTypeId }])),
+               'Failed to retrieve data for content id ' + contentTypeId);
+        },
 
         /**
          * @ngdoc method

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.controller.js
@@ -8,6 +8,12 @@
  */
 function DocumentTypesDeleteController($scope, dataTypeResource, contentTypeResource, treeService, navigationService) {
 
+    $scope.canDelete = true;
+
+    contentTypeResource.getTypesUsingComposite($scope.currentNode.id).then(function (data) {
+        $scope.canDelete = data.length === 0;
+    });
+
     $scope.performDelete = function() {
 
         //mark it for deletion (used in the UI)

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.html
@@ -2,42 +2,54 @@
 
     <div class="umb-dialog-body">
 
-        <p class="umb-abstract">
-            <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize>
-            <strong>{{currentNode.name}}</strong> ?
-        </p>
+        <div ng-show="canDelete">
 
-        <ng-switch on="currentNode.nodeType">
-            <div ng-switch-when="container">
-                <umb-confirm
-                    on-confirm="performContainerDelete"
-                    on-cancel="cancel">
-                </umb-confirm>
+            <p class="umb-abstract">
+                <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize>
+                <strong>{{currentNode.name}}</strong> ?
+            </p>
+
+            <ng-switch on="currentNode.nodeType">
+                <div ng-switch-when="container">
+                    <umb-confirm on-confirm="performContainerDelete"
+                                 on-cancel="cancel">
+                    </umb-confirm>
+                </div>
+
+                <div ng-switch-default>
+                    <p>
+                        <i class="icon-alert red"></i>
+                        <strong class="red">
+                            <localize key="contentTypeEditor_allDocuments">All Documents</localize>
+                        </strong>
+                        <localize key="contentTypeEditor_usingThisDocument">
+                            using this document type will be deleted permanently, please confirm you want to delete these as well.
+                        </localize>
+                    </p>
+
+                    <hr/>
+
+                    <label class="checkbox">
+                        <input type="checkbox" ng-model="confirmed"/>
+                        <localize key="contentTypeEditor_yesDelete">Yes, delete</localize> {{currentNode.name}} <localize key="contentTypeEditor_andAllDocuments">and all documents using this type</localize>
+                    </label>
+
+                    <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel">
+                    </umb-confirm>
+                </div>
+            </ng-switch>
+
+        </div>
+
+        <div ng-hide="canDelete">
+            <localize key="contentTypeEditor_cannotDeleteType">This document type cannot be deleted as it used as a composition in one or more other types. To remove this type, remove it as a composition from those other types first.</localize>
+
+            <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+                <a class="btn btn-link" ng-click="nav.hideDialog()">
+                    <localize key="general_cancel">Cancel</localize>
+                </a>
             </div>
-
-            <div ng-switch-default>
-                <p>
-                	<i class="icon-alert red"></i>
-                    <strong class="red">
-                        <localize key="contentTypeEditor_allDocuments">All Documents</localize>
-                    </strong>
-                    <localize key="contentTypeEditor_usingThisDocument">
-                        using this document type will be deleted permanently, please confirm you want to delete these as well.
-                    </localize>
-                </p>
-
-                <hr />
-
-                <label class="checkbox">
-                	<input type="checkbox" ng-model="confirmed" />
-                    <localize key="contentTypeEditor_yesDelete">Yes, delete</localize> {{currentNode.name}} <localize key="contentTypeEditor_andAllDocuments">and all documents using this type</localize>
-                </label>
-
-                <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel">
-                </umb-confirm>
-            </div>
-        </ng-switch>
-
+        </div>
 
     </div>
 </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1064,6 +1064,8 @@ To manage your website, simply open the Umbraco back office and start adding con
       <key alias="andAllMembers">and all members using this type</key>
 
       <key alias="thisEditorUpdateSettings">using this editor will get updated with the new settings</key>
+
+      <key alias="cannotDeleteType">This document type cannot be deleted as it used as a composition in one or more other types.  To remove this type, remove it as a composition from those other types first.</key>
   </area>
 
   <area alias="templateEditor">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1007,7 +1007,7 @@ To manage your website, simply open the Umbraco back office and start adding con
   </area>
 
   <area alias="contentTypeEditor">
-    <key alias="compositions">Compositions</key>
+    <key alias="compositions">Compositions</key>`
     <key alias="noTabs">You have not added any tabs</key>
     <key alias="addNewTab">Add new tab</key>
     <key alias="addAnotherTab">Add another tab</key>
@@ -1057,6 +1057,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="andAllMembers">and all members using this type</key>
     
     <key alias="thisEditorUpdateSettings">using this editor will get updated with the new settings</key>
+
+    <key alias="cannotDeleteType">This document type cannot be deleted as it used as a composition in one or more other types.  To remove this type, remove it as a composition from those other types first.</key>
   </area>
   
   <area alias="templateEditor">

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -98,9 +98,9 @@ namespace Umbraco.Web.Editors
         {
             return ApplicationContext.Services.ContentTypeService.GetAllPropertyTypeAliases();
         }
-
+        
         /// <summary>
-        /// Returns the avilable compositions for this content type
+        /// Returns the available compositions for this content type
         /// </summary>
         /// <param name="contentTypeId"></param>
         /// <param name="filterContentTypes">
@@ -252,14 +252,7 @@ namespace Umbraco.Web.Editors
         public IEnumerable<ContentTypeBasic> GetAll()
         {
             var types = Services.ContentTypeService.GetAllContentTypes();
-            var basics = types.Select(Mapper.Map<IContentType, ContentTypeBasic>);
-
-            return basics.Select(basic =>
-            {
-                basic.Name = TranslateItem(basic.Name);
-                basic.Description = TranslateItem(basic.Description);
-                return basic;
-            });
+            return MapTypesForResponse(types);
         }
 
         /// <summary>
@@ -296,16 +289,32 @@ namespace Umbraco.Web.Editors
                 types = Services.ContentTypeService.GetAllContentTypes(ids).ToList();
             }
 
-            var basics = types.Select(Mapper.Map<IContentType, ContentTypeBasic>).ToList();
+            return MapTypesForResponse(types);
+        }
 
-            var localizedTextService = Services.TextService;
-            foreach (var basic in basics)
+        /// <summary>
+        /// Returns the content types that use the passed type as a composition
+        /// </summary>
+        /// <param name="contentTypeId"></param>
+        /// <returns></returns>
+        [UmbracoTreeAuthorize(Constants.Trees.DocumentTypes, Constants.Trees.Content)]
+        public IEnumerable<ContentTypeBasic> GetTypesUsingComposite(int contentTypeId)
+        {
+            var types = Services.ContentTypeService.GetAllContentTypes()
+                .Where(x => x.ContentTypeComposition.Any(y => y.Id == contentTypeId));
+            return MapTypesForResponse(types);
+        }
+
+        private IEnumerable<ContentTypeBasic> MapTypesForResponse(IEnumerable<IContentType> types)
+        {
+            var basics = types.Select(Mapper.Map<IContentType, ContentTypeBasic>);
+
+            return basics.Select(basic =>
             {
-                basic.Name = localizedTextService.UmbracoDictionaryTranslate(basic.Name);
-                basic.Description = localizedTextService.UmbracoDictionaryTranslate(basic.Description);
-            }
-
-            return basics;
+                basic.Name = TranslateItem(basic.Name);
+                basic.Description = TranslateItem(basic.Description);
+                return basic;
+            });
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Editors/ContentTypeControllerBase.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeControllerBase.cs
@@ -50,6 +50,7 @@ namespace Umbraco.Web.Editors
         /// <summary>
         /// Returns the available composite content types for a given content type
         /// </summary>
+        /// <param name="contentTypeId"></param>       
         /// <param name="type"></param>
         /// <param name="filterContentTypes">
         /// This is normally an empty list but if additional content type aliases are passed in, any content types containing those aliases will be filtered out
@@ -60,7 +61,6 @@ namespace Umbraco.Web.Editors
         /// This is required because in the case of creating/modifying a content type because new property types being added to it are not yet persisted so cannot
         /// be looked up via the db, they need to be passed in.
         /// </param>
-        /// <param name="contentTypeId"></param>        
         /// <returns></returns>
         protected IEnumerable<Tuple<EntityBasic, bool>> PerformGetAvailableCompositeContentTypes(int contentTypeId, 
             UmbracoObjectTypes type, 


### PR DESCRIPTION
Currently there's an issue if you try to delete a content type that's used in a composition for another type and at least one node of content has been created.  Deleting a content type deletes the content created of that type, but if you delete a composed type this doesn't happen so you get an error due to the database constraint.

On the basis that automatically deleting the content could take out quite a lot and be an expensive operation, this PR prevents you from doing that.  If you want to delete a type used as a composition, you'll need to delete all the types using it first.

It works on the UI level to display a message if you attempt to delete a composition type and at the service API level by doing this same check and throwing an exception.