### PR TITLE
U4-8629 Displays link to version report on our.umb during Upgrade step

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/upgrade.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/upgrade.html
@@ -3,10 +3,17 @@
     <p>
         Welcome to the Umbraco installer. You see this screen because your Umbraco installation needs a quick upgrade of its database and files, which will ensure your website is kept as fast, secure and up to date as possible.
     </p>
+
+    <p>
+        To read a report of changes between your current version <strong>{{installer.current.model.currentVersion}}</strong> and this version your upgrading to <strong>{{installer.current.model.newVersion}}</strong>
+    </p>
+    <p>
+        <a ng-href="{{installer.current.model.reportUrl}}" target="_blank" class="btn">View Report</a>
+    </p>
+
     <p>
         Simply click <strong>continue</strong> below to be guided through the rest of the upgrade
     </p>
-
     <p>
         <button class="btn btn-success" ng-click="install()">Continue</button>
    </p>


### PR DESCRIPTION
This displays a simple link to the our.umbraco.org version comparison tool based on the current version the user has installed, by checking the latest run Umbraco DB Migration and the new version you are upgrading from the class `UmbracoVersion`

I reckon the UI needs tweaking & the designer boy'z @simonbusborg & @madsrasmussen will want to update what I have done as opposed to the shoved in ugly button I added for the link

![screen shot 2016-07-12 at 15 55 30](https://cloud.githubusercontent.com/assets/1389894/16772000/62939d4c-484a-11e6-9f5f-aa00d587bac5.png)
