### PR TITLE
U4-7160: Stylesheet RegEx to capture multi class properties

### DIFF
--- a/src/Umbraco.Core/Strings/Css/StylesheetHelper.cs
+++ b/src/Umbraco.Core/Strings/Css/StylesheetHelper.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Core.Strings.Css
 {
     internal class StylesheetHelper
     {
-        private const string RuleRegexFormat = @"/\*\*\s*umb_name:\s*(?<Name>{0}?)\s*\*/\s*(?<Selector>[^\s,{{]*?)\s*{{\s*(?<Styles>.*?)\s*}}";
+        private const string RuleRegexFormat = @"/\*\*\s*umb_name:\s*(?<Name>{0}?)\s*\*/\s*(?<Selector>[^,{{]*?)\s*{{\s*(?<Styles>.*?)\s*}}";
 
         public static IEnumerable<StylesheetRule> ParseRules(string input)
         {


### PR DESCRIPTION
Change the RegEx in Stylesheet Helper to capture mutli element classes
as stylesheet properties (See [U4-7160](http://issues.umbraco.org/issue/U4-7160))

Previously single class names "H1", "P", ".test" all work but multi
".btn btn-default" fail - this change fixes that