### PR TITLE
Pass the $element scope to the Markdown library.  The Markdown code t…

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/markdown/markdown.editor.js
+++ b/src/Umbraco.Web.UI.Client/lib/markdown/markdown.editor.js
@@ -49,7 +49,7 @@
     // - getConverter() returns the markdown converter object that was passed to the constructor
     // - run() actually starts the editor; should be called after all necessary plugins are registered. Calling this more than once is a no-op.
     // - refreshPreview() forces the preview to be updated. This method is only available after run() was called.
-    Markdown.Editor = function (markdownConverter, idPostfix, help) {
+    Markdown.Editor = function (markdownConverter, $element, idPostfix, help) {
 
         idPostfix = idPostfix || "";
 
@@ -70,7 +70,7 @@
             if (panels)
                 return; // already initialized
 
-            panels = new PanelCollection(idPostfix);
+            panels = new PanelCollection($element, idPostfix);
             var commandManager = new CommandManager(hooks);
             var previewManager = new PreviewManager(markdownConverter, panels, function () { hooks.onPreviewRefresh(); });
             var undoManager, uiManager;
@@ -246,10 +246,10 @@
     // This ONLY affects Internet Explorer (tested on versions 6, 7
     // and 8) and ONLY on button clicks.  Keyboard shortcuts work
     // normally since the focus never leaves the textarea.
-    function PanelCollection(postfix) {
-        this.buttonBar = doc.getElementById("wmd-button-bar" + postfix);
-        this.preview = doc.getElementById("wmd-preview" + postfix);
-        this.input = doc.getElementById("wmd-input" + postfix);
+    function PanelCollection($element, postfix) {
+        this.buttonBar = $("#wmd-button-bar" + postfix, $element)[0];
+        this.preview = $("#wmd-preview" + postfix, $element)[0];
+        this.input = $("#wmd-input" + postfix, $element)[0];
     };
 
     // Returns true if the DOM element is visible, false if it's hidden.

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
@@ -47,7 +47,7 @@ function MarkdownEditorController($scope, $element, assetsService, dialogService
                 // so run the init on a timeout
                 $timeout(function () {
                     var converter2 = new Markdown.Converter();
-                    var editor2 = new Markdown.Editor(converter2, "-" + $scope.model.alias);
+                    var editor2 = new Markdown.Editor(converter2, $element, "-" + $scope.model.alias);
                     editor2.run();
 
                     //subscribe to the image dialog clicks


### PR DESCRIPTION
…ries to load and bind controls by ID.  In some cases the developers my create a setup with repeating or nested datatypes where multiple markdown fields exists with the same allies.

Instead of doing some complex change to ensure that the control ID"s are unique, this change simply passes the current controllers $element scoped to its html to the library.  Then the library uses the jQuery $("#Id", $element) call to load the proper control from within the scope instead of document.getElementById() which is global.