### PR TITLE
U4-8749: Allow default sort order to be custom properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
@@ -1,7 +1,7 @@
 (function() {
   'use strict';
 
-  function ListViewSettingsDirective(contentTypeResource, dataTypeResource, dataTypeHelper) {
+  function ListViewSettingsDirective(contentTypeResource, dataTypeResource, dataTypeHelper, listViewPrevalueHelper) {
 
     function link(scope, el, attr, ctrl) {
 
@@ -20,6 +20,7 @@
 
               scope.dataType = dataType;
 
+              listViewPrevalueHelper.setPrevalues(dataType.preValues);
               scope.customListViewCreated = checkForCustomListView();
 
             });

--- a/src/Umbraco.Web.UI.Client/src/common/services/listviewprevaluehelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/listviewprevaluehelper.service.js
@@ -1,0 +1,61 @@
+﻿/**
+ @ngdoc service
+ * @name umbraco.services.listViewPrevalueHelper
+ *
+ *
+ * @description
+ * Service for accessing the prevalues of a list view being edited in the inline list view editor in the doctype editor
+ */
+(function () {
+    'use strict';
+
+    function listViewPrevalueHelper() {
+
+        var prevalues = [];
+
+        /**
+        * @ngdoc method
+        * @name umbraco.services.listViewPrevalueHelper#getPrevalues
+        * @methodOf umbraco.services.listViewPrevalueHelper
+        *
+        * @description
+        * Set the collection of prevalues
+        */
+
+        function getPrevalues() {
+            return prevalues;
+        }
+
+        /**
+        * @ngdoc method
+        * @name umbraco.services.listViewPrevalueHelper#setPrevalues
+        * @methodOf umbraco.services.listViewPrevalueHelper
+        *
+        * @description
+        * Changes the current layout used by the listview to the layout passed in. Stores selection in localstorage
+        *
+        * @param {Array} values Array of prevalues
+        */
+
+        function setPrevalues(values) {
+            prevalues = values;
+        }
+
+        
+
+        var service = {
+
+            getPrevalues: getPrevalues,
+            setPrevalues: setPrevalues
+
+        };
+
+        return service;
+
+    }
+
+
+    angular.module('umbraco.services').factory('listViewPrevalueHelper', listViewPrevalueHelper);
+
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -151,13 +151,21 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
          layouts: $scope.model.config.layouts,
          activeLayout: listViewHelper.getLayout($routeParams.id, $scope.model.config.layouts)
       },
-        orderBySystemField: true,
       allowBulkPublish: $scope.entityType === 'content' && $scope.model.config.bulkActionPermissions.allowBulkPublish,
       allowBulkUnpublish: $scope.entityType === 'content' && $scope.model.config.bulkActionPermissions.allowBulkUnpublish,
       allowBulkCopy: $scope.entityType === 'content' && $scope.model.config.bulkActionPermissions.allowBulkCopy,
       allowBulkMove: $scope.model.config.bulkActionPermissions.allowBulkMove,
       allowBulkDelete: $scope.model.config.bulkActionPermissions.allowBulkDelete
    };
+
+    // Check if selected order by field is actually custom field
+    for (var j = 0; j < $scope.options.includeProperties.length; j++) {
+        var includedProperty = $scope.options.includeProperties[j];
+        if (includedProperty.alias.toLowerCase() === $scope.options.orderBy.toLowerCase()) {
+            $scope.options.orderBySystemField = includedProperty.isSystem === 1;
+            break;
+        }
+    }
 
    //update all of the system includeProperties to enable sorting
    _.each($scope.options.includeProperties, function (e, i) {
@@ -180,12 +188,12 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
         }
 
         if (e.isSystem) {
-         //localize the header
-         var key = getLocalizedKey(e.alias);
-         localizationService.localize(key).then(function (v) {
-            e.header = v;
-         });
-      }
+            //localize the header
+            var key = getLocalizedKey(e.alias);
+            localizationService.localize(key).then(function (v) {
+                e.header = v;
+            });
+        }
    });
 
    $scope.selectLayout = function (selectedLayout) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
@@ -1,7 +1,17 @@
-function sortByPreValsController($rootScope, $scope, localizationService, editorState) {
+function sortByPreValsController($rootScope, $scope, localizationService, editorState, listViewPrevalueHelper) {
+    //Get the prevalue from the correct place
+    function getPrevalues() {
+        if (editorState.current.preValues) {
+            return editorState.current.preValues;
+        }
+        else {
+            return listViewPrevalueHelper.getPrevalues();
+        }
+    }
+
     //Watch the prevalues
     $scope.$watch(function () {
-        return _.findWhere(editorState.current.preValues, { key: "includeProperties" }).value;
+            return _.findWhere(getPrevalues(), { key: "includeProperties" }).value;
     }, function () {
         populateFields();
     }, true); //Use deep watching, otherwise we won't pick up header changes
@@ -15,7 +25,7 @@ function sortByPreValsController($rootScope, $scope, localizationService, editor
         }
 
         // Get list of properties assigned as columns of the list view
-        var propsPreValue = _.findWhere(editorState.current.preValues, { key: "includeProperties" });
+        var propsPreValue = _.findWhere(getPrevalues(), { key: "includeProperties" });
 
         // Populate list of options for the default sort (all the columns plus then node name)
         $scope.sortByFields = [];

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
@@ -26,42 +26,6 @@ function sortByPreValsController($rootScope, $scope, localizationService, editor
         //The old implementation pre Umbraco 7.5 used PascalCase aliases, this uses camelCase, so this ensures that any previous value is set
         $scope.model.value = existingValue.alias;
     }
-
-    //$scope.sortByFields = [
-    //    { value: "SortOrder", key: "general_sort" },
-    //    { value: "Name", key: "general_name" },
-    //    { value: "VersionDate", key: "content_updateDate" },
-    //    { value: "Updater", key: "content_updatedBy" },
-    //    { value: "CreateDate", key: "content_createDate" },
-    //    { value: "Owner", key: "content_createBy" },
-    //    { value: "ContentTypeAlias", key: "content_documentType" },
-    //    { value: "Published", key: "content_isPublished" },
-    //    { value: "Email", key: "general_email" },
-    //    { value: "Username", key: "general_username" }
-    //];
-    
-    ////now we'll localize these strings, for some reason the directive doesn't work inside of the select group with an ng-model declared
-    //_.each($scope.sortByFields, function (e, i) {
-    //    localizationService.localize(e.key).then(function (v) {
-    //        e.name = v;
-
-    //        switch (e.value) {
-    //            case "Updater":
-    //                e.name += " (Content only)";
-    //                break;
-    //            case "Published":
-    //                e.name += " (Content only)";
-    //                break;
-    //            case "Email":
-    //                e.name += " (Members only)";
-    //                break;
-    //            case "Username":
-    //                e.name += " (Members only)";
-    //                break;
-    //        }
-    //    });
-    //});
-
 }
 
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
@@ -67,6 +67,18 @@ function sortByPreValsController($rootScope, $scope, localizationService, editor
                 }
             });
         });
+
+        // Check existing model value is available in list and ensure a value is set
+        var existingValue = findFromSortByFields($scope.model.value);
+        if (existingValue) {
+            // Set the existing value
+            // The old implementation pre Umbraco 7.5 used PascalCase aliases, this uses camelCase, so this ensures that any previous value is set
+            $scope.model.value = existingValue.value;
+        }
+        else {
+            // Existing value not found, set to first value
+            $scope.model.value = $scope.sortByFields[0].value;
+        }
     }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
@@ -1,39 +1,66 @@
-function sortByPreValsController($rootScope, $scope, localizationService) {
+function sortByPreValsController($rootScope, $scope, localizationService, editorState) {
+    var propsPreValue = _.findWhere(editorState.current.preValues, { key: "includeProperties" });
 
-    $scope.sortByFields = [
-        { value: "SortOrder", key: "general_sort" },
-        { value: "Name", key: "general_name" },
-        { value: "VersionDate", key: "content_updateDate" },
-        { value: "Updater", key: "content_updatedBy" },
-        { value: "CreateDate", key: "content_createDate" },
-        { value: "Owner", key: "content_createBy" },
-        { value: "ContentTypeAlias", key: "content_documentType" },
-        { value: "Published", key: "content_isPublished" },
-        { value: "Email", key: "general_email" },
-        { value: "Username", key: "general_username" }
-    ];
-    
-    //now we'll localize these strings, for some reason the directive doesn't work inside of the select group with an ng-model declared
-    _.each($scope.sortByFields, function (e, i) {
-        localizationService.localize(e.key).then(function (v) {
-            e.name = v;
+    if(propsPreValue != undefined){
+        $scope.sortByFields = propsPreValue.value;
+    }
+    else {
+        $scope.sortByFields = [];
+    }
 
-            switch (e.value) {
-                case "Updater":
-                    e.name += " (Content only)";
-                    break;
-                case "Published":
-                    e.name += " (Content only)";
-                    break;
-                case "Email":
-                    e.name += " (Members only)";
-                    break;
-                case "Username":
-                    e.name += " (Members only)";
-                    break;
-            }
-        });
+    var existingValue = _.find($scope.sortByFields, function (e) {
+        return e.alias.toLowerCase() === $scope.model.value;
     });
+
+    if (existingValue === undefined) {
+        //Existing value not found
+
+        //Set to first value
+        if($scope.sortByFields.length > 0){
+            $scope.model.value = $scope.sortByFields[0].alias;
+        }
+        
+    }
+    else {
+        //Set the existing value
+        //The old implementation pre Umbraco 7.5 used PascalCase aliases, this uses camelCase, so this ensures that any previous value is set
+        $scope.model.value = existingValue.alias;
+    }
+
+    //$scope.sortByFields = [
+    //    { value: "SortOrder", key: "general_sort" },
+    //    { value: "Name", key: "general_name" },
+    //    { value: "VersionDate", key: "content_updateDate" },
+    //    { value: "Updater", key: "content_updatedBy" },
+    //    { value: "CreateDate", key: "content_createDate" },
+    //    { value: "Owner", key: "content_createBy" },
+    //    { value: "ContentTypeAlias", key: "content_documentType" },
+    //    { value: "Published", key: "content_isPublished" },
+    //    { value: "Email", key: "general_email" },
+    //    { value: "Username", key: "general_username" }
+    //];
+    
+    ////now we'll localize these strings, for some reason the directive doesn't work inside of the select group with an ng-model declared
+    //_.each($scope.sortByFields, function (e, i) {
+    //    localizationService.localize(e.key).then(function (v) {
+    //        e.name = v;
+
+    //        switch (e.value) {
+    //            case "Updater":
+    //                e.name += " (Content only)";
+    //                break;
+    //            case "Published":
+    //                e.name += " (Content only)";
+    //                break;
+    //            case "Email":
+    //                e.name += " (Members only)";
+    //                break;
+    //            case "Username":
+    //                e.name += " (Members only)";
+    //                break;
+    //        }
+    //    });
+    //});
 
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
@@ -1,77 +1,73 @@
 function sortByPreValsController($rootScope, $scope, localizationService, editorState) {
-    // Helper to find a particular value from the list of sort by options
-    function findFromSortByFields(value) {
-        return _.find($scope.sortByFields, function (e) {
-            return e.value.toLowerCase() === value.toLowerCase();
-        });
-    }
+    //Watch the prevalues
+    $scope.$watch(function () {
+        return _.findWhere(editorState.current.preValues, { key: "includeProperties" }).value;
+    }, function () {
+        populateFields();
+    }, true); //Use deep watching, otherwise we won't pick up header changes
 
-    // Get list of properties assigned as columns of the list view
-    var propsPreValue = _.findWhere(editorState.current.preValues, { key: "includeProperties" });
-
-    // Populate list of options for the default sort (all the columns plus then node name)
-    $scope.sortByFields = [];
-    $scope.sortByFields.push({ value: "name", name: "Name", isSystem: 1 });
-    if (propsPreValue != undefined) {
-        for (var i = 0; i < propsPreValue.value.length; i++) {
-            var value = propsPreValue.value[i];
-            $scope.sortByFields.push({
-                value: value.alias,
-                name: value.header,
-                isSystem: value.isSystem
+    function populateFields() {
+        // Helper to find a particular value from the list of sort by options
+        function findFromSortByFields(value) {
+            return _.find($scope.sortByFields, function (e) {
+                return e.value.toLowerCase() === value.toLowerCase();
             });
         }
-    }
 
-    // Localize the system fields, for some reason the directive doesn't work inside of the select group with an ng-model declared
-    var systemFields = [
-        { value: "SortOrder", key: "general_sort" },
-        { value: "Name", key: "general_name" },
-        { value: "VersionDate", key: "content_updateDate" },
-        { value: "Updater", key: "content_updatedBy" },
-        { value: "CreateDate", key: "content_createDate" },
-        { value: "Owner", key: "content_createBy" },
-        { value: "ContentTypeAlias", key: "content_documentType" },
-        { value: "Published", key: "content_isPublished" },
-        { value: "Email", key: "general_email" },
-        { value: "Username", key: "general_username" }
-    ];
-    _.each(systemFields, function (e) {
-        localizationService.localize(e.key).then(function (v) {
+        // Get list of properties assigned as columns of the list view
+        var propsPreValue = _.findWhere(editorState.current.preValues, { key: "includeProperties" });
 
-            var sortByListValue = findFromSortByFields(e.value);
-            if (sortByListValue) {
-                sortByListValue.name = v;
-                switch (e.value) {
-                    case "Updater":
-                        e.name += " (Content only)";
-                        break;
-                    case "Published":
-                        e.name += " (Content only)";
-                        break;
-                    case "Email":
-                        e.name += " (Members only)";
-                        break;
-                    case "Username":
-                        e.name += " (Members only)";
-                        break;
-                }
+        // Populate list of options for the default sort (all the columns plus then node name)
+        $scope.sortByFields = [];
+        $scope.sortByFields.push({ value: "name", name: "Name", isSystem: 1 });
+        if (propsPreValue != undefined) {
+            for (var i = 0; i < propsPreValue.value.length; i++) {
+                var value = propsPreValue.value[i];
+                $scope.sortByFields.push({
+                    value: value.alias,
+                    name: value.header,
+                    isSystem: value.isSystem
+                });
             }
+        }
+
+        // Localize the system fields, for some reason the directive doesn't work inside of the select group with an ng-model declared
+        var systemFields = [
+            { value: "SortOrder", key: "general_sort" },
+            { value: "Name", key: "general_name" },
+            { value: "VersionDate", key: "content_updateDate" },
+            { value: "Updater", key: "content_updatedBy" },
+            { value: "CreateDate", key: "content_createDate" },
+            { value: "Owner", key: "content_createBy" },
+            { value: "ContentTypeAlias", key: "content_documentType" },
+            { value: "Published", key: "content_isPublished" },
+            { value: "Email", key: "general_email" },
+            { value: "Username", key: "general_username" }
+        ];
+        _.each(systemFields, function (e) {
+            localizationService.localize(e.key).then(function (v) {
+
+                var sortByListValue = findFromSortByFields(e.value);
+                if (sortByListValue) {
+                    sortByListValue.name = v;
+                    switch (e.value) {
+                        case "Updater":
+                            e.name += " (Content only)";
+                            break;
+                        case "Published":
+                            e.name += " (Content only)";
+                            break;
+                        case "Email":
+                            e.name += " (Members only)";
+                            break;
+                        case "Username":
+                            e.name += " (Members only)";
+                            break;
+                    }
+                }
+            });
         });
-    });
-
-    // Check existing model value is available in list and ensure a value is set
-    var existingValue = findFromSortByFields($scope.model.value);
-    if (existingValue) {
-        // Set the existing value
-        // The old implementation pre Umbraco 7.5 used PascalCase aliases, this uses camelCase, so this ensures that any previous value is set
-        $scope.model.value = existingValue.value;
     }
-    else {
-        // Existing value not found, set to first value
-        $scope.model.value = $scope.sortByFields[0].value;
-    }
-
 }
 
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.html
@@ -1,5 +1,5 @@
 ﻿<select ng-model="model.value"
         ng-controller="Umbraco.PrevalueEditors.SortByListViewController"
-        ng-options="field.value as field.name for field in sortByFields">
+        ng-options="field.alias as field.header for field in sortByFields">
     
 </select>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.html
@@ -1,5 +1,4 @@
 ﻿<select ng-model="model.value"
         ng-controller="Umbraco.PrevalueEditors.SortByListViewController"
-        ng-options="field.alias as field.header for field in sortByFields">
-    
+        ng-options="field.value as field.name for field in sortByFields">
 </select>

--- a/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
@@ -53,8 +53,16 @@ namespace Umbraco.Web.PropertyEditors
         {
             [PreValueField("displayAtTabNumber", "Display At Tab Number", "number", Description = "Which tab position that the list of child items will be displayed")]
             public int DisplayAtTabNumber { get; set; }
+
             [PreValueField("pageSize", "Page Size", "number", Description = "Number of items per page")]
             public int PageSize { get; set; }
+
+            [PreValueField("layouts", "Layouts", "views/propertyeditors/listview/layouts.prevalues.html")]
+            public int Layouts { get; set; }
+
+            [PreValueField("includeProperties", "Columns Displayed", "views/propertyeditors/listview/includeproperties.prevalues.html",
+                Description = "The properties that will be displayed for each column")]
+            public object IncludeProperties { get; set; }
 
             [PreValueField("orderBy", "Order By", "views/propertyeditors/listview/sortby.prevalues.html",
                 Description = "The default sort order for the list")]
@@ -63,15 +71,10 @@ namespace Umbraco.Web.PropertyEditors
             [PreValueField("orderDirection", "Order Direction", "views/propertyeditors/listview/orderdirection.prevalues.html")]
             public int OrderDirection { get; set; }
 
-            [PreValueField("layouts", "Layouts", "views/propertyeditors/listview/layouts.prevalues.html")]
-            public int Layouts { get; set; }
-
-            [PreValueField("includeProperties", "Columns Displayed", "views/propertyeditors/listview/includeproperties.prevalues.html", 
-                Description = "The properties that will be displayed for each column")]
-            public object IncludeProperties { get; set; }
             [PreValueField("bulkActionPermissions", "Bulk Action Permissions", "views/propertyeditors/listview/bulkactionpermissions.prevalues.html",
                 Description = "The bulk actions that are allowed from the list view")]
             public BulkActionPermissionSettings BulkActionPermissions { get; set; }
+
             internal class BulkActionPermissionSettings
             {
                 public bool AllowBulkPublish { get; set; }


### PR DESCRIPTION
Now that the List View in 7.5 can sort by custom properties, the default sort order needs to be able to be set to these properties.

This PR implements this by populating the Default sort order list from the list of columns added to the list view, instead of the previous hardcoded list.

This does mean that you cannot sort by a column not added to the list view. In my opinion, this should never have been possible in the first place, as the editor has no way to get back to the initial sort, short of reloading. However, this could be considered a breaking change.

This PR is now finished and ready for review. Thanks to @AndyButland for making major improvements to my initial PR.

UPDATE AUG 3: The inline list view editor is now working. A new service has been added to allow acces to the prevalues in this case.

http://issues.umbraco.org/issue/U4-8749