### PR TITLE
U4-8336: Renamed icon-globe---europe-africa to icon-globe-europe-africa.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/helveticons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/helveticons.less
@@ -1569,7 +1569,7 @@ i.small{
 .icon-hd:before {
 	content: "\e1f9";
 }
-.icon-globe-europe---africa:before {
+.icon-globe-europe-africa:before {
 	content: "\e1fa";
 }
 .icon-hat:before {


### PR DESCRIPTION
Simplifies the name of the icon by replacing the triple - with a single one as is requested in this issue: http://issues.umbraco.org/issue/U4-8336 

A working example:

<img width="610" alt="globe" src="https://cloud.githubusercontent.com/assets/3789875/19666965/35c529d0-9a3d-11e6-8d39-14a880ad1fde.png">
