### PR TITLE
Localize move and copy overlay titles opened from listview actions.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/copy/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/copy/copy.html
@@ -31,8 +31,8 @@
    </div>
 
    <div class="umb-control-group -no-border">
-      <input type="checkbox" class="pull-left" style="margin-right: 10px;" ng-model="model.relateToOriginal" />
       <label>
+          <input type="checkbox" class="pull-left" style="margin-right: 10px;" ng-model="model.relateToOriginal" />
           <localize key="defaultdialogs_relateToOriginalLabel">Relate to originalt</localize>
       </label>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -371,41 +371,34 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
       applySelected(
              function (selected, index) { return deleteItemCallback(getIdCallback(selected[index])); },
              function (count, total) {
-                 return "Deleted " + count + " out of " + total + " item" + (total > 1 ? "s" : "");
-                 //var key = (total === 1 ? "bulk_deletedItemOfItem" : "bulk_deletedItemOfItems");
-                 //localizationService.localize(key, [count, total]).then(function (value) {
-                 //    return value;
-                 //});
+                 var key = (total === 1 ? "bulk_deletedItemOfItem" : "bulk_deletedItemOfItems");
+                 localizationService.localize(key, [count, total]).then(function (value) {
+                     return value;
+                 });
              },
              function (total) {
-                 return "Deleted " + total + " item" + (total > 1 ? "s" : "");
-                 //var key = (total === 1 ? "bulk_deletedItem" : "bulk_deletedItems");
-                 //localizationService.localize(key, [total]).then(function (value) {
-                 //    return value;
-                 //});
+                 var key = (total === 1 ? "bulk_deletedItem" : "bulk_deletedItems");
+                 localizationService.localize(key, [total]).then(function (value) {
+                     return value;
+                 });
              },
-             //localizationService.localize("defaultdialogs_confirmdelete") + "?"
-             "Sure you want to delete?");
+             localizationService.localize("defaultdialogs_confirmdelete") + "?");
    };
 
    $scope.publish = function () {        
       applySelected(
              function (selected, index) { return contentResource.publishById(getIdCallback(selected[index])); },
              function (count, total) {
-                return "Published " + count + " out of " + total + " item" + (total > 1 ? "s" : "");
-                //var key = (total === 1 ? "bulk_publishedItemOfItem" : "bulk_publishedItemOfItems");
-                //localizationService.localize(key, [count, total]).then(function (value) {
-                //    console.log(key, value);
-                //    return value;
-                //});
+                var key = (total === 1 ? "bulk_publishedItemOfItem" : "bulk_publishedItemOfItems");
+                localizationService.localize(key, [count, total]).then(function (value) {
+                    return value;
+                });
              },
              function (total) {
-                 return "Published " + total + " item" + (total > 1 ? "s" : "");
-                //var key = (total === 1 ? "bulk_publishedItem" : "bulk_publishedItems");
-                //localizationService.localize(key, [total]).then(function (value) {
-                //    console.log(key, value);
-                //    return value;
-                //});
+                var key = (total === 1 ? "bulk_publishedItem" : "bulk_publishedItems");
+                localizationService.localize(key, [total]).then(function (value) {
+                    return value;
+                });
              });
    };
 
@@ -413,18 +406,16 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
       applySelected(
              function (selected, index) { return contentResource.unPublish(getIdCallback(selected[index])); },
              function (count, total) {
-                 return "Unpublished " + count + " out of " + total + " item" + (total > 1 ? "s" : "");
-                 //var key = (total === 1 ? "bulk_unpublishedItemOfItem" : "bulk_unpublishedItemOfItems");
-                 //localizationService.localize(key, [count, total]).then(function (value) {
-                 //    return value;
-                 //});
+                 var key = (total === 1 ? "bulk_unpublishedItemOfItem" : "bulk_unpublishedItemOfItems");
+                 localizationService.localize(key, [count, total]).then(function (value) {
+                     return value;
+                 });
              },
              function (total) {
-                 return "Unpublished " + total + " item" + (total > 1 ? "s" : "");
-                 //var key = (total === 1 ? "bulk_unpublishedItem" : "bulk_unpublishedItems");
-                 //localizationService.localize(key, [total]).then(function (value) {
-                 //    return value;
-                 //});
+                 var key = (total === 1 ? "bulk_unpublishedItem" : "bulk_unpublishedItems");
+                 localizationService.localize(key, [total]).then(function (value) {
+                     return value;
+                 });
              });
    };
 
@@ -458,18 +449,16 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
       applySelected(
              function (selected, index) { return contentResource.move({ parentId: target.id, id: getIdCallback(selected[index]) }); },
              function (count, total) {
-                 return "Moved " + count + " out of " + total + " item" + (total > 1 ? "s" : "");
-                 //var key = (total === 1 ? "bulk_movedItemOfItem" : "bulk_movedItemOfItems");
-                 //localizationService.localize(key, [count, total]).then(function (value) {
-                 //    return value;
-                 //});
+                 var key = (total === 1 ? "bulk_movedItemOfItem" : "bulk_movedItemOfItems");
+                 localizationService.localize(key, [count, total]).then(function (value) {
+                     return value;
+                 });
              },
              function (total) {
-                 return "Moved " + total + " item" + (total > 1 ? "s" : "");
-                 //var key = (total === 1 ? "bulk_movedItem" : "bulk_movedItems");
-                 //localizationService.localize(key, [total]).then(function (value) {
-                 //    return value;
-                 //});
+                 var key = (total === 1 ? "bulk_movedItem" : "bulk_movedItems");
+                 localizationService.localize(key, [total]).then(function (value) {
+                     return value;
+                 });
              });
    }
 
@@ -501,18 +490,16 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
       applySelected(
              function (selected, index) { return contentResource.copy({ parentId: target.id, id: getIdCallback(selected[index]), relateToOriginal: relateToOriginal }); },
              function (count, total) {
-                 return "Copied " + count + " out of " + total + " item" + (total > 1 ? "s" : "");
-                 //var key = (total === 1 ? "bulk_copiedItemOfItem" : "bulk_copiedItemOfItems");
-                 //localizationService.localize(key, [count, total]).then(function (value) {
-                 //    return value;
-                 //});
+                 var key = (total === 1 ? "bulk_copiedItemOfItem" : "bulk_copiedItemOfItems");
+                 localizationService.localize(key, [count, total]).then(function (value) {
+                     return value;
+                 });
              },
              function (total) {
-                 return "Copied " + total + " item" + (total > 1 ? "s" : "");
-                 //var key = (total === 1 ? "bulk_copiedItem" : "bulk_copiedItems");
-                 //localizationService.localize(key, [total]).then(function (value) {
-                 //    return value;
-                 //});
+                 var key = (total === 1 ? "bulk_copiedItem" : "bulk_copiedItems");
+                 localizationService.localize(key, [total]).then(function (value) {
+                     return value;
+                 });
              });
    }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -208,7 +208,7 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
       $timeout(function () {
          $scope.bulkStatus = "";
          $scope.actionInProgress = false;
-      }, 0);
+      }, 500);
 
       if (reload === true) {
          $scope.reloadView($scope.contentId);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -208,7 +208,7 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
       $timeout(function () {
          $scope.bulkStatus = "";
          $scope.actionInProgress = false;
-      }, 500);
+      }, 0);
 
       if (reload === true) {
          $scope.reloadView($scope.contentId);
@@ -220,7 +220,9 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
          }
       }
       else if (successMsg) {
-         notificationsService.success("Done", successMsg);
+         localizationService.localize("bulk_done").then(function (v) {
+             notificationsService.success(v, successMsg);
+         });
       }
    }
 
@@ -368,28 +370,67 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
    $scope.delete = function () {
       applySelected(
              function (selected, index) { return deleteItemCallback(getIdCallback(selected[index])); },
-             function (count, total) { return "Deleted " + count + " out of " + total + " item" + (total > 1 ? "s" : ""); },
-             function (total) { return "Deleted " + total + " item" + (total > 1 ? "s" : ""); },
+             function (count, total) {
+                 return "Deleted " + count + " out of " + total + " item" + (total > 1 ? "s" : "");
+                 //var key = (total === 1 ? "bulk_deletedItemOfItem" : "bulk_deletedItemOfItems");
+                 //localizationService.localize(key, [count, total]).then(function (value) {
+                 //    return value;
+                 //});
+             },
+             function (total) {
+                 return "Deleted " + total + " item" + (total > 1 ? "s" : "");
+                 //var key = (total === 1 ? "bulk_deletedItem" : "bulk_deletedItems");
+                 //localizationService.localize(key, [total]).then(function (value) {
+                 //    return value;
+                 //});
+             },
+             //localizationService.localize("defaultdialogs_confirmdelete") + "?"
              "Sure you want to delete?");
    };
 
-   $scope.publish = function () {
+   $scope.publish = function () {        
       applySelected(
              function (selected, index) { return contentResource.publishById(getIdCallback(selected[index])); },
-             function (count, total) { return "Published " + count + " out of " + total + " item" + (total > 1 ? "s" : ""); },
-             function (total) { return "Published " + total + " item" + (total > 1 ? "s" : ""); });
+             function (count, total) {
+                return "Published " + count + " out of " + total + " item" + (total > 1 ? "s" : "");
+                //var key = (total === 1 ? "bulk_publishedItemOfItem" : "bulk_publishedItemOfItems");
+                //localizationService.localize(key, [count, total]).then(function (value) {
+                //    console.log(key, value);
+                //    return value;
+                //});
+             },
+             function (total) {
+                 return "Published " + total + " item" + (total > 1 ? "s" : "");
+                //var key = (total === 1 ? "bulk_publishedItem" : "bulk_publishedItems");
+                //localizationService.localize(key, [total]).then(function (value) {
+                //    console.log(key, value);
+                //    return value;
+                //});
+             });
    };
 
    $scope.unpublish = function () {
       applySelected(
              function (selected, index) { return contentResource.unPublish(getIdCallback(selected[index])); },
-             function (count, total) { return "Unpublished " + count + " out of " + total + " item" + (total > 1 ? "s" : ""); },
-             function (total) { return "Unpublished " + total + " item" + (total > 1 ? "s" : ""); });
+             function (count, total) {
+                 return "Unpublished " + count + " out of " + total + " item" + (total > 1 ? "s" : "");
+                 //var key = (total === 1 ? "bulk_unpublishedItemOfItem" : "bulk_unpublishedItemOfItems");
+                 //localizationService.localize(key, [count, total]).then(function (value) {
+                 //    return value;
+                 //});
+             },
+             function (total) {
+                 return "Unpublished " + total + " item" + (total > 1 ? "s" : "");
+                 //var key = (total === 1 ? "bulk_unpublishedItem" : "bulk_unpublishedItems");
+                 //localizationService.localize(key, [total]).then(function (value) {
+                 //    return value;
+                 //});
+             });
    };
 
    $scope.move = function () {
       $scope.moveDialog = {};
-      $scope.moveDialog.title = "Move";
+      $scope.moveDialog.title = localizationService.localize("general_move");
       $scope.moveDialog.section = $scope.entityType;
       $scope.moveDialog.currentNode = $scope.contentId;
       $scope.moveDialog.view = "move";
@@ -416,13 +457,25 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
 
       applySelected(
              function (selected, index) { return contentResource.move({ parentId: target.id, id: getIdCallback(selected[index]) }); },
-             function (count, total) { return "Moved " + count + " out of " + total + " item" + (total > 1 ? "s" : ""); },
-             function (total) { return "Moved " + total + " item" + (total > 1 ? "s" : ""); });
+             function (count, total) {
+                 return "Moved " + count + " out of " + total + " item" + (total > 1 ? "s" : "");
+                 //var key = (total === 1 ? "bulk_movedItemOfItem" : "bulk_movedItemOfItems");
+                 //localizationService.localize(key, [count, total]).then(function (value) {
+                 //    return value;
+                 //});
+             },
+             function (total) {
+                 return "Moved " + total + " item" + (total > 1 ? "s" : "");
+                 //var key = (total === 1 ? "bulk_movedItem" : "bulk_movedItems");
+                 //localizationService.localize(key, [total]).then(function (value) {
+                 //    return value;
+                 //});
+             });
    }
 
    $scope.copy = function () {
       $scope.copyDialog = {};
-      $scope.copyDialog.title = "Copy";
+      $scope.copyDialog.title = localizationService.localize("general_copy");
       $scope.copyDialog.section = $scope.entityType;
       $scope.copyDialog.currentNode = $scope.contentId;
       $scope.copyDialog.view = "copy";
@@ -447,8 +500,20 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
    function performCopy(target, relateToOriginal) {
       applySelected(
              function (selected, index) { return contentResource.copy({ parentId: target.id, id: getIdCallback(selected[index]), relateToOriginal: relateToOriginal }); },
-             function (count, total) { return "Copied " + count + " out of " + total + " item" + (total > 1 ? "s" : ""); },
-             function (total) { return "Copied " + total + " item" + (total > 1 ? "s" : ""); });
+             function (count, total) {
+                 return "Copied " + count + " out of " + total + " item" + (total > 1 ? "s" : "");
+                 //var key = (total === 1 ? "bulk_copiedItemOfItem" : "bulk_copiedItemOfItems");
+                 //localizationService.localize(key, [count, total]).then(function (value) {
+                 //    return value;
+                 //});
+             },
+             function (total) {
+                 return "Copied " + total + " item" + (total > 1 ? "s" : "");
+                 //var key = (total === 1 ? "bulk_copiedItem" : "bulk_copiedItems");
+                 //localizationService.localize(key, [total]).then(function (value) {
+                 //    return value;
+                 //});
+             });
    }
 
    function getCustomPropertyValue(alias, properties) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -368,38 +368,34 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
    }
 
    $scope.delete = function () {
-      applySelected(
-             function (selected, index) { return deleteItemCallback(getIdCallback(selected[index])); },
-             function (count, total) {
-                 var key = (total === 1 ? "bulk_deletedItemOfItem" : "bulk_deletedItemOfItems");
-                 localizationService.localize(key, [count, total]).then(function (value) {
-                     return value;
-                 });
-             },
-             function (total) {
-                 var key = (total === 1 ? "bulk_deletedItem" : "bulk_deletedItems");
-                 localizationService.localize(key, [total]).then(function (value) {
-                     return value;
-                 });
-             },
-             localizationService.localize("defaultdialogs_confirmdelete") + "?");
+       var confirmDeleteText = '';
+       localizationService.localize("defaultdialogs_confirmdelete").then(function (value) {
+           confirmDeleteText = value;
+           applySelected(
+                function (selected, index) { return deleteItemCallback(getIdCallback(selected[index])); },
+                function (count, total) {
+                    var key = (total === 1 ? "bulk_deletedItemOfItem" : "bulk_deletedItemOfItems");
+                    return localizationService.localize(key, [count, total]);
+                },
+                function (total) {
+                    var key = (total === 1 ? "bulk_deletedItem" : "bulk_deletedItems");
+                    return localizationService.localize(key, [total]);
+                },
+                confirmDeleteText + "?");
+       });
    };
 
-   $scope.publish = function () {        
-      applySelected(
-             function (selected, index) { return contentResource.publishById(getIdCallback(selected[index])); },
-             function (count, total) {
-                var key = (total === 1 ? "bulk_publishedItemOfItem" : "bulk_publishedItemOfItems");
-                localizationService.localize(key, [count, total]).then(function (value) {
-                    return value;
+   $scope.publish = function () {
+        applySelected(
+                function (selected, index) { return contentResource.publishById(getIdCallback(selected[index])); },
+                function (count, total) {
+                    var key = (total === 1 ? "bulk_publishedItemOfItem" : "bulk_publishedItemOfItems");
+                    return localizationService.localize(key, [count, total]);
+                },
+                function (total) {
+                    var key = (total === 1 ? "bulk_publishedItem" : "bulk_publishedItems");
+                    return localizationService.localize(key, [total]);
                 });
-             },
-             function (total) {
-                var key = (total === 1 ? "bulk_publishedItem" : "bulk_publishedItems");
-                localizationService.localize(key, [total]).then(function (value) {
-                    return value;
-                });
-             });
    };
 
    $scope.unpublish = function () {
@@ -407,15 +403,11 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
              function (selected, index) { return contentResource.unPublish(getIdCallback(selected[index])); },
              function (count, total) {
                  var key = (total === 1 ? "bulk_unpublishedItemOfItem" : "bulk_unpublishedItemOfItems");
-                 localizationService.localize(key, [count, total]).then(function (value) {
-                     return value;
-                 });
+                 return localizationService.localize(key, [count, total]);
              },
              function (total) {
                  var key = (total === 1 ? "bulk_unpublishedItem" : "bulk_unpublishedItems");
-                 localizationService.localize(key, [total]).then(function (value) {
-                     return value;
-                 });
+                 return localizationService.localize(key, [total]);
              });
    };
 
@@ -450,15 +442,11 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
              function (selected, index) { return contentResource.move({ parentId: target.id, id: getIdCallback(selected[index]) }); },
              function (count, total) {
                  var key = (total === 1 ? "bulk_movedItemOfItem" : "bulk_movedItemOfItems");
-                 localizationService.localize(key, [count, total]).then(function (value) {
-                     return value;
-                 });
+                 return localizationService.localize(key, [count, total]);
              },
              function (total) {
                  var key = (total === 1 ? "bulk_movedItem" : "bulk_movedItems");
-                 localizationService.localize(key, [total]).then(function (value) {
-                     return value;
-                 });
+                 return localizationService.localize(key, [total]);
              });
    }
 
@@ -491,15 +479,11 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
              function (selected, index) { return contentResource.copy({ parentId: target.id, id: getIdCallback(selected[index]), relateToOriginal: relateToOriginal }); },
              function (count, total) {
                  var key = (total === 1 ? "bulk_copiedItemOfItem" : "bulk_copiedItemOfItems");
-                 localizationService.localize(key, [count, total]).then(function (value) {
-                     return value;
-                 });
+                 return localizationService.localize(key, [count, total]);
              },
              function (total) {
                  var key = (total === 1 ? "bulk_copiedItem" : "bulk_copiedItems");
-                 localizationService.localize(key, [total]).then(function (value) {
-                     return value;
-                 });
+                 return localizationService.localize(key, [total]);
              });
    }
 

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
@@ -185,6 +185,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Název</key>
     <key alias="assignDomain">Spravovat názvy hostitelů</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -192,6 +192,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+    <area alias="bulk">
+    <key alias="done">Done</key>
+    
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Navn på lokal link</key>
     <key alias="assignDomain">Rediger domener</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -192,7 +192,7 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
-    <area alias="bulk">
+  <area alias="bulk">
     <key alias="done">Done</key>
     
     <key alias="deletedItem">Deleted %0% item</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -198,6 +198,34 @@
     <key alias="unsavedChanges">Du har ikke-gemte ændringer</key>
     <key alias="unsavedChangesWarning">Er du sikker på du vil navigere væk fra denne side? - du har ikke-gemte ændringer</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Færdig</key>
+    
+    <key alias="deletedItem">Slettede %0% element</key>
+    <key alias="deletedItems">Slettede %0% elementer</key>
+    <key alias="deletedItemOfItem">Slettede %0% ud af %1% element</key>
+    <key alias="deletedItemOfItems">Slettede %0% ud af %1% elementer</key>
+    
+    <key alias="publishedItem">Udgav %0% element</key>
+    <key alias="publishedItems">Udgav %0% elementer</key>
+    <key alias="publishedItemOfItem">Udgav %0% ud af %1% element</key>
+    <key alias="publishedItemOfItems">Udgav %0% ud af %1% elementer</key>
+
+    <key alias="unpublishedItem">Fjernede %0% element fra udgivelse</key>
+    <key alias="unpublishedItems">Fjernede %0% elementer fra udgivelse</key>
+    <key alias="unpublishedItemOfItem">Fjernede %0% ud af %1% element fra udgivelse</key>
+    <key alias="unpublishedItemOfItems">Fjernede %0% ud af %1% elementer fra udgivelse</key>
+
+    <key alias="movedItem">Flyttede %0% element</key>
+    <key alias="movedItems">Flyttede %0% elementer</key>
+    <key alias="movedItemOfItem">Flyttede %0% ud af %1% element</key>
+    <key alias="movedItemOfItems">Flyttede %0% ud af %1% elementer</key>
+
+    <key alias="copiedItem">Kopierede %0% element</key>
+    <key alias="copiedItems">Kopierede %0% elementer</key>
+    <key alias="copiedItemOfItem">Kopierede %0% ud af %1% element</key>
+    <key alias="copiedItemOfItems">Kopierede %0% ud af %1% elementer</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Navn på lokalt link</key>
     <key alias="assignDomain">Rediger domæner</key>
@@ -242,7 +270,36 @@
     <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Vælg et placeholder id</strong> fra listen herunder. Du kan kun vælge id'er fra den nuværende masterskabelon.]]></key>
     <key alias="thumbnailimageclickfororiginal">Klik på billedet for at se den fulde størrelse</key>
     <key alias="treepicker">Vælg</key>
-    <key alias="viewCacheItem">Se Cache Item</key>
+    <key alias="viewCacheItem">Se cache element</key>
+    <key alias="createFolder">Opret mappe...</key>
+
+    <key alias="relateToOriginalLabel">Relatér til original</key>
+
+    <key alias="linkToPage">Link til side</key>
+
+    <key alias="openInNewWindow">Åbner det linket dokument i et nyt vindue eller fane</key>
+    <key alias="openInFullBody">Åbner det linket dokument i fuld visning af vinduet</key>
+    <key alias="openInParentFrame">Åbner det linket dokument i "parent frame"</key>
+
+    <key alias="linkToMedia">Link til medie</key>
+
+    <key alias="selectMedia">Vælg medie</key>
+    <key alias="selectIcon">Vælg ikon</key>
+    <key alias="selectItem">Vælg item</key>
+    <key alias="selectLink">Vælg link</key>
+    <key alias="selectMacro">Vælg makro</key>
+    <key alias="selectContent">Vælg indhold</key>
+    <key alias="selectMember">Vælg medlem</key>
+    <key alias="selectMemberGroup">Vælg medlemsgruppe</key>
+    
+    <key alias="noMacroParams">Der er ingen parametre for denne makro</key>
+
+    <key alias="linkYour">Link dit</key>
+    <key alias="unLinkYour">Fjern link fra dit</key>    
+    
+    <key alias="account">konto</key>
+    
+    <key alias="selectEditor">Vælg editor</key>
   </area>
   <area alias="dictionaryItem">
     <key alias="description">Rediger de forskellige sprogversioner for ordbogselementet '%0%' herunder. Du tilføjer flere sprog under 'sprog' i menuen til venstre </key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -644,9 +644,9 @@
     <key alias="noNodeSelected">Intet element valgt, vælg et element i listen ovenfor før der klikkes 'fortsæt'</key>
     <key alias="notAllowedByContentType">Det nuværende element kan ikke lægges under denne pga. sin type</key>
     <key alias="notAllowedByPath">Det nuværende element kan ikke ligge under en af dens undersider</key>
-	  <key alias="notAllowedAtRoot">Dette element må ikke findes på rodniveau</key>
+    <key alias="notAllowedAtRoot">Dette element må ikke findes på rodniveau</key>
     <key alias="notValid">Denne handling er ikke tilladt fordi du ikke har de fornødne rettigheder på et eller flere af under-dokumenterne</key>
-	<key alias="relateToOriginal">Relater det kopierede element til originalen</key>
+    <key alias="relateToOriginal">Relater det kopierede element til originalen</key>
   </area>
   <area alias="notifications">
     <key alias="editNotifications">Rediger dine notificeringer for %0%</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -28,7 +28,7 @@
     <key alias="publish">Udgiv</key>
     <key alias="unpublish">Fortryd udgivelse</key>
     <key alias="refreshNode">Genindlæs elementer</key>
-    <key alias="republish">Genudgiv hele siten</key>
+    <key alias="republish">Genudgiv hele sitet</key>
     <key alias="restore" version="7.3.0">Gendan</key>
     <key alias="rights">Rettigheder</key>
     <key alias="rollback">Fortryd ændringer</key>
@@ -262,7 +262,7 @@
     <key alias="removeMacro">Fjern makro</key>
     <key alias="requiredField">Obligatorisk</key>
     <key alias="sitereindexed">Sitet er genindekseret</key>
-    <key alias="siterepublished">Siten er nu genudgivet</key>
+    <key alias="siterepublished">Sitet er nu genudgivet</key>
     <key alias="siterepublishHelp">Websitets cache vil blive genopfrisket. Alt udgivet indhold vil blive opdateret, mens upubliceret indhold vil forblive upubliceret.</key>
     <key alias="tableColumns">Antal kolonner</key>
     <key alias="tableRows">Antal rækker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -429,7 +429,7 @@
     <key alias="layout">Layout</key>
     <key alias="loading">Henter</key>
     <key alias="locked">Låst</key>
-    <key alias="login">Login</key>
+    <key alias="login">Log ind</key>
     <key alias="logoff">Log af</key>
     <key alias="logout">Log ud</key>
     <key alias="macro">Makro</key>
@@ -606,7 +606,6 @@
     <key alias="renewSession">Forny for at gemme dine ændringer</key>
   </area>
   <area alias="login">
-
     <key alias="greeting0">Så er det søndag!</key>
     <key alias="greeting1">Smil, det er mandag!</key>
     <key alias="greeting2">Hurra, det er tirsdag!</key>
@@ -614,13 +613,21 @@
     <key alias="greeting4">Glædelig torsdag!</key>
     <key alias="greeting5">Endelig fredag!</key>
     <key alias="greeting6">Glædelig lørdag</key>
-
-
+    <key alias="instruction">Log ind nedenfor</key>
     <key alias="instruction">indtast brugernavn og kodeord</key>
     <key alias="timeout">Din session er udløbet</key>
-
-
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">umbraco.com</a></p> ]]></key>
+    <key alias="forgottenPassword">Glemt adgangskode?</key>
+    <key alias="forgottenPasswordInstruction">En e-mail vil blive sendt til den angivne adresse med et link til at nulstille din adgangskode</key>
+    <key alias="requestPasswordResetConfirmation">En e-mail med instruktioner for nulstilling af adgangskoden vil blive sendt til den angivne adresse, hvis det matcher vores optegnelser</key>
+    <key alias="returnToLogin">Tilbage til login formular</key>
+    <key alias="setPasswordInstruction">Angiv en ny adgangskode</key>
+    <key alias="setPasswordConfirmation">Din adgangskode er blevet opdateret</key>
+    <key alias="resetCodeExpired">Det link, du har klikket på, er ugyldigt eller udløbet</key>
+    <key alias="resetPasswordEmailCopySubject">Umbraco: Nulstil adgangskode</key>
+    <key alias="resetPasswordEmailCopyFormat">
+      <![CDATA[<p>Dit brugernavn til at logge på Umbraco backoffice er: <strong>%0%</strong></p><p>Klik <a href="%1%"><strong>her</strong></a> for at nulstille din adgangskode eller kopier/indsæt denne URL i din browser:</p><p><em>%1%</em></p>]]>
+    </key>
   </area>
   <area alias="main">
     <key alias="dashboard">Skrivebord</key>
@@ -637,7 +644,7 @@
     <key alias="noNodeSelected">Intet element valgt, vælg et element i listen ovenfor før der klikkes 'fortsæt'</key>
     <key alias="notAllowedByContentType">Det nuværende element kan ikke lægges under denne pga. sin type</key>
     <key alias="notAllowedByPath">Det nuværende element kan ikke ligge under en af dens undersider</key>
-	<key alias="notAllowedAtRoot">Dette element må ikke findes på rodniveau</key>
+	  <key alias="notAllowedAtRoot">Dette element må ikke findes på rodniveau</key>
     <key alias="notValid">Denne handling er ikke tilladt fordi du ikke har de fornødne rettigheder på et eller flere af under-dokumenterne</key>
 	<key alias="relateToOriginal">Relater det kopierede element til originalen</key>
   </area>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -192,6 +192,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Name</key>
     <key alias="assignDomain">Hostnamen verwalten</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -205,6 +205,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+    
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Name</key>
     <key alias="assignDomain">Manage hostnames</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -207,6 +207,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+    
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Name</key>
     <key alias="assignDomain">Manage hostnames</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -191,6 +191,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Nombre</key>
     <key alias="assignDomain">Administrar dominios</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -187,6 +187,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Name</key>
     <key alias="assignDomain">Gérer les noms d'hôtes</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
@@ -137,6 +137,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">שם</key>
     <key alias="assignDomain">ניהול שם מתחם</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
@@ -133,6 +133,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Nome</key>
     <key alias="assignDomain">Gestione alias Hostnames</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
@@ -200,6 +200,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">名前</key>
     <key alias="assignDomain">ドメインの割り当て</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
@@ -131,6 +131,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">이름</key>
     <key alias="assignDomain">호스트네임 관리</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -194,6 +194,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Naam</key>
     <key alias="assignDomain">Beheer domeinnamen</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -131,6 +131,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Nazwa</key>
     <key alias="assignDomain">Zarządzaj nazwami hostów</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
@@ -131,6 +131,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Nome</key>
     <key alias="assignDomain">Gerenciar hostnames</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -260,6 +260,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Название</key>
     <key alias="assignDomain">Управление доменами</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -187,6 +187,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+  <area alias="bulk">
+    <key alias="done">Done</key>
+
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">Namn</key>
     <key alias="assignDomain">Hantera domännamn</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -172,6 +172,34 @@
     <key alias="unsavedChanges">You have unsaved changes</key>
     <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
   </area>
+    <area alias="bulk">
+    <key alias="done">Done</key>
+    
+    <key alias="deletedItem">Deleted %0% item</key>
+    <key alias="deletedItems">Deleted %0% items</key>
+    <key alias="deletedItemOfItem">Deleted %0% out of %1% item</key>
+    <key alias="deletedItemOfItems">Deleted %0% out of %1% items</key>
+
+    <key alias="publishedItem">Published %0% item</key>
+    <key alias="publishedItems">Published %0% items</key>
+    <key alias="publishedItemOfItem">Published %0% out of %1% item</key>
+    <key alias="publishedItemOfItems">Published %0% out of %1% items</key>
+
+    <key alias="unpublishedItem">Unpublished %0% item</key>
+    <key alias="unpublishedItems">Unpublished %0% items</key>
+    <key alias="unpublishedItemOfItem">Unpublished %0% out of %1% item</key>
+    <key alias="unpublishedItemOfItems">Unpublished %0% out of %1% items</key>
+
+    <key alias="movedItem">Moved %0% item</key>
+    <key alias="movedItems">Moved %0% items</key>
+    <key alias="movedItemOfItem">Moved %0% out of %1% item</key>
+    <key alias="movedItemOfItems">Moved %0% out of %1% items</key>
+
+    <key alias="copiedItem">Copied %0% item</key>
+    <key alias="copiedItems">Copied %0% items</key>
+    <key alias="copiedItemOfItem">Copied %0% out of %1% item</key>
+    <key alias="copiedItemOfItems">Copied %0% out of %1% items</key>
+  </area>
   <area alias="defaultdialogs">
     <key alias="anchorInsert">锚点名称</key>
     <key alias="assignDomain">管理主机名</key>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8488

Localize move and copy overlay titles opened from listview actions and prepare localization of bulk messages.

In the bulk messages I have tried to localize the messages and although the console show the correct translations, it seems to be too late to ensure status message above listview table, delete alert and notification messages are translated.

Any idea how to solve that?

I have also translated some additional text in `defaultdialogs` area in `da.xml` and basically added four messages for each bul operation. I think it would be easiest to translate in the context just by looking at the language file and sometimes you want to add additional text than just translation of `ìtem`/`items` and I think this way it is most flexible.

e.g. these keys in English:
```
 <key alias="unpublishedItem">Unpublished %0% item</key>
 <key alias="unpublishedItems">Unpublished %0% items</key>
```
in Danish I found the most correct translation like:
```
<key alias="unpublishedItem">Fjernede %0% element fra udgivelse</key>
<key alias="unpublishedItems">Fjernede %0% elementer fra udgivelse</key>
```

I have also updated the translations for the new password reset in da.xml
https://github.com/umbraco/Umbraco-CMS/pull/1276/commits/06077820287171923ed3ab46befa6b66692d44d5