### PR TITLE
Changed allow upload whitelist to disallow extensions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
@@ -6,7 +6,9 @@
         var vm = this;
 
         vm.nodeId = $scope.contentId;
-        vm.acceptedFileTypes = mediaHelper.formatFileTypes(Umbraco.Sys.ServerVariables.umbracoSettings.imageFileTypes);
+        //vm.acceptedFileTypes = mediaHelper.formatFileTypes(Umbraco.Sys.ServerVariables.umbracoSettings.imageFileTypes);
+        //instead of passing in a whitelist, we pass in a blacklist by adding ! to the ext
+        vm.acceptedFileTypes = mediaHelper.formatFileTypes(Umbraco.Sys.ServerVariables.umbracoSettings.disallowedUploadFiles).replace(/./g, "!.");
         vm.maxFileSize = Umbraco.Sys.ServerVariables.umbracoSettings.maxFileSize + "KB";
         vm.activeDrag = false;
         vm.isRecycleBin = $scope.contentId === '-21' || $scope.contentId === '-20';


### PR DESCRIPTION
It is not possible to upload files in 7.4.0 with an extension different then the imageTypes in the Umbraco.Sys.ServerVariables.umbracoSettings.imageFileTypes, in the single upload this was changed after beta 7.4.0-beta1 to Umbraco.Sys.ServerVariables.umbracoSettings.disallowedUploadFiles. However the change was not added to the drag-drop-uploader. This fixes that.