### PR TITLE
Added editor alias to the list of available editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
@@ -75,6 +75,7 @@
                                   checklist-model="currentCell.allowed"
                                   checklist-value="editor.alias">
                                    <i class="icon {{editor.icon}}"></i> {{editor.name}}
+                                   <small style="display: inline-block;">({{editor.alias}})</small>
                           </label>
                       </li>
                   </ul>


### PR DESCRIPTION
The name of the editor is often targeted the editors, so the name is more clear to them. As a developer, I really miss the alias, since it may tell more about the context of the editor, and it is the same I use in the code anyways.

Two editors may also have the same name (eg. if they don't do exactly the same and are used in different grid layouts). They will however have unique aliases.