### PR TITLE
Ensure correct font is used for icon-check

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -208,7 +208,9 @@
 	content: "\e165";
 }
 
-.umb-tree .umb-tree-node-checked i {
+.umb-tree .umb-tree-node-checked i[class^="icon-"],
+.umb-tree .umb-tree-node-checked i[class*=" icon-"] {
+    font-family: icomoon !important;
     color:@blue !important;
 }
 .umb-tree .umb-tree-node-checked i:before {

--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -210,7 +210,7 @@
 
 .umb-tree .umb-tree-node-checked i[class^="icon-"],
 .umb-tree .umb-tree-node-checked i[class*=" icon-"] {
-    font-family: icomoon !important;
+    font-family: 'icomoon' !important;
     color:@blue !important;
 }
 .umb-tree .umb-tree-node-checked i:before {


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8489

Ensures the correct font is used, when using custom icon fonts in tree nodes.

**Before**
![image](https://cloud.githubusercontent.com/assets/2919859/15450983/6302b4ee-1fae-11e6-9923-25126d4a6e49.png)

**After** 
![image](https://cloud.githubusercontent.com/assets/2919859/15450985/6744d262-1fae-11e6-95de-5a719503ca73.png)

**Before**
![image](https://cloud.githubusercontent.com/assets/2919859/15450992/d0e064c0-1fae-11e6-8aa4-f329b32e96a9.png)

**After**
![image](https://cloud.githubusercontent.com/assets/2919859/15450994/e2953bb4-1fae-11e6-999a-73956471ef93.png)
