### PR TITLE
U4-9151 Bug fix for getImagePropertyValue typeerror

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
@@ -58,9 +58,19 @@ function mediaHelper(umbRequestHelper) {
             }
 
             var mediaVal;
+            
+            // our default images might store one or many images (as csv) inside either
+            // imageProp.value or imageProp.value.src so check both.
+            var split = "";
+            if (imageProp.value) {
+                if ("string" === typeof(imageProp.value.src)) {
+                    split = imageProp.value.src.split(',');
+                } else if ("string" === typeof(imageProp.value)) {
+                    split = imageProp.value.split(',');
+                }
+            }
 
-            //our default images might store one or many images (as csv)            
-            var split = (imageProp.value && imageProp.value.src) ? imageProp.value.src.split(',') : '';
+
             var self = this;
             mediaVal = _.map(split, function (item) {
                 return { file: item, isImage: self.detectIfImageByExtension(item) };

--- a/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
@@ -23,6 +23,7 @@ function mediaHelper(umbRequestHelper) {
          * @param {object} options.imageOnly Optional, if true then will only return a path if the media item is an image
          */
         getMediaPropertyValue: function (options) {
+
             if (!options || !options.mediaModel) {
                 throw "The options objet does not contain the required parameters: mediaModel";
             }
@@ -58,8 +59,8 @@ function mediaHelper(umbRequestHelper) {
 
             var mediaVal;
 
-            //our default images might store one or many images (as csv)
-            var split = imageProp.value.split(',');
+            //our default images might store one or many images (as csv)            
+            var split = (imageProp.value && imageProp.value.src) ? imageProp.value.src.split(',') : '';
             var self = this;
             mediaVal = _.map(split, function (item) {
                 return { file: item, isImage: self.detectIfImageByExtension(item) };

--- a/src/Umbraco.Web.UI.Client/test/unit/common/services/umb-media-helper.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/services/umb-media-helper.spec.js
@@ -1,0 +1,64 @@
+describe('media helper tests', function () {
+    var umbMediaHelper;
+
+    beforeEach(module('umbraco.services'));  
+
+    beforeEach(inject(function ($injector) {
+        umbMediaHelper = $injector.get('mediaHelper');
+    }));
+
+    describe('mediaHelper service tests', function () {
+
+        it('returns file path associated with media property', function () {
+
+            // dummy imageModel
+            var imageModel =
+            {
+                "isChildOfListView": false,
+                "treeNodeUrl": "/umbraco/backoffice/UmbracoTrees/MediaTree/GetTreeNode/2061",
+                "contentTypeName": "Image",
+                "isContainer": false,
+                "notifications": [],
+                "ModelState": {},
+                "tabs": [
+                  {
+                      "id": 3,
+                      "active": true,
+                      "label": "Image",
+                      "alias": "Image",
+                      "properties": [
+                        {
+                            "label": "Upload image",
+                            "description": null,
+                            "view": "imagecropper",
+                            "config": {
+                                "focalPoint": {
+                                    "left": 0.5,
+                                    "top": 0.5
+                                },
+                                "src": ""
+                            },
+                            "hideLabel": false,
+                            "validation": {
+                                "mandatory": false,
+                                "pattern": null
+                            },
+                            "id": 1097,
+                            "value": {
+                                "src": "/media/1001/TestImage123.jpg",
+                                "crops": []
+                            },
+                            "alias": "umbracoFile",
+                            "editor": "Umbraco.ImageCropper"
+                        }
+                      ]
+                  }
+                ]
+            };
+            
+            // test returns file path associated with media property
+            expect(umbMediaHelper.getMediaPropertyValue({ mediaModel: imageModel, imageOnly: true })).toBe("/media/1001/TestImage123.jpg");
+        });
+
+    });
+});


### PR DESCRIPTION
Calling getImagePropertyValue  on mediahelper.service.js  - mediaHelper.getImagePropertyValue({ mediaModel: item}) - resulted in a type error.

- Problem caused by a reference to imageProp.value instead of imageProp.value.src. 
- Amended mediahelper.service.js to return the image path using ImageProp.value.src.
- Added unit test as umb-media-helper-spec.js to test path is returned using a dummy imageModel.

Note: The src attribute is being added by ImageCropperPropertyEditor.cs line 219  - p.Value = "{src: '" + p.Value + "', crops: " + crops + "}"; following a PostAddfile request; and is reflected in database table cmsPropertyData (dataNtext). I have presumed the addition of this src attribute is desirable and not the true bug.