### PR TITLE
U4-7836 YSOD when upgrading Umbraco with error during AddUserDataClaims

### DIFF
--- a/src/Umbraco.Core/Persistence/Relators/UserSectionRelator.cs
+++ b/src/Umbraco.Core/Persistence/Relators/UserSectionRelator.cs
@@ -18,8 +18,11 @@ namespace Umbraco.Core.Persistence.Relators
             // Is this the same DictionaryItem as the current one we're processing
             if (Current != null && Current.Id == a.Id)
             {
-                // Yes, just add this User2AppDto to the current item's collection
-                Current.User2AppDtos.Add(p);
+                if (p.AppAlias.IsNullOrWhiteSpace() == false)
+                {
+                    // Yes, just add this User2AppDto to the current item's collection
+                    Current.User2AppDtos.Add(p);
+                }
 
                 // Return null to indicate we're not done with this User yet
                 return null;
@@ -35,7 +38,7 @@ namespace Umbraco.Core.Persistence.Relators
             Current = a;
             Current.User2AppDtos = new List<User2AppDto>();
             //this can be null since we are doing a left join
-            if (p.AppAlias != null)
+            if (p.AppAlias.IsNullOrWhiteSpace() == false)
             {
                 Current.User2AppDtos.Add(p);    
             }

--- a/src/Umbraco.Web/Install/InstallSteps/SetUmbracoVersionStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/SetUmbracoVersionStep.cs
@@ -40,9 +40,14 @@ namespace Umbraco.Web.Install.InstallSteps
             var clientDependencyConfig = new ClientDependencyConfiguration(_applicationContext.ProfilingLogger.Logger);
             var clientDependencyUpdated = clientDependencyConfig.IncreaseVersionNumber();
 
-            var security = new WebSecurity(_httpContext, _applicationContext);
-            security.PerformLogin(0);
-
+            //During a new install we'll log the default user in (which is id = 0).
+            // During an upgrade, the user will already need to be logged in in order to run the installer.
+            if (InstallTypeTarget == InstallationType.NewInstall)
+            {
+                var security = new WebSecurity(_httpContext, _applicationContext);
+                security.PerformLogin(0);
+            }
+            
             //reports the ended install
             var ih = new InstallHelper(UmbracoContext.Current);
             ih.InstallStatus(true, "");


### PR DESCRIPTION
…ms - this also ensures that no empty/null sections can be added to the user object since this is where the original exception was coming from.