### PR TITLE
U4-9132 Macros from packages are empty when restored

### DIFF
--- a/src/umbraco.cms/businesslogic/Packager/Installer.cs
+++ b/src/umbraco.cms/businesslogic/Packager/Installer.cs
@@ -411,19 +411,12 @@ namespace umbraco.cms.businesslogic.packager
                     #endregion
 
                     #region Macros
-                    foreach (XmlNode n in Config.DocumentElement.SelectNodes("//macro"))
+                    var macroItemsElement = rootElement.Descendants("Macros").FirstOrDefault();
+                    if (macroItemsElement != null)
                     {
-                        //TODO: Fix this, this should not use the legacy API
-                        Macro m = Macro.Import(n);
-
-                        if (m != null)
-                        {
-                            insPack.Data.Macros.Add(m.Id.ToString(CultureInfo.InvariantCulture));
-                            //saveNeeded = true;
-                        }
+                        var insertedMacros = packagingService.ImportMacros(macroItemsElement);
+                        insPack.Data.Macros.AddRange(insertedMacros.Select(m => m.Id.ToString()));
                     }
-
-                    //if (saveNeeded) { insPack.Save(); saveNeeded = false; }
                     #endregion
 
                     #region Templates

--- a/src/umbraco.cms/businesslogic/Packager/Installer.cs
+++ b/src/umbraco.cms/businesslogic/Packager/Installer.cs
@@ -396,7 +396,7 @@ namespace umbraco.cms.businesslogic.packager
                     if (languageItemsElement != null)
                     {
                         var insertedLanguages = packagingService.ImportLanguages(languageItemsElement);
-                        insPack.Data.Languages.AddRange(insertedLanguages.Select(l => l.Id.ToString()));
+                        insPack.Data.Languages.AddRange(insertedLanguages.Select(l => l.Id.ToString(CultureInfo.InvariantCulture)));
                     }
 
                     #endregion
@@ -406,7 +406,7 @@ namespace umbraco.cms.businesslogic.packager
                     if (dictionaryItemsElement != null)
                     {
                         var insertedDictionaryItems = packagingService.ImportDictionaryItems(dictionaryItemsElement);
-                        insPack.Data.DictionaryItems.AddRange(insertedDictionaryItems.Select(d => d.Id.ToString()));
+                        insPack.Data.DictionaryItems.AddRange(insertedDictionaryItems.Select(d => d.Id.ToString(CultureInfo.InvariantCulture)));
                     }
                     #endregion
 
@@ -415,7 +415,7 @@ namespace umbraco.cms.businesslogic.packager
                     if (macroItemsElement != null)
                     {
                         var insertedMacros = packagingService.ImportMacros(macroItemsElement);
-                        insPack.Data.Macros.AddRange(insertedMacros.Select(m => m.Id.ToString()));
+                        insPack.Data.Macros.AddRange(insertedMacros.Select(m => m.Id.ToString(CultureInfo.InvariantCulture)));
                     }
                     #endregion
 
@@ -454,7 +454,7 @@ namespace umbraco.cms.businesslogic.packager
                     {
                         StyleSheet s = StyleSheet.Import(n, currentUser);
 
-                        insPack.Data.Stylesheets.Add(s.Id.ToString());
+                        insPack.Data.Stylesheets.Add(s.Id.ToString(CultureInfo.InvariantCulture));
                         //saveNeeded = true;
                     }
 

--- a/src/umbraco.cms/businesslogic/macro/Macro.cs
+++ b/src/umbraco.cms/businesslogic/macro/Macro.cs
@@ -1,11 +1,8 @@
 using System;
-using System.Data;
-using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
-using System.Runtime.CompilerServices;
 using Umbraco.Core;
 using Umbraco.Core.Cache;
 using Umbraco.Core.IO;
@@ -185,23 +182,26 @@ namespace umbraco.cms.businesslogic.macro
 	                }).ToArray();
 	        }
 	    }
-        
-		/// <summary>
-		/// Macro initializer
-		/// </summary>
-		public Macro()
+
+        /// <summary>
+        /// Macro initializer
+        /// </summary>
+        [Obsolete("This should no longer be used, use the IMacroService and related models instead")]
+        public Macro()
 		{
 		}
 
-		/// <summary>
-		/// Macro initializer
-		/// </summary>
-		/// <param name="Id">The id of the macro</param>
-		public Macro(int Id)
+        /// <summary>
+        /// Macro initializer
+        /// </summary>
+        /// <param name="Id">The id of the macro</param>
+        [Obsolete("This should no longer be used, use the IMacroService and related models instead")]
+        public Macro(int Id)
 		{
             Setup(Id);
 		}
 
+        [Obsolete("This should no longer be used, use the IMacroService and related models instead")]
         internal Macro(IMacro macro)
         {
             MacroEntity = macro;
@@ -211,15 +211,17 @@ namespace umbraco.cms.businesslogic.macro
         /// Initializes a new instance of the <see cref="Macro"/> class.
         /// </summary>
         /// <param name="alias">The alias.</param>
+        [Obsolete("This should no longer be used, use the IMacroService and related models instead")]
         public Macro(string alias)
         {
             Setup(alias);
         }
 
-	    /// <summary>
-	    /// Used to persist object changes to the database. In Version3.0 it's just a stub for future compatibility
-	    /// </summary>
-	    public virtual void Save()
+        /// <summary>
+        /// Used to persist object changes to the database. In Version3.0 it's just a stub for future compatibility
+        /// </summary>
+        [Obsolete("This should no longer be used, use the IMacroService and related models instead")]
+        public virtual void Save()
 	    {
 	        //event
 	        var e = new SaveEventArgs();
@@ -250,8 +252,7 @@ namespace umbraco.cms.businesslogic.macro
 		    }
 		}
 
-        //TODO: Fix this, this should wrap a new API!
-
+        [Obsolete("This is no longer used, use the IMacroService and related models instead")]
         public static Macro Import(XmlNode n)
         {
             var alias = XmlHelper.GetNodeValue(n.SelectSingleNode("alias"));


### PR DESCRIPTION
changing the package installer to use the new API macroservice instead of the old legacy classes.
marked a few methods as obsoleted.