### PR TITLE
Only add class "-light" to grid items in content.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-content-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-content-grid.html
@@ -5,23 +5,23 @@
       ng-repeat="item in content"
       ng-class="{'-selected': item.selected}"
       ng-click="clickItem(item, $event, $index)">
-
+      
       <i ng-if="item.selected" class="icon-check umb-content-grid__checkmark"></i>
 
       <div class="umb-content-grid__icon-container">
-          <i class="umb-content-grid__icon {{ item.icon }}" ng-class="{'-light': !item.published}"></i>
+          <i class="umb-content-grid__icon {{ item.icon }}" ng-class="{'-light': !item.published && item.updater != null}"></i>
       </div>
 
       <div class="umb-content-grid__content">
 
-         <div class="umb-content-grid__item-name" ng-click="clickItemName(item, $event, $index)" ng-class="{'-light': !item.published}">{{ item.name }}</div>
+          <div class="umb-content-grid__item-name" ng-click="clickItemName(item, $event, $index)" ng-class="{'-light': !item.published && item.updater != null}">{{ item.name }}</div>
 
-         <ul class="umb-content-grid__details-list" ng-class="{'-light': !item.published}">
-            <li class="umb-content-grid__details-item" ng-repeat="property in contentProperties">
-               <div class="umb-content-grid__details-label">{{ property.header }}:</div>
-               <div class="umb-content-grid__details-value">{{ item[property.alias] }}</div>
-            </li>
-         </ul>
+          <ul class="umb-content-grid__details-list" ng-class="{'-light': !item.published&& item.updater != null}">
+              <li class="umb-content-grid__details-item" ng-repeat="property in contentProperties">
+                  <div class="umb-content-grid__details-label">{{ property.header }}:</div>
+                  <div class="umb-content-grid__details-value">{{ item[property.alias] }}</div>
+              </li>
+          </ul>
 
       </div>
 


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8696

Media and member don't have published and unpublished state, so `published` property seems always to be false for e.g. member items.

There exists an updater property and it seems to be available for content, but not members. So I have included that in the conditional statement.

Alternative it could check start of editPath or add a property for content type: content, media, member.

![image](https://cloud.githubusercontent.com/assets/2919859/16670110/0267bc82-4499-11e6-8dff-12e8b3e6b6c7.png)

![image](https://cloud.githubusercontent.com/assets/2919859/16670128/1b4d1bf2-4499-11e6-90d0-dab1f6141d04.png)
