### PR TITLE
Set border radius for modal to zero.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/modals.less
+++ b/src/Umbraco.Web.UI.Client/src/less/modals.less
@@ -114,7 +114,7 @@
 .umbracoDialog{
 	width: auto !Important;
 	height: auto !Important;
-  padding: 20px;
+    padding: 20px;
 }
 .umbracoDialog .umb-pane{margin-left: 0px; margin-right: 0px; margin-top: 0px;}
 .umbracoDialog .umb-dialog-body .umb-pane{margin-left: 20px; margin-right: 20px; margin-top: 20px;}
@@ -125,7 +125,11 @@
 .umb-modal .controls-row{margin-left: 0px !important;}
 
 /* modal and umb-modal are used for right.hand dialogs */
-.modal.fade.in{border: none !important; border-radius: none !important;}
+.modal {
+    border-radius: 0 !important;
+
+    &.fade.in{border: none !important;}
+}
 .umb-modal.fade {
 	outline: none;
 	top: 0 !important;


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8844

`none` is not a valid value for `border-radius`.

Set it to zero and moved it directly to modal class.