### PR TITLE
U4-8956 PublicAccessEntry.ClearRules() triggers an unhandled exception

### DIFF
--- a/src/Umbraco.Core/Models/PublicAccessEntry.cs
+++ b/src/Umbraco.Core/Models/PublicAccessEntry.cs
@@ -107,9 +107,9 @@ namespace Umbraco.Core.Models
 
         public void ClearRules()
         {
-            foreach (var rule in _ruleCollection)
+            for (var i = _ruleCollection.Count - 1; i >= 0; i--)
             {
-                RemoveRule(rule);
+                RemoveRule(_ruleCollection[i]);
             }
         }
 


### PR DESCRIPTION
fixed System.InvalidOperationException (Collection was modified;
enumeration operation may not execute.) by reverse iterating the
collection.