### PR TITLE
Fixes  U4-8772, adds icon to published but changed listview items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
@@ -36,7 +36,7 @@
                 }"
                  ng-click="selectItem(item, $index, $event)">
 
-                <div class="umb-table-cell">
+                <div class="umb-table-cell" ng-class="{'has-unpublished-version':!item.published && item.hasPublishedVersion}">
                     <i class="umb-table-body__icon umb-table-body__fileicon {{item.icon}}" ng-class="getIcon(item)"></i>
                     <i class="umb-table-body__icon umb-table-body__checkicon icon-check"></i>
                 </div>

--- a/src/Umbraco.Web/Models/ContentEditing/ContentItemBasic.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentItemBasic.cs
@@ -25,6 +25,9 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "published")]
         public bool Published { get; set; }
 
+        [DataMember(Name = "hasPublishedVersion")]
+        public bool HasPublishedVersion { get; set; }
+
         [DataMember(Name = "owner")]
         public UserBasic Owner { get; set; }
 

--- a/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
@@ -87,6 +87,9 @@ namespace Umbraco.Web.Models.Mapping
                 .ForMember(
                     dto => dto.Trashed,
                     expression => expression.MapFrom(content => content.Trashed))
+                    .ForMember(
+                    dto => dto.HasPublishedVersion,
+                    expression => expression.MapFrom(content => content.HasPublishedVersion))
                 .ForMember(
                     dto => dto.ContentTypeAlias,
                     expression => expression.MapFrom(content => content.ContentType.Alias))


### PR DESCRIPTION
adds HasPublishedVersion property to mapping of IContent to ContentItemBasic, then adds existing 'has-unpublished-version' css class to list view row if item is published but has unpublished changes.

Obviously not sure if we should be adding properties 'randomly' to ContentItemBasic, presumably the idea is to have this as 'basic' as possible :-)

Also I've applied the same user effect as you get in the tree view, when an item has been changed but not published, there maybe a better UI effect for a table ListView interaction.

but hopefully you get a gist of the problem, and the possible way to fix it.

To Test, go to a list view - create an unpublished item, (it should be greyed out), make a change to a different already published item, but don't publish that change. both will be greyed out, but there should be the tiny green icon appear on the item that has an existingly published version, indicating something has changed but hasn't been published.

