### PR TITLE
U4-9003 - Add checkboxlist prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -45,6 +45,10 @@
     overflow-x: hidden;
     position: relative;
     height: auto;
+
+    .checkbox, .radio {
+        padding-left: 0;
+    }
 }
 
 .umb-overlay .umb-overlay-drawer {

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -133,12 +133,12 @@ ul.color-picker li a  {
         .icon {
             display: inline-block;
             line-height: 100%;
-            font-size: 32px;
-            width: 32px;
+            font-size: 24px;
+            width: 24px;
         }
         .icon + span {
             vertical-align: top;
-            line-height: 32px;
+            line-height: 24px;
         }
     }
     .checkbox input[type="checkbox"]:checked + .icon,

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -123,6 +123,33 @@ ul.color-picker li a  {
 
 
 //
+// Checkbox List
+// --------------------------------------------------
+
+/* pre-value editor */
+.umb-checkbox-list-preval,
+.umb-radiobutton-list-preval {
+    .checkbox, .radio {
+        .icon {
+            display: inline-block;
+            line-height: 100%;
+            font-size: 32px;
+            width: 32px;
+        }
+        .icon + span {
+            vertical-align: top;
+            line-height: 32px;
+        }
+    }
+    .checkbox input[type="checkbox"]:checked + .icon,
+    .radio input[type="radio"]:checked + .icon
+    {
+        color: @blue;
+    }
+}
+
+
+//
 // Media picker
 // --------------------------------------------------
 .umb-mediapicker .add-link {

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
@@ -1,7 +1,8 @@
-<ul class="unstyled">
-	<li ng-repeat="preval in model.prevalues">
-	    <label class="checkbox">
-            <input type="checkbox" checklist-model="model.value" checklist-value="preval" value="{{preval.value || preval}}" /> {{preval.label || preval.value || preval}}
-	    </label>
-	</li>
+<ul class="unstyled umb-checkbox-list-preval">
+    <li ng-repeat="preval in model.prevalues">
+        <label class="checkbox">
+            <input type="checkbox" ng-hide="preval.icon" checklist-model="model.value" checklist-value="preval" value="{{preval.value || preval}}" />
+            <i ng-if="preval.icon" class="icon {{preval.icon}}"></i> <span>{{preval.label || preval.value || preval}}</span>
+        </label>
+    </li>
 </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
@@ -1,0 +1,7 @@
+<ul class="unstyled">
+	<li ng-repeat="preval in model.prevalues">
+	    <label class="checkbox">
+            <input type="checkbox" checklist-model="model.value" checklist-value="preval" value="{{preval.value || preval}}" /> {{preval.label || preval.value || preval}}
+	    </label>
+	</li>
+</ul>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/radiobuttonlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/radiobuttonlist.html
@@ -1,7 +1,8 @@
-<ul class="unstyled">
-	<li ng-repeat="preval in model.prevalues">
-	    <label class="checkbox">
-	        <input type="radio" ng-model="model.value" value="{{preval.value || preval}}" /> {{preval.label || preval.value || preval}}
-	    </label>
-	</li>
+<ul class="unstyled umb-radiobutton-list-preval">
+    <li ng-repeat="preval in model.prevalues">
+        <label class="radio">
+            <input type="radio" ng-hide="preval.icon" ng-model="model.value" value="{{preval.value || preval}}" />
+            <i ng-if="preval.icon" class="icon {{preval.icon}}"></i> <span>{{preval.label || preval.value || preval}}</span>
+        </label>
+    </li>
 </ul>

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap2-Fluid.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap2-Fluid.cshtml
@@ -63,22 +63,46 @@
         var attrs = new List<string>();
         JObject cfg = contentItem.config;
 
-        if(cfg != null)
-            foreach (JProperty property in cfg.Properties()) {
-                attrs.Add(property.Name + "='" + property.Value.ToString() + "'");
+        if (cfg != null)
+        {
+            foreach (JProperty property in cfg.Properties())
+            {
+                var propertyValue = string.Empty;
+                if (property.Value is JValue)
+                {
+                    propertyValue = property.Value.ToString();
+                }
+                else if (property.Value is JArray)
+                {
+                    // join multiple values from checkboxlist
+                    var items = (JArray)property.Value;
+                    var values = items.Select(o => o.Type == JTokenType.Object ? o.SelectToken("value") : o.Value<string>())
+                                       .OrderByDescending(x => x);
+                    propertyValue = string.Join(" ", values);
+                }
+
+                attrs.Add(property.Name + "='" + propertyValue + "'");
             }
-                
+        }
+
         JObject style = contentItem.styles;
 
-        if (style != null) { 
-        var cssVals = new List<string>();
-        foreach (JProperty property in style.Properties())
-            cssVals.Add(property.Name + ":" + property.Value.ToString() + ";");
+        if (style != null) {
+            var cssVals = new List<string>();
+            foreach (JProperty property in style.Properties())
+            {
+                var propertyValue = string.Empty;
+                if (property.Value is JValue)
+                {
+                    propertyValue = property.Value.ToString();
+                }
+                cssVals.Add(property.Name + ":" + propertyValue + ";");
+            }
 
-        if (cssVals.Any())
-            attrs.Add("style='" + string.Join(" ", cssVals) + "'");
+            if (cssVals.Any())
+                attrs.Add("style='" + string.Join(" ", cssVals) + "'");
         }
-            
+
         return new MvcHtmlString(string.Join(" ", attrs));
     }
 }

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap2.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap2.cshtml
@@ -63,22 +63,46 @@
         var attrs = new List<string>();
         JObject cfg = contentItem.config;
 
-        if(cfg != null)
-            foreach (JProperty property in cfg.Properties()) {
-                attrs.Add(property.Name + "=\"" + property.Value.ToString() + "\"");
+        if (cfg != null)
+        {
+            foreach (JProperty property in cfg.Properties())
+            {
+                var propertyValue = string.Empty;
+                if (property.Value is JValue)
+                {
+                    propertyValue = property.Value.ToString();
+                }
+                else if (property.Value is JArray)
+                {
+                    // join multiple values from checkboxlist
+                    var items = (JArray)property.Value;
+                    var values = items.Select(o => o.Type == JTokenType.Object ? o.SelectToken("value") : o.Value<string>())
+                                       .OrderByDescending(x => x);
+                    propertyValue = string.Join(" ", values);
+                }
+
+                attrs.Add(property.Name + "='" + propertyValue + "'");
             }
-                
+        }
+
         JObject style = contentItem.styles;
 
-        if (style != null) { 
-        var cssVals = new List<string>();
-        foreach (JProperty property in style.Properties())
-            cssVals.Add(property.Name + ":" + property.Value.ToString() + ";");
+        if (style != null) {
+            var cssVals = new List<string>();
+            foreach (JProperty property in style.Properties())
+            {
+                var propertyValue = string.Empty;
+                if (property.Value is JValue)
+                {
+                    propertyValue = property.Value.ToString();
+                }
+                cssVals.Add(property.Name + ":" + propertyValue + ";");
+            }
 
-        if (cssVals.Any())
-            attrs.Add("style=\"" + string.Join(" ", cssVals) + "\"");
+            if (cssVals.Any())
+                attrs.Add("style='" + string.Join(" ", cssVals) + "'");
         }
-            
+
         return new MvcHtmlString(string.Join(" ", attrs));
     }
 }

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3-Fluid.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3-Fluid.cshtml
@@ -58,22 +58,46 @@
         var attrs = new List<string>();
         JObject cfg = contentItem.config;
 
-        if(cfg != null)
-            foreach (JProperty property in cfg.Properties()) {
-                attrs.Add(property.Name + "='" + property.Value.ToString() + "'");
+        if (cfg != null)
+        {
+            foreach (JProperty property in cfg.Properties())
+            {
+                var propertyValue = string.Empty;
+                if (property.Value is JValue)
+                {
+                    propertyValue = property.Value.ToString();
+                }
+                else if (property.Value is JArray)
+                {
+                    // join multiple values from checkboxlist
+                    var items = (JArray)property.Value;
+                    var values = items.Select(o => o.Type == JTokenType.Object ? o.SelectToken("value") : o.Value<string>())
+                                       .OrderByDescending(x => x);
+                    propertyValue = string.Join(" ", values);
+                }
+
+                attrs.Add(property.Name + "='" + propertyValue + "'");
             }
-                
+        }
+
         JObject style = contentItem.styles;
 
-        if (style != null) { 
-        var cssVals = new List<string>();
-        foreach (JProperty property in style.Properties())
-            cssVals.Add(property.Name + ":" + property.Value.ToString() + ";");
+        if (style != null) {
+            var cssVals = new List<string>();
+            foreach (JProperty property in style.Properties())
+            {
+                var propertyValue = string.Empty;
+                if (property.Value is JValue)
+                {
+                    propertyValue = property.Value.ToString();
+                }
+                cssVals.Add(property.Name + ":" + propertyValue + ";");
+            }
 
-        if (cssVals.Any())
-            attrs.Add("style='" + string.Join(" ", cssVals) + "'");
+            if (cssVals.Any())
+                attrs.Add("style='" + string.Join(" ", cssVals) + "'");
         }
-            
+
         return new MvcHtmlString(string.Join(" ", attrs));
     }
 }

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3.cshtml
@@ -63,22 +63,45 @@
         var attrs = new List<string>();
         JObject cfg = contentItem.config;
 
-        if(cfg != null)
-            foreach (JProperty property in cfg.Properties()) {
-                attrs.Add(property.Name + "=\"" + property.Value.ToString() + "\"");
+        if (cfg != null)
+        {
+            foreach (JProperty property in cfg.Properties())
+            {
+                var propertyValue = string.Empty;
+                if (property.Value is JValue)
+                {
+                    propertyValue = property.Value.ToString();
+                }
+                else if (property.Value is JArray)
+                {
+                    var items = (JArray)property.Value;
+                    var values = items.Select(o => o.Type == JTokenType.Object ? o.SelectToken("value") : o.Value<string>())
+                                       .OrderByDescending(x => x);
+                    propertyValue = string.Join(" ", values);
+                }
+
+                attrs.Add(property.Name + "='" + propertyValue + "'");
             }
-                
+        }
+
         JObject style = contentItem.styles;
 
-        if (style != null) { 
-        var cssVals = new List<string>();
-        foreach (JProperty property in style.Properties())
-            cssVals.Add(property.Name + ":" + property.Value.ToString() + ";");
+        if (style != null) {
+            var cssVals = new List<string>();
+            foreach (JProperty property in style.Properties())
+            {
+                var propertyValue = string.Empty;
+                if (property.Value is JValue)
+                {
+                    propertyValue = property.Value.ToString();
+                }
+                cssVals.Add(property.Name + ":" + propertyValue + ";");
+            }
 
-        if (cssVals.Any())
-            attrs.Add("style=\"" + string.Join(" ", cssVals) + "\"");
+            if (cssVals.Any())
+                attrs.Add("style='" + string.Join(" ", cssVals) + "'");
         }
-            
+
         return new MvcHtmlString(string.Join(" ", attrs));
     }
 }


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-9003

Currently there is a radiobuttonlist prevalue editor, but not a checkboxlist prevalue editor. A scenario where a checkboxlist prevalue editor would be useful it for e.g. a weekdays property.

Actually I was missing this in this PR https://github.com/umbraco/Umbraco-CMS/pull/984 to extend datepicker options. At the time of submitting the PR it created this weedays checkboxlist prevalue editor, but it would be great to have it in core: https://github.com/bjarnef/Umbraco-CMS/blob/0dbf686a0fa3bf8c3f4c701498b7b457ee9998f6/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/weekdays.prevalues.html

Umbraco seems to include checklist-model, but I am not sure how much it is used: https://vitalets.github.io/checklist-model/ 

As an alternative it could have a controller to split the selected values.

It could also be useful it grid editor settings. I also included the option to define the labels , which @clausjensen added in this PR https://github.com/umbraco/Umbraco-CMS/pull/1486

![image](https://cloud.githubusercontent.com/assets/2919859/18727553/75b0da52-8049-11e6-9121-bbf605b52555.png)

Both radiobuttonlist and checkboxlist is missing the option to specify prevalues from package.manifest:
http://issues.umbraco.org/issue/U4-7030
