### PR TITLE
Update imagecropper.html

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
@@ -44,7 +44,7 @@
                     center="model.value.focalPoint"
                     on-image-loaded="imageLoaded">
                 </umb-image-gravity>
-                <a href class="btn btn-link btn-crop-delete" ng-show="imageIsLoaded" ng-click="clear()"><i class="icon-delete red"></i> <localize key="content_uploadClear">Remove file</localize></a>
+                <a href class="btn btn-link btn-crop-delete" ng-click="clear()"><i class="icon-delete red"></i> <localize key="content_uploadClear">Remove file</localize></a>
             </div>
 
             <ul class="umb-sortable-thumbnails cropList clearfix">


### PR DESCRIPTION
Remove ng-show="imageIsLoaded" so "Remove file" is always visible when there's an image or file uploaded, even if it can't be rendered because whether is .tif-file (correct image, but not rendered in modern browsers), .pdf-file (foolish action) or the image is removed from the server (staging with a production-environment-database).

Related to http://issues.umbraco.org/issue/U4-8490