### PR TITLE
Fixes: U4-7700 7.4 beta Backoffice Routing problem for Custom Sections or Installed Packages with a custom section

### DIFF
--- a/src/Umbraco.Core/Services/ApplicationTreeService.cs
+++ b/src/Umbraco.Core/Services/ApplicationTreeService.cs
@@ -3,13 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
-using System.Xml.XPath;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Events;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
-using Umbraco.Core.Cache;
 using File = System.IO.File;
 
 namespace Umbraco.Core.Services

--- a/src/Umbraco.Core/Services/ApplicationTreeService.cs
+++ b/src/Umbraco.Core/Services/ApplicationTreeService.cs
@@ -107,7 +107,20 @@ namespace Umbraco.Core.Services
                                             }
                                             else
                                             {
-                                                doc.Root.Add(new XElement("add",
+                                                if (tree.Title.IsNullOrWhiteSpace())
+                                                {
+                                                    doc.Root.Add(new XElement("add",
+                                                        new XAttribute("initialize", tree.Initialize),
+                                                        new XAttribute("sortOrder", tree.SortOrder),
+                                                        new XAttribute("alias", tree.Alias),
+                                                        new XAttribute("application", tree.ApplicationAlias),                                                        
+                                                        new XAttribute("iconClosed", tree.IconClosed),
+                                                        new XAttribute("iconOpen", tree.IconOpened),
+                                                        new XAttribute("type", tree.Type)));
+                                                }
+                                                else
+                                                {
+                                                    doc.Root.Add(new XElement("add",
                                                     new XAttribute("initialize", tree.Initialize),
                                                     new XAttribute("sortOrder", tree.SortOrder),
                                                     new XAttribute("alias", tree.Alias),
@@ -116,6 +129,8 @@ namespace Umbraco.Core.Services
                                                     new XAttribute("iconClosed", tree.IconClosed),
                                                     new XAttribute("iconOpen", tree.IconOpened),
                                                     new XAttribute("type", tree.Type)));
+                                                }
+                                                
                                             }
                                             count++;
                                         }

--- a/src/Umbraco.Core/Services/ApplicationTreeService.cs
+++ b/src/Umbraco.Core/Services/ApplicationTreeService.cs
@@ -373,13 +373,15 @@ namespace Umbraco.Core.Services
                     {
                         list.Add(new ApplicationTree(
                                      addElement.Attribute("initialize") == null || Convert.ToBoolean(addElement.Attribute("initialize").Value),
-                                     addElement.Attribute("sortOrder") != null ? Convert.ToByte(addElement.Attribute("sortOrder").Value) : (byte)0,
-                                     addElement.Attribute("application").Value,
-                                     addElement.Attribute("alias").Value,
-                                     addElement.Attribute("title").Value,
-                                     addElement.Attribute("iconClosed").Value,
-                                     addElement.Attribute("iconOpen").Value,
-                                     addElement.Attribute("type").Value));
+                                     addElement.Attribute("sortOrder") != null 
+                                        ? Convert.ToByte(addElement.Attribute("sortOrder").Value) 
+                                        : (byte)0,
+                                     (string)addElement.Attribute("application"),
+                                     (string)addElement.Attribute("alias"),
+                                     (string)addElement.Attribute("title"),
+                                     (string)addElement.Attribute("iconClosed"),
+                                     (string)addElement.Attribute("iconOpen"),
+                                     (string)addElement.Attribute("type")));
                     }
                 }
 

--- a/src/Umbraco.Core/Services/ApplicationTreeService.cs
+++ b/src/Umbraco.Core/Services/ApplicationTreeService.cs
@@ -98,18 +98,14 @@ namespace Umbraco.Core.Services
                                         var count = 0;
                                         foreach (var tree in unregistered)
                                         {
-                                            //ugly translate hack to allow case insensitive matching since 'matches' is a xpath2.0 feature...
-                                            var existingElement = doc.Root.XPathSelectElement("//add[translate(@alias,'abcdefghijklmnopqrstuvwxyz','ABCDEFGHIJKLMNOPQRSTUVWXYZ')=translate('" + tree.Alias + "','abcdefghijklmnopqrstuvwxyz','ABCDEFGHIJKLMNOPQRSTUVWXYZ')]");
+                                            var existingElement = doc.Root.Elements("add").SingleOrDefault(x =>
+                                                string.Equals(x.Attribute("alias").Value, tree.Alias,
+                                                    StringComparison.InvariantCultureIgnoreCase) &&
+                                                string.Equals(x.Attribute("application").Value, tree.ApplicationAlias,
+                                                    StringComparison.InvariantCultureIgnoreCase));
                                             if (existingElement != null)
                                             {
-                                                existingElement.SetAttributeValue("initialize", tree.Initialize);
-                                                existingElement.SetAttributeValue("sortOrder", tree.Initialize);
                                                 existingElement.SetAttributeValue("alias", tree.Alias);
-                                                existingElement.SetAttributeValue("application", tree.ApplicationAlias);
-                                                existingElement.SetAttributeValue("title", tree.Title);
-                                                existingElement.SetAttributeValue("iconClosed", tree.IconClosed);
-                                                existingElement.SetAttributeValue("iconOpen", tree.IconOpened);
-                                                existingElement.SetAttributeValue("type", tree.Type);
                                             }
                                             else
                                             {
@@ -141,11 +137,7 @@ namespace Umbraco.Core.Services
                             }
                         }
                     }
-
-
                     return list;
-
-
                 }, new TimeSpan(0, 10, 0));
         }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -108,7 +108,7 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
          * @param {String} source The URL to load into the iframe
          */
         loadLegacyIFrame: function (source) {
-            $location.path("/" + appState.getSectionState("currentSection").toLowerCase() + "/framed/" + encodeURIComponent(source));
+            $location.path("/" + appState.getSectionState("currentSection") + "/framed/" + encodeURIComponent(source));
         },
 
         /**
@@ -132,7 +132,7 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
             appState.setSectionState("currentSection", sectionAlias);
             this.showTree(sectionAlias);
 
-            $location.path(sectionAlias.toLowerCase());
+            $location.path(sectionAlias);
         },
 
         /**
@@ -214,7 +214,9 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
 
             //this reacts to tree items themselves being clicked
             //the tree directive should not contain any handling, simply just bubble events
-            mainTreeEventHandler.bind("treeNodeSelect", function(ev, args) {
+            mainTreeEventHandler.bind("treeNodeSelect", function (ev, args) {
+                console.log('navigating-ev', ev);
+                console.log('navigating-args', args);
                 var n = args.node;
                 ev.stopPropagation();
                 ev.preventDefault();
@@ -250,10 +252,10 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
                     appState.setMenuState("currentNode", args.node);
 
                     //not legacy, lets just set the route value and clear the query string if there is one.
-                    $location.path(n.routePath.toLowerCase()).search("");
+                    $location.path(n.routePath).search("");
                 }
                 else if (args.element.section) {
-                    $location.path(args.element.section.toLowerCase()).search("");
+                    $location.path(args.element.section).search("");
                 }
 
                 service.hideNavigation();
@@ -446,7 +448,7 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
             if (action.metaData && action.metaData["actionRoute"] && angular.isString(action.metaData["actionRoute"])) {
                 //first check if the menu item simply navigates to a route
                 var parts = action.metaData["actionRoute"].split("?");
-                $location.path(parts[0].toLowerCase()).search(parts.length > 1 ? parts[1] : "");
+                $location.path(parts[0]).search(parts.length > 1 ? parts[1] : "");
                 this.hideNavigation();
                 return;
             }

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -215,8 +215,6 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
             //this reacts to tree items themselves being clicked
             //the tree directive should not contain any handling, simply just bubble events
             mainTreeEventHandler.bind("treeNodeSelect", function (ev, args) {
-                console.log('navigating-ev', ev);
-                console.log('navigating-args', args);
                 var n = args.node;
                 ev.stopPropagation();
                 ev.preventDefault();

--- a/src/Umbraco.Web.UI.Client/src/routes.js
+++ b/src/Umbraco.Web.UI.Client/src/routes.js
@@ -130,7 +130,7 @@ app.config(function ($routeProvider) {
                 // angular dashboards working. Perhaps a normal section dashboard would list out the registered
                 // dashboards (as tabs if we wanted) and each tab could actually be a route link to one of these views?
 
-                return ('views/' + rp.tree + '/' + rp.method + '.html').toLowerCase();
+                return ('views/' + rp.tree + '/' + rp.method + '.html');
             },
             resolve: canRoute(true)
         })
@@ -156,10 +156,10 @@ app.config(function ($routeProvider) {
                 if (packageTreeFolder) {
                     $scope.templateUrl = (Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath +
                         "/" + packageTreeFolder +
-                        "/backoffice/" + $routeParams.tree + "/" + $routeParams.method + ".html").toLowerCase();
+                        "/backoffice/" + $routeParams.tree + "/" + $routeParams.method + ".html");
                 }
                 else {
-                    $scope.templateUrl = ('views/' + $routeParams.tree + '/' + $routeParams.method + '.html').toLowerCase();
+                    $scope.templateUrl = ('views/' + $routeParams.tree + '/' + $routeParams.method + '.html');
                 }
 
             },


### PR DESCRIPTION
Reverted lowercasing of routes which was done to ensure documentTypes tree renaming was supported without requiring to update trees.config.
Lowercasing however broke custom package routes so instead we now just update the trees.config file if casing in the tree alias has changed.