### PR TITLE
U4-7862 Brackets cause issues in the stylesheet editor

### DIFF
--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -1380,6 +1380,30 @@ namespace Umbraco.Core
             */
         }
 
+        public static string EscapeRegexSpecialCharacters(this string text)
+        {
+            var regexSpecialCharacters = new Dictionary<string, string>
+            {
+                {".", @"\."},
+                {"(", @"\("},
+                {")", @"\)"},
+                {"]", @"\]"},
+                {"[", @"\["},
+                {"{", @"\{"},
+                {"}", @"\}"},
+                {"?", @"\?"},
+                {"!", @"\!"},
+                {"$", @"\$"},
+                {"^", @"\^"},
+                {"+", @"\+"},
+                {"*", @"\*"},
+                {"|", @"\|"},
+                {"<", @"\<"},
+                {">", @"\>"}
+            };
+            return ReplaceMany(text, regexSpecialCharacters);
+        }
+
         public static bool ContainsAny(this string haystack, IEnumerable<string> needles, StringComparison comparison = StringComparison.CurrentCulture)
         {
             if (haystack == null) throw new ArgumentNullException("haystack");

--- a/src/Umbraco.Core/Strings/Css/StylesheetHelper.cs
+++ b/src/Umbraco.Core/Strings/Css/StylesheetHelper.cs
@@ -39,7 +39,7 @@ namespace Umbraco.Core.Strings.Css
         public static string ReplaceRule(string input, string oldRuleName, StylesheetRule rule)
         {
             var contents = input;
-            var ruleRegex = new Regex(string.Format(RuleRegexFormat, oldRuleName), RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            var ruleRegex = new Regex(string.Format(RuleRegexFormat, oldRuleName.EscapeRegexSpecialCharacters()), RegexOptions.IgnoreCase | RegexOptions.Singleline);
             contents = ruleRegex.Replace(contents, rule != null ? rule.ToString() : "");
             return contents;
         }


### PR DESCRIPTION
Ensuring special characters are escaped before being passed into the regex.