### PR TITLE
Enabled localization of grid editor names

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -822,6 +822,14 @@ angular.module("umbraco")
         gridService.getGridEditors().then(function (response) {
             $scope.availableEditors = response.data;
 
+            //Localize the grid editor names
+            angular.forEach($scope.availableEditors, function (value, key) {
+                //If no translation is provided, keep using the editor name from the manifest
+                if (localizationService.dictionary.hasOwnProperty("grid_" + value.alias)) {
+                    value.name = localizationService.localize("grid_" + value.alias);
+                }
+            });
+
             $scope.contentReady = true;
 
             // *********************************************

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
@@ -862,6 +862,13 @@
     <key alias="settingDialogDetails">Settings will only save if the entered json configuration is valid</key>
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+  
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternativní pole</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -834,6 +834,13 @@ Vennlig hilsen Umbraco roboten
     <key alias="chooseExtra">Velg ekstra</key>
     <key alias="chooseDefault">Velg standard</key>
     <key alias="areAdded">er lagt til</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternativt felt</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -723,6 +723,13 @@ Mange hilsner fra Umbraco robotten
     <key alias="chooseExtra">Vælg ekstra</key>
     <key alias="chooseDefault">Vælg standard</key>
     <key alias="areAdded">er tilføjet</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
 
   <area alias="contentTypeEditor">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -852,6 +852,13 @@ Wenn Sie sich für Runway entscheiden, können Sie optional Blöcke nutzen, die 
     <key alias="settingDialogDetails">Die Einstellungen werden nur gespeichert, wenn die angegebene JSON-Konfiguration gültig ist.</key>
     <key alias="allowAllEditors">Alle Elemente erlauben</key>
     <key alias="allowAllRowConfigurations">Alle Zeilenlayouts erlauben</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternatives Feld</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1035,6 +1035,13 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="chooseExtra">Choose extra</key>
     <key alias="chooseDefault">Choose default</key>
     <key alias="areAdded">are added</key>
+    
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
 
   <area alias="contentTypeEditor">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1035,6 +1035,13 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="chooseExtra">Choose extra</key>
     <key alias="chooseDefault">Choose default</key>
     <key alias="areAdded">are added</key>
+      
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
 
   <area alias="contentTypeEditor">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -761,6 +761,13 @@
 
     <key alias="allowAllEditors">Permitir todos los controles de edición</key>
     <key alias="allowAllRowConfigurations">Permitir todas las configuraciones de fila</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Campo opcional</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -882,6 +882,13 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
 
     <key alias="allowAllEditors">Autoriser tous les éditeurs</key>
     <key alias="allowAllRowConfigurations">Autoriser toutes les configurations de lignes</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Champ alternatif</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
@@ -771,6 +771,13 @@ To manage your website, simply open the Umbraco back office and start adding con
 
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">שדה אלטרנטיבי</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
@@ -741,6 +741,13 @@ Per gestire il tuo sito web, è sufficiente aprire il back office di Umbraco e i
 
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField"><![CDATA[Campo alternativo]]></key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
@@ -1014,6 +1014,13 @@ Runwayをインストールして作られた新しいウェブサイトがど�
     <key alias="chooseExtra">追加を選択</key>
     <key alias="chooseDefault">デフォルトの選択</key>
     <key alias="areAdded">追加されました</key>
+      
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
 
   <area alias="contentTypeEditor">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
@@ -747,6 +747,13 @@
 
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">대체 필드</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -855,6 +855,13 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
 
     <key alias="allowAllEditors">Alle editors toelaten</key>
     <key alias="allowAllRowConfigurations">Alle rijconfiguraties toelaten</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
 </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternatief veld</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -663,6 +663,13 @@ Miłego dnia!]]></key>
 
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Pole alternatywne</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
@@ -736,6 +736,13 @@ Você pode publicar esta página e todas suas sub-páginas ao selecionar <em>pub
 
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+      
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Campo alternativo</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -576,6 +576,13 @@
     <key alias="chooseExtra">Выбрать дополнительно</key>
     <key alias="chooseDefault">Выбрать по-умолчанию</key>
     <key alias="areAdded">добавлены</key>
+      
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="headers">
     <key alias="page">Страница</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -768,6 +768,13 @@
     <key alias="settingDialogDetails">Inställningarna kommer bara att sparas om det inmatade json-konfigurationen är giltig</key>
     <key alias="allowAllEditors">Tillåt alla editors</key>
     <key alias="allowAllRowConfigurations">Tillåt alla rad- konfigurationer</key>
+
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternativt fält</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -822,6 +822,13 @@
 
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+      
+    <key alias="rte">Rich Text Editor</key>
+    <key alias="media">Image</key>
+    <key alias="macro">Macro</key>
+    <key alias="embed">Embed</key>
+    <key alias="headline">Headline</key>
+    <key alias="quote">Quote</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">替代字段</key>


### PR DESCRIPTION
Enabled localisation of grid editor names. If no localized name exists, the grid editor will continue using the name in the package manifest.

To add localized grid editor names, create a language resource file with key grid_editorAlias.
