### PR TITLE
U4-8592 Decimal Publish Bug: Behaves differently when publishing thro…

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -443,6 +444,9 @@ namespace Umbraco.Core.Persistence.Repositories
                 property.Id = keyDictionary[property.PropertyTypeId];
             }
 
+            //Update property values with correct types from DataTypeDatabaseType
+            UpdatePropertyTypeValues(entity);
+
             //lastly, check if we are a creating a published version , then update the tags table
             if (entity.Published)
             {
@@ -607,6 +611,9 @@ namespace Umbraco.Core.Persistence.Repositories
                     property.Id = keyDictionary[property.PropertyTypeId];
                 }
             }
+
+            //Update property values with correct types from DataTypeDatabaseType
+            UpdatePropertyTypeValues(entity);
 
             //lastly, check if we are a newly published version and then update the tags table
             if (publishedStateChanged && entity.Published)

--- a/src/Umbraco.Core/Persistence/Repositories/MediaRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/MediaRepository.cs
@@ -335,6 +335,9 @@ namespace Umbraco.Core.Persistence.Repositories
                 property.Id = keyDictionary[property.PropertyTypeId];
             }
 
+            //Update property values with correct types from DataTypeDatabaseType
+            UpdatePropertyTypeValues(entity);
+
             UpdatePropertyTags(entity, _tagRepository);
 
             entity.ResetDirtyProperties();
@@ -416,6 +419,9 @@ namespace Umbraco.Core.Persistence.Repositories
                     property.Id = keyDictionary[property.PropertyTypeId];
                 }
             }
+
+            //Update property values with correct types from DataTypeDatabaseType
+            UpdatePropertyTypeValues(entity);
 
             UpdatePropertyTags(entity, _tagRepository);
 

--- a/src/Umbraco.Core/Persistence/Repositories/MemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/MemberRepository.cs
@@ -256,6 +256,9 @@ namespace Umbraco.Core.Persistence.Repositories
                 property.Id = keyDictionary[property.PropertyTypeId];
             }
 
+            //Update property values with correct types from DataTypeDatabaseType
+            UpdatePropertyTypeValues(entity);
+
             UpdatePropertyTags(entity, _tagRepository);
 
             ((Member)entity).ResetDirtyProperties();
@@ -368,6 +371,9 @@ namespace Umbraco.Core.Persistence.Repositories
                     property.Id = keyDictionary[property.PropertyTypeId];
                 }
             }
+
+            //Update property values with correct types from DataTypeDatabaseType
+            UpdatePropertyTypeValues(entity);
 
             UpdatePropertyTags(entity, _tagRepository);
 

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1991,7 +1991,7 @@ namespace Umbraco.Core.Services
                 }
 
                 //we are successfully published if our publishStatus is still Successful
-                bool published = publishStatus.StatusType == PublishStatusType.Success;
+                var published = publishStatus.StatusType == PublishStatusType.Success;
 
                 var uow = UowProvider.GetUnitOfWork();
                 using (var repository = RepositoryFactory.CreateContentRepository(uow))
@@ -2008,6 +2008,8 @@ namespace Umbraco.Core.Services
                     content.WriterId = userId;
 
                     repository.AddOrUpdate(content);
+                    
+                    content = repository.Get(content.Id);
 
                     //Generate a new preview
                     repository.AddOrUpdatePreviewXml(content, c => _entitySerializer.Serialize(this, _dataTypeService, _userService, c));

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1991,7 +1991,7 @@ namespace Umbraco.Core.Services
                 }
 
                 //we are successfully published if our publishStatus is still Successful
-                var published = publishStatus.StatusType == PublishStatusType.Success;
+                bool published = publishStatus.StatusType == PublishStatusType.Success;
 
                 var uow = UowProvider.GetUnitOfWork();
                 using (var repository = RepositoryFactory.CreateContentRepository(uow))
@@ -2008,8 +2008,6 @@ namespace Umbraco.Core.Services
                     content.WriterId = userId;
 
                     repository.AddOrUpdate(content);
-                    
-                    content = repository.Get(content.Id);
 
                     //Generate a new preview
                     repository.AddOrUpdatePreviewXml(content, c => _entitySerializer.Serialize(this, _dataTypeService, _userService, c));

--- a/src/Umbraco.Tests/Persistence/Repositories/ContentRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/ContentRepositoryTest.cs
@@ -44,6 +44,14 @@ namespace Umbraco.Tests.Persistence.Repositories
             base.TearDown();
         }
 
+        private ContentRepository CreateRepository(IDatabaseUnitOfWork unitOfWork, out ContentTypeRepository contentTypeRepository, out DataTypeDefinitionRepository dtdRepository)
+        {
+            TemplateRepository tr;
+            var ctRepository = CreateRepository(unitOfWork, out contentTypeRepository, out tr);
+            dtdRepository = new DataTypeDefinitionRepository(unitOfWork, CacheHelper, Logger, SqlSyntax, contentTypeRepository);
+            return ctRepository;
+        }
+
         private ContentRepository CreateRepository(IDatabaseUnitOfWork unitOfWork, out ContentTypeRepository contentTypeRepository)
         {
             TemplateRepository tr;
@@ -220,6 +228,68 @@ namespace Umbraco.Tests.Persistence.Repositories
                 repository.RebuildXmlStructures(media => new XElement("test"), 10, contentTypeIds: new[] { contentType1.Id, contentType2.Id });
 
                 Assert.AreEqual(60, unitOfWork.Database.ExecuteScalar<int>("SELECT COUNT(*) FROM cmsContentXml"));
+            }
+        }
+
+        /// <summary>
+        /// This test ensures that when property values using special database fields are saved, the actual data in the
+        /// object being stored is also transformed in the same way as the data being stored in the database is.
+        /// Before you would see that ex: a decimal value being saved as 100 or "100", would be that exact value in the 
+        /// object, but the value saved to the database was actually 100.000000.
+        /// When querying the database for the value again - the value would then differ from what is in the object. 
+        /// This caused inconsistencies between saving+publishing and simply saving and then publishing, due to the former 
+        /// sending the non-transformed data directly on to publishing.
+        /// </summary>
+        [Test]
+        public void Property_Values_With_Special_DatabaseTypes_Are_Equal_Before_And_After_Being_Persisted()
+        {
+            var provider = new PetaPocoUnitOfWorkProvider(Logger);
+            var unitOfWork = provider.GetUnitOfWork();
+            ContentTypeRepository contentTypeRepository;
+            DataTypeDefinitionRepository dataTypeDefinitionRepository;
+            using (var repository = CreateRepository(unitOfWork, out contentTypeRepository, out dataTypeDefinitionRepository))
+            {
+                // Setup
+                var dtd = new DataTypeDefinition(-1, Constants.PropertyEditors.DecimalAlias) {Name = "test", DatabaseType = DataTypeDatabaseType.Decimal};
+                dataTypeDefinitionRepository.AddOrUpdate(dtd);
+                unitOfWork.Commit();
+
+                var decimalPropertyAlias = "decimalProperty";
+                var intPropertyAlias = "intProperty";
+                var dateTimePropertyAlias = "datetimeProperty";
+                var dateValue = new DateTime(2016, 1, 6);
+
+                var propertyTypeCollection = new PropertyTypeCollection(
+                    new List<PropertyType>
+                    {
+                        MockedPropertyTypes.CreateDecimalProperty(decimalPropertyAlias, "Decimal property", dtd.Id),
+                        MockedPropertyTypes.CreateIntegerProperty(intPropertyAlias, "Integer property"),
+                        MockedPropertyTypes.CreateDateTimeProperty(dateTimePropertyAlias, "DateTime property")
+
+                    });
+                var contentType = MockedContentTypes.CreateSimpleContentType("umbTextpage1", "Textpage", propertyTypeCollection);
+                contentTypeRepository.AddOrUpdate(contentType);
+                unitOfWork.Commit();
+                
+                // Int and decimal values are passed in as strings as they would be from the backoffice UI
+                var textpage = MockedContent.CreateSimpleContentWithSpecialDatabaseTypes(contentType, "test@umbraco.org", -1, "100", "150", dateValue);
+                
+                // Act
+                repository.AddOrUpdate(textpage);
+                unitOfWork.Commit();
+
+                // Assert
+                Assert.That(contentType.HasIdentity, Is.True);
+                Assert.That(textpage.HasIdentity, Is.True);
+                
+                var persistedTextpage = repository.Get(textpage.Id);
+                Assert.That(persistedTextpage.Name, Is.EqualTo(textpage.Name));
+                Assert.AreEqual(100m, persistedTextpage.GetValue(decimalPropertyAlias));
+                Assert.AreEqual(persistedTextpage.GetValue(decimalPropertyAlias), textpage.GetValue(decimalPropertyAlias));
+                Assert.AreEqual(150, persistedTextpage.GetValue(intPropertyAlias));
+                Assert.AreEqual(persistedTextpage.GetValue(intPropertyAlias), textpage.GetValue(intPropertyAlias));
+                Assert.AreEqual(dateValue, persistedTextpage.GetValue(dateTimePropertyAlias));
+                Assert.AreEqual(persistedTextpage.GetValue(dateTimePropertyAlias), textpage.GetValue(dateTimePropertyAlias));
             }
         }
 

--- a/src/Umbraco.Tests/TestHelpers/Entities/MockedContent.cs
+++ b/src/Umbraco.Tests/TestHelpers/Entities/MockedContent.cs
@@ -79,6 +79,24 @@ namespace Umbraco.Tests.TestHelpers.Entities
             return content;
         }
 
+        public static Content CreateSimpleContentWithSpecialDatabaseTypes(IContentType contentType, string name, int parentId, string decimalValue, string intValue, DateTime datetimeValue)
+        {
+            var content = new Content(name, parentId, contentType) { Language = "en-US", CreatorId = 0, WriterId = 0 };
+            object obj =
+                new
+                {
+                    decimalProperty = decimalValue,
+                    intProperty = intValue,
+                    datetimeProperty = datetimeValue
+                };
+
+            content.PropertyValues(obj);
+
+            content.ResetDirtyProperties(false);
+
+            return content;
+        }
+
         public static Content CreateAllTypesContent(IContentType contentType, string name, int parentId)
         {
             var content = new Content("Random Content Name", parentId, contentType) { Language = "en-US", Level = 1, SortOrder = 1, CreatorId = 0, WriterId = 0 };

--- a/src/Umbraco.Tests/TestHelpers/Entities/MockedPropertyTypes.cs
+++ b/src/Umbraco.Tests/TestHelpers/Entities/MockedPropertyTypes.cs
@@ -1,0 +1,66 @@
+﻿using Umbraco.Core.Models;
+
+namespace Umbraco.Tests.TestHelpers.Entities
+{
+    public class MockedPropertyTypes
+    {
+        /// <summary>
+        /// Returns a decimal property.
+        /// Requires a datatype definition Id, since this is not one of the pre-populated datatypes
+        /// </summary>
+        /// <param name="alias">Alias of the created property type</param>
+        /// <param name="name">Name of the created property type</param>
+        /// <param name="dtdId">Integer Id of a decimal datatype to use</param>
+        /// <returns>Property type storing decimal value</returns>
+        public static PropertyType CreateDecimalProperty(string alias, string name, int dtdId)
+        {
+            return
+                new PropertyType("test", DataTypeDatabaseType.Decimal, alias)
+                {
+                    Name = name,
+                    Description = "Decimal property type",
+                    Mandatory = false,
+                    SortOrder = 4,
+                    DataTypeDefinitionId = dtdId
+                };
+        }
+
+        /// <summary>
+        /// Returns a integer property.
+        /// </summary>
+        /// <param name="alias">Alias of the created property type</param>
+        /// <param name="name">Name of the created property type</param>
+        /// <returns>Property type storing integer value</returns>
+        public static PropertyType CreateIntegerProperty(string alias, string name)
+        {
+            return
+                new PropertyType("test", DataTypeDatabaseType.Integer, alias)
+                {
+                    Name = name,
+                    Description = "Integer property type",
+                    Mandatory = false,
+                    SortOrder = 4,
+                    DataTypeDefinitionId = -51
+                };
+        }
+
+        /// <summary>
+        /// Returns a DateTime property.
+        /// </summary>
+        /// <param name="alias">Alias of the created property type</param>
+        /// <param name="name">Name of the created property type</param>
+        /// <returns>Property type storing DateTime value</returns>
+        public static PropertyType CreateDateTimeProperty(string alias, string name)
+        {
+            return
+                new PropertyType("test", DataTypeDatabaseType.Date, alias)
+                {
+                    Name = name,
+                    Description = "DateTime property type",
+                    Mandatory = false,
+                    SortOrder = 4,
+                    DataTypeDefinitionId = -36
+                };
+        }
+    }
+}

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Migrations\MigrationIssuesTests.cs" />
     <Compile Include="Persistence\Migrations\MigrationStartupHandlerTests.cs" />
     <Compile Include="Persistence\Repositories\RedirectUrlRepositoryTests.cs" />
+    <Compile Include="TestHelpers\Entities\MockedPropertyTypes.cs" />
     <Compile Include="Web\AngularIntegration\AngularAntiForgeryTests.cs" />
     <Compile Include="Web\AngularIntegration\ContentModelSerializationTests.cs" />
     <Compile Include="Web\AngularIntegration\JsInitializationTests.cs" />


### PR DESCRIPTION
…ugh Edit Content vs the API

The properties coming from the save event, are sent on to publishing without any potential changes happening upon saving to the database.
One of these changes is the value doesn't actually become a real decimal value before it is persisted so it would get published as the value typed in the editor field instead of what is actually now persisted to the database.