### PR TITLE
Link to member type from member properties

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
@@ -233,7 +233,26 @@ namespace Umbraco.Web.Models.Mapping
             };
 
 
-            TabsAndPropertiesResolver.MapGenericProperties(member, display, localizedText, genericProperties);
+            TabsAndPropertiesResolver.MapGenericProperties(member, display, localizedText, genericProperties, properties => {
+                if (HttpContext.Current != null && UmbracoContext.Current != null && UmbracoContext.Current.Security.CurrentUser != null
+                    && UmbracoContext.Current.Security.CurrentUser.AllowedSections.Any(x => x.Equals(Constants.Applications.Settings)))
+                {
+                    var docTypeLink = string.Format("#/member/memberTypes/edit/{0}", member.ContentTypeId);
+
+                    //Replace the doc type property
+                    var docTypeProp = properties.First(x => x.Alias == string.Format("{0}doctype", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
+                    docTypeProp.Value = new List<object>
+                        {
+                            new
+                            {
+                                linkText = member.ContentType.Name,
+                                url = docTypeLink,
+                                target = "_self", icon = "icon-item-arrangement"
+                            }
+                        };
+                    docTypeProp.View = "urllist";
+                }
+            });
 
             //check if there's an approval field
             var provider = membersProvider as global::umbraco.providers.members.UmbracoMembershipProvider;


### PR DESCRIPTION
Under member properties the member type link to the current member type. This is just like now where document type under content properties link to the current document type.

![membertype](https://cloud.githubusercontent.com/assets/3634628/20120295/9a0ebfac-a60c-11e6-94f4-6cc94a7d220a.png)
