### PR TITLE
U4-205: [Feature request] Rename dictionary items

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -236,6 +236,12 @@
   <area alias="dictionaryItem">
     <key alias="description">Rediger de forskellige sprogversioner for ordbogselementet '%0%' herunder. Du tilføjer flere sprog under 'sprog' i menuen til venstre </key>
     <key alias="displayName">Kulturnavn</key>
+    <key alias="changeKey">Her kan du ændre nøglen på ordbogselementet.</key>
+    <key alias="changeKeyError">
+      <![CDATA[
+      Nøglen '%0%' eksisterer allerede.
+   ]]>
+    </key>
   </area>
   <area alias="placeholders">
     <key alias="username">Indtast dit brugernavn</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -234,7 +234,9 @@
     <key alias="viewCacheItem">Se Cache Item</key>
   </area>
   <area alias="dictionaryItem">
-    <key alias="description">Rediger de forskellige sprogversioner for ordbogselementet '%0%' herunder. Du tilføjer flere sprog under 'sprog' i menuen til venstre </key>
+    <key alias="description"><![CDATA[
+      Rediger de forskellige sprogversioner for ordbogselementet '%0%' herunder.<br />Du tilføjer flere sprog under 'sprog' i menuen til venstre </key>
+      ]]></key>
     <key alias="displayName">Kulturnavn</key>
     <key alias="changeKey">Her kan du ændre nøglen på ordbogselementet.</key>
     <key alias="changeKeyError">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -284,6 +284,12 @@
       Edit the different language versions for the dictionary item '<em>%0%</em>' below<br/>You can add additional languages under the 'languages' in the menu on the left
    ]]></key>
     <key alias="displayName">Culture Name</key>
+    <key alias="changeKey">Here you can change the key of the dictionary item.</key>
+    <key alias="changeKeyError">
+      <![CDATA[
+      The key '%0%' already exists.
+   ]]>
+    </key>
   </area>
   <area alias="placeholders">
     <key alias="username">Enter your username</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -285,6 +285,12 @@
       Edit the different language versions for the dictionary item '<em>%0%</em>' below<br/>You can add additional languages under the 'languages' in the menu on the left
    ]]></key>
     <key alias="displayName">Culture Name</key>
+    <key alias="changeKey">Here you can change the key of the dictionary item.</key>
+    <key alias="changeKeyError">
+      <![CDATA[
+      The key '%0%' already exists.
+   ]]>
+    </key>
   </area>
   <area alias="placeholders">
     <key alias="username">Enter your username</key>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/EditDictionaryItem.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/EditDictionaryItem.aspx.cs
@@ -8,6 +8,7 @@ using System.Web.SessionState;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using System.Web.UI.HtmlControls;
+using umbraco.BusinessLogic;
 using umbraco.cms.businesslogic;
 using umbraco.cms.presentation.Trees;
 using Umbraco.Core;
@@ -28,10 +29,12 @@ namespace umbraco.settings
         private cms.businesslogic.Dictionary.DictionaryItem currentItem;
 	    protected TextBox boxChangeKey;
 	    protected Label labelChangeKey;
+	    protected User currentUser;
 
 		protected void Page_Load(object sender, System.EventArgs e)
 		{
 			currentItem = new cms.businesslogic.Dictionary.DictionaryItem(int.Parse(Request.QueryString["id"]));
+		    currentUser = getUser();
 
 			// Put user code to initialize the page here
 			Panel1.hasMenu = true;
@@ -47,7 +50,7 @@ namespace umbraco.settings
             uicontrols.Pane p = new uicontrols.Pane();
 
             Literal txt = new Literal();
-            txt.Text = "<p>" + ui.Text("dictionaryItem", "description", currentItem.key, base.getUser()) + "</p><br/>";
+            txt.Text = "<p>" + ui.Text("dictionaryItem", "description", currentItem.key, currentUser) + "</p><br/>";
             p.addProperty(txt);
 			
 			foreach (cms.businesslogic.language.Language l in cms.businesslogic.language.Language.getAll)
@@ -81,8 +84,7 @@ namespace umbraco.settings
             
             p.addProperty(new Literal
             {
-                Text = "<p>&nbsp;</p>" +
-                       "<p>Change the key of the dictionary item. Carefull :)</p>"
+                Text = "<p>&nbsp;</p><p>" + ui.Text("dictionaryItem", "changeKey") + "</p>"
             });
             p.addProperty(boxChangeKey);
             p.addProperty(labelChangeKey);
@@ -116,15 +118,15 @@ namespace umbraco.settings
 				}
 			}
 
-            labelChangeKey.Text = "";
+            labelChangeKey.Text = ""; // reset error text 
             var newKey = boxChangeKey.Text;
             if (string.IsNullOrWhiteSpace(newKey) == false && newKey != currentItem.key)
             {
                 // key already exists, save but inform
                 if (Dictionary.DictionaryItem.hasKey(newKey) == true)
                 {
-                    labelChangeKey.Text = "The key '" + newKey + "' already exists, sorry..";
-                    boxChangeKey.Text = currentItem.key; // reset the key                    
+                    labelChangeKey.Text = ui.Text("dictionaryItem", "changeKeyError", newKey, currentUser);
+                    boxChangeKey.Text = currentItem.key; // reset key                    
                 }
                 else
                 {

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/EditDictionaryItem.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/EditDictionaryItem.aspx.cs
@@ -84,7 +84,7 @@ namespace umbraco.settings
             
             p.addProperty(new Literal
             {
-                Text = "<p>&nbsp;</p><p>" + ui.Text("dictionaryItem", "changeKey") + "</p>"
+                Text = "<p>&nbsp;</p><p>" + ui.Text("dictionaryItem", "changeKey", currentUser) + "</p>"
             });
             p.addProperty(boxChangeKey);
             p.addProperty(labelChangeKey);

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/EditDictionaryItem.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/EditDictionaryItem.aspx.cs
@@ -25,6 +25,7 @@ namespace umbraco.settings
 		protected uicontrols.TabView tbv = new uicontrols.TabView();
 		private System.Collections.ArrayList languageFields = new System.Collections.ArrayList();
         private cms.businesslogic.Dictionary.DictionaryItem currentItem;
+	    protected TextBox keyNameBox;
 
 		protected void Page_Load(object sender, System.EventArgs e)
 		{
@@ -33,15 +34,15 @@ namespace umbraco.settings
 			// Put user code to initialize the page here
 			Panel1.hasMenu = true;
 			Panel1.Text = ui.Text("editdictionary") + ": " + currentItem.key;
-			
-            uicontrols.Pane p = new uicontrols.Pane();
 
-			var save = Panel1.Menu.NewButton();
+		    var save = Panel1.Menu.NewButton();
             save.Text = ui.Text("save");
             save.Click += save_Click;
 			save.ToolTip = ui.Text("save");
             save.ID = "save";
             save.ButtonType = uicontrols.MenuButtonType.Primary;
+
+            uicontrols.Pane p = new uicontrols.Pane();
 
             Literal txt = new Literal();
             txt.Text = "<p>" + ui.Text("dictionaryItem", "description", currentItem.key, base.getUser()) + "</p><br/>";
@@ -63,14 +64,29 @@ namespace umbraco.settings
 
 			}
 
-			if (!IsPostBack)
+            keyNameBox = new TextBox
+            {
+                ID = "editname-" + currentItem.id,
+                CssClass = "umbEditorTextField",
+                Text = currentItem.key
+            };
+
+            var txtChangeKey = new Literal
+            {
+                Text = "<p>&nbsp;</p>" +
+                       "<p>Change the key of the dictionary item. Carefull :)</p>"
+            };
+
+            p.addProperty(txtChangeKey);
+            p.addProperty(keyNameBox);
+
+            if (!IsPostBack)
 			{
 			    var path = BuildPath(currentItem);
 				ClientTools
 					.SetActiveTreeType(TreeDefinitionCollection.Instance.FindTree<loadDictionary>().Tree.Alias)
 					.SyncTree(path, false);
 			}
-
 
             Panel1.Controls.Add(p);
 		}
@@ -92,8 +108,21 @@ namespace umbraco.settings
 					currentItem.setValue(int.Parse(t.ID),t.Text);
 				}
 			}
+
+            var newKey = keyNameBox.Text;
+            if (string.IsNullOrWhiteSpace(newKey) == false && newKey != currentItem.key)
+            {
+                currentItem.setKey(newKey);
+
+                Panel1.title.InnerHtml = ui.Text("editdictionary") + ": " + currentItem.key;
+
+                var path = BuildPath(currentItem);
+                ClientTools.SyncTree(path, true);
+            }            
+
             ClientTools.ShowSpeechBubble(speechBubbleIcon.save, ui.Text("speechBubbles", "dictionaryItemSaved"), "");	
 		}
+
 		#region Web Form Designer generated code
 		override protected void OnInit(EventArgs e)
 		{

--- a/src/umbraco.cms/businesslogic/Dictionary.cs
+++ b/src/umbraco.cms/businesslogic/Dictionary.cs
@@ -169,6 +169,12 @@ namespace umbraco.cms.businesslogic
                 }
             }
 
+            public void setKey(string value)
+            {
+                key = value;
+                Save();
+            }
+
             public string Value(int languageId)
             {
                 if (languageId == 0)


### PR DESCRIPTION
Functionality for renaming/changing Umbraco dictionary keys. Comes with translations for en, en_us and da and a check for existing keys, to avoid key collisions.
To avoid messing too much with the existing ui, as this is all hardcore legacy code, I've simply added a new text field to the bottom of the dictionary item page.
Also, I've tried not to 'resharper-optimize' the existing code or change old apis to new ones, which should make it easier to discover the actual changes.

Cheers :smile: 