### PR TITLE
U4-7967 - Fix errors when saving document type when no icon is selected

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -212,15 +212,22 @@ Use this directive to construct a header inside the main editor window.
                 scope.dialogModel = {
                     view: "iconpicker",
                     show: true,
-                    submit: function(model) {
-                        if (model.color) {
-                            scope.icon = model.icon + " " + model.color;
-                        } else {
-                            scope.icon = model.icon;
-                        }
+                    submit: function (model) {
 
-                        // set form to dirty
-                        ctrl.$setDirty();
+                        /* ensure an icon is selected, because on focus on close button
+                           or an element in background no icon is submitted. So don't clear/update existing icon/preview.
+                        */
+                        if (model.icon) {
+
+                            if (model.color) {
+                                scope.icon = model.icon + " " + model.color;
+                            } else {
+                                scope.icon = model.icon;
+                            }
+
+                            // set form to dirty
+                            ctrl.$setDirty();
+                        }
 
                         scope.dialogModel.show = false;
                         scope.dialogModel = null;

--- a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
@@ -109,11 +109,16 @@ function iconHelper($q, $timeout) {
         },
         formatContentTypeIcons: function (contentTypes) {
             for (var i = 0; i < contentTypes.length; i++) {
-                contentTypes[i].icon = this.convertFromLegacyIcon(contentTypes[i].icon);
+                if (!contentTypes[i].icon) {
+                    //just to be safe (e.g. when focus was on close link and hitting save)
+                    contentTypes[i].icon = "icon-document"; // default icon
+                } else {
+                    contentTypes[i].icon = this.convertFromLegacyIcon(contentTypes[i].icon);
+                }
 
                 //couldnt find replacement
                 if(contentTypes[i].icon.indexOf(".") > 0){
-                     contentTypes[i].icon = "icon-document-dashed-line";   
+                     contentTypes[i].icon = "icon-document-dashed-line";
                 }
             }
             return contentTypes;
@@ -128,6 +133,10 @@ function iconHelper($q, $timeout) {
         },
         /** If the icon is legacy */
         isLegacyIcon: function (icon) {
+            if(!icon) {
+                return false;
+            }
+
             if(icon.startsWith('..')){
                 return false;
             }

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/iconpicker.controller.js
@@ -7,13 +7,14 @@ angular.module("umbraco")
             	$scope.icons = icons;
             });
 
-			$scope.submitClass = function(icon){
-				if($scope.color)
-				{
+            $scope.submitClass = function (icon) {
+				if($scope.color) {
 					$scope.submit(icon + " " + $scope.color);
-				}else{
-					$scope.submit(icon);	
+				}
+                else {
+					$scope.submit(icon);
 				}
 			};
+
 		}
 	);

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/iconpicker.html
@@ -4,10 +4,11 @@
 	        <div class="form-search">
                 <i class="icon-search"></i>
                 <input type="text"
-                	   style="width: 100%"
+                       style="width: 100%"
                        ng-model="searchTerm"
                        class="umb-search-field search-query input-block-level"
-                       placeholder="Filter...">
+                       placeholder="Filter..."
+                       no-dirty-check>
             </div>
     	</div>
 	</div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
@@ -9,7 +9,8 @@
                    class="umb-search-field search-query input-block-level"
                    localize="placeholder"
                    placeholder="@placeholders_filter"
-                   umb-auto-focus>
+                   umb-auto-focus
+                   no-dirty-check>
         </div>
     </div>
 


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-7967

This fix a console error when one focus "close"-link in icon picker or an element in background and then save the document type. Because of the model submitted doesn't contains a value for icon, it breaks the document type editor when refreshing the view because of the error 
`TypeError: Cannot read property 'startsWith' of null` in `isLegacyIcon` function in iconHelper.

Furthermore I have changes, so it check that the model contains a value for icon, so it doesn't update/clear the existing icon/preview.

Maybe it should also check server side when saving a document type that it has a value for icon?
At least this fix the issue, so you don't by an accident can "break" the document type because of a missing icon value.