### PR TITLE
Show only empty recycle bin text, when filter doesn't has a value

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/grid/grid.html
@@ -18,7 +18,7 @@
       </umb-empty-state>
 
       <umb-empty-state
-          ng-if="!items && vm.isRecycleBin"
+          ng-if="!items && options.filter.length == 0 && vm.isRecycleBin"
           position="center">
           <localize key="general_recycleBinEmpty"></localize>
       </umb-empty-state>
@@ -68,7 +68,7 @@
       </umb-tooltip>
 
       <umb-empty-state
-          ng-if="vm.itemsWithoutFolders.length === 0 && vm.isRecycleBin"
+          ng-if="vm.itemsWithoutFolders.length === 0 && options.filter.length == 0 && vm.isRecycleBin"
           position="center">
           <localize key="general_recycleBinEmpty"></localize>
       </umb-empty-state>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.html
@@ -58,7 +58,7 @@
     </umb-empty-state>
 
     <umb-empty-state
-        ng-if="!items && vm.isRecycleBin"
+        ng-if="!items && options.filter.length == 0 && vm.isRecycleBin"
         position="center">
         <localize key="general_recycleBinEmpty"></localize>
     </umb-empty-state>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8809

Hide "Your recycle bin is empty" text, when a value has been entered in the search field.

Furthermore in listview.html we could also disable filter input when there is no results.
However this will not quite work since `listViewResultSet.items` is filtered, so as soon you enter text in the search input it become disabled (and you can't delete the text again - you need to refresh view).
`ng-disabled="!listViewResultSet.items"`

I am not sure if you want to add this too? It doesn't make much sense to filter an empty result set anyway. Then we just need a copy of original listViewResultSet.items or add a scope property to remember the original number of items, so the filter input only is diabled when the original result set is empty :)