### PR TITLE
Fix line-height when using custom icon font as section icon

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -22,6 +22,8 @@ ul.sections li [class^="icon-"]:before,
 ul.sections li [class*=" icon-"]:before,
 ul.sections li img.icon-section {
 	font-size: 30px;
+    line-height: 20px; /* set line-height to ensure all icons use same line-height */
+    display: inline-block;
 	margin: 1px 0 0 0;
 	opacity: 0.4;
 	-webkit-transition: all .3s linear;


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8330

Just a minor fix for line-height when using custom icon font as section icon. Didn't noticed in my previously PR: http://issues.umbraco.org/issue/U4-8248

**Before**
![image](https://cloud.githubusercontent.com/assets/2919859/14542549/bfc9893c-028f-11e6-975c-1f0cedbe56c6.png)

**After**
![image](https://cloud.githubusercontent.com/assets/2919859/14542565/d8ec5584-028f-11e6-9a7d-707d1410d2b9.png)
