### PR TITLE
Added check for publish permissions to remove option for Publish At a…

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
@@ -174,20 +174,20 @@ namespace Umbraco.Web.Models.Mapping
                     Value = localizedText.UmbracoDictionaryTranslate(display.ContentTypeName),
                     View = PropertyEditorResolver.Current.GetByAlias(Constants.PropertyEditors.NoEditAlias).ValueEditor.View
                 },
-                display.AllowedActions.Contains('P') ? new ContentPropertyDisplay
+                 new ContentPropertyDisplay
                 {
                     Alias = string.Format("{0}releasedate", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
                     Label = localizedText.Localize("content/releaseDate"),
                     Value = display.ReleaseDate.HasValue ? display.ReleaseDate.Value.ToIsoString() : null,
-                    View = "datepicker" //TODO: Hard coding this because the templatepicker doesn't necessarily need to be a resolvable (real) property editor
-                } : null,
-                display.AllowedActions.Contains('P') ? new ContentPropertyDisplay
+                    View =  display.AllowedActions.Contains('P') ? "datepicker"  : PropertyEditorResolver.Current.GetByAlias(Constants.PropertyEditors.NoEditAlias).ValueEditor.View  //TODO: Hard coding this because the templatepicker doesn't necessarily need to be a resolvable (real) property editor
+                } ,
+                new ContentPropertyDisplay
                 {
                     Alias = string.Format("{0}expiredate", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
                     Label = localizedText.Localize("content/unpublishDate"),
                     Value = display.ExpireDate.HasValue ? display.ExpireDate.Value.ToIsoString() : null,
-                    View = "datepicker" //TODO: Hard coding this because the templatepicker doesn't necessarily need to be a resolvable (real) property editor
-                } : null,
+                    View = display.AllowedActions.Contains('P') ? "datepicker"  : PropertyEditorResolver.Current.GetByAlias(Constants.PropertyEditors.NoEditAlias).ValueEditor.View  //TODO: Hard coding this because the templatepicker doesn't necessarily need to be a resolvable (real) property editor
+                },
                 new ContentPropertyDisplay
                 {
                     Alias = string.Format("{0}template", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
@@ -207,9 +207,6 @@ namespace Umbraco.Web.Models.Mapping
                     View = "urllist" //TODO: Hard coding this because the templatepicker doesn't necessarily need to be a resolvable (real) property editor
                 }
             };
-
-            //we need to remove null or the properties page will be totally blank
-            properties = properties.Where(x => x != null).ToList();
 
             TabsAndPropertiesResolver.MapGenericProperties(content, display, localizedText, properties.ToArray(),
                 genericProperties =>

--- a/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
@@ -164,6 +164,7 @@ namespace Umbraco.Web.Models.Mapping
                 TabsAndPropertiesResolver.AddListView(display, "content", dataTypeService, localizedText);
             }
             
+            //Added check for publish permissions before adding releaseDate and expireDate
             var properties = new List<ContentPropertyDisplay>
             {
                 new ContentPropertyDisplay
@@ -173,20 +174,20 @@ namespace Umbraco.Web.Models.Mapping
                     Value = localizedText.UmbracoDictionaryTranslate(display.ContentTypeName),
                     View = PropertyEditorResolver.Current.GetByAlias(Constants.PropertyEditors.NoEditAlias).ValueEditor.View
                 },
-                new ContentPropertyDisplay
+                display.AllowedActions.Contains('P') ? new ContentPropertyDisplay
                 {
                     Alias = string.Format("{0}releasedate", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
                     Label = localizedText.Localize("content/releaseDate"),
                     Value = display.ReleaseDate.HasValue ? display.ReleaseDate.Value.ToIsoString() : null,
                     View = "datepicker" //TODO: Hard coding this because the templatepicker doesn't necessarily need to be a resolvable (real) property editor
-                },
-                new ContentPropertyDisplay
+                } : null,
+                display.AllowedActions.Contains('P') ? new ContentPropertyDisplay
                 {
                     Alias = string.Format("{0}expiredate", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
                     Label = localizedText.Localize("content/unpublishDate"),
                     Value = display.ExpireDate.HasValue ? display.ExpireDate.Value.ToIsoString() : null,
                     View = "datepicker" //TODO: Hard coding this because the templatepicker doesn't necessarily need to be a resolvable (real) property editor
-                },
+                } : null,
                 new ContentPropertyDisplay
                 {
                     Alias = string.Format("{0}template", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
@@ -206,6 +207,9 @@ namespace Umbraco.Web.Models.Mapping
                     View = "urllist" //TODO: Hard coding this because the templatepicker doesn't necessarily need to be a resolvable (real) property editor
                 }
             };
+
+            //we need to remove null or the properties page will be totally blank
+            properties = properties.Where(x => x != null).ToList();
 
             TabsAndPropertiesResolver.MapGenericProperties(content, display, localizedText, properties.ToArray(),
                 genericProperties =>


### PR DESCRIPTION
…nd Unpublish At if the user doesnt have Publish permissions

Hi,
I had 2 routes to implement this simple change, though none of them felt 100% ideal they both solve the problem. I've added nulls to the properties list where the permissions don't allow it and then stripped out any nulls at the end because Umbraco doesn't like this nulls present and leaves and empty Properties page. This leaves some nice looking code, but feels awkward because I'm adding and then removing items from the list

The alternative I came up with was to change the constructor for the properties to not include the release and unpublish items and use an insert to add them after the constructor, but this meant hard coding the locations in the list to keep them in the same order as is standard in Umbraco.

Hope this makes sense :)
t
