### PR TITLE
U4-8462: Change list view tab id to not be hardcoded

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
@@ -163,12 +163,12 @@ namespace Umbraco.Web.Models.Mapping
             }
 
             //U4-8462: Pick a tab id that doesn't clash with an existing tab
-            int listViewId = display.Tabs.Max(x => x.Id) + 1;
+            int listViewTabId = display.Tabs.Max(x => x.Id) + 1;
 
             var listViewTab = new Tab<ContentPropertyDisplay>();
             listViewTab.Alias = Constants.Conventions.PropertyGroups.ListViewGroupName;
             listViewTab.Label = localizedTextService.Localize("content/childItems");
-            listViewTab.Id = listViewId;
+            listViewTab.Id = listViewTabId;
             listViewTab.IsActive = true;
 
             var listViewConfig = editor.PreValueEditor.ConvertDbToEditor(editor.DefaultPreValues, preVals);

--- a/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
@@ -162,10 +162,13 @@ namespace Umbraco.Web.Models.Mapping
                 throw new NullReferenceException("The property editor with alias " + dt.PropertyEditorAlias + " does not exist");
             }
 
+            //U4-8462: Pick a tab id that doesn't clash with an existing tab
+            int listViewId = display.Tabs.Max(x => x.Id) + 1;
+
             var listViewTab = new Tab<ContentPropertyDisplay>();
             listViewTab.Alias = Constants.Conventions.PropertyGroups.ListViewGroupName;
             listViewTab.Label = localizedTextService.Localize("content/childItems");
-            listViewTab.Id = 25;
+            listViewTab.Id = listViewId;
             listViewTab.IsActive = true;
 
             var listViewConfig = editor.PreValueEditor.ConvertDbToEditor(editor.DefaultPreValues, preVals);


### PR DESCRIPTION
The list view tab ID was hardcoded to 25. If you happen to have another tab with id 25, this causes you to be unable to view this tab. This PR changes the tab id to always be one larger than the largest existing one, thus avoiding the risk of colliding with an existing id.
