### PR TITLE
Fix U4-8532 - No built in Active Directory authentication in Umbraco 

### DIFF
--- a/src/Umbraco.Core/Security/ActiveDirectoryBackOfficeUserPasswordChecker.cs
+++ b/src/Umbraco.Core/Security/ActiveDirectoryBackOfficeUserPasswordChecker.cs
@@ -1,0 +1,25 @@
+﻿using System.Configuration;
+using System.DirectoryServices.AccountManagement;
+using System.Threading.Tasks;
+using Umbraco.Core.Models.Identity;
+
+namespace Umbraco.Core.Security
+{
+    public class ActiveDirectoryBackOfficeUserPasswordChecker : IBackOfficeUserPasswordChecker
+    {
+        public Task<BackOfficeUserPasswordCheckerResult> CheckPasswordAsync(BackOfficeIdentityUser user, string password)
+        {
+            bool isValid;
+            using (var pc = new PrincipalContext(ContextType.Domain, ConfigurationManager.AppSettings["ActiveDirectoryDomain"]))
+            {
+                isValid = pc.ValidateCredentials(user.UserName, password);
+            }
+
+            var result = isValid
+                ? BackOfficeUserPasswordCheckerResult.ValidCredentials
+                : BackOfficeUserPasswordCheckerResult.InvalidCredentials;
+
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/src/Umbraco.Core/Security/ActiveDirectoryBackOfficeUserPasswordChecker.cs
+++ b/src/Umbraco.Core/Security/ActiveDirectoryBackOfficeUserPasswordChecker.cs
@@ -7,10 +7,16 @@ namespace Umbraco.Core.Security
 {
     public class ActiveDirectoryBackOfficeUserPasswordChecker : IBackOfficeUserPasswordChecker
     {
+        public virtual string ActiveDirectoryDomain {
+            get {
+                return ConfigurationManager.AppSettings["ActiveDirectoryDomain"];
+            }
+        }
+
         public Task<BackOfficeUserPasswordCheckerResult> CheckPasswordAsync(BackOfficeIdentityUser user, string password)
         {
             bool isValid;
-            using (var pc = new PrincipalContext(ContextType.Domain, ConfigurationManager.AppSettings["ActiveDirectoryDomain"]))
+            using (var pc = new PrincipalContext(ContextType.Domain, ActiveDirectoryDomain))
             {
                 isValid = pc.ValidateCredentials(user.UserName, password);
             }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -110,6 +110,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\SqlServerCE.4.0.0.1\lib\System.Data.SqlServerCe.Entity.dll</HintPath>
     </Reference>
+    <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
@@ -485,6 +486,7 @@
     <Compile Include="PropertyEditors\ValueConverters\ImageCropperValueConverter.cs" />
     <Compile Include="Publishing\UnPublishedStatusType.cs" />
     <Compile Include="Publishing\UnPublishStatus.cs" />
+    <Compile Include="Security\ActiveDirectoryBackOfficeUserPasswordChecker.cs" />
     <Compile Include="Security\BackOfficeClaimsIdentityFactory.cs" />
     <Compile Include="Security\BackOfficeCookieAuthenticationProvider.cs" />
     <Compile Include="Security\BackOfficeSignInManager.cs" />


### PR DESCRIPTION
Fix U4-8532 - No built in Active Directory authentication in Umbraco.

http://issues.umbraco.org/issue/U4-8532
