### PR TITLE
U4-7819: Use correct messages when saving Media and Member types

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -871,6 +871,8 @@ Mange hilsner fra Umbraco robotten
     <key alias="fileSavedHeader">Fil gemt</key>
     <key alias="fileSavedText">Fil gemt uden fejl</key>
     <key alias="languageSaved">Sprog gemt</key>
+    <key alias="mediaTypeSavedHeader">Medietype gemt</key>
+    <key alias="memberTypeSavedHeader">Medlemstype gemt</key>
     <key alias="pythonErrorHeader">Python script ikke gemt</key>
     <key alias="pythonErrorText">Python-script kunne ikke gemmes pga. fejl</key>
     <key alias="pythonSavedHeader">Python-script gemt</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -927,6 +927,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="fileSavedHeader">File saved</key>
     <key alias="fileSavedText">File saved without any errors</key>
     <key alias="languageSaved">Language saved</key>
+    <key alias="mediaTypeSavedHeader">Media Type saved</key>
+    <key alias="memberTypeSavedHeader">Member Type saved</key>
     <key alias="pythonErrorHeader">Python script not saved</key>
     <key alias="pythonErrorText">Python script could not be saved due to error</key>
     <key alias="pythonSavedHeader">Python script saved</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -925,6 +925,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="fileSavedHeader">File saved</key>
     <key alias="fileSavedText">File saved without any errors</key>
     <key alias="languageSaved">Language saved</key>
+    <key alias="mediaTypeSavedHeader">Media Type saved</key>
+    <key alias="memberTypeSavedHeader">Member Type saved</key>
     <key alias="pythonErrorHeader">Python script not saved</key>
     <key alias="pythonErrorText">Python script could not be saved due to error</key>
     <key alias="pythonSavedHeader">Python script saved</key>

--- a/src/Umbraco.Web/Editors/MediaTypeController.cs
+++ b/src/Umbraco.Web/Editors/MediaTypeController.cs
@@ -167,7 +167,7 @@ namespace Umbraco.Web.Editors
             var display = Mapper.Map<MediaTypeDisplay>(savedCt);
 
             display.AddSuccessNotification(
-                            Services.TextService.Localize("speechBubbles/contentTypeSavedHeader"),
+                            Services.TextService.Localize("speechBubbles/mediaTypeSavedHeader"),
                             string.Empty);
 
             return display;

--- a/src/Umbraco.Web/Editors/MemberTypeController.cs
+++ b/src/Umbraco.Web/Editors/MemberTypeController.cs
@@ -139,7 +139,7 @@ namespace Umbraco.Web.Editors
             var display = Mapper.Map<MemberTypeDisplay>(savedCt);
 
             display.AddSuccessNotification(
-                            Services.TextService.Localize("speechBubbles/contentTypeSavedHeader"),
+                            Services.TextService.Localize("speechBubbles/memberTypeSavedHeader"),
                             string.Empty);
 
             return display;


### PR DESCRIPTION
This adds the correct message when saving Member types and Media types (previously these just said "Document type saved").
I have added two new language keys for these messages to en.xml, en_us.xml and da.xml:
speechBubbles_mediaTypeSavedHeader
speechBubbles_memberTypeSavedHeader