### PR TITLE
u4-3805 - Ensured click-jacking meta-tag health check searches case insensitively...

### DIFF
--- a/src/Umbraco.Web/HealthCheck/Checks/Security/ClickJackingCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/ClickJackingCheck.cs
@@ -126,7 +126,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 
         private static Dictionary<string, string> ParseMetaTags(string html)
         {
-            var regex = new Regex("<meta http-equiv=\"(.+?)\" content=\"(.+?)\">");
+            var regex = new Regex("<meta http-equiv=\"(.+?)\" content=\"(.+?)\"", RegexOptions.IgnoreCase);
 
             return regex.Matches(html)
                 .Cast<Match>()


### PR DESCRIPTION
... and doesn't worry about how the tag is closed.