### PR TITLE
U4-8290 - made label property editor should be configurable to declare data type storage

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -419,6 +419,12 @@ namespace Umbraco.Core
             /// Alias for the email address property editor
             /// </summary>
             public const string EmailAddressAlias = "Umbraco.EmailAddress";
+
+            /// <summary>
+            /// Pre-value name used to indicate a field that can be used to override the database field to which data for the associated
+            /// property is saved
+            /// </summary>
+            public const string DataValueTypePreValueKey = "umbracoDataValueType";
         }
 	}
 }

--- a/src/Umbraco.Core/Models/DataTypeDatabaseType.cs
+++ b/src/Umbraco.Core/Models/DataTypeDatabaseType.cs
@@ -6,10 +6,6 @@ namespace Umbraco.Core.Models
     /// <summary>
     /// Enum of the various DbTypes for which the Property values are stored
     /// </summary>
-    /// <remarks>
-    /// Object is added to support complex values from PropertyEditors, 
-    /// but will be saved under the Ntext column.
-    /// </remarks>
     [Serializable]
     [DataContract]
     public enum DataTypeDatabaseType

--- a/src/Umbraco.Core/Models/PropertyType.cs
+++ b/src/Umbraco.Core/Models/PropertyType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
@@ -423,6 +424,19 @@ namespace Umbraco.Core.Models
                 return true;
 
             return false;
+        }
+
+        /// <summary>
+        /// Checks the underlying property editor prevalues to see if the one that allows changing of the database field
+        /// to which data is saved (dataInt, dataVarchar etc.) is included.  If so that means the field could be changed when the data
+        /// type is saved.
+        /// </summary>
+        /// <returns></returns>
+        internal bool CanHaveDataValueTypeChanged()
+        {
+            var propertyEditor = PropertyEditorResolver.Current.GetByAlias(_propertyEditorAlias);
+            return propertyEditor.PreValueEditor.Fields
+                .SingleOrDefault(x => x.Key == Constants.PropertyEditors.DataValueTypePreValueKey) != null;
         }
 
         /// <summary>

--- a/src/Umbraco.Core/PropertyEditors/PropertyEditorAttribute.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyEditorAttribute.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Core.PropertyEditors
             EditorView = editorView;
 
             //defaults
-            ValueType = "string";
+            ValueType = PropertyEditorValueTypes.StringType;
             Icon = Constants.Icons.PropertyEditor;
             Group = "common";
         }
@@ -33,7 +33,7 @@ namespace Umbraco.Core.PropertyEditors
             Name = name;
 
             //defaults
-            ValueType = "string";
+            ValueType = PropertyEditorValueTypes.StringType;
             Icon = Constants.Icons.PropertyEditor;
             Group = "common";
         }

--- a/src/Umbraco.Core/PropertyEditors/PropertyEditorValueTypes.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyEditorValueTypes.cs
@@ -1,0 +1,25 @@
+﻿namespace Umbraco.Core.PropertyEditors
+{
+    public static class PropertyEditorValueTypes
+    {
+        public const string DateType = "DATE";
+
+        public const string DateTimeType = "DATETIME";
+
+        public const string DecimalType = "DECIMAL";
+
+        public const string IntegerType = "INT";
+
+        public const string IntegerTypeAlternative = "INTEGER";
+
+        public const string JsonType = "JSON";
+
+        public const string TextType = "TEXT";
+
+        public const string TimeType = "TIME";
+
+        public const string StringType = "STRING";
+
+        public const string XmlType = "XML";
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/PropertyValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueEditor.cs
@@ -130,20 +130,20 @@ namespace Umbraco.Core.PropertyEditors
         {
             switch (ValueType.ToUpper(CultureInfo.InvariantCulture))
             {
-                case "INT":
-                case "INTEGER":
+                case PropertyEditorValueTypes.IntegerType:
+                case PropertyEditorValueTypes.IntegerTypeAlternative:
                     return DataTypeDatabaseType.Integer;
-                case "DECIMAL":
+                case PropertyEditorValueTypes.DecimalType:
                     return DataTypeDatabaseType.Decimal;
-                case "STRING":
+                case PropertyEditorValueTypes.StringType:
                     return DataTypeDatabaseType.Nvarchar;
-                case "TEXT":
-                case "JSON":
-                case "XML":
+                case PropertyEditorValueTypes.TextType:
+                case PropertyEditorValueTypes.JsonType:
+                case PropertyEditorValueTypes.XmlType:
                     return DataTypeDatabaseType.Ntext;
-                case "DATETIME":
-                case "DATE":
-                case "TIME":
+                case PropertyEditorValueTypes.DateTimeType:
+                case PropertyEditorValueTypes.DateType:
+                case PropertyEditorValueTypes.TimeType:
                     return DataTypeDatabaseType.Date;
                 default:
                     throw new FormatException("The ValueType does not match a known value type");

--- a/src/Umbraco.Core/PropertyEditors/PropertyValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueEditor.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Core.PropertyEditors
         /// </summary>
         public PropertyValueEditor()
         {
-            ValueType = "string";
+            ValueType = PropertyEditorValueTypes.StringType;
             //set a default for validators
             Validators = new List<IPropertyValidator>();
         }
@@ -238,7 +238,7 @@ namespace Umbraco.Core.PropertyEditors
         public virtual object ConvertEditorToDb(ContentPropertyData editorValue, object currentValue)
         {
             //if it's json but it's empty json, then return null
-            if (ValueType.InvariantEquals("JSON") && editorValue.Value != null && editorValue.Value.ToString().DetectIsEmptyJson())
+            if (ValueType.InvariantEquals(PropertyEditorValueTypes.JsonType) && editorValue.Value != null && editorValue.Value.ToString().DetectIsEmptyJson())
             {
                 return null;
             }

--- a/src/Umbraco.Core/PropertyEditors/RequiredManifestValueValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/RequiredManifestValueValidator.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Core.PropertyEditors
             {
                 var asString = value.ToString();
 
-                if (editor.ValueEditor.ValueType.InvariantEquals("JSON"))
+                if (editor.ValueEditor.ValueType.InvariantEquals(PropertyEditorValueTypes.JsonType))
                 {
                     if (asString.DetectIsEmptyJson())
                     {

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/JsonValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/JsonValueConverter.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
         {
             var propertyEditor = PropertyEditorResolver.Current.GetByAlias(propertyType.PropertyEditorAlias);
             if (propertyEditor == null) return false;
-            return propertyEditor.ValueEditor.ValueType.InvariantEquals("json");
+            return propertyEditor.ValueEditor.ValueType.InvariantEquals(PropertyEditorValueTypes.JsonType);
         }
 
         public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -504,6 +504,8 @@ namespace Umbraco.Core.Services
             if (Saving.IsRaisedEventCancelled(new SaveEventArgs<IDataTypeDefinition>(dataTypeDefinition), this))
                 return;
 
+            OverrideDatabaseTypeIfProvidedInPreValues(dataTypeDefinition, values);
+
             var uow = UowProvider.GetUnitOfWork();
             using (var repository = RepositoryFactory.CreateDataTypeDefinitionRepository(uow))
             {
@@ -523,6 +525,36 @@ namespace Umbraco.Core.Services
             Audit(AuditType.Save, string.Format("Save DataTypeDefinition performed by user"), userId, dataTypeDefinition.Id);
         }
 
+        /// <summary>
+        /// If the database data field is provided in the pre-values update the data type definition to that instead of the
+        /// default for the property editor 
+        /// </summary>
+        /// <param name="dataTypeDefinition"></param>
+        /// <param name="values"></param>
+        private static void OverrideDatabaseTypeIfProvidedInPreValues(IDataTypeDefinition dataTypeDefinition, IDictionary<string, PreValue> values)
+        {
+            if (values != null && values.ContainsKey(Constants.PropertyEditors.DataValueTypePreValueKey))
+            {
+                switch (values[Constants.PropertyEditors.DataValueTypePreValueKey].Value)
+                {
+                    case PropertyEditorValueTypes.StringType:
+                        dataTypeDefinition.DatabaseType = DataTypeDatabaseType.Nvarchar;
+                        break;
+                    case PropertyEditorValueTypes.IntegerType:
+                        dataTypeDefinition.DatabaseType = DataTypeDatabaseType.Integer;
+                        break;
+                    case PropertyEditorValueTypes.DecimalType:
+                        dataTypeDefinition.DatabaseType = DataTypeDatabaseType.Decimal;
+                        break;
+                    case PropertyEditorValueTypes.DateTimeType:
+                        dataTypeDefinition.DatabaseType = DataTypeDatabaseType.Date;
+                        break;
+                    case PropertyEditorValueTypes.TextType:
+                        dataTypeDefinition.DatabaseType = DataTypeDatabaseType.Ntext;
+                        break;
+                }
+            }
+        }
 
         /// <summary>
         /// Deletes an <see cref="IDataTypeDefinition"/>

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -476,6 +476,7 @@
     <Compile Include="Persistence\Repositories\TaskRepository.cs" />
     <Compile Include="Persistence\Repositories\TaskTypeRepository.cs" />
     <Compile Include="PropertyEditors\DecimalValidator.cs" />
+    <Compile Include="PropertyEditors\PropertyEditorValueTypes.cs" />
     <Compile Include="PropertyEditors\ValueConverters\GridValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DecimalValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\LabelValueConverter.cs" />

--- a/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueEditorTests.cs
+++ b/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueEditorTests.cs
@@ -41,8 +41,8 @@ namespace Umbraco.Tests.PropertyEditors
 
             var valueEditor = new PropertyValueEditor
                 {
-                    ValueType = "STRING"
-                };
+                    ValueType = PropertyEditorValueTypes.StringType
+            };
 
             var result = valueEditor.ConvertDbToEditor(prop, prop.PropertyType, new Mock<IDataTypeService>().Object);
             Assert.AreEqual(isOk, !(result is string));
@@ -73,7 +73,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             var valueEditor = new PropertyValueEditor
             {
-                ValueType = "DECIMAL"
+                ValueType = PropertyEditorValueTypes.DecimalType
             };
 
             var result = valueEditor.TryConvertValueToCrlType("12.34");
@@ -86,7 +86,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             var valueEditor = new PropertyValueEditor
             {
-                ValueType = "DECIMAL"
+                ValueType = PropertyEditorValueTypes.DecimalType
             };
 
             var result = valueEditor.TryConvertValueToCrlType("12,34");
@@ -99,7 +99,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             var valueEditor = new PropertyValueEditor
             {
-                ValueType = "DECIMAL"
+                ValueType = PropertyEditorValueTypes.DecimalType
             };
 
             var result = valueEditor.TryConvertValueToCrlType(string.Empty);
@@ -112,20 +112,20 @@ namespace Umbraco.Tests.PropertyEditors
         {
             var valueEditor = new PropertyValueEditor
                 {
-                    ValueType = "DATE"
-                };
+                    ValueType = PropertyEditorValueTypes.DateType
+            };
 
             var result = valueEditor.TryConvertValueToCrlType("2010-02-05");
             Assert.IsTrue(result.Success);
             Assert.AreEqual(new DateTime(2010, 2, 5), result.Result);
         }
 
-        [TestCase("STRING", "hello", "hello")]
-        [TestCase("TEXT", "hello", "hello")]
-        [TestCase("INT", 123, "123")]
-        [TestCase("INTEGER", 123, "123")]
-        [TestCase("INTEGER", "", "")] //test empty string for int        
-        [TestCase("DATETIME", "", "")] //test empty string for date
+        [TestCase(PropertyEditorValueTypes.StringType, "hello", "hello")]
+        [TestCase(PropertyEditorValueTypes.TextType, "hello", "hello")]
+        [TestCase(PropertyEditorValueTypes.IntegerType, 123, "123")]
+        [TestCase(PropertyEditorValueTypes.IntegerTypeAlternative, 123, "123")]
+        [TestCase(PropertyEditorValueTypes.IntegerType, "", "")] //test empty string for int        
+        [TestCase(PropertyEditorValueTypes.DateTimeType, "", "")] //test empty string for date
         public void Value_Editor_Can_Serialize_Value(string valueType, object val, string expected)
         {
             var prop = new Property(1, Guid.NewGuid(), new PropertyType("test", DataTypeDatabaseType.Nvarchar), val);
@@ -145,8 +145,8 @@ namespace Umbraco.Tests.PropertyEditors
             var value = 12.34M;
             var valueEditor = new PropertyValueEditor
                 {
-                    ValueType = "DECIMAL"
-                };
+                    ValueType = PropertyEditorValueTypes.DecimalType
+            };
 
             var prop = new Property(1, Guid.NewGuid(), new PropertyType("test", DataTypeDatabaseType.Decimal), value);
 
@@ -159,8 +159,8 @@ namespace Umbraco.Tests.PropertyEditors
         {
             var valueEditor = new PropertyValueEditor
                 {
-                    ValueType = "DECIMAL"
-                };
+                    ValueType = PropertyEditorValueTypes.DecimalType
+            };
 
             var prop = new Property(1, Guid.NewGuid(), new PropertyType("test", DataTypeDatabaseType.Decimal), string.Empty);
 
@@ -174,8 +174,8 @@ namespace Umbraco.Tests.PropertyEditors
             var now = DateTime.Now;
             var valueEditor = new PropertyValueEditor
                 {
-                    ValueType = "DATE"
-                };
+                    ValueType = PropertyEditorValueTypes.DateType
+            };
 
             var prop = new Property(1, Guid.NewGuid(), new PropertyType("test", DataTypeDatabaseType.Date), now);
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/valuetype.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/valuetype.html
@@ -1,0 +1,7 @@
+<select ng-model="model.value">
+    <option value="STRING">String</option>
+    <option value="DECIMAL">Decimal</option>
+    <option value="DATETIME">Date/time</option>
+    <option value="INT">Integer</option>
+    <option value="TEXT">Long string</option>
+</select>

--- a/src/Umbraco.Web/PropertyEditors/ContentPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ContentPickerPropertyEditor.cs
@@ -4,7 +4,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.ContentPickerAlias, "Content Picker", "INT", "contentpicker", IsParameterEditor = true, Group = "Pickers")]
+    [PropertyEditor(Constants.PropertyEditors.ContentPickerAlias, "Content Picker", PropertyEditorValueTypes.IntegerType, "contentpicker", IsParameterEditor = true, Group = "Pickers")]
     public class ContentPickerPropertyEditor : PropertyEditor
     {
 

--- a/src/Umbraco.Web/PropertyEditors/DatePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DatePropertyEditor.cs
@@ -9,7 +9,7 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.DateAlias, "Date", "DATE", "datepicker", Icon="icon-calendar")]
+    [PropertyEditor(Constants.PropertyEditors.DateAlias, "Date", PropertyEditorValueTypes.DateType, "datepicker", Icon="icon-calendar")]
     public class DatePropertyEditor : PropertyEditor
     {
         public DatePropertyEditor()

--- a/src/Umbraco.Web/PropertyEditors/DateTimePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DateTimePropertyEditor.cs
@@ -5,7 +5,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.DateTimeAlias, "Date/Time", "datepicker", ValueType = "DATETIME", Icon="icon-time")]
+    [PropertyEditor(Constants.PropertyEditors.DateTimeAlias, "Date/Time", "datepicker", ValueType = PropertyEditorValueTypes.DateTimeType, Icon="icon-time")]
     public class DateTimePropertyEditor : PropertyEditor
     {
         public DateTimePropertyEditor()

--- a/src/Umbraco.Web/PropertyEditors/DecimalPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DecimalPropertyEditor.cs
@@ -3,7 +3,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.DecimalAlias, "Decimal", "decimal", "decimal", IsParameterEditor = true)]
+    [PropertyEditor(Constants.PropertyEditors.DecimalAlias, "Decimal", PropertyEditorValueTypes.DecimalType, "decimal", IsParameterEditor = true)]
     public class DecimalPropertyEditor : PropertyEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/DropDownPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DropDownPropertyEditor.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Web.PropertyEditors
     /// as INT and we have logic in here to ensure it is formatted correctly including ensuring that the string value is published
     /// in cache and not the int ID.
     /// </remarks>
-    [PropertyEditor(Constants.PropertyEditors.DropDownListAlias, "Dropdown list", "dropdown", ValueType = "STRING", Group = "lists", Icon = "icon-indent")]
+    [PropertyEditor(Constants.PropertyEditors.DropDownListAlias, "Dropdown list", "dropdown", ValueType = PropertyEditorValueTypes.StringType, Group = "lists", Icon = "icon-indent")]
     public class DropDownPropertyEditor : DropDownWithKeysPropertyEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/DropDownWithKeysPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DropDownWithKeysPropertyEditor.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Web.PropertyEditors
     /// as INT and we have logic in here to ensure it is formatted correctly including ensuring that the INT ID value is published
     /// in cache and not the string value.
     /// </remarks>
-    [PropertyEditor(Constants.PropertyEditors.DropdownlistPublishingKeysAlias, "Dropdown list, publishing keys", "dropdown", ValueType = "INT", Group = "lists", Icon = "icon-indent")]
+    [PropertyEditor(Constants.PropertyEditors.DropdownlistPublishingKeysAlias, "Dropdown list, publishing keys", "dropdown", ValueType = PropertyEditorValueTypes.IntegerType, Group = "lists", Icon = "icon-indent")]
     public class DropDownWithKeysPropertyEditor : PropertyEditor
     {
 

--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -9,7 +9,7 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Core.Constants.PropertyEditors.GridAlias, "Grid layout", "grid", HideLabel = true, IsParameterEditor = false, ValueType = "JSON", Group="rich content", Icon="icon-layout")]
+    [PropertyEditor(Core.Constants.PropertyEditors.GridAlias, "Grid layout", "grid", HideLabel = true, IsParameterEditor = false, ValueType = PropertyEditorValueTypes.JsonType, Group="rich content", Icon="icon-layout")]
     public class GridPropertyEditor : PropertyEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -15,7 +15,7 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.ImageCropperAlias, "Image Cropper", "imagecropper", ValueType = "JSON", HideLabel = false, Group="media", Icon="icon-crop")]
+    [PropertyEditor(Constants.PropertyEditors.ImageCropperAlias, "Image Cropper", "imagecropper", ValueType = PropertyEditorValueTypes.JsonType, HideLabel = false, Group="media", Icon="icon-crop")]
     public class ImageCropperPropertyEditor : PropertyEditor
     {
 

--- a/src/Umbraco.Web/PropertyEditors/IntegerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/IntegerPropertyEditor.cs
@@ -3,7 +3,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.IntegerAlias, "Numeric", "integer", IsParameterEditor = true, ValueType = "integer")]
+    [PropertyEditor(Constants.PropertyEditors.IntegerAlias, "Numeric", "integer", IsParameterEditor = true, ValueType = PropertyEditorValueTypes.IntegerTypeAlternative)]
     public class IntegerPropertyEditor : PropertyEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/LabelPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/LabelPropertyEditor.cs
@@ -41,7 +41,6 @@ namespace Umbraco.Web.PropertyEditors
 
         internal class LabelPreValueEditor : PreValueEditor
         {
-            private const string ValueTypeKey = "valueType";
             private const string LegacyPropertyEditorValuesKey = "values";
 
             public LabelPreValueEditor()
@@ -56,7 +55,7 @@ namespace Umbraco.Web.PropertyEditors
                 ValueType = PropertyEditorValueTypes.StringType;
             }
 
-            [PreValueField(ValueTypeKey, "Value type", "valuetype")]
+            [PreValueField(Constants.PropertyEditors.DataValueTypePreValueKey, "Value type", "valuetype")]
             public string ValueType { get; set; }
 
             /// <summary>
@@ -72,19 +71,19 @@ namespace Umbraco.Web.PropertyEditors
 
                 // Check for a saved value type.  If not found set to default string type.
                 var valueType = PropertyEditorValueTypes.StringType;
-                if (existing.ContainsKey(ValueTypeKey))
+                if (existing.ContainsKey(Constants.PropertyEditors.DataValueTypePreValueKey))
                 {
-                    valueType = (string)existing[ValueTypeKey];
+                    valueType = (string)existing[Constants.PropertyEditors.DataValueTypePreValueKey];
                 }
 
                 // Convert any other values from a legacy property editor to a list, easier to enumerate on the editor.
                 // Make sure to exclude values defined on the label property editor itself.
                 var asList = existing
                     .Select(e => new KeyValuePair<string, object>(e.Key, e.Value))
-                    .Where(e => e.Key != ValueTypeKey)
+                    .Where(e => e.Key != Constants.PropertyEditors.DataValueTypePreValueKey)
                     .ToList();
 
-                var result = new Dictionary<string, object> { { ValueTypeKey, valueType } };
+                var result = new Dictionary<string, object> { { Constants.PropertyEditors.DataValueTypePreValueKey, valueType } };
                 if (asList.Any())
                 {
                     result.Add("values", asList);

--- a/src/Umbraco.Web/PropertyEditors/LabelPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/LabelPropertyEditor.cs
@@ -1,17 +1,15 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using System.Web.Mvc;
+using Newtonsoft.Json.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.NoEditAlias, "Label", "readonlyvalue", Icon="icon-readonly")]
+    [PropertyEditor(Constants.PropertyEditors.NoEditAlias, "Label", "readonlyvalue", Icon = "icon-readonly")]
     public class LabelPropertyEditor : PropertyEditor
     {
-
         protected override PropertyValueEditor CreateValueEditor()
         {
             return new LabelPropertyValueEditor(base.CreateValueEditor());
@@ -43,19 +41,27 @@ namespace Umbraco.Web.PropertyEditors
 
         internal class LabelPreValueEditor : PreValueEditor
         {
+            private const string ValueTypeKey = "valueType";
+            private const string LegacyPropertyEditorValuesKey = "values";
+
             public LabelPreValueEditor()
             {
                 Fields.Add(new PreValueField()
                 {
                     HideLabel = true,
                     View = "readonlykeyvalues",
-                    Key = "values"
+                    Key = LegacyPropertyEditorValuesKey
                 });
+
+                ValueType = PropertyEditorValueTypes.StringType;
             }
 
+            [PreValueField(ValueTypeKey, "Value type", "valuetype")]
+            public string ValueType { get; set; }
+
             /// <summary>
-            /// Chuck all the values into one field so devs can see what is stored there - we want this in case we've converted a legacy proeprty editor over to a label
-            /// we should still show the pre-values stored for the data type.
+            /// Other than for the pre-value fields defined on this property editor, chuck all the values into one field so devs can see what is stored there.
+            /// We want this in case we've converted a legacy property editor over to a label as we should still show the pre-values stored for the data type.
             /// </summary>
             /// <param name="defaultPreVals"></param>
             /// <param name="persistedPreVals"></param>
@@ -63,12 +69,67 @@ namespace Umbraco.Web.PropertyEditors
             public override IDictionary<string, object> ConvertDbToEditor(IDictionary<string, object> defaultPreVals, PreValueCollection persistedPreVals)
             {
                 var existing = base.ConvertDbToEditor(defaultPreVals, persistedPreVals);
-                //convert to a list, easier to enumerate on the editor
-                var asList = existing.Select(e => new KeyValuePair<string, object>(e.Key, e.Value)).ToList();
-                var result = new Dictionary<string, object> { { "values", asList } };
+
+                // Check for a saved value type.  If not found set to default string type.
+                var valueType = PropertyEditorValueTypes.StringType;
+                if (existing.ContainsKey(ValueTypeKey))
+                {
+                    valueType = (string)existing[ValueTypeKey];
+                }
+
+                // Convert any other values from a legacy property editor to a list, easier to enumerate on the editor.
+                // Make sure to exclude values defined on the label property editor itself.
+                var asList = existing
+                    .Select(e => new KeyValuePair<string, object>(e.Key, e.Value))
+                    .Where(e => e.Key != ValueTypeKey)
+                    .ToList();
+
+                var result = new Dictionary<string, object> { { ValueTypeKey, valueType } };
+                if (asList.Any())
+                {
+                    result.Add("values", asList);
+                }
+
                 return result;
             }
-        }
 
+            /// <summary>
+            /// When saving we want to avoid saving an empty "legacy property editor values" field if there are none.
+            /// </summary>
+            /// <param name="editorValue"></param>
+            /// <param name="currentValue"></param>
+            /// <returns></returns>
+            public override IDictionary<string, PreValue> ConvertEditorToDb(IDictionary<string, object> editorValue, PreValueCollection currentValue)
+            {
+                if (editorValue.ContainsKey(LegacyPropertyEditorValuesKey))
+                {
+                    // If provided value contains an empty legacy property editor values, don't save it
+                    if (editorValue[LegacyPropertyEditorValuesKey] == null)
+                    {
+                        editorValue.Remove(LegacyPropertyEditorValuesKey);
+                    }
+                    else
+                    {
+                        // If provided value contains legacy property editor values, unwrap the value to save so it doesn't get repeatedly nested on saves.
+                        // This is a bit funky - but basically needing to parse out the original value from a JSON structure that is passed in 
+                        // looking like: 
+                        //   Value = {[
+                        //   {
+                        //      "Key": "values",
+                        //      "Value": {
+                        //          <legacy property editor values>
+                        //      }}
+                        //   ]}
+                        var values = editorValue[LegacyPropertyEditorValuesKey] as JArray;
+                        if (values != null && values.Count == 1 && values.First.Values().Count() == 2)
+                        {
+                            editorValue[LegacyPropertyEditorValuesKey] = values.First.Values().Last();
+                        }
+                    }
+                }
+
+                return base.ConvertEditorToDb(editorValue, currentValue);
+            }
+        }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MacroContainerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MacroContainerPropertyEditor.cs
@@ -9,7 +9,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.MacroContainerAlias, "Macro container", "macrocontainer", ValueType = "TEXT", Group="rich content", Icon="icon-settings-alt")]
+    [PropertyEditor(Constants.PropertyEditors.MacroContainerAlias, "Macro container", "macrocontainer", ValueType = PropertyEditorValueTypes.TextType, Group="rich content", Icon="icon-settings-alt")]
     public class MacroContainerPropertyEditor : PropertyEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/MarkdownPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MarkdownPropertyEditor.cs
@@ -3,7 +3,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.MarkdownEditorAlias, "Markdown editor", "markdowneditor", ValueType = "TEXT", Icon="icon-code", Group="rich content")]
+    [PropertyEditor(Constants.PropertyEditors.MarkdownEditorAlias, "Markdown editor", "markdowneditor", ValueType = PropertyEditorValueTypes.TextType, Icon="icon-code", Group="rich content")]
     public class MarkdownPropertyEditor : PropertyEditor
     {
         protected override PreValueEditor CreatePreValueEditor()

--- a/src/Umbraco.Web/PropertyEditors/MediaPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPickerPropertyEditor.cs
@@ -9,7 +9,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.MediaPickerAlias, "Legacy Media Picker", "INT", "mediapicker", Group="media", Icon="icon-picture")]
+    [PropertyEditor(Constants.PropertyEditors.MediaPickerAlias, "Legacy Media Picker", PropertyEditorValueTypes.IntegerType, "mediapicker", Group="media", Icon="icon-picture")]
     public class MediaPickerPropertyEditor : PropertyEditor
     {
         public MediaPickerPropertyEditor()

--- a/src/Umbraco.Web/PropertyEditors/MemberPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MemberPickerPropertyEditor.cs
@@ -8,7 +8,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.MemberPickerAlias, "Member Picker", "INT", "memberpicker", Group = "People", Icon = "icon-user")]
+    [PropertyEditor(Constants.PropertyEditors.MemberPickerAlias, "Member Picker", PropertyEditorValueTypes.IntegerType, "memberpicker", Group = "People", Icon = "icon-user")]
     public class MemberPickerPropertyEditor : PropertyEditor
     {
     }

--- a/src/Umbraco.Web/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -14,7 +14,7 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.MultipleTextstringAlias, "Repeatable textstrings", "multipletextbox", ValueType = "TEXT", Icon="icon-ordered-list", Group="lists")]
+    [PropertyEditor(Constants.PropertyEditors.MultipleTextstringAlias, "Repeatable textstrings", "multipletextbox", ValueType = PropertyEditorValueTypes.TextType, Icon="icon-ordered-list", Group="lists")]
     public class MultipleTextStringPropertyEditor : PropertyEditor
     {
         protected override PropertyValueEditor CreateValueEditor()

--- a/src/Umbraco.Web/PropertyEditors/RadioButtonsPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RadioButtonsPropertyEditor.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Web.PropertyEditors
     /// as INT and we have logic in here to ensure it is formatted correctly including ensuring that the INT ID value is published
     /// in cache and not the string value.
     /// </remarks>
-    [PropertyEditor(Constants.PropertyEditors.RadioButtonListAlias, "Radio button list", "radiobuttons", ValueType = "INT", Group="lists", Icon="icon-target")]
+    [PropertyEditor(Constants.PropertyEditors.RadioButtonListAlias, "Radio button list", "radiobuttons", ValueType = PropertyEditorValueTypes.IntegerType, Group="lists", Icon="icon-target")]
     public class RadioButtonsPropertyEditor : DropDownWithKeysPropertyEditor
     {
 

--- a/src/Umbraco.Web/PropertyEditors/RelatedLinksPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RelatedLinksPropertyEditor.cs
@@ -8,7 +8,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.RelatedLinksAlias, "Related links", "relatedlinks", ValueType ="JSON", Icon="icon-thumbnail-list", Group="pickers")]
+    [PropertyEditor(Constants.PropertyEditors.RelatedLinksAlias, "Related links", "relatedlinks", ValueType = PropertyEditorValueTypes.JsonType, Icon="icon-thumbnail-list", Group="pickers")]
     public class RelatedLinksPropertyEditor : PropertyEditor
     {
         protected override PreValueEditor CreatePreValueEditor()

--- a/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
@@ -7,7 +7,7 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.TinyMCEAlias, "Rich Text Editor", "rte", ValueType = "TEXT",  HideLabel = false, Group="Rich Content", Icon="icon-browser-window")]
+    [PropertyEditor(Constants.PropertyEditors.TinyMCEAlias, "Rich Text Editor", "rte", ValueType = PropertyEditorValueTypes.TextType,  HideLabel = false, Group="Rich Content", Icon="icon-browser-window")]
     public class RichTextPropertyEditor : PropertyEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/TextAreaPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TextAreaPropertyEditor.cs
@@ -3,7 +3,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.TextboxMultipleAlias, "Textarea", "textarea", IsParameterEditor = true, ValueType = "TEXT", Icon="icon-application-window-alt")]
+    [PropertyEditor(Constants.PropertyEditors.TextboxMultipleAlias, "Textarea", "textarea", IsParameterEditor = true, ValueType = PropertyEditorValueTypes.TextType, Icon="icon-application-window-alt")]
     public class TextAreaPropertyEditor : PropertyEditor
     {
     }

--- a/src/Umbraco.Web/PropertyEditors/TrueFalsePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalsePropertyEditor.cs
@@ -3,7 +3,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.TrueFalseAlias, "True/False", "INT", "boolean", IsParameterEditor = true, Group = "Common", Icon="icon-checkbox")]
+    [PropertyEditor(Constants.PropertyEditors.TrueFalseAlias, "True/False", PropertyEditorValueTypes.IntegerType, "boolean", IsParameterEditor = true, Group = "Common", Icon="icon-checkbox")]
     public class TrueFalsePropertyEditor : PropertyEditor
     {
         protected override PreValueEditor CreatePreValueEditor()

--- a/src/Umbraco.Web/PropertyEditors/UserPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/UserPickerPropertyEditor.cs
@@ -6,7 +6,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.UserPickerAlias, "User picker", "INT", "entitypicker", Group="People", Icon="icon-user")]
+    [PropertyEditor(Constants.PropertyEditors.UserPickerAlias, "User picker", PropertyEditorValueTypes.IntegerType, "entitypicker", Group="People", Icon="icon-user")]
     public class UserPickerPropertyEditor : PropertyEditor
     {
         private IDictionary<string, object> _defaultPreValues;


### PR DESCRIPTION
This PR implements the change described in U4-8290, to allow the label property editor to define the field used for saving data (`dataInt`, `dataVarchar` etc.).

Was a little bit fiddly but see what you think of how it's been addressed.  I've made the following amends:

- Firstly, moved all references of property editor value types to constants.  There were already a few variations ("integer" and "int" for example).  I've not amended any of these, just moved them all to constants instead of raw string values.
- Have added a pre-value to the label property editor to allow selection of the value type
- Whilst the pre-value is good for editing, we actually need to change the value held in `cmsDataType.dbType`.  So to do this I've treated the pre-value key as a "special" value, recorded as a constant in `Constants.PropertyEditors`.  if that pre-value is found, the value of it will be used to change the `dbType` field when the data type is saved.
    - This could also be used on other property editors of course, not just label, if there were a need to configure the databased field in other cases
- I've then added some logic to handle parsing the value when rendering in the back-office.  Previously an exception would be thrown here if the type of value didn't match the database field, but now it can be changed in just these cases it now tries to parse the value and doesn't throw an exception.