### PR TITLE
U4-8542 Require https attribute for back office web api controllers

### DIFF
--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Web.Editors
     /// <summary>
     /// A controller to render out the default back office view and JS results
     /// </summary>
-    [UmbracoUseHttps]
+    [UmbracoRequireHttps]
     [DisableClientCache]
     public class BackOfficeController : UmbracoController
     {

--- a/src/Umbraco.Web/Mvc/UmbracoRequireHttpsAttribute.cs
+++ b/src/Umbraco.Web/Mvc/UmbracoRequireHttpsAttribute.cs
@@ -1,0 +1,39 @@
+﻿using System.Web.Mvc;
+using GlobalSettings = Umbraco.Core.Configuration.GlobalSettings;
+
+namespace Umbraco.Web.Mvc
+{
+    /// <summary>
+    /// If umbracoUseSSL property in web.config is set to true, this filter will redirect any http access to https.
+    /// </summary>
+    public class UmbracoRequireHttpsAttribute : RequireHttpsAttribute
+    {
+        /// <summary>
+        /// If umbracoUseSSL is true and we have a non-HTTPS request, handle redirect.
+        /// </summary>
+        /// <param name="filterContext">Filter context</param>
+        protected override void HandleNonHttpsRequest(AuthorizationContext filterContext)
+        {
+            // If umbracoUseSSL is set, let base method handle redirect.  Otherwise, we don't care.
+            if (GlobalSettings.UseSSL)
+            {
+                base.HandleNonHttpsRequest(filterContext);
+            }
+        }
+
+        /// <summary>
+        /// Check to see if HTTPS is currently being used if umbracoUseSSL is true.
+        /// </summary>
+        /// <param name="filterContext">Filter context</param>
+        public override void OnAuthorization(AuthorizationContext filterContext)
+        {
+            // If umbracoSSL is set, let base method handle checking for HTTPS.  Otherwise, we don't care.
+            if (GlobalSettings.UseSSL)
+            {
+                base.OnAuthorization(filterContext);
+            }
+        }
+
+
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -380,6 +380,7 @@
     <Compile Include="Mvc\IRenderController.cs" />
     <Compile Include="Mvc\ModelBindingException.cs" />
     <Compile Include="Mvc\RenderIndexActionSelectorAttribute.cs" />
+    <Compile Include="Mvc\UmbracoRequireHttpsAttribute.cs" />
     <Compile Include="Mvc\ValidateMvcAngularAntiForgeryTokenAttribute.cs" />
     <Compile Include="OwinMiddlewareConfiguredEventArgs.cs" />
     <Compile Include="PropertyEditors\DatePreValueEditor.cs" />
@@ -739,6 +740,7 @@
     <Compile Include="WebApi\Filters\OverridableAuthorizationAttribute.cs" />
     <Compile Include="WebApi\Filters\SetAngularAntiForgeryTokensAttribute.cs" />
     <Compile Include="WebApi\Filters\UmbracoBackOfficeLogoutAttribute.cs" />
+    <Compile Include="WebApi\Filters\UmbracoWebApiRequireHttpsAttribute.cs" />
     <Compile Include="WebApi\Filters\UmbracoTreeAuthorizeAttribute.cs" />
     <Compile Include="WebApi\Filters\UmbracoUseHttps.cs" />
     <Compile Include="WebApi\Filters\ValidateAngularAntiForgeryTokenAttribute.cs" />

--- a/src/Umbraco.Web/WebApi/Filters/UmbracoUseHttps.cs
+++ b/src/Umbraco.Web/WebApi/Filters/UmbracoUseHttps.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using Umbraco.Core;
@@ -7,37 +9,9 @@ using GlobalSettings = Umbraco.Core.Configuration.GlobalSettings;
 
 namespace Umbraco.Web.WebApi.Filters
 {
-    /// <summary>
-    /// If umbracoUseSSL property in web.config is set to true, this filter will redirect any http access to https.
-    /// </summary>
-    public class UmbracoUseHttps : RequireHttpsAttribute
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use the filter Umbraco.Web.Mvc.UmbracoRequireHttpsAttribute instead, this one is in the wrong namespace")]
+    public class UmbracoUseHttps : Umbraco.Web.Mvc.UmbracoRequireHttpsAttribute
     {
-        /// <summary>
-        /// If umbracoUseSSL is true and we have a non-HTTPS request, handle redirect.
-        /// </summary>
-        /// <param name="filterContext">Filter context</param>
-        protected override void HandleNonHttpsRequest(AuthorizationContext filterContext)
-        {
-            // If umbracoUseSSL is set, let base method handle redirect.  Otherwise, we don't care.
-            if (GlobalSettings.UseSSL)
-            {
-                base.HandleNonHttpsRequest(filterContext);
-            }
-        }
-
-        /// <summary>
-        /// Check to see if HTTPS is currently being used if umbracoUseSSL is true.
-        /// </summary>
-        /// <param name="filterContext">Filter context</param>
-        public override void OnAuthorization(AuthorizationContext filterContext)
-        {
-            // If umbracoSSL is set, let base method handle checking for HTTPS.  Otherwise, we don't care.
-            if (GlobalSettings.UseSSL)
-            {
-                base.OnAuthorization(filterContext);
-            }
-        }
-
-
     }
 }

--- a/src/Umbraco.Web/WebApi/Filters/UmbracoWebApiRequireHttpsAttribute.cs
+++ b/src/Umbraco.Web/WebApi/Filters/UmbracoWebApiRequireHttpsAttribute.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using Umbraco.Core.Configuration;
+
+namespace Umbraco.Web.WebApi.Filters
+{
+    /// <summary>
+    /// If umbracoUseSSL property in web.config is set to true, this filter will redirect any http access to https.
+    /// </summary>
+    /// <remarks>
+    /// This will only redirect Head/Get requests, otherwise will respond with text
+    /// 
+    /// References: 
+    /// http://issues.umbraco.org/issue/U4-8542
+    /// https://blogs.msdn.microsoft.com/carlosfigueira/2012/03/09/implementing-requirehttps-with-asp-net-web-api/
+    /// </remarks>
+    public class UmbracoWebApiRequireHttpsAttribute : AuthorizationFilterAttribute
+    {
+        public override void OnAuthorization(HttpActionContext actionContext)
+        {
+            var request = actionContext.Request;
+            if (GlobalSettings.UseSSL && request.RequestUri.Scheme != Uri.UriSchemeHttps)
+            {
+                HttpResponseMessage response;
+                var uri = new UriBuilder(request.RequestUri)
+                {
+                    Scheme = Uri.UriSchemeHttps,
+                    Port = 443
+                };
+                var body = string.Format("<p>The resource can be found at <a href =\"{0}\">{0}</a>.</p>",
+                uri.Uri.AbsoluteUri);
+                if (request.Method.Equals(HttpMethod.Get) || request.Method.Equals(HttpMethod.Head))
+                {
+                    response = request.CreateResponse(HttpStatusCode.Found);
+                    response.Headers.Location = uri.Uri;
+                    if (request.Method.Equals(HttpMethod.Get))
+                    {
+                        response.Content = new StringContent(body, Encoding.UTF8, "text/html");
+                    }
+                }
+                else
+                {
+                    response = request.CreateResponse(HttpStatusCode.NotFound);
+                    response.Content = new StringContent(body, Encoding.UTF8, "text/html");
+                }
+
+                actionContext.Response = response;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/WebApi/UmbracoAuthorizedApiController.cs
+++ b/src/Umbraco.Web/WebApi/UmbracoAuthorizedApiController.cs
@@ -19,6 +19,7 @@ namespace Umbraco.Web.WebApi
     [UmbracoUserTimeoutFilter]
     [UmbracoAuthorize]
     [DisableBrowserCache]
+    [UmbracoWebApiRequireHttps]
     public abstract class UmbracoAuthorizedApiController : UmbracoApiController
     {
         protected UmbracoAuthorizedApiController()


### PR DESCRIPTION
This adds the webapi filter and also creates a new MVC one with a better name and the correct namespace since it was previously in the wrong namespace . I've obsoleted the old one and proxied the logic to the new renamed one so there are no breaking changes.