### PR TITLE
Fixed issue with member properties sort order

### DIFF
--- a/src/Umbraco.Web/Security/MembershipHelper.cs
+++ b/src/Umbraco.Web/Security/MembershipHelper.cs
@@ -428,7 +428,8 @@ namespace Umbraco.Web.Security
             var viewProperties = new List<UmbracoProperty>();
 
             foreach (var prop in memberType.PropertyTypes
-                    .Where(x => builtIns.Contains(x.Alias) == false && memberType.MemberCanEditProperty(x.Alias)))
+                    .Where(x => builtIns.Contains(x.Alias) == false && memberType.MemberCanEditProperty(x.Alias))
+                    .OrderBy(p => p.SortOrder))
             {
                 var value = string.Empty;
                 if (member != null)


### PR DESCRIPTION
Member profile properties were unsorted. Added .OrderBy(p => p.SortOrder) to ensure properties are in the same order specified in the CMS

http://issues.umbraco.org/issue/U4-9127
