### PR TITLE
U4-9042: Fixes backoffice members list view for custom membership providers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
@@ -36,7 +36,8 @@
          }
 
       function clickItem(item) {
-         $location.path($scope.entityType + '/' +$scope.entityType + '/edit/' +item.id);
+         // if item.id is 0 use item.key
+         $location.path($scope.entityType + '/' +$scope.entityType + '/edit/' + (item.id === 0 ? item.key : item.id));
          }
 
       function isSortDirection(col, direction) {

--- a/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
@@ -37,8 +37,8 @@ namespace Umbraco.Web.Models.Mapping
             //FROM MembershipUser TO IMember - used when using a non-umbraco membership provider
             config.CreateMap<MembershipUser, IMember>()
                 .ConstructUsing(user => MemberService.CreateGenericMembershipProviderMember(user.UserName, user.Email, user.UserName, ""))
-                //we're giving this entity an ID - we cannot really map it but it needs an id so the system knows it's not a new entity
-                .ForMember(member => member.Id, expression => expression.MapFrom(user => int.MaxValue))
+                //we're giving this entity an ID of 0 - we cannot really map it but it needs an id so the system knows it's not a new entity
+                .ForMember(member => member.Id, expression => expression.MapFrom(user => 0))
                 .ForMember(member => member.Comments, expression => expression.MapFrom(user => user.Comment))
                 .ForMember(member => member.CreateDate, expression => expression.MapFrom(user => user.CreationDate))
                 .ForMember(member => member.UpdateDate, expression => expression.MapFrom(user => user.LastActivityDate))
@@ -118,8 +118,8 @@ namespace Umbraco.Web.Models.Mapping
 
             //FROM MembershipUser TO MemberBasic
             config.CreateMap<MembershipUser, MemberBasic>()
-                //we're giving this entity an ID - we cannot really map it but it needs an id so the system knows it's not a new entity
-                .ForMember(member => member.Id, expression => expression.MapFrom(user => int.MaxValue))
+                //we're giving this entity an ID of 0 - we cannot really map it but it needs an id so the system knows it's not a new entity
+                .ForMember(member => member.Id, expression => expression.MapFrom(user => 0))
                 .ForMember(member => member.CreateDate, expression => expression.MapFrom(user => user.CreationDate))
                 .ForMember(member => member.UpdateDate, expression => expression.MapFrom(user => user.LastActivityDate))
                 .ForMember(member => member.Key, expression => expression.MapFrom(user => user.ProviderUserKey.TryConvertTo<Guid>().Result.ToString("N")))


### PR DESCRIPTION
Fixes backoffice members list view for custom membership providers by using key instead of id in edit URL

When using a custom membership provider in Umbraco >7.3 the list view means it's not possible to edit a member in the backoffice. Clicking on any member leads to loading a member of ID 2147483647 (int32 maxvalue).

This is due to int.MaxValue being hardcoded within the MemberModelMapper - see https://github.com/umbraco/Umbraco-CMS/blob/5397f2c53acbdeb0805e1fe39fda938f571d295a/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs#L41

As suggested by @Shazwazza I have changed this value to 0 and updated the List View layout Angular controller to use the "key" (MembershipUser.ProviderUserKey) in the edit URL when "id" is 0.