### PR TITLE
U4 8975

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.controller.js
@@ -16,7 +16,7 @@ angular.module("umbraco")
     		};
 
     		$scope.scaleDown = function(section){
-    		   var remove = (section.grid > 1) ? 1 : section.grid;
+    		   var remove = (section.grid > 1) ? 1 : 0;
     		   section.grid = section.grid-remove;
     		};
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.controller.js
@@ -49,9 +49,12 @@ angular.module("umbraco")
     		    $scope.currentSection = section;
     		};
 
-
-    		$scope.deleteSection = function(index){
-    		    $scope.currentTemplate.sections.splice(index, 1);
+    		$scope.deleteSection = function(section, template) {
+    			if ($scope.currentSection === section) {
+    				$scope.currentSection = undefined;
+    			}
+    			var index = template.sections.indexOf(section)
+    			template.sections.splice(index, 1);
     		};
     		
     		$scope.closeSection = function(){

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.html
@@ -46,6 +46,13 @@
              </div>
           </umb-control-group>
 
+		  <umb-control-group hide-label="true">
+			<i class="icon-delete red"></i>
+	  		<a class="btn btn-small btn-link" href="" ng-click="deleteSection(currentSection, currentLayout)">
+			  <localize key="general_delete" class="ng-isolate-scope ng-scope">Delete</localize>
+			</a>
+	  	</umb-control-group>
+
 
           <umb-control-group hide-label="true">
              <ul class="unstyled">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.controller.js
@@ -58,9 +58,14 @@ function RowConfigController($scope) {
         }
     };
 
-    $scope.deleteArea = function(index) {
-        $scope.currentRow.areas.splice(index, 1);
+    $scope.deleteArea = function (cell, row) {
+    	if ($scope.currentCell === cell) {
+    		$scope.currentCell = undefined;
+    	}
+    	var index = row.areas.indexOf(cell)
+    	row.areas.splice(index, 1);
     };
+
     $scope.closeArea = function() {
         $scope.currentCell = undefined;
     };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.controller.js
@@ -14,7 +14,7 @@ function RowConfigController($scope) {
     };
 
     $scope.scaleDown = function(section) {
-        var remove = (section.grid > 1) ? 1 : section.grid;
+        var remove = (section.grid > 1) ? 1 : 0;
         section.grid = section.grid - remove;
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
@@ -57,6 +57,12 @@
              </div>
           </umb-control-group>
 
+	  	  <umb-control-group hide-label="true">
+	  		  <i class="icon-delete red"></i>
+	  		  <a class="btn btn-small btn-link" href="" ng-click="deleteArea(currentCell, currentRow)">
+	  			  <localize key="general_delete" class="ng-isolate-scope ng-scope">Delete</localize>
+	  		  </a>
+	  	  </umb-control-group>
 
           <umb-control-group hide-label="true">
              <ul class="unstyled">


### PR DESCRIPTION
This PR fixes Issue U4 8975: Can't delete a column when defining columns in the grid editor configuration.

Changes:

1. layoutconfig.controller.js:
    - on line 19 - this function is responsible for saling selected section down. The condition evaluates the value by which the selected section should be scaled down. When current section's width was 1 it was still evaluating to 1. Changed that to return 0, when current width is 1 (minimum)
    - on line 52 - refactored unused function "deleteSection" to delete selected section

2. layoutconfig.html:
    - For selected section: added 'Delete' button (which deletes selected section from current layout).

3.  For rowconfig.controller.js and rowconfig.html **changes are analogous**.