### PR TITLE
Multiple fixes for Umbraco's PetaPoco implementation.

### DIFF
--- a/src/Umbraco.Core/Persistence/PetaPoco.cs
+++ b/src/Umbraco.Core/Persistence/PetaPoco.cs
@@ -2417,6 +2417,7 @@ namespace Umbraco.Core.Persistence
 			else
 				_rhs = sql;
 
+			_sqlFinal = null;
 			return this;
 		}
 

--- a/src/Umbraco.Core/Persistence/PetaPocoSqlExtensions.cs
+++ b/src/Umbraco.Core/Persistence/PetaPocoSqlExtensions.cs
@@ -51,7 +51,8 @@ namespace Umbraco.Core.Persistence
         public static Sql OrderBy<TColumn>(this Sql sql, Expression<Func<TColumn, object>> columnMember, ISqlSyntaxProvider sqlSyntax)
         {
             var column = ExpressionHelper.FindProperty(columnMember) as PropertyInfo;
-            var columnName = column.FirstAttribute<ColumnAttribute>().Name;
+            var columnAttribute = column.FirstAttribute<ColumnAttribute>();
+            var columnName = columnAttribute == null || string.IsNullOrEmpty(columnAttribute.Name) ? column.Name : columnAttribute.Name;
 
             var type = typeof(TColumn);
             var tableNameAttribute = type.FirstAttribute<TableNameAttribute>();
@@ -74,7 +75,8 @@ namespace Umbraco.Core.Persistence
         public static Sql OrderByDescending<TColumn>(this Sql sql, Expression<Func<TColumn, object>> columnMember, ISqlSyntaxProvider sqlSyntax)
         {
             var column = ExpressionHelper.FindProperty(columnMember) as PropertyInfo;
-            var columnName = column.FirstAttribute<ColumnAttribute>().Name;
+            var columnAttribute = column.FirstAttribute<ColumnAttribute>();
+            var columnName = columnAttribute == null || string.IsNullOrEmpty(columnAttribute.Name) ? column.Name : columnAttribute.Name;
 
             var type = typeof(TColumn);
             var tableNameAttribute = type.FirstAttribute<TableNameAttribute>();
@@ -96,7 +98,8 @@ namespace Umbraco.Core.Persistence
         public static Sql GroupBy<TColumn>(this Sql sql, Expression<Func<TColumn, object>> columnMember, ISqlSyntaxProvider sqlProvider)
         {
             var column = ExpressionHelper.FindProperty(columnMember) as PropertyInfo;
-            var columnName = column.FirstAttribute<ColumnAttribute>().Name;
+            var columnAttribute = column.FirstAttribute<ColumnAttribute>();
+            var columnName = columnAttribute == null || string.IsNullOrEmpty(columnAttribute.Name) ? column.Name : columnAttribute.Name;
 
             return sql.GroupBy(sqlProvider.GetQuotedColumnName(columnName));
         }
@@ -178,8 +181,11 @@ namespace Umbraco.Core.Persistence
 
             var left = ExpressionHelper.FindProperty(leftMember) as PropertyInfo;
             var right = ExpressionHelper.FindProperty(rightMember) as PropertyInfo;
-            var leftColumnName = left.FirstAttribute<ColumnAttribute>().Name;
-            var rightColumnName = right.FirstAttribute<ColumnAttribute>().Name;
+
+            var leftColumnAttribute = left.FirstAttribute<ColumnAttribute>();
+            var leftColumnName = leftColumnAttribute == null || string.IsNullOrEmpty(leftColumnAttribute.Name) ? left.Name : leftColumnAttribute.Name;
+            var rightColumnAttribute = right.FirstAttribute<ColumnAttribute>();
+            var rightColumnName = rightColumnAttribute == null || string.IsNullOrEmpty(rightColumnAttribute.Name) ? right.Name : rightColumnAttribute.Name;
 
             string onClause = string.Format("{0}.{1} = {2}.{3}",
                 sqlSyntax.GetQuotedTableName(leftTableName),

--- a/src/Umbraco.Core/Persistence/SqlSyntax/MicrosoftSqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/MicrosoftSqlSyntaxProviderBase.cs
@@ -29,7 +29,11 @@ namespace Umbraco.Core.Persistence.SqlSyntax
 
         public override string GetQuotedTableName(string tableName)
         {
-            return string.Format("[{0}]", tableName);
+            if (tableName.Contains(".")) {
+                var tableNameParts = tableName.Split(new char[] { '.' }, 2);
+                return string.Format("[{0}].[{1}]", tableNameParts[0], tableNameParts[1]);
+            }  else
+                return string.Format("[{0}]", tableName);
         }
 
         public override string GetQuotedColumnName(string columnName)


### PR DESCRIPTION
More details here. http://issues.umbraco.org/issue/U4-8729

These issues create rather difficult to track down invalid SQL when trying to use Poco's generated with PetaPoco T4 templates.

Fixed an issues with user generated PetaPoco's would not work if they included schema's.

Fixed an issue where strong typed helper methods would not generate valid SQL for column names if the poco didn't explicitly set a [Column(Name="")] attribute. The PetaPoco format allows for this though and will default to the property name.  Again this would cause issues for developers trying to use the DatabaseContext.Database class with their own Poco's.

Both the above causes would happen for example if using the PetaPoco T4 templates to automatically generate Poco's.