### PR TITLE
Change color of remove button to red

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/healthcheck.less
+++ b/src/Umbraco.Web.UI.Client/src/less/healthcheck.less
@@ -151,6 +151,15 @@
 	background-color: @blueDark;
 }
 
+.umb-era-button.-red {
+	background: @btnDangerBackground;
+	color: white;
+}
+
+.umb-era-button.-red:hover {
+	background-color: darken(@btnDangerBackground, 5%);
+}
+
 .umb-era-button.-link {
 	padding: 0;
     background: transparent;

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.html
@@ -77,7 +77,7 @@
                         <a class="umb-table-body__link" href="{{redirectUrl.destinationUrl}}" target="_blank" title="{{redirectUrl.destinationUrl}}">{{redirectUrl.destinationUrl}}</a>
                     </div>
 
-                    <button type="button" class="umb-era-button -gray umb-button--s" ng-click="vm.removeRedirect(redirectUrl)"><localize key="redirectUrls_removeButton">Remove</localize></button>
+                    <button type="button" class="umb-era-button umb-button--s -red" ng-click="vm.removeRedirect(redirectUrl)"><localize key="redirectUrls_removeButton">Remove</localize></button>
                 </div>
 
             </div>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8897

Change the remove button to red, so it is more consistent with other remove/delete buttons.
I have just used the base color of the bootstrap `btn-danger` button, but feel free to change the color.

![image](https://cloud.githubusercontent.com/assets/2919859/18759384/8d9229ec-80fc-11e6-8835-6ad2889b32c1.png)

Maybe also consider to add the button styles in a separate less, since there are some duplicates in `healthcheck.less` and `umb-packages-less` ... 

Even I have only added these styles in `healthcheck.less` I could also use it in the new packager by using the class `-red`.