### PR TITLE
U4-8898 Blank login screen after upgrade to 7.5.x

### DIFF
--- a/src/Umbraco.Web/Install/Controllers/InstallController.cs
+++ b/src/Umbraco.Web/Install/Controllers/InstallController.cs
@@ -44,6 +44,10 @@ namespace Umbraco.Web.Install.Controllers
 
             if (ApplicationContext.Current.IsUpgrading)
             {
+                // Update ClientDependency version
+                var clientDependencyConfig = new ClientDependencyConfiguration(ApplicationContext.Current.ProfilingLogger.Logger);
+                var clientDependencyUpdated = clientDependencyConfig.IncreaseVersionNumber();
+
                 var result = _umbracoContext.Security.ValidateCurrentUser(false);
 
                 switch (result)

--- a/src/Umbraco.Web/Install/InstallSteps/SetUmbracoVersionStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/SetUmbracoVersionStep.cs
@@ -49,10 +49,6 @@ namespace Umbraco.Web.Install.InstallSteps
 
             // Update configurationStatus
             GlobalSettings.ConfigurationStatus = UmbracoVersion.GetSemanticVersion().ToSemanticString();
-
-            // Update ClientDependency version
-            var clientDependencyConfig = new ClientDependencyConfiguration(_applicationContext.ProfilingLogger.Logger);
-            var clientDependencyUpdated = clientDependencyConfig.IncreaseVersionNumber();
             
             //reports the ended install            
             ih.InstallStatus(true, "");


### PR DESCRIPTION
Moves the updating of the CDF version to the very beginning before we even redirect to the login screen so it is nicely cachebusted