### PR TITLE
Fix for missing doc.setLine() function breaking code mirror editor.

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/codemirror/source.html
+++ b/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/codemirror/source.html
@@ -210,7 +210,7 @@ function submit()
 	if (findDepth(curLineHTML, cc) !== 0) {
 		// Cursor is inside a <tag>, don't set cursor:
 		curLineHTML = curLineHTML.replace(cc, '');
-		doc.setLine(pos.line, curLineHTML);
+		doc.getLineHandle(pos.line).text = curLineHTML;
 	}
 
 	// Submit HTML to TinyMCE:


### PR DESCRIPTION
This is a simple fix for the breaking change in CodeMirror that prevents submitting source code changes when using the CodeMirror editor.

http://issues.umbraco.org/issue/U4-8044