### PR TITLE
U4-9012 The word "Oops" should probably be removed, because we can ca…

### DIFF
--- a/src/Umbraco.Core/Persistence/Factories/ContentTypeFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/ContentTypeFactory.cs
@@ -122,7 +122,7 @@ namespace Umbraco.Core.Persistence.Factories
             else if (entity is IMemberType)
                 nodeObjectType = Constants.ObjectTypes.MemberTypeGuid;
             else
-                throw new Exception("oops: invalid entity.");
+                throw new Exception("Invalid entity.");
 
             var contentTypeDto = new ContentTypeDto
             {

--- a/src/Umbraco.Core/Persistence/Factories/MemberTypeReadOnlyFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/MemberTypeReadOnlyFactory.cs
@@ -79,7 +79,7 @@ namespace Umbraco.Core.Persistence.Factories
                 {
                     // note: no idea why Id is nullable here, but better check
                     if (groupDto.Id.HasValue == false)
-                        throw new Exception("oops: groupDto.Id has no value.");
+                        throw new Exception("GroupDto.Id has no value.");
                     group.Id = groupDto.Id.Value;
                 }
 

--- a/src/Umbraco.Web.UI.Client/src/common/mocks/services/localization.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/services/localization.mocks.js
@@ -134,7 +134,7 @@ angular.module('umbraco.mocks').
                   "content_nodeName": "Page Title",
                   "content_otherElements": "Properties",
                   "content_parentNotPublished": "This document is published but is not visible because the parent '%0%' is unpublished",
-                  "content_parentNotPublishedAnomaly": "Oops: this document is published but is not in the cache (internal error)",
+                  "content_parentNotPublishedAnomaly": "This document is published but is not in the cache",
                   "content_publish": "Publish",
                   "content_publishStatus": "Publication Status",
                   "content_releaseDate": "Publish at",

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -147,9 +147,9 @@
     <key alias="nodeName">Page Title</key>
     <key alias="otherElements">Properties</key>
     <key alias="parentNotPublished">This document is published but is not visible because the parent '%0%' is unpublished</key>
-    <key alias="parentNotPublishedAnomaly">Oops: this document is published but is not in the cache (internal error - see log)</key>
-    <key alias="getUrlException">Oops: could not get the url (internal error - see log)</key>
-    <key alias="routeError">Oops: this document is published but its url would collide with content %0%</key>
+    <key alias="parentNotPublishedAnomaly">This document is published but is not in the cache</key>
+    <key alias="getUrlException">Could not get the url</key>
+    <key alias="routeError">This document is published but its url would collide with content %0%</key>
     <key alias="publish">Publish</key>
     <key alias="publishStatus">Publication Status</key>
     <key alias="releaseDate">Publish at</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -148,9 +148,9 @@
     <key alias="nodeName">Page Title</key>
     <key alias="otherElements">Properties</key>
     <key alias="parentNotPublished">This document is published but is not visible because the parent '%0%' is unpublished</key>
-    <key alias="parentNotPublishedAnomaly">Oops: this document is published but is not in the cache (internal error - see log)</key>
-    <key alias="getUrlException">Oops: could not get the url (internal error - see log)</key>
-    <key alias="routeError">Oops: this document is published but its url would collide with content %0%</key>
+    <key alias="parentNotPublishedAnomaly">This document is published but is not in the cache</key>
+    <key alias="getUrlException">Could not get the url</key>
+    <key alias="routeError">This document is published but its url would collide with content %0%</key>
     <key alias="publish">Publish</key>
     <key alias="publishStatus">Publication Status</key>
     <key alias="releaseDate">Publish at</key>

--- a/src/Umbraco.Web.UI/umbraco_client/FolderBrowser/Js/folderbrowser.js
+++ b/src/Umbraco.Web.UI/umbraco_client/FolderBrowser/Js/folderbrowser.js
@@ -389,12 +389,12 @@ Umbraco.Sys.registerNamespace("Umbraco.Controls");
                             processData: false,
                             success: function (data, textStatus) {
                                 if (textStatus == "error") {
-                                    alert("Oops. Could not update sort order");
+                                    alert("Could not update sort order");
                                     self._getChildNodes();
                                 }
                             },
                             error: function(data) {
-                                alert("Oops. Could not update sort order. Err: " + data.statusText);
+                                alert("Could not update sort order. Err: " + data.statusText);
                                 self._getChildNodes();
                             }
                         });


### PR DESCRIPTION
U4-9012 The word "Oops" should probably be removed, because we can cancel publish by API, it may be deliberate. http://issues.umbraco.org/issue/U4-9012