### PR TITLE
Keeping form UI button styling inline with rest of the backoffice

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/dialogs/ChangeDocType.aspx
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/ChangeDocType.aspx
@@ -112,7 +112,7 @@
         <br />
         <p>
             <asp:PlaceHolder ID="SavePlaceholder" runat="server">        
-                <asp:Button ID="ValidateAndSave" runat="server" OnClick="ValidateAndSave_Click" />
+                <asp:Button CssClass="btn" ID="ValidateAndSave" runat="server" OnClick="ValidateAndSave_Click" />
                 <em> <%= umbraco.ui.Text("or") %> </em>
             </asp:PlaceHolder>        
             <a href="#" style="color: blue" onclick="UmbClientMgr.closeModalWindow()"><%=umbraco.ui.Text("general", "cancel", Security.CurrentUser)%></a>  


### PR DESCRIPTION
Every other button in the backoffice has this styling and it was bugging me to see the change doctype save button was inheriting the default browser styles.
