### PR TITLE
U4-8822- Fixes Unpublish error with empty RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -322,7 +322,8 @@ angular.module("umbraco")
                 //this is instead of doing a watch on the model.value = faster
                 $scope.model.onValueChanged = function (newVal, oldVal) {
                     //update the display val again if it has changed from the server;
-                    tinyMceEditor.setContent(newVal, { format: 'raw' });
+                    //uses an empty string in the editor when the value is null
+                    tinyMceEditor.setContent(newVal || "", { format: 'raw' });
                     //we need to manually fire this event since it is only ever fired based on loading from the DOM, this
                     // is required for our plugins listening to this event to execute
                     tinyMceEditor.fire('LoadContent', null);


### PR DESCRIPTION
When unpublishing a node with an empty RTE, the value sometimes will be reloaded in the RTE as null. The RTE editor has some logic that checks the length of this value, so it throws an exception when it has no value. When the exception happens it prevents umbraco from leaving the "Saving" state.

This change makes sure there is at least an empty string passed in when the new value is null.
