### PR TITLE
Bugfix in Initialize method of UmbracoMediaFile

### DIFF
--- a/src/Umbraco.Core/IO/UmbracoMediaFile.cs
+++ b/src/Umbraco.Core/IO/UmbracoMediaFile.cs
@@ -86,7 +86,7 @@ namespace Umbraco.Core.IO
         private void Initialize()
         {
             Filename = _fs.GetFileName(Path);
-            Extension = _fs.GetExtension(Path) != null
+            Extension = !string.IsNullOrEmpty(_fs.GetExtension(Path))
                 ? _fs.GetExtension(Path).Substring(1).ToLowerInvariant()
                 : "";
             Url = _fs.GetUrl(Path);

--- a/src/Umbraco.Core/IO/UmbracoMediaFile.cs
+++ b/src/Umbraco.Core/IO/UmbracoMediaFile.cs
@@ -86,7 +86,7 @@ namespace Umbraco.Core.IO
         private void Initialize()
         {
             Filename = _fs.GetFileName(Path);
-            Extension = !string.IsNullOrEmpty(_fs.GetExtension(Path))
+            Extension = string.IsNullOrEmpty(_fs.GetExtension(Path)) == false
                 ? _fs.GetExtension(Path).Substring(1).ToLowerInvariant()
                 : "";
             Url = _fs.GetUrl(Path);


### PR DESCRIPTION
GetExtension returns an empty string instead of null which causes the substring to return an argumentoutofrange exception. Discovered this when trying to use Save(HttpPostedFile file) and Save(HttpPostedFileBase file), but since the temporary generated path didn't include an extension, these methods always threw an exception