### PR TITLE
Implemented better translations for the create data type dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/create.html
@@ -10,7 +10,7 @@
                     <i class="large icon-autofill"></i>
 
                     <span class="menu-label">
-                        <localize key="general_new">New</localize>&nbsp;Data type
+                        <localize key="create_newDataType">New data type</localize>
                     </span>
 
                 </a>
@@ -21,7 +21,7 @@
                     <i class="large icon-folder"></i>
 
                     <span class="menu-label">
-                        Folder
+                        <localize key="create_newFolder">New folder</localize>
                     </span>
                 </a>
             </li>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -182,6 +182,8 @@
     <key alias="noDocumentTypes" version="7.0"><![CDATA[Der kunne ikke findes nogen tilladte dokument typer. Du skal tillade disse i indstillinger under <strong>"dokument typer"</strong>.]]></key>
     <key alias="noMediaTypes" version="7.0"><![CDATA[Der kunne ikke findes nogen tilladte media typer. Du skal tillade disse i indstillinger under <strong>"media typer"</strong>.]]></key>
     <key alias="documentTypeWithoutTemplate">Dokument type uden skabelon</key>
+    <key alias="newFolder">Ny mappe</key>
+    <key alias="newDataType">Ny datatype</key>
   </area>
   <area alias="dashboard">
     <key alias="browser">Til dit website</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -189,6 +189,8 @@
     <key alias="noDocumentTypes" version="7.0"><![CDATA[There are no allowed document types available. You must enable these in the settings section under <strong>"document types"</strong>.]]></key>
     <key alias="noMediaTypes" version="7.0"><![CDATA[There are no allowed media types available. You must enable these in the settings section under <strong>"media types"</strong>.]]></key>
     <key alias="documentTypeWithoutTemplate">Document Type without a template</key>
+    <key alias="newFolder">New folder</key>
+    <key alias="newDataType">New data type</key>
   </area>
   <area alias="dashboard">
     <key alias="browser">Browse your website</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -191,6 +191,8 @@
     <key alias="noDocumentTypes" version="7.0"><![CDATA[There are no allowed document types available. You must enable these in the settings section under <strong>"document types"</strong>.]]></key>
     <key alias="noMediaTypes" version="7.0"><![CDATA[There are no allowed media types available. You must enable these in the settings section under <strong>"media types"</strong>.]]></key>
     <key alias="documentTypeWithoutTemplate">Document Type without a template</key>
+    <key alias="newFolder">New folder</key>
+    <key alias="newDataType">New data type</key>
   </area>
   <area alias="dashboard">
     <key alias="browser">Browse your website</key>


### PR DESCRIPTION
Rather than the **Data type** part of the **New Data type** link text being hardcoded, I have now added an item in the language files for the entire string (for `da`, `en` and `en-US`). This means that the link text now will be **Ny datatype** if the user has selected Danish for the backoffice. For English, the d is now also lowercase, which I believe is more correct.

I have also added a translation for **Folder**, which is now **New folder** in English, or **Ny mappe** in Danish.

Since this pull request contains rather simple changes, I'm not sure whether I need to create an issue on the issue tracker. Just throw an angry smiley at me if an issue is required ;)