### PR TITLE
GetResized - Uri creation uses UriKind.RelativeOrAbsolute

### DIFF
--- a/src/Umbraco.Web/Editors/ImagesController.cs
+++ b/src/Umbraco.Web/Editors/ImagesController.cs
@@ -125,7 +125,7 @@ namespace Umbraco.Web.Editors
             //redirect to ImageProcessor thumbnail with rnd generated from last modified time of original media file
             var response = Request.CreateResponse( HttpStatusCode.Found );
             var imageLastModified = mediaFileSystem.GetLastModified( imagePath );
-            response.Headers.Location = new Uri( string.Format( "{0}?rnd={1}&width={2}", imagePath, string.Format( "{0:yyyyMMddHHmmss}", imageLastModified ), width ), UriKind.Relative );
+            response.Headers.Location = new Uri( string.Format( "{0}?rnd={1}&width={2}", imagePath, string.Format( "{0:yyyyMMddHHmmss}", imageLastModified ), width ), UriKind.RelativeOrAbsolute );
             return response;
         }
     }


### PR DESCRIPTION
Correctly handles either Uri kind, such as Absolute Uris resulting from IFileSystem implementations targeting Amazon S3 or Azure.
