### PR TITLE
Update UmbracoCms.nuspec

### DIFF
--- a/build/NuSpecs/UmbracoCms.nuspec
+++ b/build/NuSpecs/UmbracoCms.nuspec
@@ -16,7 +16,7 @@
     <tags>umbraco</tags>
     <dependencies>
       <dependency id="UmbracoCms.Core" version="[$version$]" />
-      <dependency id="Newtonsoft.Json" version="[6.0.8, 9.0.0)" />
+      <dependency id="Newtonsoft.Json" version="[6.0.8, 10.0.0)" />
       <dependency id="Umbraco.ModelsBuilder" version="[3.0.4, 4.0.0)" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Update Newtonsoft.Json dependency to allow version 9.0.1 . This will match the same change in UmbracoCms.Core.nuspec file