### PR TITLE
Fix localization of listview buttons/links actions.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -31,13 +31,14 @@
                    <umb-button
                        type="button"
                        label="Clear selection"
+                       label-key="buttons_clearSelection"
                        action="clearSelection()"
                        disabled="actionInProgress">
                    </umb-button>
                </umb-editor-sub-header-section>
 
                <umb-editor-sub-header-section ng-if="isAnythingSelected()">
-                   <strong ng-show="!actionInProgress">{{ selectedItemsCount() }} of {{ listViewResultSet.items.length }} selected</strong>
+                   <strong ng-show="!actionInProgress">{{ selectedItemsCount() }} <localize key="general_of">of</localize> {{ listViewResultSet.items.length }} <localize key="general_selected">selected</localize></strong>
                    <strong ng-show="actionInProgress" ng-bind="bulkStatus"></strong>
 
                    <div class="umb-loader-wrapper -bottom" ng-show="actionInProgress">
@@ -86,7 +87,7 @@
                        type="button"
                        button-style="link"
                        label="Publish"
-                       key="actions_publish"
+                       label-key="actions_publish"
                        icon="icon-globe"
                        action="publish()"
                        disabled="actionInProgress">
@@ -97,7 +98,7 @@
                        type="button"
                        button-style="link"
                        label="Unpublish"
-                       key="actions_unpublish"
+                       label-key="actions_unpublish"
                        icon="icon-block"
                        action="unpublish()"
                        disabled="actionInProgress">
@@ -108,7 +109,7 @@
                        type="button"
                        button-style="link"
                        label="Copy"
-                       key="actions_copy"
+                       label-key="actions_copy"
                        icon="icon-documents"
                        action="copy()"
                        disabled="actionInProgress">
@@ -119,7 +120,7 @@
                        type="button"
                        button-style="link"
                        label="Move"
-                       key="actions_move"
+                       label-key="actions_move"
                        icon="icon-enter"
                        action="move()"
                        disabled="actionInProgress">
@@ -129,8 +130,8 @@
                        ng-if="options.allowBulkDelete && (buttonPermissions == null || buttonPermissions.canDelete)"
                        type="button"
                        button-style="link"
-                       label="Delete"
-                       key="actions_delete"
+                       label="Delete"              
+                       label-key="actions_delete"
                        icon="icon-trash"
                        action="delete()"
                        disabled="actionInProgress">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -60,6 +60,7 @@
     <key alias="atViewingFor">For</key>
   </area>
   <area alias="buttons">
+    <key alias="clearSelection">Ryd valg</key>
     <key alias="select">Vælg</key>
     <key alias="selectCurrentFolder">Vælg nuværende mappe</key>
     <key alias="somethingElse">Gør noget andet</key>
@@ -165,6 +166,10 @@
   <area alias="media">
     <key alias="clickToUpload">Klik for at uploade</key>
     <key alias="dropFilesHere">Slip filerne her...</key>
+    <key alias="urls">Link til medie</key>
+    <key alias="orClickHereToUpload">eller klik her for at vælge filer</key>
+    <key alias="onlyAllowedFiles">Tilladte filtyper er kun</key>
+    <key alias="maxFileSize">Maks filstørrelse er</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Opret et nyt medlem</key>
@@ -197,7 +202,7 @@
     <key alias="confirmlogout">Er du sikker på at du vil forlade Umbraco?</key>
     <key alias="confirmSure">Er du sikker?</key>
     <key alias="cut">Klip</key>
-    <key alias="editdictionary">Rediger ordbogs nøgle</key>
+    <key alias="editdictionary">Rediger ordbogsnøgle</key>
     <key alias="editlanguage">Rediger sprog</key>
     <key alias="insertAnchor">Indsæt lokalt link</key>
     <key alias="insertCharacter">Indsæt tegn</key>
@@ -421,8 +426,8 @@
     <key alias="listView">Listevisning</key>
     <key alias="saving">Gemmer...</key>
     <key alias="current">nuværende</key>
-    <key alias="move">Flyt</key>
     <key alias="embed">Indlejring</key>
+    <key alias="selected">valgt</key>
   </area>
 
   <area alias="colors">
@@ -985,7 +990,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="memberRoles">Roller</key>
     <key alias="memberTypes">Medlemstype</key>
     <key alias="documentTypes">Dokumenttyper</key>
-    <key alias="relationTypes">Dokumenttyper</key>
+    <key alias="relationTypes">Relationstyper</key>
 
     <key alias="packager">Pakker</key>
     <key alias="packages">Pakker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -65,6 +65,7 @@
     <key alias="atViewingFor">Viewing for</key>
   </area>
   <area alias="buttons">
+    <key alias="clearSelection">Clear selection</key>
     <key alias="select">Select</key>
     <key alias="selectCurrentFolder">Select current folder</key>
     <key alias="somethingElse">Do something else</key>
@@ -171,7 +172,7 @@
   <area alias="media">
     <key alias="clickToUpload">Click to upload</key>
     <key alias="dropFilesHere">Drop your files here...</key>
-	<key alias="urls">Link to media</key>
+	  <key alias="urls">Link to media</key>
     <key alias="orClickHereToUpload">or click here to choose files</key>
     <key alias="onlyAllowedFiles">Only allowed file types are</key>
     <key alias="maxFileSize">Max file size is</key>
@@ -479,8 +480,8 @@
     <key alias="listView">List view</key>
     <key alias="saving">Saving...</key>
     <key alias="current">current</key>
-    <key alias="move">Move</key>
     <key alias="embed">Embed</key>
+    <key alias="selected">selected</key>
   </area>
 
   <area alias="colors">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -65,6 +65,7 @@
     <key alias="atViewingFor">Viewing for</key>
   </area>
   <area alias="buttons">
+    <key alias="clearSelection">Clear selection</key>
     <key alias="select">Select</key>
     <key alias="selectCurrentFolder">Select current folder</key>
     <key alias="somethingElse">Do something else</key>
@@ -483,8 +484,8 @@
     <key alias="listView">List view</key>
     <key alias="saving">Saving...</key>
     <key alias="current">current</key>
-    <key alias="move">Move</key>
     <key alias="embed">Embed</key>
+    <key alias="selected">selected</key>
   </area>
   <area alias="colors">
     <key alias="black">Black</key>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8347

This PR fix localization of listview buttons/links actions above table as it used `key` instead of `label-key`.

Furthermore I have removed a few duplicated keys, localization of "clear button" and "x of x selected" text. And Danish translation in media section upload "dropzone".