### PR TITLE
U4-8319 - Sort data types array by name A-Z

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Packages/editPackage.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Packages/editPackage.aspx.cs
@@ -162,6 +162,13 @@ namespace umbraco.presentation.developer.packages
 
                     /*Data types */
                     cms.businesslogic.datatype.DataTypeDefinition[] umbDataType = cms.businesslogic.datatype.DataTypeDefinition.GetAll();
+
+                    // sort array by name
+                    Array.Sort(umbDataType, delegate(cms.businesslogic.datatype.DataTypeDefinition umbDataType1, cms.businesslogic.datatype.DataTypeDefinition umbDataType2)
+                    {
+                        return umbDataType1.Text.CompareTo(umbDataType2.Text);
+                    });
+
                     foreach (cms.businesslogic.datatype.DataTypeDefinition umbDtd in umbDataType)
                     {
 


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8319

Sort data types in package contents tab alphabetical - A-Z

Maybe it could also just be GetAll method that by default is sorted alphabetical like in seems like for document types and templates.
Macros are also not sorted alphabetically.

![image](https://cloud.githubusercontent.com/assets/2919859/14545189/4f2e6bbc-029d-11e6-8c06-1346ad0ee595.png)

![image](https://cloud.githubusercontent.com/assets/2919859/14545172/393389e6-029d-11e6-89cc-77f61ab17790.png)

http://www.csharp-examples.net/sort-array/
http://www.dotnetperls.com/sort-list
