### PR TITLE
U4-9180 Optimise Log4net

### DIFF
--- a/src/Umbraco.Web.UI/config/log4net.Release.config
+++ b/src/Umbraco.Web.UI/config/log4net.Release.config
@@ -1,18 +1,19 @@
 <?xml version="1.0"?>
 <log4net>
-  
+
   <root>
     <priority value="Info"/>
     <appender-ref ref="AsynchronousLog4NetAppender" />
   </root>
 
   <appender name="rollingFile" type="log4net.Appender.RollingFileAppender">
-	  <file type="log4net.Util.PatternString" value="App_Data\Logs\UmbracoTraceLog.%property{log4net:HostName}.txt" />
+    <file type="log4net.Util.PatternString" value="App_Data\Logs\UmbracoTraceLog.%property{log4net:HostName}.txt" />
     <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
     <appendToFile value="true" />
     <rollingStyle value="Composite" />
     <datePattern value=".yyyy-MM-dd.'log'"/>
     <maximumFileSize value="5MB" />
+    <maxSizeRollBackups value="90"/>
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value=" %date [P%property{processId}/D%property{appDomainId}/T%thread] %-5level %logger - %message%newline" />
     </layout>
@@ -28,6 +29,6 @@
   <logger name="NHibernate">
     <level value="WARN" />
   </logger>
-  
-  
+
+
 </log4net>

--- a/src/Umbraco.Web.UI/config/log4net.Release.config
+++ b/src/Umbraco.Web.UI/config/log4net.Release.config
@@ -11,7 +11,7 @@
     <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
     <appendToFile value="true" />
     <rollingStyle value="Composite" />
-    <datePattern value=".yyyy-MM-dd"/>
+    <datePattern value=".yyyy-MM-dd.'log'"/>
     <maximumFileSize value="5MB" />
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value=" %date [P%property{processId}/D%property{appDomainId}/T%thread] %-5level %logger - %message%newline" />

--- a/src/Umbraco.Web.UI/config/log4net.Release.config
+++ b/src/Umbraco.Web.UI/config/log4net.Release.config
@@ -10,7 +10,8 @@
 	  <file type="log4net.Util.PatternString" value="App_Data\Logs\UmbracoTraceLog.%property{log4net:HostName}.txt" />
     <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
     <appendToFile value="true" />
-    <rollingStyle value="Date" />
+    <rollingStyle value="Composite" />
+    <datePattern value=".yyyy-MM-dd"/>
     <maximumFileSize value="5MB" />
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value=" %date [P%property{processId}/D%property{appDomainId}/T%thread] %-5level %logger - %message%newline" />

--- a/src/Umbraco.Web.UI/config/log4net.config
+++ b/src/Umbraco.Web.UI/config/log4net.config
@@ -11,7 +11,7 @@
     <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
     <appendToFile value="true" />
      <rollingStyle value="Composite" />
-     <datePattern value=".yyyy-MM-dd"/>
+     <datePattern value=".yyyy-MM-dd.'log'"/>
     <maximumFileSize value="5MB" />
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value=" %date [P%property{processId}/D%property{appDomainId}/T%thread] %-5level %logger - %message%newline" />

--- a/src/Umbraco.Web.UI/config/log4net.config
+++ b/src/Umbraco.Web.UI/config/log4net.config
@@ -1,18 +1,19 @@
 <?xml version="1.0"?>
 <log4net>
-  
+
   <root>
     <priority value="Debug"/>
     <appender-ref ref="AsynchronousLog4NetAppender" />
   </root>
 
   <appender name="rollingFile" type="log4net.Appender.RollingFileAppender">
-	  <file type="log4net.Util.PatternString" value="App_Data\Logs\UmbracoTraceLog.%property{log4net:HostName}.txt" />
+    <file type="log4net.Util.PatternString" value="App_Data\Logs\UmbracoTraceLog.%property{log4net:HostName}.txt" />
     <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
     <appendToFile value="true" />
-     <rollingStyle value="Composite" />
-     <datePattern value=".yyyy-MM-dd.'log'"/>
+    <rollingStyle value="Composite" />
+    <datePattern value=".yyyy-MM-dd.'log'"/>
     <maximumFileSize value="5MB" />
+    <maxSizeRollBackups value="90"/>
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value=" %date [P%property{processId}/D%property{appDomainId}/T%thread] %-5level %logger - %message%newline" />
     </layout>
@@ -28,6 +29,6 @@
   <logger name="NHibernate">
     <level value="WARN" />
   </logger>
-  
-  
+
+
 </log4net>

--- a/src/Umbraco.Web.UI/config/log4net.config
+++ b/src/Umbraco.Web.UI/config/log4net.config
@@ -10,7 +10,8 @@
 	  <file type="log4net.Util.PatternString" value="App_Data\Logs\UmbracoTraceLog.%property{log4net:HostName}.txt" />
     <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
     <appendToFile value="true" />
-    <rollingStyle value="Date" />
+     <rollingStyle value="Composite" />
+     <datePattern value=".yyyy-MM-dd"/>
     <maximumFileSize value="5MB" />
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value=" %date [P%property{processId}/D%property{appDomainId}/T%thread] %-5level %logger - %message%newline" />


### PR DESCRIPTION
A fix for maximum file size to work.
Limited number of backups to keep to 90.
Fixed backup file extension.