### PR TITLE
U4-9077 Relation repos don't use cache

### DIFF
--- a/src/Umbraco.Core/Persistence/RepositoryFactory.cs
+++ b/src/Umbraco.Core/Persistence/RepositoryFactory.cs
@@ -197,7 +197,7 @@ namespace Umbraco.Core.Persistence
         {
             return new RelationRepository(
                 uow,
-                _cacheHelper,
+                _noCache,
                 _logger, _sqlSyntax,
                 CreateRelationTypeRepository(uow));
         }

--- a/src/Umbraco.Core/Persistence/RepositoryFactory.cs
+++ b/src/Umbraco.Core/Persistence/RepositoryFactory.cs
@@ -197,7 +197,7 @@ namespace Umbraco.Core.Persistence
         {
             return new RelationRepository(
                 uow,
-                _noCache, //never cache
+                _cacheHelper,
                 _logger, _sqlSyntax,
                 CreateRelationTypeRepository(uow));
         }
@@ -206,7 +206,7 @@ namespace Umbraco.Core.Persistence
         {
             return new RelationTypeRepository(
                 uow,
-                _noCache, //never cache
+                _cacheHelper,
                 _logger, _sqlSyntax);
         }
 


### PR DESCRIPTION
Added default cachehelper to the relation repositories

Following up with a thread on our/contributing
