### PR TITLE
Fix tiny issues with dropzone border and sticky header

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/subheader/umb-editor-sub-header.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/subheader/umb-editor-sub-header.less
@@ -12,7 +12,7 @@
 .umb-editor-sub-header.-umb-sticky-bar {
    box-shadow: 0 5px 0 rgba(0, 0, 0, 0.08), 0 1px 0 rgba(0, 0, 0, 0.16);
    transition: box-shadow 1s;
-   top: 100px;
+   top: 101px; /* height of header: 100px + its bottom-border: 1px */
    transform: translate(0, 50%);
 
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-file-dropzone.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-file-dropzone.less
@@ -5,7 +5,7 @@
   // tall and small version - animate height
   .dropzone {
     height: 400px;
-    width: 100%;
+    width: auto;
     padding: 50px 0;
     border: 1px dashed @grayLight;
     text-align: center;


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8525

This is tiny issues with dropzone border to the left for fixed header and header jump by 1px when it get sticky, but my eyes do notice it :yum:

Because dropzone it set to width: 100% and has 1px left and right border it is actually more than 100% of the width. Alternative it could use `width: calc(100% - 2px)`.

I also noticed that when scrolling and the header get sticky it jumped by 1px due it was positioned 100px from top, but header + bottom-border makes the non-sticky header positioned 101px from top, so with this fix the header get fixed more smooth.

**Before**
![image](https://cloud.githubusercontent.com/assets/2919859/15587155/45cd7890-2388-11e6-82b1-57995e96c400.png)

**After**
![image](https://cloud.githubusercontent.com/assets/2919859/15587178/5919e244-2388-11e6-94d4-1ac959ec500a.png)

:cake::cookie::coffee: