### PR TITLE
U4-7332 Default gravatar link broken

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
@@ -19,7 +19,7 @@ function MainController($scope, $rootScope, $location, $routeParams, $timeout, $
         { value: "assets/img/application/logo@3x.png" }
     ];
     $scope.touchDevice = appState.getGlobalState("touchDevice");
-    
+
 
     $scope.removeNotification = function (index) {
         notificationsService.remove(index);
@@ -28,12 +28,12 @@ function MainController($scope, $rootScope, $location, $routeParams, $timeout, $
     $scope.closeDialogs = function (event) {
         //only close dialogs if non-link and non-buttons are clicked
         var el = event.target.nodeName;
-        var els = ["INPUT","A","BUTTON"];
+        var els = ["INPUT", "A", "BUTTON"];
 
-        if(els.indexOf(el) >= 0){return;}
+        if (els.indexOf(el) >= 0) { return; }
 
         var parents = $(event.target).parents("a,button");
-        if(parents.length > 0){
+        if (parents.length > 0) {
             return;
         }
 
@@ -49,31 +49,31 @@ function MainController($scope, $rootScope, $location, $routeParams, $timeout, $
     var evts = [];
 
     //when a user logs out or timesout
-    evts.push(eventsService.on("app.notAuthenticated", function() {
+    evts.push(eventsService.on("app.notAuthenticated", function () {
         $scope.authenticated = null;
         $scope.user = null;
     }));
-    
+
     //when the app is read/user is logged in, setup the data
     evts.push(eventsService.on("app.ready", function (evt, data) {
-        
+
         $scope.authenticated = data.authenticated;
         $scope.user = data.user;
 
-        updateChecker.check().then(function(update){
-            if(update && update !== "null"){
-                if(update.type !== "None"){
+        updateChecker.check().then(function(update) {
+            if (update && update !== "null") {
+                if (update.type !== "None") {
                     var notification = {
-                           headline: "Update available",
-                           message: "Click to download",
-                           sticky: true,
-                           type: "info",
-                           url: update.url
+                        headline: "Update available",
+                        message: "Click to download",
+                        sticky: true,
+                        type: "info",
+                        url: update.url
                     };
                     notificationsService.add(notification);
                 }
             }
-        })
+        });
 
         //if the user has changed we need to redirect to the root so they don't try to continue editing the
         //last item in the URL (NOTE: the user id can equal zero, so we cannot just do !data.lastUserId since that will resolve to true)
@@ -91,38 +91,40 @@ function MainController($scope, $rootScope, $location, $routeParams, $timeout, $
         if ($scope.user.emailHash) {
 
             //let's attempt to load the avatar, it might not exist or we might not have 
-            // internet access so we'll detect it first
-            $http.get("https://www.gravatar.com/avatar/" + $scope.user.emailHash + ".jpg?s=64&d=404")
+            // internet access, well get an empty string back
+            $http.get(umbRequestHelper.getApiUrl("gravatarApiBaseUrl", "GetCurrentUserGravatarUrl"))
                 .then(
-                    function successCallback(response) {                        
-                        $("#avatar-img").fadeTo(1000, 0, function () {
-                            $scope.$apply(function () {
-                                //this can be null if they time out
-                                if ($scope.user && $scope.user.emailHash) {
-	                            var avatarBaseUrl = "https://www.gravatar.com/avatar/",
-	                                hash = $scope.user.emailHash;
+                    function successCallback(response) {
+                        // if we can't download the gravatar for some reason, an null gets returned, we cannot do anything
+                        if (response.data !== "null") {
+                            $("#avatar-img").fadeTo(1000, 0, function () {
+                                $scope.$apply(function () {
+                                    //this can be null if they time out
+                                    if ($scope.user && $scope.user.emailHash) {
+                                        var avatarBaseUrl = "https://www.gravatar.com/avatar/",
+                                            hash = $scope.user.emailHash;
 
-	                            $scope.avatar = [
-	                                { value: avatarBaseUrl + hash + ".jpg?s=30&d=mm" },
-	                                { value: avatarBaseUrl + hash + ".jpg?s=60&d=mm" },
-	                                { value: avatarBaseUrl + hash + ".jpg?s=90&d=mm" }
-	                            ];
-                                }
+                                        $scope.avatar = [
+                                            { value: avatarBaseUrl + hash + ".jpg?s=30&d=mm" },
+                                            { value: avatarBaseUrl + hash + ".jpg?s=60&d=mm" },
+                                            { value: avatarBaseUrl + hash + ".jpg?s=90&d=mm" }
+                                        ];
+                                    }
+                                });
+                                $("#avatar-img").fadeTo(1000, 1);
                             });
-                            $("#avatar-img").fadeTo(1000, 1);
-                        });
+                        }
                     }, function errorCallback(response) {
                         //cannot load it from the server so we cannot do anything
                     });
         }
-
     }));
 
-    evts.push(eventsService.on("app.ysod", function(name, error) {
+    evts.push(eventsService.on("app.ysod", function (name, error) {
         $scope.ysodOverlay = {
             view: "ysod",
             error: error,
-            show:  true
+            show: true
         };
     }));
 

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -292,6 +292,10 @@ namespace Umbraco.Web.Editors
                                     controller => controller.GetEntityLog(0))
                             },
                             {
+                                "gravatarApiBaseUrl", Url.GetUmbracoApiServiceBaseUrl<GravatarController>(
+                                    controller => controller.GetCurrentUserGravatarUrl())
+                            },
+                            {
                                 "memberApiBaseUrl", Url.GetUmbracoApiServiceBaseUrl<MemberController>(
                                     controller => controller.GetByKey(Guid.Empty))
                             },

--- a/src/Umbraco.Web/Editors/GravatarController.cs
+++ b/src/Umbraco.Web/Editors/GravatarController.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Net;
+using Umbraco.Core;
+using Umbraco.Web.Mvc;
+
+namespace Umbraco.Web.Editors
+{
+    /// <summary>
+    /// API controller used for getting Gravatar urls
+    /// </summary>
+    [PluginController("UmbracoApi")]
+    public class GravatarController : UmbracoAuthorizedJsonController
+    {
+        public string GetCurrentUserGravatarUrl()
+        {
+            var userService = Services.UserService;
+            var user = userService.GetUserById(UmbracoContext.Security.CurrentUser.Id);
+            var gravatarHash = user.Email.ToMd5();
+            var gravatarUrl = "https://www.gravatar.com/avatar/" + gravatarHash;
+           
+            // Test if we can reach this URL, will fail when there's network or firewall errors
+            var request = (HttpWebRequest)WebRequest.Create(gravatarUrl);
+            // Require response within 10 seconds
+            request.Timeout = 10000;
+            try
+            {
+                using ((HttpWebResponse)request.GetResponse()) { }
+            }
+            catch (Exception)
+            {
+                // There was an HTTP or other error, return an null instead
+                return null;
+            }
+
+            return gravatarUrl;
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -318,6 +318,7 @@
     <Compile Include="Editors\BackOfficeNotificationsController.cs" />
     <Compile Include="Editors\EditorValidationResolver.cs" />
     <Compile Include="Editors\EditorValidator.cs" />
+    <Compile Include="Editors\GravatarController.cs" />
     <Compile Include="IHttpContextAccessor.cs" />
     <Compile Include="Models\ContentEditing\GetAvailableCompositionsFilter.cs" />
     <Compile Include="Editors\IEditorValidator.cs" />


### PR DESCRIPTION
Rather then just trying to get the gravatar client side, try to get it serverside first, if there's any errors, don't try to get it again in the browser. This stops that ugly 404 error from being logged in the console so you don't get confused and think there's JS errors when there really are none.

Tested with: 
- Email that does have a Gravatar set up: shows up fine
- Email that does not have a Gravatar set up: the grey default shows up fine
- No network connection: the umbraco logo just stays there as the avatar, no errors in the console