### PR TITLE
Render preview of SVG files

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
@@ -138,6 +138,22 @@ Use this directive to generate a thumbnail grid of media items.
                 if (!item.isFolder) {
                     item.thumbnail = mediaHelper.resolveFile(item, true);
                     item.image = mediaHelper.resolveFile(item, false);
+
+                    var fileProp = _.find(item.properties, function (v) {
+                        return (v.alias === "umbracoFile");
+                    });
+
+                    if (fileProp && fileProp.value) {
+                        item.file = fileProp.value;
+                    }
+
+                    var extensionProp = _.find(item.properties, function (v) {
+                        return (v.alias === "umbracoExtension");
+                    });
+
+                    if (extensionProp && extensionProp.value) {
+                        item.extension = extensionProp.value;
+                    }
                 }
             }
 

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -704,6 +704,31 @@ ul.color-picker li a  {
   padding-top: 27px;
 }
 
+.umb-fileupload .file-icon {
+  text-align: center;
+  display: block;
+  position: relative;
+  padding: 5px 0;
+
+  > .icon {
+    font-size: 70px;
+    line-height: 110%;
+    color: #666;
+    text-align: center;
+  }
+
+  > span {
+    color: #fff;
+    background: #666;
+    padding: 1px 3px;
+    font-size: 12px;
+    line-height: 130%;
+    position: absolute;
+    top: 45px;
+    left: 110px;
+  }
+}
+
 .umb-fileupload input {
   font-size: 12px;
   line-height: 1;

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -1,5 +1,5 @@
 <div class="umb-media-grid">
-    <div class="umb-media-grid__item" ng-click="clickItem(item, $event, $index)" ng-repeat="item in items | filter:filterBy" ng-style="item.flexStyle" ng-class="{'-selected': item.selected, '-file': !item.thumbnail}">
+    <div class="umb-media-grid__item" ng-click="clickItem(item, $event, $index)" ng-repeat="item in items | filter:filterBy" ng-style="item.flexStyle" ng-class="{'-selected': item.selected, '-file': !item.thumbnail, '-svg': item.extension == 'svg'}">
         <div>
             <i ng-show="item.selected" class="icon-check umb-media-grid__checkmark"></i>
 
@@ -10,7 +10,8 @@
 
             <div class="umb-media-grid__image-background" ng-if="item.thumbnail || item.extension == 'svg'"></div>
             <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="item.thumbnail" ng-src="{{item.thumbnail}}" alt="{{item.name}}" draggable="false" />
-            <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="!item.thumbnail && item.extension == 'svg'" ng-src="{{item.file}}" alt="{{item.name}}" draggable="false" />
+            <object class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="!item.thumbnail && item.extension == 'svg'" type="image/svg+xml" data="{{item.file}}" alt="{{item.name}}" draggable="false"></object>
+
             <img class="umb-media-grid__item-image-placeholder" ng-if="!item.thumbnail && item.extension != 'svg'" src="assets/img/transparent.png" alt="{{item.name}}" draggable="false" />
 
             <i class="umb-media-grid__item-icon {{item.icon}}" ng-if="!item.thumbnail && item.extension != 'svg'"></i>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -1,7 +1,6 @@
 <div class="umb-media-grid">
     <div class="umb-media-grid__item" ng-click="clickItem(item, $event, $index)" ng-repeat="item in items | filter:filterBy" ng-style="item.flexStyle" ng-class="{'-selected': item.selected, '-file': !item.thumbnail}">
         <div>
-
             <i ng-show="item.selected" class="icon-check umb-media-grid__checkmark"></i>
 
             <div class="umb-media-grid__item-overlay" ng-class="{'-locked': item.selected}" ng-click="clickItemName(item, $event, $index)">
@@ -9,11 +8,12 @@
                 <div class="umb-media-grid__item-name">{{item.name}}</div>
             </div>
 
-            <div class="umb-media-grid__image-background" ng-if="item.thumbnail"></div>
-            <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="item.thumbnail" ng-src="{{item.thumbnail}}" alt="{{item.name}}" draggable="false"/>
-            <img class="umb-media-grid__item-image-placeholder" ng-if="!item.thumbnail" src="assets/img/transparent.png" alt="{{item.name}}" draggable="false"/>
+            <div class="umb-media-grid__image-background" ng-if="item.thumbnail || item.extension == 'svg'"></div>
+            <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="item.thumbnail" ng-src="{{item.thumbnail}}" alt="{{item.name}}" draggable="false" />
+            <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="!item.thumbnail && item.extension == 'svg'" ng-src="{{item.file}}" alt="{{item.name}}" draggable="false" />
+            <img class="umb-media-grid__item-image-placeholder" ng-if="!item.thumbnail && item.extension != 'svg'" src="assets/img/transparent.png" alt="{{item.name}}" draggable="false" />
 
-            <i class="umb-media-grid__item-icon {{ item.icon }}" ng-if="!item.thumbnail"></i>
+            <i class="umb-media-grid__item-icon {{item.icon}}" ng-if="!item.thumbnail && item.extension != 'svg'"></i>
 
         </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
@@ -71,7 +71,10 @@ function fileUploadController($scope, $element, $compile, imageHelper, fileManag
                         "GetBigThumbnail",
                         [{ originalImagePath: file.file }]);
 
+            var extension = file.file.substring(file.file.lastIndexOf(".") + 1, file.file.length);
+
             file.thumbnail = thumbnailUrl;
+            file.extension = extension.toLowerCase();
         });
 
         $scope.clearFiles = false;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
@@ -1,10 +1,15 @@
 ﻿<div class="umb-editor umb-fileupload" ng-controller="Umbraco.PropertyEditors.FileUploadController">
-
+    
     <div ng-show="persistedFiles.length > 0">
         <ul class="thumbnails">
             <li class="span4 thumbnail" ng-repeat="file in persistedFiles">
-                <a href="{{file.file}}" target="_blank" ng-switch on="file.isImage" >
-                    <img ng-src="{{file.thumbnail}}" ng-switch-when="true" alt="{{file.file}}"/>
+                <a href="{{file.file}}" target="_blank" ng-switch on="file.isImage">
+                    <img ng-src="{{file.thumbnail}}" ng-switch-when="true" alt="{{file.file}}" />
+                    <img ng-src="{{file.file}}" ng-switch-when="false" ng-if="file.extension == 'svg'" alt="{{file.file}}" />
+                    <span class="file-icon" ng-if="!file.isImage && file.extension != 'svg'">
+                        <i class="icon icon-document"></i>
+                        <span>.{{file.extension}}</span>
+                    </span>
                     <span ng-switch-default>{{file.file}}</span>
                 </a>
             </li>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8580

For svg files they are displayed in an `<img>` element and for other files types there is a font icon + the extension. Maybe we can take this further and e.g. display a font icon for audio files, on for video files, one for compressed files like .zip and .rar ... and maybe also one for word, excel, pdf  files like these icons included in font awesome http://glyphsearch.com/?query=file
However the different "file" icons included in core are limited to e.g. `icon-document` and a few other. So I have done like this for now (only for fileupload property at the moment).

![image](https://cloud.githubusercontent.com/assets/2919859/17138651/932b0f92-5341-11e6-9f04-b2cdb97239c7.png)

![image](https://cloud.githubusercontent.com/assets/2919859/17138660/a1a8f156-5341-11e6-8d5d-1aa59ad188cd.png)


Now SVG files are displayed like this so you get a nice preview (before just url to media).
![image](https://cloud.githubusercontent.com/assets/2919859/17138736/f476a2ac-5341-11e6-9055-1f840fcd7f86.png)

It also looks great for animated SVG files (like animated GIF files are displayed via ImageProcessor).
![mmhrf4xpwd](https://cloud.githubusercontent.com/assets/2919859/17139123/71bdd25c-5343-11e6-8c29-729d2f2726c5.gif)

I have tested with different SVG files with and without animation - some of them found on codepen.io and the fox is from here:
http://stylecampaign.com/blog/2014/02/svg-animation/
http://stylecampaign.com/blog/?p=164&preview=true
http://stylecampaign.com/blog/blogimages/SVG/svgbase64img-link-fox-final.html
http://stylecampaign.com/blog/blogimages/SVG/svgbase64bg-fox-big-final.html

The listview media grid also display the SVG files (both non-animated and animated SVG) - however here I would like to disable the animations.
![image](https://cloud.githubusercontent.com/assets/2919859/17139683/c962c7cc-5345-11e6-9474-b96b008c9624.png)

![sejmituiha](https://cloud.githubusercontent.com/assets/2919859/17139341/526729e8-5344-11e6-84aa-3374597230ce.gif)

I am not sure how to stop animations of SVG files, maybe like this? http://stackoverflow.com/a/26349286 - `SVGRoot.pauseAnimations();` - although I haven't tested that part.
And I guess ImageProcessor can't generate thumbnails of SVG files?

Alternative I believe there are different options to convert SVG -> Canvas -> png ... or SVG -> png, which doesn't animate. But it would be nicest to keep it in vector.

Finally I think we can optimize the listview media grid a bit to use full width (I have noticed similar issue in media picker).
E.g. the screen resolution of my laptop is 1366x768 pixels and can almost contain 4 items per row.

The non-animated and animated SVG files are attached in the issue.