### PR TITLE
Added missing Sql mapping for standard Replace function:

### DIFF
--- a/src/Umbraco.Core/Persistence/Querying/BaseExpressionHelper.cs
+++ b/src/Umbraco.Core/Persistence/Querying/BaseExpressionHelper.cs
@@ -440,6 +440,55 @@ namespace Umbraco.Core.Persistence.Querying
                     }
 
                     return HandleStringComparison(visitedObjectForMethod, compareValue, m.Method.Name, colType);
+
+                case "Replace":
+                    string searchValue;
+
+                    if (methodArgs[0].NodeType != ExpressionType.Constant)
+                    {
+                        //This occurs when we are getting a value from a non constant such as: x => x.Path.StartsWith(content.Path)
+                        // So we'll go get the value:
+                        var member = Expression.Convert(methodArgs[0], typeof(object));
+                        var lambda = Expression.Lambda<Func<object>>(member);
+                        var getter = lambda.Compile();
+                        searchValue = getter().ToString();
+                    }
+                    else
+                    {
+                        searchValue = methodArgs[0].ToString();
+                    }
+
+                    if (methodArgs[0].Type != typeof(string) && TypeHelper.IsTypeAssignableFrom<IEnumerable>(methodArgs[0].Type))
+                    {
+                        throw new NotSupportedException("An array Contains method is not supported");
+                    }
+
+                    string replaceValue;
+
+                    if (methodArgs[1].NodeType != ExpressionType.Constant)
+                    {
+                        //This occurs when we are getting a value from a non constant such as: x => x.Path.StartsWith(content.Path)
+                        // So we'll go get the value:
+                        var member = Expression.Convert(methodArgs[1], typeof(object));
+                        var lambda = Expression.Lambda<Func<object>>(member);
+                        var getter = lambda.Compile();
+                        replaceValue = getter().ToString();
+                    }
+                    else
+                    {
+                        replaceValue = methodArgs[1].ToString();
+                    }
+
+                    if (methodArgs[1].Type != typeof(string) && TypeHelper.IsTypeAssignableFrom<IEnumerable>(methodArgs[1].Type))
+                    {
+                        throw new NotSupportedException("An array Contains method is not supported");
+                    }
+
+                    SqlParameters.Add(RemoveQuote(searchValue));
+
+                    SqlParameters.Add(RemoveQuote(replaceValue));
+
+                    return string.Format("replace({0}, @{1}, @{2})", visitedObjectForMethod, SqlParameters.Count - 2, SqlParameters.Count - 1);
                 //case "Substring":
                 //    var startIndex = Int32.Parse(args[0].ToString()) + 1;
                 //    if (args.Count == 2)
@@ -501,7 +550,7 @@ namespace Umbraco.Core.Persistence.Querying
                 //case "As":
                 //    return string.Format("{0} As {1}", r,
                 //                                GetQuotedColumnName(RemoveQuoteFromAlias(RemoveQuote(args[0].ToString()))));
-                
+
                 default:
 
                     throw new ArgumentOutOfRangeException("No logic supported for " + m.Method.Name);

--- a/src/Umbraco.Tests/Persistence/Querying/ExpressionTests.cs
+++ b/src/Umbraco.Tests/Persistence/Querying/ExpressionTests.cs
@@ -126,9 +126,10 @@ namespace Umbraco.Tests.Persistence.Querying
 
             Console.WriteLine("Model to Sql ExpressionHelper: \n" + result);
 
-            Assert.AreEqual("replace([umbracoUser].[userLogin], @0, @1", result);
-            Assert.AreEqual("@world", modelToSqlExpressionHelper.GetSqlParameters()[0]);
-            Assert.AreEqual("@test", modelToSqlExpressionHelper.GetSqlParameters()[0]);
+            Assert.AreEqual("(replace([umbracoUser].[userLogin], @1, @2) = @0)", result);
+            Assert.AreEqual("hello@test.com", modelToSqlExpressionHelper.GetSqlParameters()[0]);
+            Assert.AreEqual("@world", modelToSqlExpressionHelper.GetSqlParameters()[1]);
+            Assert.AreEqual("@test", modelToSqlExpressionHelper.GetSqlParameters()[2]);
         }
 
     }

--- a/src/Umbraco.Tests/Persistence/Querying/ExpressionTests.cs
+++ b/src/Umbraco.Tests/Persistence/Querying/ExpressionTests.cs
@@ -117,5 +117,19 @@ namespace Umbraco.Tests.Persistence.Querying
             Assert.AreEqual("mydomain\\myuser%", modelToSqlExpressionHelper.GetSqlParameters()[0]);
         }
 
+        [Test]
+        public void Sql_Replace_Mapped()
+        {
+            Expression<Func<IUser, bool>> predicate = user => user.Username.Replace("@world", "@test") == "hello@test.com";
+            var modelToSqlExpressionHelper = new ModelToSqlExpressionHelper<IUser>();
+            var result = modelToSqlExpressionHelper.Visit(predicate);
+
+            Console.WriteLine("Model to Sql ExpressionHelper: \n" + result);
+
+            Assert.AreEqual("replace([umbracoUser].[userLogin], @0, @1", result);
+            Assert.AreEqual("@world", modelToSqlExpressionHelper.GetSqlParameters()[0]);
+            Assert.AreEqual("@test", modelToSqlExpressionHelper.GetSqlParameters()[0]);
+        }
+
     }
 }


### PR DESCRIPTION
.Where<MyModel>(s => s.Name.Replace(" ", "-") == userName)

Should generate valid SQL:
REPLACE([dbo].[MyModel].[Name], ' ', '-')