### PR TITLE
Grid translations

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -788,29 +788,46 @@ Vennlig hilsen Umbraco roboten
   </area>
   <area alias="grid">
     <key alias="insertControl">Sett inn element</key>
-    <key alias="addRows">Velg ett oppsett for denne seksjonen</key>
-    <key alias="addElement"><![CDATA[Kom i gang ved å trykke på <i class=" icon icon-add blue"></i> nedenfor og legg til det første elementet]]></key>
+    <key alias="chooseLayout">Velg layout</key>
+    <key alias="addRows">Legg til rad</key>
+    <key alias="addElement">Legg til innhold</key>
+    <key alias="dropElement">Slipp innhold</key>
+    <key alias="settingsApplied">Raden har tilpasset design</key>
+
+    <key alias="contentNotAllowed">Innholdstypen er ikke tillatt her</key>
+    <key alias="contentAllowed">Innholdstypen er tillatt her</key>
+
     <key alias="clickToEmbed">Klikk for å bygge inn</key>
     <key alias="clickToInsertImage">Klikk for å sette inn et bilde</key>
     <key alias="placeholderImageCaption">Bildetekst...</key>
     <key alias="placeholderWriteHere">Skriv her...</key>
+    
     <key alias="gridLayouts">Rutenettoppsett</key>
-    <key alias="gridLayoutsDetail">Et oppsett er det overordnede arbeidsområdet til ditt rutenett - du vil typisk kun behøve ét eller to</key>
+    <key alias="gridLayoutsDetail">Et oppsett er det overordnede arbeidsområdet til ditt rutenett - du vil typisk kun behøve ett eller to</key>
     <key alias="addGridLayout">Legg til rutenettoppsett</key>
-    <key alias="addGridLayoutDetail">Juster oppsettet ved at justere kolonnebredder og legg til ytterligere seksjoner</key>
+    <key alias="addGridLayoutDetail">Juster oppsettet ved å konfigurere kolonnebredder og legge til ytterligere seksjoner</key>
     <key alias="rowConfigurations">Radkonfigurasjoner</key>
     <key alias="rowConfigurationsDetail">Rader er forhåndsdefinerte celler arrangert vannrett</key>
     <key alias="addRowConfiguration">Legg til radkonfigurasjon</key>
-    <key alias="addRowConfigurationDetail">Juster raden ved å sette celle bredder og legge til flere celler</key>
+    <key alias="addRowConfigurationDetail">Juster raden ved å sette cellebredder og legge til flere celler</key>
+
     <key alias="columns">Kolonner</key>
-    <key alias="columnsDetails">Totale antallet kolonner i rutenettet</key>
+    <key alias="columnsDetails">Totalt antall kolonner i rutenettet</key>
+    
     <key alias="settings">Innstillinger</key>
     <key alias="settingsDetails">Konfigurer hvilke innstillinger brukeren kan endre</key>
+
     <key alias="styles">Stiler</key>
     <key alias="stylesDetails">Konfigurer hvilke stiler redaktørene kan endre</key>
-    <key alias="settingDialogDetails">Innstillingene lagres kun når json-konfigurasjonen er gyldig</key>
+
+    <key alias="settingDialogDetails">Innstillingene lagres kun når konfigurasjonen er gyldig</key>
+    
     <key alias="allowAllEditors">Tillatt alle editorer</key>
     <key alias="allowAllRowConfigurations">Tillat alle radkonfigurasjoner</key>
+    <key alias="setAsDefault">Bruk som standard</key>
+    <key alias="chooseExtra">Velg ekstra</key>
+    <key alias="chooseDefault">Velg standard</key>
+    <key alias="areAdded">er lagt til</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternativt felt</key>


### PR DESCRIPTION
Fixed a silly long translation of "Add content".
Added missing keys.
Fixed a few spelling mistakes.