### PR TITLE
U4-8751: Put format parameter at the end when format is specified in furtherOptions

### DIFF
--- a/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
@@ -302,7 +302,11 @@ namespace Umbraco.Web
                     }
                 }
 
-                if (quality != null)
+                bool hasFormat = furtherOptions != null && furtherOptions.Contains("&format=");
+
+                //Only put quality here, if we don't have a format specified. 
+                //Otherwise we need to put quality at the end to avoid it being overridden by the format.
+                if (quality != null && !hasFormat)
                 {
                     imageProcessorUrl.Append("&quality=" + quality);
                 }
@@ -349,6 +353,12 @@ namespace Umbraco.Web
                 if (furtherOptions != null)
                 {
                     imageProcessorUrl.Append(furtherOptions);
+                }
+
+                //If furtherOptions contains a format, we need to put the quality after the format.
+                if (quality != null && hasFormat)
+                {
+                    imageProcessorUrl.Append("&quality=" + quality);
                 }
 
                 if (cacheBusterValue != null)


### PR DESCRIPTION
The quality parameter needs to go after the format parameter, otherwise the default quality of the format (only for jpg) will override what is specified.