### PR TITLE
U4-7238 issue sorting listview after 7.3.0 upgrade

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
@@ -610,6 +610,8 @@ WHERE EXISTS(
                     return "cmsContentVersion.VersionDate";
                 case "NAME":
                     return "umbracoNode.text";
+                case "PUBLISHED":
+                    return "cmsDocument.published";
                 case "OWNER":
                     //TODO: This isn't going to work very nicely because it's going to order by ID, not by letter
                     return "umbracoNode.nodeUser";


### PR DESCRIPTION
http://issues.umbraco.org/issue/U4-7238

System field publish only available for Content, didn't work on content
sorting by this field. Fixed by prefixing the field with table:
cmsDocument.published.