### PR TITLE
U4-8960 Misc classes have hard dependencies on HttpContext.Server.MapPath

### DIFF
--- a/src/Umbraco.Core/IO/IOHelper.cs
+++ b/src/Umbraco.Core/IO/IOHelper.cs
@@ -13,7 +13,9 @@ using Umbraco.Core.Logging;
 namespace Umbraco.Core.IO
 {
 	public static class IOHelper
-    {
+	{
+	    public static bool IAmUnitTestingSoNeverUseHttpContextEver = false;
+
         private static string _rootDir = "";
 
         // static compiled regex for faster performance
@@ -97,6 +99,8 @@ namespace Umbraco.Core.IO
 
         public static string MapPath(string path, bool useHttpContext)
         {
+            useHttpContext = useHttpContext && IAmUnitTestingSoNeverUseHttpContextEver == false;
+
             // Check if the path is already mapped
             if ((path.Length >= 2 && path[1] == Path.VolumeSeparatorChar)
                 || path.StartsWith(@"\\")) //UNC Paths start with "\\". If the site is running off a network drive mapped paths will look like "\\Whatever\Boo\Bar"

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/GridValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/GridValueConverter.cs
@@ -44,8 +44,8 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
                     var gridConfig = UmbracoConfig.For.GridConfig(
                         ApplicationContext.Current.ProfilingLogger.Logger,
                         ApplicationContext.Current.ApplicationCache.RuntimeCache,
-                        new DirectoryInfo(HttpContext.Current.Server.MapPath(SystemDirectories.AppPlugins)),
-                        new DirectoryInfo(HttpContext.Current.Server.MapPath(SystemDirectories.Config)),
+                        new DirectoryInfo(IOHelper.MapPath(SystemDirectories.AppPlugins)),
+                        new DirectoryInfo(IOHelper.MapPath(SystemDirectories.Config)),
                         HttpContext.Current.IsDebuggingEnabled);
                     
                     var sections = GetArray(obj, "sections");

--- a/src/Umbraco.Core/TypeFinder.cs
+++ b/src/Umbraco.Core/TypeFinder.cs
@@ -26,6 +26,8 @@ namespace Umbraco.Core
     /// </summary>
     public static class TypeFinder
     {
+        public static bool IAmUnitTestingSoNeverUseHttpContextEver = false;
+
         private static volatile HashSet<Assembly> _localFilteredAssemblyCache = null;
         private static readonly object LocalFilteredAssemblyCacheLocker = new object();
 
@@ -52,7 +54,7 @@ namespace Umbraco.Core
             HashSet<Assembly> assemblies = null;
             try
             {
-                var isHosted = HttpContext.Current != null;
+                var isHosted = HttpContext.Current != null && IAmUnitTestingSoNeverUseHttpContextEver == false;
 
                 try
                 {

--- a/src/Umbraco.Tests/TestHelpers/BaseDatabaseFactoryTest.cs
+++ b/src/Umbraco.Tests/TestHelpers/BaseDatabaseFactoryTest.cs
@@ -375,7 +375,7 @@ namespace Umbraco.Tests.TestHelpers
             return ctx;
         }
 
-        protected FakeHttpContextFactory GetHttpContextFactory(string url, RouteData routeData = null)
+        protected virtual FakeHttpContextFactory GetHttpContextFactory(string url, RouteData routeData = null)
         {
             var factory = routeData != null
                             ? new FakeHttpContextFactory(url, routeData)

--- a/src/Umbraco.Tests/TestHelpers/BaseDatabaseFactoryTest.cs
+++ b/src/Umbraco.Tests/TestHelpers/BaseDatabaseFactoryTest.cs
@@ -381,7 +381,6 @@ namespace Umbraco.Tests.TestHelpers
                             ? new FakeHttpContextFactory(url, routeData)
                             : new FakeHttpContextFactory(url);
 
-
             //set the state helper
             StateHelper.HttpContext = factory.HttpContext;
 


### PR DESCRIPTION
Removing HttpContext dependency from GridValueConverter. Adding configuration for IOHelper when testing to remove usage of HttpContext.

Don't pull it immediately. Working on a presentation where I test drive views. Not quite done yet, so might stumble upon some more showstoppers.
