### PR TITLE
U4 5722

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
@@ -48,14 +48,18 @@
                   <a href ng-click="scaleDown(currentCell)">
                       <i class="icon icon-remove"></i>
                   </a>
-                      {{currentCell.grid}}
+                  {{currentCell.grid}}
                   <a href ng-click="scaleUp(currentCell, availableRowSpace, true)">
                       <i class="icon icon-add"></i>
                   </a>
               </div>
           </umb-control-group>
+          
+          <umb-control-group label="@grid_maxItems" description="@grid_maxItemsDescription">
+              <input type="number" ng-model="currentCell.maxItems" class="umb-editor-tiny" placeholder="Max" min="0" />
+          </umb-control-group>
 
-	  	  <umb-control-group hide-label="true">
+          <umb-control-group hide-label="true">
 	  		  <i class="icon-delete red"></i>
 	  		  <a class="btn btn-small btn-link" href="" ng-click="deleteArea(currentCell, currentRow)">
 	  			  <localize key="general_delete" class="ng-isolate-scope ng-scope">Delete</localize>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -81,6 +81,7 @@ angular.module("umbraco")
 
         var notIncludedRte = [];
         var cancelMove = false;
+        var startingArea;
 
         $scope.sortableOptionsCell = {
             distance: 10,
@@ -112,9 +113,11 @@ angular.module("umbraco")
             },
 
             over: function (event, ui) {
-                var allowedEditors = $(event.target).scope().area.allowed;
+                var area = $(event.target).scope().area;
+                var allowedEditors = area.allowed;
 
-                if ($.inArray(ui.item.scope().control.editor.alias, allowedEditors) < 0 && allowedEditors) {
+                if (($.inArray(ui.item.scope().control.editor.alias, allowedEditors) < 0 && allowedEditors) ||
+                        (startingArea != area && area.maxItems != '' && area.maxItems > 0 && area.maxItems < area.controls.length + 1)) {
 
                     $scope.$apply(function () {
                         $(event.target).scope().area.dropNotAllowed = true;
@@ -167,6 +170,10 @@ angular.module("umbraco")
             },
 
             start: function (e, ui) {
+
+                //Get the starting area for reference
+                var area = $(e.target).scope().area;
+                startingArea = area;
 
                 // fade out control when sorting
                 ui.item.context.style.display = "block";

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -224,7 +224,7 @@
                                                       <!-- Controls repeat end -->
 
                                                       <!-- if area is empty tools -->
-                                                      <div class="umb-grid-add-more-content" ng-if="area.controls.length > 0 && !sortMode">
+                                                      <div class="umb-grid-add-more-content" ng-if="area.controls.length > 0 && !sortMode && (area.maxItems == undefined || area.maxItems == '' || area.maxItems == 0 || area.maxItems > area.controls.length)">
                                                           <div class="cell-tools-add -bar newbtn" ng-click="openEditorOverlay($event, area, 0, area.$uniqueId);"><localize key="grid_addElement" /></div>
                                                       </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
@@ -65,7 +65,9 @@
                                     ng-repeat="area in layout.areas | filter:zeroWidthFilter"
                                     ng-style="{width: percentage(area.grid) + '%', 'max-width': '100%'}">
 
-                                    <div class="preview-cell"></div>
+                                    <div class="preview-cell">
+                                        <p style="font-size: 6px; line-height: 8px; text-align: center" ng-show="area.maxItems > 0">{{area.maxItems}}</p>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -830,7 +830,8 @@ Mange hilsner fra Umbraco robotten
 
     <key alias="allowAllEditors">Tillad alle editorer</key>
     <key alias="allowAllRowConfigurations">Tillad alle rækkekonfigurationer</key>
-
+    <key alias="maxItems">Maksimalt emner</key>
+    <key alias="maxItemsDescription">Efterlad blank eller sat til 0 ubegrænset for</key>
     <key alias="setAsDefault">Sæt som standard</key>
     <key alias="chooseExtra">Vælg ekstra</key>
     <key alias="chooseDefault">Vælg standard</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1248,6 +1248,8 @@ To manage your website, simply open the Umbraco back office and start adding con
 
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+    <key alias="maxItemsDescription">Leave blank or set to 0 for unlimited</key>
+    <key alias="maxItems">Maximum items</key>
     <key alias="setAsDefault">Set as default</key>
     <key alias="chooseExtra">Choose extra</key>
     <key alias="chooseDefault">Choose default</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1241,6 +1241,8 @@ To manage your website, simply open the Umbraco back office and start adding con
 
     <key alias="allowAllEditors">Allow all editors</key>
     <key alias="allowAllRowConfigurations">Allow all row configurations</key>
+    <key alias="maxItems">Maximum items</key>
+    <key alias="maxItemsDescription">Leave blank or set to 0 for unlimited</key>
     <key alias="setAsDefault">Set as default</key>
     <key alias="chooseExtra">Choose extra</key>
     <key alias="chooseDefault">Choose default</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -790,6 +790,9 @@
 
     <key alias="allowAllEditors">Permitir todos los controles de edición</key>
     <key alias="allowAllRowConfigurations">Permitir todas las configuraciones de fila</key>
+    <key alias="maxItems">Artículos máximos</key>
+    <key alias="maxItemsDescription">Laat dit leeg of is ingesteld op -1 voor onbeperkt</key>
+    <key alias="maxItemsDescription">Dejar en blanco o se establece en 0 para ilimitada</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Campo opcional</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -1080,7 +1080,9 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
 
     <key alias="allowAllEditors">Alle editors toelaten</key>
     <key alias="allowAllRowConfigurations">Alle rijconfiguraties toelaten</key>
-	<key alias="setAsDefault">Instellen als standaard</key>
+    <key alias="maxItems">Maximale artikelen</key>
+    <key alias="maxItemsDescription">Laat dit leeg of is ingesteld op -1 voor onbeperkt</key>
+	  <key alias="setAsDefault">Instellen als standaard</key>
     <key alias="chooseExtra">Kies extra</key>
     <key alias="chooseDefault">Kies standaard</key>
     <key alias="areAdded">zijn toegevoegd</key>


### PR DESCRIPTION
This is a re-working of some of the code found here:
[Pull request: https://github.com/umbraco/Umbraco-CMS/pull/651](https://github.com/umbraco/Umbraco-CMS/pull/651)

[Associated issue:  #U4-5722](http://issues.umbraco.org/issue/U4-5722)

Taking on-board comments on the associated pull request and the issue tracker this only implements an "Max Items" option on the grid cell. This prevents additional items from being added to a cell when the total number of controls >= the max items config. However if the config is not set or is equal to 0 then there is no limit. 

Unlike the previous pull request, there is no "min items" option in this version as I believe it needs further consideration and validation rules to be defined.

This work performed on the previous pull request has been updated for the re-worked grid in 7.5+ and issue related to moving items has been addressed.
