### PR TITLE
U4-8780 Error migrating from 7.2.2 -> 7.5 beta 2 - cmsStylesheetProperty invalid object name

### DIFF
--- a/src/Umbraco.Core/DatabaseContext.cs
+++ b/src/Umbraco.Core/DatabaseContext.cs
@@ -625,13 +625,8 @@ namespace Umbraco.Core
 
                 var installedSchemaVersion = new SemVersion(schemaResult.DetermineInstalledVersion());
 
-                var installedMigrationVersion = new SemVersion(0);
-                //we cannot check the migrations table if it doesn't exist, this will occur when upgrading to 7.3
-                if (schemaResult.ValidTables.Any(x => x.InvariantEquals("umbracoMigration")))
-                {
-                    installedMigrationVersion = schemaResult.DetermineInstalledVersionByMigrations(migrationEntryService);    
-                }
-
+                var installedMigrationVersion = schemaResult.DetermineInstalledVersionByMigrations(migrationEntryService);    
+                
                 var targetVersion = UmbracoVersion.Current;
                 
                 //In some cases - like upgrading from 7.2.6 -> 7.3, there will be no migration information in the database and therefore it will

--- a/src/Umbraco.Core/Persistence/Migrations/Initial/DatabaseSchemaResult.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Initial/DatabaseSchemaResult.cs
@@ -43,8 +43,13 @@ namespace Umbraco.Core.Persistence.Migrations.Initial
         /// <returns></returns>
         public SemVersion DetermineInstalledVersionByMigrations(IMigrationEntryService migrationEntryService)
         {
-            var allMigrations = migrationEntryService.GetAll(GlobalSettings.UmbracoMigrationName);
-            var mostrecent = allMigrations.OrderByDescending(x => x.Version).Select(x => x.Version).FirstOrDefault();
+            SemVersion mostrecent = null;
+
+            if (ValidTables.Any(x => x.InvariantEquals("umbracoMigrations")))
+            {
+                var allMigrations = migrationEntryService.GetAll(GlobalSettings.UmbracoMigrationName);
+                 mostrecent = allMigrations.OrderByDescending(x => x.Version).Select(x => x.Version).FirstOrDefault();
+            }
 
             return mostrecent ?? new SemVersion(new Version(0, 0, 0));
         }

--- a/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenFiveZero/RemoveStylesheetDataAndTablesAgain.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenFiveZero/RemoveStylesheetDataAndTablesAgain.cs
@@ -19,22 +19,32 @@ namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenFiveZer
 
         public override void Up()
         {
+            // defer, because we are making decisions based upon what's in the database
+            Execute.Code(MigrationCode);
+        }
+
+        private string MigrationCode(Database database)
+        {
+            var localContext = new LocalMigrationContext(Context.CurrentDatabaseProvider, database, SqlSyntax, Logger);
+            
             //Clear all stylesheet data if the tables exist
             var tables = SqlSyntax.GetTablesInSchema(Context.Database).ToArray();
             if (tables.InvariantContains("cmsStylesheetProperty"))
             {
-                Delete.FromTable("cmsStylesheetProperty").AllRows();
-                Delete.FromTable("umbracoNode").Row(new { nodeObjectType = new Guid(Constants.ObjectTypes.StylesheetProperty) });
+                localContext.Delete.FromTable("cmsStylesheetProperty").AllRows();
+                localContext.Delete.FromTable("umbracoNode").Row(new { nodeObjectType = new Guid(Constants.ObjectTypes.StylesheetProperty) });
 
-                Delete.Table("cmsStylesheetProperty");
+                localContext.Delete.Table("cmsStylesheetProperty");
             }
             if (tables.InvariantContains("cmsStylesheet"))
             {
-                Delete.FromTable("cmsStylesheet").AllRows();
-                Delete.FromTable("umbracoNode").Row(new { nodeObjectType = new Guid(Constants.ObjectTypes.Stylesheet) });
+                localContext.Delete.FromTable("cmsStylesheet").AllRows();
+                localContext.Delete.FromTable("umbracoNode").Row(new { nodeObjectType = new Guid(Constants.ObjectTypes.Stylesheet) });
 
-                Delete.Table("cmsStylesheet");
+                localContext.Delete.Table("cmsStylesheet");
             }
+
+            return localContext.GetSql();
         }
 
         public override void Down()

--- a/src/Umbraco.Web/Install/InstallSteps/UpgradeStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/UpgradeStep.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Semver;
 using Umbraco.Core;
 using Umbraco.Core.Configuration;
@@ -52,12 +54,35 @@ namespace Umbraco.Web.Install.InstallSteps
 
             //If we have a db context available, if we don't then we are not installed anyways
             if (ApplicationContext.Current.DatabaseContext.IsDatabaseConfigured && ApplicationContext.Current.DatabaseContext.CanConnect)
-            {
                 version = ApplicationContext.Current.DatabaseContext.ValidateDatabaseSchema().DetermineInstalledVersionByMigrations(ApplicationContext.Current.Services.MigrationEntryService);
+
+            if (version != new SemVersion(0))
+                return version;
+
+            // If we aren't able to get a result from the umbracoMigrations table then use the version in web.config, if it's available
+            if (string.IsNullOrWhiteSpace(GlobalSettings.ConfigurationStatus))
+                return version;
+
+            var configuredVersion = GlobalSettings.ConfigurationStatus;
+
+            string currentComment = null;
+
+            var current = configuredVersion.Split('-');
+            if (current.Length > 1)
+                currentComment = current[1];
+
+            Version currentVersion;
+            if (Version.TryParse(current[0], out currentVersion))
+            {
+                version = new SemVersion(
+                    currentVersion.Major,
+                    currentVersion.Minor,
+                    currentVersion.Build,
+                    string.IsNullOrWhiteSpace(currentComment) ? null : currentComment,
+                    currentVersion.Revision > 0 ? currentVersion.Revision.ToString() : null);
             }
 
             return version;
         }
-        
     }
 }


### PR DESCRIPTION
http://issues.umbraco.org/issue/U4-8780

There were a few issues here, first of the `umbracoMigrations` table could (logically) not be found in Umbraco 7.2.2. 
Two commits for that: 

- DetermineInstalledVersionByMigrations needs to check if the table exists, not the code asking for a version
- If the umbracoMigration table does not yet exist, then get the configured version from the web.config and parse it

Then the cmsStylesheetProperty error was because we tried to delete it twice in the upgrade

- Because the cmsStylesheetProperty table was already deleted by an earlier migration, it can't be deleted again. However because all of this runs in one transaction, it will try anyway, we need to do this in a "local" context instead
