### PR TITLE
Fix for U4-7842

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/template/querybuilder.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/template/querybuilder.controller.js
@@ -33,7 +33,7 @@ angular.module("umbraco").controller('Umbraco.Dialogs.Template.QueryBuilderContr
 						alias: "",
 						name: "",
 					},
-					direction: "Ascending"
+					direction: "ascending"
 				}
 			};
 


### PR DESCRIPTION
The Query Builder has a button for toggling between `ascending` and `descending` - only it starts out as `Ascending`

http://issues.umbraco.org/issue/U4-7842

#justincase