### PR TITLE
U4-9209 - Updates web.config.install.xdt to re-add the assemblyBinding for Html…

### DIFF
--- a/build/NuSpecs/tools/Web.config.install.xdt
+++ b/build/NuSpecs/tools/Web.config.install.xdt
@@ -335,7 +335,7 @@
 
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
+      <dependentAssembly xdt:Transform="Insert">
         <assemblyIdentity name="HtmlAgilityPack" publicKeyToken="bd319b19eaf3b43a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.4.9.0" newVersion="1.4.9.0" />
       </dependentAssembly>


### PR DESCRIPTION
…AgilityPack after removing it earlier.

The xdt removes the assemblyBindings we are dependent upon, and re-adds them later for the versions we ship with. The add-part for the HtmlAgilityPack wasnt done proper, and therefore never applied like the other transoforms. It was just missing the xdt:Transform="Insert" attribute.
