### PR TITLE
U4-6228: Inserting images via the rich text editor generates an invalid "rel" (According to HTML5 specification)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -98,7 +98,7 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                         currentTarget = {
                             altText: img.attr("alt"),
                             url: img.attr("src"),
-                            id: img.attr("rel")
+                            id: img.attr("id")
                         };
                     }
 
@@ -118,15 +118,14 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                var data = {
                    alt: img.altText || "",
                    src: (img.url) ? img.url : "nothing.jpg",
-                   rel: img.id,
+                   id: img.id,
                    'data-id': img.id,
-                   id: '__mcenew'
                };
 
                editor.insertContent(editor.dom.createHTML('img', data));
 
                $timeout(function () {
-                   var imgElm = editor.dom.get('__mcenew');
+                   imgElm = editor.dom.get(img.id)
                    var size = editor.dom.getSize(imgElm);
 
                    if (editor.settings.maxImageSize && editor.settings.maxImageSize !== 0) {


### PR DESCRIPTION
U4-6228: Inserting images via the rich text editor generates an invalid "rel" tag on the image links which is not valid in HTML5. This change applies the image id to the "ID" attribute rather than the "rel" attribute. 

This fix is associated with this issue: http://issues.umbraco.org/issue/U4-6228
