### PR TITLE
U4-9183 Multinode TreePicker: show tree nodes when current node is a container

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -252,7 +252,7 @@ function umbTreeDirective($compile, $log, $q, $rootScope, treeService, notificat
 
                         //default args
                         var args = { section: scope.section, tree: scope.treealias, cacheKey: scope.cachekey, isDialog: scope.isdialog ? scope.isdialog : false };
-
+         
                         //add the extra query string params if specified
                         if (scope.customtreeparams) {
                             args["queryString"] = scope.customtreeparams;

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -213,12 +213,12 @@ namespace Umbraco.Web.Trees
             //before we get the children we need to see if this is a container node
             var current = Services.EntityService.Get(int.Parse(id), UmbracoObjectType);
 
-            //test if the parent is a listview / container
-            if (current != null && current.IsContainer())
-            {
-                //no children!
-                return new TreeNodeCollection();
-            }
+            ////test if the parent is a listview / container
+            //if (current != null && current.IsContainer())
+            //{
+            //    //no children!
+            //    return new TreeNodeCollection();
+            //}
 
             return PerformGetTreeNodes(id, queryStrings);
         }


### PR DESCRIPTION
When a node is a listview and a multinode treepicker is used to pick nodes from his children then the list is empty by default when you open the picker.

This is because an empty list is returned when its a container.

Removing this code causes to show the nodes perfectly by default.