### PR TITLE
Fix U4-8968: Add missing check for backoffice session in ClaimsIdentity

### DIFF
--- a/src/Umbraco.Core/Security/AuthenticationExtensions.cs
+++ b/src/Umbraco.Core/Security/AuthenticationExtensions.cs
@@ -113,8 +113,8 @@ namespace Umbraco.Core.Security
 
             //Otherwise convert to a UmbracoBackOfficeIdentity if it's auth'd and has the back office session            
             var claimsIdentity = http.User.Identity as ClaimsIdentity;
-            if (claimsIdentity != null && claimsIdentity.IsAuthenticated)
-            {                
+            if (claimsIdentity != null && claimsIdentity.IsAuthenticated && claimsIdentity.HasClaim(x => x.Type == Constants.Security.SessionIdClaimType))
+            {                 
                 try
                 {
                     return UmbracoBackOfficeIdentity.FromClaimsIdentity(claimsIdentity);


### PR DESCRIPTION
The comment in the code says to check for the backoffice session, but that is never actually done. So it ends trying to convert a front-end login (using Forms Authentication or other types) into a BackOfficeIdentity, which of course does not work. This throws 6 exceptions into the log file every time you use the API to save and publish while a member is logged in and no-one is logged in to the backoffice.