### PR TITLE
Use product name in migration runner instead of Umbraco productname

### DIFF
--- a/src/Umbraco.Core/Persistence/Migrations/MigrationRunner.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/MigrationRunner.cs
@@ -289,7 +289,7 @@ namespace Umbraco.Core.Persistence.Migrations
                 //NOTE: We CANNOT do this as part of the transaction!!! This is because when upgrading to 7.3, we cannot
                 // create the migrations table and then add data to it in the same transaction without issuing things like GO
                 // commands and since we need to support all Dbs, we need to just do this after the fact.
-                var exists = _migrationEntryService.FindEntry(GlobalSettings.UmbracoMigrationName, _targetVersion);
+                var exists = _migrationEntryService.FindEntry(_productName, _targetVersion);
                 if (exists == null)
                 {
                     _migrationEntryService.CreateEntry(_productName, _targetVersion);    


### PR DESCRIPTION
Fixes http://issues.umbraco.org/issue/U4-7872