### PR TITLE
An attempt to speed up sorting a large set of nodes when a large set …

### DIFF
--- a/src/Umbraco.Core/Services/INotificationService.cs
+++ b/src/Umbraco.Core/Services/INotificationService.cs
@@ -30,6 +30,20 @@ namespace Umbraco.Core.Services
                                Func<IUser, string[], string> createBody);
 
         /// <summary>
+        /// Sends the notifications for the specified user regarding the specified node and action.
+        /// </summary>
+        /// <param name="entities"></param>
+        /// <param name="operatingUser"></param>
+        /// <param name="action"></param>
+        /// <param name="actionName"></param>
+        /// <param name="http"></param>
+        /// <param name="createSubject"></param>
+        /// <param name="createBody"></param>
+        void SendNotifications(IUser operatingUser, IEnumerable<IUmbracoEntity> entities, string action, string actionName, HttpContextBase http,
+                               Func<IUser, string[], string> createSubject,
+                               Func<IUser, string[], string> createBody);
+
+        /// <summary>
         /// Gets the notifications for the user
         /// </summary>
         /// <param name="user"></param>

--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -9,6 +9,7 @@ using Umbraco.Core.Models.EntityBase;
 using Umbraco.Core.Services;
 using umbraco;
 using umbraco.BusinessLogic.Actions;
+using Umbraco.Core.Models;
 
 namespace Umbraco.Web.Strategies
 {
@@ -36,6 +37,9 @@ namespace Umbraco.Web.Strategies
             //Send notifications for the update and created actions
             ContentService.Saved += (sender, args) =>
                 {
+                    var newEntities = new List<IContent>();
+                    var updatedEntities =  new List<IContent>();
+
                     //need to determine if this is updating or if it is new
                     foreach (var entity in args.SavedEntities)
                     {
@@ -43,16 +47,16 @@ namespace Umbraco.Web.Strategies
                         if (dirty.WasPropertyDirty("Id"))
                         {
                             //it's new
-                            applicationContext.Services.NotificationService.SendNotification(
-                                entity, ActionNew.Instance, applicationContext);
+                            newEntities.Add(entity);
                         }
                         else
                         {
                             //it's updating
-                            applicationContext.Services.NotificationService.SendNotification(
-                                entity, ActionUpdate.Instance, applicationContext);
+                            updatedEntities.Add(entity);
                         }
                     }
+                    applicationContext.Services.NotificationService.SendNotification(newEntities, ActionNew.Instance, applicationContext);
+                    applicationContext.Services.NotificationService.SendNotification(updatedEntities, ActionUpdate.Instance, applicationContext);
                 };
 
             //Send notifications for the delete action

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/webservices/nodeSorter.asmx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/webservices/nodeSorter.asmx.cs
@@ -177,13 +177,15 @@ namespace umbraco.presentation.webservices
             var sortedContent = new List<IContent>();
             try
             {
-                for (var i = 0; i < ids.Length; i++)
-                {
-                    var id = int.Parse(ids[i]);
-                    var c = contentService.GetById(id);
-                    sortedContent.Add(c);
-                }
+                int [] intIds = ids.Select(id => int.Parse(id)).ToArray();
 
+                sortedContent = contentService.GetByIds(intIds).ToList();
+
+                sortedContent = (from id in intIds
+                                join content in sortedContent
+                                on id equals content.Id
+                                select content).ToList();
+                
                 // Save content with new sort order and update db+cache accordingly
                 var sorted = contentService.Sort(sortedContent);
 


### PR DESCRIPTION
…of users exist.  Our sorts were failing in azure because the user notifications were taking long enough that azure would kill the thread.

I modified the way nodes were being gathered from Umbraco and sorted. Also, I refactored the user content notifications to reduce the number of database interactions and provide the ability to notify on a collection of nodes instead of one at a time. The user content notification was in testing primarilly what was causing the thread to be long running. 

The end result is the sort operation which was taking 3.8+ minutes before thread abortion by the Azure App Service has been reduced to ~18 seconds.