### PR TITLE
Fixes some styling for login screen on narrow screen sizes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -81,6 +81,7 @@
 }
 
 @media (max-width: 767px) and (max-height: 420px){
+  // Move form closer to top on narrow screen sizes
   .login-overlay .form {
     top: 60px;
   }

--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -13,7 +13,9 @@
     left: 0;
     margin: 0 !important;
     padding: 0;
+    border: none;
     border-radius: 0;
+    overflow-y: auto;
 }
 
 
@@ -50,7 +52,7 @@
 }
 
 .login-overlay .form {
-    position:fixed;
+    position:relative;
     display: block;
     top: 100px;
     left: 165px;
@@ -78,11 +80,25 @@
     margin-top: 10px;    
 }
 
+@media (max-width: 767px) and (max-height: 420px){
+  .login-overlay .form {
+    top: 60px;
+  }
+}
+
 @media (max-width: 565px) {
   // Remove padding on login-form on smaller devices
   .login-overlay .form {
+    top: 60px;
+    right: 25px;
     left: inherit;
-    right:25px;
+    padding-left: 25px;
+    padding-right:25px;
+    width: auto;
+
+    input[type="text"], input[type="password"] {
+        width: 250px;
+    }
   }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -80,10 +80,10 @@
     margin-top: 10px;    
 }
 
-@media (max-width: 767px) and (max-height: 420px){
+@media (max-width: 767px) and (max-height: 420px) and (orientation: landscape) {
   // Move form closer to top on narrow screen sizes
   .login-overlay .form {
-    top: 60px;
+    top: 50px;
   }
 }
 
@@ -96,9 +96,13 @@
     padding-left: 25px;
     padding-right:25px;
     width: auto;
+  }
+}
 
+@media (max-width: 339px) {
+  .login-overlay .form {
     input[type="text"], input[type="password"] {
-        width: 250px;
+      width: 250px;
     }
   }
 }


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8486

It fixed some styling for login screen on narrow screen sizes, e.g. Nexus 5 and other narrow screen sizes where the form it closer to the top.

![image](https://cloud.githubusercontent.com/assets/2919859/15450762/6c30d950-1fa5-11e6-9261-ef0e9cee1a5e.png)

![image](https://cloud.githubusercontent.com/assets/2919859/15450768/893f24d4-1fa5-11e6-8027-2d75aafecbd8.png)

![image](https://cloud.githubusercontent.com/assets/2919859/15450769/98ffd7a6-1fa5-11e6-905a-ac163c70510d.png)

![image](https://cloud.githubusercontent.com/assets/2919859/15450779/fd18d71a-1fa5-11e6-9186-129f395bb448.png)
