### PR TITLE
Grid: Quote editor - wrong CSS style rule for italic

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/mocks/editors/prevalues.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/editors/prevalues.mocks.js
@@ -58,7 +58,7 @@ angular.module('umbraco.mocks').
 						"view": "textstring",
 						"icon": "icon-quote",
 						"config": {
-							"style": "border-left: 3px solid #ccc; padding: 10px; color: #ccc; font-family: serif; font-variant: italic; font-size: 18px",
+							"style": "border-left: 3px solid #ccc; padding: 10px; color: #ccc; font-family: serif; font-style: italic; font-size: 18px",
 							"markup": "<blockquote>#value#</blockquote>"
 						}
 					}

--- a/src/Umbraco.Web.UI.Client/src/config/grid.editors.config.js
+++ b/src/Umbraco.Web.UI.Client/src/config/grid.editors.config.js
@@ -39,7 +39,7 @@
 	    "view": "textstring",
 	    "icon": "icon-quote",
 	    "config": {
-	        "style": "border-left: 3px solid #ccc; padding: 10px; color: #ccc; font-family: serif; font-variant: italic; font-size: 18px",
+	        "style": "border-left: 3px solid #ccc; padding: 10px; color: #ccc; font-family: serif; font-style: italic; font-size: 18px",
 	        "markup": "<blockquote>#value#</blockquote>"
 	    }
 	}

--- a/src/Umbraco.Web.UI/config/grid.editors.config.js
+++ b/src/Umbraco.Web.UI/config/grid.editors.config.js
@@ -39,7 +39,7 @@
 	    "view": "textstring",
 	    "icon": "icon-quote",
 	    "config": {
-	        "style": "border-left: 3px solid #ccc; padding: 10px; color: #ccc; font-family: serif; font-variant: italic; font-size: 18px",
+	        "style": "border-left: 3px solid #ccc; padding: 10px; color: #ccc; font-family: serif; font-style: italic; font-size: 18px",
 	        "markup": "<blockquote>#value#</blockquote>"
 	    }
 	}


### PR DESCRIPTION
[Issue #U4-9073](http://issues.umbraco.org/issue/U4-9073)

In `grid.editors.config.js`, the style config for the Quote editor has an incorrect CSS style rule for italic, it has...

```css
font-variant: italic;
```

It should be...

```css
font-style: italic;
```

I wasn't sure which `grid.editors.config.js` to change, so I did them all.