### PR TITLE
Link to mediatype from media properties

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MediaModelMapper.cs
@@ -155,7 +155,27 @@ namespace Umbraco.Web.Models.Mapping
                 genericProperties.Add(link);
             }
 
-            TabsAndPropertiesResolver.MapGenericProperties(media, display, localizedText, genericProperties);
+            TabsAndPropertiesResolver.MapGenericProperties(media, display, localizedText, genericProperties, properties => {
+                if (HttpContext.Current != null && UmbracoContext.Current != null && UmbracoContext.Current.Security.CurrentUser != null
+                    && UmbracoContext.Current.Security.CurrentUser.AllowedSections.Any(x => x.Equals(Constants.Applications.Settings)))
+                {
+                    var docTypeLink = string.Format("#/settings/mediatypes/edit/{0}", media.ContentTypeId);
+
+                    //Replace the doc type property
+                    var docTypeProp = properties.First(x => x.Alias == string.Format("{0}doctype", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
+                    docTypeProp.Value = new List<object>
+                        {
+                            new
+                            {
+                                linkText = media.ContentType.Name,
+                                url = docTypeLink,
+                                target = "_self", icon = "icon-item-arrangement"
+                            }
+                        };
+                    docTypeProp.View = "urllist";
+                }
+
+            });
         }
 
     }

--- a/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
@@ -233,26 +233,7 @@ namespace Umbraco.Web.Models.Mapping
             };
 
 
-            TabsAndPropertiesResolver.MapGenericProperties(member, display, localizedText, genericProperties, properties => {
-                if (HttpContext.Current != null && UmbracoContext.Current != null && UmbracoContext.Current.Security.CurrentUser != null
-                    && UmbracoContext.Current.Security.CurrentUser.AllowedSections.Any(x => x.Equals(Constants.Applications.Settings)))
-                {
-                    var docTypeLink = string.Format("#/member/memberTypes/edit/{0}", member.ContentTypeId);
-
-                    //Replace the doc type property
-                    var docTypeProp = properties.First(x => x.Alias == string.Format("{0}doctype", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
-                    docTypeProp.Value = new List<object>
-                        {
-                            new
-                            {
-                                linkText = member.ContentType.Name,
-                                url = docTypeLink,
-                                target = "_self", icon = "icon-item-arrangement"
-                            }
-                        };
-                    docTypeProp.View = "urllist";
-                }
-            });
+            TabsAndPropertiesResolver.MapGenericProperties(member, display, localizedText, genericProperties);
 
             //check if there's an approval field
             var provider = membersProvider as global::umbraco.providers.members.UmbracoMembershipProvider;

--- a/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
@@ -233,7 +233,26 @@ namespace Umbraco.Web.Models.Mapping
             };
 
 
-            TabsAndPropertiesResolver.MapGenericProperties(member, display, localizedText, genericProperties);
+            TabsAndPropertiesResolver.MapGenericProperties(member, display, localizedText, genericProperties, properties => {
+                if (HttpContext.Current != null && UmbracoContext.Current != null && UmbracoContext.Current.Security.CurrentUser != null
+                    && UmbracoContext.Current.Security.CurrentUser.AllowedSections.Any(x => x.Equals(Constants.Applications.Settings)))
+                {
+                    var docTypeLink = string.Format("#/member/memberTypes/edit/{0}", member.ContentTypeId);
+
+                    //Replace the doc type property
+                    var docTypeProp = properties.First(x => x.Alias == string.Format("{0}doctype", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
+                    docTypeProp.Value = new List<object>
+                        {
+                            new
+                            {
+                                linkText = member.ContentType.Name,
+                                url = docTypeLink,
+                                target = "_self", icon = "icon-item-arrangement"
+                            }
+                        };
+                    docTypeProp.View = "urllist";
+                }
+            });
 
             //check if there's an approval field
             var provider = membersProvider as global::umbraco.providers.members.UmbracoMembershipProvider;


### PR DESCRIPTION
Under media properties the media type link to the current media type. This is just like now where document type under content properties link to the current document type.

![mediatype](https://cloud.githubusercontent.com/assets/3634628/19946439/6f1470fc-a144-11e6-90bc-ad92b00ac3a2.png)
