### PR TITLE
U4-8437 - Allow for property editors to be able to determine what values are indexed by Examine

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/PropertyValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueEditor.cs
@@ -390,5 +390,20 @@ namespace Umbraco.Core.PropertyEditors
                     throw new ArgumentOutOfRangeException();
             }
         }
+
+        /// <summary>
+        /// Converts the property db value to an XML fragment for use with UmbracoContentIndexer
+        /// </summary>
+        /// <param name="property"></param>
+        /// <param name="propertyType"></param>
+        /// <param name="dataTypeService"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// By default this will just return the value of ConvertDbToXml.
+        /// </remarks>
+        public virtual IEnumerable<XElement> ConvertDbToExamine(Property property, PropertyType propertyType, IDataTypeService dataTypeService)
+        {
+            yield return new XElement(property.Alias, ConvertDbToXml(property, propertyType, dataTypeService));
+        }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/PropertyValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueEditor.cs
@@ -401,9 +401,9 @@ namespace Umbraco.Core.PropertyEditors
         /// <remarks>
         /// By default this will just return the value of ConvertDbToXml.
         /// </remarks>
-        public virtual IEnumerable<XElement> ConvertDbToExamine(Property property, PropertyType propertyType, IDataTypeService dataTypeService)
+        public virtual IEnumerable<SearchDataValue> ConvertDbToExamine(Property property, PropertyType propertyType, IDataTypeService dataTypeService)
         {
-            yield return new XElement(property.Alias, ConvertDbToXml(property, propertyType, dataTypeService));
+            yield return new SearchDataValue(property.Alias, ConvertDbToString(property, propertyType, dataTypeService));
         }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/SearchDataValue.cs
+++ b/src/Umbraco.Core/PropertyEditors/SearchDataValue.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Umbraco.Core.PropertyEditors
+{
+    public class SearchDataValue
+    {
+        public string FieldName { get; set; }
+        public string Value { get; set; }
+        public bool Analyze { get; set; }
+        public bool Store { get; set; }
+
+        public SearchDataValue()
+        {
+        }
+
+        public SearchDataValue(string fieldName, string value, bool analyze = true, bool store = true)
+        {
+            FieldName = fieldName;
+            Value = value;
+            Analyze = analyze;
+            Store = store;
+        }
+
+        public XElement ToXml()
+        {
+            var xElement = new XElement(FieldName, Value);
+            xElement.Add(new XAttribute("analyze", Analyze));
+            xElement.Add(new XAttribute("store", Store));
+            return xElement;
+        }
+    }
+}

--- a/src/Umbraco.Core/Services/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/EntityXmlSerializer.cs
@@ -143,9 +143,10 @@ namespace Umbraco.Core.Services
             var propertyEditor = PropertyEditorResolver.Current.GetByAlias(property.PropertyType.PropertyEditorAlias);
             if (propertyEditor != null)
             {
+                var searchDataValues = propertyEditor.ValueEditor.ConvertDbToExamine(property, propertyType, dataTypeService);
                 IEnumerable<XElement> xmlValues;
                 // TODO: Transform to XML here instead of from the valueeditor
-                xmlValues = propertyEditor.ValueEditor.ConvertDbToExamine(property, propertyType, dataTypeService);
+                xmlValues = searchDataValues.Select(v => v.ToXml());
                 if (!xmlValues.Any())
                     xmlValues = new[] {new XElement(nodeName, propertyEditor.ValueEditor.ConvertDbToXml(property, propertyType, dataTypeService))};
                 foreach (var value in xmlValues)

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -479,6 +479,7 @@
     <Compile Include="Persistence\Repositories\TaskTypeRepository.cs" />
     <Compile Include="PropertyEditors\DecimalValidator.cs" />
     <Compile Include="PropertyEditors\PropertyEditorValueTypes.cs" />
+    <Compile Include="PropertyEditors\SearchDataValue.cs" />
     <Compile Include="PropertyEditors\ValueConverters\GridValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DecimalValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\LabelValueConverter.cs" />

--- a/src/Umbraco.Tests/TestHelpers/MockHelper.cs
+++ b/src/Umbraco.Tests/TestHelpers/MockHelper.cs
@@ -35,7 +35,11 @@ namespace Umbraco.Tests.TestHelpers
                 new Mock<IAuditService>().Object,
                 new Mock<IDomainService>().Object,
                 new Mock<ITaskService>().Object,
-                new Mock<IMacroService>().Object);
+                new Mock<IMacroService>().Object,
+                new Mock<IPublicAccessService>().Object,
+                new Mock<IExternalLoginService>().Object,
+                new Mock<IMigrationEntryService>().Object
+                );
         }
     }
 }

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -59,8 +59,9 @@
       <HintPath>..\packages\AutoMapper.3.0.0\lib\net40\AutoMapper.Net4.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Examine, Version=0.1.68.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Examine, Version=0.1.69.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Examine.0.1.68.0\lib\Examine.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
@@ -177,6 +178,7 @@
   <ItemGroup>
     <Compile Include="Migrations\MigrationIssuesTests.cs" />
     <Compile Include="Persistence\Migrations\MigrationStartupHandlerTests.cs" />
+    <Compile Include="UmbracoExamine\IndexValueConverterTests.cs" />
     <Compile Include="Web\AngularIntegration\AngularAntiForgeryTests.cs" />
     <Compile Include="Web\AngularIntegration\ContentModelSerializationTests.cs" />
     <Compile Include="Web\AngularIntegration\JsInitializationTests.cs" />

--- a/src/Umbraco.Tests/UmbracoExamine/IndexValueConverterTests.cs
+++ b/src/Umbraco.Tests/UmbracoExamine/IndexValueConverterTests.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using System.Xml.Linq;
+using Examine;
+using Examine.LuceneEngine.Config;
+using Examine.LuceneEngine.Providers;
+using Lucene.Net.Index;
+using Lucene.Net.Store;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using umbraco.interfaces;
+using umbraco.presentation;
+using Umbraco.Core;
+using Umbraco.Core.Cache;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.ObjectResolution;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.DatabaseModelDefinitions;
+using Umbraco.Core.Persistence.SqlSyntax;
+using Umbraco.Core.Profiling;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
+using Umbraco.Core.Strings;
+using Umbraco.Tests.TestHelpers;
+using Umbraco.Web.PropertyEditors;
+using UmbracoExamine;
+using UmbracoExamine.DataServices;
+using IContentService = UmbracoExamine.DataServices.IContentService;
+
+namespace Umbraco.Tests.UmbracoExamine
+{
+    [TestFixture]
+    public class IndexValueConverterTests : BaseDatabaseFactoryTest
+    {
+        [Test]
+        public void Index_Delegates_To_Property_Value_Converters()
+        {
+            var content = new Mock<IContent>();
+            long total;
+            Mock.Get(serviceContext.ContentService)
+                .Setup(c => c.GetPagedDescendants(-1, 0, 1000, out total, "Path", Direction.Ascending, ""))
+                .Returns(new List<IContent> { content.Object });
+
+            content.Setup(c => c.ContentType).Returns(new ContentType(-1) { Alias = "someType" });
+            content.Setup(c => c.Id).Returns(1);
+            content.Setup(c => c.Name).Returns("Some doc");
+            content.Setup(c => c.Path).Returns("-1 1");
+            content.Setup(c => c.Properties).Returns(new PropertyCollection {
+                new Property(new PropertyType("textstring", DataTypeDatabaseType.Nvarchar) { Alias = "a-string"} )
+                {
+                    Value = "a string"
+                },
+                new Property(new PropertyType("indexer-test", DataTypeDatabaseType.Ntext) { Alias = "indexer-test" })
+                {
+                    Value = @"{
+  ""name"": ""1 column layout"",
+  ""sections"": [
+    {
+      ""grid"": 12,
+      ""rows"": [
+        {
+          ""name"": ""Headline"",
+          ""areas"": [
+            {
+              ""grid"": 12,
+              ""hasConfig"": false,
+              ""controls"": [
+                {
+                  ""value"": ""Hello world!"",
+                  ""editor"": {
+                    ""alias"": ""headline""
+                  },
+                  ""active"": false
+                },
+                {
+                ""value"": ""<p>Here's the first article</p>"",
+                  ""editor"": {
+                    ""alias"": ""rte""
+                  },
+                  ""active"": false
+                },
+                {
+                ""value"": ""<p>And here's some more RTE content</p>"",
+                  ""editor"": {
+                    ""alias"": ""rte""
+                  },
+                  ""active"": true
+                }
+              ],
+              ""active"": true,
+              ""hasActiveChild"": true
+            }
+          ],
+          ""hasConfig"": false,
+          ""id"": ""f49faed0-0df4-4ddc-0b41-c841d07b0889"",
+          ""hasActiveChild"": true,
+          ""active"": true
+        }
+      ]
+    }
+  ]
+}"
+            } });
+
+            _indexer.IndexAll(IndexTypes.Content);
+
+            var reader = _indexer.GetIndexWriter().GetReader();
+            var allTerms = reader.Terms();
+            while (allTerms.Next())
+                Console.WriteLine(allTerms.Term().Field() + ": " + allTerms.Term().Text());
+
+            var rteDocs = reader.Terms(new Term("indexerTest.rte"));
+
+            var count = 0;
+            while (rteDocs.Next())
+                count++;
+
+            Assert.AreEqual(6, count);
+        }
+
+        private static UmbracoExamineSearcher _searcher;
+        private static UmbracoContentIndexer _indexer;
+        private RAMDirectory _luceneDir;
+        private ServiceContext serviceContext;
+
+        [SetUp]
+        public override void Initialize()
+        {
+            UmbracoExamineSearcher.DisableInitializationCheck = true;
+            BaseUmbracoIndexer.DisableInitializationCheck = true;
+            ShortStringHelperResolver.Current = new ShortStringHelperResolver(new DefaultShortStringHelper(SettingsForTests.GetDefault()));
+
+            base.Initialize();
+
+            GetUmbracoContext("http://localhost", -1, null, true);
+
+            _luceneDir = new RAMDirectory();
+            var dataService = Mock.Of<IDataService>();
+            var contentService = Mock.Of<IContentService>();
+            Mock.Get(dataService).Setup(s => s.ContentService).Returns(contentService);
+            Mock.Get(dataService).Setup(s => s.LogService).Returns(Mock.Of<ILogService>());
+            Mock.Get(contentService).Setup(s => s.GetAllUserPropertyNames()).Returns(new[] { "aString", "indexerTest" });
+            _indexer = IndexInitializer.GetUmbracoIndexer(_luceneDir,
+                dataService: dataService,
+                contentService: serviceContext.ContentService, mediaService: Mock.Of<Umbraco.Core.Services.IMediaService>());
+            _indexer.Initialize("indexer", new NameValueCollection { { "supportUnpublished", "true" }, { "runAsync", "false" } });
+
+
+            _indexer.RebuildIndex();
+            _searcher = IndexInitializer.GetUmbracoSearcher(_luceneDir);
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+            _luceneDir.Dispose();
+            UmbracoExamineSearcher.DisableInitializationCheck = null;
+            BaseUmbracoIndexer.DisableInitializationCheck = null;
+        }
+
+        protected override ApplicationContext CreateApplicationContext()
+        {
+            serviceContext = MockHelper.GetMockedServiceContext();
+
+            return new ApplicationContext(
+                new DatabaseContext(Mock.Of<IDatabaseFactory>(), Mock.Of<ILogger>(), Mock.Of<ISqlSyntaxProvider>(), ""),
+                serviceContext,
+                CacheHelper.CreateDisabledCacheHelper(),
+                new ProfilingLogger(Mock.Of<ILogger>(), Mock.Of<IProfiler>())
+                );
+        }
+
+        protected override string GetXmlContent(int templateId)
+        {
+            return TestFiles.umbraco;
+        }
+    }
+
+    [PropertyEditor("indexer-test", "Test indexing", "indexer-test", HideLabel = true, IsParameterEditor = false, ValueType = PropertyEditorValueTypes.Json, Group = "rich content", Icon = "icon-layout")]
+    public class TestGridPropertyEditor : PropertyEditor
+    {
+        protected override PropertyValueEditor CreateValueEditor()
+        {
+            return new TestGridPropertyValueEditor();
+        }
+    }
+
+    public class TestGridPropertyValueEditor : PropertyValueEditor
+    {
+        public override IEnumerable<XElement> ConvertDbToExamine(Property property, PropertyType propertyType, IDataTypeService dataTypeService)
+        {
+            var nodeName = UmbracoConfig.For.UmbracoSettings().Content.UseLegacyXmlSchema ? "data" : property.Alias.ToSafeAlias();
+            var value = property.Value as string;
+            if (String.IsNullOrWhiteSpace(value))
+                yield return null;
+            else
+            {
+                var json = JsonConvert.DeserializeObject<JObject>(value);
+                //section.row.area.control
+                foreach (var section in json["sections"])
+                {
+                    foreach (var row in section["rows"])
+                    {
+                        foreach (var area in row["areas"])
+                        {
+                            foreach (var control in area["controls"])
+                            {
+                                var controlValue = control["value"].Value<string>();
+                                var editorName = control["editor"]["alias"].Value<string>();
+                                if (!String.IsNullOrWhiteSpace(controlValue))
+                                    yield return new XElement(nodeName + "." + editorName, controlValue.StripHtml());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/UmbracoExamine/UmbracoContentIndexer.cs
+++ b/src/UmbracoExamine/UmbracoContentIndexer.cs
@@ -457,7 +457,9 @@ namespace UmbracoExamine
                     _contentService,
                     _dataTypeService,
                     _userService,
-                    c);
+                    c,
+                    deep:false,
+                    forExamine:true);
 
                 //add a custom 'icon' attribute
                 xml.Add(new XAttribute("icon", c.ContentType.Icon));


### PR DESCRIPTION
PropertyValueEditor can now return multiple XML elements for a field and have them indexed in lucene.
