### PR TITLE
U4-8923 Adding new property to media breaks ability to save

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/MediaRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/MediaRepository.cs
@@ -413,6 +413,8 @@ namespace Umbraco.Core.Persistence.Repositories
             {
                 foreach (var property in entity.Properties)
                 {
+                    if (keyDictionary.ContainsKey(property.PropertyTypeId) == false) continue;
+
                     property.Id = keyDictionary[property.PropertyTypeId];
                 }
             }

--- a/src/Umbraco.Core/Persistence/Repositories/MemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/MemberRepository.cs
@@ -365,6 +365,8 @@ namespace Umbraco.Core.Persistence.Repositories
             {
                 foreach (var property in ((Member)entity).Properties)
                 {
+                    if (keyDictionary.ContainsKey(property.PropertyTypeId) == false) continue;
+
                     property.Id = keyDictionary[property.PropertyTypeId];
                 }
             }


### PR DESCRIPTION
If you add a new property to a member or media type and then try to update an
existing media item/member then it would YSOD with a KeyNotFoundException
ContentRepository didn't have this problem because it was already using the 
additional if statement that has now also been added to MemberRepository and MediaRepository