### PR TITLE
U4-8939 Old openContentPicker() method is failing

### DIFF
--- a/src/Umbraco.Web/UI/Bundles/JsJQueryCore.cs
+++ b/src/Umbraco.Web/UI/Bundles/JsJQueryCore.cs
@@ -8,6 +8,7 @@ namespace Umbraco.Web.UI.Bundles
     /// </summary>
     [ClientDependency(ClientDependencyType.Javascript, "ui/jquery.js", "UmbracoClient", Priority = 0, Group = 1)]
     [ClientDependency(ClientDependencyType.Javascript, "ui/jqueryui.js", "UmbracoClient", Priority = 1, Group = 1)]
+    [ClientDependency(ClientDependencyType.Javascript, "lib/jquery-migrate/jquery-migrate.min.js", "UmbracoRoot", Priority = 2, Group = 1)]
     public class JsJQueryCore : Control
     {
     }


### PR DESCRIPTION
Adding jquery-migrate to make sure legacy applications keep working