### PR TITLE
Fix Newtonsoft.JSON dependency when running in debug mode in v8

### DIFF
--- a/src/Umbraco.Web.UI/web.Template.Debug.config
+++ b/src/Umbraco.Web.UI/web.Template.Debug.config
@@ -378,7 +378,7 @@
 												 xdt:Locator="Condition(_defaultNamespace:assemblyIdentity[@name='Newtonsoft.Json']])"/>
       <dependentAssembly xdt:Transform="Insert">
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
 
       <dependentAssembly xdt:Transform="Remove"


### PR DESCRIPTION
When running in debug mode Umbraco will not start as the assembly redirect for Newtonsoft.JSON is wrong. (newtonsoft.json was updated here 4355761da143e14da465ade87cc8427c2837aae6)