### PR TITLE
Add error callback handler for unpublish event in content.edit.controller

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -190,6 +190,15 @@ function ContentEditController($scope, $rootScope, $routeParams, $q, $timeout, $
 
                     $scope.page.buttonGroupState = "success";
 
+                }, function (err) {
+                    $scope.page.buttonGroupState = "error";
+                    $scope.busy = false;
+                    //show any notifications
+                    if (angular.isArray(err.data.notifications)) {
+                        for (var i = 0; i < err.data.notifications.length; i++) {
+                            notificationsService.showNotification(err.data.notifications[i]);
+                        }
+                    }
                 });
         }
 


### PR DESCRIPTION
For some cases user may not be allowed to unpublish a content, and he need to get a notification message that explains the reason.
