### PR TITLE
U4-5448

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadDictionary.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadDictionary.cs
@@ -13,7 +13,7 @@ using Umbraco.Web._Legacy.Actions;
 namespace umbraco
 {
 
-    [Tree(Constants.Applications.Settings, Constants.Trees.Dictionary, "Dictionary", sortOrder: 3)]
+    [Tree(Constants.Applications.Translation, Constants.Trees.Dictionary, "Dictionary", sortOrder: 3)]
     public class loadDictionary : BaseTree
 	{
         public loadDictionary(string application) : base(application) { }


### PR DESCRIPTION
Move dictionary tree to translation section instead of settings section

Should the dictionary also be changed to the new tree version?
So we have to create a new tree controller and so on...

Are there any services which provides the data for the dictionary tree?