### PR TITLE
U4-8507 - Edit embed in grid editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -403,7 +403,18 @@
     margin-bottom: 10px;
 }
 
+.umb-grid .umb-editor-preview {
+    position: relative;
 
+    .umb-editor-preview-overlay {
+        cursor: pointer;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+    }
+}
 
 // Active states
 // -------------------------

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/embed/embed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/embed/embed.html
@@ -1,8 +1,8 @@
 <form ng-controller="Umbraco.Overlays.EmbedOverlay as vm">
 
-   <umb-control-group label="Url">
+   <umb-control-group label="@general_url">
        <input id="url" class="umb-editor input-block-level" type="text" style="margin-bottom: 10px;" ng-model="model.embed.url" ng-keyup="$event.keyCode == 13 ? vm.showPreview() : null" required />
-       <input type="button" ng-click="vm.showPreview()" class="btn" value="Retrieve" />
+       <input type="button" ng-click="vm.showPreview()" class="btn" value="@general_retrieve" localize="value" />
    </umb-control-group>
 
    <umb-control-group>
@@ -11,16 +11,16 @@
    </umb-control-group>
 
    <div ng-show="model.embed.supportsDimensions">
-       <umb-control-group label="Width">
-           <input type="text" ng-model="model.embed.width" on-blur="vm.changeSize('width')" />
+       <umb-control-group label="@width">
+          <input type="number" pattern="[0-9]*" min="0" ng-model="model.embed.width" on-blur="vm.changeSize('width')" />
        </umb-control-group>
 
-       <umb-control-group label="Height">
-          <input type="text" ng-model="model.embed.height" on-blur="vm.changeSize('height')" />
+       <umb-control-group label="@height">
+          <input type="number" pattern="[0-9]*" min="0" ng-model="model.embed.height" on-blur="vm.changeSize('height')" />
        </umb-control-group>
 
-       <umb-control-group label="Constrain:">
-          <input id="constrain" type="checkbox" ng-model="model.embed.constrain" />
+       <umb-control-group label="@constrainProportions">
+           <input id="constrain" type="checkbox" ng-model="model.embed.constrain" />
        </umb-control-group>
    </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/embed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/embed.html
@@ -5,7 +5,10 @@
 		<div class="help-text"><localize key="grid_clickToEmbed">Click to embed</localize></div>
 	</div>
 
-	<div ng-if="control.value" ng-bind-html-unsafe="control.value"></div>
+    <div class="umb-editor-preview" ng-if="control.value" ng-click="setEmbed()">
+        <div class="umb-editor-preview-overlay"></div>
+        <div ng-bind-html-unsafe="control.value"></div>
+    </div>
 
 	<umb-overlay
 		ng-if="embedDialog.show"

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -424,7 +424,7 @@
     <key alias="showPageOnSend">Hvilken side skal vises etter at skjemaet er sendt</key>
     <key alias="size">Størrelse</key>
     <key alias="sort">Sorter</key>
-    <key alias="submit">Submit</key> <!-- TODO: Translate this -->
+    <key alias="submit">Send</key>
     <key alias="type">Type</key>
     <key alias="typeToSearch">Søk...</key>
     <key alias="up">Opp</key>
@@ -441,6 +441,17 @@
     <key alias="yes">Ja</key>
     <key alias="folder">Mappe</key>
     <key alias="searchResults">Søkeresultater</key>
+    <key alias="reorder">Sorter</key>
+    <key alias="reorderDone">Avslutt sortering</key>
+    <key alias="preview">Eksempel</key>
+    <key alias="changePassword">Bytt passord</key>
+    <key alias="to">til</key>
+    <key alias="listView">Listevisning</key>
+    <key alias="saving">Lagrer...</key>
+    <key alias="current">nåværende</key>
+    <key alias="embed">Innbygging</key>
+    <key alias="retrieve">Hent</key>
+    <key alias="selected">valgt</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">Bakgrunnsfarge</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -470,7 +470,6 @@
     <key alias="size">Størrelse</key>
     <key alias="sort">Sortér</key>
     <key alias="submit">Indsend</key>
-    <!-- TODO: Translate this -->
     <key alias="type">Type</key>
     <key alias="typeToSearch">Skriv for at søge...</key>
     <key alias="up">Op</key>
@@ -496,6 +495,7 @@
     <key alias="saving">Gemmer...</key>
     <key alias="current">nuværende</key>
     <key alias="embed">Indlejring</key>
+    <key alias="retrieve">Hent</key>
     <key alias="selected">valgt</key>
   </area>
 

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -521,6 +521,7 @@
     <key alias="saving">Saving...</key>
     <key alias="current">current</key>
     <key alias="embed">Embed</key>
+    <key alias="retrieve">Retrieve</key>
     <key alias="selected">selected</key>
   </area>
 

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -526,6 +526,7 @@
     <key alias="saving">Saving...</key>
     <key alias="current">current</key>
     <key alias="embed">Embed</key>
+    <key alias="retrieve">Retrieve</key>
     <key alias="selected">selected</key>
   </area>
   <area alias="colors">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -412,7 +412,7 @@
     <key alias="showPageOnSend">Vilken sida skall visas när formuläret är skickat</key>
     <key alias="size">Storlek</key>
     <key alias="sort">Sortera</key>
-    <key alias="submit">Submit</key> <!-- TODO: Translate this -->
+    <key alias="submit">Skicka</key>
     <key alias="type">Skriv</key>
     <key alias="typeToSearch">Skriv för att söka...</key>
     <key alias="up">Upp</key>
@@ -427,8 +427,17 @@
     <key alias="width">Bredd</key>
     <key alias="view">Titta på</key>
     <key alias="yes">Ja</key>
-    <key alias="reorder">Reorder</key>
-    <key alias="reorderDone">I am done reordering</key>
+    <key alias="reorder">Sortera</key>
+    <key alias="reorderDone">Avsluta sortering</key>
+    <key alias="preview">Förhandsvisning</key>
+    <key alias="changePassword">Ändra lösenord</key>
+    <key alias="to">till</key>
+    <key alias="listView">Listvy</key>
+    <key alias="saving">Sparar...</key>
+    <key alias="current">nuvarande</key>
+    <key alias="embed">Inbäddning</key>
+    <key alias="retrieve">Hämta</key>
+    <key alias="selected">valgt</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">Bakgrundsfärg</key>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-8507

This add a overlay on top of the rendered value - iframe, so it is possible to edit/insert a new video.

However both for image/media and embed it has at the moment only a method `setMedia` or `setEmbed`, which inserts a new value. Maybe both media and embed should open the existing one in dialog/overlay? E.g. for media if you just want to change position of focal point or change alternative text ... or for embed want to change constrain proportions.

For now I think this enhance the editing experience and I think it isn't necessary to play the video inside the grid (you can do that when retrieving the embed - and probably later when opening edit dialog for media and embed it init with the existing embed or media).

I have also change the input for width and height to numeric inputs and added pattern attribute on these:
http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms/

A minor issue I noticed with the constrain proportions:
After retrieving a video it set e.g. 360x240 .. but if then changing width to zero or a low value that set height to 0, you could end up with a invalid request like /umbraco/backoffice/UmbracoApi/RteEmbed/GetEmbed?height=0&url=https:%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DZ5hKnDI0NIw&width=NaN 400 (Bad Request) 
and a message "Could not embed media - please ensure the URL is valid".
On YouTube it actually doesn't allow you to set a width less than 200px e.g. for this video https://www.youtube.com/watch?v=tF03jgCgV7s

Will submit a new issue for this part.

Finally I have localized some of the texts.