### PR TITLE
U4-7915: Fix missing remove button in imagepicker prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -158,7 +158,6 @@ ul.color-picker li a  {
   height: 32px;
   width: 32px;
   overflow: hidden;
-  display: none;
   text-decoration: none;
 }
 


### PR DESCRIPTION
Removing the display:none rule makes the remove button show up as expected. I have found no adverse effects in my (admittedly limited) testing, but I suspect that this rule has some use, so maybe a different solution is needed. If so, then please feel free to ignore this PR.