### PR TITLE
Fixes U4 7468 - mis-assigned translator when sending to translation

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1145,6 +1145,7 @@ To manage your website, simply open the Umbraco back office and start adding con
      To close a translation task, please go to the Details view and click the "Close" button.
     ]]></key>
     <key alias="pageHasBeenSendToTranslation">The page '%0%' has been send to translation</key>
+    <key alias="noLanguageSelected">Please select the language that the content should be translated into</key>
     <key alias="sendToTranslate">Send the page '%0%' to translation</key>
     <key alias="taskAssignedBy">Assigned by</key>
     <key alias="taskOpened">Task opened</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1149,6 +1149,7 @@ To manage your website, simply open the Umbraco back office and start adding con
      To close a translation task, please go to the Details view and click the "Close" button.
     ]]></key>
     <key alias="pageHasBeenSendToTranslation">The page '%0%' has been send to translation</key>
+    <key alias="noLanguageSelected">Please select the language that the content should be translated into</key>
     <key alias="sendToTranslate">Send the page '%0%' to translation</key>
     <key alias="taskAssignedBy">Assigned by</key>
     <key alias="taskOpened">Task opened</key>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/sendToTranslation.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/sendToTranslation.aspx.cs
@@ -92,20 +92,30 @@ namespace umbraco.presentation.dialogs
 
         protected void doTranslation_Click(object sender, EventArgs e)
         {
-            // testing translate
-            cms.businesslogic.translation.Translation.MakeNew(
-                _currentPage,
-                getUser(),
-                BusinessLogic.User.GetUser(int.Parse(translator.SelectedValue)),
-                new cms.businesslogic.language.Language(int.Parse(language.SelectedValue)),
-                comment.Text, includeSubpages.Checked,
-                true);
+            int languageId;
+            if (int.TryParse(language.SelectedValue, out languageId))
+            {
+                cms.businesslogic.translation.Translation.MakeNew(
+                    _currentPage,
+                    getUser(),
+                    BusinessLogic.User.GetUser(int.Parse(translator.SelectedValue)),
+                    new cms.businesslogic.language.Language(languageId),
+                    comment.Text, includeSubpages.Checked,
+                    true);
 
-            pane_form.Visible = false;
-            pl_buttons.Visible = false;
+                pane_form.Visible = false;
+                pl_buttons.Visible = false;
 
-            feedback.Text = ui.Text("translation","pageHasBeenSendToTranslation", _currentPage.Text, base.getUser()) + "</p><p><a href=\"#\" onclick=\"" + ClientTools.Scripts.CloseModalWindow() + "\">" + ui.Text("defaultdialogs", "closeThisWindow") + "</a></p>";
-            feedback.type = uicontrols.Feedback.feedbacktype.success;
+                feedback.Text = ui.Text("translation", "pageHasBeenSendToTranslation", _currentPage.Text, base.getUser()) +
+                    "</p><p><a href=\"#\" onclick=\"" + ClientTools.Scripts.CloseModalWindow() + "\">" +
+                    ui.Text("defaultdialogs", "closeThisWindow") + "</a></p>";
+                feedback.type = uicontrols.Feedback.feedbacktype.success;
+            }
+            else
+            {
+                feedback.Text = ui.Text("translation", "noLanguageSelected");
+                feedback.type = uicontrols.Feedback.feedbacktype.error;
+            }
         }
     }
 }

--- a/src/umbraco.cms/businesslogic/task/Task.cs
+++ b/src/umbraco.cms/businesslogic/task/Task.cs
@@ -131,7 +131,7 @@ namespace umbraco.cms.businesslogic.task
             set
             {
                 _user = value;
-                TaskEntity.OwnerUserId = _user.Id;
+                TaskEntity.AssigneeUserId = _user.Id;
             }
         }
 


### PR DESCRIPTION
Also provided a better response for the user to another issue, which was that sending to translation without selecting a language would trigger an error.  A message indicating the problem is now returned instead.