### PR TITLE
Fix transparency for image icons in the tray

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/sectionicon.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/sectionicon.directive.js
@@ -17,7 +17,7 @@
                 if(convert){
                     element.html("<i class='icon-section " + convert + "'></i>");
                 }else{
-                    element.html("<img src='images/tray/" + icon + "'>");
+                    element.html("<img class='icon-section' src='images/tray/" + icon + "'>");
                 }
                 //it's a file, normally legacy so look in the icon tray images
             }

--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -19,7 +19,8 @@ ul.sections li {
 }
 
 ul.sections li [class^="icon-"]:before, 
-ul.sections li [class*=" icon-"]:before{
+ul.sections li [class*=" icon-"]:before,
+ul.sections li img.icon-section {
 	font-size: 30px;
 	margin: 1px 0 0 0;
 	opacity: 0.4;
@@ -29,7 +30,8 @@ ul.sections li [class*=" icon-"]:before{
 }
 
 ul.sections:hover li [class^="icon-"]:before, 
-ul.sections:hover li [class*=" icon-"]:before {
+ul.sections:hover li [class*=" icon-"]:before,
+ul.sections:hover li img.icon-section {
 	opacity: 1
 }
 


### PR DESCRIPTION
Currently, if an application icon in the tray has an image icon (and not CSS font-based icons like the built-in ones), the icon is just shown at 100 % opacity all the time, which really makes it stand out. This PR just applies the same fading effect to both icon types.
A prime example where this occurs is Merchello.

This fixes issue U4-5498 (http://issues.umbraco.org/issue/U4-5498)