### PR TITLE
Macro's inserted in the grid should block link clicks so that users d…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/macro.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/macro.html
@@ -7,7 +7,7 @@
 		</div>
 		<div ng-if="preview">
 			<div
-				ng-if="preview" style="text-align: left"
+				ng-if="preview" style="text-align: left; pointer-events: none; cursor: default;"
 				ng-bind-html-unsafe="preview">
 			</div>
 		</div>


### PR DESCRIPTION
…one accidentally navigate away from backoffice when trying to edit macro settings.

This is fixed by adding pointer-events: none css to the preview container.