### PR TITLE
Make custom icons more dynamic

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
@@ -181,7 +181,11 @@ function iconHelper($q, $timeout) {
                                     if(hasPseudo>0){
                                         s = s.substring(0, hasPseudo);
                                     }
-
+                                    var hasDots = s.indexOf(".");
+                                    if (hasDots>0) {
+                                        s = s.replace(/\./g, " ");
+                                    }
+                                    
                                     if(collectedIcons.indexOf(s) < 0){
                                         collectedIcons.push(s);
                                     }


### PR DESCRIPTION
Separate the class by dots and return the whole class, to make it easier, to add icons from any vendor, without having to change much to the original css.
Example:
Add this icon to umbraco and it will just work in the frontend with no changes to font-awesome.
.icon-fa.fa.fa-glass:before { ... }

Same could be done with other icons.
Simple addition - great benefits!
