### PR TITLE
Headline in the "Republish entire site" dialog is now translated

### DIFF
--- a/src/Umbraco.Web/Trees/LegacyTreeDataConverter.cs
+++ b/src/Umbraco.Web/Trees/LegacyTreeDataConverter.cs
@@ -254,7 +254,7 @@ namespace Umbraco.Web.Trees
                     return Attempt.Succeed(
                         new LegacyUrlAction(
                             "dialogs/republish.aspx?rnd=" + DateTime.UtcNow.Ticks,
-                            "Republishing entire site"));
+                            ui.GetText("actions", "republish")));
                 case "UmbClientMgr.appActions().actionAssignDomain()":
                     return Attempt.Succeed(
                         new LegacyUrlAction(


### PR DESCRIPTION
See screenshot (in Danish):

![image](https://cloud.githubusercontent.com/assets/3634580/19943085/451c43e6-a136-11e6-8a25-8df15640e0d2.png)

The headline/title is now translated, and uses the `republish` key in the `actions` section. For English, this will mean that the title is now *Republish entire site* rather than *Republishing entire site* (I would argue that this change is for the better).