### PR TITLE
Added an open in new window link to the page header for published…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -242,6 +242,7 @@ Use this directive to construct a header inside the main editor window.
                 nameLocked: "=",
                 menu: "=",
                 icon: "=",
+                url: "=",
                 hideIcon: "@",
                 alias: "=",
                 hideAlias: "@",

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -48,6 +48,7 @@
 
                </div>
 
+                <a class="icon-out fa-lg " ng-href="{{url}}" target="_blank" style="padding:.5em .5em 0 .5em;" ng-if="url"></a>
             </div>
 
             <umb-editor-menu ng-if="menu.currentNode" current-node="menu.currentNode" current-section="{{menu.currentSection}}"></umb-editor-menu>

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -35,6 +35,7 @@ function ContentEditController($scope, $rootScope, $routeParams, $q, $timeout, $
         });
         $scope.defaultButton = buttons.defaultButton;
         $scope.subButtons = buttons.subButtons;
+        $scope.page.url = $scope.content.published && $scope.content.template != null ? $scope.content.urls.shift() : "";
 
         editorState.set($scope.content);
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/edit.html
@@ -13,6 +13,7 @@
             menu="page.menu"
             name="content.name"
             tabs="content.tabs"
+            url="page.url"
             hide-icon="true"
             hide-description="true"
             hide-alias="true">


### PR DESCRIPTION
…content pages with a template assigned.  This is essentially duplicating the Link to Document link on the properties tab, but is a quicker shortcut for editors.  I don't see the more detailed links on the properties going away, rather this is just for quick access.