### PR TITLE
U4 3805 - further additions to health check

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/healthcheck.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/healthcheck.html
@@ -85,6 +85,10 @@
 
                             <div class="umb-healthcheck-group__details-status-actions">
                                 <div class="umb-healthcheck-group__details-status-action" ng-repeat="action in status.actions">
+                                    <span ng-show="action.valueRequired">
+                                        Set new value: 
+                                        <input type="text" ng-model="action.providedValue" required/>
+                                    </span>
                                     <button type="button" class="umb-era-button" ng-click="vm.executeAction(check, $index, action);">{{action.name}}</button>
                                     <div class="umb-healthcheck-group__details-status-action-description" ng-if="action.description" ng-bind-html="action.description"></div>
                                 </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1326,7 +1326,9 @@ To manage your website, simply open the Umbraco back office and start adding con
 	  <key alias="httpsCheckEnableHttpsSuccess">The appSetting 'umbracoUseSSL' is now set to 'true' in your web.config file, your cookies will be marked as secure.</key>
 	
 	  <key alias="rectifyButton">Fix</key>
-	  <key alias="cannotRectifyShouldNotEqual">Cannot rectify a check with a value comparison type of 'ShouldNotEqual'.</key>
+    <key alias="cannotRectifyShouldNotEqual">Cannot fix a check with a value comparison type of 'ShouldNotEqual'.</key>
+    <key alias="cannotRectifyShouldEqualWithValue">Cannot fix a check with a value comparison type of 'ShouldEqual' with a provided value.</key>
+    <key alias="valueToRectifyNotProvided">Value to fix check not provided.</key>
 		
 	  <key alias="compilationDebugCheckSuccessMessage">Debug compilation mode is disabled.</key>
 	  <key alias="compilationDebugCheckErrorMessage">Debug compilation mode is currently enabled. It is recommended to disable this setting before go live.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1363,5 +1363,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="smtpMailSettingsHostNotConfigured">In the Web.config file system.net/mailsettings section, the host is not configured.</key>
     <key alias="smtpMailSettingsConnectionSuccess">SMTP settings are configured correctly and the service is operating as expected.</key>
     <key alias="smtpMailSettingsConnectionFail">The SMTP server configured with host '%0%' and port '%1%' could not be reached. Please check to ensure the SMTP settings in the Web.config file system.net/mailsettings are correct.</key>
+
+    <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Notification email has been set to <strong>%0%</strong>.]]></key>
+    <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
   </area>  
 </language>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1350,8 +1350,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
     <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
 
-    <key alias="clickJackingCheckHeaderFound"><![CDATA[The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was found.]]></key>
-    <key alias="clickJackingCheckHeaderNotFound"><![CDATA[The header <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was not found.]]></key>
+    <key alias="clickJackingCheckHeaderFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was found.]]></key>
+    <key alias="clickJackingCheckHeaderNotFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was not found.]]></key>
 
     <!-- The following key get these tokens passed in:
 	    0: Comma delimitted list of headers found

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1358,5 +1358,10 @@ To manage your website, simply open the Umbraco back office and start adding con
   	-->
     <key alias="excessiveHeadersFound"><![CDATA[The following headers revealing information about the website technology were found: <strong>%0%</strong>.]]></key>
     <key alias="excessiveHeadersNotFound">No headers revealing information about the website technology were found.</key>
+
+    <key alias="smtpMailSettingsNotFound">In the Web.config file, system.net/mailsettings could not be found.</key>
+    <key alias="smtpMailSettingsHostNotConfigured">In the Web.config file system.net/mailsettings section, the host is not configured.</key>
+    <key alias="smtpMailSettingsConnectionSuccess">SMTP settings are configured correctly and the service is operating as expected.</key>
+    <key alias="smtpMailSettingsConnectionFail">The SMTP server configured with host '%0%' and port '%1%' could not be reached. Please check to ensure the SMTP settings in the Web.config file system.net/mailsettings are correct.</key>
   </area>  
 </language>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1351,9 +1351,13 @@ To manage your website, simply open the Umbraco back office and start adding con
   	-->
     <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
     <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
-
+    
     <key alias="clickJackingCheckHeaderFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was found.]]></key>
     <key alias="clickJackingCheckHeaderNotFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was not found.]]></key>
+    <key alias="clickJackingSetHeaderInConfig">Set Header in Config</key>
+    <key alias="clickJackingSetHeaderInConfigDescription">Added a value to the httpProtocol/customHeaders section of web.config to prevent the site being IFRAMed.</key>
+    <key alias="clickJackingSetHeaderInConfigSuccess">A setting to create a header preventing IFRAMing of the site has been added to your web.config file.</key>
+    <key alias="clickJackingSetHeaderInConfigError">Could not update web.config file. Error: %0%</key>
 
     <!-- The following key get these tokens passed in:
 	    0: Comma delimitted list of headers found

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1331,7 +1331,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="httpsCheckEnableHttpsSuccess">The appSetting 'umbracoUseSSL' is now set to 'true' in your web.config file, your cookies will be marked as secure.</key>
 
     <key alias="rectifyButton">Fix</key>
-    <key alias="cannotRectifyShouldNotEqual">Cannot rectify a check with a value comparison type of 'ShouldNotEqual'.</key>
+    <key alias="cannotRectifyShouldNotEqual">Cannot fix a check with a value comparison type of 'ShouldNotEqual'.</key>
+    <key alias="cannotRectifyShouldEqualWithValue">Cannot fix a check with a value comparison type of 'ShouldEqual' with a provided value.</key>
+    <key alias="valueToRectifyNotProvided">Value to fix check not provided.</key>
 
     <key alias="compilationDebugCheckSuccessMessage">Debug compilation mode is disabled.</key>
     <key alias="compilationDebugCheckErrorMessage">Debug compilation mode is currently enabled. It is recommended to disable this setting before go live.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1363,5 +1363,10 @@ To manage your website, simply open the Umbraco back office and start adding con
   	-->
     <key alias="excessiveHeadersFound"><![CDATA[The following headers revealing information about the website technology were found: <strong>%0%</strong>.]]></key>
     <key alias="excessiveHeadersNotFound">No headers revealing information about the website technology were found.</key>
+
+    <key alias="smtpMailSettingsNotFound">In the Web.config file, system.net/mailsettings could not be found.</key>
+    <key alias="smtpMailSettingsHostNotConfigured">In the Web.config file system.net/mailsettings section, the host is not configured.</key>
+    <key alias="smtpMailSettingsConnectionSuccess">SMTP settings are configured correctly and the service is operating as expected.</key>
+    <key alias="smtpMailSettingsConnectionFail">The SMTP server configured with host '%0%' and port '%1%' could not be reached. Please check to ensure the SMTP settings in the Web.config file system.net/mailsettings are correct.</key>
   </area>
 </language>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1355,6 +1355,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
     <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
 
+    <key alias="clickJackingCheckHeaderFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was found.]]></key>
+    <key alias="clickJackingCheckHeaderNotFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was not found.]]></key>
+
     <!-- The following key get these tokens passed in:
 	    0: Comma delimitted list of headers found
   	-->

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1368,5 +1368,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="smtpMailSettingsHostNotConfigured">In the Web.config file system.net/mailsettings section, the host is not configured.</key>
     <key alias="smtpMailSettingsConnectionSuccess">SMTP settings are configured correctly and the service is operating as expected.</key>
     <key alias="smtpMailSettingsConnectionFail">The SMTP server configured with host '%0%' and port '%1%' could not be reached. Please check to ensure the SMTP settings in the Web.config file system.net/mailsettings are correct.</key>
+
+    <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Notification email has been set to <strong>%0%</strong>.]]></key>
+    <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
   </area>
 </language>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1359,6 +1359,10 @@ To manage your website, simply open the Umbraco back office and start adding con
 
     <key alias="clickJackingCheckHeaderFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was found.]]></key>
     <key alias="clickJackingCheckHeaderNotFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMed by another was not found.]]></key>
+    <key alias="clickJackingSetHeaderInConfig">Set Header in Config</key>
+    <key alias="clickJackingSetHeaderInConfigDescription">Added a value to the httpProtocol/customHeaders section of web.config to prevent the site being IFRAMed.</key>
+    <key alias="clickJackingSetHeaderInConfigSuccess">A setting to create a header preventing IFRAMing of the site has been added to your web.config file.</key>
+    <key alias="clickJackingSetHeaderInConfigError">Could not update web.config file. Error: %0%</key>
 
     <!-- The following key get these tokens passed in:
 	    0: Comma delimitted list of headers found

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/AbstractConfigCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/AbstractConfigCheck.cs
@@ -34,6 +34,11 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
         public string CurrentValue { get; set; }
 
         /// <summary>
+        /// Gets the provided value
+        /// </summary>
+        public string ProvidedValue { get; set; }
+
+        /// <summary>
         /// Gets the comparison type for checking the value.
         /// </summary>
         public abstract ValueComparisonType ValueComparisonType { get; }
@@ -94,8 +99,18 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
         {
             get
             {
+                var recommendedValue = Values.FirstOrDefault(v => v.IsRecommended);
+                var rectifiedValue = recommendedValue != null
+                    ? recommendedValue.Value
+                    : ProvidedValue;
                 return _textService.Localize("healthcheck/rectifySuccessMessage",
-                    new[] { CurrentValue, Values.First(v => v.IsRecommended).Value, XPath, AbsoluteFilePath });
+                    new[]
+                    {
+                        CurrentValue,
+                        rectifiedValue,
+                        XPath,
+                        AbsoluteFilePath
+                    });
             }
         }
 
@@ -105,6 +120,14 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
         public virtual bool CanRectify
         {
             get { return ValueComparisonType == ValueComparisonType.ShouldEqual; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this check can be rectified automatically if a value is provided.
+        /// </summary>
+        public virtual bool CanRectifyWithValue
+        {
+            get { return ValueComparisonType == ValueComparisonType.ShouldNotEqual; }
         }
 
         public override IEnumerable<HealthCheckStatus> GetStatus()
@@ -126,7 +149,11 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
             }
 
             // Declare the action for rectifying the config value
-            var rectifyAction = new HealthCheckAction("rectify", Id) { Name = _textService.Localize("healthcheck/rectifyButton") };
+            var rectifyAction = new HealthCheckAction("rectify", Id)
+            {
+                Name = _textService.Localize("healthcheck/rectifyButton"),
+                ValueRequired = CanRectifyWithValue,
+            };
 
             var resultMessage = string.Format(CheckErrorMessage, FileName, XPath, Values, CurrentValue);
             return new[]
@@ -134,7 +161,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
                 new HealthCheckStatus(resultMessage)
                 {
                     ResultType = StatusResultType.Error,
-                    Actions = CanRectify ? new[] { rectifyAction } : new HealthCheckAction[0]
+                    Actions = CanRectify || CanRectifyWithValue ? new[] { rectifyAction } : new HealthCheckAction[0]
                 }
             };
         }
@@ -149,7 +176,31 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
                 throw new InvalidOperationException(_textService.Localize("healthcheck/cannotRectifyShouldNotEqual"));
 
             var recommendedValue = Values.First(v => v.IsRecommended).Value;
-            var updateConfigFile = _configurationService.UpdateConfigFile(recommendedValue);
+            return UpdateConfigurationValue(recommendedValue);
+        }
+
+        /// <summary>
+        /// Rectifies this check with a provided value.
+        /// </summary>
+        /// <param name="value">Value provided</param>
+        /// <returns></returns>
+        public virtual HealthCheckStatus Rectify(string value)
+        {
+            if (ValueComparisonType == ValueComparisonType.ShouldEqual)
+                throw new InvalidOperationException(_textService.Localize("healthcheck/cannotRectifyShouldEqualWithValue"));
+
+            if (string.IsNullOrWhiteSpace(value))
+                throw new InvalidOperationException(_textService.Localize("healthcheck/valueToRectifyNotProvided"));
+
+            // Need to track provided value in order to correctly put together the rectify message
+            ProvidedValue = value;
+
+            return UpdateConfigurationValue(value);
+        }
+
+        private HealthCheckStatus UpdateConfigurationValue(string value)
+        {
+            var updateConfigFile = _configurationService.UpdateConfigFile(value);
 
             if (updateConfigFile.Success == false)
             {
@@ -163,7 +214,9 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
 
         public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
         {
-            return Rectify();
+            return string.IsNullOrEmpty(action.ProvidedValue)
+                ? Rectify()
+                : Rectify(action.ProvidedValue);
         }
     }
 }

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/AbstractConfigCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/AbstractConfigCheck.cs
@@ -119,7 +119,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
             CurrentValue = configValue.Result;
 
             var valueFound = Values.Any(value => string.Equals(CurrentValue, value.Value, StringComparison.InvariantCultureIgnoreCase));
-            if (ValueComparisonType == ValueComparisonType.ShouldEqual && valueFound || ValueComparisonType == ValueComparisonType.ShouldNotEqual && valueFound)
+            if (ValueComparisonType == ValueComparisonType.ShouldEqual && valueFound || ValueComparisonType == ValueComparisonType.ShouldNotEqual && valueFound == false)
             {
                 var message = string.Format(CheckSuccessMessage, FileName, XPath, Values, CurrentValue);
                 return new[] { new HealthCheckStatus(message) { ResultType = StatusResultType.Success } };

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/AbstractConfigCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/AbstractConfigCheck.cs
@@ -2,11 +2,12 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Web;
+using Umbraco.Core.IO;
 using Umbraco.Core.Services;
 
 namespace Umbraco.Web.HealthCheck.Checks.Config
 {
+
     public abstract class AbstractConfigCheck : HealthCheck
     {
         private readonly ConfigurationService _configurationService;
@@ -56,7 +57,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
         /// </summary>
         private string AbsoluteFilePath
         {
-            get { return HttpContext.Current.Server.MapPath(FilePath); }
+            get { return IOHelper.MapPath(FilePath); }
         }
 
         /// <summary>

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/NotificationEmailCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/NotificationEmailCheck.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Web.HealthCheck.Checks.Config
+{
+    [HealthCheck("3E2F7B14-4B41-452B-9A30-E67FBC8E1206", "Notification Email Settings",
+        Description = "If notifications are used, the 'from' email address should be specified and changed from the default value.",
+        Group = "Configuration")]
+    public class NotificationEmailCheck : AbstractConfigCheck
+    {
+        private readonly ILocalizedTextService _textService;
+        private const string DefaultFromEmail = "your@email.here";
+
+        public NotificationEmailCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
+        {
+            _textService = healthCheckContext.ApplicationContext.Services.TextService;
+        }
+
+        public override string FilePath
+        {
+            get { return "~/Config/umbracoSettings.config"; }
+        }
+
+        public override string XPath
+        {
+            get { return "/settings/content/notifications/email"; }
+        }
+
+        public override ValueComparisonType ValueComparisonType
+        {
+            get { return ValueComparisonType.ShouldNotEqual; }
+        }
+
+        public override IEnumerable<AcceptableConfiguration> Values
+        {
+            get
+            {
+                return new List<AcceptableConfiguration>
+                {
+                    new AcceptableConfiguration { IsRecommended = false, Value = DefaultFromEmail }
+                };
+            }
+        }
+
+        public override string CheckSuccessMessage
+        {
+            get { return _textService.Localize("healthcheck/notificationEmailsCheckSuccessMessage", new [] { CurrentValue } ); }
+        }
+
+        public override string CheckErrorMessage
+        {
+            get { return _textService.Localize("healthcheck/notificationEmailsCheckErrorMessage", new[] { DefaultFromEmail }); }
+        }
+    }
+}

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/TrySkipIisCustomErrorsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/TrySkipIisCustomErrorsCheck.cs
@@ -7,7 +7,7 @@ using Umbraco.Core.Services;
 namespace Umbraco.Web.HealthCheck.Checks.Config
 {
     [HealthCheck("046A066C-4FB2-4937-B931-069964E16C66", "Try Skip IIS Custom Errors",
-        Description = "Starting with IIS 7.5, this must be set to true for Umbraco 404 pages to show. Else, IIS will takeover and render its built-in error page.",
+        Description = "Starting with IIS 7.5, this must be set to true for Umbraco 404 pages to show. Otherwise, IIS will takeover and render its built-in error page.",
         Group = "Configuration")]
     public class TrySkipIisCustomErrorsCheck : AbstractConfigCheck
     {

--- a/src/Umbraco.Web/HealthCheck/Checks/Permissions/FolderAndFilePermissionsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Permissions/FolderAndFilePermissionsCheck.cs
@@ -28,9 +28,6 @@ namespace Umbraco.Web.HealthCheck.Checks.Permissions
     {
         private readonly ILocalizedTextService _textService;
 
-        private const string CheckFolderPermissionsAction = "checkFolderPermissions";
-        private const string CheckFilePermissionsAction = "checkFilePermissions";
-
         public FolderAndFilePermissionsCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
         {
             _textService = healthCheckContext.ApplicationContext.Services.TextService;
@@ -53,15 +50,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Permissions
         /// <returns></returns>
         public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
         {
-            switch (action.Alias)
-            {
-                case CheckFolderPermissionsAction:
-                    return CheckFolderPermissions();
-                case CheckFilePermissionsAction:
-                    return CheckFilePermissions();
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+            throw new InvalidOperationException("FolderAndFilePermissionsCheck has no executable actions");
         }
 
         private HealthCheckStatus CheckFolderPermissions()

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/ClickJackingCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/ClickJackingCheck.cs
@@ -38,13 +38,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         /// <returns></returns>
         public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
         {
-            switch (action.Alias)
-            {
-                case "checkForFrameOptionsHeader":
-                    return CheckForFrameOptionsHeader();
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+            throw new InvalidOperationException("ClickJackingCheck has no executable actions");
         }
 
         private HealthCheckStatus CheckForFrameOptionsHeader()

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/ClickJackingCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/ClickJackingCheck.cs
@@ -4,12 +4,13 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Umbraco.Core.IO;
 using Umbraco.Core.Services;
 
 namespace Umbraco.Web.HealthCheck.Checks.Security
 {
-    using System.Text.RegularExpressions;
-
     [HealthCheck(
         "ED0D7E40-971E-4BE8-AB6D-8CC5D0A6A5B0",
         "Click-Jacking Protection",
@@ -18,6 +19,8 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
     public class ClickJackingCheck : HealthCheck
     {
         private readonly ILocalizedTextService _textService;
+
+        private const string SetFrameOptionsHeaderInConfigActiobn = "setFrameOptionsHeaderInConfig";
 
         private const string XFrameOptionsHeader = "X-Frame-Options";
 
@@ -43,7 +46,13 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         /// <returns></returns>
         public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
         {
-            throw new InvalidOperationException("ClickJackingCheck has no executable actions");
+            switch (action.Alias)
+            {
+                case SetFrameOptionsHeaderInConfigActiobn:
+                    return SetFrameOptionsHeaderInConfig();
+                default:
+                    throw new InvalidOperationException("HttpsCheck action requested is either not executable or does not exist");
+            }
         }
 
         private HealthCheckStatus CheckForFrameOptionsHeader()
@@ -79,6 +88,14 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             }
 
             var actions = new List<HealthCheckAction>();
+            if (success == false)
+            {
+                actions.Add(new HealthCheckAction(SetFrameOptionsHeaderInConfigActiobn, Id)
+                {
+                    Name = _textService.Localize("healthcheck/clickJackingSetHeaderInConfig"),
+                    Description = _textService.Localize("healthcheck/clickJackingSetHeaderInConfigDescription")
+                });
+            }
 
             return
                 new HealthCheckStatus(message)
@@ -114,6 +131,83 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             return regex.Matches(html)
                 .Cast<Match>()
                 .ToDictionary(m => m.Groups[1].Value, m => m.Groups[2].Value);
+        }
+
+        private HealthCheckStatus SetFrameOptionsHeaderInConfig()
+        {
+            var errorMessage = string.Empty;
+            var success = SaveHeaderToConfigFile(out errorMessage);
+
+            if (success)
+            {
+                return
+                    new HealthCheckStatus(_textService.Localize("healthcheck/clickJackingSetHeaderInConfigSuccess"))
+                    {
+                        ResultType = StatusResultType.Success
+                    };
+            }
+
+            return
+                new HealthCheckStatus(_textService.Localize("healthcheck/clickJackingSetHeaderInConfigError", new [] { errorMessage }))
+                {
+                    ResultType = StatusResultType.Error
+                };
+        }
+
+        private static bool SaveHeaderToConfigFile(out string errorMessage)
+        {
+            try
+            {
+                // There don't look to be any useful classes defined in https://msdn.microsoft.com/en-us/library/system.web.configuration(v=vs.110).aspx
+                // for working with the customHeaders section, so working with the XML directly.
+                var configFile = IOHelper.MapPath("~/Web.config");
+                var doc = XDocument.Load(configFile);
+                var systemWebServerElement = doc.XPathSelectElement("/configuration/system.webServer");
+                var httpProtocolElement = systemWebServerElement.Element("httpProtocol");
+                if (httpProtocolElement == null)
+                {
+                    httpProtocolElement = new XElement("httpProtocol");
+                    systemWebServerElement.Add(httpProtocolElement);
+                }
+
+                var customHeadersElement = httpProtocolElement.Element("customHeaders");
+                if (customHeadersElement == null)
+                {
+                    customHeadersElement = new XElement("customHeaders");
+                    httpProtocolElement.Add(customHeadersElement);
+                }
+
+                var removeHeaderElement = customHeadersElement.Elements("remove")
+                    .SingleOrDefault(x => x.Attribute("name") != null &&
+                                          x.Attribute("name").Value == XFrameOptionsHeader);
+                if (removeHeaderElement == null)
+                {
+                    removeHeaderElement = new XElement("remove");
+                    removeHeaderElement.Add(new XAttribute("name", XFrameOptionsHeader));
+                    customHeadersElement.Add(removeHeaderElement);
+                }
+
+                var addHeaderElement = customHeadersElement.Elements("add")
+                    .SingleOrDefault(x => x.Attribute("name") != null &&
+                                          x.Attribute("name").Value == XFrameOptionsHeader);
+                if (addHeaderElement == null)
+                {
+                    addHeaderElement = new XElement("add");
+                    addHeaderElement.Add(new XAttribute("name", XFrameOptionsHeader));
+                    addHeaderElement.Add(new XAttribute("value", "deny"));
+                    customHeadersElement.Add(addHeaderElement);
+                }
+
+                doc.Save(configFile);
+
+                errorMessage = string.Empty;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                errorMessage = ex.Message;
+                return false;
+            }
         }
     }
 }

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/ExcessiveHeadersCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/ExcessiveHeadersCheck.cs
@@ -38,13 +38,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         /// <returns></returns>
         public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
         {
-            switch (action.Alias)
-            {
-                case "checkForHeaders":
-                    return CheckForHeaders();
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+            throw new InvalidOperationException("ExcessiveHeadersCheck has no executable actions");
         }
 
         private HealthCheckStatus CheckForHeaders()

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
@@ -16,9 +16,6 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
     {
         private readonly ILocalizedTextService _textService;
 
-        private const string CheckForValidCertificateAction = "checkForValidCertificate";
-        private const string CheckHttpsConfigurationSettingAction = "checkHttpsConfigurationSetting";
-        private const string CheckIfCurrentSchemeIsHttpsAction = "checkIfCurrentSchemeIsHttps";
         private const string FixHttpsSettingAction = "fixHttpsSetting";
 
         public HttpsCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
@@ -45,16 +42,10 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         {
             switch (action.Alias)
             {
-                case CheckForValidCertificateAction:
-                    return CheckForValidCertificate();
-                case CheckHttpsConfigurationSettingAction:
-                    return CheckHttpsConfigurationSetting();
-                case CheckIfCurrentSchemeIsHttpsAction:
-                    return CheckIfCurrentSchemeIsHttps();
                 case FixHttpsSettingAction:
                     return FixHttpsSetting();
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new InvalidOperationException("HttpsCheck action requested is either not executable or does not exist");
             }
         }
 

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Web;
+using Umbraco.Core.IO;
 using Umbraco.Core.Services;
 using Umbraco.Web.HealthCheck.Checks.Config;
 
@@ -112,7 +113,6 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             var uri = HttpContext.Current.Request.Url;
             var actions = new List<HealthCheckAction>();
 
-
             string resultMessage;
             StatusResultType resultType;
             if (uri.Scheme != "https")
@@ -144,7 +144,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 
         private HealthCheckStatus FixHttpsSetting()
         {
-            var configFile = HttpContext.Current.Server.MapPath("~/Web.config");
+            var configFile = IOHelper.MapPath("~/Web.config");
             const string xPath = "/configuration/appSettings/add[@key='umbracoUseSSL']/@value";
             var configurationService = new ConfigurationService(configFile, xPath);
             var updateConfigFile = configurationService.UpdateConfigFile("true");

--- a/src/Umbraco.Web/HealthCheck/Checks/Services/SmtpCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Services/SmtpCheck.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Configuration;
+using System.Net.Sockets;
+using System.Web.Configuration;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Web.HealthCheck.Checks.Services
+{
+    [HealthCheck(
+        "1B5D221B-CE99-4193-97CB-5F3261EC73DF",
+        "SMTP Settings",
+        Description = "Checks that valid settings for sending emails are in place.",
+        Group = "Services")]
+    public class SmtpCheck : HealthCheck
+    {
+        private readonly ILocalizedTextService _textService;
+
+        public SmtpCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
+        {
+            _textService = healthCheckContext.ApplicationContext.Services.TextService;
+        }
+
+        /// <summary>
+        /// Get the status for this health check
+        /// </summary>
+        /// <returns></returns>
+        public override IEnumerable<HealthCheckStatus> GetStatus()
+        {
+            //return the statuses
+            return new[] { CheckSmtpSettings() };
+        }
+
+        /// <summary>
+        /// Executes the action and returns it's status
+        /// </summary>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            throw new InvalidOperationException("SmtpCheck has no executable actions");
+        }
+
+        private HealthCheckStatus CheckSmtpSettings()
+        {
+            const int DefaultSmtpPort = 25;
+            var message = string.Empty;
+            var success = false;
+
+            var config = WebConfigurationManager.OpenWebConfiguration(HealthCheckContext.HttpContext.Request.ApplicationPath);
+            var settings = (MailSettingsSectionGroup)config.GetSectionGroup("system.net/mailSettings");
+            if (settings == null)
+            {
+                message = _textService.Localize("healthcheck/smtpMailSettingsNotFound");
+            }
+            else
+            {
+                var host = settings.Smtp.Network.Host;
+                var port = settings.Smtp.Network.Port == 0 ? DefaultSmtpPort : settings.Smtp.Network.Port;
+                if (string.IsNullOrEmpty(host))
+                {
+                    message = _textService.Localize("healthcheck/smtpMailSettingsHostNotConfigured");
+                }
+                else
+                {
+                    success = CanMakeSmtpConnection(host, port);
+                    message = success
+                        ? _textService.Localize("healthcheck/smtpMailSettingsConnectionSuccess")
+                        : _textService.Localize("healthcheck/smtpMailSettingsConnectionFail", new [] { host, port.ToString() });
+                }
+            }
+
+            var actions = new List<HealthCheckAction>();
+            return
+                new HealthCheckStatus(message)
+                {
+                    ResultType = success ? StatusResultType.Success : StatusResultType.Error,
+                    Actions = actions
+                };
+        }
+
+        private bool CanMakeSmtpConnection(string host, int port)
+        {
+            try
+            {
+                using (var client = new TcpClient())
+                {
+                    client.Connect(host, port);
+                    using (var stream = client.GetStream())
+                    {
+                        using (var writer = new StreamWriter(stream))
+                        using (var reader = new StreamReader(stream))
+                        {
+                            writer.WriteLine("EHLO " + host);
+                            writer.Flush();
+                            reader.ReadLine();
+                            return true;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/HealthCheck/HealthCheckAction.cs
+++ b/src/Umbraco.Web/HealthCheck/HealthCheckAction.cs
@@ -36,7 +36,7 @@ namespace Umbraco.Web.HealthCheck
         /// <remarks>
         /// This is used to find the Health Check instance to execute this action
         /// </remarks>
-        [DataMember(Name = "healtCheckId")]
+        [DataMember(Name = "healthCheckId")]
         public Guid HealthCheckId { get; set; }
 
         /// <summary>
@@ -63,5 +63,17 @@ namespace Umbraco.Web.HealthCheck
         /// </summary>
         [DataMember(Name = "description")]
         public string Description { get; set; }
+
+        /// <summary>
+        /// Indicates if a value is required to rectify the issue
+        /// </summary>
+        [DataMember(Name = "valueRequired")]
+        public bool ValueRequired { get; set; }
+
+        /// <summary>
+        /// Provides a value to rectify the issue
+        /// </summary>
+        [DataMember(Name = "providedValue")]
+        public string ProvidedValue { get; set; }
     }
 }

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -324,6 +324,7 @@
     <Compile Include="HealthCheck\Checks\Config\ConfigurationService.cs" />
     <Compile Include="HealthCheck\Checks\Config\ConfigurationServiceResult.cs" />
     <Compile Include="HealthCheck\Checks\Config\MacroErrorsCheck.cs" />
+    <Compile Include="HealthCheck\Checks\Config\NotificationEmailCheck.cs" />
     <Compile Include="HealthCheck\Checks\Config\TrySkipIisCustomErrorsCheck.cs" />
     <Compile Include="HealthCheck\Checks\Config\CustomErrorsCheck.cs" />
     <Compile Include="HealthCheck\Checks\Config\TraceCheck.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -329,6 +329,7 @@
     <Compile Include="HealthCheck\Checks\Config\TraceCheck.cs" />
     <Compile Include="HealthCheck\Checks\Config\ValueComparisonType.cs" />
     <Compile Include="HealthCheck\Checks\Config\CompilationDebugCheck.cs" />
+    <Compile Include="HealthCheck\Checks\Services\SmtpCheck.cs" />
     <Compile Include="HealthCheck\Checks\Permissions\FolderAndFilePermissionsCheck.cs" />
     <Compile Include="HealthCheck\Checks\Security\ExcessiveHeadersCheck.cs" />
     <Compile Include="HealthCheck\Checks\Security\ClickJackingCheck.cs" />


### PR DESCRIPTION
- Reworked some existing code to make explicit that only fixable actions can be executed
- Extended click-jack test to check for meta-tag and to be fixable by writing to the web.config file
- Added checks for SMTP and notification settings
- Allowed for checks that require user input to be fixable