### PR TITLE
Multiple fixes and improvements for Media Picker and Link Picker popup dialogs used in grid and rte editors.

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
+++ b/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
@@ -125,6 +125,7 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
 		data.href = anchorElm ? dom.getAttrib(anchorElm, 'href') : '';
 		data.target = anchorElm ? dom.getAttrib(anchorElm, 'target') : '';
 		data.rel = anchorElm ? dom.getAttrib(anchorElm, 'rel') : '';
+		data.class = anchorElm ? dom.getAttrib(anchorElm, 'class') : '';
 
 		if (selectedElm.nodeName == "IMG") {
 			data.text = initialText = " ";
@@ -167,7 +168,8 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
 			currentTarget = {
 				name: anchor.attr("title"),
 				url: anchor.attr("href"),
-				target: anchor.attr("target")
+				target: anchor.attr("target"),
+				'class': anchor.attr("class")
 			};
 
 			//locallink detection, we do this here, to avoid poluting the dialogservice
@@ -190,7 +192,8 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
     								title: data.name, 
     								target: data.target ? data.target : null,
     								rel: data.rel ? data.rel : null,
-    								'data-id': data.id ? data.id : null
+    								'data-id': data.id ? data.id : null,
+    								'class': data.class ? data.class : null
     							});
 
     							selection.select(anchorElm);
@@ -201,7 +204,8 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
 									title: data.name, 
 									target: data.target ? data.target : null,
 									rel: data.rel ? data.rel : null,
-									'data-id': data.id ? data.id : null
+									'data-id': data.id ? data.id : null,
+									'class': data.class ? data.class : null
 								});
     						}
     				}

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
@@ -109,7 +109,8 @@ angular.module("umbraco.directives")
 						$timeout(function(){
 							setDimensions();
 							scope.loaded = true;
-							scope.onImageLoaded();
+							if (scope.onImageLoaded)
+							    scope.onImageLoaded();
 						});
 					});
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -98,7 +98,10 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                         currentTarget = {
                             altText: img.attr("alt"),
                             url: img.attr("src"),
-                            id: img.attr("rel")
+                            id: img.attr("rel"),
+                            'class': img.attr("class"),
+                            width: img.attr("width"),
+                            height: img.attr("height")
                         };
                     }
 
@@ -120,6 +123,7 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                    src: (img.url) ? img.url : "nothing.jpg",
                    rel: img.id,
                    'data-id': img.id,
+                   'class': img.class,
                    id: '__mcenew'
                };
 
@@ -130,16 +134,25 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                    var size = editor.dom.getSize(imgElm);
 
                    if (editor.settings.maxImageSize && editor.settings.maxImageSize !== 0) {
-                        var newSize = imageHelper.scaleToMaxSize(editor.settings.maxImageSize, size.w, size.h);
+                        var newSize = imageHelper.scaleToMaxSize(editor.settings.maxImageSize, img.width, img.height);
 
-                        var s = "width: " + newSize.width + "px; height:" + newSize.height + "px;";
-                        editor.dom.setAttrib(imgElm, 'style', s);
+                        //var s = "width: " + newSize.width + "px; height:" + newSize.height + "px;";
+                        //editor.dom.setAttrib(imgElm, 'style', s);
+                        editor.dom.setAttrib(imgElm, 'width', newSize.width);
+                        editor.dom.setAttrib(imgElm, 'height', newSize.height);
                         editor.dom.setAttrib(imgElm, 'id', null);
 
                         if (img.url) {
                             var src = img.url + "?width=" + newSize.width + "&height=" + newSize.height;
                             editor.dom.setAttrib(imgElm, 'data-mce-src', src);
                         }
+
+                   } else {
+                        //var s = "width: " + size.w + "px; height:" + size.h + "px;";
+                        //editor.dom.setAttrib(imgElm, 'style', s);
+                        editor.dom.setAttrib(imgElm, 'width', img.width);
+                        editor.dom.setAttrib(imgElm, 'height', img.height);
+                        editor.dom.setAttrib(imgElm, 'id', null);
                    }
                }, 500);
             }
@@ -625,6 +638,7 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                 data.href = anchorElm ? dom.getAttrib(anchorElm, 'href') : '';
                 data.target = anchorElm ? dom.getAttrib(anchorElm, 'target') : '';
                 data.rel = anchorElm ? dom.getAttrib(anchorElm, 'rel') : '';
+                data.class = anchorElm ? dom.getAttrib(anchorElm, 'class') : '';
 
                 if (selectedElm.nodeName === "IMG") {
                     data.text = initialText = " ";
@@ -667,7 +681,8 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                     currentTarget = {
                         name: anchor.attr("title"),
                         url: anchor.attr("href"),
-                        target: anchor.attr("target")
+                        target: anchor.attr("target"),
+                        'class': anchor.attr("class")
                     };
 
                     //locallink detection, we do this here, to avoid poluting the dialogservice
@@ -724,7 +739,8 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                         title: target.name,
                         target: target.target ? target.target : null,
                         rel: target.rel ? target.rel : null,
-                        'data-id': target.id ? target.id : null
+                        'data-id': target.id ? target.id : null,
+                        'class': data.class ? data.class : null
                     });
 
                     editor.selection.select(anchorElm);
@@ -735,7 +751,8 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
                         title: target.name,
                         target: target.target ? target.target : null,
                         rel: target.rel ? target.rel : null,
-                        'data-id': target.id ? target.id : null
+                        'data-id': target.id ? target.id : null,
+                        'class': data.class ? data.class : null
                     });
                 }
             }

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -19,6 +19,12 @@
 	left: 0px;
 }
 
+.umb-editor + .hover-show {
+    display: none;
+}
+.umb-editor:hover + .hover-show, .umb-editor + .hover-show:hover {
+    display: inline-block;
+}
 
 .umb-editor-container {
 	top: 101px;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -5,6 +5,18 @@
   min-width:66.6%;
 }
 
+.umb-editor.small {
+    width: 20%;
+    min-width: 20%;
+}
+
+.umb-editor + .hover-show {
+    display: none;
+}
+.umb-editor:hover + .hover-show, .umb-editor + .hover-show:hover {
+    display: inline-block;
+}
+
 .umb-editor-tiny {
   width: 50px;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.html
@@ -11,12 +11,13 @@
 					 />
 			</umb-control-group>
 
-			<umb-control-group label="@content_nodeName">
+			<umb-control-group label="@content_nodeNameOptional">
 				<input type="text"
 					localize="placeholder" 
 					placeholder="@placeholders_entername" 
 					class="umb-editor umb-textstring" 
 					ng-model="target.name" />
+                <i class="icon icon-delete red hover-show pull-right" style="position:absolute;padding-top:6px;right:33px;" ng-click="target.name=''"></i>
 			</umb-control-group>
 
 			<umb-control-group label="@content_target">
@@ -27,6 +28,14 @@
 					<option value="_parent">Opens the linked document in the parent frame</option>
 				</select>
 			</umb-control-group>
+
+            <umb-control-group label="@content_classOptional">
+                <input type="text"
+                       localize="placeholder"
+                       placeholder="@placeholders_enterClass"
+                       class="umb-editor umb-textstring"
+                       ng-model="target.class" />
+            </umb-control-group>
 		</umb-pane>
 
         <umb-tree-search-box hide-search-callback="hideSearch"

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.html
@@ -40,6 +40,29 @@
                            class="umb-editor umb-textstring"
                            ng-model="target.altText" />
                 </umb-control-group>
+
+
+                <umb-control-group label="@general_dimensions">
+                    <input type="text"
+                           localize="placeholder"
+                           placeholder="@general_width"
+                           class="umb-editor umb-textstring small"
+                           ng-model="target.width" />
+                    <localize key="general_by">by</localize>
+                    <input type="text"
+                           localize="placeholder"
+                           placeholder="@general_height"
+                           class="umb-editor umb-textstring small"
+                           ng-model="target.height" />
+                </umb-control-group>
+
+                <umb-control-group label="@content_classOptional">
+                    <input type="text"
+                           localize="placeholder"
+                           placeholder="@placeholders_enterClass"
+                           class="umb-editor umb-textstring"
+                           ng-model="target.class" />
+                </umb-control-group>
             </umb-pane>
         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -153,6 +153,13 @@ angular.module("umbraco")
                         $scope.target = image;
                         $scope.target.url = mediaHelper.resolveFile(image);
                         $scope.openDetailsDialog();
+                        // restore original size
+                        _.each($scope.target.properties, function (prop) {
+                            if (prop.alias == "umbracoWidth")
+                                $scope.target.width = prop.value;
+                            if (prop.alias == "umbracoHeight")
+                                $scope.target.height = prop.value;
+                        });
                     } else {
                         selectImage(image);
                     }
@@ -208,6 +215,28 @@ angular.module("umbraco")
                 $scope.activeDrag = false;
             };
 
+            $scope.openDetailsDialog = function () {
+
+                $scope.mediaPickerDetailsOverlay = {};
+                $scope.mediaPickerDetailsOverlay.show = true;
+
+                $scope.mediaPickerDetailsOverlay.submit = function (model) {
+
+                    $scope.model.selectedImages.push($scope.target);
+                    $scope.model.submit($scope.model);
+
+                    $scope.mediaPickerDetailsOverlay.show = false;
+                    $scope.mediaPickerDetailsOverlay = null;
+
+                };
+
+                $scope.mediaPickerDetailsOverlay.close = function (oldModel) {
+                    $scope.mediaPickerDetailsOverlay.show = false;
+                    $scope.mediaPickerDetailsOverlay = null;
+                };
+
+            };
+
             //default root item
             if (!$scope.target) {
 
@@ -235,29 +264,8 @@ angular.module("umbraco")
 
                }
 
+            } else {
+                $scope.openDetailsDialog();
             }
-
-            $scope.openDetailsDialog = function() {
-
-               $scope.mediaPickerDetailsOverlay = {};
-               $scope.mediaPickerDetailsOverlay.show = true;
-
-               $scope.mediaPickerDetailsOverlay.submit = function(model) {
-
-                  $scope.model.selectedImages.push($scope.target);
-                  $scope.model.submit($scope.model);
-
-                  $scope.mediaPickerDetailsOverlay.show = false;
-                  $scope.mediaPickerDetailsOverlay = null;
-
-               };
-
-               $scope.mediaPickerDetailsOverlay.close = function(oldModel) {
-                  $scope.mediaPickerDetailsOverlay.show = false;
-                  $scope.mediaPickerDetailsOverlay = null;
-               };
-
-            };
-
 
         });

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -16,6 +16,7 @@ angular.module("umbraco")
             $scope.startNodeId = dialogOptions.startNodeId ? dialogOptions.startNodeId : -1;
             $scope.cropSize = dialogOptions.cropSize;
             $scope.lastOpenedNode = $cookieStore.get("umbLastOpenedMediaNodeId");
+            $scope.constrain = { proportions: true }; // Can't be a primtive
             if($scope.onlyImages){
                 $scope.acceptedFileTypes = mediaHelper.formatFileTypes(Umbraco.Sys.ServerVariables.umbracoSettings.imageFileTypes);
             }
@@ -25,6 +26,15 @@ angular.module("umbraco")
             $scope.maxFileSize = Umbraco.Sys.ServerVariables.umbracoSettings.maxFileSize + "KB";
 
             $scope.model.selectedImages = [];
+
+            $scope.changeDimensions = function (type) {
+                if ($scope.constrain.proportions) {
+                    if (type == 'width')
+                        $scope.target.height = (parseInt($scope.target.width) / $scope.target.aspectRatio).toFixed(0);
+                    else if (type == 'height')
+                        $scope.target.width = (parseInt($scope.target.height) * $scope.target.aspectRatio).toFixed(0);
+                }
+            }
 
             //preload selected item
             $scope.target = undefined;
@@ -265,6 +275,9 @@ angular.module("umbraco")
                }
 
             } else {
+                if (!$scope.target.aspectRatio && $scope.target.width && $scope.target.height)
+                    $scope.target.aspectRatio = parseInt($scope.target.width) / parseInt($scope.target.height);
+
                 $scope.openDetailsDialog();
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
@@ -149,13 +149,15 @@
                       localize="placeholder"
                       placeholder="@general_width"
                       class="umb-editor umb-textstring small"
-                      ng-model="target.width" />
+                      ng-model="target.width" ng-change="changeDimensions('width')" />
                <localize key="general_by" style="vertical-align: bottom;vertical-align: -webkit-baseline-middle;">by</localize>
                <input type="text"
                       localize="placeholder"
                       placeholder="@general_height"
                       class="umb-editor umb-textstring small"
-                      ng-model="target.height" />
+                      ng-model="target.height" ng-change="changeDimensions('height')" />
+               <input type="checkbox" ng-model="constrain.proportions" style="vertical-align:middle;margin-left:.5em;" id="constrainProportions">
+               <label style="vertical-align:bottom;vertical-align:-webkit-baseline-middle; padding-left: 2px;" for="constrainProportions"><localize key="general_constrainProportions">Constrain proportions</localize></label>
           </div>
       </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
@@ -119,21 +119,56 @@
       </div>
 
       <div class="umb-control-group">
-         <label><localize key="@general_url"></localize></label>
-         <input
-            type="text"
-            localize="placeholder"
-            placeholder="@general_url"
-            class="umb-editor umb-textstring"
-            ng-model="target.url"
-            ng-disabled="target.id" />
+         <label class="control-label"><localize key="@general_url"></localize></label>
+          <div class="controls controls-row">
+             <input
+                type="text"
+                localize="placeholder"
+                placeholder="@general_url"
+                class="umb-editor umb-textstring"
+                ng-model="target.url"
+                ng-disabled="target.id" />
+          </div>
       </div>
 
       <div class="umb-control-group">
-         <label><localize key="@content_altTextOptional"></localize></label>
-         <input type="text" class="umb-editor umb-textstring" ng-model="target.altText" />
+         <label class="control-label"><localize key="@content_altTextOptional"></localize></label>
+          <div class="controls controls-row">
+            <input type="text" 
+				localize="placeholder" 
+				placeholder="@placeholders_entername" 
+                class="umb-editor umb-textstring" 
+                ng-model="target.altText" />
+          </div>
+      </div>
+       
+       <div class="umb-control-group">
+           <label class="control-label"><localize key="@general_dimensions"></localize></label>
+           <div class="controls controls-row">
+               <input type="text"
+                      localize="placeholder"
+                      placeholder="@general_width"
+                      class="umb-editor umb-textstring small"
+                      ng-model="target.width" />
+               <localize key="general_by" style="vertical-align: bottom;vertical-align: -webkit-baseline-middle;">by</localize>
+               <input type="text"
+                      localize="placeholder"
+                      placeholder="@general_height"
+                      class="umb-editor umb-textstring small"
+                      ng-model="target.height" />
+          </div>
       </div>
 
+       <div class="umb-control-group">
+           <label class="control-label"><localize key="@content_classOptional"></localize></label>
+           <div class="controls controls-row">
+               <input type="text"
+                      localize="placeholder"
+                      placeholder="@placeholders_enterClass"
+                      class="umb-editor umb-textstring"
+                      ng-model="target.class" />
+           </div>
+       </div>
 
 	</umb-overlay>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
@@ -11,14 +11,29 @@ angular.module("umbraco")
             $scope.mediaPickerOverlay.onlyImages = true;
             $scope.mediaPickerOverlay.show = true;
 
+            if ($scope.control.value)
+                $scope.mediaPickerOverlay.currentTarget = {
+                    altText: $scope.control.value.altText,
+                    url: $scope.control.value.image,
+                    id: $scope.control.value.id,
+                    'class': $scope.control.value.class,
+                    width: $scope.control.value.width,
+                    height: $scope.control.value.height,
+                    focalPoint: $scope.control.value.focalPoint
+                }
+
+
             $scope.mediaPickerOverlay.submit = function(model) {
                 var selectedImage = model.selectedImages[0];
 
                 $scope.control.value = {
                     focalPoint: selectedImage.focalPoint,
                     id: selectedImage.id,
-                    image: selectedImage.image,
-                    altText: selectedImage.altText
+                    image: selectedImage.image ? selectedImage.image : selectedImage.url,
+                    altText: selectedImage.altText,
+                    'class': selectedImage.class,
+                    width: selectedImage.width,
+                    height: selectedImage.height
                 };
 
                 $scope.setUrl();

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/Media.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/Media.cshtml
@@ -14,7 +14,7 @@
         }
     }
     
-    <img src="@url" alt="@Model.value.altText">
+    <img src="@url" alt="@Model.value.altText" class="@Model.value["class"]" width="@Model.value.width" height="@Model.value.height">
     
     if (Model.value.caption != null)
     {

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -144,6 +144,8 @@
     <key alias="membertype">Member Type</key>
     <key alias="noDate">No date chosen</key>
     <key alias="nodeName">Page Title</key>
+    <key alias="nodeNameOptional">Page Title (Optional)</key>
+    <key alias="classOptional">Css Class (Optional)</key>
     <key alias="otherElements">Properties</key>
     <key alias="parentNotPublished">This document is published but is not visible because the parent '%0%' is unpublished</key>
     <key alias="parentNotPublishedAnomaly">Oops: this document is published but is not in the cache (internal error)</key>
@@ -297,6 +299,7 @@
     <key alias="search">Type to search...</key>
     <key alias="filter">Type to filter...</key>
     <key alias="enterTags">Type to add tags (press enter after each tag)...</key>
+    <key alias="enterClass">Enter class selectors...</key>
   </area>
   <area alias="editcontenttype">
     <key alias="allowAtRoot" version="7.2">Allow at root</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -145,6 +145,8 @@
     <key alias="membertype">Member Type</key>
     <key alias="noDate">No date chosen</key>
     <key alias="nodeName">Page Title</key>
+    <key alias="nodeNameOptional">Page Title (Optional)</key>
+    <key alias="classOptional">Css Class (Optional)</key>
     <key alias="otherElements">Properties</key>
     <key alias="parentNotPublished">This document is published but is not visible because the parent '%0%' is unpublished</key>
     <key alias="parentNotPublishedAnomaly">Oops: this document is published but is not in the cache (internal error)</key>
@@ -298,6 +300,7 @@
     <key alias="search">Type to search...</key>
     <key alias="filter">Type to filter...</key>
     <key alias="enterTags">Type to add tags (press enter after each tag)...</key>
+    <key alias="enterClass">Enter class selectors...</key>
   </area>
 
   <area alias="editcontenttype">


### PR DESCRIPTION
Fix for media picker overlay not reselecting current item.
Fix for image sizing when no MaxImageSize is specified.
Added optional Css Class field to link picker dialog.
Added optional Css Class field to media picker dialog.
Added visible with and height fields to media picker dialog. (Allows setting specific dimensions without having to insert then going into html and edit every image.)
Added shortcut button to clear link title as some people may not want to use it and it is auto-filled in when selecting a content node.
Added a Constrain Properties checkbox.  When selected and width or height are changed the aspect ratio is used to retain the proportions.  When unselected any values can be entered including percentages. (This is working same way that the media picker worked in v6.)

This contains some common image and link attributes as new fields in the dialog popups and is meant as a quality of life improvement so that developers don't have so as often go into the raw HTML and change attributes.

includes fixes and features for http://issues.umbraco.org/issue/U4-5288 and more not listed there.  (Maybe a new linked issue should be created?)
