### PR TITLE
Fix issue where subsequent submit of reset password form cleared…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.controller.js
@@ -79,7 +79,7 @@
         }
 
         $scope.loginSubmit = function (login, password) {
-
+            
             //if the login and password are not empty we need to automatically 
             // validate them - this is because if there are validation errors on the server
             // then the user has to change both username & password to resubmit which isn't ideal,
@@ -121,12 +121,17 @@
 
         $scope.requestPasswordResetSubmit = function (email) {
 
-            $scope.errorMsg = "";
+            if (email && email.length > 0) {
+                $scope.requestPasswordResetForm.email.$setValidity('auth', true);
+            }
+            
             $scope.showEmailResetConfirmation = false;
 
             if ($scope.requestPasswordResetForm.$invalid) {
                 return;
             }
+
+            $scope.errorMsg = "";
 
             authResource.performRequestPasswordReset(email)
                 .then(function () {

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
@@ -25,7 +25,7 @@
                                     id="{{login.authType}}" name="provider" value="{{login.authType}}"
                                     title="Log in using your {{login.caption}} account">
                                 <i class="fa" ng-class="login.properties.SocialIcon"></i>
-                                Sign in with {{login.caption}}
+                                <localize key="login_signInWith">Sign in with</localize> {{login.caption}}
                             </button>
 
                         </div>
@@ -33,7 +33,7 @@
 
                     <div id="hrOr">
                         <hr />
-                        <div>Or</div>
+                        <div><localize key="general_or">or</localize></div>
                     </div>
 
                 </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -502,6 +502,7 @@
     <key alias="greeting5">Endelig fredag!</key>
     <key alias="greeting6">Gledelig lørdag</key>
     <key alias="instruction">Logg på nedenfor</key>
+    <key alias="signInWith">Logg på med</key>
     <key alias="timeout">Din sesjon er utløpt</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">umbraco.com</a></p> ]]></key>
   </area>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -551,7 +551,6 @@
     <key alias="renewSession">Forny for at gemme dine ændringer</key>
   </area>
   <area alias="login">
-
     <key alias="greeting0">Så er det søndag!</key>
     <key alias="greeting1">Smil, det er mandag!</key>
     <key alias="greeting2">Hurra, det er tirsdag!</key>
@@ -559,12 +558,9 @@
     <key alias="greeting4">Glædelig torsdag!</key>
     <key alias="greeting5">Endelig fredag!</key>
     <key alias="greeting6">Glædelig lørdag</key>
-
-
     <key alias="instruction">indtast brugernavn og kodeord</key>
+    <key alias="signInWith">Log ind med</key>
     <key alias="timeout">Din session er udløbet</key>
-
-
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">umbraco.com</a></p> ]]></key>
   </area>
   <area alias="main">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -537,6 +537,7 @@ Wenn Sie sich für Runway entscheiden, können Sie optional Blöcke nutzen, die 
     <key alias="greeting5">Frohen freundlichen Freitag</key>
     <key alias="greeting6">Wunderbaren sonnigen Samstag</key>
     <key alias="instruction">Hier anmelden:</key>
+    <key alias="signInWith">Anmelden mit</key>
     <key alias="timeout">Sitzung abgelaufen</key>
     <key alias="bottomText">&lt;p style="text-align:right;"&gt;&amp;copy; 2001 - %0% &lt;br /&gt;&lt;a href="http://umbraco.com" style="text-decoration: none" target="_blank"&gt;umbraco.org&lt;/a&gt;&lt;/p&gt; </key>
   </area>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -672,6 +672,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="greeting5">Happy funky Friday</key>
     <key alias="greeting6">Happy Caturday</key>
     <key alias="instruction">Log in below</key>
+    <key alias="signInWith">Sign in with</key>
     <key alias="timeout">Session timed out</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">Umbraco.com</a></p> ]]></key>
     <key alias="forgottenPassword">Forgotten password?</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -670,6 +670,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="greeting5">Happy funky Friday</key>
     <key alias="greeting6">Happy Caturday</key>
     <key alias="instruction">Log in below</key>
+    <key alias="signInWith">Sign in with</key>
     <key alias="timeout">Session timed out</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">Umbraco.com</a></p> ]]></key>
     <key alias="forgottenPassword">Forgotten password?</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -492,6 +492,7 @@
     <key alias="greeting5">Happy friendly Friday</key>
     <key alias="greeting6">Happy shiny Saturday</key>
     <key alias="instruction">Logga in nedan</key>
+    <key alias="signInWith">Logga in med</key>
     <key alias="timeout">Sessionen har nått sin maxgräns</key>
   </area>
   <area alias="main">


### PR DESCRIPTION
…error message.

Issue: http://issues.umbraco.org/issue/U4-8597

It first clear the error message, when form is submitted again (not already invalid) and then set the new error message.

I also localized a few missing keys. Maybe also fix localization of this `title="Log in using your {{login.caption}} account"`