### PR TITLE
Update markdowneditor.controller.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
@@ -57,9 +57,11 @@ function MarkdownEditorController($scope, $element, assetsService, dialogService
                     });
 
                     editor2.hooks.set("onPreviewRefresh", function () {
-                        angularHelper.getCurrentForm($scope).$setDirty();
-                        // We must manually update the model as there is no way to hook into the markdown editor events without editing that code.
-                        $scope.model.value = $("textarea", $element).val();
+                        // We must manually update the model as there is no way to hook into the markdown editor events without exstensive edits to the library.
+                        if ($scope.model.value != $("textarea", $element).val()) {
+                            angularHelper.getCurrentForm($scope).$setDirty();
+                            $scope.model.value = $("textarea", $element).val();
+                        }
                     });
 
                 }, 200);


### PR DESCRIPTION
This is a important fix for the Markdown property type.  I added code previously to get it to properly record changes made via the button controls.  This was causing every document loaded with a markdown property on it to immedetly be flagged as checked with IsDirty() instead of only when a change was actually made.