### PR TITLE
Wrap text "Include all child nodes" in a label

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/developer/Packages/editPackage.aspx
+++ b/src/Umbraco.Web.UI/umbraco/developer/Packages/editPackage.aspx
@@ -75,7 +75,7 @@
             <asp:PlaceHolder ID="content" runat="server"></asp:PlaceHolder>
             <br />
             <asp:CheckBox ID="packageContentSubdirs" runat="server" />
-            Include all child nodes
+            <asp:Label ID="packageContentSubdirsLabel" Text="Include all child nodes" AssociatedControlID="packageContentSubdirs" runat="server" />
         </cc2:PropertyPanel>
     </cc2:Pane>
     <cc2:Pane ID="Pane2_1" runat="server">


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8300

Wrap text in a label, so it is consistent with other checkbox options.