### PR TITLE
Add filters to remove inline styles and classes from package description

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/filters/stripClasses.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/stripClasses.filter.js
@@ -1,0 +1,5 @@
+angular.module("umbraco.filters").filter('stripClasses', function () {
+    return function (str) {
+        return str ? str.replace(/class=['"]([^"]*)["']/gi, '') : '';
+    };
+  });

--- a/src/Umbraco.Web.UI.Client/src/common/filters/stripStyles.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/stripStyles.filter.js
@@ -1,6 +1,5 @@
 angular.module("umbraco.filters").filter('stripStyles', function () {
     return function (str) {
-        console.log("str", str);
         return str ? str.replace(/style=['"]([^"]*)["']/gi, '') : '';
     };
   });

--- a/src/Umbraco.Web.UI.Client/src/common/filters/stripStyles.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/stripStyles.filter.js
@@ -1,0 +1,7 @@
+angular.module("umbraco.filters").filter('stripStyles', function () {
+    return function (str) {
+        console.log("str", str);
+        return str ? str.replace(/style=['"]([^"]*)["']/gi, '') : '';
+        //return str ? str.replace(/style=['"].*["']/, '') : '';
+    };
+  });

--- a/src/Umbraco.Web.UI.Client/src/common/filters/stripStyles.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/stripStyles.filter.js
@@ -2,6 +2,5 @@ angular.module("umbraco.filters").filter('stripStyles', function () {
     return function (str) {
         console.log("str", str);
         return str ? str.replace(/style=['"]([^"]*)["']/gi, '') : '';
-        //return str ? str.replace(/style=['"].*["']/, '') : '';
     };
   });

--- a/src/Umbraco.Web.UI.Client/src/views/packager/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packager/views/repo.html
@@ -131,11 +131,11 @@
 
                     <div class="umb-packages-view-title">{{ vm.package.name }}</div>
 
-                    <div class="umb-package-details__description" ng-bind-html-unsafe="vm.package.description"></div>
+                    <div class="umb-package-details__description" ng-bind-html-unsafe="vm.package.description | stripStyles | stripClasses"></div>
 
                     <div class="umb-gallery">
                         <div class="umb-gallery__thumbnails">
-                        <a class="umb-gallery__thumbnail" ng-repeat="image in vm.package.images" ng-click="vm.openLightbox($index, vm.package.images)">
+                            <a class="umb-gallery__thumbnail" ng-repeat="image in vm.package.images" ng-click="vm.openLightbox($index, vm.package.images)">
                                 <img ng-src="{{ image.thumbnail }}" />
                             </a>
                         </div>
@@ -165,10 +165,10 @@
                         <div class="umb-package-details__owner-profile">
 
                             <div class="umb-package-details__owner-profile-avatar">
-                            <umb-avatar
-                                size="m"
-                                img-src="{{ 'https://our.umbraco.org' + vm.package.ownerInfo.ownerAvatar }}">
-                            </umb-avatar>
+                                <umb-avatar
+                                    size="m"
+                                    img-src="{{ 'https://our.umbraco.org' + vm.package.ownerInfo.ownerAvatar }}">
+                                </umb-avatar>
                             </div>
 
                             <div>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8768

This add two new filters to remove inline styles and classes from package description to make it consistent in backoffice since package descriptions on our.umbraco.org actually can contain inline styles and classes, which might conflict with Umbraco.
Sometimes package developers just copy the readme description on their Github repository, which get a different style than if you just manually enter text in the TinyMCE editor.

I was inspired from this example - however it only remove style attribute on first match, so added `g` to regex for global and `i` for ignoring casing.

Furhermore `.*` was actually too agressive since it removed elements from html, but noticed `[^"]*` did the job: http://stackoverflow.com/a/4101711

Finally there seems to be an issue with a link for e.g. the **SEO Metadata** package here: https://our.umbraco.org/projects/backoffice-extensions/seo-metadata-for-umbraco/ ... its package description has the following text 

> A Property Editor Value Converter is installed for getting a strongly-typed SeoMetadata instance.

"Property Editor Value Converter" is a link with the following html:
```
<a style="box-sizing: border-box; color: #4183c4; text-decoration: none; background: transparent;" href="../../../documentation/extending-umbraco/Property-Editors/PropertyEditorValueConverters">Property Editor Value Converter</a>
```

on our,umbraco.org that becomes: https://our.umbraco.org/documentation/extending-umbraco/Property-Editors/PropertyEditorValueConverters

.. but in backoffice: http://localhost:7500/documentation/extending-umbraco/Property-Editors/PropertyEditorValueConverters

I am not sure if this was added using link button TinyMCE toolbar or...? Maybe it saves relative urls - should probably be absolute urls then?

Some examples to compare before and after:

**SEO Metadata**

*Before*
![image](https://cloud.githubusercontent.com/assets/2919859/17074442/818633a2-507b-11e6-87f2-15a492f34a48.png)

*After*
![image](https://cloud.githubusercontent.com/assets/2919859/17074545/a1df3792-507c-11e6-83a9-328996f45d80.png)


**Color Palettes**
*(Notice e.g. the links to Adobe Kuler and COLOURlovers)*

*Before*
![image](https://cloud.githubusercontent.com/assets/2919859/17074597/37b2aa56-507d-11e6-8fb3-d71ea1d7b171.png)

*After*
![image](https://cloud.githubusercontent.com/assets/2919859/17074604/4faf7af8-507d-11e6-9eff-9057d0b7db59.png)


Then we could specific adjust styling for h1, h2, h3,.. pre and other tags inside package description.