### PR TITLE
U4 5178

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
@@ -27,6 +27,8 @@
    border-radius: 0;
    position: relative;
    margin-bottom: 0;
+   max-height: calc(75vh);
+   overflow: auto;   
 }
 
 .umb-notifications__notification.-extra-padding {
@@ -35,8 +37,7 @@
 }
 
 .umb-notifications__notification .close {
-    position: absolute;
-    bottom: 5px;
-    right: 21px;
+    position: fixed;
     top: initial;
+    right: 25px;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
@@ -33,3 +33,10 @@
    padding-top: 20px;
    padding-bottom: 20px;
 }
+
+.umb-notifications__notification .close {
+    position: absolute;
+    bottom: 5px;
+    right: 21px;
+    top: initial;
+}


### PR DESCRIPTION
Red exception box cannot be closed if very large - meaning the alerts from the notifications service. 
Set a maximum height and overflow auto for the notifications so the top of the box is always visible as well as the closing icon. As it is not common to get such a large notification message, in order to test it you can add several extra lines to the notification view umb-notifications.html just for testing purposes.