### PR TITLE
U4-8365: Fix decimal property value converter to work on non EN-US cultures

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/DecimalValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/DecimalValueConverter.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.Models.PublishedContent;
+﻿using System.Globalization;
+using Umbraco.Core.Models.PublishedContent;
 
 namespace Umbraco.Core.PropertyEditors.ValueConverters
 {
@@ -20,7 +21,7 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
             if (sourceString != null)
             {
                 decimal d;
-                return (decimal.TryParse(sourceString, out d)) ? d : 0M;
+                return (decimal.TryParse(sourceString, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture,  out d)) ? d : 0M;
             }
 
             // in the database an a decimal is an a decimal 


### PR DESCRIPTION
The `DecimalValueConverter` class did not specify `CultureInfo.InvariantCulture` when parsing the number string is stored with EN-US notation, thus breaking when the culture of the current thread is anything that uses comma as decimal separator.