### PR TITLE
U4-7318 Core property value converters

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/CheckboxListValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/CheckboxListValueConverter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Core.PropertyEditors.ValueConverters
+{
+    public class CheckboxListValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors.CheckBoxListAlias);
+        }
+
+        public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            var sourceString = (source ?? "").ToString();
+
+            if (string.IsNullOrEmpty(sourceString))
+                return Enumerable.Empty<string>();
+
+            var values =
+                sourceString.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(v => v.Trim());
+
+            return values;
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(IEnumerable<string>);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType,
+                                                        PropertyCacheValue cacheValue)
+        {
+            return PropertyCacheLevel.Content;
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/ColorPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/ColorPickerValueConverter.cs
@@ -1,8 +1,9 @@
-﻿using Umbraco.Core.Models.PublishedContent;
+﻿using System;
+using Umbraco.Core.Models.PublishedContent;
 
 namespace Umbraco.Core.PropertyEditors.ValueConverters
 {
-    public class ColorPickerValueConverter : PropertyValueConverterBase
+    public class ColorPickerValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
     {
         public override bool IsConverter(PublishedPropertyType propertyType)
         {
@@ -13,6 +14,16 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
         {
             // make sure it's a string
             return source.ToString();
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(string);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType, PropertyCacheValue cacheValue)
+        {
+            return PropertyCacheLevel.Content;
         }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/DropdownListMultipleValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/DropdownListMultipleValueConverter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Core.PropertyEditors.ValueConverters
+{
+    public class DropdownListMultipleValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors.DropDownListMultipleAlias);
+        }
+
+        public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            var sourceString = (source ?? "").ToString();
+
+            if (string.IsNullOrEmpty(sourceString))
+                return Enumerable.Empty<string>();
+
+            var values =
+                sourceString.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(v => v.Trim());
+
+            return values;
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(IEnumerable<string>);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType,
+                                                        PropertyCacheValue cacheValue)
+        {
+            return PropertyCacheLevel.Content;
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/DropdownListMultipleWithKeysValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/DropdownListMultipleWithKeysValueConverter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Core.PropertyEditors.ValueConverters
+{
+    public class DropdownListMultipleWithKeysValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.PropertyEditorAlias.InvariantEquals(
+                                                                    Constants.PropertyEditors
+                                                                             .DropdownlistMultiplePublishKeysAlias);
+        }
+
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source == null)
+                return new int[] { };
+
+            var prevalueIds = source.ToString()
+                                    .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                                    .Select(p => p.Trim())
+                                    .Select(int.Parse)
+                                    .ToArray();
+
+            return prevalueIds;
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(IEnumerable<int>);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType,
+                                                        PropertyCacheValue cacheValue)
+        {
+            return PropertyCacheLevel.Content;
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/DropdownListValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/DropdownListValueConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Core.PropertyEditors.ValueConverters
+{
+    public class DropdownListValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors.DropDownListAlias);
+        }
+
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            return source == null ? string.Empty : source.ToString();
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(string);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType,
+                                                        PropertyCacheValue cacheValue)
+        {
+            return PropertyCacheLevel.Content;
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/DropdownListWithKeysValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/DropdownListWithKeysValueConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Core.PropertyEditors.ValueConverters
+{
+    public class DropdownListWithKeysValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return
+                propertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors
+                                                                          .DropdownlistPublishingKeysAlias);
+        }
+
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            var intAttempt = source.TryConvertTo<int>();
+            if (intAttempt.Success)
+                return intAttempt.Result;
+
+            return null;
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(int);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType,
+                                                        PropertyCacheValue cacheValue)
+        {
+            return PropertyCacheLevel.Content;
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/EmailAddressValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/EmailAddressValueConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Core.PropertyEditors.ValueConverters
+{
+    public class EmailAddressValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors.EmailAddressAlias);
+        }
+
+        public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            return source.ToString();
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(string);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType,
+                                                        PropertyCacheValue cacheValue)
+        {
+            return PropertyCacheLevel.Content;
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberGroupPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberGroupPickerValueConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Core.PropertyEditors.ValueConverters
+{
+    public class MemberGroupPickerValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors.MemberGroupPickerAlias);
+        }
+
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            return source == null ? string.Empty : source.ToString();
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(string);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType,
+                                                        PropertyCacheValue cacheValue)
+        {
+            return PropertyCacheLevel.Content;
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/RadioButtonListValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/RadioButtonListValueConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Core.PropertyEditors.ValueConverters
+{
+    public class RadioButtonListValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors.RadioButtonListAlias);
+        }
+
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            var intAttempt = source.TryConvertTo<int>();
+            if (intAttempt.Success)
+                return intAttempt.Result;
+
+            return null;
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(int);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType,
+                                                        PropertyCacheValue cacheValue)
+        {
+            return PropertyCacheLevel.Content;
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/UserPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/UserPickerValueConverter.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Models.Membership;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Core.PropertyEditors.ValueConverters
+{
+    public class UserPickerValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        private readonly IUserService _userService;
+
+        public UserPickerValueConverter()
+        {
+            _userService = ApplicationContext.Current.Services.UserService;
+        }
+
+        public UserPickerValueConverter(IUserService userService)
+        {
+            Mandate.That<ArgumentNullException>(userService != null);
+            _userService = userService;
+        }
+
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors.UserPickerAlias);
+        }
+
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            var intAttempt = source.TryConvertTo<int>();
+            if (intAttempt.Success)
+                return intAttempt.Result;
+
+            return null;
+        }
+
+        public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            var userId = (int) source;
+            var user = _userService.GetUserById(userId);
+            if (user != null)
+            {
+                return user;
+            }
+
+            return userId;
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(IUser);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType, PropertyCacheValue cacheValue)
+        {
+            PropertyCacheLevel returnLevel;
+            switch (cacheValue)
+            {
+                case PropertyCacheValue.Object:
+                    returnLevel = PropertyCacheLevel.ContentCache;
+                    break;
+                case PropertyCacheValue.Source:
+                    returnLevel = PropertyCacheLevel.Content;
+                    break;
+                case PropertyCacheValue.XPath:
+                    returnLevel = PropertyCacheLevel.Content;
+                    break;
+                default:
+                    returnLevel = PropertyCacheLevel.None;
+                    break;
+            }
+
+            return returnLevel;
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -501,6 +501,7 @@
     <Compile Include="PropertyEditors\ValueConverters\DropdownListMultipleValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DropdownListMultipleWithKeysValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DropdownListValueConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\DropdownListWithKeysValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\EmailAddressValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\GridValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DecimalValueConverter.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -497,6 +497,7 @@
     <Compile Include="Persistence\Repositories\TaskTypeRepository.cs" />
     <Compile Include="PropertyEditors\DecimalValidator.cs" />
     <Compile Include="PropertyEditors\PropertyEditorValueTypes.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\CheckboxListValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\EmailAddressValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\GridValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DecimalValueConverter.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -500,6 +500,7 @@
     <Compile Include="PropertyEditors\ValueConverters\CheckboxListValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DropdownListMultipleValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DropdownListMultipleWithKeysValueConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\DropdownListValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\EmailAddressValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\GridValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DecimalValueConverter.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -509,6 +509,7 @@
     <Compile Include="PropertyEditors\ValueConverters\ImageCropperValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\MemberGroupPickerValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\RadioButtonListValueConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\UserPickerValueConverter.cs" />
     <Compile Include="PublishedContentTypeConverter.cs" />
     <Compile Include="Publishing\UnPublishedStatusType.cs" />
     <Compile Include="Publishing\UnPublishStatus.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -507,6 +507,7 @@
     <Compile Include="PropertyEditors\ValueConverters\DecimalValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\LabelValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\ImageCropperValueConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\MemberGroupPickerValueConverter.cs" />
     <Compile Include="PublishedContentTypeConverter.cs" />
     <Compile Include="Publishing\UnPublishedStatusType.cs" />
     <Compile Include="Publishing\UnPublishStatus.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -499,6 +499,7 @@
     <Compile Include="PropertyEditors\PropertyEditorValueTypes.cs" />
     <Compile Include="PropertyEditors\ValueConverters\CheckboxListValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DropdownListMultipleValueConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\DropdownListMultipleWithKeysValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\EmailAddressValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\GridValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DecimalValueConverter.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -498,6 +498,7 @@
     <Compile Include="PropertyEditors\DecimalValidator.cs" />
     <Compile Include="PropertyEditors\PropertyEditorValueTypes.cs" />
     <Compile Include="PropertyEditors\ValueConverters\CheckboxListValueConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\DropdownListMultipleValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\EmailAddressValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\GridValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DecimalValueConverter.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -497,6 +497,7 @@
     <Compile Include="Persistence\Repositories\TaskTypeRepository.cs" />
     <Compile Include="PropertyEditors\DecimalValidator.cs" />
     <Compile Include="PropertyEditors\PropertyEditorValueTypes.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\EmailAddressValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\GridValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\DecimalValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\LabelValueConverter.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -508,6 +508,7 @@
     <Compile Include="PropertyEditors\ValueConverters\LabelValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\ImageCropperValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\MemberGroupPickerValueConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\RadioButtonListValueConverter.cs" />
     <Compile Include="PublishedContentTypeConverter.cs" />
     <Compile Include="Publishing\UnPublishedStatusType.cs" />
     <Compile Include="Publishing\UnPublishStatus.cs" />

--- a/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueConverterTests.cs
+++ b/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueConverterTests.cs
@@ -83,5 +83,18 @@ namespace Umbraco.Tests.PropertyEditors
 
             Assert.AreEqual(expected, result);
 	    }
+
+        [TestCase("100", new[] {100})]
+        [TestCase("100,200", new[] {100, 200})]
+        [TestCase("100 , 200, 300 ", new[] {100, 200, 300})]
+        [TestCase("", new int[] {})]
+        [TestCase(null, new int[] {})]
+	    public void CanConvertDropdownListMultipleWithKeysPropertyEditor(object value, IEnumerable<int> expected)
+	    {
+	        var converter = new DropdownListMultipleWithKeysValueConverter();
+	        var result = converter.ConvertDataToSource(null, value, false);
+
+            Assert.AreEqual(expected, result);
+	    }
     }
 }

--- a/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueConverterTests.cs
+++ b/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueConverterTests.cs
@@ -70,5 +70,18 @@ namespace Umbraco.Tests.PropertyEditors
 
             Assert.AreEqual(expected, result);
         }
+
+        [TestCase("apples", new[] {"apples"})]
+        [TestCase("apples,oranges", new[] {"apples", "oranges"})]
+        [TestCase("apples , oranges, pears ", new[] {"apples", "oranges", "pears"})]
+        [TestCase("", new string[] {})]
+        [TestCase(null, new string[] {})]
+	    public void CanConvertDropdownListMultiplePropertyEditor(object value, IEnumerable<string> expected)
+	    {
+	        var converter = new DropdownListMultipleValueConverter();
+	        var result = converter.ConvertSourceToObject(null, value, false);
+
+            Assert.AreEqual(expected, result);
+	    }
     }
 }

--- a/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueConverterTests.cs
+++ b/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueConverterTests.cs
@@ -1,8 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
-using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.PropertyEditors.ValueConverters;
-using Umbraco.Tests.TestHelpers;
 
 namespace Umbraco.Tests.PropertyEditors
 {
@@ -58,5 +57,18 @@ namespace Umbraco.Tests.PropertyEditors
 
             Assert.AreEqual(expected, result);
         }
-	}
+
+        [TestCase("apples", new[] { "apples" })]
+        [TestCase("apples,oranges", new[] { "apples", "oranges" })]
+        [TestCase(" apples, oranges, pears ", new[] { "apples", "oranges", "pears" })]
+        [TestCase("", new string[] { })]
+        [TestCase(null, new string[] { })]
+        public void CanConvertCheckboxListPropertyEditor(object value, IEnumerable<string> expected)
+        {
+            var converter = new CheckboxListValueConverter();
+            var result = converter.ConvertSourceToObject(null, value, false);
+
+            Assert.AreEqual(expected, result);
+        }
+    }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MemberPickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MemberPickerPropertyConverter.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Web.Security;
+
+namespace Umbraco.Web.PropertyEditors.ValueConverters
+{
+    public class MemberPickerPropertyConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors.MemberPickerAlias);
+        }
+
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            var intAttempt = source.TryConvertTo<int>();
+            if (intAttempt.Success)
+                return intAttempt.Result;
+
+            return null;
+        }
+
+        public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source == null)
+                return null;
+
+            if (UmbracoContext.Current != null)
+            {
+                var membershipHelper = new MembershipHelper(UmbracoContext.Current);
+                return membershipHelper.GetById((int) source);
+            }
+
+            return null;
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return typeof(IPublishedContent);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType,
+                                                        PropertyCacheValue cacheValue)
+        {
+            PropertyCacheLevel returnLevel;
+            switch (cacheValue)
+            {
+                case PropertyCacheValue.Object:
+                    returnLevel = PropertyCacheLevel.ContentCache;
+                    break;
+                case PropertyCacheValue.Source:
+                    returnLevel = PropertyCacheLevel.Content;
+                    break;
+                case PropertyCacheValue.XPath:
+                    returnLevel = PropertyCacheLevel.Content;
+                    break;
+                default:
+                    returnLevel = PropertyCacheLevel.None;
+                    break;
+            }
+
+            return returnLevel;
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -398,6 +398,7 @@
     <Compile Include="PropertyEditors\ValueConverters\ImageCropDataSetConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\ImageCropperValueConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\MediaPickerPropertyConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\MemberPickerPropertyConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\MultiNodeTreePickerPropertyConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\MultipleMediaPickerPropertyConverter.cs" />
     <Compile Include="Routing\RedirectTrackingEventHandler.cs" />


### PR DESCRIPTION
Added core property value converters for the following property editors:

- Email address
- Checkbox list
- Radio button list
- Dropdown list
- Dropdown list (publishing keys)
- Dropdown list multiple
- Dropdown list multiple (publishing keys)
- Member group picker
- User picker
- Member picker

Updated the existing colour picker converter to return values as strings.