### PR TITLE
U4-4652 - added decimal/double to contentbase

### DIFF
--- a/src/Umbraco.Core/Models/ContentBase.cs
+++ b/src/Umbraco.Core/Models/ContentBase.cs
@@ -372,6 +372,30 @@ namespace Umbraco.Core.Models
         }
 
         /// <summary>
+        /// Sets the <see cref="System.Decimal"/> value of a Property
+        /// </summary>
+        /// <param name="propertyTypeAlias">Alias of the PropertyType</param>
+        /// <param name="value">Value to set for the Property</param>
+        public virtual void SetPropertyValue(string propertyTypeAlias, decimal value)
+        {
+            string val = value.ToString();
+            SetValueOnProperty(propertyTypeAlias, val);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="System.Double"/> value of a Property
+        /// </summary>
+        /// <param name="propertyTypeAlias">Alias of the PropertyType</param>
+        /// <param name="value">Value to set for the Property</param>
+        public virtual void SetPropertyValue(string propertyTypeAlias, double value)
+        {
+            string val = value.ToString();
+            SetValueOnProperty(propertyTypeAlias, val);
+        }
+
+
+
+        /// <summary>
         /// Sets the <see cref="System.Boolean"/> value of a Property
         /// </summary>
         /// <param name="propertyTypeAlias">Alias of the PropertyType</param>


### PR DESCRIPTION
Currently, when I try to something like this:
tournament.SetValue("propertySetToUmbracoDecimal", .5M); it throws an error.
tournament.SetValue("propertySetToUmbracoDecimal", .5); it throws an error.
If I do this:
tournament.SetValue("propertySetToUmbracoDecimal", 1); 
tournament.SetValue("propertySetToUmbracoDecimal", ".5");

It works.

Hopefully, this will fix that issue., 

