### PR TITLE
U4-8157 Right-click on root node returns console error when it doesn'…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/tree.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/tree.resource.js
@@ -16,7 +16,7 @@ function treeResource($q, $http, umbRequestHelper) {
     /** internal method to get the tree menu url */
     function getTreeMenuUrl(node) {
         if (!node.menuUrl) {
-            throw "No menuUrl property found on the tree node, cannot load menu";
+            return null;
         }
         return node.menuUrl;
     }
@@ -26,10 +26,16 @@ function treeResource($q, $http, umbRequestHelper) {
         
         /** Loads in the data to display the nodes menu */
         loadMenu: function (node) {
-              
-            return umbRequestHelper.resourcePromise(
-                $http.get(getTreeMenuUrl(node)),
-                "Failed to retrieve data for a node's menu " + node.id);
+            var treeMenuUrl = getTreeMenuUrl(node);
+            if (treeMenuUrl !== undefined && treeMenuUrl !== null && treeMenuUrl.length > 0) {
+                return umbRequestHelper.resourcePromise(
+                    $http.get(getTreeMenuUrl(node)),
+                    "Failed to retrieve data for a node's menu " + node.id);
+            } else {
+                return $q.reject({
+                    errorMsg: "No tree menu url defined for node " + node.id
+                });
+            }
         },
 
         /** Loads in the data to display the nodes for an application */


### PR DESCRIPTION
…t has any actions

Ensured we don't use throw to stop the program flow if no menuUrl is defined on the node. It is a likely scenario that some root node don't have right click actions so its better to handle this.