### PR TITLE
Fix for plugins lot loading local language rules for en-US culture.

### DIFF
--- a/src/Umbraco.Core/Services/LocalizedTextServiceFileSources.cs
+++ b/src/Umbraco.Core/Services/LocalizedTextServiceFileSources.cs
@@ -190,7 +190,7 @@ namespace Umbraco.Core.Services
                 var found = _supplementFileSources.Where(x =>
                 {
                     var fileName = Path.GetFileName(x.File.FullName);
-                    return fileName.InvariantStartsWith(culture.Name) && fileName.InvariantEndsWith(".xml");
+                    return fileName.InvariantStartsWith(culture.Name.Replace("-", "_")) && fileName.InvariantEndsWith(".xml");
                 });
                 
                 foreach (var supplementaryFile in found)


### PR DESCRIPTION
The TextService code to load plugin provided language files fails for the en-US culture because it does not look for a consistent filename format.

The core system used the pathing style of ```/umbraco/config/lang/en_us.xml``` for its en-US language file.  A developer attempting to use the plugin language features would expect to be able create a local file at ```/App_Plugins/plugin/land/en_us.xml``` to add new definitions.  This is how it works for all other languages.

The big that is fixed where incorrectly tries to load ```/App_Plugins/plugin/lang/en-us.xml`` instead, and though it will technically work if a developer somehow divines this and changes the name, the bug should be fixed.

This only affects visitors on the the en-US culture.