### PR TITLE
Localize "unsaved changes" dialog.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/notifications/confirmroutechange.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/notifications/confirmroutechange.html
@@ -1,7 +1,7 @@
 <div ng-controller="Umbraco.Notifications.ConfirmRouteChangeController">
-	<h4><localize key="notifications_unsavedChanges">You have unsaved changes</localize></h4>
-	<p><localize key="notifications_unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</localize></p>
+	<h4><localize key="prompt_unsavedChanges">You have unsaved changes</localize></h4>
+	<p><localize key="prompt_unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</localize></p>
 
-	<button class="btn btn-warning" ng-click="discard(notification)"><localize key="notifications_discardChanges">Discard changes</localize></button>
-	<button class="btn" ng-click="stay(notification)" umb-auto-focus><localize key="notifications_stay">Stay</localize></button>
+	<button class="btn btn-warning" ng-click="discard(notification)"><localize key="prompt_discardChanges">Discard changes</localize></button>
+	<button class="btn" ng-click="stay(notification)" umb-auto-focus><localize key="prompt_stay">Stay</localize></button>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/notifications/confirmroutechange.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/notifications/confirmroutechange.html
@@ -1,7 +1,7 @@
 <div ng-controller="Umbraco.Notifications.ConfirmRouteChangeController">
-	<h4>You have unsaved changes</h4>
-	<p>Are you sure you want to navigate away from this page? - you have unsaved changes</p>
+	<h4><localize key="notifications_unsavedChanges">You have unsaved changes</localize></h4>
+	<p><localize key="notifications_unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</localize></p>
 
-	<button class="btn btn-warning" ng-click="discard(notification)">Discard changes</button>
-	<button class="btn" ng-click="stay(notification)" umb-auto-focus>Stay</button>
+	<button class="btn btn-warning" ng-click="discard(notification)"><localize key="notifications_discardChanges">Discard changes</localize></button>
+	<button class="btn" ng-click="stay(notification)" umb-auto-focus><localize key="notifications_stay">Stay</localize></button>
 </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
@@ -179,7 +179,7 @@
     <key alias="visit">Navštívit</key>
     <key alias="welcome">Vítejte</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
@@ -179,6 +179,12 @@
     <key alias="visit">Navštívit</key>
     <key alias="welcome">Vítejte</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Název</key>
     <key alias="assignDomain">Spravovat názvy hostitelů</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -186,7 +186,7 @@
     <key alias="visit">Besøk</key>
     <key alias="welcome">Velkommen</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -186,6 +186,12 @@
     <key alias="visit">Besøk</key>
     <key alias="welcome">Velkommen</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Navn på lokal link</key>
     <key alias="assignDomain">Rediger domener</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -187,6 +187,12 @@
     <key alias="visit">Besøg</key>
     <key alias="welcome">Velkommen</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Bliv</key>
+    <key alias="discardChanges">Kassér ændringer</key>
+    <key alias="unsavedChanges">Du har ikke-gemte ændringer</key>
+    <key alias="unsavedChangesWarning">Er du sikker på du vil navigere væk fra denne side? - du har ikke-gemte ændringer</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Navn på lokalt link</key>
     <key alias="assignDomain">Rediger domæner</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -187,7 +187,7 @@
     <key alias="visit">Besøg</key>
     <key alias="welcome">Velkommen</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Bliv</key>
     <key alias="discardChanges">Kassér ændringer</key>
     <key alias="unsavedChanges">Du har ikke-gemte ændringer</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -186,7 +186,7 @@
     <key alias="visit">Besuchen</key>
     <key alias="welcome">Willkommen</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -186,6 +186,12 @@
     <key alias="visit">Besuchen</key>
     <key alias="welcome">Willkommen</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Name</key>
     <key alias="assignDomain">Hostnamen verwalten</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -197,7 +197,7 @@
     <key alias="visit">Visit</key>
     <key alias="welcome">Welcome</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -197,6 +197,12 @@
     <key alias="visit">Visit</key>
     <key alias="welcome">Welcome</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Name</key>
     <key alias="assignDomain">Manage hostnames</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -199,6 +199,12 @@
     <key alias="visit">Visit</key>
     <key alias="welcome">Welcome</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Name</key>
     <key alias="assignDomain">Manage hostnames</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -199,7 +199,7 @@
     <key alias="visit">Visit</key>
     <key alias="welcome">Welcome</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -185,6 +185,12 @@
     <key alias="visit">Visita</key>
     <key alias="welcome">Bienvenido</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Nombre</key>
     <key alias="assignDomain">Administrar dominios</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -185,7 +185,7 @@
     <key alias="visit">Visita</key>
     <key alias="welcome">Bienvenido</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -181,7 +181,7 @@
     <key alias="visit">Visiter</key>
     <key alias="welcome">Bienvenue</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -181,6 +181,12 @@
     <key alias="visit">Visiter</key>
     <key alias="welcome">Bienvenue</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Name</key>
     <key alias="assignDomain">Gérer les noms d'hôtes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
@@ -131,7 +131,7 @@
     <key alias="visit">בקר</key>
     <key alias="welcome">ברוכים הבאים</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
@@ -131,6 +131,12 @@
     <key alias="visit">בקר</key>
     <key alias="welcome">ברוכים הבאים</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">שם</key>
     <key alias="assignDomain">ניהול שם מתחם</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
@@ -127,7 +127,7 @@
     <key alias="visit">Visita</key>
     <key alias="welcome">Benvenuto</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
@@ -127,6 +127,12 @@
     <key alias="visit">Visita</key>
     <key alias="welcome">Benvenuto</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Nome</key>
     <key alias="assignDomain">Gestione alias Hostnames</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
@@ -194,6 +194,12 @@
     <key alias="visit">訪れる</key>
     <key alias="welcome">ようこそ</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">名前</key>
     <key alias="assignDomain">ドメインの割り当て</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
@@ -194,7 +194,7 @@
     <key alias="visit">訪れる</key>
     <key alias="welcome">ようこそ</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
@@ -125,7 +125,7 @@
     <key alias="visit">방문</key>
     <key alias="welcome">환영합니다</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
@@ -125,6 +125,12 @@
     <key alias="visit">방문</key>
     <key alias="welcome">환영합니다</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">이름</key>
     <key alias="assignDomain">호스트네임 관리</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -188,6 +188,12 @@
     <key alias="visit">Bezoek</key>
     <key alias="welcome">Welkom</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Naam</key>
     <key alias="assignDomain">Beheer domeinnamen</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -188,7 +188,7 @@
     <key alias="visit">Bezoek</key>
     <key alias="welcome">Welkom</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -125,7 +125,7 @@
     <key alias="visit">Odwiedź</key>
     <key alias="welcome">Witaj</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -125,6 +125,12 @@
     <key alias="visit">Odwiedź</key>
     <key alias="welcome">Witaj</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Nazwa</key>
     <key alias="assignDomain">Zarządzaj nazwami hostów</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
@@ -125,7 +125,7 @@
     <key alias="visit">Visitar</key>
     <key alias="welcome">Bem Vindo(a)</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
@@ -125,6 +125,12 @@
     <key alias="visit">Visitar</key>
     <key alias="welcome">Bem Vindo(a)</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Nome</key>
     <key alias="assignDomain">Gerenciar hostnames</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -254,6 +254,12 @@
     <key alias="visit">Посетить</key>
     <key alias="welcome">Рады приветствовать</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Название</key>
     <key alias="assignDomain">Управление доменами</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -254,7 +254,7 @@
     <key alias="visit">Посетить</key>
     <key alias="welcome">Рады приветствовать</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -181,7 +181,7 @@
     <key alias="welcome">Välkommen</key>
     <key alias="visit">Besök</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -181,6 +181,12 @@
     <key alias="welcome">Välkommen</key>
     <key alias="visit">Besök</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Namn</key>
     <key alias="assignDomain">Hantera domännamn</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -166,7 +166,7 @@
     <key alias="visit">访问</key>
     <key alias="welcome">欢迎</key>
   </area>
-  <area alias="notifications">
+  <area alias="prompt">
     <key alias="stay">Stay</key>
     <key alias="discardChanges">Discard changes</key>
     <key alias="unsavedChanges">You have unsaved changes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -166,6 +166,12 @@
     <key alias="visit">访问</key>
     <key alias="welcome">欢迎</key>
   </area>
+  <area alias="notifications">
+    <key alias="stay">Stay</key>
+    <key alias="discardChanges">Discard changes</key>
+    <key alias="unsavedChanges">You have unsaved changes</key>
+    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">锚点名称</key>
     <key alias="assignDomain">管理主机名</key>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8343

Added localization of "unsaved changes" dialog. I have translated the text in Danish and also added the keys for the other languages - so they will still see the English translation and it also make other developers aware of the changes, so they can translate the text in other PRs.