### PR TITLE
U4-7317: Template no selected by default on new content items

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
@@ -160,9 +160,10 @@ namespace Umbraco.Web.Models.Mapping
                 var url = urlHelper.GetUmbracoApiService<ContentTreeController>(controller => controller.GetTreeNode(display.Id.ToString(), null));
                 display.TreeNodeUrl = url;
             }
-            
+
             //fill in the template config to be passed to the template drop down.
-            var templateItemConfig = new Dictionary<string, string> { { "", "Choose..." } };
+
+            var templateItemConfig = new Dictionary<string, string> { };
             foreach (var t in content.ContentType.AllowedTemplates
                 .Where(t => t.Alias.IsNullOrWhiteSpace() == false && t.Name.IsNullOrWhiteSpace() == false))
             {
@@ -213,7 +214,7 @@ namespace Umbraco.Web.Models.Mapping
                 {
                     Alias = string.Format("{0}template", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
                     Label = localizedText.Localize("template/template"),
-                    Value = display.TemplateAlias,
+                    Value = content.ContentType.DefaultTemplate.Alias,
                     View = "dropdown", //TODO: Hard coding until we make a real dropdown property editor to lookup
                     Config = new Dictionary<string, object>
                     {

--- a/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
@@ -174,7 +174,7 @@ namespace Umbraco.Web.Models.Mapping
             {
                 TabsAndPropertiesResolver.AddListView(display, "content", dataTypeService, localizedText);
             }
-            
+
             var properties = new List<ContentPropertyDisplay>
             {
                 new ContentPropertyDisplay
@@ -214,7 +214,7 @@ namespace Umbraco.Web.Models.Mapping
                 {
                     Alias = string.Format("{0}template", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
                     Label = localizedText.Localize("template/template"),
-                    Value = content.ContentType.DefaultTemplate.Alias,
+                    Value = content.ContentType.DefaultTemplate == null ? "" : content.ContentType.DefaultTemplate.Alias,
                     View = "dropdown", //TODO: Hard coding until we make a real dropdown property editor to lookup
                     Config = new Dictionary<string, object>
                     {


### PR DESCRIPTION
The default Template is now preselected. The "Default..."-Text has been removed.
