### PR TITLE
U4-8253 'You have unsaved changes' message was not disappearing when 'Save and Publish' button was clicked

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/notifications.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/notifications.service.js
@@ -38,6 +38,26 @@ angular.module('umbraco.services')
 		return view;
 	}
 
+	function findView(viewName) {
+	    var viewPath = setViewPath(viewName).toLowerCase();
+	    return _.find(nArray, function (notification) {
+	        return notification.view.toLowerCase() === viewPath;
+	    });
+	}
+
+	function remove(index) {
+	    if (angular.isObject(index)) {
+	        var i = nArray.indexOf(index);
+	        angularHelper.safeApply($rootScope, function () {
+	            nArray.splice(i, 1);
+	        });
+	    } else {
+	        angularHelper.safeApply($rootScope, function () {
+	            nArray.splice(index, 1);
+	        });
+	    }
+	}
+
 	var service = {
 
 		/**
@@ -244,18 +264,7 @@ angular.module('umbraco.services')
 		 *
 		 * @param {Int} index index where the notication should be removed from
 		 */
-		remove: function (index) {
-			if(angular.isObject(index)){
-				var i = nArray.indexOf(index);
-				angularHelper.safeApply($rootScope, function() {
-				    nArray.splice(i, 1);
-				});
-			}else{
-				angularHelper.safeApply($rootScope, function() {
-				    nArray.splice(index, 1);
-				});	
-			}
-		},
+		remove: remove,
 
 		/**
 		 * @ngdoc method
@@ -269,7 +278,21 @@ angular.module('umbraco.services')
 	        angularHelper.safeApply($rootScope, function() {
 	            nArray = [];
 	        });
-		},
+	    },
+
+	     /**
+         * @ngdoc method
+         * @name umbraco.services.notificationsService#removeByName
+         * @methodOf umbraco.services.notificationsService
+         *
+         * @description
+         * Removes single notification by name
+         */
+	    removeByName: function (viewName) {
+	        var view = findView(viewName);
+	        var index = nArray.indexOf(view);
+	        remove(index);
+	    },
 
 		/**
 		 * @ngdoc property

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -89,6 +89,10 @@ function ContentEditController($scope, $rootScope, $routeParams, $q, $timeout, $
             init($scope.content);
             syncTreeNode($scope.content, data.path);
 
+            if (notificationsService.hasView("confirmroutechange")) {
+                notificationsService.removeByName("confirmroutechange");
+            }
+
             $scope.page.buttonGroupState = "success";
 
             deferred.resolve(data);


### PR DESCRIPTION
Original issue: http://issues.umbraco.org/issue/U4-8253

We added method removeByName to notificationService.
When user clicks on SaveAndPublish and notificationService contains 'confirmroutechange' notification we are removing it because it's not needed.

Suggestion:
Maybe we should unify the way we are using names of views across application by creating some helper with hardcoded views names to keep it only in one place.