### PR TITLE
U4-7840 - Ability to disable/hide bulk operations with list views on data type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewlayout.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewlayout.directive.js
@@ -21,6 +21,7 @@
             contentId: '=',
             folders: '=',
             items: '=',
+            allowSelectAll: '=',
             selection: '=',
             options: '=',
             entityType: '@',

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbtable.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbtable.directive.js
@@ -51,13 +51,14 @@
          templateUrl: 'views/components/umb-table.html',
          scope: {
             items: '=',
-            itemProperties: "=",
+            itemProperties: '=',
+            allowSelectAll: '=',
             onSelect: '=',
-            onClick: "=",
-            onSelectAll: "=",
-            onSelectedAll: "=",
-            onSortingDirection: "=",
-            onSort:"="
+            onClick: '=',
+            onSelectAll: '=',
+            onSelectedAll: '=',
+            onSortingDirection: '=',
+            onSort: '='
          },
          link: link
       };

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -644,3 +644,10 @@ ul.color-picker li a  {
 	height: 100%;
     min-height:200px;
 }
+
+//
+// Nested boolean (e.g. list view bulk action permissions)
+// ---------------------=====-----------------------------
+.umb-nested-boolean label {margin-bottom: 8px; float: left; width: 320px;}
+.umb-nested-boolean label span {float: left; width: 80%;}
+.umb-nested-boolean label input[type='checkbox'] {float: left;}

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
@@ -8,9 +8,9 @@
 
                 <div class="umb-table-cell">
                     <input class="umb-table__input" type="checkbox"
-                    ng-click="selectAll($event)"
-                    ng-checked="isSelectedAll()"
-                    >
+                           ng-if="allowSelectAll"
+                           ng-click="selectAll($event)"
+                           ng-checked="isSelectedAll()">
                 </div>
 
                 <div class="umb-table-cell umb-table__name">
@@ -22,8 +22,8 @@
 
                 <div class="umb-table-cell" ng-repeat="column in itemProperties">
                     <a class="umb-table-head__link" title="Sort by {{ column.header }}" href="#"
-                        ng-click="sort(column.alias, column.allowSorting)"
-                        ng-class="{'sortable':column.allowSorting}" prevent-default>
+                       ng-click="sort(column.alias, column.allowSorting)"
+                       ng-class="{'sortable':column.allowSorting}" prevent-default>
 
                         <span ng-bind="column.header"></span>
                         <i class="umb-table-head__icon icon" ng-class="{'icon-navigation-up': isSortDirection(column.alias, 'asc'), 'icon-navigation-down': isSortDirection(column.alias, 'desc')}"></i>
@@ -36,14 +36,13 @@
         <!-- Listview body section -->
         <div class="umb-table-body">
             <div class="umb-table-row"
-                ng-repeat="item in items"
-                ng-class="{
+                 ng-repeat="item in items"
+                 ng-class="{
                     '-selected':item.selected,
                     '-published':item.published,
                     '-unpublished':!item.published
                 }"
-                ng-click="selectItem(item, $index, $event)"
-                >
+                 ng-click="selectItem(item, $index, $event)">
 
 
                 <div class="umb-table-cell">
@@ -53,8 +52,8 @@
 
                 <div class="umb-table-cell umb-table__name">
                     <a title="{{ item.name }}" class="umb-table-body__link" href=""
-                        ng-click="clickItem(item, $event)"
-                        ng-bind="item.name">
+                       ng-click="clickItem(item, $event)"
+                       ng-bind="item.name">
                     </a>
                 </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/bulkActionPermissions.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/bulkActionPermissions.prevalues.controller.js
@@ -1,0 +1,17 @@
+/**
+ * @ngdoc controller
+ * @name Umbraco.PrevalueEditors.ListViewBulkActionPermissionsPreValsController
+ * @function
+ *
+ * @description
+ * The controller for configuring the allowed bulk actions for list views
+ */
+(function () {
+    "use strict";
+
+    function ListViewBulkActionPermissionsPreValsController($scope) {
+    }
+
+    angular.module("umbraco").controller("Umbraco.PrevalueEditors.ListViewBulkActionPermissionsPreValsController", ListViewBulkActionPermissionsPreValsController);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/bulkActionPermissions.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/bulkActionPermissions.prevalues.html
@@ -1,0 +1,32 @@
+﻿<div class="umb-editor" ng-controller="Umbraco.PrevalueEditors.ListViewBulkActionPermissionsPreValsController">
+    <div class="umb-nested-boolean">
+        <label for="allowBulkPublish">
+            <span>Allow bulk publish (content only)</span>
+            <input type="checkbox" ng-model="model.value.allowBulkPublish" id="allowBulkPublish"/>
+        </label>
+    </div>
+    <div class="umb-nested-boolean">
+        <label for="allowBulkPublish">
+            <span>Allow bulk unpublish (content only)</span>
+            <input type="checkbox" ng-model="model.value.allowBulkUnpublish" id="allowBulkUnpublish" />
+        </label>
+    </div>
+    <div class="umb-nested-boolean">
+        <label for="allowBulkPublish">
+            <span>Allow bulk copy (content only)</span>
+            <input type="checkbox" ng-model="model.value.allowBulkCopy" id="allowBulkCopy" />
+        </label>
+    </div>
+    <div class="umb-nested-boolean">
+        <label for="allowBulkPublish">
+            <span>Allow bulk move</span>
+            <input type="checkbox" ng-model="model.value.allowBulkMove" id="allowBulkMove" />
+        </label>
+    </div>
+    <div class="umb-nested-boolean">
+        <label for="allowBulkPublish">
+            <span>Allow bulk delete</span>
+            <input type="checkbox" ng-model="model.value.allowBulkDelete" id="allowBulkDelete" />
+        </label>
+    </div>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.html
@@ -22,6 +22,7 @@
         <umb-table
             ng-if="items"
             items="items"
+            allow-select-all="allowSelectAll"
             item-properties="options.includeProperties"
             on-select="vm.selectItem"
             on-click="vm.clickItem"
@@ -38,6 +39,7 @@
         <umb-table
             ng-if="items"
             items="items"
+            allow-select-all="allowSelectAll"
             item-properties="options.includeProperties"
             on-select="vm.selectItem"
             on-click="vm.clickItem"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
@@ -5,7 +5,6 @@
 
         var vm = this;
 
-
         vm.nodeId = $scope.contentId;
         vm.acceptedFileTypes = mediaHelper.formatFileTypes(Umbraco.Sys.ServerVariables.umbracoSettings.imageFileTypes);
         vm.maxFileSize = Umbraco.Sys.ServerVariables.umbracoSettings.maxFileSize + "KB";

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -73,11 +73,11 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
            layouts: $scope.model.config.layouts,
            activeLayout: listViewHelper.getLayout($routeParams.id, $scope.model.config.layouts)
         },
-        allowBulkPublish: true,
-        allowBulkUnpublish: true,
-        allowBulkCopy: true,
-        allowBulkMove: true,
-        allowBulkDelete: true,
+        allowBulkPublish: $scope.entityType === 'content' && $scope.model.config.bulkActionPermissions.allowBulkPublish,
+        allowBulkUnpublish: $scope.entityType === 'content' && $scope.model.config.bulkActionPermissions.allowBulkUnpublish,
+        allowBulkCopy: $scope.entityType === 'content' && $scope.model.config.bulkActionPermissions.allowBulkCopy,
+        allowBulkMove: $scope.model.config.bulkActionPermissions.allowBulkMove,
+        allowBulkDelete: $scope.model.config.bulkActionPermissions.allowBulkDelete
     };
 
     //update all of the system includeProperties to enable sorting
@@ -436,6 +436,15 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
 
         $scope.contentId = id;
         $scope.isTrashed = id === "-20" || id === "-21";
+
+        $scope.options.allowBulkPublish = $scope.options.allowBulkPublish && !$scope.isTrashed;
+        $scope.options.allowBulkUnpublish = $scope.options.allowBulkUnpublish && !$scope.isTrashed;
+
+        $scope.bulkActionsAllowed = $scope.options.allowBulkPublish ||
+            $scope.options.allowBulkUnpublish ||
+            $scope.options.allowBulkCopy ||
+            $scope.options.allowBulkMove ||
+            $scope.options.allowBulkDelete;
 
         $scope.reloadView($scope.contentId);
     }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -6,147 +6,148 @@
 
    <div class="row-fluid" ng-switch-when="false">
 
-      <umb-editor-sub-header>
+       <umb-editor-sub-header>
 
-         <umb-editor-sub-header-content-left>
+           <umb-editor-sub-header-content-left>
 
-            <umb-editor-sub-header-section ng-if="listViewAllowedTypes && listViewAllowedTypes.length > 0 && !isAnythingSelected()">
-               <div class="btn-group">
-                   <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                       <localize key="actions_create">Create</localize>
-                       <span class="caret"></span>
-                   </a>
-                   <ul class="dropdown-menu">
-                       <li ng-repeat="contentType in listViewAllowedTypes">
-                           <a href="#/{{entityType}}/{{entityType}}/edit/{{contentId}}?doctype={{contentType.alias}}&create=true">
-                               <i class="icon-{{contentType.cssClass}}"></i>
-                               {{contentType.name}}
-                           </a>
-                       </li>
-                   </ul>
-               </div>
-            </umb-editor-sub-header-section>
-
-            <umb-editor-sub-header-section ng-if="isAnythingSelected()">
-               <umb-button
-                  type="button"
-                  label="Clear selection"
-                  action="clearSelection()"
-                  disabled="actionInProgress">
-               </umb-button>
-            </umb-editor-sub-header-section>
-
-            <umb-editor-sub-header-section ng-if="isAnythingSelected()">
-               <strong ng-show="!actionInProgress">{{ selectedItemsCount() }} of {{ listViewResultSet.items.length }} selected</strong>
-               <strong ng-show="actionInProgress" ng-bind="bulkStatus"></strong>
-
-               <div class="umb-loader-wrapper -bottom" ng-show="actionInProgress">
-                  <div class="umb-loader"></div>
-               </div>
-            </umb-editor-sub-header-section>
-
-         </umb-editor-sub-header-content-left>
-
-
-         <umb-editor-sub-header-content-right>
-
-            <umb-editor-sub-header-section ng-if="!isAnythingSelected()">
-
-               <umb-layout-selector
-                  ng-if="options.layout.layouts"
-                  layouts="options.layout.layouts"
-                  active-layout="options.layout.activeLayout"
-                  on-layout-select="selectLayout">
-               </umb-layout-selector>
-
-            </umb-editor-sub-header-section>
-
-            <umb-editor-sub-header-section ng-if="!isAnythingSelected()">
-               <form class="form-search -no-margin-bottom pull-right" novalidate>
-                   <div class="inner-addon left-addon">
-                       <i class="icon icon-search" ng-click="enterSearch($event)"></i>
-                       <input
-                        class="form-control search-input"
-                        type="text"
-                        localize="placeholder"
-                        placeholder="@general_typeToSearch"
-                        ng-model="options.filter"
-                        ng-change="enterSearch()"
-                        ng-keydown="forceSearch($event)"
-                        prevent-enter-submit
-                        no-dirty-check>
+               <umb-editor-sub-header-section ng-if="listViewAllowedTypes && listViewAllowedTypes.length > 0 && !isAnythingSelected()">
+                   <div class="btn-group">
+                       <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+                           <localize key="actions_create">Create</localize>
+                           <span class="caret"></span>
+                       </a>
+                       <ul class="dropdown-menu">
+                           <li ng-repeat="contentType in listViewAllowedTypes">
+                               <a href="#/{{entityType}}/{{entityType}}/edit/{{contentId}}?doctype={{contentType.alias}}&create=true">
+                                   <i class="icon-{{contentType.cssClass}}"></i>
+                                   {{contentType.name}}
+                               </a>
+                           </li>
+                       </ul>
                    </div>
-               </form>
-            </umb-editor-sub-header-section>
+               </umb-editor-sub-header-section>
 
-            <umb-editor-sub-header-section ng-if="isAnythingSelected()">
+               <umb-editor-sub-header-section ng-if="isAnythingSelected()">
+                   <umb-button
+                       type="button"
+                       label="Clear selection"
+                       action="clearSelection()"
+                       disabled="actionInProgress">
+                   </umb-button>
+               </umb-editor-sub-header-section>
 
-               <umb-button
-                  ng-if="entityType === 'content' && !isTrashed && options.allowBulkPublish"
-                  type="button"
-                  button-style="link"
-                  label="Publish"
-                  key="actions_publish"
-                  icon="icon-globe"
-                  action="publish()"
-                  disabled="actionInProgress">
-               </umb-button>
+               <umb-editor-sub-header-section ng-if="isAnythingSelected()">
+                   <strong ng-show="!actionInProgress">{{ selectedItemsCount() }} of {{ listViewResultSet.items.length }} selected</strong>
+                   <strong ng-show="actionInProgress" ng-bind="bulkStatus"></strong>
 
-               <umb-button
-                  ng-if="entityType === 'content' && !isTrashed && options.allowBulkUnpublish"
-                  type="button"
-                  button-style="link"
-                  label="Unpublish"
-                  key="actions_unpublish"
-                  icon="icon-block"
-                  action="unpublish()"
-                  disabled="actionInProgress">
-               </umb-button>
+                   <div class="umb-loader-wrapper -bottom" ng-show="actionInProgress">
+                       <div class="umb-loader"></div>
+                   </div>
+               </umb-editor-sub-header-section>
 
-               <umb-button
-                  ng-if="entityType === 'content' && options.allowBulkCopy"
-                  type="button"
-                  button-style="link"
-                  label="Copy"
-                  key="actions_copy"
-                  icon="icon-documents"
-                  action="copy()"
-                  disabled="actionInProgress">
-               </umb-button>
+           </umb-editor-sub-header-content-left>
 
-               <umb-button
-                  ng-if="options.allowBulkMove"
-                  type="button"
-                  button-style="link"
-                  label="Move"
-                  key="actions_move"
-                  icon="icon-enter"
-                  action="move()"
-                  disabled="actionInProgress">
-               </umb-button>
 
-               <umb-button
-                  ng-if="options.allowBulkDelete"
-                  type="button"
-                  button-style="link"
-                  label="Delete"
-                  key="actions_delete"
-                  icon="icon-trash"
-                  action="delete()"
-                  disabled="actionInProgress">
-               </umb-button>
+           <umb-editor-sub-header-content-right>
 
-            </umb-editor-sub-header-section>
+               <umb-editor-sub-header-section ng-if="!isAnythingSelected()">
 
-         </umb-editor-sub-header-content-right>
+                   <umb-layout-selector
+                       ng-if="options.layout.layouts"
+                       layouts="options.layout.layouts"
+                       active-layout="options.layout.activeLayout"
+                       on-layout-select="selectLayout">
+                   </umb-layout-selector>
 
-      </umb-editor-sub-header>
+               </umb-editor-sub-header-section>
 
-      <umb-list-view-layout
+               <umb-editor-sub-header-section ng-if="!isAnythingSelected()">
+                   <form class="form-search -no-margin-bottom pull-right" novalidate>
+                       <div class="inner-addon left-addon">
+                           <i class="icon icon-search" ng-click="enterSearch($event)"></i>
+                           <input
+                               class="form-control search-input"
+                               type="text"
+                               localize="placeholder"
+                               placeholder="@general_typeToSearch"
+                               ng-model="options.filter"
+                               ng-change="enterSearch()"
+                               ng-keydown="forceSearch($event)"
+                               prevent-enter-submit
+                               no-dirty-check>
+                       </div>
+                   </form>
+               </umb-editor-sub-header-section>
+
+               <umb-editor-sub-header-section ng-if="isAnythingSelected()">
+
+                   <umb-button
+                       ng-if="options.allowBulkPublish"
+                       type="button"
+                       button-style="link"
+                       label="Publish"
+                       key="actions_publish"
+                       icon="icon-globe"
+                       action="publish()"
+                       disabled="actionInProgress">
+                   </umb-button>
+
+                   <umb-button
+                       ng-if="options.allowBulkUnpublish"
+                       type="button"
+                       button-style="link"
+                       label="Unpublish"
+                       key="actions_unpublish"
+                       icon="icon-block"
+                       action="unpublish()"
+                       disabled="actionInProgress">
+                   </umb-button>
+
+                   <umb-button
+                       ng-if="options.allowBulkCopy"
+                       type="button"
+                       button-style="link"
+                       label="Copy"
+                       key="actions_copy"
+                       icon="icon-documents"
+                       action="copy()"
+                       disabled="actionInProgress">
+                   </umb-button>
+
+                   <umb-button
+                       ng-if="options.allowBulkMove"
+                       type="button"
+                       button-style="link"
+                       label="Move"
+                       key="actions_move"
+                       icon="icon-enter"
+                       action="move()"
+                       disabled="actionInProgress">
+                   </umb-button>
+
+                   <umb-button
+                       ng-if="options.allowBulkDelete"
+                       type="button"
+                       button-style="link"
+                       label="Delete"
+                       key="actions_delete"
+                       icon="icon-trash"
+                       action="delete()"
+                       disabled="actionInProgress">
+                   </umb-button>
+
+               </umb-editor-sub-header-section>
+
+           </umb-editor-sub-header-content-right>
+
+       </umb-editor-sub-header>
+
+       <umb-list-view-layout
          ng-if="viewLoaded"
          content-id="contentId"
          folders="folders"
          items="listViewResultSet.items"
+         allow-select-all="bulkActionsAllowed"
          selection="selection"
          options="options"
          entity-type="{{entityType}}"

--- a/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Umbraco.Core;
-using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
@@ -40,14 +35,21 @@ namespace Umbraco.Web.PropertyEditors
                             new {name = "List", path = "views/propertyeditors/listview/layouts/list/list.html", icon = "icon-list", isSystem = 1, selected = true},
                             new {name = "Grid", path = "views/propertyeditors/listview/layouts/grid/grid.html", icon = "icon-thumbnails-small", isSystem = 1, selected = true}
                         }
-                    }
+                    },
+                    {"bulkActionPermissions", new
+                        {
+                            allowBulkPublish = true,
+                            allowBulkUnpublish = true,
+                            allowBulkCopy = true,
+                            allowBulkMove = true,
+                            allowBulkDelete = true
+                        }}
                 };
             }
         }
 
         internal class ListViewPreValueEditor : PreValueEditor
         {
-
             [PreValueField("pageSize", "Page Size", "number", Description = "Number of items per page")]
             public int PageSize { get; set; }
 
@@ -64,8 +66,23 @@ namespace Umbraco.Web.PropertyEditors
             [PreValueField("includeProperties", "Columns Displayed", "views/propertyeditors/listview/includeproperties.prevalues.html", 
                 Description = "The properties that will be displayed for each column")]
             public object IncludeProperties { get; set; }
+
+            [PreValueField("bulkActionPermissions", "Bulk Action Permissions", "views/propertyeditors/listview/bulkactionpermissions.prevalues.html",
+                Description = "The bulk actions that are allowed from the list view")]
+            public BulkActionPermissionSettings BulkActionPermissions { get; set; }
+
+            internal class BulkActionPermissionSettings
+            {
+                public bool AllowBulkPublish { get; set; }
+
+                public bool AllowBulkUnpublish { get; set; }
+
+                public bool AllowBulkCopy { get; set; }
+
+                public bool AllowBulkMove { get; set; }
+
+                public bool AllowBulkDelete { get; set; }                
+            }
         }
-
-
     }
 }


### PR DESCRIPTION
This was partly set up already with the flags to allow or otherwise each bulk actions on the list view, but all were fixed to be available.  This PR adds the ability to enable or disable these actions when managing the data type.  I've also set up the list view so that the "select all" feature is only available if at least one bulk action can be carried out.