### PR TITLE
Add parens around all BinaryExpressions

### DIFF
--- a/src/Umbraco.Core/Persistence/Querying/BaseExpressionHelper.cs
+++ b/src/Umbraco.Core/Persistence/Querying/BaseExpressionHelper.cs
@@ -152,7 +152,7 @@ namespace Umbraco.Core.Persistence.Querying
                 case "COALESCE":
                     return string.Format("{0}({1},{2})", operand, left, right);
                 default:
-                    return left + " " + operand + " " + right;
+                    return "(" + left + " " + operand + " " + right + ")";
             }
         }
 


### PR DESCRIPTION
In U4-8026 (http://issues.umbraco.org/issue/U4-8026) a case is documented where the lack of parentheses around the WHERE expressions in the generated SQL cause the wrong results to be returned. 
This PR works around the problem by adding parentheses around _every_ BinaryExpression. This will result in extra unneeded parentheses, but this should cause little difference in the execution of the query - and it is certainly better than having too few.
This might not be the most elegant way to fix it, but I could not find a simple way to reliably detect whehter parentheses are needed or not.