### PR TITLE
This minor fix will restore the editors cursor in CoreArea editor boxes…

### DIFF
--- a/src/Umbraco.Web.UI/umbraco_client/CodeArea/UmbracoEditor.js
+++ b/src/Umbraco.Web.UI/umbraco_client/CodeArea/UmbracoEditor.js
@@ -35,9 +35,18 @@ Umbraco.Sys.registerNamespace("Umbraco.Controls.CodeEditor");
                     this._control.val(code);
                 }
                 else {
-                    //this is a wrapper for CodeMirror
+					//this is a wrapper for CodeMirror
                     this._editor.focus();
+
+                    var codeChanged = this._editor.getValue() != code;
+                    var cursor = this._editor.doc.getCursor();
+
                     this._editor.setValue(code);
+
+                    // Restore cursor position if the server saved code matches.
+                    if (!codeChanged)
+                        this._editor.setCursor(cursor);
+
                     this._editor.focus();
                 }
             },

--- a/src/Umbraco.Web.UI/umbraco_client/Editors/EditView.js
+++ b/src/Umbraco.Web.UI/umbraco_client/Editors/EditView.js
@@ -174,6 +174,9 @@
             }
             if (args.contents) {
                 UmbEditor.SetCode(args.contents);
+            } else if (!this.IsSimpleEditor) {
+                // Restore focuse to text region. SetCode also does this.
+                UmbEditor._editor.focus();
             }
 
             UmbClientMgr.mainTree().setActiveTreeType(this._opts.currentTreeType);


### PR DESCRIPTION
… when they save the item.  There is a check included to prevent this behavior is the server level code changes the file for some reason as then the cursor location could act unpredictably, so instead we just let it reset to the beginning of the file.

This is a fix for http://issues.umbraco.org/issue/U4-7956#tab=Comments