### PR TITLE
U4 3805 - folder and file permissions health check

### DIFF
--- a/src/Umbraco.Core/IO/SystemDirectories.cs
+++ b/src/Umbraco.Core/IO/SystemDirectories.cs
@@ -77,14 +77,6 @@ namespace Umbraco.Core.IO
                 return "~/App_Code";
             }
         }
-        public static string AppData
-        {
-            get
-            {
-                //NOTE: this is not configurable and shouldn't need to be
-                return "~/App_Data";
-            }
-        }
 
         public static string AppPlugins
 		{

--- a/src/Umbraco.Core/IO/SystemDirectories.cs
+++ b/src/Umbraco.Core/IO/SystemDirectories.cs
@@ -69,7 +69,24 @@ namespace Umbraco.Core.IO
             }
         }
 
-		public static string AppPlugins
+        public static string AppCode
+        {
+            get
+            {
+                //NOTE: this is not configurable and shouldn't need to be
+                return "~/App_Code";
+            }
+        }
+        public static string AppData
+        {
+            get
+            {
+                //NOTE: this is not configurable and shouldn't need to be
+                return "~/App_Data";
+            }
+        }
+
+        public static string AppPlugins
 		{
 			get
 			{

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/healthcheck.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/healthcheck.controller.js
@@ -3,6 +3,11 @@
 
     function HealthCheckController($scope, healthCheckResource) {
 
+        var SUCCESS = 0;
+        var INFO = 2;
+        var WARNING = 1;
+        var ERROR = 2;
+
         var vm = this;
 
         vm.viewState = "list";
@@ -20,7 +25,7 @@
 			function(response) {
 
                 // set number of checks which has been executed
-                for(var i = 0; i < response.length; i++) {
+                for (var i = 0; i < response.length; i++) {
                     var group = response[i];
                     group.checkCounter = 0;
                     checkAllInGroup(group, group.checks);
@@ -33,7 +38,7 @@
 
         function setGroupGlobalResultType(group) {
 
-            var totalSucces = 0;
+            var totalSuccess = 0;
             var totalError = 0;
             var totalWarning = 0;
             var totalInfo = 0;
@@ -42,16 +47,16 @@
             angular.forEach(group.checks, function(check){
                 angular.forEach(check.status, function(status){
                     switch(status.resultType) {
-                        case 0:
-                            totalSucces = totalSucces + 1;
+                        case SUCCESS:
+                            totalSuccess = totalSuccess + 1;
                             break;
-                        case 1:
+                        case WARNING:
                             totalWarning = totalWarning + 1;
                             break;
-                        case 2:
+                        case ERROR:
                             totalError = totalError + 1;
                             break;
-                        case 3:
+                        case INFO:
                             totalInfo = totalInfo + 1;
                             break;
                     }
@@ -59,25 +64,25 @@
             });
 
             // set global group result
-            if(totalError > 0) {
+            if (totalError > 0) {
 
                 // set group to error
-                group.resultType = 2;
+                group.resultType = ERROR;
 
             } else if ( totalWarning > 0 ) {
 
                 // set group to warning
-                group.resultType = 1;
+                group.resultType = WARNING;
 
             } else if ( totalInfo > 0 ) {
 
                 // set group to info
-                group.resultType = 3;
+                group.resultType = INFO;
 
-            } else if (totalSucces > 0) {
+            } else if (totalSuccess > 0) {
 
                 // set group to success
-                group.resultType = 0;
+                group.resultType = SUCCESS;
 
             }
 
@@ -116,7 +121,7 @@
                     check.loading = false;
 
                     // when all checks are done, set global group result
-                    if(group.checkCounter === checks.length) {
+                    if (group.checkCounter === checks.length) {
                         setGroupGlobalResultType(group);
                         group.loading = false;
                     }

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1272,67 +1272,81 @@ To manage your website, simply open the Umbraco back office and start adding con
       <key alias="fieldIsMandatory">Field is mandatory</key>
   </area>
   <area alias="healthcheck">
-	<!-- The following keys get these tokens passed in:
+	  <!-- The following keys get these tokens passed in:
 	     0: Current value
-		 1: Recommended value
-		 2: XPath
-		 3: Configuration file path
-	-->
+		   1: Recommended value
+		   2: XPath
+		   3: Configuration file path
+	  -->
     <key alias="checkSuccessMessage">Value is set to the recommended value: '%0%'.</key>
-	<key alias="rectifySuccessMessage">Value was set to '%1%' for XPath '%2%' in configuration file '%3%'.</key>
+	  <key alias="rectifySuccessMessage">Value was set to '%1%' for XPath '%2%' in configuration file '%3%'.</key>
     <key alias="checkErrorMessageDifferentExpectedValue">Expected value '%1%' for '%2%' in configuration file '%3%', but found '%0%'.</key>
     <key alias="checkErrorMessageUnexpectedValue">Found unexpected value '%0%' for '%2%' in configuration file '%3%'.</key>	
 	
-	<!-- The following keys get these tokens passed in:
+	  <!-- The following keys get these tokens passed in:
 	     0: Current value
-		 1: Recommended value
-	-->	
-	<key alias="customErrorsCheckSuccessMessage">Custom errors are set to '%0%'.</key>
-	<key alias="customErrorsCheckErrorMessage">Custom errors are currently set to '%0%'. It is recommended to set this to '%1%' before go live.</key>
-	<key alias="customErrorsCheckRectifySuccessMessage">Custom errors successfully set to '%0%'.</key>
+		   1: Recommended value
+	  -->	
+	  <key alias="customErrorsCheckSuccessMessage">Custom errors are set to '%0%'.</key>
+	  <key alias="customErrorsCheckErrorMessage">Custom errors are currently set to '%0%'. It is recommended to set this to '%1%' before go live.</key>
+	  <key alias="customErrorsCheckRectifySuccessMessage">Custom errors successfully set to '%0%'.</key>
 	
-	<key alias="macroErrorModeCheckSuccessMessage">MacroErrors are set to '%0%'.</key>
-	<key alias="macroErrorModeCheckErrorMessage">MacroErrors are set to '%0%' which will prevent some or all pages in your site from loading completely when there's any errors in macros. Rectifying this will set the value to '%1%'.</key>
-	<key alias="macroErrorModeCheckRectifySuccessMessage">MacroErrors are now set to '%0%'.</key>
+	  <key alias="macroErrorModeCheckSuccessMessage">MacroErrors are set to '%0%'.</key>
+	  <key alias="macroErrorModeCheckErrorMessage">MacroErrors are set to '%0%' which will prevent some or all pages in your site from loading completely when there's any errors in macros. Rectifying this will set the value to '%1%'.</key>
+	  <key alias="macroErrorModeCheckRectifySuccessMessage">MacroErrors are now set to '%0%'.</key>
 		
-	<!-- The following keys get these tokens passed in:
+	  <!-- The following keys get these tokens passed in:
 	     0: Current value
-		 1: Recommended value
-		 2: Server version
-	-->		
-	<key alias="trySkipIisCustomErrorsCheckSuccessMessage">Try Skip IIS Custom Errors is set to '%0%' and you're using IIS version '%1%'.</key>
-	<key alias="trySkipIisCustomErrorsCheckErrorMessage">Try Skip IIS Custom Errors is currently '%0%'. It is recommended to set this to '%1%' for your IIS version (%2%).</key>
-	<key alias="trySkipIisCustomErrorsCheckRectifySuccessMessage">Try Skip IIS Custom Errors successfully set to '%0%'.</key>
+		   1: Recommended value
+		   2: Server version
+	  -->		
+	  <key alias="trySkipIisCustomErrorsCheckSuccessMessage">Try Skip IIS Custom Errors is set to '%0%' and you're using IIS version '%1%'.</key>
+	  <key alias="trySkipIisCustomErrorsCheckErrorMessage">Try Skip IIS Custom Errors is currently '%0%'. It is recommended to set this to '%1%' for your IIS version (%2%).</key>
+	  <key alias="trySkipIisCustomErrorsCheckRectifySuccessMessage">Try Skip IIS Custom Errors successfully set to '%0%'.</key>
 	
-	<!-- The following keys get predefined tokens passed in that are not all the same, like above -->
-	<key alias="configurationServiceFileNotFound">File does not exist: '%0%'.</key>
-	<key alias="configurationServiceNodeNotFound"><![CDATA[Unable to find <strong>'%0%'</strong> in config file <strong>'%1%'</strong>.]]></key>
-	<key alias="configurationServiceError">There was an error, check log for full error: %0%.</key>
+	  <!-- The following keys get predefined tokens passed in that are not all the same, like above -->
+	  <key alias="configurationServiceFileNotFound">File does not exist: '%0%'.</key>
+	  <key alias="configurationServiceNodeNotFound"><![CDATA[Unable to find <strong>'%0%'</strong> in config file <strong>'%1%'</strong>.]]></key>
+	  <key alias="configurationServiceError">There was an error, check log for full error: %0%.</key>
 	
-	<key alias="xmlDataIntegrityCheckMembers">Total XML: %0%, Total: %1%</key>
-	<key alias="xmlDataIntegrityCheckMedia">Total XML: %0%, Total: %1%</key>
-	<key alias="xmlDataIntegrityCheckContent">Total XML: %0%, Total published: %1%</key>
+	  <key alias="xmlDataIntegrityCheckMembers">Total XML: %0%, Total: %1%</key>
+	  <key alias="xmlDataIntegrityCheckMedia">Total XML: %0%, Total: %1%</key>
+	  <key alias="xmlDataIntegrityCheckContent">Total XML: %0%, Total published: %1%</key>
 	
-	<key alias="httpsCheckInvalidCertificate">Certificate validation error: '%0%'</key>
-	<key alias="httpsCheckInvalidUrl">Error pinging the URL %0% - '%1%'</key>
-	<key alias="httpsCheckIsCurrentSchemeHttps">You are currently %0% viewing the site using the HTTPS scheme.</key>
-	<key alias="httpsCheckConfigurationCheckResult">The appSetting 'umbracoUseSSL' is set to '%0%' in your web.config file, your cookies are %1% marked as secure.</key>
-	<key alias="httpsCheckEnableHttpsError">Could not update the 'umbracoUseSSL' setting in your web.config file. Error: %0%</key>
+	  <key alias="httpsCheckInvalidCertificate">Certificate validation error: '%0%'</key>
+	  <key alias="httpsCheckInvalidUrl">Error pinging the URL %0% - '%1%'</key>
+	  <key alias="httpsCheckIsCurrentSchemeHttps">You are currently %0% viewing the site using the HTTPS scheme.</key>
+	  <key alias="httpsCheckConfigurationCheckResult">The appSetting 'umbracoUseSSL' is set to '%0%' in your web.config file, your cookies are %1% marked as secure.</key>
+	  <key alias="httpsCheckEnableHttpsError">Could not update the 'umbracoUseSSL' setting in your web.config file. Error: %0%</key>
 
-	<!-- The following keys don't get tokens passed in -->
-	<key alias="httpsCheckEnableHttpsButton">Enable HTTPS</key>
-	<key alias="httpsCheckEnableHttpsDescription">Sets umbracoSSL setting to true in the appSettings of the web.config file.</key>
-	<key alias="httpsCheckEnableHttpsSuccess">The appSetting 'umbracoUseSSL' is now set to 'true' in your web.config file, your cookies will be marked as secure.</key>
+	  <!-- The following keys don't get tokens passed in -->
+	  <key alias="httpsCheckEnableHttpsButton">Enable HTTPS</key>
+	  <key alias="httpsCheckEnableHttpsDescription">Sets umbracoSSL setting to true in the appSettings of the web.config file.</key>
+	  <key alias="httpsCheckEnableHttpsSuccess">The appSetting 'umbracoUseSSL' is now set to 'true' in your web.config file, your cookies will be marked as secure.</key>
 	
-	<key alias="rectifyButton">Rectify</key>
-	<key alias="cannotRectifyShouldNotEqual">Cannot rectify a check with a value comparison type of 'ShouldNotEqual'.</key>
+	  <key alias="rectifyButton">Rectify</key>
+	  <key alias="cannotRectifyShouldNotEqual">Cannot rectify a check with a value comparison type of 'ShouldNotEqual'.</key>
 		
-	<key alias="compilationDebugCheckSuccessMessage">Debug compilation mode is disabled.</key>
-	<key alias="compilationDebugCheckErrorMessage">Debug compilation mode is currently enabled. It is recommended to disable this setting before go live.</key>
-	<key alias="compilationDebugCheckRectifySuccessMessage">Debug compilation mode successfully disabled.</key>
+	  <key alias="compilationDebugCheckSuccessMessage">Debug compilation mode is disabled.</key>
+	  <key alias="compilationDebugCheckErrorMessage">Debug compilation mode is currently enabled. It is recommended to disable this setting before go live.</key>
+	  <key alias="compilationDebugCheckRectifySuccessMessage">Debug compilation mode successfully disabled.</key>
 
-	<key alias="traceModeCheckSuccessMessage">Trace mode is disabled.</key>
-	<key alias="traceModeCheckErrorMessage">Trace mode is currently enabled. It is recommended to disable this setting before go live.</key>
-	<key alias="traceModeCheckRectifySuccessMessage">Trace mode successfully disabled.</key>
+	  <key alias="traceModeCheckSuccessMessage">Trace mode is disabled.</key>
+	  <key alias="traceModeCheckErrorMessage">Trace mode is currently enabled. It is recommended to disable this setting before go live.</key>
+	  <key alias="traceModeCheckRectifySuccessMessage">Trace mode successfully disabled.</key>
+
+    <key alias="folderPermissionsCheckMessage">All folders have the correct permissions set.</key>
+    <!-- The following keys get these tokens passed in:
+	    0: Comma delimitted list of failed folder paths
+  	-->
+    <key alias="requiredFolderPermissionFailed"><![CDATA[The following folders must be set up with modify permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
+    <key alias="optionalFolderPermissionFailed"><![CDATA[The following folders must be set up with modify permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
+
+    <key alias="filePermissionsCheckMessage">All files have the correct permissions set.</key>
+    <!-- The following keys get these tokens passed in:
+	    0: Comma delimitted list of failed folder paths
+  	-->
+    <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
+    <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
   </area>  
 </language>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1277,67 +1277,81 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="fieldIsMandatory">Field is mandatory</key>
   </area>
   <area alias="healthcheck">
-	<!-- The following keys get these tokens passed in:
+    <!-- The following keys get these tokens passed in:
 	     0: Current value
-		 1: Recommended value
-		 2: XPath
-		 3: Configuration file path
-	-->
+		   1: Recommended value
+		   2: XPath
+		   3: Configuration file path
+	  -->
     <key alias="checkSuccessMessage">Value is set to the recommended value: '%0%'.</key>
-	<key alias="rectifySuccessMessage">Value was set to '%1%' for XPath '%2%' in configuration file '%3%'.</key>
+    <key alias="rectifySuccessMessage">Value was set to '%1%' for XPath '%2%' in configuration file '%3%'.</key>
     <key alias="checkErrorMessageDifferentExpectedValue">Expected value '%1%' for '%2%' in configuration file '%3%', but found '%0%'.</key>
-    <key alias="checkErrorMessageUnexpectedValue">Found unexpected value '%0%' for '%2%' in configuration file '%3%'.</key>	
-	
-	<!-- The following keys get these tokens passed in:
-	     0: Current value
-		 1: Recommended value
-	-->	
-	<key alias="customErrorsCheckSuccessMessage">Custom errors are set to '%0%'.</key>
-	<key alias="customErrorsCheckErrorMessage">Custom errors are currently set to '%0%'. It is recommended to set this to '%1%' before go live.</key>
-	<key alias="customErrorsCheckRectifySuccessMessage">Custom errors successfully set to '%0%'.</key>
-	
-	<key alias="macroErrorModeCheckSuccessMessage">MacroErrors are set to '%0%'.</key>
-	<key alias="macroErrorModeCheckErrorMessage">MacroErrors are set to '%0%' which will prevent some or all pages in your site from loading completely when there's any errors in macros. Rectifying this will set the value to '%1%'.</key>
-	<key alias="macroErrorModeCheckRectifySuccessMessage">MacroErrors are now set to '%0%'.</key>
-		
-	<!-- The following keys get these tokens passed in:
-	     0: Current value
-		 1: Recommended value
-		 2: Server version
-	-->		
-	<key alias="trySkipIisCustomErrorsCheckSuccessMessage">Try Skip IIS Custom Errors is set to '%0%' and you're using IIS version '%1%'.</key>
-	<key alias="trySkipIisCustomErrorsCheckErrorMessage">Try Skip IIS Custom Errors is currently '%0%'. It is recommended to set this to '%1%' for your IIS version (%2%).</key>
-	<key alias="trySkipIisCustomErrorsCheckRectifySuccessMessage">Try Skip IIS Custom Errors successfully set to '%0%'.</key>
-	
-	<!-- The following keys get predefined tokens passed in that are not all the same, like above -->
-	<key alias="configurationServiceFileNotFound">File does not exist: '%0%'.</key>
-	<key alias="configurationServiceNodeNotFound"><![CDATA[Unable to find <strong>'%0%'</strong> in config file <strong>'%1%'</strong>.]]></key>
-	<key alias="configurationServiceError">There was an error, check log for full error: %0%.</key>
-	
-	<key alias="xmlDataIntegrityCheckMembers">Total XML: %0%, Total: %1%</key>
-	<key alias="xmlDataIntegrityCheckMedia">Total XML: %0%, Total: %1%</key>
-	<key alias="xmlDataIntegrityCheckContent">Total XML: %0%, Total published: %1%</key>
-	
-	<key alias="httpsCheckInvalidCertificate">Certificate validation error: '%0%'</key>
-	<key alias="httpsCheckInvalidUrl">Error pinging the URL %0% - '%1%'</key>
-	<key alias="httpsCheckIsCurrentSchemeHttps">You are currently %0% viewing the site using the HTTPS scheme.</key>
-	<key alias="httpsCheckConfigurationCheckResult">The appSetting 'umbracoUseSSL' is set to '%0%' in your web.config file, your cookies are %1% marked as secure.</key>
-	<key alias="httpsCheckEnableHttpsError">Could not update the 'umbracoUseSSL' setting in your web.config file. Error: %0%</key>
+    <key alias="checkErrorMessageUnexpectedValue">Found unexpected value '%0%' for '%2%' in configuration file '%3%'.</key>
 
-	<!-- The following keys don't get tokens passed in -->
-	<key alias="httpsCheckEnableHttpsButton">Enable HTTPS</key>
-	<key alias="httpsCheckEnableHttpsDescription">Sets umbracoSSL setting to true in the appSettings of the web.config file.</key>
-	<key alias="httpsCheckEnableHttpsSuccess">The appSetting 'umbracoUseSSL' is now set to 'true' in your web.config file, your cookies will be marked as secure.</key>
-	
-	<key alias="rectifyButton">Rectify</key>
-	<key alias="cannotRectifyShouldNotEqual">Cannot rectify a check with a value comparison type of 'ShouldNotEqual'.</key>
-		
-	<key alias="compilationDebugCheckSuccessMessage">Debug compilation mode is disabled.</key>
-	<key alias="compilationDebugCheckErrorMessage">Debug compilation mode is currently enabled. It is recommended to disable this setting before go live.</key>
-	<key alias="compilationDebugCheckRectifySuccessMessage">Debug compilation mode successfully disabled.</key>
+    <!-- The following keys get these tokens passed in:
+	     0: Current value
+		   1: Recommended value
+	  -->
+    <key alias="customErrorsCheckSuccessMessage">Custom errors are set to '%0%'.</key>
+    <key alias="customErrorsCheckErrorMessage">Custom errors are currently set to '%0%'. It is recommended to set this to '%1%' before go live.</key>
+    <key alias="customErrorsCheckRectifySuccessMessage">Custom errors successfully set to '%0%'.</key>
 
-	<key alias="traceModeCheckSuccessMessage">Trace mode is disabled.</key>
-	<key alias="traceModeCheckErrorMessage">Trace mode is currently enabled. It is recommended to disable this setting before go live.</key>
-	<key alias="traceModeCheckRectifySuccessMessage">Trace mode successfully disabled.</key>
+    <key alias="macroErrorModeCheckSuccessMessage">MacroErrors are set to '%0%'.</key>
+    <key alias="macroErrorModeCheckErrorMessage">MacroErrors are set to '%0%' which will prevent some or all pages in your site from loading completely when there's any errors in macros. Rectifying this will set the value to '%1%'.</key>
+    <key alias="macroErrorModeCheckRectifySuccessMessage">MacroErrors are now set to '%0%'.</key>
+
+    <!-- The following keys get these tokens passed in:
+	     0: Current value
+		   1: Recommended value
+		   2: Server version
+	  -->
+    <key alias="trySkipIisCustomErrorsCheckSuccessMessage">Try Skip IIS Custom Errors is set to '%0%' and you're using IIS version '%1%'.</key>
+    <key alias="trySkipIisCustomErrorsCheckErrorMessage">Try Skip IIS Custom Errors is currently '%0%'. It is recommended to set this to '%1%' for your IIS version (%2%).</key>
+    <key alias="trySkipIisCustomErrorsCheckRectifySuccessMessage">Try Skip IIS Custom Errors successfully set to '%0%'.</key>
+
+    <!-- The following keys get predefined tokens passed in that are not all the same, like above -->
+    <key alias="configurationServiceFileNotFound">File does not exist: '%0%'.</key>
+    <key alias="configurationServiceNodeNotFound"><![CDATA[Unable to find <strong>'%0%'</strong> in config file <strong>'%1%'</strong>.]]></key>
+    <key alias="configurationServiceError">There was an error, check log for full error: %0%.</key>
+
+    <key alias="xmlDataIntegrityCheckMembers">Total XML: %0%, Total: %1%</key>
+    <key alias="xmlDataIntegrityCheckMedia">Total XML: %0%, Total: %1%</key>
+    <key alias="xmlDataIntegrityCheckContent">Total XML: %0%, Total published: %1%</key>
+
+    <key alias="httpsCheckInvalidCertificate">Certificate validation error: '%0%'</key>
+    <key alias="httpsCheckInvalidUrl">Error pinging the URL %0% - '%1%'</key>
+    <key alias="httpsCheckIsCurrentSchemeHttps">You are currently %0% viewing the site using the HTTPS scheme.</key>
+    <key alias="httpsCheckConfigurationCheckResult">The appSetting 'umbracoUseSSL' is set to '%0%' in your web.config file, your cookies are %1% marked as secure.</key>
+    <key alias="httpsCheckEnableHttpsError">Could not update the 'umbracoUseSSL' setting in your web.config file. Error: %0%</key>
+
+    <!-- The following keys don't get tokens passed in -->
+    <key alias="httpsCheckEnableHttpsButton">Enable HTTPS</key>
+    <key alias="httpsCheckEnableHttpsDescription">Sets umbracoSSL setting to true in the appSettings of the web.config file.</key>
+    <key alias="httpsCheckEnableHttpsSuccess">The appSetting 'umbracoUseSSL' is now set to 'true' in your web.config file, your cookies will be marked as secure.</key>
+
+    <key alias="rectifyButton">Rectify</key>
+    <key alias="cannotRectifyShouldNotEqual">Cannot rectify a check with a value comparison type of 'ShouldNotEqual'.</key>
+
+    <key alias="compilationDebugCheckSuccessMessage">Debug compilation mode is disabled.</key>
+    <key alias="compilationDebugCheckErrorMessage">Debug compilation mode is currently enabled. It is recommended to disable this setting before go live.</key>
+    <key alias="compilationDebugCheckRectifySuccessMessage">Debug compilation mode successfully disabled.</key>
+
+    <key alias="traceModeCheckSuccessMessage">Trace mode is disabled.</key>
+    <key alias="traceModeCheckErrorMessage">Trace mode is currently enabled. It is recommended to disable this setting before go live.</key>
+    <key alias="traceModeCheckRectifySuccessMessage">Trace mode successfully disabled.</key>
+
+    <key alias="folderPermissionsCheckMessage">All folders have the correct permissions set.</key>
+    <!-- The following keys get these tokens passed in:
+	    0: Comma delimitted list of failed folder paths
+  	-->
+    <key alias="requiredFolderPermissionFailed"><![CDATA[The following folders must be set up with modify permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
+    <key alias="optionalFolderPermissionFailed"><![CDATA[The following folders must be set up with modify permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
+
+    <key alias="filePermissionsCheckMessage">All files have the correct permissions set.</key>
+    <!-- The following keys get these tokens passed in:
+	    0: Comma delimitted list of failed folder paths
+  	-->
+    <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
+    <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
   </area>
 </language>

--- a/src/Umbraco.Web/HealthCheck/Checks/DataIntegrity/XmlDataIntegrityHealthCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/DataIntegrity/XmlDataIntegrityHealthCheck.cs
@@ -15,10 +15,14 @@ namespace Umbraco.Web.HealthCheck.Checks.DataIntegrity
         "D999EB2B-64C2-400F-B50C-334D41F8589A",
         "XML Data Integrity",
         Description = "Checks the integrity of the XML data in Umbraco",
-        Group = "DataIntegrity")]
+        Group = "Data Integrity")]
     public class XmlDataIntegrityHealthCheck : HealthCheck
     {
         private readonly ILocalizedTextService _textService;
+
+        private const string CheckContentXmlTableAction = "checkContentXmlTable";
+        private const string CheckMediaXmlTableAction = "checkMediaXmlTable";
+        private const string CheckMembersXmlTableAction = "checkMembersXmlTable";
 
         public XmlDataIntegrityHealthCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
         {
@@ -51,13 +55,13 @@ namespace Umbraco.Web.HealthCheck.Checks.DataIntegrity
         {
             switch (action.Alias)
             {
-                case "checkContentXmlTable":
+                case CheckContentXmlTableAction:
                     _services.ContentService.RebuildXmlStructures();
                     return CheckContent();
-                case "checkMediaXmlTable":
+                case CheckMediaXmlTableAction:
                     _services.MediaService.RebuildXmlStructures();
                     return CheckMedia();
-                case "checkMembersXmlTable":
+                case CheckMembersXmlTableAction:
                     _services.MemberService.RebuildXmlStructures();
                     return CheckMembers();
                 default:
@@ -79,7 +83,7 @@ namespace Umbraco.Web.HealthCheck.Checks.DataIntegrity
 
             var actions = new List<HealthCheckAction>();
             if (totalXml != total)
-                actions.Add(new HealthCheckAction("checkMembersXmlTable", Id));
+                actions.Add(new HealthCheckAction(CheckMembersXmlTableAction, Id));
             
             return new HealthCheckStatus(_textService.Localize("healthcheck/xmlDataIntegrityCheckMembers", new[] { totalXml.ToString(), total.ToString() }))
             {
@@ -102,7 +106,7 @@ namespace Umbraco.Web.HealthCheck.Checks.DataIntegrity
 
             var actions = new List<HealthCheckAction>();
             if (totalXml != total)
-                actions.Add(new HealthCheckAction("checkMediaXmlTable", Id));
+                actions.Add(new HealthCheckAction(CheckMediaXmlTableAction, Id));
 
             return new HealthCheckStatus(_textService.Localize("healthcheck/xmlDataIntegrityCheckMedia", new[] { totalXml.ToString(), total.ToString() }))
             {
@@ -123,7 +127,7 @@ namespace Umbraco.Web.HealthCheck.Checks.DataIntegrity
 
             var actions = new List<HealthCheckAction>();
             if (totalXml != total)
-                actions.Add(new HealthCheckAction("checkContentXmlTable", Id));
+                actions.Add(new HealthCheckAction(CheckContentXmlTableAction, Id));
 
             return new HealthCheckStatus(_textService.Localize("healthcheck/xmlDataIntegrityCheckContent", new[] { totalXml.ToString(), total.ToString() }))
             {

--- a/src/Umbraco.Web/HealthCheck/Checks/Permissions/FolderAndFilePermissionsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Permissions/FolderAndFilePermissionsCheck.cs
@@ -71,7 +71,9 @@ namespace Umbraco.Web.HealthCheck.Checks.Permissions
             var pathsToCheck = new Dictionary<string, PermissionCheckRequirement>
             {
                 { SystemDirectories.AppCode, PermissionCheckRequirement.Optional },
-                { SystemDirectories.AppData, PermissionCheckRequirement.Required },
+                { SystemDirectories.Data, PermissionCheckRequirement.Required },
+                { SystemDirectories.Packages, PermissionCheckRequirement.Optional },
+                { SystemDirectories.Preview, PermissionCheckRequirement.Optional },
                 { SystemDirectories.AppPlugins, PermissionCheckRequirement.Required },
                 { SystemDirectories.Bin, PermissionCheckRequirement.Optional },
                 { SystemDirectories.Config, PermissionCheckRequirement.Optional },

--- a/src/Umbraco.Web/HealthCheck/Checks/Permissions/FolderAndFilePermissionsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Permissions/FolderAndFilePermissionsCheck.cs
@@ -72,8 +72,8 @@ namespace Umbraco.Web.HealthCheck.Checks.Permissions
             {
                 { SystemDirectories.AppCode, PermissionCheckRequirement.Optional },
                 { SystemDirectories.Data, PermissionCheckRequirement.Required },
-                { SystemDirectories.Packages, PermissionCheckRequirement.Optional },
-                { SystemDirectories.Preview, PermissionCheckRequirement.Optional },
+                { SystemDirectories.Packages, PermissionCheckRequirement.Required},
+                { SystemDirectories.Preview, PermissionCheckRequirement.Required },
                 { SystemDirectories.AppPlugins, PermissionCheckRequirement.Required },
                 { SystemDirectories.Bin, PermissionCheckRequirement.Optional },
                 { SystemDirectories.Config, PermissionCheckRequirement.Optional },

--- a/src/Umbraco.Web/HealthCheck/Checks/Permissions/FolderAndFilePermissionsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Permissions/FolderAndFilePermissionsCheck.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.IO;
+using Umbraco.Core.Services;
+using Umbraco.Web.Install;
+
+namespace Umbraco.Web.HealthCheck.Checks.Permissions
+{
+    internal enum PermissionCheckRequirement
+    {
+        Required,
+        Optional
+    }
+
+    internal enum PermissionCheckFor
+    {
+        Folder,
+        File
+    }
+
+    [HealthCheck(
+        "53DBA282-4A79-4B67-B958-B29EC40FCC23",
+        "Folder & File Permissions",
+        Description = "Checks that the web server folder and file permissions are set correctly for Umbraco to run.",
+        Group = "Permissions")]
+    public class FolderAndFilePermissionsCheck : HealthCheck
+    {
+        private readonly ILocalizedTextService _textService;
+
+        private const string CheckFolderPermissionsAction = "checkFolderPermissions";
+        private const string CheckFilePermissionsAction = "checkFilePermissions";
+
+        public FolderAndFilePermissionsCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
+        {
+            _textService = healthCheckContext.ApplicationContext.Services.TextService;
+        }
+
+        /// <summary>
+        /// Get the status for this health check
+        /// </summary>
+        /// <returns></returns>
+        public override IEnumerable<HealthCheckStatus> GetStatus()
+        {
+            //return the statuses
+            return new[] { CheckFolderPermissions(), CheckFilePermissions() };
+        }
+
+        /// <summary>
+        /// Executes the action and returns it's status
+        /// </summary>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            switch (action.Alias)
+            {
+                case CheckFolderPermissionsAction:
+                    return CheckFolderPermissions();
+                case CheckFilePermissionsAction:
+                    return CheckFilePermissions();
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private HealthCheckStatus CheckFolderPermissions()
+        {
+            // Create lists of paths to check along with a flag indicating if modify rights are required
+            // in ALL circumstances or just some
+            var pathsToCheck = new Dictionary<string, PermissionCheckRequirement>
+            {
+                { SystemDirectories.AppCode, PermissionCheckRequirement.Optional },
+                { SystemDirectories.AppData, PermissionCheckRequirement.Required },
+                { SystemDirectories.AppPlugins, PermissionCheckRequirement.Required },
+                { SystemDirectories.Bin, PermissionCheckRequirement.Optional },
+                { SystemDirectories.Config, PermissionCheckRequirement.Optional },
+                { SystemDirectories.Css, PermissionCheckRequirement.Optional },
+                { SystemDirectories.Masterpages, PermissionCheckRequirement.Optional },
+                { SystemDirectories.Media, PermissionCheckRequirement.Optional },
+                { SystemDirectories.Scripts, PermissionCheckRequirement.Optional },
+                { SystemDirectories.Umbraco, PermissionCheckRequirement.Optional },
+                { SystemDirectories.UmbracoClient, PermissionCheckRequirement.Optional },
+                { SystemDirectories.UserControls, PermissionCheckRequirement.Optional },
+                { SystemDirectories.MvcViews, PermissionCheckRequirement.Optional },
+                { SystemDirectories.Xslt, PermissionCheckRequirement.Optional },
+            };
+
+            // Run checks for required and optional paths for modify permission
+            List<string> requiredFailedPaths;
+            List<string> optionalFailedPaths;
+            var requiredPathCheckResult = FilePermissionHelper.TestDirectories(GetPathsToCheck(pathsToCheck, PermissionCheckRequirement.Required), out requiredFailedPaths);
+            var optionalPathCheckResult = FilePermissionHelper.TestDirectories(GetPathsToCheck(pathsToCheck, PermissionCheckRequirement.Optional), out optionalFailedPaths);
+
+            return GetStatus(requiredPathCheckResult, requiredFailedPaths, optionalPathCheckResult, optionalFailedPaths, PermissionCheckFor.Folder);
+        }
+
+        private HealthCheckStatus CheckFilePermissions()
+        {
+            // Create lists of paths to check along with a flag indicating if modify rights are required
+            // in ALL circumstances or just some
+            var pathsToCheck = new Dictionary<string, PermissionCheckRequirement>
+            {
+                { "~/Web.config", PermissionCheckRequirement.Optional },
+            };
+
+            // Run checks for required and optional paths for modify permission
+            List<string> requiredFailedPaths;
+            List<string> optionalFailedPaths;
+            var requiredPathCheckResult = FilePermissionHelper.TestFiles(GetPathsToCheck(pathsToCheck, PermissionCheckRequirement.Required), out requiredFailedPaths);
+            var optionalPathCheckResult = FilePermissionHelper.TestFiles(GetPathsToCheck(pathsToCheck, PermissionCheckRequirement.Optional), out optionalFailedPaths);
+
+            return GetStatus(requiredPathCheckResult, requiredFailedPaths, optionalPathCheckResult, optionalFailedPaths, PermissionCheckFor.File);
+        }
+
+        private static string[] GetPathsToCheck(Dictionary<string, PermissionCheckRequirement> pathsToCheck,
+            PermissionCheckRequirement requirement)
+        {
+            return pathsToCheck
+                .Where(x => x.Value == requirement)
+                .Select(x => IOHelper.MapPath(x.Key))
+                .OrderBy(x => x)
+                .ToArray();
+        }
+
+        private HealthCheckStatus GetStatus(bool requiredPathCheckResult, List<string> requiredFailedPaths,
+            bool optionalPathCheckResult, IEnumerable<string> optionalFailedPaths,
+            PermissionCheckFor checkingFor)
+        {
+            // Return error if any required parths fail the check, or warning if any optional ones do
+            var resultType = StatusResultType.Success;
+            var messageKey = string.Format("healthcheck/{0}PermissionsCheckMessage",
+                checkingFor == PermissionCheckFor.Folder ? "folder" : "file");
+            var message = _textService.Localize(messageKey);
+            if (requiredPathCheckResult == false)
+            {
+                resultType = StatusResultType.Error;
+                messageKey = string.Format("healthcheck/required{0}PermissionFailed",
+                    checkingFor == PermissionCheckFor.Folder ? "Folder" : "File");
+                message = GetMessageForPathCheckFailure(messageKey, requiredFailedPaths);
+            }
+            else if (optionalPathCheckResult == false)
+            {
+                resultType = StatusResultType.Warning;
+                messageKey = string.Format("healthcheck/optional{0}PermissionFailed",
+                    checkingFor == PermissionCheckFor.Folder ? "Folder" : "File");
+                message = GetMessageForPathCheckFailure(messageKey, optionalFailedPaths);
+            }
+
+            var actions = new List<HealthCheckAction>();
+            return
+                new HealthCheckStatus(message)
+                {
+                    ResultType = resultType,
+                    Actions = actions
+                };
+        }
+
+        private string GetMessageForPathCheckFailure(string messageKey, IEnumerable<string> failedPaths)
+        {
+            var rootFolder = IOHelper.MapPath("/");
+            var failedFolders = failedPaths
+                .Select(x => ParseFolderFromFullPath(rootFolder, x));
+            return _textService.Localize(messageKey,
+                new[] { string.Join(", ", failedFolders) });
+        }
+
+        private string ParseFolderFromFullPath(string rootFolder, string filePath)
+        {
+            return filePath.Replace(rootFolder, string.Empty);
+        }
+    }
+}

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
@@ -7,9 +7,6 @@ using Umbraco.Web.HealthCheck.Checks.Config;
 
 namespace Umbraco.Web.HealthCheck.Checks.Security
 {
-    /// <summary>
-    /// Checks Umbraco backoffice users against the HaveIBeenPwned database to check if they've been breached
-    /// </summary>
     [HealthCheck(
         "EB66BB3B-1BCD-4314-9531-9DA2C1D6D9A7",
         "HTTPS Configuration",
@@ -18,6 +15,11 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
     public class HttpsCheck : HealthCheck
     {
         private readonly ILocalizedTextService _textService;
+
+        private const string CheckForValidCertificateAction = "checkForValidCertificate";
+        private const string CheckHttpsConfigurationSettingAction = "checkHttpsConfigurationSetting";
+        private const string CheckIfCurrentSchemeIsHttpsAction = "checkIfCurrentSchemeIsHttps";
+        private const string FixHttpsSettingAction = "fixHttpsSetting";
 
         public HttpsCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
         {
@@ -43,13 +45,13 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         {
             switch (action.Alias)
             {
-                case "checkForValidCertificate":
+                case CheckForValidCertificateAction:
                     return CheckForValidCertificate();
-                case "checkHttpsConfigurationSetting":
+                case CheckHttpsConfigurationSettingAction:
                     return CheckHttpsConfigurationSetting();
-                case "checkIfCurrentSchemeIsHttps":
+                case CheckIfCurrentSchemeIsHttpsAction:
                     return CheckIfCurrentSchemeIsHttps();
-                case "fixHttpsSetting":
+                case FixHttpsSettingAction:
                     return FixHttpsSetting();
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -120,7 +122,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 
             var actions = new List<HealthCheckAction>();
             if (httpsSettingEnabled == false)
-                actions.Add(new HealthCheckAction("fixHttpsSetting", Id) {
+                actions.Add(new HealthCheckAction(FixHttpsSettingAction, Id) {
                     Name = _textService.Localize("healthcheck/httpsCheckEnableHttpsButton"),
                     Description = _textService.Localize("healthcheck/httpsCheckEnableHttpsDescription")
                 });

--- a/src/Umbraco.Web/HealthCheck/HealthCheckController.cs
+++ b/src/Umbraco.Web/HealthCheck/HealthCheckController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Web.Http;
 using Umbraco.Web.Editors;
 
@@ -24,25 +23,24 @@ namespace Umbraco.Web.HealthCheck
             _healthCheckResolver = healthCheckResolver;
         }
 
-        //TODO: make this happen
-        // * Get all checks
-        // * Execute action
-        // * more?
-
         /// <summary>
         /// Gets a grouped list of health checks, but doesn't actively check the status of each health check.
         /// </summary>
         /// <returns>Returns a collection of anonymous objects representing each group.</returns>
         public object GetAllHealthChecks()
         {
-            var groups = _healthCheckResolver.HealthChecks.GroupBy(x => x.Group);
+            var groups = _healthCheckResolver.HealthChecks
+                .GroupBy(x => x.Group)
+                .OrderBy(x => x.Key);
             var healthCheckGroups = new List<HealthCheckGroup>();
             foreach (var healthCheckGroup in groups)
             {
                 var hcGroup = new HealthCheckGroup
                 {
                     Name = healthCheckGroup.Key,
-                    Checks = healthCheckGroup.ToList()
+                    Checks = healthCheckGroup
+                        .OrderBy(x => x.Name)
+                        .ToList()
                 };
                 healthCheckGroups.Add(hcGroup);
             }

--- a/src/Umbraco.Web/Install/FilePermissionHelper.cs
+++ b/src/Umbraco.Web/Install/FilePermissionHelper.cs
@@ -62,7 +62,7 @@ namespace Umbraco.Web.Install
         {
             errorReport = new List<string>();
             bool succes = true;
-            foreach (string file in PermissionFiles)
+            foreach (string file in files)
             {
                 bool result = OpenFileForWrite(IOHelper.MapPath(file));
                 if (result == false)

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -329,6 +329,7 @@
     <Compile Include="HealthCheck\Checks\Config\TraceCheck.cs" />
     <Compile Include="HealthCheck\Checks\Config\ValueComparisonType.cs" />
     <Compile Include="HealthCheck\Checks\Config\CompilationDebugCheck.cs" />
+    <Compile Include="HealthCheck\Checks\Permissions\FolderAndFilePermissionsCheck.cs" />
     <Compile Include="HealthCheck\HealthCheckAction.cs" />
     <Compile Include="HealthCheck\HealthCheckAttribute.cs" />
     <Compile Include="HealthCheck\HealthCheckContext.cs" />


### PR DESCRIPTION
This PR provides an implementation of a folder and file permission check for the health check dashboard.

Couple of implementation points:

- Considered that there are actually two checks to do, one for files and folders that have to be written to in all circumstances and those that don't always have to be and in some cases you might want to lock down more.  So this works by returning red errors for any of the former that can't be written to and orange warnings for the latter.
- For that reason, although code for the actual checks is reused from the existing `FilePermissionHelper`, the list of files and whether writing is required or optional isn't, it's held in the health check file itself
- Took the liberty of a little minor clean-up of other health check code as I was going through figuring out how it worked