### PR TITLE
Fix for issue causing the entire stylesheets tree to reload when …

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/stylesheet/editstylesheet.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/stylesheet/editstylesheet.aspx.cs
@@ -60,7 +60,7 @@ namespace umbraco.cms.presentation.settings.stylesheet
 
             lttPath.Text = "<a id=\"" + lttPath.ClientID + "\" target=\"_blank\" href=\"" + stylesheet.VirtualPath + "\">" + stylesheet.VirtualPath + "</a>";
             editorSource.Text = stylesheet.Content;
-            TreeSyncPath = DeepLink.GetTreePathFromFilePath(filename);
+            TreeSyncPath = DeepLink.GetTreePathFromFilePath(filename).TrimEnd(".css");
 
             // name derives from path, without the .css extension, clean for xss
             NameTxt.Text = stylesheet.Path.TrimEnd(".css").CleanForXss('\\', '/');


### PR DESCRIPTION
…selecting a item.

In short the tree id's strip the .css extension while the syncTree call doesn't so they don't match.

![screen shot 2016-03-02 at 4 23 33 pm](https://cloud.githubusercontent.com/assets/458367/13475874/20cca8e6-e093-11e5-9642-982a4549b03b.png)
