### PR TITLE
Removed required attribute from slider-handle

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/handle.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/handle.prevalues.html
@@ -1,5 +1,5 @@
 ﻿<div>
-    <select ng-model="model.value" required name="handle">
+    <select ng-model="model.value" name="handle">
         <option value="round">Round</option>
         <option value="square">Square</option>
         <option value="triangle">Triangle</option>


### PR DESCRIPTION
Removed required attribute. Slider defaults to round, so doesn’t need
to be required