### PR TITLE
U4-8845 - Prevents double-click on confirm delete from deleting from bin

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -10,8 +10,12 @@ function ContentDeleteController($scope, contentResource, treeService, navigatio
 
     $scope.performDelete = function() {
 
+        // stop from firing again on double-click
+        if ($scope.busy) { return false; }
+
         //mark it for deletion (used in the UI)
         $scope.currentNode.loading = true;
+        $scope.busy = true;
 
         contentResource.deleteById($scope.currentNode.id).then(function () {
             $scope.currentNode.loading = false;
@@ -44,6 +48,7 @@ function ContentDeleteController($scope, contentResource, treeService, navigatio
         }, function(err) {
 
             $scope.currentNode.loading = false;
+            $scope.busy = false;
 
             //check if response is ysod
             if (err.status && err.status >= 500) {

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
@@ -10,8 +10,12 @@ function MediaDeleteController($scope, mediaResource, treeService, navigationSer
 
     $scope.performDelete = function() {
 
+        // stop from firing again on double-click
+        if ($scope.busy) { return false; }
+
         //mark it for deletion (used in the UI)
         $scope.currentNode.loading = true;
+        $scope.busy = true;
 
         mediaResource.deleteById($scope.currentNode.id).then(function () {
             $scope.currentNode.loading = false;
@@ -45,6 +49,7 @@ function MediaDeleteController($scope, mediaResource, treeService, navigationSer
         }, function (err) {
 
             $scope.currentNode.loading = false;
+            $scope.busy = false;
 
             //check if response is ysod
             if (err.status && err.status >= 500) {


### PR DESCRIPTION
Fix for a destructive bug, where an accidental double-click on the confirm delete OK button completely deletes the Content or Media node.
http://issues.umbraco.org/issue/U4-8845