### PR TITLE
Fixes U4-8455 stop cropper img stretching in ie11

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -298,7 +298,7 @@ ul.color-picker li a  {
  }
 
  .umb-cropper img {
-     max-width: initial;
+     max-width: none;
  }
 
  .umb-cropper .overlay, .umb-cropper-gravity .overlay {


### PR DESCRIPTION
IE11 doesn't support max-width:initial and so was taking the wrong maximum width ie that of the viewport, when using the Image cropper to slide in and out of an image, (see the video on the issue) the image in IE11 became stretched when it's width hit the viewport and it became difficult for the editor to set the crop; setting max-width:none seems to allows the image to slide in an out correctly without stretching - and is ok on chrome and firefox too - I'm slightly tentative as I'm not sure what the max-width:initial was trying to do ?
