### PR TITLE
U4 3805 - click jacking/excessive headers health check

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1348,5 +1348,8 @@ To manage your website, simply open the Umbraco back office and start adding con
   	-->
     <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
     <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
+
+    <key alias="clickJackingCheckHeaderFound">The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was found.</key>
+    <key alias="clickJackingCheckHeaderNotFound">The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was not found.</key>
   </area>  
 </language>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1349,7 +1349,13 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
     <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
 
-    <key alias="clickJackingCheckHeaderFound">The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was found.</key>
-    <key alias="clickJackingCheckHeaderNotFound">The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was not found.</key>
+    <key alias="clickJackingCheckHeaderFound"><![CDATA[The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was found.]]></key>
+    <key alias="clickJackingCheckHeaderNotFound"><![CDATA[The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was not found.]]></key>
+
+    <!-- The following key get these tokens passed in:
+	    0: Comma delimitted list of headers found
+  	-->
+    <key alias="excessiveHeadersFound"><![CDATA[The following headers revealing information about the website technology were found: <strong>%0%</strong>.]]></key>
+    <key alias="excessiveHeadersNotFound">No headers revealing information about the website technology were found.</key>
   </area>  
 </language>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1353,5 +1353,8 @@ To manage your website, simply open the Umbraco back office and start adding con
   	-->
     <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
     <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
+    
+    <key alias="clickJackingCheckHeaderFound">The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was found.</key>
+    <key alias="clickJackingCheckHeaderNotFound">The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was not found.</key>
   </area>
 </language>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1353,8 +1353,11 @@ To manage your website, simply open the Umbraco back office and start adding con
   	-->
     <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
     <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
-    
-    <key alias="clickJackingCheckHeaderFound">The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was found.</key>
-    <key alias="clickJackingCheckHeaderNotFound">The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was not found.</key>
+
+    <!-- The following key get these tokens passed in:
+	    0: Comma delimitted list of headers found
+  	-->
+    <key alias="excessiveHeadersFound"><![CDATA[The following headers revealing information about the website technology were found: <strong>%0%</strong>.]]></key>
+    <key alias="excessiveHeadersNotFound">No headers revealing information about the website technology were found.</key>
   </area>
 </language>

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/ClickJackingCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/ClickJackingCheck.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Web;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Web.HealthCheck.Checks.Security
+{
+    [HealthCheck(
+        "ED0D7E40-971E-4BE8-AB6D-8CC5D0A6A5B0",
+        "Click-Jacking Protection",
+        Description = "Checks if your site allowed to be IFRAMed by another site and thus would be susceptible to click-jacking.",
+        Group = "Security")]
+    public class ClickJackingCheck : HealthCheck
+    {
+        private readonly ILocalizedTextService _textService;
+
+        public ClickJackingCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
+        {
+            _textService = healthCheckContext.ApplicationContext.Services.TextService;
+        }
+
+        /// <summary>
+        /// Get the status for this health check
+        /// </summary>
+        /// <returns></returns>
+        public override IEnumerable<HealthCheckStatus> GetStatus()
+        {
+            //return the statuses
+            return new[] { CheckForFrameOptionsHeader() };
+        }
+
+        /// <summary>
+        /// Executes the action and returns it's status
+        /// </summary>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            switch (action.Alias)
+            {
+                case "checkForFrameOptionsHeader":
+                    return CheckForFrameOptionsHeader();
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private HealthCheckStatus CheckForFrameOptionsHeader()
+        {
+            var message = string.Empty;
+            var success = false;
+            var url = HealthCheckContext.HttpContext.Request.Url;
+
+            // Access the site home page and check for the click-jack protection header
+            using (var webClient = new WebClient())
+            {
+                var address = string.Format("http://{0}:{1}", url.Host.ToLower(), url.Port);
+                try
+                {
+                    webClient.DownloadString(address);
+                    success = webClient.ResponseHeaders.AllKeys.Contains("X-Frame-Options");
+                    message = success
+                        ? _textService.Localize("healthcheck/clickJackingCheckHeaderFound")
+                        : _textService.Localize("healthcheck/clickJackingCheckHeaderNotFound");
+                }
+                catch (Exception ex)
+                {
+                    message = _textService.Localize("healthcheck/httpsCheckInvalidUrl", new[] { address, ex.Message });
+                }
+            }
+
+            var actions = new List<HealthCheckAction>();
+
+            return
+                new HealthCheckStatus(message)
+                {
+                    ResultType = success ? StatusResultType.Success : StatusResultType.Error,
+                    Actions = actions
+                };
+        }
+   }
+}

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
@@ -62,7 +62,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         {
             var message = string.Empty;
             var success = false;
-            var url = HttpContext.Current.Request.Url;
+            var url = HealthCheckContext.HttpContext.Request.Url;
 
             // Attempt to access the site over HTTPS to see if it HTTPS is supported 
             // and a valid certificate has been configured

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -330,6 +330,7 @@
     <Compile Include="HealthCheck\Checks\Config\ValueComparisonType.cs" />
     <Compile Include="HealthCheck\Checks\Config\CompilationDebugCheck.cs" />
     <Compile Include="HealthCheck\Checks\Permissions\FolderAndFilePermissionsCheck.cs" />
+    <Compile Include="HealthCheck\Checks\Security\ExcessiveHeadersCheck.cs" />
     <Compile Include="HealthCheck\Checks\Security\ClickJackingCheck.cs" />
     <Compile Include="HealthCheck\HealthCheckAction.cs" />
     <Compile Include="HealthCheck\HealthCheckAttribute.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -330,6 +330,7 @@
     <Compile Include="HealthCheck\Checks\Config\ValueComparisonType.cs" />
     <Compile Include="HealthCheck\Checks\Config\CompilationDebugCheck.cs" />
     <Compile Include="HealthCheck\Checks\Permissions\FolderAndFilePermissionsCheck.cs" />
+    <Compile Include="HealthCheck\Checks\Security\ClickJackingCheck.cs" />
     <Compile Include="HealthCheck\HealthCheckAction.cs" />
     <Compile Include="HealthCheck\HealthCheckAttribute.cs" />
     <Compile Include="HealthCheck\HealthCheckContext.cs" />


### PR DESCRIPTION
Provides a health check for click-jacking (see [here](https://asafaweb.com/Home/Scans)) - checks to see if the header that controls if a site can be IFRAMed is provided.  It should be really either way - it's necessary if it's to be denied.  If IFRAMing is required it can be omitted, but likely better that it's explicitly opted into by providing the header.

Also added a check for "excessive headers" (again see link above).  Seems that Umbraco strips most of these out anyway but there is one as I recall that has to be removed at the IIS level and in any case maybe no bad thing to give a positive indication that all is OK on this front.