### PR TITLE
U4-9149 - Fix z-index of focal point

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -305,7 +305,7 @@ ul.color-picker li a  {
   top: 0;
   left: 0;
   cursor: move;
-  z-index: 6001;
+  z-index: 499;
   position: absolute;
 }
 


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-9149

This fixes z-index so it is behind sticky subheader when scrolling.

Before:
![image](https://cloud.githubusercontent.com/assets/2919859/20543842/b14e17d4-b107-11e6-8511-5a879a91c22d.png)

After (focal point is behind sticky subheader):
![image](https://cloud.githubusercontent.com/assets/2919859/20543848/b7a85446-b107-11e6-883a-a69a108d6444.png)
