### PR TITLE
Fix for U4-8260

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html
@@ -1,6 +1,6 @@
 <h3>Start here</h3>
 <h4>This section contains the building blocks for your Umbraco site</h4>
-<p>Follow the below links to find out more about working with the items in the Setings section:</p>
+<p>Follow the below links to find out more about working with the items in the Settings section:</p>
 
 <h4>Find out more:</h4>
 

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html
@@ -5,9 +5,9 @@
 <h4>Find out more:</h4>
 
 <ul>
-<li>Download the <a class="btn-link -underline" href="http://our.umbraco.org/projects/website-utilities/umbraco-7-editors-manual" target="_blank">Editors Manual</a> for details on working with the Umbraco UI</li>
-<li>Ask a question in the <a class="btn-link -underline" href="http://our.umbraco.org/" target="_blank">Community Forum</a></li>
 <li>Read more about working with the Items in Settings <a class="btn-link -underline" href="https://our.umbraco.org/documentation/Getting-Started/Backoffice/Sections/" target="_blank">in the Documentation section</a> of Our Umbraco</li>
+<li>Download the <a class="btn-link -underline" href="https://our.umbraco.org/projects/website-utilities/umbraco-7-editors-manual" target="_blank">Editors Manual</a> for details on working with the Umbraco UI</li>
+<li>Ask a question in the <a class="btn-link -underline" href="https://our.umbraco.org/" target="_blank">Community Forum</a></li>
 <li>Watch our <a class="btn-link -underline" href="http://umbraco.tv" target="_blank">tutorial videos</a> (some are free, some require a subscription)</li>
 <li>Find out about our <a class="btn-link -underline" href="http://umbraco.com/products" target="_blank">productivity boosting tools and commercial support</a></li>
 <li>Find out about real-life <a class="btn-link -underline" href="http://umbraco.com/products/training/schedule" target="_blank">training and certification</a> opportunities</li>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html
@@ -5,9 +5,9 @@
 <h4>Find out more:</h4>
 
 <ul>
-<li>Read more about working with the Items in Settings <a class="btn-link -underline" href="http://our.umbraco.org/wiki/umbraco-help/settings" target="_blank">in the Community Wiki</a></li>
 <li>Download the <a class="btn-link -underline" href="http://our.umbraco.org/projects/website-utilities/umbraco-7-editors-manual" target="_blank">Editors Manual</a> for details on working with the Umbraco UI</li>
 <li>Ask a question in the <a class="btn-link -underline" href="http://our.umbraco.org/" target="_blank">Community Forum</a></li>
+<li>Read more about working with the Items in Settings <a class="btn-link -underline" href="https://our.umbraco.org/documentation/Getting-Started/Backoffice/Sections/" target="_blank">in the Documentation section</a> of Our Umbraco</li>
 <li>Watch our <a class="btn-link -underline" href="http://umbraco.tv" target="_blank">tutorial videos</a> (some are free, some require a subscription)</li>
 <li>Find out about our <a class="btn-link -underline" href="http://umbraco.com/products" target="_blank">productivity boosting tools and commercial support</a></li>
 <li>Find out about real-life <a class="btn-link -underline" href="http://umbraco.com/products/training/schedule" target="_blank">training and certification</a> opportunities</li>


### PR DESCRIPTION
This fixes the typo, and (in separate commits to ease cherry-picking if necessary) corrects the link that currently goes to the legacy wiki, to point to the newer *Sections* documentation.