### PR TITLE
Added translations for v7 only entries

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
@@ -86,6 +86,7 @@
     <key alias="save">保存</key>
     <key alias="saveAndPublish">保存及び公開</key>
     <key alias="saveToPublish">保存して承認に送る</key>
+	<key alias="saveListView">リスト ビューの保存</key>
     <key alias="showPage">プレビュー</key>
     <key alias="showPageDisabled">テンプレートが指定されていないのでプレビューは無効になっています</key>
     <key alias="styleChoose">スタイルの選択</key>
@@ -130,6 +131,7 @@
     <key alias="itemChanged">このページは公開後変更されています</key>
     <key alias="itemNotPublished">このページは公開されていません</key>
     <key alias="lastPublished">公開日時</key>
+	<key alias="noItemsToShow">表示するアイテムはありません</key>
     <key alias="listViewNoItems" version="7.1.5">リストに表示するアイテムはありません</key>
     <key alias="mediatype">メディアタイプ</key>
     <key alias="mediaLinks">メディアの項目へのリンク</key>
@@ -165,6 +167,10 @@
   <area alias="media">
     <key alias="clickToUpload">クリックしてアップロードする</key>
     <key alias="dropFilesHere">ファイルをここへドロップ..</key>
+	<key alias="urls">メディアへリンク</key>
+    <key alias="orClickHereToUpload">またはクリックしてファイルを選択</key>
+    <key alias="onlyAllowedFiles">使用可能なファイル タイプ</key>
+    <key alias="maxFileSize">ファイルの最大サイズ</key>
   </area>
     <area alias="member">
     <key alias="createNewMember">メンバーの新規作成</key>
@@ -176,6 +182,7 @@
     <key alias="updateData">型とタイトルを選んでください</key>
     <key alias="noDocumentTypes" version="7.0"><![CDATA[利用可能なドキュメントタイプがありません。以下の設定セクションでこれらを有効にする必要があります。<strong>"document types"</strong>.]]></key>
     <key alias="noMediaTypes" version="7.0"><![CDATA[利用可能なメディアタイプがありません。以下の設定セクションでこれらを有効にする必要があります。<strong>"media types"</strong>.]]></key>
+	<key alias="documentTypeWithoutTemplate">テンプレートなしのドキュメント タイプ</key>
   </area>
   <area alias="dashboard">
     <key alias="browser">ウェブサイトを参照する</key>
@@ -233,6 +240,40 @@
     <key alias="thumbnailimageclickfororiginal">クリックすると画像がフルサイズで表示されます</key>
     <key alias="treepicker">項目の選択</key>
     <key alias="viewCacheItem">キャッシュされている項目の表示</key>
+	<key alias="createFolder">フォルダーの作成...</key>
+	
+    <key alias="relateToOriginalLabel">オリジナルに関連付ける</key>
+    <key alias="theFriendliestCommunity">フレンドリーなコミュニティ</key>
+
+    <key alias="linkToPage">ページへリンク</key>
+
+    <key alias="openInNewWindow">リンク ドキュメントを新しいウィンドウまたはタブで開く</key>
+    <key alias="openInFullBody">リンク ドキュメントをウィンドウ全文表示で開く</key>
+    <key alias="openInParentFrame">親フレームでリンク ドキュメントを開く</key>
+
+    <key alias="linkToMedia">メディアへリンク</key>
+
+    <key alias="selectMedia">メディアの選択</key>
+    <key alias="selectIcon">アイコンの選択</key>
+    <key alias="selectItem">アイテムの選択</key>
+    <key alias="selectLink">リンクの選択</key>
+    <key alias="selectMacro">マクロの選択</key>
+    <key alias="selectContent">コンテンツの選択</key>
+    <key alias="selectMember">メンバーの選択</key>
+    <key alias="selectMemberGroup">メンバー グループの選択</key>
+
+    <key alias="noMacroParams">このマクロのパラメーターはありません</key>
+
+    <key alias="externalLoginProviders">外部ログイン プロバイダー</key>
+    <key alias="exceptionDetail">例外の詳細</key>
+    <key alias="stracktrace">スタックトレース</key>
+
+    <key alias="linkYour">次をリンク:</key>
+    <key alias="unLinkYour">次をリンク解除:</key>
+
+    <key alias="account">アカウント</key>
+
+    <key alias="selectEditor">エディターの選択</key>
   </area>
   <area alias="dictionaryItem">
     <key alias="description"><![CDATA[
@@ -245,6 +286,8 @@
     <key alias="password">パスワードを入力...</key>
     <key alias="nameentity">%0%と命名します...</key>
     <key alias="entername">ここに名称を入力してください...</key>
+	<key alias="label">ラベル...</key>
+    <key alias="enterDescription">説明を入力してください...</key>
     <key alias="search">検索する...</key>
     <key alias="filter">条件で絞り込む...</key>
     <key alias="enterTags">タグを追加します...</key>
@@ -294,6 +337,7 @@
     <key alias="errorRegExpWithoutTab">%0% は正しい書式ではありません</key>
   </area>
   <area alias="errors">
+	<key alias="receivedErrorFromServer">サーバー エラーが発生しました</key>
     <key alias="dissallowedMediaType">指定されたファイルタイプは管理者のみに許可されます</key>
     <key alias="codemirroriewarning">注意! CodeMirrorが設定で有効化されていますが、 Internet Explorerでは不安定なので無効化してください。</key>
     <key alias="contentTypeAliasAndNameNotNull">新しいプロパティ型のエイリアスと名前の両方を設定してください！</key>
@@ -318,6 +362,7 @@
     <key alias="actions">アクション選択</key>
     <key alias="add">追加</key>
     <key alias="alias">エイリアス</key>
+	<key alias="all">すべて</key>
     <key alias="areyousure">確かですか?</key>
     <key alias="border">枠線</key>
     <key alias="by">または</key>
@@ -355,6 +400,7 @@
     <key alias="innerMargin">内側の余白</key>
     <key alias="insert">挿入</key>
     <key alias="install">インストール</key>
+	<key alias="invalid">無効</key>
     <key alias="justify">位置揃え</key>
     <key alias="language">言語</key>
     <key alias="layout">レイアウト</key>
@@ -413,7 +459,44 @@
     <key alias="searchResults">検索結果</key>
     <key alias="reorder">Reorder</key>
     <key alias="reorderDone">I am done reordering</key>
+	<key alias="preview">プレビュー</key>
+    <key alias="changePassword">パスワードの変更</key>
+    <key alias="to">-&gt;　</key>
+    <key alias="listView">リスト ビュー</key>
+    <key alias="saving">保存...</key>
+    <key alias="current">現在</key>
+    <key alias="move">移動</key>
+    <key alias="embed">埋め込み</key>
   </area>
+  
+  <area alias="colors">
+    <key alias="black">ブラック</key>
+    <key alias="green">グリーン</key>
+    <key alias="yellow">イエロー</key>
+    <key alias="orange">オレンジ</key>
+    <key alias="blue">ブルー</key>
+    <key alias="red">レッド</key>
+  </area>
+  
+  <area alias="shortcuts">
+      <key alias="addTab">タブの追加</key>
+      <key alias="addProperty">プロパティの追加</key>
+      <key alias="addEditor">エディターの追加</key>
+      <key alias="addTemplate">テンプレートの追加</key>
+      <key alias="addChildNode">子ノードの追加</key>
+      <key alias="addChild">子の追加</key>
+
+      <key alias="editDataType">データ タイプの編集</key>
+
+      <key alias="navigateSections">セクションの移動</key>
+
+      <key alias="shortcut">ショートカット</key>
+      <key alias="showShortcuts">ショートカットの表示</key>
+
+      <key alias="toggleListView">リスト ビューの切り替え</key>
+      <key alias="toggleAllowAsRoot">ルートとして許可に切り替え</key>
+  </area>
+  
   <area alias="graphicheadline">
     <key alias="backgroundcolor">背景色</key>
     <key alias="bold">太字</key>
@@ -685,6 +768,9 @@ Runwayをインストールして作られた新しいウェブサイトがど�
     <![CDATA[
       %0% ページは公開がスケジュールされているため、公開されませんでした。
     ]]></key>
+	<key alias="contentPublishedFailedExpired"><![CDATA[
+      アイテムの有効期限が切れているため %0% を公開できません。
+    ]]></key>
     <key alias="contentPublishedFailedInvalid"><![CDATA[
       %1% のプロパティがバリデーション定義に違反したため、%0% は公開できませんでした。
     ]]></key>
@@ -783,6 +869,7 @@ Runwayをインストールして作られた新しいウェブサイトがど�
     <key alias="noPropertiesDefinedOnTab">このタブにはプロパティが定義されていません、上部のリンクから新しいプロパティを作成してください</key>
     <key alias="masterDocumentType">マスタードキュメントタイプ</key>
     <key alias="createMatchingTemplate">テンプレートを作成する</key>
+	<key alias="addIcon">アイコンの追加</key>
   </area>
   <area alias="sort">
     <key alias="sortDone">ソートが完了しました。</key>
@@ -908,8 +995,68 @@ Runwayをインストールして作られた新しいウェブサイトがど�
 
     <key alias="allowAllEditors">すべてのエディタを許可する</key>
     <key alias="allowAllRowConfigurations">すべての行の構成を許可する</key>
+	<key alias="setAsDefault">デフォルトとして設定</key>
+    <key alias="chooseExtra">追加を選択</key>
+    <key alias="chooseDefault">デフォルトの選択</key>
+    <key alias="areAdded">追加されました</key>
   </area>
 
+  <area alias="contentTypeEditor">
+
+    <key alias="compositions">構成</key>
+    <key alias="noTabs">タブが追加されていません</key>
+    <key alias="addNewTab">新しいタブの追加</key>
+    <key alias="addAnotherTab">他のタブの追加</key>
+    <key alias="inheritedFrom">次から継承:</key>
+    <key alias="addProperty">プロパティの追加</key>
+    <key alias="requiredLabel">必要なラベル</key>
+
+    <key alias="enableListViewHeading">リスト ビューの有効化</key>
+    <key alias="enableListViewDescription">並べ替えと検索が可能な子のリストを表示するコンテンツ アイテムを設定します。子はツリーに表示されません。</key>
+
+    <key alias="allowedTemplatesHeading">利用可能なテンプレート</key>
+    <key alias="allowedTemplatesDescription">このタイプのコンテンツで使用できるテンプレート エディターを選択してください</key>
+
+    <key alias="allowAsRootHeading">ルートとして許可</key>
+    <key alias="allowAsRootDescription">コンテンツ ツリーのルートでこのタイプのコンテンツをエディターで作成することを許可</key>
+    <key alias="allowAsRootCheckbox">はい - ルートでこのタイプのコンテンツを許可</key>
+
+    <key alias="childNodesHeading">許可された子ノード タイプ</key>
+    <key alias="childNodesDescription">このタイプの下部コンテンツに指定タイプのコンテンツを作成することを許可</key>
+
+    <key alias="chooseChildNode">子ノードの選択</key>
+
+    <key alias="compositionsDescription">既存ドキュメント タイプのタブとプロパティを継承。新しいタブを現在のドキュメント タイプに追加、または同じ名前のタブがある場合はマージされます。</key>
+    <key alias="compositionInUse">このコンテンツ タイプが構成で使用されるため、自身を構成することはできません。</key>
+    <key alias="noAvailableCompositions">構成に使用できるコンテンツ タイプはありません。</key>
+
+    <key alias="availableEditors">使用可能なエディター</key>
+    <key alias="reuse">再利用</key>
+    <key alias="editorSettings">エディター設定</key>
+
+    <key alias="configuration">設定</key>
+
+    <key alias="yesDelete">削除します</key>
+
+    <key alias="movedUnderneath">下部に移動しました。</key>
+    <key alias="folderToMove">以下のツリー構造へ移動する</key>
+    <key alias="structureBelow">フォルダーを選択します</key>
+
+    <key alias="allDocumentTypes">すべてのドキュメント タイプ</key>
+    <key alias="allDocuments">すべてのドキュメント</key>
+    <key alias="allMediaItems">すべてのメディア アイテム</key>
+
+    <key alias="usingThisDocument">このドキュメント タイプを使用すると完全に削除されます。削除してもよろしいですか？</key>
+    <key alias="usingThisMedia">このメディア タイプを使用すると完全に削除されます。削除してもよろしいですか？</key>
+    <key alias="usingThisMember">このメンバー タイプを使用すると完全に削除されます。削除してもよろしいですか？</key>
+
+    <key alias="andAllDocuments">およびこのタイプを使用したすべてのドキュメント</key>
+    <key alias="andAllMediaItems">およびこのタイプを使用したこのメディア アイテム</key>
+    <key alias="andAllMembers">およびこのタイプを使用したすべてのメンバー</key>
+
+    <key alias="thisEditorUpdateSettings">このエディターを使用すると新しい設定で更新されます</key>
+  </area>
+  
   <area alias="templateEditor">
     <key alias="alternativeField">代替フィールド</key>
     <key alias="alternativeText">代替テキスト</key>
@@ -1065,5 +1212,13 @@ Runwayをインストールして作られた新しいウェブサイトがど�
     <key alias="yourProfile" version="7.0">あなたのプロフィール</key>
     <key alias="yourHistory" version="7.0">あなたの最新の履歴</key>
     <key alias="sessionExpires" version="7.0">セッションの期限</key>
+  </area>
+  <area alias="validation">
+    <key alias="validation">検証</key>
+    <key alias="validateAsEmail">メールで検証</key>
+    <key alias="validateAsNumber">数値で検証</key>
+    <key alias="validateAsUrl">URL で検証</key>
+    <key alias="enterCustomValidation">... またはカスタム検証を入力</key>
+    <key alias="fieldIsMandatory">必須フィールドです</key>
   </area>
 </language>


### PR DESCRIPTION
Added Japanese translations to entries that were previously missing from ja.xml in dev-v7.  I forked the repository, created a branch off of dev-v7, then made the changes.

These changes should only be applied in dev-v7 as the entries are not present in dev-v8.  This mismatch occurs in the en.xml file and I assume it is intentional.

I will submit a separate pull request for changes that should be applied to both v7 and v8 branches.

This is my first time submitting a pull request so please let me know if I can improve it.