### PR TITLE
Added title attribute to image tags

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -12,10 +12,10 @@
             <div class="umb-media-grid__image-background" ng-if="item.thumbnail || item.extension == 'svg'"></div>
 
             <!-- Image thumbnail -->
-            <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="item.thumbnail" ng-src="{{item.thumbnail}}" alt="{{item.name}}" draggable="false" />
+            <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="item.thumbnail" ng-src="{{item.thumbnail}}" alt="{{item.name}}" title="{{item.name}}" draggable="false" />
 
             <!-- SVG -->
-            <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="!item.thumbnail && item.extension == 'svg'" ng-src="{{item.file}}" alt="{{item.name}}" draggable="false" />
+            <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="!item.thumbnail && item.extension == 'svg'" ng-src="{{item.file}}" alt="{{item.name}}" title="{{item.name}}" draggable="false" />
 
             <!-- Transparent image - fallback - used to keep image proportions on wrapper-->
             <img class="umb-media-grid__item-image-placeholder" ng-if="!item.thumbnail && item.extension != 'svg'" src="assets/img/transparent.png" alt="{{item.name}}" draggable="false" />

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -4,10 +4,10 @@
 		<li style="width: 120px; height: 100px; overflow: hidden;" ng-repeat="image in images">
 
 			<!-- IMAGE -->
-			<img ng-src="{{image.thumbnail}}" alt="" ng-show="image.thumbnail" />
+			<img ng-src="{{image.thumbnail}}" alt="" ng-show="image.thumbnail" title="{{image.name}}" />
 
 			<!-- SVG -->
-			<img ng-if="image.metaData.umbracoExtension.Value === 'svg'" ng-src="{{image.metaData.umbracoFile.Value}}" alt="" />
+			<img ng-if="image.metaData.umbracoExtension.Value === 'svg'" ng-src="{{image.metaData.umbracoFile.Value}}" alt="" title="{{image.name}}" />
 			<img ng-if="image.extension === 'svg'" ng-src="{{image.file}}" alt="" />
 
 			<!-- FILE -->


### PR DESCRIPTION
When a media item has a long file name the name preview in  the media grid is not large enough to display the file name hiding the full name from users. This can make it difficult to distinguish media items with similar thumbnails so the full file name is needed (i.e. MyLongFileNameWithADifferentSize_1200x1080.png vs MyLongFileNameWithADifferentSize_100x50.png). Added the title attribute to the image tags so that on image hover the file name is displayed.  Updated mediapicker.html and umb-media-grid.html with the title attribute.