### PR TITLE
Styled toolbar buttons in ChangeDocType dialog

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/dialogs/ChangeDocType.aspx
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/ChangeDocType.aspx
@@ -108,16 +108,14 @@
         </div>
     </asp:PlaceHolder>
 
-    <asp:PlaceHolder ID="SaveAndCancelPlaceholder" runat="server">
-        <br />
-        <p>
+    <div class="btn-toolbar umb-btn-toolbar">
+        <asp:PlaceHolder ID="SaveAndCancelPlaceholder" runat="server">
+            <a href="#" class="btn btn-link" onclick="UmbClientMgr.closeModalWindow()"><%=umbraco.ui.Text("cancel")%></a>
             <asp:PlaceHolder ID="SavePlaceholder" runat="server">        
-                <asp:Button ID="ValidateAndSave" runat="server" OnClick="ValidateAndSave_Click" />
-                <em> <%= umbraco.ui.Text("or") %> </em>
-            </asp:PlaceHolder>        
-            <a href="#" style="color: blue" onclick="UmbClientMgr.closeModalWindow()"><%=umbraco.ui.Text("general", "cancel", Security.CurrentUser)%></a>  
-        </p>
-    </asp:PlaceHolder>
-  
+                <asp:Button ID="ValidateAndSave" runat="server" CssClass="btn btn-primary" Text="Create" OnClick="ValidateAndSave_Click"></asp:Button>
+            </asp:PlaceHolder>
+        </asp:Placeholder>
+    </div>
+     
 </asp:Content>
   


### PR DESCRIPTION
It's been bugging me for some time now that the Save and Cancel buttons in the Change Document Type dialog don't have the same look as other similar buttons. This change fixes all that, making the experience a little bit nicer.