### PR TITLE
U4-8999 - health check, debug compilation mode is being reported in error when config missing

### DIFF
--- a/src/Umbraco.Web/HealthCheck/Checks/Config/CompilationDebugCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/CompilationDebugCheck.cs
@@ -30,6 +30,11 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
             get { return ValueComparisonType.ShouldEqual; }
         }
 
+        public override bool ValidIfConfigMissing
+        {
+            get { return true; }
+        }
+
         public override IEnumerable<AcceptableConfiguration> Values
         {
             get


### PR DESCRIPTION
Fixes debug setting health check to correctly indicate no issue if config setting is missing
