### PR TITLE
U4-8199 - Removal of the internal unused obsolete HasAccess method in PublicAccessServiceExtensions.cs

### DIFF
--- a/src/Umbraco.Core/Services/PublicAccessServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/PublicAccessServiceExtensions.cs
@@ -53,23 +53,6 @@ namespace Umbraco.Core.Services
                                         && currentMemberRoles.Contains(x.RuleValue));
         }
 
-        [Obsolete("this is only used for backward compat")]
-        internal static bool HasAccess(this IPublicAccessService publicAccessService, int documentId, object providerUserKey, IContentService contentService, MembershipProvider membershipProvider, RoleProvider roleProvider)
-        {
-            var content = contentService.GetById(documentId);
-            if (content == null) return true;
-
-            var entry = publicAccessService.GetEntryForContent(content);
-            if (entry == null) return true;
-
-            var member = membershipProvider.GetUser(providerUserKey, false);
-            if (member == null) return false;
-
-            var roles = roleProvider.GetRolesForUser(member.UserName);
-            return entry.Rules.Any(x => x.RuleType == Constants.Conventions.PublicAccess.MemberRoleRuleType
-                                        && roles.Contains(x.RuleValue));
-        }
-
         public static bool HasAccess(this IPublicAccessService publicAccessService, string path, MembershipUser member, RoleProvider roleProvider)
         {
             var entry = publicAccessService.GetEntryForContent(path.EnsureEndsWith(path));


### PR DESCRIPTION
It it not used and marked as obsolete so looks safe to delete.