### PR TITLE
U4-9192 Add jQuery migrate for user controls used in tabs

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/dashboard/UserControlProxy.aspx
+++ b/src/Umbraco.Web.UI/Umbraco/dashboard/UserControlProxy.aspx
@@ -13,6 +13,7 @@
     
    <umb:JsInclude ID="JsInclude1" runat="server" FilePath="Application/NamespaceManager.js" PathNameAlias="UmbracoClient" Priority="0" />
    <umb:JsInclude ID="JsInclude3" runat="server" FilePath="ui/jquery.js" PathNameAlias="UmbracoClient" Priority="1" />
+   <umb:JsInclude ID="JsInclude4" runat="server" FilePath="lib/jquery-migrate/jquery-migrate.min.js" PathNameAlias="UmbracoRoot" Priority="1" />
    <umb:JsInclude ID="JsInclude6" runat="server" FilePath="ui/base2.js" PathNameAlias="UmbracoClient" Priority="1" />
    <umb:JsInclude ID="JsInclude11" runat="server" FilePath="UI/knockout.js" PathNameAlias="UmbracoClient" Priority="3" />
    <umb:JsInclude ID="JsInclude12" runat="server" FilePath="UI/knockout.mapping.js" PathNameAlias="UmbracoClient" Priority="4" />

--- a/src/Umbraco.Web.UI/Umbraco/dashboard/UserControlProxy.aspx.designer.cs
+++ b/src/Umbraco.Web.UI/Umbraco/dashboard/UserControlProxy.aspx.designer.cs
@@ -49,6 +49,15 @@ namespace Umbraco.Web.UI.Umbraco.Dashboard {
         protected global::ClientDependency.Core.Controls.JsInclude JsInclude3;
         
         /// <summary>
+        /// JsInclude4 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::ClientDependency.Core.Controls.JsInclude JsInclude4;
+        
+        /// <summary>
         /// JsInclude6 control.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Add jQuery migrate for user controls used in tabs that will improve backwards compatibility.

Specifically this fixes an issue with using "umbDP:DateTimePicker" inside of a customer user control that is used in a tab. 