### PR TITLE
Truncate should not finish halfway through a two word unicode character

### DIFF
--- a/src/Umbraco.Web/HtmlStringUtilities.cs
+++ b/src/Umbraco.Web/HtmlStringUtilities.cs
@@ -211,6 +211,13 @@ namespace Umbraco.Web
 
                                     if (!lengthReached && currentTextLength >= length)
                                     {
+                                        // if the last character added was the first of a two character unicode pair, add the second character
+                                        if (Char.IsHighSurrogate((char)ic))
+                                        {
+                                            var lowSurrogate = tr.Read();
+                                            outputtw.Write((char)lowSurrogate);
+                                        }
+
                                         // Reached truncate limit.
                                         if (addElipsis)
                                         {


### PR DESCRIPTION
When truncating if the last character was the first half of a two word unicode character, also include the second half to avoid YSOD

See issue: http://issues.umbraco.org/issue/U4-9068