### PR TITLE
Fixed U4-7888 - Cannot change default template for document type

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/ContentTypeBaseRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentTypeBaseRepository.cs
@@ -914,7 +914,7 @@ AND umbracoNode.id <> @id",
                     //check for default templates                    
                     bool? isDefaultTemplate = Convert.ToBoolean(ct.dtIsDefault);
                     int? templateId = ct.dtTemplateId;
-                    if (currDefaultTemplate == -1 && isDefaultTemplate.HasValue && templateId.HasValue)
+                    if (currDefaultTemplate == -1 && isDefaultTemplate.HasValue && isDefaultTemplate.Value && templateId.HasValue)
                     {
                         currDefaultTemplate = templateId.Value;
                     }


### PR DESCRIPTION
Fix issue with database field check that led to default template for content type not being set.