### PR TITLE
Indent of toolbar options in TinyMCE config

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -140,7 +140,10 @@ h5.-black {
 
 /* LABELS*/
 .umb-control-group label.control-label {
-  text-align: left
+  text-align: left;
+}
+.umb-control-group label.control-label > div > label {
+  padding-left: 0;
 }
 .umb-control-group label .help-block,
 .umb-control-group label small {
@@ -150,7 +153,7 @@ h5.-black {
   padding-top: 5px;
 }
 .umb-nolabel .controls {
-  margin-left: 0px;
+  margin-left: 0;
 }
 
 .controls-row {
@@ -159,11 +162,15 @@ h5.-black {
 }
 
 .umb-user-panel .controls-row {
-    margin-left: 0px;
+    margin-left: 0;
 }
 
 .controls-row label {
-  display: inline-block
+  display: inline-block;
+}
+
+.controls-row > div > label {
+  padding-left: 0;
 }
 
 .block-form .controls-row {
@@ -171,10 +178,24 @@ h5.-black {
    padding-top: 0;
 }
 
-.hidelabel > div > .controls-row, .hidelabel > .controls-row, .hidelabel .controls {
-  padding: 0px;
+.hidelabel > div > .controls-row, .hidelabel > .controls-row, .hidelabel > div > .controls {
+  padding: 0;
   border: none;
-  margin: 0px !important;
+  margin: 0 !important;
+}
+
+.controls-row > .vertical-align-items {
+  display: flex;
+  align-items: center;
+}
+
+.controls-row > .vertical-align-items > input.umb-editor-tiny {
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
+.controls-row > .vertical-align-items > input.umb-editor-tiny:first-child {
+  margin-left: 0;
 }
 
 .thumbnails .selected {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -2,35 +2,41 @@
 
 	<umb-control-group label="Toolbar" hide-label="false">
 		<div ng-repeat="cmd in tinyMceConfig.commands">
-			<input type="checkbox" 
-				ng-checked="selected(cmd, cmd.frontEndCommand, model.value.toolbar)" 
-				ng-model="cmd.selected" 
-				ng-change="selectCommand(cmd)"
-				/> 
+            <label>
+			    <input type="checkbox" 
+				       ng-checked="selected(cmd, cmd.frontEndCommand, model.value.toolbar)" 
+				       ng-model="cmd.selected" 
+				       ng-change="selectCommand(cmd)" /> 
 
 				<img ng-src="{{cmd.icon}}" />
 
 				{{cmd.frontEndCommand}}
+            </label>
 		</div>
 	</umb-control-group>
 
 	<umb-control-group label="Stylesheets" hide-label="0">
 		<div ng-repeat="css in stylesheets">
-			<input type="checkbox" 
-				ng-checked="selected(css, css.name, model.value.stylesheets)" 
-				ng-model="css.selected" 
-				ng-change="selectStylesheet(css)"
-				/> 
-				{{css.name}}
+            <label>
+			    <input type="checkbox" 
+				       ng-checked="selected(css, css.name, model.value.stylesheets)" 
+				       ng-model="css.selected" 
+				       ng-change="selectStylesheet(css)" /> 
+		        {{css.name}}
+            </label>
 		</div>
 	</umb-control-group>
 
 	<umb-control-group label="Dimensions" description="Width x Height">
-		<input type="number" ng-model="model.value.dimensions.width" class="umb-editor-tiny" placeholder="Width" /> &times; 
-		<input type="number" ng-model="model.value.dimensions.height" class="umb-editor-tiny" placeholder="Height" /> Pixels   
+        <div class="vertical-align-items">
+            <input type="number" min="0" ng-model="model.value.dimensions.width" class="umb-editor-tiny" placeholder="Width" /> &times; 
+            <input type="number" min="0" ng-model="model.value.dimensions.height" class="umb-editor-tiny" placeholder="Height" /> Pixels
+        </div> 
 	</umb-control-group>
 
     <umb-control-group label="Maximum size for inserted images" description="0 to disable resizing">
-        <input type="number" ng-model="model.value.maxImageSize" class="umb-editor-tiny" placeholder="Width/Height" /> Pixels
+        <div class="vertical-align-items">
+            <input type="number" min="0" ng-model="model.value.maxImageSize" class="umb-editor-tiny" placeholder="Width/Height" /> Pixels
+        </div> 
     </umb-control-group>
 </div>


### PR DESCRIPTION
Issues:
http://issues.umbraco.org/issue/U4-3935
http://issues.umbraco.org/issue/U4-7800

Related to https://github.com/umbraco/Umbraco-CMS/pull/1050

It seems to be okay for both Richtext editor config and Richtext editor in Grid editor config.