### PR TITLE
Removed old options for linked targets and replaced with checkbox ins…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
@@ -18,18 +18,9 @@
     </umb-control-group>
 
     <umb-control-group label="@content_target">
-        <select class="umb-editor umb-dropdown" ng-model="model.target.target">
-            <option value=""></option>
-            <option value="_blank">
-                <localize key="defaultdialogs_openInNewWindow">Opens the linked document in a new window or tab</localize>
-            </option>
-            <option value="_top">
-                <localize key="defaultdialogs_openInFullBody">Opens the linked document in the full body of the window</localize>
-            </option>
-            <option value="_parent">
-                <localize key="defaultdialogs_openInParentFrame">Opens the linked document in the parent frame</localize>
-            </option>
-        </select>
+        <label class="checkbox no-indent">
+            <input type="checkbox" ng-model="model.target.target" ng-true-value="_blank" ng-false-value="" /> <localize key="defaultdialogs_openInNewWindow">Opens the linked document in a new window or tab</localize>
+        </label>
     </umb-control-group>
 
     <div class="umb-control-group">


### PR DESCRIPTION
Removed _top and _parent options from the target-dialog, as i don´t think they are relevant any more (based on our experience as educators in Umbraco). As this leave only one option (_blank), i have changed the select-input to a checkbox instead.

regards
René

<img width="558" alt="skaermbillede 2016-11-02 kl 21 06 54" src="https://cloud.githubusercontent.com/assets/3634592/19945421/59e43914-a140-11e6-80f5-0bb066b78a4a.png">
