### PR TITLE
Refactor all usages of SqlHelper, ExecuteReader and ExecuteXmlReader …

### DIFF
--- a/src/SQLCE4Umbraco/SqlCEInstaller.cs
+++ b/src/SQLCE4Umbraco/SqlCEInstaller.cs
@@ -21,15 +21,15 @@ namespace SqlCE4Umbraco
     public class SqlCEInstaller : DefaultInstallerUtility<SqlCEHelper>
     {
         #region Private Constants
-       
+
         /// <summary>The latest database version this installer supports.</summary>
         private const DatabaseVersion LatestVersionSupported = DatabaseVersion.Version4_8;
 
         /// <summary>The specifications to determine the database version.</summary>
         private static readonly VersionSpecs[] m_VersionSpecs = new VersionSpecs[] {
-					new VersionSpecs("SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS LEFT OUTER JOIN umbracoApp ON appAlias = appAlias WHERE CONSTRAINT_NAME = 'FK_umbracoUser2app_umbracoApp'", 0, DatabaseVersion.Version4_8), 
-					new VersionSpecs("SELECT id FROM umbracoNode WHERE id = -21", 1, DatabaseVersion.Version4_1),        
-					new VersionSpecs("SELECT action FROM umbracoAppTree",DatabaseVersion.Version4),
+                    new VersionSpecs("SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS LEFT OUTER JOIN umbracoApp ON appAlias = appAlias WHERE CONSTRAINT_NAME = 'FK_umbracoUser2app_umbracoApp'", 0, DatabaseVersion.Version4_8),
+                    new VersionSpecs("SELECT id FROM umbracoNode WHERE id = -21", 1, DatabaseVersion.Version4_1),
+                    new VersionSpecs("SELECT action FROM umbracoAppTree",DatabaseVersion.Version4),
                     new VersionSpecs("SELECT description FROM cmsContentType",DatabaseVersion.Version3),
                     new VersionSpecs("SELECT id FROM sysobjects",DatabaseVersion.None) };
 
@@ -43,8 +43,9 @@ namespace SqlCE4Umbraco
         public override bool CanConnect
         {
             get
-            {                
-                SqlHelper.CreateEmptyDatabase();
+            {
+                using (var sqlHelper = SqlHelper)
+                    sqlHelper.CreateEmptyDatabase();
                 return base.CanConnect;
             }
         }
@@ -93,22 +94,22 @@ namespace SqlCE4Umbraco
 
         #region DefaultInstaller Members       
 
-		/// <summary>
-		/// Returns the sql to do a full install
-		/// </summary>
-		protected override string FullInstallSql
-		{
-			get { return string.Empty; }
-		}
+        /// <summary>
+        /// Returns the sql to do a full install
+        /// </summary>
+        protected override string FullInstallSql
+        {
+            get { return string.Empty; }
+        }
 
 
-		/// <summary>
-		/// Returns the sql to do an upgrade
-		/// </summary>
-		protected override string UpgradeSql
-		{
-			get { return string.Empty; }
-		}
+        /// <summary>
+        /// Returns the sql to do an upgrade
+        /// </summary>
+        protected override string UpgradeSql
+        {
+            get { return string.Empty; }
+        }
 
         // We need to override this as the default way of detection a db connection checks for systables that doesn't exist
         // in a CE db
@@ -123,8 +124,9 @@ namespace SqlCE4Umbraco
             // verify connection
             try
             {
-                if (SqlCeApplicationBlock.VerifyConnection(base.SqlHelper.ConnectionString))
-                    return DatabaseVersion.None;
+                using (var sqlHelper = SqlHelper)
+                    if (SqlCeApplicationBlock.VerifyConnection(sqlHelper.ConnectionString))
+                        return DatabaseVersion.None;
             }
             catch (Exception e)
             {

--- a/src/SQLCE4Umbraco/SqlCETableUtility.cs
+++ b/src/SQLCE4Umbraco/SqlCETableUtility.cs
@@ -37,13 +37,15 @@ namespace SqlCE4Umbraco
             ITable table = null;
 
             // get name in correct casing
-            name = SqlHelper.ExecuteScalar<string>("SELECT name FROM sys.tables WHERE name=@name",
-                                                          SqlHelper.CreateParameter("name", name));
+            using (var sqlHelper = SqlHelper)
+                name = sqlHelper.ExecuteScalar<string>("SELECT name FROM sys.tables WHERE name=@name",
+                                                          sqlHelper.CreateParameter("name", name));
             if (name != null)
             {
                 table = new DefaultTable(name);
 
-                using (IRecordsReader reader = SqlHelper.ExecuteReader(
+                using (var sqlHelper = SqlHelper)
+                using (IRecordsReader reader = sqlHelper.ExecuteReader(
                         @"SELECT c.name AS Name, st.name AS DataType, c.max_length, c.is_nullable, c.is_identity
                           FROM sys.tables AS t
                             JOIN sys.columns AS c ON t.object_id = c.object_id
@@ -51,7 +53,7 @@ namespace SqlCE4Umbraco
                             JOIN sys.types AS ty ON ty.user_type_id = c.user_type_id
                             JOIN sys.types st ON ty.system_type_id = st.user_type_id
                           WHERE t.name = @name
-                          ORDER BY c.column_id", SqlHelper.CreateParameter("name", name)))
+                          ORDER BY c.column_id", sqlHelper.CreateParameter("name", name)))
                 {
                     while (reader.Read())
                     {
@@ -112,7 +114,8 @@ namespace SqlCE4Umbraco
 
             // create query
             StringBuilder createTableQuery = new StringBuilder();
-            createTableQuery.AppendFormat("CREATE TABLE [{0}] (", SqlHelper.EscapeString(table.Name));
+            using (var sqlHelper = SqlHelper)
+                createTableQuery.AppendFormat("CREATE TABLE [{0}] (", sqlHelper.EscapeString(table.Name));
 
             // add fields
             while (hasNext)
@@ -136,7 +139,8 @@ namespace SqlCE4Umbraco
             // execute query
             try
             {
-                SqlHelper.ExecuteNonQuery(createTableQuery.ToString());
+                using (var sqlHelper = SqlHelper)
+                    sqlHelper.ExecuteNonQuery(createTableQuery.ToString());
             }
             catch (Exception executeException)
             {
@@ -154,13 +158,15 @@ namespace SqlCE4Umbraco
             Debug.Assert(table != null && field != null);
 
             StringBuilder addColumnQuery = new StringBuilder();
-            addColumnQuery.AppendFormat("ALTER TABLE [{0}] ADD [{1}] {2}",
-                                        SqlHelper.EscapeString(table.Name),
-                                        SqlHelper.EscapeString(field.Name),
-                                        SqlHelper.EscapeString(GetDatabaseType(field)));
+            using (var sqlHelper = SqlHelper)
+                addColumnQuery.AppendFormat("ALTER TABLE [{0}] ADD [{1}] {2}",
+                                        sqlHelper.EscapeString(table.Name),
+                                        sqlHelper.EscapeString(field.Name),
+                                        sqlHelper.EscapeString(GetDatabaseType(field)));
             try
             {
-                SqlHelper.ExecuteNonQuery(addColumnQuery.ToString());
+                using (var sqlHelper = SqlHelper)
+                    sqlHelper.ExecuteNonQuery(addColumnQuery.ToString());
             }
             catch (Exception executeException)
             {

--- a/src/Umbraco.Web/UI/Controls/UmbracoControl.cs
+++ b/src/Umbraco.Web/UI/Controls/UmbracoControl.cs
@@ -84,9 +84,10 @@ namespace Umbraco.Web.UI.Controls
             get { return _url ?? (_url = new UrlHelper(new RequestContext(new HttpContextWrapper(Context), new RouteData()))); }
         }
 
-		/// <summary>
-		/// Returns the legacy SqlHelper
-		/// </summary>
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
 		protected ISqlHelper SqlHelper
 		{
 			get { return Application.SqlHelper; }

--- a/src/Umbraco.Web/UI/Controls/UmbracoUserControl.cs
+++ b/src/Umbraco.Web/UI/Controls/UmbracoUserControl.cs
@@ -123,8 +123,9 @@ namespace Umbraco.Web.UI.Controls
         }
 
         /// <summary>
-        /// Returns the legacy SqlHelper
+        /// Unused, please do not use
         /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected ISqlHelper SqlHelper
         {
             get { return global::umbraco.BusinessLogic.Application.SqlHelper; }

--- a/src/Umbraco.Web/umbraco.presentation/content.cs
+++ b/src/Umbraco.Web/umbraco.presentation/content.cs
@@ -152,6 +152,10 @@ namespace umbraco
             get { return _xmlContent == null; }
         }
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }

--- a/src/Umbraco.Web/umbraco.presentation/library.cs
+++ b/src/Umbraco.Web/umbraco.presentation/library.cs
@@ -77,9 +77,13 @@ namespace umbraco
 
         #region Properties
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
-            get { return umbraco.BusinessLogic.Application.SqlHelper; }
+            get { return Application.SqlHelper; }
         }
 
         #endregion
@@ -1275,8 +1279,9 @@ namespace umbraco
             XmlDocument xd = new XmlDocument();
             xd.LoadXml("<preValues/>");
 
-            using (IRecordsReader dr = SqlHelper.ExecuteReader("Select id, [value] from cmsDataTypeprevalues where DataTypeNodeId = @dataTypeId order by sortorder",
-                SqlHelper.CreateParameter("@dataTypeId", DataTypeId)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader("Select id, [value] from cmsDataTypeprevalues where DataTypeNodeId = @dataTypeId order by sortorder",
+                sqlHelper.CreateParameter("@dataTypeId", DataTypeId)))
             {
                 while (dr.Read())
                 {
@@ -1298,8 +1303,9 @@ namespace umbraco
         {
             try
             {
-                return SqlHelper.ExecuteScalar<string>("select [value] from cmsDataTypePreValues where id = @id",
-                                                       SqlHelper.CreateParameter("@id", Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    return sqlHelper.ExecuteScalar<string>("select [value] from cmsDataTypePreValues where id = @id",
+                        sqlHelper.CreateParameter("@id", Id));
             }
             catch
             {

--- a/src/Umbraco.Web/umbraco.presentation/macro.cs
+++ b/src/Umbraco.Web/umbraco.presentation/macro.cs
@@ -64,6 +64,10 @@ namespace umbraco
         private const string MacrosAddedKey = "macrosAdded";
         public IList<Exception> Exceptions = new List<Exception>();
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }

--- a/src/Umbraco.Web/umbraco.presentation/template.cs
+++ b/src/Umbraco.Web/umbraco.presentation/template.cs
@@ -468,12 +468,14 @@ namespace umbraco
 
 
         #endregion
-
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }
         }
-
         #region constructors
 
         public static string GetMasterPageName(int templateID)
@@ -497,11 +499,12 @@ namespace umbraco
             var t = ApplicationContext.Current.ApplicationCache.RuntimeCache.GetCacheItem<template>(
                string.Format("{0}{1}", CacheKeys.TemplateFrontEndCacheKey, tId), () =>
                {
-                   using (var templateData = SqlHelper.ExecuteReader(@"select nodeId, alias, node.parentID as master, text, design
+                   using (var sqlHelper = Application.SqlHelper)
+                   using (var templateData = sqlHelper.ExecuteReader(@"select nodeId, alias, node.parentID as master, text, design
 from cmsTemplate
 inner join umbracoNode node on (node.id = cmsTemplate.nodeId)
 where nodeId = @templateID",
-                           SqlHelper.CreateParameter("@templateID", templateID)))
+                           sqlHelper.CreateParameter("@templateID", templateID)))
                     {
                        if (templateData.Read())
                        {
@@ -515,7 +518,7 @@ where nodeId = @templateID",
                            if (!templateData.IsNull("design"))
                                _templateDesign = templateData.GetString("design");
                        }
-                   }
+                    }
                    return this;
                });
 

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadMacros.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/Trees/loadMacros.cs
@@ -44,9 +44,13 @@ namespace umbraco
             rootNode.NodeID = "init";
         }
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
-            get { return umbraco.BusinessLogic.Application.SqlHelper; }
+            get { return Application.SqlHelper; }
         }
 
         /// <summary>
@@ -70,9 +74,9 @@ function openMacro(id) {
         /// <param name="tree"></param>
         public override void Render(ref XmlTree tree)
         {
-            using (IRecordsReader macros = SqlHelper.ExecuteReader("select id, macroName from cmsMacro order by macroName"))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader macros = sqlHelper.ExecuteReader("select id, macroName from cmsMacro order by macroName"))
             {
-                
                 while (macros.Read())
                 {
                     XmlTreeNode xNode = XmlTreeNode.Create(this);

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/macroTasks.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/macroTasks.cs
@@ -12,7 +12,10 @@ namespace umbraco
 {
     public class macroTasks : LegacyDialogTask
     {
-        
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/EditRelationType.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/EditRelationType.aspx.cs
@@ -82,7 +82,8 @@ namespace umbraco.cms.presentation.developer.RelationTypes
 				{
 					this._relations = new List<ReadOnlyRelation>();
 
-				    using (var reader = uQuery.SqlHelper.ExecuteReader(@"
+                    using (var sqlHelper = BusinessLogic.Application.SqlHelper)
+                    using (var reader = sqlHelper.ExecuteReader(@"
                         SELECT  A.id, 
                                 A.parentId,
 		                        B.[text] AS parentText,
@@ -114,7 +115,7 @@ namespace umbraco.cms.presentation.developer.RelationTypes
 					}
 				}
 
-				return this._relations;
+			    return this._relations;
 			}
 		}
 

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/editMacro.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/editMacro.aspx.cs
@@ -125,17 +125,22 @@ namespace umbraco.dialogs
 				}
 				else
 				{
-					IRecordsReader macroRenderings;
-					if (Request.GetItemAsString("editor") != "")
-						macroRenderings = SqlHelper.ExecuteReader("select macroAlias, macroName from cmsMacro where macroUseInEditor = 1 order by macroName");
-					else
-						macroRenderings = SqlHelper.ExecuteReader("select macroAlias, macroName from cmsMacro order by macroName");
+				    string query;
+				    if (Request.GetItemAsString("editor") != "")
+				        query = "select macroAlias, macroName from cmsMacro where macroUseInEditor = 1 order by macroName";
+				    else
+				        query = "select macroAlias, macroName from cmsMacro order by macroName";
 
-					umb_macroAlias.DataSource = macroRenderings;
-					umb_macroAlias.DataValueField = "macroAlias";
-					umb_macroAlias.DataTextField = "macroName";
-					umb_macroAlias.DataBind();
-					macroRenderings.Close();
+                    using (var sqlHelper = BusinessLogic.Application.SqlHelper)
+                    {
+                        using (IRecordsReader macroRenderings = sqlHelper.ExecuteReader(query))
+                        {
+                            umb_macroAlias.DataSource = macroRenderings;
+                            umb_macroAlias.DataValueField = "macroAlias";
+                            umb_macroAlias.DataTextField = "macroName";
+                            umb_macroAlias.DataBind();
+                        }
+                    }
 				}
 			}
 

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/insertMacro.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/insertMacro.aspx.cs
@@ -17,12 +17,12 @@ using umbraco.businesslogic.Exceptions;
 
 namespace umbraco.dialogs
 {
-	/// <summary>
-	/// Summary description for insertMacro.
-	/// </summary>
-	public partial class insertMacro : BasePages.UmbracoEnsuredPage
-	{
-		protected Button Button1;
+    /// <summary>
+    /// Summary description for insertMacro.
+    /// </summary>
+    public partial class insertMacro : BasePages.UmbracoEnsuredPage
+    {
+        protected Button Button1;
 
         protected override void OnInit(EventArgs e)
         {
@@ -33,44 +33,44 @@ namespace umbraco.dialogs
                 throw new UserAuthorizationException("The current user doesn't have access to the section/app");
         }
 
-		protected void Page_Load(object sender, EventArgs e)
-		{
-            pane_edit.Text = ui.Text("general", "edit",this.getUser()) + " " + ui.Text("general", "macro",this.getUser());
-            pane_insert.Text = ui.Text("general", "insert",this.getUser()) + " " + ui.Text("general", "macro",this.getUser());
+        protected void Page_Load(object sender, EventArgs e)
+        {
+            pane_edit.Text = ui.Text("general", "edit", this.getUser()) + " " + ui.Text("general", "macro", this.getUser());
+            pane_insert.Text = ui.Text("general", "insert", this.getUser()) + " " + ui.Text("general", "macro", this.getUser());
 
-			if (Request["macroID"] != null || Request["macroAlias"] != null) 
-			{
-				// Put user code to initialize the page here
-				cms.businesslogic.macro.Macro m;
-				if (helper.Request("macroID") != "")
-					m = new cms.businesslogic.macro.Macro(int.Parse(helper.Request("macroID")));
-				else
-					m = cms.businesslogic.macro.Macro.GetByAlias(helper.Request("macroAlias"));
+            if (Request["macroID"] != null || Request["macroAlias"] != null)
+            {
+                // Put user code to initialize the page here
+                cms.businesslogic.macro.Macro m;
+                if (helper.Request("macroID") != "")
+                    m = new cms.businesslogic.macro.Macro(int.Parse(helper.Request("macroID")));
+                else
+                    m = cms.businesslogic.macro.Macro.GetByAlias(helper.Request("macroAlias"));
 
 			    foreach (var mp in m.Properties) {
-		
-					var macroAssembly = mp.Type.Assembly;
-					var macroType = mp.Type.Type;
-					try 
-					{
 
-                        var assembly = Assembly.LoadFrom( IOHelper.MapPath(SystemDirectories.Bin + "/" + macroAssembly + ".dll"));
+                    var macroAssembly = mp.Type.Assembly;
+                    var macroType = mp.Type.Type;
+                    try
+                    {
 
-						Type type = assembly.GetType(macroAssembly+"."+macroType);
-						var typeInstance = Activator.CreateInstance(type) as interfaces.IMacroGuiRendering;
-						if (typeInstance != null) 
-						{
-							var control = Activator.CreateInstance(type) as Control;	
-							control.ID = mp.Alias;
-							if (Request[mp.Alias] != null) 
-							{
-								if (Request[mp.Alias] != "") 
-								{
-									type.GetProperty("Value").SetValue(control, Convert.ChangeType(Request[mp.Alias], type.GetProperty("Value").PropertyType), null);
-								}
-							}
+                        var assembly = Assembly.LoadFrom(IOHelper.MapPath(SystemDirectories.Bin + "/" + macroAssembly + ".dll"));
 
-							// register alias
+                        Type type = assembly.GetType(macroAssembly + "." + macroType);
+                        var typeInstance = Activator.CreateInstance(type) as interfaces.IMacroGuiRendering;
+                        if (typeInstance != null)
+                        {
+                            var control = Activator.CreateInstance(type) as Control;
+                            control.ID = mp.Alias;
+                            if (Request[mp.Alias] != null)
+                            {
+                                if (Request[mp.Alias] != "")
+                                {
+                                    type.GetProperty("Value").SetValue(control, Convert.ChangeType(Request[mp.Alias], type.GetProperty("Value").PropertyType), null);
+                                }
+                            }
+
+                            // register alias
                             var pp = new uicontrols.PropertyPanel();
                             pp.Text = mp.Name;
                             pp.Controls.Add(control);
@@ -83,35 +83,43 @@ namespace umbraco.dialogs
 							macroProperties.Controls.Add(control);
 							macroProperties.Controls.Add(new LiteralControl("</td></tr>"));
                             */
-						} 
-						else 
-						{						
-							Trace.Warn("umbEditContent", "Type doesn't exist or is not umbraco.interfaces.DataFieldI ('" + macroAssembly + "." + macroType + "')");
-						}
+                        }
+                        else
+                        {
+                            Trace.Warn("umbEditContent", "Type doesn't exist or is not umbraco.interfaces.DataFieldI ('" + macroAssembly + "." + macroType + "')");
+                        }
 
-					} 
-					catch (Exception fieldException)
-					{
-						Trace.Warn("umbEditContent", "Error creating type '" + macroAssembly + "." + macroType + "'", fieldException);
-					}
-				}
-			} 
-			else 
-			{
-				IRecordsReader macroRenderings;
+                    }
+                    catch (Exception fieldException)
+                    {
+                        Trace.Warn("umbEditContent", "Error creating type '" + macroAssembly + "." + macroType + "'", fieldException);
+                    }
+                }
+            }
+            else
+            {
+                IRecordsReader macroRenderings;
 				if (helper.Request("editor") != "")
-					macroRenderings = SqlHelper.ExecuteReader("select macroAlias, macroName from cmsMacro where macroUseInEditor = 1 order by macroName");
-				else
-					macroRenderings = SqlHelper.ExecuteReader("select macroAlias, macroName from cmsMacro order by macroName");
-				
-				macroAlias.DataSource = macroRenderings;
-				macroAlias.DataValueField = "macroAlias";
-				macroAlias.DataTextField = "macroName";
-				macroAlias.DataBind();
-				macroRenderings.Close();
+                {
+                    const string query = "select macroAlias, macroName from cmsMacro where macroUseInEditor = 1 order by macroName";
+                    using (var sqlHelper = BusinessLogic.Application.SqlHelper)
+                    using (var renderings = sqlHelper.ExecuteReader(query))
+                        macroRenderings = renderings;
+                }
+                else
+                {
+                    const string query = "select macroAlias, macroName from cmsMacro order by macroName";
+                    using (var sqlHelper = BusinessLogic.Application.SqlHelper)
+                    using (var renderings = sqlHelper.ExecuteReader(query))
+                        macroRenderings = renderings;
+                }
 
-			}
-
-		}
-	}
+                macroAlias.DataSource = macroRenderings;
+                macroAlias.DataValueField = "macroAlias";
+                macroAlias.DataTextField = "macroName";
+                macroAlias.DataBind();
+                macroRenderings.Close();
+            }
+        }
+    }
 }

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/umbracoField.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/umbracoField.aspx.cs
@@ -73,27 +73,30 @@ namespace umbraco.dialogs
 			fieldPicker.StandardPropertiesLabel = ui.Text("templateEditor", "standardFields");
 			fieldPicker.CustomPropertiesLabel = ui.Text("templateEditor", "customFields");
 
-			IRecordsReader dataTypes = SqlHelper.ExecuteReader(fieldSql);
-			fieldPicker.DataTextField = "alias";
-			fieldPicker.DataValueField = "alias";
-			fieldPicker.DataSource = dataTypes;
-			fieldPicker.DataBind();
-			fieldPicker.Attributes.Add("onChange", "document.forms[0].field.value = document.forms[0]." + fieldPicker.ClientID + "[document.forms[0]." + fieldPicker.ClientID + ".selectedIndex].value;");
-			dataTypes.Close();
-
-			altFieldPicker.ChooseText = ui.Text("templateEditor", "chooseField");
+            using (var sqlHelper = BusinessLogic.Application.SqlHelper)
+            using (IRecordsReader dataTypes = sqlHelper.ExecuteReader(fieldSql))
+		    {
+		        fieldPicker.DataTextField = "alias";
+		        fieldPicker.DataValueField = "alias";
+		        fieldPicker.DataSource = dataTypes;
+		        fieldPicker.DataBind();
+                fieldPicker.Attributes.Add("onChange", "document.forms[0].field.value = document.forms[0]." + fieldPicker.ClientID + "[document.forms[0]." + fieldPicker.ClientID + ".selectedIndex].value;");
+            }
+		    altFieldPicker.ChooseText = ui.Text("templateEditor", "chooseField");
 			altFieldPicker.StandardPropertiesLabel = ui.Text("templateEditor", "standardFields");
 			altFieldPicker.CustomPropertiesLabel = ui.Text("templateEditor", "customFields");
 
-			IRecordsReader dataTypes2 = SqlHelper.ExecuteReader(fieldSql);
-			altFieldPicker.DataTextField = "alias";
-			altFieldPicker.DataValueField = "alias";
-			altFieldPicker.DataSource = dataTypes2;
-			altFieldPicker.DataBind();
-			altFieldPicker.Attributes.Add("onChange", "document.forms[0].useIfEmpty.value = document.forms[0]." + altFieldPicker.ClientID + "[document.forms[0]." + altFieldPicker.ClientID + ".selectedIndex].value;");
-			dataTypes2.Close();
+            using (var sqlHelper = BusinessLogic.Application.SqlHelper)
+            using (IRecordsReader dataTypes2 = sqlHelper.ExecuteReader(fieldSql))
+		    {
+		        altFieldPicker.DataTextField = "alias";
+		        altFieldPicker.DataValueField = "alias";
+		        altFieldPicker.DataSource = dataTypes2;
+		        altFieldPicker.DataBind();
+                altFieldPicker.Attributes.Add("onChange", "document.forms[0].useIfEmpty.value = document.forms[0]." + altFieldPicker.ClientID + "[document.forms[0]." + altFieldPicker.ClientID + ".selectedIndex].value;");
+            }
 
-			// Pre values
+		    // Pre values
 			if (!m_IsDictionaryMode)
 			{
 				foreach (string s in preValuesSource)

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertMacro.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/plugins/tinymce3/insertMacro.aspx.cs
@@ -165,10 +165,20 @@ namespace umbraco.presentation.tinymce3
             {
                 IRecordsReader macroRenderings;
                 if (Request["editor"] != "")
-                    macroRenderings = SqlHelper.ExecuteReader("select macroAlias, macroName from cmsMacro where macroUseInEditor = 1 order by macroName");
+                {
+                    const string query = "select macroAlias, macroName from cmsMacro where macroUseInEditor = 1 order by macroName";
+                    using (var sqlHelper = BusinessLogic.Application.SqlHelper)
+                    using (var renderings = sqlHelper.ExecuteReader(query))
+                        macroRenderings = renderings;
+                }
                 else
-                    macroRenderings = SqlHelper.ExecuteReader("select macroAlias, macroName from cmsMacro order by macroName");
-
+                {
+                    const string query = "select macroAlias, macroName from cmsMacro order by macroName";
+                    using (var sqlHelper = BusinessLogic.Application.SqlHelper)
+                    using (var renderings = sqlHelper.ExecuteReader(query))
+                        macroRenderings = renderings;
+                }
+                
                 umb_macroAlias.DataSource = macroRenderings;
                 umb_macroAlias.DataValueField = "macroAlias";
                 umb_macroAlias.DataTextField = "macroName";

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/editTemplate.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/editTemplate.aspx.cs
@@ -198,23 +198,24 @@ namespace umbraco.cms.presentation.settings
 
 		private void LoadMacros()
 		{
-			IRecordsReader macroRenderings =
-				SqlHelper.ExecuteReader("select id, macroAlias, macroName from cmsMacro order by macroName");
-
-			rpt_macros.DataSource = macroRenderings;
-			rpt_macros.DataBind();
-
-			macroRenderings.Close();
+		    using (var sqlHelper = BusinessLogic.Application.SqlHelper)
+            using (IRecordsReader macroRenderings = 
+                sqlHelper.ExecuteReader("select id, macroAlias, macroName from cmsMacro order by macroName"))
+		    {
+		        rpt_macros.DataSource = macroRenderings;
+		        rpt_macros.DataBind();
+		    }
 		}
 
 		public string DoesMacroHaveSettings(string macroId)
 		{
-			if (
-				SqlHelper.ExecuteScalar<int>(string.Format("select 1 from cmsMacroProperty where macro = {0}", macroId)) ==
-				1)
-				return "1";
-			else
-				return "0";
+            using (var sqlHelper = BusinessLogic.Application.SqlHelper)
+                if (
+				    sqlHelper.ExecuteScalar<int>(string.Format("select 1 from cmsMacroProperty where macro = {0}", macroId)) ==
+				    1)
+				    return "1";
+			    else
+				    return "0";
 		}
 
 		/// <summary>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/PreValueExtensions.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/PreValueExtensions.cs
@@ -1,4 +1,5 @@
-﻿using umbraco.cms.businesslogic.datatype;
+﻿using umbraco.BusinessLogic;
+using umbraco.cms.businesslogic.datatype;
 
 namespace umbraco
 {
@@ -14,9 +15,10 @@ namespace umbraco
 		/// <returns>The alias</returns>
 		public static string GetAlias(this PreValue preValue)
 		{
-			using (var reader = uQuery.SqlHelper.ExecuteReader(
-				"SELECT alias FROM cmsDataTypePreValues WHERE id = @id",
-				uQuery.SqlHelper.CreateParameter("@id", preValue.Id)))
+            using(var sqlHelper = Application.SqlHelper)
+			using (var reader = sqlHelper.ExecuteReader(
+				"SELECT alias FROM cmsDataTypePreValues WHERE id = @id", 
+				sqlHelper.CreateParameter("@id", preValue.Id)))
 			{
 				var hasRows = reader.Read();
 

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/RelationTypeExtensions.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/RelationTypeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using umbraco.BusinessLogic;
 using umbraco.cms.businesslogic.relation;
 
 namespace umbraco
@@ -16,9 +17,12 @@ namespace umbraco
 		/// <returns>an UmbracoObjectType value</returns>
 		public static uQuery.UmbracoObjectType GetParentUmbracoObjectType(this RelationType relationType)
 		{
-			return uQuery.GetUmbracoObjectType(
-				uQuery.SqlHelper.ExecuteScalar<Guid>(
-					string.Concat("SELECT parentObjectType FROM umbracoRelationType WHERE id = ", relationType.Id)));
+		    using (var sqlHelper = Application.SqlHelper)
+		    {
+		        var guid = sqlHelper.ExecuteScalar<Guid>(
+		            string.Concat("SELECT parentObjectType FROM umbracoRelationType WHERE id = ", relationType.Id));
+		        return uQuery.GetUmbracoObjectType(guid);
+		    }
 		}
 
 		/// <summary>
@@ -28,9 +32,12 @@ namespace umbraco
 		/// <returns>an UmbracoObjectType value</returns>
 		public static uQuery.UmbracoObjectType GetChildUmbracoObjectType(this RelationType relationType)
 		{
-			return uQuery.GetUmbracoObjectType(
-				uQuery.SqlHelper.ExecuteScalar<Guid>(
-					string.Concat("SELECT childObjectType FROM umbracoRelationType WHERE id = ", relationType.Id)));
+		    using (var sqlHelper = Application.SqlHelper)
+		    {
+		        var guid = sqlHelper.ExecuteScalar<Guid>(
+		            string.Concat("SELECT childObjectType FROM umbracoRelationType WHERE id = ", relationType.Id));
+		        return uQuery.GetUmbracoObjectType(guid);
+		    }
 		}
 
 		/// <summary>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery-Content.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery-Content.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using umbraco.BusinessLogic;
 using umbraco.cms.businesslogic;
 
 namespace umbraco
@@ -15,7 +16,8 @@ namespace umbraco
 			if (propertyId > 0)
 			{
 				var sql = "SELECT contentNodeId FROM cmsPropertyData WHERE id = @propertyId";
-				return uQuery.SqlHelper.ExecuteScalar<int>(sql, uQuery.SqlHelper.CreateParameter("@propertyId", propertyId));
+                using (var sqlHelper = Application.SqlHelper)
+                    return sqlHelper.ExecuteScalar<int>(sql, sqlHelper.CreateParameter("@propertyId", propertyId));
 			}
 
 			return uQuery.RootNodeId;

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery-DataTypes.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery-DataTypes.cs
@@ -35,7 +35,8 @@ namespace umbraco
 		{
 			var datatypes = new Dictionary<int, string>();
 
-			using (var reader = uQuery.SqlHelper.ExecuteReader("SELECT d.nodeId, n.text FROM cmsDataType d, umbracoNode n WHERE d.nodeId = n.id"))
+            using (var sqlHelper = Application.SqlHelper)
+            using (var reader = sqlHelper.ExecuteReader("SELECT d.nodeId, n.text FROM cmsDataType d, umbracoNode n WHERE d.nodeId = n.id"))
 			{
 				// Go through the values from the database and store them in the array.
 				while (reader.Read())

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery-PreValues.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery-PreValues.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using umbraco.BusinessLogic;
 using umbraco.cms.businesslogic.datatype;
 using umbraco.cms.businesslogic.propertytype;
 using umbraco.NodeFactory;
@@ -24,20 +25,23 @@ namespace umbraco
 		/// </returns>
 		public static PreValue MakeNewPreValue(int dataTypeDefinitionId, string value, string alias = "", int sortOrder = 0)
 		{
-			var result =
-				SqlHelper.ExecuteNonQuery(
-					"INSERT INTO cmsDataTypePreValues (datatypeNodeId, value, alias, sortorder) VALUES (@dtdefid, @value, @alias, @sortorder)",
-					SqlHelper.CreateParameter("@dtdefid", dataTypeDefinitionId),
-					SqlHelper.CreateParameter("@value", value),
-					SqlHelper.CreateParameter("@alias", alias),
-					SqlHelper.CreateParameter("@sortorder", sortOrder));
+		    using (var sqlHelper = Application.SqlHelper)
+		    {
+		        var result =
+		            sqlHelper.ExecuteNonQuery(
+		                "INSERT INTO cmsDataTypePreValues (datatypeNodeId, value, alias, sortorder) VALUES (@dtdefid, @value, @alias, @sortorder)",
+		                sqlHelper.CreateParameter("@dtdefid", dataTypeDefinitionId),
+		                sqlHelper.CreateParameter("@value", value),
+		                sqlHelper.CreateParameter("@alias", alias),
+		                sqlHelper.CreateParameter("@sortorder", sortOrder));
 
-			if (result > -1)
-			{
-				return uQuery.GetPreValues(dataTypeDefinitionId).Single(x => x.Value.Equals(value) && x.GetAlias().Equals(alias) && x.SortOrder == sortOrder);
-			}
+		        if (result > -1)
+		        {
+		            return uQuery.GetPreValues(dataTypeDefinitionId).Single(x => x.Value.Equals(value) && x.GetAlias().Equals(alias) && x.SortOrder == sortOrder);
+		        }
 
-			return null;
+		        return null;
+		    }
 		}
 
 		/// <summary>
@@ -94,17 +98,18 @@ namespace umbraco
 		/// <returns></returns>
 		public static bool ReorderPreValue(int preValueId, int sortOrder)
 		{
-			var result =
-				SqlHelper.ExecuteNonQuery(
-					"UPDATE cmsDataTypePreValues SET sortorder = @sortorder WHERE id = @prevalueid",
-					SqlHelper.CreateParameter("@prevalueid", preValueId),
-					SqlHelper.CreateParameter("@sortorder", sortOrder));
+            using (var sqlHelper = Application.SqlHelper) { 
+                var result =
+				    sqlHelper.ExecuteNonQuery(
+					    "UPDATE cmsDataTypePreValues SET sortorder = @sortorder WHERE id = @prevalueid",
+					    sqlHelper.CreateParameter("@prevalueid", preValueId),
+					    sqlHelper.CreateParameter("@sortorder", sortOrder));
 
-			if (result > 0)
-			{
-				return true;
-			}
-
+			    if (result > 0)
+			    {
+				    return true;
+			    }
+            }
 			return false;
 		}
 	}

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery-UmbracoObjectType.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery-UmbracoObjectType.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using umbraco.BusinessLogic;
 using Umbraco.Core;
 
 namespace umbraco
@@ -151,9 +152,11 @@ namespace umbraco
 		/// <returns>an UmbracoObjectType Enum value</returns>
 		public static UmbracoObjectType GetUmbracoObjectType(int id)
 		{
-			return uQuery.GetUmbracoObjectType(
-						uQuery.SqlHelper.ExecuteScalar<Guid>(
-							string.Concat("SELECT nodeObjectType FROM umbracoNode WHERE id = ", id)));
+		    using (var sqlHelper = Application.SqlHelper)
+		    {
+		        var guid = sqlHelper.ExecuteScalar<Guid>(string.Concat("SELECT nodeObjectType FROM umbracoNode WHERE id = ", id));
+		        return GetUmbracoObjectType(guid);
+		    }
 		}
 
 		/// <summary>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/uQuery/uQuery.cs
@@ -18,23 +18,21 @@ namespace umbraco
 	/// </summary>
 	public static partial class uQuery
 	{
-		/// <summary>
-		/// Gets the SqlHelper used by Umbraco
-		/// </summary>
-		public static ISqlHelper SqlHelper
-		{
-			get
-			{
-				return Application.SqlHelper;
-			}
-		}
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
+        public static ISqlHelper SqlHelper
+        {
+            get { return Application.SqlHelper; }
+        }
 
-		/// <summary>
-		/// Constructs the XML source from the cmsContentXml table used for Media and Members.
-		/// </summary>
-		/// <param name="umbracoObjectType">an UmbracoObjectType value</param>
-		/// <returns>XML built from the cmsContentXml table</returns>
-		public static XmlDocument GetPublishedXml(UmbracoObjectType umbracoObjectType)
+        /// <summary>
+        /// Constructs the XML source from the cmsContentXml table used for Media and Members.
+        /// </summary>
+        /// <param name="umbracoObjectType">an UmbracoObjectType value</param>
+        /// <returns>XML built from the cmsContentXml table</returns>
+        public static XmlDocument GetPublishedXml(UmbracoObjectType umbracoObjectType)
 		{
 			try
 			{
@@ -43,7 +41,8 @@ namespace umbraco
 				var xmlDoc = new XmlDocument();
 				var sql = "SELECT umbracoNode.id, umbracoNode.parentId, umbracoNode.sortOrder, cmsContentXml.xml FROM umbracoNode INNER JOIN cmsContentXml ON cmsContentXml.nodeId = umbracoNode.id AND umbracoNode.nodeObjectType = @nodeObjectType ORDER BY umbracoNode.level, umbracoNode.sortOrder";
 
-				using (var dr = uQuery.SqlHelper.ExecuteReader(sql, uQuery.SqlHelper.CreateParameter("@nodeObjectType", umbracoObjectType.GetGuid())))
+                using (var sqlHelper = Application.SqlHelper)
+                using (var dr = sqlHelper.ExecuteReader(sql, sqlHelper.CreateParameter("@nodeObjectType", umbracoObjectType.GetGuid())))
 				{
 					while (dr.Read())
 					{

--- a/src/umbraco.businesslogic/BasePages/BasePage.cs
+++ b/src/umbraco.businesslogic/BasePages/BasePage.cs
@@ -49,9 +49,9 @@ namespace umbraco.BasePages
         protected long timeout = 0;
 
         /// <summary>
-        /// Gets the SQL helper.
+        /// Unused, please do not use
         /// </summary>
-        /// <value>The SQL helper.</value>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return BusinessLogic.Application.SqlHelper; }

--- a/src/umbraco.cms/businesslogic/CMSNode.cs
+++ b/src/umbraco.cms/businesslogic/CMSNode.cs
@@ -107,7 +107,8 @@ namespace umbraco.cms.businesslogic
         /// </returns>
         public static int CountByObjectType(Guid objectType)
         {
-            return SqlHelper.ExecuteScalar<int>("SELECT COUNT(*) from umbracoNode WHERE nodeObjectType = @type", SqlHelper.CreateParameter("@type", objectType));
+            using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<int>("SELECT COUNT(*) from umbracoNode WHERE nodeObjectType = @type", sqlHelper.CreateParameter("@type", objectType));
         }
 
         /// <summary>
@@ -119,7 +120,9 @@ namespace umbraco.cms.businesslogic
         /// </returns>
         public static int CountSubs(int Id)
         {
-            return SqlHelper.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoNode WHERE ','+path+',' LIKE '%," + Id.ToString() + ",%'");
+            using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoNode WHERE ','+path+',' LIKE '%,@nodeId,%'", 
+                    sqlHelper.CreateParameter("nodeId", Id));
         }
 
         /// <summary>
@@ -130,9 +133,10 @@ namespace umbraco.cms.businesslogic
         /// <returns></returns>
         public static int CountLeafNodes(int parentId, Guid objectType)
         {
-            return SqlHelper.ExecuteScalar<int>("Select count(uniqueID) from umbracoNode where nodeObjectType = @type And parentId = @parentId",
-                SqlHelper.CreateParameter("@type", objectType),
-                SqlHelper.CreateParameter("@parentId", parentId));
+            using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<int>("Select count(uniqueID) from umbracoNode where nodeObjectType = @type And parentId = @parentId",
+	                sqlHelper.CreateParameter("@type", objectType),
+	                sqlHelper.CreateParameter("@parentId", parentId));
         }
 
         /// <summary>
@@ -163,7 +167,8 @@ namespace umbraco.cms.businesslogic
         /// <returns>True if there is a CMSNode with the given Guid</returns>
         public static bool IsNode(Guid uniqueID)
         {
-            return (SqlHelper.ExecuteScalar<int>("select count(id) from umbracoNode where uniqueID = @uniqueID", SqlHelper.CreateParameter("@uniqueId", uniqueID)) > 0);
+            using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<int>("select count(id) from umbracoNode where uniqueID = @uniqueID", sqlHelper.CreateParameter("@uniqueId", uniqueID)) > 0;
         }
 
         /// <summary>
@@ -173,7 +178,8 @@ namespace umbraco.cms.businesslogic
         /// <returns>True if there is a CMSNode with the given id</returns>
         public static bool IsNode(int Id)
         {
-            return (SqlHelper.ExecuteScalar<int>("select count(id) from umbracoNode where id = @id", SqlHelper.CreateParameter("@id", Id)) > 0);
+            using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<int>("select count(id) from umbracoNode where id = @id", sqlHelper.CreateParameter("@id", Id)) > 0;
         }
 
         /// <summary>
@@ -185,16 +191,19 @@ namespace umbraco.cms.businesslogic
         /// </returns>
         public static Guid[] getAllUniquesFromObjectType(Guid objectType)
         {
-            IRecordsReader dr = SqlHelper.ExecuteReader("Select uniqueID from umbracoNode where nodeObjectType = @type",
-                SqlHelper.CreateParameter("@type", objectType));
-            System.Collections.ArrayList tmp = new System.Collections.ArrayList();
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader("Select uniqueID from umbracoNode where nodeObjectType = @type",
+                sqlHelper.CreateParameter("@type", objectType)))
+            {
+                System.Collections.ArrayList tmp = new System.Collections.ArrayList();
 
-            while (dr.Read()) tmp.Add(dr.GetGuid("uniqueID"));
-            dr.Close();
+                while (dr.Read()) tmp.Add(dr.GetGuid("uniqueID"));
+                dr.Close();
 
-            Guid[] retval = new Guid[tmp.Count];
-            for (int i = 0; i < tmp.Count; i++) retval[i] = (Guid)tmp[i];
-            return retval;
+                Guid[] retval = new Guid[tmp.Count];
+                for (int i = 0; i < tmp.Count; i++) retval[i] = (Guid)tmp[i];
+                return retval;
+            }
         }
 
         /// <summary>
@@ -206,14 +215,17 @@ namespace umbraco.cms.businesslogic
         /// </returns>
         public static int[] getAllUniqueNodeIdsFromObjectType(Guid objectType)
         {
-            IRecordsReader dr = SqlHelper.ExecuteReader("Select id from umbracoNode where nodeObjectType = @type",
-                SqlHelper.CreateParameter("@type", objectType));
-            System.Collections.ArrayList tmp = new System.Collections.ArrayList();
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader("Select id from umbracoNode where nodeObjectType = @type",
+                sqlHelper.CreateParameter("@type", objectType)))
+            {
+                System.Collections.ArrayList tmp = new System.Collections.ArrayList();
 
-            while (dr.Read()) tmp.Add(dr.GetInt("id"));
-            dr.Close();
+                while (dr.Read()) tmp.Add(dr.GetInt("id"));
+                dr.Close();
 
-            return (int[])tmp.ToArray(typeof(int));
+                return (int[])tmp.ToArray(typeof(int));
+            }
         }
 
 
@@ -226,16 +238,19 @@ namespace umbraco.cms.businesslogic
         /// </returns>
         public static Guid[] TopMostNodeIds(Guid ObjectType)
         {
-            IRecordsReader dr = SqlHelper.ExecuteReader("Select uniqueID from umbracoNode where nodeObjectType = @type And parentId = -1 order by sortOrder",
-                SqlHelper.CreateParameter("@type", ObjectType));
-            System.Collections.ArrayList tmp = new System.Collections.ArrayList();
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader("Select uniqueID from umbracoNode where nodeObjectType = @type And parentId = -1 order by sortOrder", 
+                sqlHelper.CreateParameter("@type", ObjectType)))
+            {
+                System.Collections.ArrayList tmp = new System.Collections.ArrayList();
 
-            while (dr.Read()) tmp.Add(dr.GetGuid("uniqueID"));
-            dr.Close();
+                while (dr.Read()) tmp.Add(dr.GetGuid("uniqueID"));
+                dr.Close();
 
-            Guid[] retval = new Guid[tmp.Count];
-            for (int i = 0; i < tmp.Count; i++) retval[i] = (Guid)tmp[i];
-            return retval;
+                Guid[] retval = new Guid[tmp.Count];
+                for (int i = 0; i < tmp.Count; i++) retval[i] = (Guid)tmp[i];
+                return retval;
+            }
         }
 
         #endregion
@@ -272,18 +287,18 @@ namespace umbraco.cms.businesslogic
             // Ruben 8/1/2007: I replace this with a parameterized version.
             // But does anyone know what the 'level++' is supposed to be doing there?
             // Nothing obviously, since it's a postfix.
-
-            SqlHelper.ExecuteNonQuery("INSERT INTO umbracoNode(trashed, parentID, nodeObjectType, nodeUser, level, path, sortOrder, uniqueID, text, createDate) VALUES(@trashed, @parentID, @nodeObjectType, @nodeUser, @level, @path, @sortOrder, @uniqueID, @text, @createDate)",
-                                      SqlHelper.CreateParameter("@trashed", 0),
-                                      SqlHelper.CreateParameter("@parentID", parentId),
-                                      SqlHelper.CreateParameter("@nodeObjectType", objectType),
-                                      SqlHelper.CreateParameter("@nodeUser", userId),
-                                      SqlHelper.CreateParameter("@level", level++),
-                                      SqlHelper.CreateParameter("@path", path),
-                                      SqlHelper.CreateParameter("@sortOrder", sortOrder),
-                                      SqlHelper.CreateParameter("@uniqueID", uniqueID),
-                                      SqlHelper.CreateParameter("@text", text),
-                                      SqlHelper.CreateParameter("@createDate", DateTime.Now));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("INSERT INTO umbracoNode(trashed, parentID, nodeObjectType, nodeUser, level, path, sortOrder, uniqueID, text, createDate) VALUES(@trashed, @parentID, @nodeObjectType, @nodeUser, @level, @path, @sortOrder, @uniqueID, @text, @createDate)",
+                                        sqlHelper.CreateParameter("@trashed", 0),
+                                        sqlHelper.CreateParameter("@parentID", parentId),
+                                        sqlHelper.CreateParameter("@nodeObjectType", objectType),
+                                        sqlHelper.CreateParameter("@nodeUser", userId),
+                                        sqlHelper.CreateParameter("@level", level++),
+                                        sqlHelper.CreateParameter("@path", path),
+                                        sqlHelper.CreateParameter("@sortOrder", sortOrder),
+                                        sqlHelper.CreateParameter("@uniqueID", uniqueID),
+                                        sqlHelper.CreateParameter("@text", text),
+                                        sqlHelper.CreateParameter("@createDate", DateTime.Now));
 
             CMSNode retVal = new CMSNode(uniqueID);
             retVal.Path = path + "," + retVal.Id.ToString();
@@ -309,11 +324,12 @@ namespace umbraco.cms.businesslogic
         private static int GetNewDocumentSortOrder(int parentId)
         {
             var sortOrder = 0;
-            using (IRecordsReader dr = SqlHelper.ExecuteReader(
-                        "SELECT MAX(sortOrder) AS sortOrder FROM umbracoNode WHERE parentID = @parentID AND nodeObjectType = @GuidForNodesOfTypeDocument",
-                        SqlHelper.CreateParameter("@parentID", parentId),
-                        SqlHelper.CreateParameter("@GuidForNodesOfTypeDocument", Document._objectType)
-                  ))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader(
+                    "SELECT MAX(sortOrder) AS sortOrder FROM umbracoNode WHERE parentID = @parentID AND nodeObjectType = @GuidForNodesOfTypeDocument",
+                    sqlHelper.CreateParameter("@parentID", parentId),
+                    sqlHelper.CreateParameter("@GuidForNodesOfTypeDocument", Document._objectType)
+                ))
             {
                 while (dr.Read())
                     sortOrder = dr.GetInt("sortOrder") + 1;
@@ -332,19 +348,18 @@ namespace umbraco.cms.businesslogic
         /// </returns>
         protected static int[] getUniquesFromObjectTypeAndFirstLetter(Guid objectType, char letter)
         {
-            using (IRecordsReader dr = SqlHelper.ExecuteReader("Select id from umbracoNode where nodeObjectType = @objectType AND text like @letter", SqlHelper.CreateParameter("@objectType", objectType), SqlHelper.CreateParameter("@letter", letter.ToString() + "%")))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader("Select id from umbracoNode where nodeObjectType = @objectType AND text like @letter", sqlHelper.CreateParameter("@objectType", objectType), sqlHelper.CreateParameter("@letter", letter.ToString() + "%")))
             {
                 List<int> tmp = new List<int>();
                 while (dr.Read()) tmp.Add(dr.GetInt("id"));
                 return tmp.ToArray();
             }
         }
-
-
+        
         /// <summary>
-        /// Gets the SQL helper.
+        /// Unused, please do not use
         /// </summary>
-        /// <value>The SQL helper.</value>
         [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
@@ -410,13 +425,15 @@ namespace umbraco.cms.businesslogic
         /// <param name="uniqueID">The unique ID.</param>
         public CMSNode(Guid uniqueID)
         {
-            _id = SqlHelper.ExecuteScalar<int>("SELECT id FROM umbracoNode WHERE uniqueID = @uniqueId", SqlHelper.CreateParameter("@uniqueId", uniqueID));
+            using (var sqlHelper = Application.SqlHelper)
+                _id = sqlHelper.ExecuteScalar<int>("SELECT id FROM umbracoNode WHERE uniqueID = @uniqueId", sqlHelper.CreateParameter("@uniqueId", uniqueID));
             setupNode();
         }
 
         public CMSNode(Guid uniqueID, bool noSetup)
         {
-            _id = SqlHelper.ExecuteScalar<int>("SELECT id FROM umbracoNode WHERE uniqueID = @uniqueId", SqlHelper.CreateParameter("@uniqueId", uniqueID));
+            using (var sqlHelper = Application.SqlHelper)
+                _id = sqlHelper.ExecuteScalar<int>("SELECT id FROM umbracoNode WHERE uniqueID = @uniqueId", sqlHelper.CreateParameter("@uniqueId", uniqueID));
 
             if (!noSetup)
                 setupNode();
@@ -500,14 +517,17 @@ inner join cmsPreviewXml on cmsPreviewXml.nodeId = umbracoNode.id
 where trashed = 0 and path like '{0}' 
 order by level,sortOrder";
 
-            string pathExp = childrenOnly ? Path + ",%" : Path;
+            var pathExp = childrenOnly ? Path + ",%" : Path;
 
-            IRecordsReader dr = SqlHelper.ExecuteReader(String.Format(sql, pathExp));
-            while (dr.Read())
-                nodes.Add(new CMSPreviewNode(dr.GetInt("id"), dr.GetGuid("uniqueID"), dr.GetInt("parentId"), dr.GetShort("level"), dr.GetInt("sortOrder"), dr.GetString("xml"), false));
-            dr.Close();
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader(string.Format(sql, pathExp)))
+            {
+                while (dr.Read())
+                    nodes.Add(new CMSPreviewNode(dr.GetInt("id"), dr.GetGuid("uniqueID"), dr.GetInt("parentId"), dr.GetShort("level"), dr.GetInt("sortOrder"), dr.GetString("xml"), false));
+                dr.Close();
 
-            return nodes;
+                return nodes;
+            }
         }
 
         /// <summary>
@@ -552,11 +572,13 @@ order by level,sortOrder";
                 //level and path might change even if it's the same newParent because the newParent could be moving somewhere.
                 if (ParentId != newParent.Id)
                 {
-                    int maxSortOrder = SqlHelper.ExecuteScalar<int>("select coalesce(max(sortOrder),0) from umbracoNode where parentid = @parentId",
-                        SqlHelper.CreateParameter("@parentId", newParent.Id));
-
-                    this.Parent = newParent;
-                    this.sortOrder = maxSortOrder + 1;
+                    using (var sqlHelper = Application.SqlHelper)
+                    {
+                        int maxSortOrder = sqlHelper.ExecuteScalar<int>("select coalesce(max(sortOrder),0) from umbracoNode where parentid = @parentId",
+                                sqlHelper.CreateParameter("@parentId", newParent.Id));
+                        this.Parent = newParent;
+                        this.sortOrder = maxSortOrder + 1;
+                    }
                 }
 
                 //detect if we have moved, then update the level and path
@@ -654,8 +676,8 @@ order by level,sortOrder";
 
                 //removes tag associations (i know the key is set to cascade but do it anyways)
                 Tag.RemoveTagsFromNode(this.Id);
-
-                SqlHelper.ExecuteNonQuery("DELETE FROM umbracoNode WHERE uniqueID= @uniqueId", SqlHelper.CreateParameter("@uniqueId", _uniqueID));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("DELETE FROM umbracoNode WHERE uniqueID= @uniqueId", sqlHelper.CreateParameter("@uniqueId", _uniqueID));
                 FireAfterDelete(e);
             }
         }
@@ -672,9 +694,12 @@ order by level,sortOrder";
             {
                 if (!_hasChildrenInitialized)
                 {
-                    int tmpChildrenCount = SqlHelper.ExecuteScalar<int>("select count(id) from umbracoNode where ParentId = @id",
-                        SqlHelper.CreateParameter("@id", Id));
-                    HasChildren = (tmpChildrenCount > 0);
+                    using (var sqlHelper = Application.SqlHelper)
+                    {
+                        int tmpChildrenCount = sqlHelper.ExecuteScalar<int>("select count(id) from umbracoNode where ParentId = @id",
+                                sqlHelper.CreateParameter("@id", Id));
+                        HasChildren = (tmpChildrenCount > 0);
+                    }
                 }
                 return _hasChildren;
             }
@@ -696,7 +721,8 @@ order by level,sortOrder";
         public virtual IEnumerable GetDescendants()
         {
             var descendants = new List<CMSNode>();
-            using (IRecordsReader dr = SqlHelper.ExecuteReader(string.Format(SqlDescendants, Id)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader(string.Format(SqlDescendants, Id)))
             {
                 while (dr.Read())
                 {
@@ -722,17 +748,21 @@ order by level,sortOrder";
             {
                 if (!_isTrashed.HasValue)
                 {
-                    _isTrashed = Convert.ToBoolean(SqlHelper.ExecuteScalar<object>("SELECT trashed FROM umbracoNode where id=@id",
-                        SqlHelper.CreateParameter("@id", this.Id)));
+                    using (var sqlHelper = Application.SqlHelper)
+                    {
+                        const string query = "SELECT trashed FROM umbracoNode where id=@id";
+                        _isTrashed = Convert.ToBoolean(sqlHelper.ExecuteScalar<object>(query, sqlHelper.CreateParameter("@id", this.Id)));
+                    }
                 }
                 return _isTrashed.Value;
             }
             set
             {
                 _isTrashed = value;
-                SqlHelper.ExecuteNonQuery("update umbracoNode set trashed = @trashed where id = @id",
-                    SqlHelper.CreateParameter("@trashed", value),
-                    SqlHelper.CreateParameter("@id", this.Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("update umbracoNode set trashed = @trashed where id = @id",
+                    sqlHelper.CreateParameter("@trashed", value),
+                    sqlHelper.CreateParameter("@id", this.Id));
             }
         }
 
@@ -746,7 +776,8 @@ order by level,sortOrder";
             set
             {
                 _sortOrder = value;
-                SqlHelper.ExecuteNonQuery("update umbracoNode set sortOrder = '" + value + "' where id = " + this.Id.ToString());
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("update umbracoNode set sortOrder = '" + value + "' where id = " + this.Id);
 
                 if (Entity != null)
                     Entity.SortOrder = value;
@@ -763,7 +794,8 @@ order by level,sortOrder";
             set
             {
                 _createDate = value;
-                SqlHelper.ExecuteNonQuery("update umbracoNode set createDate = @createDate where id = " + this.Id.ToString(), SqlHelper.CreateParameter("@createDate", _createDate));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("update umbracoNode set createDate = @createDate where id = " + this.Id, sqlHelper.CreateParameter("@createDate", _createDate));
             }
         }
 
@@ -816,7 +848,8 @@ order by level,sortOrder";
             set
             {
                 _parentid = value.Id;
-                SqlHelper.ExecuteNonQuery("update umbracoNode set parentId = " + value.Id + " where id = " + this.Id.ToString());
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("update umbracoNode set parentId = " + value.Id + " where id = " + this.Id.ToString());
 
                 if (Entity != null)
                     Entity.ParentId = value.Id;
@@ -836,7 +869,8 @@ order by level,sortOrder";
             set
             {
                 _path = value;
-                SqlHelper.ExecuteNonQuery("update umbracoNode set path = '" + _path + "' where id = " + this.Id.ToString());
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("update umbracoNode set path = '" + _path + "' where id = " + this.Id.ToString());
 
                 if (Entity != null)
                     Entity.Path = value;
@@ -854,7 +888,8 @@ order by level,sortOrder";
             set
             {
                 _level = value;
-                SqlHelper.ExecuteNonQuery("update umbracoNode set level = " + _level.ToString() + " where id = " + this.Id.ToString());
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("update umbracoNode set level = " + _level.ToString() + " where id = " + this.Id.ToString());
 
                 if (Entity != null)
                     Entity.Level = value;
@@ -893,8 +928,9 @@ order by level,sortOrder";
         {
             get
             {
-                return SqlHelper.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoNode where ParentID = @parentId",
-                                                    SqlHelper.CreateParameter("@parentId", this.Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    return sqlHelper.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoNode where ParentID = @parentId",
+                                                    sqlHelper.CreateParameter("@parentId", this.Id));
             }
         }
 
@@ -907,9 +943,10 @@ order by level,sortOrder";
             get
             {
                 System.Collections.ArrayList tmp = new System.Collections.ArrayList();
-                using (IRecordsReader dr = SqlHelper.ExecuteReader("SELECT id, createDate, trashed, parentId, nodeObjectType, nodeUser, level, path, sortOrder, uniqueID, text FROM umbracoNode WHERE ParentID = @ParentID AND nodeObjectType = @type order by sortOrder",
-                    SqlHelper.CreateParameter("@type", this.nodeObjectType),
-                    SqlHelper.CreateParameter("ParentID", this.Id)))
+                using (var sqlHelper = Application.SqlHelper)
+                using (IRecordsReader dr = sqlHelper.ExecuteReader("SELECT id, createDate, trashed, parentId, nodeObjectType, nodeUser, level, path, sortOrder, uniqueID, text FROM umbracoNode WHERE ParentID = @ParentID AND nodeObjectType = @type order by sortOrder",
+                    sqlHelper.CreateParameter("@type", this.nodeObjectType),
+                    sqlHelper.CreateParameter("ParentID", this.Id)))
                 {
                     while (dr.Read())
                     {
@@ -937,12 +974,12 @@ order by level,sortOrder";
             get
             {
                 System.Collections.ArrayList tmp = new System.Collections.ArrayList();
-                IRecordsReader dr = SqlHelper.ExecuteReader("select id from umbracoNode where ParentID = " + this.Id + " order by sortOrder");
-
-                while (dr.Read())
-                    tmp.Add(dr.GetInt("Id"));
-
-                dr.Close();
+                using (var sqlHelper = Application.SqlHelper)
+                using (IRecordsReader dr = sqlHelper.ExecuteReader("select id from umbracoNode where ParentID = " + this.Id + " order by sortOrder"))
+                {
+                    while (dr.Read())
+                        tmp.Add(dr.GetInt("Id"));
+                }
 
                 CMSNode[] retval = new CMSNode[tmp.Count];
 
@@ -952,7 +989,7 @@ order by level,sortOrder";
                 return retval;
             }
         }
-
+        
         #region IconI members
 
         // Unique identifier of the given node
@@ -973,9 +1010,10 @@ order by level,sortOrder";
             set
             {
                 _text = value;
-                SqlHelper.ExecuteNonQuery("UPDATE umbracoNode SET text = @text WHERE id = @id",
-                                          SqlHelper.CreateParameter("@text", value.Trim()),
-                                          SqlHelper.CreateParameter("@id", this.Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("UPDATE umbracoNode SET text = @text WHERE id = @id",
+                                          sqlHelper.CreateParameter("@text", value.Trim()),
+                                          sqlHelper.CreateParameter("@id", this.Id));
 
                 if (Entity != null)
                     Entity.Name = value;
@@ -1052,8 +1090,9 @@ order by level,sortOrder";
         /// </summary>
         protected virtual void setupNode()
         {
-            using (IRecordsReader dr = SqlHelper.ExecuteReader(SqlSingle,
-                    SqlHelper.CreateParameter("@id", this.Id)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader(SqlSingle, 
+                sqlHelper.CreateParameter("@id", this.Id)))
             {
                 if (dr.Read())
                 {
@@ -1105,10 +1144,11 @@ order by level,sortOrder";
         {
 
             XmlDocument xmlDoc = new XmlDocument();
-            using (XmlReader xmlRdr = SqlHelper.ExecuteXmlReader(
+            using (var sqlHelper = Application.SqlHelper)
+            using (XmlReader xmlRdr = sqlHelper.ExecuteXmlReader(
                                                        "select xml from cmsPreviewXml where nodeID = @nodeId and versionId = @versionId",
-                                      SqlHelper.CreateParameter("@nodeId", Id),
-                                      SqlHelper.CreateParameter("@versionId", version)))
+                                      sqlHelper.CreateParameter("@nodeId", Id),
+                                      sqlHelper.CreateParameter("@versionId", version)))
             {
                 xmlDoc.Load(xmlRdr);
             }
@@ -1118,8 +1158,9 @@ order by level,sortOrder";
 
         protected internal virtual bool PreviewExists(Guid versionId)
         {
-            return (SqlHelper.ExecuteScalar<int>("SELECT COUNT(nodeId) FROM cmsPreviewXml WHERE nodeId=@nodeId and versionId = @versionId",
-                        SqlHelper.CreateParameter("@nodeId", Id), SqlHelper.CreateParameter("@versionId", versionId)) != 0);
+            using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<int>("SELECT COUNT(nodeId) FROM cmsPreviewXml WHERE nodeId=@nodeId and versionId = @versionId",
+                           sqlHelper.CreateParameter("@nodeId", Id), sqlHelper.CreateParameter("@versionId", versionId)) != 0;
 
         }
 
@@ -1131,13 +1172,15 @@ order by level,sortOrder";
         [MethodImpl(MethodImplOptions.Synchronized)]
         protected void SavePreviewXml(XmlNode x, Guid versionId)
         {
-            string sql = PreviewExists(versionId) ? "UPDATE cmsPreviewXml SET xml = @xml, timestamp = @timestamp WHERE nodeId=@nodeId AND versionId = @versionId"
+            var sql = PreviewExists(versionId) ? "UPDATE cmsPreviewXml SET xml = @xml, timestamp = @timestamp WHERE nodeId=@nodeId AND versionId = @versionId"
                                 : "INSERT INTO cmsPreviewXml(nodeId, versionId, timestamp, xml) VALUES (@nodeId, @versionId, @timestamp, @xml)";
-            SqlHelper.ExecuteNonQuery(sql,
-                                      SqlHelper.CreateParameter("@nodeId", Id),
-                                      SqlHelper.CreateParameter("@versionId", versionId),
-                                      SqlHelper.CreateParameter("@timestamp", DateTime.Now),
-                                      SqlHelper.CreateParameter("@xml", x.OuterXml));
+
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery(sql,
+                                      sqlHelper.CreateParameter("@nodeId", Id),
+                                      sqlHelper.CreateParameter("@versionId", versionId),
+                                      sqlHelper.CreateParameter("@timestamp", DateTime.Now),
+                                      sqlHelper.CreateParameter("@xml", x.OuterXml));
         }
 
         protected void PopulateCMSNodeFromReader(IRecordsReader dr)

--- a/src/umbraco.cms/businesslogic/Content.cs
+++ b/src/umbraco.cms/businesslogic/Content.cs
@@ -11,6 +11,7 @@ using Umbraco.Core.Models.EntityBase;
 using umbraco.cms.businesslogic.property;
 using umbraco.DataLayer;
 using System.Runtime.CompilerServices;
+using umbraco.BusinessLogic;
 using umbraco.cms.helpers;
 using umbraco.cms.businesslogic.datatype.controls;
 using File = System.IO.File;
@@ -55,7 +56,7 @@ namespace umbraco.cms.businesslogic
         public Content(int id) : base(id) { }
 
         protected Content(int id, bool noSetup) : base(id, noSetup) { }
-       
+
         protected Content(Guid id) : base(id) { }
 
         protected Content(Guid id, bool noSetup) : base(id, noSetup) { }
@@ -130,23 +131,27 @@ namespace umbraco.cms.businesslogic
         {
             get
             {
-                if (_contentType == null)
+                using (var sqlHelper = Application.SqlHelper)
                 {
-                    object o = SqlHelper.ExecuteScalar<object>(
-                        "Select ContentType from cmsContent where nodeId=@nodeid",
-                            SqlHelper.CreateParameter("@nodeid", this.Id));
-                    if (o == null)
-                        return null;
-                    int contentTypeId;
-                    if (int.TryParse(o.ToString(), out contentTypeId) == false)
-                        return null;
-                    try
+                    if (_contentType == null)
                     {
-                        _contentType = new ContentType(contentTypeId);
-                    }
-                    catch
-                    {
-                        return null;
+                        object o = sqlHelper.ExecuteScalar<object>(
+                            "Select ContentType from cmsContent where nodeId=@nodeid",
+                            sqlHelper.CreateParameter("@nodeid", this.Id));
+                        if (o == null)
+                            return null;
+                        int contentTypeId;
+                        if (int.TryParse(o.ToString(), out contentTypeId) == false)
+                            return null;
+
+                        try
+                        {
+                            _contentType = new ContentType(contentTypeId);
+                        }
+                        catch
+                        {
+                            return null;
+                        }
                     }
                 }
                 return _contentType;
@@ -196,27 +201,34 @@ namespace umbraco.cms.businesslogic
                     if (this is media.Media)
                     {
                         // get the xml fragment from cmsXmlContent
-                        string xmlFragment = SqlHelper.ExecuteScalar<string>(@"SELECT [xml] FROM cmsContentXml WHERE nodeId = " + this.Id);
-                        if (!string.IsNullOrWhiteSpace(xmlFragment))
+                        using (var sqlHelper = Application.SqlHelper)
                         {
-                            XmlDocument xmlDocument = new XmlDocument();
-                            xmlDocument.LoadXml(xmlFragment);                            
+                            string xmlFragment = sqlHelper.ExecuteScalar<string>(@"SELECT [xml] FROM cmsContentXml WHERE nodeId = " + this.Id);
+                            if (!string.IsNullOrWhiteSpace(xmlFragment))
+                            {
+                                XmlDocument xmlDocument = new XmlDocument();
+                                xmlDocument.LoadXml(xmlFragment);
 
-                            _versionDateInitialized = DateTime.TryParse(xmlDocument.SelectSingleNode("//*[1]").Attributes["updateDate"].Value, out _versionDate);
+                                _versionDateInitialized = DateTime.TryParse(xmlDocument.SelectSingleNode("//*[1]").Attributes["updateDate"].Value, out _versionDate);
+                            }
                         }
                     }
 
                     if (!_versionDateInitialized)
                     {
-                        object o = SqlHelper.ExecuteScalar<object>(
-                            "select VersionDate from cmsContentVersion where versionId = '" + this.Version.ToString() + "'");
-                        if (o == null)
+
+                        using (var sqlHelper = Application.SqlHelper)
                         {
-                            _versionDate = DateTime.Now;
-                        }
-                        else
-                        {
-                            _versionDateInitialized = DateTime.TryParse(o.ToString(), out _versionDate);
+                            object o = sqlHelper.ExecuteScalar<object>(
+                                "select VersionDate from cmsContentVersion where versionId = '" + this.Version.ToString() + "'");
+                            if (o == null)
+                            {
+                                _versionDate = DateTime.Now;
+                            }
+                            else
+                            {
+                                _versionDateInitialized = DateTime.TryParse(o.ToString(), out _versionDate);
+                            }
                         }
                     }
                 }
@@ -266,7 +278,8 @@ namespace umbraco.cms.businesslogic
                     string sql = "Select versionId from cmsContentVersion where contentID = " + this.Id +
                                  " order by id desc ";
 
-                    using (IRecordsReader dr = SqlHelper.ExecuteReader(sql))
+                    using (var sqlHelper = Application.SqlHelper)
+                    using (IRecordsReader dr = sqlHelper.ExecuteReader(sql))
                     {
                         if (!dr.Read())
                             _version = Guid.Empty;
@@ -287,7 +300,7 @@ namespace umbraco.cms.businesslogic
         /// Used to persist object changes to the database. This ensures that the properties are re-loaded from the database.
         /// </summary>
         public override void Save()
-        {            
+        {
             base.Save();
 
             ClearLoadedProperties();
@@ -326,7 +339,7 @@ namespace umbraco.cms.businesslogic
         public virtual Property addProperty(PropertyType pt, Guid versionId)
         {
             ClearLoadedProperties();
-            
+
             return property.Property.MakeNew(pt, this, versionId);
 
         }
@@ -346,13 +359,15 @@ namespace umbraco.cms.businesslogic
                 // after the empty catch we'll generate the xml which is why we don't do anything in the catch part
                 try
                 {
-                    XmlReader xr = SqlHelper.ExecuteXmlReader("select xml from cmsContentXml where nodeID = " + this.Id.ToString());
-                    if (xr.MoveToContent() != System.Xml.XmlNodeType.None)
+                    using (var sqlHelper = Application.SqlHelper)
+                    using (var xr = sqlHelper.ExecuteXmlReader("select xml from cmsContentXml where nodeID = " + this.Id.ToString()))
                     {
-                        xmlDoc.Load(xr);
-                        _xml = xmlDoc.FirstChild;
+                        if (xr.MoveToContent() != System.Xml.XmlNodeType.None)
+                        {
+                            xmlDoc.Load(xr);
+                            _xml = xmlDoc.FirstChild;
+                        }
                     }
-                    xr.Close();
                 }
                 catch
                 {
@@ -395,7 +410,8 @@ namespace umbraco.cms.businesslogic
         /// </summary>
         public virtual void XmlRemoveFromDB()
         {
-            SqlHelper.ExecuteNonQuery("delete from cmsContentXml where nodeId = @nodeId", SqlHelper.CreateParameter("@nodeId", this.Id));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("delete from cmsContentXml where nodeId = @nodeId", sqlHelper.CreateParameter("@nodeId", this.Id));
         }
 
         /// <summary>
@@ -458,16 +474,20 @@ namespace umbraco.cms.businesslogic
             this.deleteAllProperties();
 
             // Remove all content preview xml
-            SqlHelper.ExecuteNonQuery("delete from cmsPreviewXml where nodeId = " + Id);
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("delete from cmsPreviewXml where nodeId = " + Id);
 
             // Delete version history
-            SqlHelper.ExecuteNonQuery("Delete from cmsContentVersion where ContentId = " + this.Id);
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("Delete from cmsContentVersion where ContentId = " + this.Id);
 
             // Delete xml
-            SqlHelper.ExecuteNonQuery("delete from cmsContentXml where nodeID = @nodeId", SqlHelper.CreateParameter("@nodeId", this.Id));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("delete from cmsContentXml where nodeID = @nodeId", sqlHelper.CreateParameter("@nodeId", this.Id));
 
             // Delete Contentspecific data ()
-            SqlHelper.ExecuteNonQuery("Delete from cmsContent where NodeId = " + this.Id);
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("Delete from cmsContent where NodeId = " + this.Id);
 
             // Delete Nodeinformation!!
             base.delete();
@@ -486,7 +506,7 @@ namespace umbraco.cms.businesslogic
         {
             //we know that there is one ctor arg and it is a GUID since we are only calling the base
             // ctor with this overload for one purpose.
-            var version = (Guid) ctorArgs[0];
+            var version = (Guid)ctorArgs[0];
             _version = version;
 
             base.PreSetupNode(ctorArgs);
@@ -518,20 +538,21 @@ namespace umbraco.cms.businesslogic
         /// <param name="ct"></param>
         protected virtual void CreateContent(ContentType ct)
         {
-            SqlHelper.ExecuteNonQuery("insert into cmsContent (nodeId,ContentType) values (" + this.Id + "," + ct.Id + ")");
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("insert into cmsContent (nodeId,ContentType) values (" + this.Id + "," + ct.Id + ")");
             createNewVersion(DateTime.Now);
         }
-        
+
         /// <summary>
         /// Method for creating a new version of the data associated to the Content. 
         /// </summary>
         /// <returns>The new version Id</returns>
-		protected Guid createNewVersion(DateTime versionDate = default(DateTime))
+        protected Guid createNewVersion(DateTime versionDate = default(DateTime))
         {
-			if (versionDate == default (DateTime))
-			{
-				versionDate = DateTime.Now;
-			}
+            if (versionDate == default(DateTime))
+            {
+                versionDate = DateTime.Now;
+            }
 
             ClearLoadedProperties();
 
@@ -539,8 +560,9 @@ namespace umbraco.cms.businesslogic
             bool tempHasVersion = hasVersion();
 
             // we need to ensure that a version in the db exist before we add related data
-            SqlHelper.ExecuteNonQuery("Insert into cmsContentVersion (ContentId,versionId,versionDate) values (" + this.Id + ",'" + newVersion + "', @updateDate)",
-                SqlHelper.CreateParameter("@updateDate", versionDate));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("Insert into cmsContentVersion (ContentId,versionId,versionDate) values (" + this.Id + ",'" + newVersion + "', @updateDate)",
+                sqlHelper.CreateParameter("@updateDate", versionDate));
 
             List<PropertyType> pts = ContentType.PropertyTypes;
             foreach (propertytype.PropertyType pt in pts)
@@ -577,16 +599,20 @@ namespace umbraco.cms.businesslogic
         protected virtual void SaveXmlDocument(XmlNode node)
         {
             // Method is synchronized so exists remains consistent (avoiding race condition)
-            bool exists = SqlHelper.ExecuteScalar<int>("SELECT COUNT(nodeId) FROM cmsContentXml WHERE nodeId = @nodeId",
-                                           SqlHelper.CreateParameter("@nodeId", Id)) > 0;
-            string query;
-            if (exists)
-                query = "UPDATE cmsContentXml SET xml = @xml WHERE nodeId = @nodeId";
-            else
-                query = "INSERT INTO cmsContentXml(nodeId, xml) VALUES (@nodeId, @xml)";
-            SqlHelper.ExecuteNonQuery(query,
-                                      SqlHelper.CreateParameter("@nodeId", Id),
-                                      SqlHelper.CreateParameter("@xml", node.OuterXml));
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                bool exists = sqlHelper.ExecuteScalar<int>("SELECT COUNT(nodeId) FROM cmsContentXml WHERE nodeId = @nodeId",
+                                           sqlHelper.CreateParameter("@nodeId", Id)) > 0;
+                string query;
+                if (exists)
+                    query = "UPDATE cmsContentXml SET xml = @xml WHERE nodeId = @nodeId";
+                else
+                    query = "INSERT INTO cmsContentXml(nodeId, xml) VALUES (@nodeId, @xml)";
+            
+                sqlHelper.ExecuteNonQuery(query,
+                                      sqlHelper.CreateParameter("@nodeId", Id),
+                                      sqlHelper.CreateParameter("@xml", node.OuterXml));
+            }
         }
 
         /// <summary>
@@ -599,9 +625,9 @@ namespace umbraco.cms.businesslogic
 
             var fs = FileSystemProviderManager.Current.GetFileSystemProvider<MediaFileSystem>();
             var uploadField = DataTypesResolver.Current.GetById(new Guid(Constants.PropertyEditors.UploadField));
-             
+
             foreach (Property p in GenericProperties)
-            {               
+            {
                 var isUploadField = false;
                 try
                 {
@@ -692,8 +718,9 @@ namespace umbraco.cms.businesslogic
 
             string sql = @"select id, propertyTypeId from cmsPropertyData where versionId=@versionId";
 
-            using (IRecordsReader dr = SqlHelper.ExecuteReader(sql,
-                SqlHelper.CreateParameter("@versionId", Version)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader(sql,
+                sqlHelper.CreateParameter("@versionId", Version)))
             {
                 while (dr.Read())
                 {
@@ -736,13 +763,16 @@ namespace umbraco.cms.businesslogic
         /// </summary>
         protected void deleteAllProperties()
         {
-            SqlHelper.ExecuteNonQuery("Delete from cmsPropertyData where contentNodeId = @nodeId", SqlHelper.CreateParameter("@nodeId", this.Id));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("Delete from cmsPropertyData where contentNodeId = @nodeId", sqlHelper.CreateParameter("@nodeId", this.Id));
         }
 
         private XmlNode importXml()
         {
             XmlDocument xmlDoc = new XmlDocument();
-            xmlDoc.Load(SqlHelper.ExecuteXmlReader("select xml from cmsContentXml where nodeID = " + this.Id.ToString()));
+            using (var sqlHelper = Application.SqlHelper)
+            using (var doc = sqlHelper.ExecuteXmlReader("select xml from cmsContentXml where nodeID = " + this.Id.ToString()))
+                xmlDoc.Load(doc);
 
             return xmlDoc.FirstChild;
         }
@@ -753,8 +783,11 @@ namespace umbraco.cms.businesslogic
         /// <returns>Returns true if the Content has a version</returns>
         private bool hasVersion()
         {
-            int versionCount = SqlHelper.ExecuteScalar<int>("select Count(Id) as tmp from cmsContentVersion where contentId = " + this.Id.ToString());
-            return (versionCount > 0);
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                int versionCount = sqlHelper.ExecuteScalar<int>("select Count(Id) as tmp from cmsContentVersion where contentId = " + this.Id.ToString());
+                return (versionCount > 0);
+            }
         }
 
         #endregion
@@ -774,7 +807,6 @@ namespace umbraco.cms.businesslogic
         {
             SavePreviewXml(generateXmlWithoutSaving(xd), Version);
         }
-
         #endregion
     }
 }

--- a/src/umbraco.cms/businesslogic/ContentType.cs
+++ b/src/umbraco.cms/businesslogic/ContentType.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Runtime.CompilerServices;
 using System.Linq;
 using System.Xml;
+using umbraco.BusinessLogic;
 using Umbraco.Core;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Logging;
@@ -206,7 +207,8 @@ namespace umbraco.cms.businesslogic
 
         internal static void Create(int nodeId, string alias, string iconUrl, bool formatAlias)
         {
-            SqlHelper.ExecuteNonQuery(
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery(
                                       "Insert into cmsContentType (nodeId,alias,icon) values (" + 
                                       nodeId + ",'" +
                                       (formatAlias ? helpers.Casing.SafeAliasWithForcingCheck(alias) : alias) +
@@ -222,8 +224,9 @@ namespace umbraco.cms.businesslogic
         /// </returns>
         public static ContentType GetByAlias(string Alias)
         {
-            return new ContentType(SqlHelper.ExecuteScalar<int>("SELECT nodeid FROM cmsContentType WHERE alias = @alias",
-                                   SqlHelper.CreateParameter("@alias", Alias)));
+            using (var sqlHelper = Application.SqlHelper)
+                return new ContentType(sqlHelper.ExecuteScalar<int>("SELECT nodeid FROM cmsContentType WHERE alias = @alias",
+                                   sqlHelper.CreateParameter("@alias", Alias)));
         }
 
         /// <summary>
@@ -233,10 +236,13 @@ namespace umbraco.cms.businesslogic
         /// <returns>The Id of the Tab on which the PropertyType is placed</returns>
         public static int getTabIdFromPropertyType(PropertyType pt)
         {
-            object tmp = SqlHelper.ExecuteScalar<object>("Select propertyTypeGroupId from cmsPropertyType where id = " + pt.Id.ToString());
-            if (tmp == DBNull.Value)
-                return 0;
-            return int.Parse(tmp.ToString());
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                object tmp = sqlHelper.ExecuteScalar<object>("Select propertyTypeGroupId from cmsPropertyType where id = " + pt.Id.ToString());
+                if (tmp == DBNull.Value)
+                    return 0;
+                return int.Parse(tmp.ToString());
+            }
         }
 
         #endregion
@@ -292,16 +298,16 @@ namespace umbraco.cms.businesslogic
         {
             var ids = new List<int>();
             //get all the content item ids of the current content type
-            using (var dr = SqlHelper.ExecuteReader(@"SELECT DISTINCT cmsContent.nodeId FROM cmsContent 
+            using (var sqlHelper = Application.SqlHelper)
+            using (var dr = sqlHelper.ExecuteReader(@"SELECT DISTINCT cmsContent.nodeId FROM cmsContent 
                                                 INNER JOIN cmsContentType ON cmsContent.contentType = cmsContentType.nodeId 
                                                 WHERE cmsContentType.nodeId = @nodeId",
-                                                    SqlHelper.CreateParameter("@nodeId", this.Id)))
+                                                    sqlHelper.CreateParameter("@nodeId", this.Id)))
             {
                 while (dr.Read())
                 {
                     ids.Add(dr.GetInt("nodeId"));
                 }
-                dr.Close();
             }
             return ids;
         }
@@ -332,11 +338,12 @@ namespace umbraco.cms.businesslogic
         internal virtual void ClearXmlStructuresForContent()
         {
             //Remove all items from the cmsContentXml table that are of this current content type
-            SqlHelper.ExecuteNonQuery(@"DELETE FROM cmsContentXml WHERE nodeId IN
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery(@"DELETE FROM cmsContentXml WHERE nodeId IN
                                         (SELECT DISTINCT cmsContent.nodeId FROM cmsContent 
                                             INNER JOIN cmsContentType ON cmsContent.contentType = cmsContentType.nodeId 
                                             WHERE cmsContentType.nodeId = @nodeId)",
-                                      SqlHelper.CreateParameter("@nodeId", this.Id));
+                                      sqlHelper.CreateParameter("@nodeId", this.Id));
         }
 
         #endregion
@@ -362,9 +369,10 @@ namespace umbraco.cms.businesslogic
                 //Note that this is currently only done to support both DocumentType and MediaType, which use the new api and MemberType that doesn't.
                 if (ContentTypeItem == null)
                 {
-                    SqlHelper.ExecuteNonQuery("update cmsContentType set alias = @alias where nodeId = @id",
-                                              SqlHelper.CreateParameter("@alias", _alias),
-                                              SqlHelper.CreateParameter("@id", Id));
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery("update cmsContentType set alias = @alias where nodeId = @id",
+                                              sqlHelper.CreateParameter("@alias", _alias),
+                                              sqlHelper.CreateParameter("@id", Id));
                 }
                 else
                 {
@@ -391,7 +399,8 @@ namespace umbraco.cms.businesslogic
                 //Note that this is currently only done to support both DocumentType and MediaType, which use the new api and MemberType that doesn't.
                 if (ContentTypeItem == null)
                 {
-                    SqlHelper.ExecuteNonQuery("update cmsContentType set icon='" + value + "' where nodeid = " + Id);
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery("update cmsContentType set icon='" + value + "' where nodeid = " + Id);
                 }
                 else
                 {
@@ -418,10 +427,11 @@ namespace umbraco.cms.businesslogic
                 //Note that this is currently only done to support both DocumentType and MediaType, which use the new api and MemberType that doesn't.
                 if (ContentTypeItem == null)
                 {
-                    SqlHelper.ExecuteNonQuery(
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery(
                                           "update cmsContentType set isContainer = @isContainer where nodeId = @id",
-                                          SqlHelper.CreateParameter("@isContainer", value),
-                                          SqlHelper.CreateParameter("@id", Id));
+                                          sqlHelper.CreateParameter("@isContainer", value),
+                                          sqlHelper.CreateParameter("@id", Id));
                 }
                 else
                 {
@@ -444,10 +454,11 @@ namespace umbraco.cms.businesslogic
                 //Note that this is currently only done to support both DocumentType and MediaType, which use the new api and MemberType that doesn't.
                 if (ContentTypeItem == null)
                 {
-                    SqlHelper.ExecuteNonQuery(
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery(
                                           "update cmsContentType set allowAtRoot = @allowAtRoot where nodeId = @id",
-                                          SqlHelper.CreateParameter("@allowAtRoot", value),
-                                          SqlHelper.CreateParameter("@id", Id));
+                                          sqlHelper.CreateParameter("@allowAtRoot", value),
+                                          sqlHelper.CreateParameter("@id", Id));
                 }
                 else
                 {
@@ -492,10 +503,11 @@ namespace umbraco.cms.businesslogic
                 //Note that this is currently only done to support both DocumentType and MediaType, which use the new api and MemberType that doesn't.
                 if (ContentTypeItem == null)
                 {
-                    SqlHelper.ExecuteNonQuery(
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery(
                                           "update cmsContentType set description = @description where nodeId = @id",
-                                          SqlHelper.CreateParameter("@description", value),
-                                          SqlHelper.CreateParameter("@id", Id));
+                                          sqlHelper.CreateParameter("@description", value),
+                                          sqlHelper.CreateParameter("@id", Id));
                 }
                 else
                 {
@@ -521,10 +533,11 @@ namespace umbraco.cms.businesslogic
                 //Note that this is currently only done to support both DocumentType and MediaType, which use the new api and MemberType that doesn't.
                 if (ContentTypeItem == null)
                 {
-                    SqlHelper.ExecuteNonQuery(
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery(
                                           "update cmsContentType set thumbnail = @thumbnail where nodeId = @id",
-                                          SqlHelper.CreateParameter("@thumbnail", value),
-                                          SqlHelper.CreateParameter("@id", Id));
+                                          sqlHelper.CreateParameter("@thumbnail", value),
+                                          sqlHelper.CreateParameter("@id", Id));
                 }
                 else
                 {
@@ -598,10 +611,10 @@ namespace umbraco.cms.businesslogic
                         //its own + inherited property types, which is wrong. Once we are able to fully switch to the new api
                         //this should no longer be a problem as the composition always contains a correct list of property types.
                         var result = new Dictionary<int, PropertyType>();
-                        using (IRecordsReader dr =
-                            SqlHelper.ExecuteReader(
+                        using (var sqlHelper = Application.SqlHelper)
+                        using (IRecordsReader dr = sqlHelper.ExecuteReader(
                                 "select id from cmsPropertyType where contentTypeId = @ctId order by sortOrder",
-                                SqlHelper.CreateParameter("@ctId", Id)))
+                                sqlHelper.CreateParameter("@ctId", Id)))
                         {
                             while (dr.Read())
                             {
@@ -648,11 +661,10 @@ namespace umbraco.cms.businesslogic
                     if (ContentTypeItem == null)
                     {
                         //TODO Make this recursive, so it looks up Masters of the Master ContentType
-                        using (
-                            var dr =
-                                SqlHelper.ExecuteReader(
-                                    @"SELECT parentContentTypeId FROM cmsContentType2ContentType WHERE childContentTypeId = @id",
-                                    SqlHelper.CreateParameter("@id", Id)))
+                        using (var sqlHelper = Application.SqlHelper)
+                        using (var dr = sqlHelper.ExecuteReader(
+                            @"SELECT parentContentTypeId FROM cmsContentType2ContentType WHERE childContentTypeId = @id",
+                                sqlHelper.CreateParameter("@id", Id)))
                         {
                             while (dr.Read())
                             {
@@ -722,10 +734,11 @@ namespace umbraco.cms.businesslogic
             {
                 if (ContentTypeItem == null)
                 {
-                    SqlHelper.ExecuteNonQuery(
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery(
                         "INSERT INTO [cmsContentType2ContentType] (parentContentTypeId, childContentTypeId) VALUES (@parentContentTypeId, @childContentTypeId)",
-                        SqlHelper.CreateParameter("@parentContentTypeId", parentContentTypeId),
-                        SqlHelper.CreateParameter("@childContentTypeId", Id));
+                        sqlHelper.CreateParameter("@parentContentTypeId", parentContentTypeId),
+                        sqlHelper.CreateParameter("@childContentTypeId", Id));
 
                     MasterContentTypes.Add(parentContentTypeId);
                 }
@@ -739,15 +752,17 @@ namespace umbraco.cms.businesslogic
 
         public bool IsMaster()
         {
-            return SqlHelper.ExecuteScalar<int>("select count(*) from cmsContentType2ContentType where parentContentTypeId = @parentContentTypeId",
-                SqlHelper.CreateParameter("@parentContentTypeId", this.Id)) > 0;
+            using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<int>("select count(*) from cmsContentType2ContentType where parentContentTypeId = @parentContentTypeId",
+                sqlHelper.CreateParameter("@parentContentTypeId", this.Id)) > 0;
         }
 
         public IEnumerable<ContentType> GetChildTypes()
         {
             var cts = new List<ContentType>();
-            using (var dr = SqlHelper.ExecuteReader(@"SELECT childContentTypeId FROM cmsContentType2ContentType WHERE parentContentTypeId = @parentContentTypeId",
-                SqlHelper.CreateParameter("@parentContentTypeId", Id)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (var dr = sqlHelper.ExecuteReader(@"SELECT childContentTypeId FROM cmsContentType2ContentType WHERE parentContentTypeId = @parentContentTypeId",
+                sqlHelper.CreateParameter("@parentContentTypeId", Id)))
             {
                 while (dr.Read())
                 {
@@ -774,10 +789,11 @@ namespace umbraco.cms.businesslogic
 
                 RemoveMasterPropertyTypeData(contentTypeToRemove, this);
 
-                SqlHelper.ExecuteNonQuery(
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery(
                                           "DELETE FROM [cmsContentType2ContentType] WHERE parentContentTypeId = @parentContentTypeId AND childContentTypeId = @childContentTypeId",
-                                          SqlHelper.CreateParameter("@parentContentTypeId", parentContentTypeId),
-                                          SqlHelper.CreateParameter("@childContentTypeId", Id));
+                                          sqlHelper.CreateParameter("@parentContentTypeId", parentContentTypeId),
+                                          sqlHelper.CreateParameter("@childContentTypeId", Id));
                 MasterContentTypes.Remove(parentContentTypeId);
             }
         }
@@ -790,13 +806,14 @@ namespace umbraco.cms.businesslogic
                 {
                     // before we can remove a parent content type we need to remove all data that 
                     // relates to property types
-                    SqlHelper.ExecuteNonQuery(
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery(
                             @"delete cmsPropertyData from cmsPropertyData
                             inner join cmsContent on cmsContent.nodeId = cmsPropertyData.contentNodeId
                             where cmsPropertyData.propertyTypeId = @propertyType
                             and contentType = @contentType",
-                        SqlHelper.CreateParameter("@contentType", currentContentType.Id),
-                        SqlHelper.CreateParameter("@propertyType", pt.Id));
+                        sqlHelper.CreateParameter("@contentType", currentContentType.Id),
+                        sqlHelper.CreateParameter("@propertyType", pt.Id));
                 }
             }
 
@@ -850,7 +867,8 @@ namespace umbraco.cms.businesslogic
                 if (_allowedChildContentTypeIDs == null)
                 {
                     _allowedChildContentTypeIDs = new List<int>();
-                    using (var dr = SqlHelper.ExecuteReader("Select AllowedId from cmsContentTypeAllowedContentType where id=" + Id))
+                    using (var sqlHelper = Application.SqlHelper)
+                    using (var dr = sqlHelper.ExecuteReader("Select AllowedId from cmsContentTypeAllowedContentType where id=" + Id))
                     {
                         while (dr.Read())
                         {
@@ -869,11 +887,13 @@ namespace umbraco.cms.businesslogic
                 //Note that this is currently only done to support both DocumentType and MediaType, which use the new api and MemberType that doesn't.
                 if (ContentTypeItem == null)
                 {
-                    SqlHelper.ExecuteNonQuery(
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery(
                         "delete from cmsContentTypeAllowedContentType where id=" + Id);
                     foreach (int i in value)
                     {
-                        SqlHelper.ExecuteNonQuery(
+                        using (var sqlHelper = Application.SqlHelper)
+                            sqlHelper.ExecuteNonQuery(
                             "insert into cmsContentTypeAllowedContentType (id,AllowedId) values (" +
                             Id + "," + i + ")");
                     }
@@ -925,8 +945,8 @@ namespace umbraco.cms.businesslogic
         {
             var contentTypes = new List<ContentType>();
 
-            using (var dr =
-                SqlHelper.ExecuteReader(m_SQLOptimizedGetAll.Trim(), SqlHelper.CreateParameter("@nodeObjectType", nodeObjectType)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (var dr = sqlHelper.ExecuteReader(m_SQLOptimizedGetAll.Trim(), sqlHelper.CreateParameter("@nodeObjectType", nodeObjectType)))
             {
                 while (dr.Read())
                 {
@@ -1110,12 +1130,14 @@ namespace umbraco.cms.businesslogic
             }
 
             //need to delete the allowed relationships between content types
-            SqlHelper.ExecuteNonQuery("delete from cmsContentTypeAllowedContentType where AllowedId=@allowedId or Id=@id",
-                SqlHelper.CreateParameter("@allowedId", Id),
-                SqlHelper.CreateParameter("@id", Id));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("delete from cmsContentTypeAllowedContentType where AllowedId=@allowedId or Id=@id",
+                sqlHelper.CreateParameter("@allowedId", Id),
+                sqlHelper.CreateParameter("@id", Id));
 
             // delete contenttype entrance
-            SqlHelper.ExecuteNonQuery("Delete from cmsContentType where NodeId = " + Id);
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("Delete from cmsContentType where NodeId = " + Id);
 
             // delete CMSNode entrance
             base.delete();
@@ -1188,7 +1210,8 @@ namespace umbraco.cms.businesslogic
             }
 
             // TODO: Load master content types
-            using (var dr = SqlHelper.ExecuteReader("Select allowAtRoot, isContainer, Alias,icon,thumbnail,description from cmsContentType where nodeid=" + Id)
+            using (var sqlHelper = Application.SqlHelper)
+            using (var dr = sqlHelper.ExecuteReader("Select allowAtRoot, isContainer, Alias,icon,thumbnail,description from cmsContentType where nodeid=" + Id)
                 )
             {
                 if (dr.Read())
@@ -1358,9 +1381,10 @@ namespace umbraco.cms.businesslogic
         private static void PopulatePropertyData(PropertyType pt, int contentTypeId)
         {
             // NH: PropertyTypeId inserted directly into SQL instead of as a parameter for SQL CE 4 compatibility
-            SqlHelper.ExecuteNonQuery(
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery(
                                       "insert into cmsPropertyData (contentNodeId, versionId, propertyTypeId) select contentId, versionId, " + pt.Id + " from cmsContent inner join cmsContentVersion on cmsContent.nodeId = cmsContentVersion.contentId where contentType = @contentTypeId",
-                                      SqlHelper.CreateParameter("@contentTypeId", contentTypeId));
+                                      sqlHelper.CreateParameter("@contentTypeId", contentTypeId));
         }
 
         #endregion
@@ -1559,10 +1583,12 @@ namespace umbraco.cms.businesslogic
             /// </summary>
             public void Delete()
             {
-                SqlHelper.ExecuteNonQuery("update cmsPropertyType set propertyTypeGroupId = NULL where propertyTypeGroupId = @id",
-                                          SqlHelper.CreateParameter("@id", Id));
-                SqlHelper.ExecuteNonQuery("delete from cmsPropertyTypeGroup where id = @id",
-                                          SqlHelper.CreateParameter("@id", Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("update cmsPropertyType set propertyTypeGroupId = NULL where propertyTypeGroupId = @id",
+                                          sqlHelper.CreateParameter("@id", Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("delete from cmsPropertyTypeGroup where id = @id",
+                                          sqlHelper.CreateParameter("@id", Id));
             }
 
             /// <summary>
@@ -1574,15 +1600,18 @@ namespace umbraco.cms.businesslogic
             {
                 try
                 {
-                    var tempCaption = SqlHelper.ExecuteScalar<string>("Select text from cmsPropertyTypeGroup where id = " + id.ToString());
-                    if (!tempCaption.StartsWith("#"))
-                        return tempCaption;
-                    var lang = Language.GetByCultureCode(Thread.CurrentThread.CurrentCulture.Name);
-                    if (lang != null)
+                    using (var sqlHelper = Application.SqlHelper)
                     {
-                        return new Dictionary.DictionaryItem(tempCaption.Substring(1, tempCaption.Length - 1)).Value(lang.id);
+                        var tempCaption = sqlHelper.ExecuteScalar<string>("Select text from cmsPropertyTypeGroup where id = " + id.ToString());
+                        if (!tempCaption.StartsWith("#"))
+                            return tempCaption;
+                        var lang = Language.GetByCultureCode(Thread.CurrentThread.CurrentCulture.Name);
+                        if (lang != null)
+                        {
+                            return new Dictionary.DictionaryItem(tempCaption.Substring(1, tempCaption.Length - 1)).Value(lang.id);
+                        }
+                        return "[" + tempCaption + "]";
                     }
-                    return "[" + tempCaption + "]";
                 }
                 catch
                 {
@@ -1599,8 +1628,11 @@ namespace umbraco.cms.businesslogic
             {
                 try
                 {
-                    var tempCaption = SqlHelper.ExecuteScalar<string>("Select text from cmsPropertyTypeGroup where id = " + id);
-                    return tempCaption;
+                    using (var sqlHelper = Application.SqlHelper)
+                    {
+                        var tempCaption = sqlHelper.ExecuteScalar<string>("Select text from cmsPropertyTypeGroup where id = " + id);
+                        return tempCaption;
+                    }
                 }
                 catch
                 {
@@ -1622,13 +1654,15 @@ namespace umbraco.cms.businesslogic
                 {
                     if (!_sortOrder.HasValue)
                     {
-                        _sortOrder = SqlHelper.ExecuteScalar<int>("select sortOrder from cmsPropertyTypeGroup where id = " + _id);
+                        using (var sqlHelper = Application.SqlHelper)
+                            _sortOrder = sqlHelper.ExecuteScalar<int>("select sortOrder from cmsPropertyTypeGroup where id = " + _id);
                     }
                     return _sortOrder.Value;
                 }
                 set
                 {
-                    SqlHelper.ExecuteNonQuery("update cmsPropertyTypeGroup set sortOrder = " + value + " where id =" + _id);
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery("update cmsPropertyTypeGroup set sortOrder = " + value + " where id =" + _id);
                 }
             }
 

--- a/src/umbraco.cms/businesslogic/Dictionary.cs
+++ b/src/umbraco.cms/businesslogic/Dictionary.cs
@@ -23,6 +23,9 @@ namespace umbraco.cms.businesslogic
     {
         private static readonly Guid TopLevelParent = new Guid(Constants.Conventions.Localization.DictionaryItemRootId);
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
         [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database")]
         protected static ISqlHelper SqlHelper
         {

--- a/src/umbraco.cms/businesslogic/Packager/Package.cs
+++ b/src/umbraco.cms/businesslogic/Packager/Package.cs
@@ -10,6 +10,10 @@ namespace umbraco.cms.businesslogic.packager
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class Package
     {
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }
@@ -32,73 +36,79 @@ namespace umbraco.cms.businesslogic.packager
 
         public Package(Guid Id)
         {
-            int installStatusId = SqlHelper.ExecuteScalar<int>(
-                "select id from umbracoInstalledPackages where package = @package and upgradeId = 0",
-                SqlHelper.CreateParameter("@package", Id));
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                int installStatusId = sqlHelper.ExecuteScalar<int>(
+                    "select id from umbracoInstalledPackages where package = @package and upgradeId = 0",
+                    sqlHelper.CreateParameter("@package", Id));
 
-            if (installStatusId > 0)
-                Initialize(installStatusId);
-            else
-                throw new ArgumentException("Package with id '" + Id.ToString() + "' is not installed");
+                if (installStatusId > 0)
+                    Initialize(installStatusId);
+                else
+                    throw new ArgumentException("Package with id '" + Id.ToString() + "' is not installed");
+            }
         }
 
         private void Initialize(int id)
         {
-
-            IRecordsReader dr =
-                SqlHelper.ExecuteReader(
-                    "select id, uninstalled, upgradeId, installDate, userId, package, versionMajor, versionMinor, versionPatch from umbracoInstalledPackages where id = @id",
-                    SqlHelper.CreateParameter("@id", id));
-
-            if (dr.Read())
-            {
-                Id = id;
-                Uninstalled = dr.GetBoolean("uninstalled");
-                UpgradeId = dr.GetInt("upgradeId");
-                InstallDate = dr.GetDateTime("installDate");
-                User = User.GetUser(dr.GetInt("userId"));
-                PackageId = dr.GetGuid("package");
-                VersionMajor = dr.GetInt("versionMajor");
-                VersionMinor = dr.GetInt("versionMinor");
-                VersionPatch = dr.GetInt("versionPatch");
+            using (var sqlHelper = Application.SqlHelper) {
+                using (IRecordsReader dr =
+                 sqlHelper.ExecuteReader(
+                     "select id, uninstalled, upgradeId, installDate, userId, package, versionMajor, versionMinor, versionPatch from umbracoInstalledPackages where id = @id",
+                     sqlHelper.CreateParameter("@id", id)))
+                {
+                    if (dr.Read())
+                    {
+                        Id = id;
+                        Uninstalled = dr.GetBoolean("uninstalled");
+                        UpgradeId = dr.GetInt("upgradeId");
+                        InstallDate = dr.GetDateTime("installDate");
+                        User = User.GetUser(dr.GetInt("userId"));
+                        PackageId = dr.GetGuid("package");
+                        VersionMajor = dr.GetInt("versionMajor");
+                        VersionMinor = dr.GetInt("versionMinor");
+                        VersionPatch = dr.GetInt("versionPatch");
+                    }
+                }
             }
-            dr.Close();
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
         public void Save()
         {
-
-            IParameter[] values = {
-                SqlHelper.CreateParameter("@uninstalled", Uninstalled),
-                SqlHelper.CreateParameter("@upgradeId", UpgradeId),
-                SqlHelper.CreateParameter("@installDate", InstallDate),
-                SqlHelper.CreateParameter("@userId", User.Id),
-                SqlHelper.CreateParameter("@versionMajor", VersionMajor),
-                SqlHelper.CreateParameter("@versionMinor", VersionMinor),
-                SqlHelper.CreateParameter("@versionPatch", VersionPatch),
-                SqlHelper.CreateParameter("@id", Id)
-            };
-
-            // check if package status exists
-            if (Id == 0)
+            using (var sqlHelper = Application.SqlHelper)
             {
-                // The method is synchronized
-                SqlHelper.ExecuteNonQuery("INSERT INTO umbracoInstalledPackages (uninstalled, upgradeId, installDate, userId, versionMajor, versionMinor, versionPatch) VALUES (@uninstalled, @upgradeId, @installDate, @userId, @versionMajor, @versionMinor, @versionPatch)", values);
-                Id = SqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM umbracoInstalledPackages");
-            }
+                IParameter[] values = {
+                    sqlHelper.CreateParameter("@uninstalled", Uninstalled),
+                    sqlHelper.CreateParameter("@upgradeId", UpgradeId),
+                    sqlHelper.CreateParameter("@installDate", InstallDate),
+                    sqlHelper.CreateParameter("@userId", User.Id),
+                    sqlHelper.CreateParameter("@versionMajor", VersionMajor),
+                    sqlHelper.CreateParameter("@versionMinor", VersionMinor),
+                    sqlHelper.CreateParameter("@versionPatch", VersionPatch),
+                    sqlHelper.CreateParameter("@id", Id)
+                };
 
-            SqlHelper.ExecuteNonQuery(
-                "update umbracoInstalledPackages set " +
-                "uninstalled = @uninstalled, " +
-                "upgradeId = @upgradeId, " +
-                "installDate = @installDate, " +
-                "userId = @userId, " +
-                "versionMajor = @versionMajor, " +
-                "versionMinor = @versionMinor, " +
-                "versionPatch = @versionPatch " +
-                "where id = @id",
-                values);
+                // check if package status exists
+                if (Id == 0)
+                {
+                    // The method is synchronized
+                    sqlHelper.ExecuteNonQuery("INSERT INTO umbracoInstalledPackages (uninstalled, upgradeId, installDate, userId, versionMajor, versionMinor, versionPatch) VALUES (@uninstalled, @upgradeId, @installDate, @userId, @versionMajor, @versionMinor, @versionPatch)", values);
+                    Id = sqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM umbracoInstalledPackages");
+                }
+
+                sqlHelper.ExecuteNonQuery(
+                    "update umbracoInstalledPackages set " +
+                    "uninstalled = @uninstalled, " +
+                    "upgradeId = @upgradeId, " +
+                    "installDate = @installDate, " +
+                    "userId = @userId, " +
+                    "versionMajor = @versionMajor, " +
+                    "versionMinor = @versionMinor, " +
+                    "versionPatch = @versionPatch " +
+                    "where id = @id",
+                    values);
+            }
         }
 
         public bool Uninstalled { get; set; }

--- a/src/umbraco.cms/businesslogic/Property/Property.cs
+++ b/src/umbraco.cms/businesslogic/Property/Property.cs
@@ -27,6 +27,10 @@ namespace umbraco.cms.businesslogic.property
         private interfaces.IData _data;
         private int _id;
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }
@@ -51,13 +55,16 @@ namespace umbraco.cms.businesslogic.property
         public Property(int Id)
         {
             _id = Id;
-            _pt = PropertyType.GetPropertyType(
-                SqlHelper.ExecuteScalar<int>("select propertytypeid from cmsPropertyData where id = @id",
-                                             SqlHelper.CreateParameter("@id", Id)));
-            if (_pt.DataTypeDefinition.DataType == null)
-                throw new Exception(string.Format("Could not load datatype '{0}'", _pt.DataTypeDefinition.Text));
-            _data = _pt.DataTypeDefinition.DataType.Data;
-            _data.PropertyId = Id;
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                _pt = PropertyType.GetPropertyType(
+                    sqlHelper.ExecuteScalar<int>("select propertytypeid from cmsPropertyData where id = @id",
+                        sqlHelper.CreateParameter("@id", Id)));
+                if (_pt.DataTypeDefinition.DataType == null)
+                    throw new Exception(string.Format("Could not load datatype '{0}'", _pt.DataTypeDefinition.Text));
+                _data = _pt.DataTypeDefinition.DataType.Data;
+                _data.PropertyId = Id;
+            }
         }
 
         internal Property(Umbraco.Core.Models.Property property)
@@ -96,17 +103,20 @@ namespace umbraco.cms.businesslogic.property
         {
             get
             {
-                using (IRecordsReader dr = SqlHelper.ExecuteReader("SELECT versionId FROM cmsPropertyData WHERE id = " + _id.ToString()))
+                using (var sqlHelper = Application.SqlHelper)
+                using (IRecordsReader dr = sqlHelper.ExecuteReader("SELECT versionId FROM cmsPropertyData WHERE id = " + _id.ToString()))
                 {
                     dr.Read();
                     return dr.GetGuid("versionId");
                 }
             }
         }
+
         public int Id
         {
             get { return _id; }
         }
+
         public propertytype.PropertyType PropertyType
         {
             get
@@ -132,10 +142,16 @@ namespace umbraco.cms.businesslogic.property
 
         public void delete()
         {
-            int contentId = SqlHelper.ExecuteScalar<int>("Select contentNodeId from cmsPropertyData where Id = " + _id);
-            SqlHelper.ExecuteNonQuery("Delete from cmsPropertyData where PropertyTypeId =" + _pt.Id + " And contentNodeId = " + contentId);
-            _data.Delete();
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                int contentId = sqlHelper.ExecuteScalar<int>("Select contentNodeId from cmsPropertyData where Id = " + _id);
+
+                sqlHelper.ExecuteNonQuery("Delete from cmsPropertyData where PropertyTypeId =" + _pt.Id + " And contentNodeId = " + contentId);
+
+                _data.Delete();
+            }
         }
+
         public XmlNode ToXml(XmlDocument xd)
         {
             var serializer = new EntityXmlSerializer();
@@ -143,21 +159,23 @@ namespace umbraco.cms.businesslogic.property
             return xml.GetXmlNode(xd);
         }
 
-
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public static Property MakeNew(propertytype.PropertyType pt, Content c, Guid versionId)
+        public static Property MakeNew(PropertyType pt, Content c, Guid versionId)
         {
             int newPropertyId = 0;
             // The method is synchronized
-            SqlHelper.ExecuteNonQuery("INSERT INTO cmsPropertyData (contentNodeId, versionId, propertyTypeId) VALUES(@contentNodeId, @versionId, @propertyTypeId)",
-                                      SqlHelper.CreateParameter("@contentNodeId", c.Id),
-                                      SqlHelper.CreateParameter("@versionId", versionId),
-                                      SqlHelper.CreateParameter("@propertyTypeId", pt.Id));
-            newPropertyId = SqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM cmsPropertyData");
-            interfaces.IData d = pt.DataTypeDefinition.DataType.Data;
-            d.MakeNew(newPropertyId);
-            return new Property(newPropertyId, pt);
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                sqlHelper.ExecuteNonQuery(
+                    "INSERT INTO cmsPropertyData (contentNodeId, versionId, propertyTypeId) VALUES(@contentNodeId, @versionId, @propertyTypeId)",
+                    sqlHelper.CreateParameter("@contentNodeId", c.Id),
+                    sqlHelper.CreateParameter("@versionId", versionId),
+                    sqlHelper.CreateParameter("@propertyTypeId", pt.Id));
+                newPropertyId = sqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM cmsPropertyData");
+                interfaces.IData d = pt.DataTypeDefinition.DataType.Data;
+                d.MakeNew(newPropertyId);
+                return new Property(newPropertyId, pt);
+            }
         }
     }
-
 }

--- a/src/umbraco.cms/businesslogic/RecycleBin.cs
+++ b/src/umbraco.cms/businesslogic/RecycleBin.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using umbraco.BusinessLogic;
 using Umbraco.Core;
 using umbraco.DataLayer;
 using umbraco.cms.businesslogic.web;
@@ -106,7 +107,8 @@ namespace umbraco.cms.businesslogic
             string sql = String.Format(RecycleBin.m_ChildCountSQL,
                         (int) type);
 
-            return SqlHelper.ExecuteScalar<int>(sql, SqlHelper.CreateParameter("@nodeObjectType", objectType));
+            using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<int>(sql, sqlHelper.CreateParameter("@nodeObjectType", objectType));
         }
         #endregion
 
@@ -157,9 +159,10 @@ namespace umbraco.cms.businesslogic
             {
                 System.Collections.ArrayList tmp = new System.Collections.ArrayList();
 
-                using (IRecordsReader dr = SqlHelper.ExecuteReader(m_ChildSQL,
-                            SqlHelper.CreateParameter("@parentId", this.Id),
-                            SqlHelper.CreateParameter("@type", _nodeObjectType)))
+                using (var sqlHelper = Application.SqlHelper)
+                using (IRecordsReader dr = sqlHelper.ExecuteReader(m_ChildSQL,
+                            sqlHelper.CreateParameter("@parentId", this.Id),
+                            sqlHelper.CreateParameter("@type", _nodeObjectType)))
                 {
                     while (dr.Read())
                     {

--- a/src/umbraco.cms/businesslogic/Tags/Tag.cs
+++ b/src/umbraco.cms/businesslogic/Tags/Tag.cs
@@ -118,11 +118,9 @@ namespace umbraco.cms.businesslogic.Tags
                 sql += "left outer join cmsTagRelationship on (cmsTags.id = cmsTagRelationship.TagId and cmsTagRelationship.nodeId = " + string.Format("{0}", nodeId) + ") ";
                 sql += "where cmsTagRelationship.tagId is null and cmsTags.id = " + string.Format("{0}", id);
 
-                SqlHelper.ExecuteNonQuery(sql);
-
-
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery(sql);
             }
-
         }
 
         public static void MergeTagsToNode(int nodeId, string tags, string group)
@@ -164,7 +162,8 @@ namespace umbraco.cms.businesslogic.Tags
             sql += " inner join  cmsTags as OldTags on (cmsTagRelationship.tagId = OldTags.Id) ";
             sql += " where NewTagsSet.Id is null ";
             sql += " )";
-            SqlHelper.ExecuteNonQuery(sql);
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery(sql);
 
             //adds any tags found in csv that aren't in cmsTag for that group
             sql = "insert into cmsTags (Tag," + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("Group") + @") ";
@@ -172,7 +171,8 @@ namespace umbraco.cms.businesslogic.Tags
             sql += " " + TagSet + " ";
             sql += " left outer join cmsTags on (TagSet.Tag = cmsTags.Tag and TagSet." + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("Group") + " = cmsTags." + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("Group") + ")";
             sql += " where cmsTags.Id is null ";
-            SqlHelper.ExecuteNonQuery(sql);
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery(sql);
 
             //adds any tags found in csv that aren't in tagrelationships
             sql = "insert into cmsTagRelationship (TagId,NodeId,propertyTypeId) ";
@@ -185,7 +185,8 @@ namespace umbraco.cms.businesslogic.Tags
             sql += "left outer join cmsTagRelationship ";
             sql += "on (cmsTagRelationship.TagId = NewTagsSet.Id and cmsTagRelationship.NodeId = " + string.Format("{0}", nodeId) + ") ";
             sql += "where cmsTagRelationship.tagId is null ";
-            SqlHelper.ExecuteNonQuery(sql);
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery(sql);
 
         }
 
@@ -195,10 +196,12 @@ namespace umbraco.cms.businesslogic.Tags
         /// <param name="tagId"></param>
         public static void RemoveTag(int tagId)
         {
-            SqlHelper.ExecuteNonQuery("DELETE FROM cmsTagRelationship WHERE (tagid = @tagId)",
-               SqlHelper.CreateParameter("@tagId", tagId));
-            SqlHelper.ExecuteNonQuery("DELETE FROM cmsTags WHERE (id = @tagId)",
-               SqlHelper.CreateParameter("@tagId", tagId));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("DELETE FROM cmsTagRelationship WHERE (tagid = @tagId)",
+                    sqlHelper.CreateParameter("@tagId", tagId));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("DELETE FROM cmsTags WHERE (id = @tagId)", 
+                    sqlHelper.CreateParameter("@tagId", tagId));
         }
 
         /// <summary>
@@ -207,8 +210,9 @@ namespace umbraco.cms.businesslogic.Tags
         /// <param name="nodeId"></param>
         public static void RemoveTagsFromNode(int nodeId)
         {
-            SqlHelper.ExecuteNonQuery("DELETE FROM cmsTagRelationship WHERE nodeId = @nodeId",
-              SqlHelper.CreateParameter("@nodeId", nodeId));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("DELETE FROM cmsTagRelationship WHERE nodeId = @nodeId",
+                    sqlHelper.CreateParameter("@nodeId", nodeId));
         }
 
         /// <summary>
@@ -218,9 +222,10 @@ namespace umbraco.cms.businesslogic.Tags
         /// <param name="group"></param>
         public static void RemoveTagsFromNode(int nodeId, string group)
         {
-            SqlHelper.ExecuteNonQuery("DELETE FROM cmsTagRelationship WHERE (nodeId = @nodeId) AND EXISTS (SELECT id FROM cmsTags WHERE (cmsTagRelationship.tagId = id) AND (" + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group") + " = @group));",
-               SqlHelper.CreateParameter("@nodeId", nodeId),
-               SqlHelper.CreateParameter("@group", group));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("DELETE FROM cmsTagRelationship WHERE (nodeId = @nodeId) AND EXISTS (SELECT id FROM cmsTags WHERE (cmsTagRelationship.tagId = id) AND (" + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group") + " = @group));",
+                    sqlHelper.CreateParameter("@nodeId", nodeId),
+                    sqlHelper.CreateParameter("@group", group));
         }
 
         /// <summary>
@@ -234,17 +239,19 @@ namespace umbraco.cms.businesslogic.Tags
             int tagId = GetTagId(tag, group);
             if (tagId != 0)
             {
-                SqlHelper.ExecuteNonQuery("DELETE FROM cmsTagRelationship WHERE (nodeId = @nodeId and tagId = @tagId)",
-                    SqlHelper.CreateParameter("@nodeId", nodeId),
-                    SqlHelper.CreateParameter("@tagId", tagId));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("DELETE FROM cmsTagRelationship WHERE (nodeId = @nodeId and tagId = @tagId)",
+                        sqlHelper.CreateParameter("@nodeId", nodeId),
+                        sqlHelper.CreateParameter("@tagId", tagId));
             }
         }
 
         public static int AddTag(string tag, string group)
         {
-            SqlHelper.ExecuteNonQuery("INSERT INTO cmsTags(tag," + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group") + ") VALUES (@tag,@group)",
-                SqlHelper.CreateParameter("@tag", tag.Trim()),
-                SqlHelper.CreateParameter("@group", group));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("INSERT INTO cmsTags(tag," + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group") + ") VALUES (@tag,@group)",
+                    sqlHelper.CreateParameter("@tag", tag.Trim()),
+                    sqlHelper.CreateParameter("@group", group));
             return GetTagId(tag, group);
         }
 
@@ -252,13 +259,15 @@ namespace umbraco.cms.businesslogic.Tags
         {
             int retval = 0;
             string sql = "SELECT id FROM cmsTags where tag=@tag AND " + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group") + "=@group;";
-            object result = SqlHelper.ExecuteScalar<object>(sql,
-                SqlHelper.CreateParameter("@tag", tag),
-                SqlHelper.CreateParameter("@group", group));
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                object result = sqlHelper.ExecuteScalar<object>(sql,
+                    sqlHelper.CreateParameter("@tag", tag),
+                    sqlHelper.CreateParameter("@group", group));
 
-            if (result != null)
-                retval = int.Parse(result.ToString());
-
+                if (result != null)
+                    retval = int.Parse(result.ToString());
+            }
             return retval;
         }
 
@@ -269,10 +278,10 @@ namespace umbraco.cms.businesslogic.Tags
                   WHERE cmsTags." + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group") + @" = @group AND cmsTagRelationship.nodeid = @nodeid
                   GROUP BY cmsTags.id, cmsTags.tag, cmsTags." + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group");
 
-            return ConvertSqlToTags(sql,
-                SqlHelper.CreateParameter("@group", group),
-                SqlHelper.CreateParameter("@nodeid", nodeId));
-
+            using (var sqlHelper = Application.SqlHelper)
+                return ConvertSqlToTags(sql,
+                    sqlHelper.CreateParameter("@group", group),
+                    sqlHelper.CreateParameter("@nodeid", nodeId));
         }
 
         /// <summary>
@@ -288,8 +297,8 @@ namespace umbraco.cms.businesslogic.Tags
                         WHERE cmsTagRelationShip.nodeid = @nodeId
                         GROUP BY cmsTags.id, cmsTags.tag, cmsTags." + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group");
 
-            return ConvertSqlToTags(sql, SqlHelper.CreateParameter("@nodeId", nodeId));
-
+            using (var sqlHelper = Application.SqlHelper)
+                return ConvertSqlToTags(sql, sqlHelper.CreateParameter("@nodeId", nodeId));
         }
 
         /// <summary>
@@ -305,8 +314,8 @@ namespace umbraco.cms.businesslogic.Tags
                             WHERE cmsTags." + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group") + @" = @group
                             GROUP BY cmsTags.id, cmsTags.tag, cmsTags." + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("group");
 
-            return ConvertSqlToTags(sql, SqlHelper.CreateParameter("@group", group));
-
+            using (var sqlHelper = Application.SqlHelper)
+                return ConvertSqlToTags(sql, sqlHelper.CreateParameter("@group", group));
         }
 
         /// <summary>
@@ -334,8 +343,9 @@ namespace umbraco.cms.businesslogic.Tags
                             INNER JOIN umbracoNode ON cmsTagRelationShip.nodeId = umbracoNode.id
                             WHERE (cmsTags.tag IN ({0})) AND nodeObjectType=@nodeType";
 
-            using (IRecordsReader rr = SqlHelper.ExecuteReader(string.Format(sql, GetSqlStringArray(tags)),
-                SqlHelper.CreateParameter("@nodeType", Document._objectType)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader rr = sqlHelper.ExecuteReader(string.Format(sql, GetSqlStringArray(tags)),
+                sqlHelper.CreateParameter("@nodeType", Document._objectType)))
             {
                 while (rr.Read())
                 {
@@ -355,7 +365,9 @@ namespace umbraco.cms.businesslogic.Tags
 
             string sql = @"SELECT DISTINCT cmsTagRelationShip.nodeid from cmsTagRelationShip
                             INNER JOIN cmsTags ON cmsTagRelationShip.tagid = cmsTags.id WHERE (cmsTags.tag IN (" + GetSqlStringArray(tags) + "))";
-            using (IRecordsReader rr = SqlHelper.ExecuteReader(sql))
+
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader rr = sqlHelper.ExecuteReader(sql))
             {
                 while (rr.Read())
                 {
@@ -364,12 +376,14 @@ namespace umbraco.cms.businesslogic.Tags
             }
             return nodes;
         }
+
         private static string GetSqlSet(string commaSeparatedArray, string group)
         {
             // create array
             var array = commaSeparatedArray.Trim().Split(',').ToList().ConvertAll(tag => string.Format("select '{0}' as Tag, '{1}' as " + SqlSyntaxContext.SqlSyntaxProvider.GetQuotedColumnName("Group"), tag.Replace("'", ""), group)).ToArray();
             return "(" + string.Join(" union ", array).Replace("  ", " ") + ") as TagSet";
         }
+
         private static string GetSqlStringArray(string commaSeparatedArray)
         {
             // create array
@@ -382,7 +396,8 @@ namespace umbraco.cms.businesslogic.Tags
                 string trimmedItem = item.Trim();
                 if (trimmedItem.Length > 0)
                 {
-                    sqlArray.Append("'").Append(SqlHelper.EscapeString(trimmedItem)).Append("',");
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlArray.Append("'").Append(sqlHelper.EscapeString(trimmedItem)).Append("',");
                 }
             }
 
@@ -395,7 +410,8 @@ namespace umbraco.cms.businesslogic.Tags
         private static IEnumerable<Tag> ConvertSqlToTags(string sql, params IParameter[] param)
         {
             List<Tag> tags = new List<Tag>();
-            using (IRecordsReader rr = SqlHelper.ExecuteReader(sql, param))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader rr = sqlHelper.ExecuteReader(sql, param))
             {
                 while (rr.Read())
                 {
@@ -411,13 +427,13 @@ namespace umbraco.cms.businesslogic.Tags
             return tags;
         }
 
-        private static ISqlHelper SqlHelper
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
+        protected static ISqlHelper SqlHelper
         {
-            get
-            {
-                return Application.SqlHelper;
-            }
+            get { return Application.SqlHelper; }
         }
-
     }
 }

--- a/src/umbraco.cms/businesslogic/datatype/BaseDataType.cs
+++ b/src/umbraco.cms/businesslogic/datatype/BaseDataType.cs
@@ -14,12 +14,7 @@ namespace umbraco.cms.businesslogic.datatype
 		private int _datatypedefinitionid;
 		private string _datafield = "";
 		private DBTypes _DBType;
-
-        private static ISqlHelper SqlHelper
-        {
-            get { return Application.SqlHelper; }
-        }
-
+        
 		public BaseDataType()
 		{}
 
@@ -48,7 +43,8 @@ namespace umbraco.cms.businesslogic.datatype
 			}
 			set {
 				_DBType = value;
-				 SqlHelper.ExecuteNonQuery("update cmsDataType set  dbType = '" + value.ToString() + "' where nodeId = @datadefinitionid", SqlHelper.CreateParameter("@datadefinitionid",_datatypedefinitionid));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("update cmsDataType set  dbType = '" + value.ToString() + "' where nodeId = @datadefinitionid", sqlHelper.CreateParameter("@datadefinitionid",_datatypedefinitionid));
 			}
 		}
 		// Umbraco legacy - get the datafield - the columnname of the cmsPropertyData table
@@ -61,10 +57,13 @@ namespace umbraco.cms.businesslogic.datatype
             {
                 if (_datafield == "")
                 {
-                    string dbtypestr = SqlHelper.ExecuteScalar<string>("select dbType from cmsDataType where nodeId = @datadefinitionid", SqlHelper.CreateParameter("@datadefinitionid", _datatypedefinitionid));
-                    DBTypes DataTypeSQLType = GetDBType(dbtypestr);
-                    _DBType = DataTypeSQLType;
-                    _datafield = GetDataFieldName(_DBType);
+                    using (var sqlHelper = Application.SqlHelper)
+                    { 
+                        string dbtypestr = sqlHelper.ExecuteScalar<string>("select dbType from cmsDataType where nodeId = @datadefinitionid", sqlHelper.CreateParameter("@datadefinitionid", _datatypedefinitionid));
+                        DBTypes DataTypeSQLType = GetDBType(dbtypestr);
+                        _DBType = DataTypeSQLType;
+                        _datafield = GetDataFieldName(_DBType);
+                    }
                 }
                 return _datafield;
             }            

--- a/src/umbraco.cms/businesslogic/datatype/DataEditorSettingsStorage.cs
+++ b/src/umbraco.cms/businesslogic/datatype/DataEditorSettingsStorage.cs
@@ -27,23 +27,21 @@ namespace umbraco.cms.businesslogic.datatype
 
         public List<Setting<string, string>> GetSettings(int dataTypeNodeID)
         {
-
             string sql = "select * from cmsDataTypePreValues where datatypenodeid = @datatypenodeid";
-            IRecordsReader settingsReader = sqlHelper.ExecuteReader(sql, sqlHelper.CreateParameter("@datatypenodeid", dataTypeNodeID));
-
-            List<Setting<string, string>> settings = new List<Setting<string, string>>();
-
-            while (settingsReader.Read())
+            using (IRecordsReader settingsReader = sqlHelper.ExecuteReader(sql, sqlHelper.CreateParameter("@datatypenodeid", dataTypeNodeID)))
             {
-                Setting<string, string> setting = new Setting<string, string>();
-                setting.Key = settingsReader.GetString("alias");
-                setting.Value = settingsReader.GetString("value");
-                settings.Add(setting);
+                List<Setting<string, string>> settings = new List<Setting<string, string>>();
+
+                while (settingsReader.Read())
+                {
+                    Setting<string, string> setting = new Setting<string, string>();
+                    setting.Key = settingsReader.GetString("alias");
+                    setting.Value = settingsReader.GetString("value");
+                    settings.Add(setting);
+                }
+
+                return settings;
             }
-
-            settingsReader.Dispose();
-
-            return settings;
         }
 
 

--- a/src/umbraco.cms/businesslogic/datatype/DefaultData.cs
+++ b/src/umbraco.cms/businesslogic/datatype/DefaultData.cs
@@ -25,6 +25,9 @@ namespace umbraco.cms.businesslogic.datatype
 		private Guid? _version = null;
 		private int? _nodeId = null;
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
         [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {

--- a/src/umbraco.cms/businesslogic/datatype/DefaultPreValueEditor.cs
+++ b/src/umbraco.cms/businesslogic/datatype/DefaultPreValueEditor.cs
@@ -30,7 +30,10 @@ namespace umbraco.cms.businesslogic.datatype
 
         private Dictionary<string, DataEditorSettingType> dtSettings = new Dictionary<string, DataEditorSettingType>();
 
-
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         public static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }
@@ -116,8 +119,8 @@ namespace umbraco.cms.businesslogic.datatype
                     else
                         throw new ArgumentException("Datatype is not initialized");
 
-                    _prevalue =
-                        SqlHelper.ExecuteScalar<string>("Select [value] from cmsDataTypePreValues where DataTypeNodeId = " + defId);
+                    using (var sqlHelper = Application.SqlHelper)
+                        _prevalue = sqlHelper.ExecuteScalar<string>("Select [value] from cmsDataTypePreValues where DataTypeNodeId = " + defId);
                 }
                 return _prevalue;
             }
@@ -133,13 +136,17 @@ namespace umbraco.cms.businesslogic.datatype
 
                 _prevalue = value;
                 ensurePrevalue();
-                IParameter[] SqlParams = new IParameter[]
+                using (var sqlHelper = Application.SqlHelper)
+                {
+                    IParameter[] SqlParams = new IParameter[]
                     {
-                        SqlHelper.CreateParameter("@value", _textbox.Text),
-                        SqlHelper.CreateParameter("@dtdefid", defId)
+                        sqlHelper.CreateParameter("@value", _textbox.Text),
+                        sqlHelper.CreateParameter("@dtdefid", defId)
                     };
-                // update prevalue
-                SqlHelper.ExecuteNonQuery("update cmsDataTypePreValues set [value] = @value where datatypeNodeId = @dtdefid", SqlParams);
+
+                    // update prevalue
+                    sqlHelper.ExecuteNonQuery("update cmsDataTypePreValues set [value] = @value where datatypeNodeId = @dtdefid", SqlParams);
+                }
             }
         }
 
@@ -257,8 +264,9 @@ namespace umbraco.cms.businesslogic.datatype
         [Obsolete("Use the PreValues class for data access instead")]
         public static string GetPrevalueFromId(int Id)
         {
-            return SqlHelper.ExecuteScalar<string>("Select [value] from cmsDataTypePreValues where id = @id",
-                                                   SqlHelper.CreateParameter("@id", Id));
+            using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<string>("Select [value] from cmsDataTypePreValues where id = @id",
+                                                   sqlHelper.CreateParameter("@id", Id));
         }
 
 

--- a/src/umbraco.cms/businesslogic/language/Item.cs
+++ b/src/umbraco.cms/businesslogic/language/Item.cs
@@ -20,11 +20,9 @@ namespace umbraco.cms.businesslogic.language
     [Obsolete("This class is no longer used, nor should it ever be used, it will be removed from the codebase in future versions")]
     public class Item
     {
-
         /// <summary>
-        /// Gets the SQL helper.
+        /// Unused, please do not use
         /// </summary>
-        /// <value>The SQL helper.</value>
         [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {

--- a/src/umbraco.cms/businesslogic/language/Language.cs
+++ b/src/umbraco.cms/businesslogic/language/Language.cs
@@ -36,9 +36,8 @@ namespace umbraco.cms.businesslogic.language
         #region Constants and static members
         
         /// <summary>
-        /// Gets the SQL helper.
+        /// Unused, please do not use
         /// </summary>
-        /// <value>The SQL helper.</value>
         [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {

--- a/src/umbraco.cms/businesslogic/macro/Macro.cs
+++ b/src/umbraco.cms/businesslogic/macro/Macro.cs
@@ -31,7 +31,11 @@ namespace umbraco.cms.businesslogic.macro
 	{
         //initialize empty model
 	    internal IMacro MacroEntity = new Umbraco.Core.Models.Macro();
-
+        
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }

--- a/src/umbraco.cms/businesslogic/macro/MacroProperty.cs
+++ b/src/umbraco.cms/businesslogic/macro/MacroProperty.cs
@@ -22,6 +22,10 @@ namespace umbraco.cms.businesslogic.macro
     [Obsolete("This is no longer used, use the IMacroService and related models instead")]
     public class MacroProperty
     {
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }
@@ -142,7 +146,8 @@ namespace umbraco.cms.businesslogic.macro
 
         private void Setup()
         {
-            using (var dr = SqlHelper.ExecuteReader("select macro, editorAlias, macroPropertySortOrder, macroPropertyAlias, macroPropertyName from cmsMacroProperty where id = @id", SqlHelper.CreateParameter("@id", Id)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (var dr = sqlHelper.ExecuteReader("select macro, editorAlias, macroPropertySortOrder, macroPropertyAlias, macroPropertyName from cmsMacroProperty where id = @id", sqlHelper.CreateParameter("@id", Id)))
             {
                 if (dr.Read())
                 {
@@ -165,7 +170,8 @@ namespace umbraco.cms.businesslogic.macro
         /// </summary>
         public void Delete()
         {
-            SqlHelper.ExecuteNonQuery("delete from cmsMacroProperty where id = @id", SqlHelper.CreateParameter("@id", this.Id));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("delete from cmsMacroProperty where id = @id", sqlHelper.CreateParameter("@id", this.Id));
         }
 
         public void Save()
@@ -174,19 +180,19 @@ namespace umbraco.cms.businesslogic.macro
             {
                 MacroProperty mp = MakeNew(Macro, Alias, Name, ParameterEditorAlias);
                 Id = mp.Id;
-
             }
             else
             {
-                SqlHelper.ExecuteNonQuery("UPDATE cmsMacroProperty set macro = @macro, " +
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("UPDATE cmsMacroProperty set macro = @macro, " +
                                           "macropropertyAlias = @alias, macroPropertyName = @name, " +
                                           "editorAlias = @editorAlias, macroPropertySortOrder = @so WHERE id = @id",
-                                          SqlHelper.CreateParameter("@id", Id),
-                                          SqlHelper.CreateParameter("@macro", Macro.Id),
-                                          SqlHelper.CreateParameter("@alias", Alias),
-                                          SqlHelper.CreateParameter("@name", Name),
-                                          SqlHelper.CreateParameter("@editorAlias", ParameterEditorAlias),
-                                          SqlHelper.CreateParameter("@so", SortOrder));
+                                          sqlHelper.CreateParameter("@id", Id),
+                                          sqlHelper.CreateParameter("@macro", Macro.Id),
+                                          sqlHelper.CreateParameter("@alias", Alias),
+                                          sqlHelper.CreateParameter("@name", Name),
+                                          sqlHelper.CreateParameter("@editorAlias", ParameterEditorAlias),
+                                          sqlHelper.CreateParameter("@so", SortOrder));
             }
         }
 
@@ -216,7 +222,8 @@ namespace umbraco.cms.businesslogic.macro
         public static MacroProperty[] GetProperties(int macroId)
         {
             var props = new List<MacroProperty>();
-            using (IRecordsReader dr = SqlHelper.ExecuteReader("select id from cmsMacroProperty where macro = @macroId order by macroPropertySortOrder, id ASC", SqlHelper.CreateParameter("@macroId", macroId)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader("select id from cmsMacroProperty where macro = @macroId order by macroPropertySortOrder, id ASC", sqlHelper.CreateParameter("@macroId", macroId)))
             {                
                 while (dr.Read())
                 {
@@ -244,7 +251,6 @@ namespace umbraco.cms.businesslogic.macro
         [MethodImpl(MethodImplOptions.Synchronized)]
         public static MacroProperty MakeNew(Macro macro, string alias, string name, string editorAlias)
         {
-
             //try to get the new mapped parameter editor
             var mapped = LegacyParameterEditorAliasConverter.GetNewAliasFromLegacyAlias(editorAlias, false);
             if (mapped.IsNullOrWhiteSpace() == false)
@@ -254,13 +260,17 @@ namespace umbraco.cms.businesslogic.macro
 
             int macroPropertyId = 0;
             // The method is synchronized
-            SqlHelper.ExecuteNonQuery("INSERT INTO cmsMacroProperty (macro, macropropertyAlias, macroPropertyName, editorAlias) VALUES (@macro, @alias, @name, @editorAlias)",
-                SqlHelper.CreateParameter("@macro", macro.Id),
-                SqlHelper.CreateParameter("@alias", alias),
-                SqlHelper.CreateParameter("@name", name),
-                SqlHelper.CreateParameter("@editorAlias", editorAlias));
-            macroPropertyId = SqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM cmsMacroProperty");
-            return new MacroProperty(macroPropertyId);
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                sqlHelper.ExecuteNonQuery(
+                    "INSERT INTO cmsMacroProperty (macro, macropropertyAlias, macroPropertyName, editorAlias) VALUES (@macro, @alias, @name, @editorAlias)",
+                    sqlHelper.CreateParameter("@macro", macro.Id),
+                    sqlHelper.CreateParameter("@alias", alias),
+                    sqlHelper.CreateParameter("@name", name),
+                    sqlHelper.CreateParameter("@editorAlias", editorAlias));
+                macroPropertyId = sqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM cmsMacroProperty");
+                return new MacroProperty(macroPropertyId);
+            }
         }
 
         #endregion

--- a/src/umbraco.cms/businesslogic/macro/macroPropertyType.cs
+++ b/src/umbraco.cms/businesslogic/macro/macroPropertyType.cs
@@ -13,6 +13,10 @@ namespace umbraco.cms.businesslogic.macro
     [Obsolete("This class is no longer used, the cmsMacroPropertyType has been removed, all methods will return empty collections and not perform any functions")]
     public class MacroPropertyType
     {
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }

--- a/src/umbraco.cms/businesslogic/member/MemberGroup.cs
+++ b/src/umbraco.cms/businesslogic/member/MemberGroup.cs
@@ -5,6 +5,7 @@ using Umbraco.Core.Models;
 using Umbraco.Core.Persistence.Querying;
 using umbraco.DataLayer;
 using System.Collections;
+using umbraco.BusinessLogic;
 using umbraco.cms.businesslogic.web;
 using Umbraco.Core;
 
@@ -136,9 +137,10 @@ namespace umbraco.cms.businesslogic.member
 
 	    public bool HasMember(int memberId)
 	    {
-	        return SqlHelper.ExecuteScalar<int>("select count(member) from cmsMember2MemberGroup where member = @member and memberGroup = @memberGroup",
-	            SqlHelper.CreateParameter("@member", memberId),
-	            SqlHelper.CreateParameter("@memberGroup", Id)) > 0;
+            using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<int>("select count(member) from cmsMember2MemberGroup where member = @member and memberGroup = @memberGroup",
+	            sqlHelper.CreateParameter("@member", memberId),
+	            sqlHelper.CreateParameter("@memberGroup", Id)) > 0;
 	    }
 
 	    /// <summary>

--- a/src/umbraco.cms/businesslogic/propertytype/PropertyTypeGroup.cs
+++ b/src/umbraco.cms/businesslogic/propertytype/PropertyTypeGroup.cs
@@ -55,41 +55,46 @@ namespace umbraco.cms.businesslogic.propertytype
         {
             if (Id != 0)
             {
-                SqlHelper.ExecuteNonQuery(
-                    @"UPDATE 
-                        cmsPropertyTypeGroup 
-                    SET 
-                        contenttypeNodeId = @contentTypeId,
-                        sortOrder = @sortOrder,                        
-                        text = @name
-                    WHERE
-                        id = @id
-                ",
-                    SqlHelper.CreateParameter("@id", Id),
-                    SqlHelper.CreateParameter("@contentTypeId", ContentTypeId),
-                    SqlHelper.CreateParameter("@sortOrder", SortOrder),
-                    SqlHelper.CreateParameter("@name", Name)
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery(
+                        @"UPDATE 
+                            cmsPropertyTypeGroup 
+                        SET 
+                            contenttypeNodeId = @contentTypeId,
+                            sortOrder = @sortOrder,                        
+                            text = @name
+                        WHERE
+                            id = @id
+                    ",
+                        sqlHelper.CreateParameter("@id", Id),
+                        sqlHelper.CreateParameter("@contentTypeId", ContentTypeId),
+                        sqlHelper.CreateParameter("@sortOrder", SortOrder),
+                        sqlHelper.CreateParameter("@name", Name)
                     );
             }
             else
             {
                 if (SortOrder == -1)
-                    SortOrder = SqlHelper.ExecuteScalar<int>("select count(*) from cmsPropertyTypeGroup where contenttypeNodeId = @nodeId",
-                        SqlHelper.CreateParameter("@nodeId", ContentTypeId)) + 1;
+                    using (var sqlHelper = Application.SqlHelper)
+                        SortOrder = sqlHelper.ExecuteScalar<int>("select count(*) from cmsPropertyTypeGroup where contenttypeNodeId = @nodeId",
+                        sqlHelper.CreateParameter("@nodeId", ContentTypeId)) + 1;
 
-                SqlHelper.ExecuteNonQuery(
-                    @"
-                    INSERT INTO 
-                        cmsPropertyTypeGroup
-                        (contenttypeNodeId, sortOrder, text)
-                    VALUES 
-                        (@contentTypeId, @sortOrder, @name)
-                ",
-                    SqlHelper.CreateParameter("@contentTypeId", ContentTypeId),
-                    SqlHelper.CreateParameter("@sortOrder", SortOrder),
-                    SqlHelper.CreateParameter("@name", Name)
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery(
+                        @"
+                        INSERT INTO 
+                            cmsPropertyTypeGroup
+                            (contenttypeNodeId, sortOrder, text)
+                        VALUES 
+                            (@contentTypeId, @sortOrder, @name)
+                    ",
+                        sqlHelper.CreateParameter("@contentTypeId", ContentTypeId),
+                        sqlHelper.CreateParameter("@sortOrder", SortOrder),
+                        sqlHelper.CreateParameter("@name", Name)
                     );
-                Id = SqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM [cmsPropertyTypeGroup]");
+
+                using (var sqlHelper = Application.SqlHelper)
+                    Id = sqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM [cmsPropertyTypeGroup]");
 
             }
         }
@@ -106,12 +111,14 @@ namespace umbraco.cms.businesslogic.propertytype
             foreach (var ptg in GetPropertyTypeGroups())
                 ptg.Delete();
 
-            SqlHelper.ExecuteNonQuery("DELETE FROM cmsPropertyTypeGroup WHERE id = @id", SqlHelper.CreateParameter("@id", Id));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("DELETE FROM cmsPropertyTypeGroup WHERE id = @id", sqlHelper.CreateParameter("@id", Id));
         }
 
         internal void Load()
         {
-            using (var dr = SqlHelper.ExecuteReader(@" SELECT contenttypeNodeId, sortOrder, text FROM cmsPropertyTypeGroup WHERE id = @id", SqlHelper.CreateParameter("@id", Id)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (var dr = sqlHelper.ExecuteReader(@" SELECT contenttypeNodeId, sortOrder, text FROM cmsPropertyTypeGroup WHERE id = @id", sqlHelper.CreateParameter("@id", Id)))
             {
                 if (dr.Read())
                 {
@@ -132,7 +139,8 @@ namespace umbraco.cms.businesslogic.propertytype
         public static IEnumerable<PropertyTypeGroup> GetPropertyTypeGroupsFromContentType(int contentTypeId)
         {
             var ptgs = new List<PropertyTypeGroup>();
-            using (var dr = SqlHelper.ExecuteReader(@" SELECT id FROM cmsPropertyTypeGroup WHERE contenttypeNodeId = @contentTypeId", SqlHelper.CreateParameter("@contentTypeId", contentTypeId)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (var dr = sqlHelper.ExecuteReader(@" SELECT id FROM cmsPropertyTypeGroup WHERE contenttypeNodeId = @contentTypeId", sqlHelper.CreateParameter("@contentTypeId", contentTypeId)))
             {
                 while (dr.Read())
                 {
@@ -144,9 +152,9 @@ namespace umbraco.cms.businesslogic.propertytype
         }
 
         /// <summary>
-        /// Gets the SQL helper.
+        /// Unused, please do not use
         /// </summary>
-        /// <value>The SQL helper.</value>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }

--- a/src/umbraco.cms/businesslogic/propertytype/propertytype.cs
+++ b/src/umbraco.cms/businesslogic/propertytype/propertytype.cs
@@ -41,6 +41,10 @@ namespace umbraco.cms.businesslogic.propertytype
 
         #endregion
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }
@@ -50,20 +54,24 @@ namespace umbraco.cms.businesslogic.propertytype
 
         public PropertyType(int id)
         {
-            using (IRecordsReader dr = SqlHelper.ExecuteReader(
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader(
                 "Select mandatory, DataTypeId, propertyTypeGroupId, ContentTypeId, sortOrder, alias, name, validationRegExp, description from cmsPropertyType where id=@id",
-                SqlHelper.CreateParameter("@id", id)))
+                sqlHelper.CreateParameter("@id", id)))
             {
                 if (!dr.Read())
                     throw new ArgumentException("Propertytype with id: " + id + " doesnt exist!");
+
                 _mandatory = dr.GetBoolean("mandatory");
                 _id = id;
+
                 if (!dr.IsNull("propertyTypeGroupId"))
                 {
                     _propertyTypeGroup = dr.GetInt("propertyTypeGroupId");
                     //TODO: Remove after refactoring!
                     _tabId = _propertyTypeGroup;
                 }
+
                 _sortOrder = dr.GetInt("sortOrder");
                 _alias = dr.GetString("alias");
                 _name = dr.GetString("Name");
@@ -85,8 +93,9 @@ namespace umbraco.cms.businesslogic.propertytype
             {
                 _DataTypeId = value.Id;
                 InvalidateCache();
-                SqlHelper.ExecuteNonQuery(
-                    "Update cmsPropertyType set DataTypeId = " + value.Id + " where id=" + Id);
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery(
+                        "Update cmsPropertyType set DataTypeId = " + value.Id + " where id=" + Id);
             }
         }
 
@@ -125,9 +134,11 @@ namespace umbraco.cms.businesslogic.propertytype
                 {
                     dbPropertyTypeGroup = DBNull.Value;
                 }
-                SqlHelper.ExecuteNonQuery("Update cmsPropertyType set propertyTypeGroupId = @propertyTypeGroupId where id = @id",
-                              SqlHelper.CreateParameter("@propertyTypeGroupId", dbPropertyTypeGroup),
-                              SqlHelper.CreateParameter("@id", Id));
+
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("Update cmsPropertyType set propertyTypeGroupId = @propertyTypeGroupId where id = @id",
+                              sqlHelper.CreateParameter("@propertyTypeGroupId", dbPropertyTypeGroup),
+                              sqlHelper.CreateParameter("@id", Id));
             }
         }
 
@@ -138,10 +149,10 @@ namespace umbraco.cms.businesslogic.propertytype
             {
                 _mandatory = value;
                 InvalidateCache();
-                SqlHelper.ExecuteNonQuery(
-                    "Update cmsPropertyType set mandatory = @mandatory where id = @id",
-                    SqlHelper.CreateParameter("@mandatory", value),
-                    SqlHelper.CreateParameter("@id", Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("Update cmsPropertyType set mandatory = @mandatory where id = @id",
+                        sqlHelper.CreateParameter("@mandatory", value),
+                        sqlHelper.CreateParameter("@id", Id));
             }
         }
 
@@ -152,9 +163,9 @@ namespace umbraco.cms.businesslogic.propertytype
             {
                 _validationRegExp = value;
                 InvalidateCache();
-                SqlHelper.ExecuteNonQuery(
-                    "Update cmsPropertyType set validationRegExp = @validationRegExp where id = @id",
-                    SqlHelper.CreateParameter("@validationRegExp", value), SqlHelper.CreateParameter("@id", Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("Update cmsPropertyType set validationRegExp = @validationRegExp where id = @id",
+                        sqlHelper.CreateParameter("@validationRegExp", value), sqlHelper.CreateParameter("@id", Id));
             }
         }
 
@@ -189,10 +200,10 @@ namespace umbraco.cms.businesslogic.propertytype
             {
                 _description = value;
                 InvalidateCache();
-                SqlHelper.ExecuteNonQuery(
-                    "Update cmsPropertyType set description = @description where id = @id",
-                    SqlHelper.CreateParameter("@description", value),
-                    SqlHelper.CreateParameter("@id", Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("Update cmsPropertyType set description = @description where id = @id",
+                        sqlHelper.CreateParameter("@description", value),
+                        sqlHelper.CreateParameter("@id", Id));
             }
         }
 
@@ -203,10 +214,10 @@ namespace umbraco.cms.businesslogic.propertytype
             {
                 _sortOrder = value;
                 InvalidateCache();
-                SqlHelper.ExecuteNonQuery(
-                    "Update cmsPropertyType set sortOrder = @sortOrder where id = @id",
-                    SqlHelper.CreateParameter("@sortOrder", value),
-                    SqlHelper.CreateParameter("@id", Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("Update cmsPropertyType set sortOrder = @sortOrder where id = @id",
+                        sqlHelper.CreateParameter("@sortOrder", value),
+                        sqlHelper.CreateParameter("@id", Id));
             }
         }
 
@@ -217,9 +228,10 @@ namespace umbraco.cms.businesslogic.propertytype
             {
                 _alias = value;
                 InvalidateCache();
-                SqlHelper.ExecuteNonQuery("Update cmsPropertyType set alias = @alias where id= @id",
-                                          SqlHelper.CreateParameter("@alias", Casing.SafeAliasWithForcingCheck(_alias)),
-                                          SqlHelper.CreateParameter("@id", Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("Update cmsPropertyType set alias = @alias where id= @id",
+                        sqlHelper.CreateParameter("@alias", Casing.SafeAliasWithForcingCheck(_alias)),
+                        sqlHelper.CreateParameter("@id", Id));
             }
         }
 
@@ -253,10 +265,11 @@ namespace umbraco.cms.businesslogic.propertytype
             {
                 _name = value;
                 InvalidateCache();
-                SqlHelper.ExecuteNonQuery(
-                    "UPDATE cmsPropertyType SET name=@name WHERE id=@id",
-                    SqlHelper.CreateParameter("@name", _name),
-                    SqlHelper.CreateParameter("@id", Id));
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery(
+                        "UPDATE cmsPropertyType SET name=@name WHERE id=@id",
+                        sqlHelper.CreateParameter("@name", _name),
+                        sqlHelper.CreateParameter("@id", Id));
             }
         }
 
@@ -289,17 +302,18 @@ namespace umbraco.cms.businesslogic.propertytype
             try
             {
                 // The method is synchronized, but we'll still look it up with an additional parameter (alias)
-                SqlHelper.ExecuteNonQuery(
-                    "INSERT INTO cmsPropertyType (DataTypeId, ContentTypeId, alias, name) VALUES (@DataTypeId, @ContentTypeId, @alias, @name)",
-                    SqlHelper.CreateParameter("@DataTypeId", dt.Id),
-                    SqlHelper.CreateParameter("@ContentTypeId", ct.Id),
-                    SqlHelper.CreateParameter("@alias", alias),
-                    SqlHelper.CreateParameter("@name", name));
-                pt =
-                    new PropertyType(
-                        SqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM cmsPropertyType WHERE alias=@alias",
-                                                     SqlHelper.CreateParameter("@alias", alias)));
-            }
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery(
+                        "INSERT INTO cmsPropertyType (DataTypeId, ContentTypeId, alias, name) VALUES (@DataTypeId, @ContentTypeId, @alias, @name)",
+                        sqlHelper.CreateParameter("@DataTypeId", dt.Id),
+                        sqlHelper.CreateParameter("@ContentTypeId", ct.Id),
+                        sqlHelper.CreateParameter("@alias", alias),
+                        sqlHelper.CreateParameter("@name", name));
+
+                using (var sqlHelper = Application.SqlHelper)
+                    pt = new PropertyType(sqlHelper.ExecuteScalar<int>("SELECT MAX(id) FROM cmsPropertyType WHERE alias=@alias",
+                            sqlHelper.CreateParameter("@alias", alias)));
+                }
             finally
             {
                 // Clear cached items
@@ -317,8 +331,9 @@ namespace umbraco.cms.businesslogic.propertytype
         public static IEnumerable<PropertyType> GetPropertyTypes()
         {
             var result = new List<PropertyType>();
-            using (IRecordsReader dr =
-                SqlHelper.ExecuteReader("select id from cmsPropertyType order by Name"))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = 
+                sqlHelper.ExecuteReader("select id from cmsPropertyType order by Name"))
             {
                 while (dr.Read())
                 {
@@ -338,9 +353,10 @@ namespace umbraco.cms.businesslogic.propertytype
 		public static IEnumerable<PropertyType> GetPropertyTypesByGroup(int groupId)
         {
             var result = new List<PropertyType>();
-            using (IRecordsReader dr =
-                SqlHelper.ExecuteReader("SELECT id FROM cmsPropertyType WHERE propertyTypeGroupId = @groupId order by SortOrder",
-                    SqlHelper.CreateParameter("@groupId", groupId)))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = 
+                sqlHelper.ExecuteReader("SELECT id FROM cmsPropertyType WHERE propertyTypeGroupId = @groupId order by SortOrder",
+                    sqlHelper.CreateParameter("@groupId", groupId)))
             {
                 while (dr.Read())
                 {
@@ -360,10 +376,11 @@ namespace umbraco.cms.businesslogic.propertytype
         public static IEnumerable<PropertyType> GetByDataTypeDefinition(int dataTypeDefId)
         {
             var result = new List<PropertyType>();
-            using (IRecordsReader dr =
-                SqlHelper.ExecuteReader(
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = 
+                sqlHelper.ExecuteReader(
                     "select id, Name from cmsPropertyType where dataTypeId=@dataTypeId order by Name",
-                    SqlHelper.CreateParameter("@dataTypeId", dataTypeDefId)))
+                    sqlHelper.CreateParameter("@dataTypeId", dataTypeDefId)))
             {
                 while (dr.Read())
                 {
@@ -384,10 +401,12 @@ namespace umbraco.cms.businesslogic.propertytype
             CleanPropertiesOnDeletion(_contenttypeid);
 
             //delete tag refs
-            SqlHelper.ExecuteNonQuery("Delete from cmsTagRelationship where propertyTypeId = " + Id);
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("Delete from cmsTagRelationship where propertyTypeId = " + Id);
 
             // Delete PropertyType ..
-            SqlHelper.ExecuteNonQuery("Delete from cmsPropertyType where id = " + Id);
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("Delete from cmsPropertyType where id = " + Id);
 
 
             // delete cache from either master (via tabid) or current contentype
@@ -416,17 +435,19 @@ namespace umbraco.cms.businesslogic.propertytype
 
             //Initially Content.getContentOfContentType() was called, but because this doesn't include members we resort to sql lookups and deletes
             var tmp = new List<int>();
-            IRecordsReader dr = SqlHelper.ExecuteReader("SELECT nodeId FROM cmsContent INNER JOIN umbracoNode ON cmsContent.nodeId = umbracoNode.id WHERE ContentType = " + contentTypeId + " ORDER BY umbracoNode.text ");
-            while (dr.Read()) tmp.Add(dr.GetInt("nodeId"));
-            dr.Close();
-
-            foreach (var contentId in tmp)
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader("SELECT nodeId FROM cmsContent INNER JOIN umbracoNode ON cmsContent.nodeId = umbracoNode.id WHERE ContentType = @contentTypeId ORDER BY umbracoNode.text", sqlHelper.CreateParameter("contentTypeId", contentTypeId)))
             {
-                SqlHelper.ExecuteNonQuery("DELETE FROM cmsPropertyData WHERE PropertyTypeId =" + this.Id + " AND contentNodeId = " + contentId);
-            }
+                while (dr.Read()) tmp.Add(dr.GetInt("nodeId"));
 
-            // invalidate content type cache
-            ContentType.FlushFromCache(contentTypeId);
+                foreach (var contentId in tmp)
+                {
+                    sqlHelper.ExecuteNonQuery("DELETE FROM cmsPropertyData WHERE PropertyTypeId =" + this.Id + " AND contentNodeId = " + contentId);
+                }
+
+                // invalidate content type cache
+                ContentType.FlushFromCache(contentTypeId);
+            }
         }
 
         public IDataType GetEditControl(object value, bool isPostBack)

--- a/src/umbraco.cms/businesslogic/relation/Relation.cs
+++ b/src/umbraco.cms/businesslogic/relation/Relation.cs
@@ -36,6 +36,10 @@ namespace umbraco.cms.businesslogic.relation
             RelationEntity = found;
         }
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }

--- a/src/umbraco.cms/businesslogic/relation/RelationType.cs
+++ b/src/umbraco.cms/businesslogic/relation/RelationType.cs
@@ -23,12 +23,7 @@ namespace umbraco.cms.businesslogic.relation
 	    internal IRelationType RelationTypeEntity;
 
 		#endregion
-
-        private static ISqlHelper SqlHelper
-        {
-            get { return Application.SqlHelper; }
-        }
-
+        
 		#region Constructors
 
 	    /// <summary>

--- a/src/umbraco.cms/businesslogic/task/Task.cs
+++ b/src/umbraco.cms/businesslogic/task/Task.cs
@@ -136,9 +136,9 @@ namespace umbraco.cms.businesslogic.task
         }
 
         /// <summary>
-        /// Gets the SQL helper.
+        /// Unused, please do not use
         /// </summary>
-        /// <value>The SQL helper.</value>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }

--- a/src/umbraco.cms/businesslogic/task/TaskType.cs
+++ b/src/umbraco.cms/businesslogic/task/TaskType.cs
@@ -51,6 +51,10 @@ namespace umbraco.cms.businesslogic.task
 
         #region Private/protected members
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }

--- a/src/umbraco.cms/businesslogic/template/Template.cs
+++ b/src/umbraco.cms/businesslogic/template/Template.cs
@@ -357,7 +357,8 @@ namespace umbraco.cms.businesslogic.template
             if (!e.Cancel)
             {
                 //remove refs from documents
-                SqlHelper.ExecuteNonQuery("UPDATE cmsDocument SET templateId = NULL WHERE templateId = " + this.Id);
+                using (var sqlHelper = Application.SqlHelper)
+                    sqlHelper.ExecuteNonQuery("UPDATE cmsDocument SET templateId = NULL WHERE templateId = " + this.Id);
 
                 
                 ApplicationContext.Current.Services.FileService.DeleteTemplate(TemplateEntity.Alias);

--- a/src/umbraco.cms/businesslogic/web/Document.cs
+++ b/src/umbraco.cms/businesslogic/web/Document.cs
@@ -432,20 +432,22 @@ namespace umbraco.cms.businesslogic.web
         public static void RegeneratePreviews()
         {
             XmlDocument xd = new XmlDocument();
-            IRecordsReader dr = SqlHelper.ExecuteReader("select nodeId from cmsDocument");
 
-            while (dr.Read())
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader("select nodeId from cmsDocument"))
             {
-                try
+                while (dr.Read())
                 {
-                    new Document(dr.GetInt("nodeId")).SaveXmlPreview(xd);
-                }
-                catch (Exception ee)
-                {
-					LogHelper.Error<Document>("Error generating preview xml", ee);
+                    try
+                    {
+                        new Document(dr.GetInt("nodeId")).SaveXmlPreview(xd);
+                    }
+                    catch (Exception ee)
+                    {
+                        LogHelper.Error<Document>("Error generating preview xml", ee);
+                    }
                 }
             }
-            dr.Close();
         }
 
         /// <summary>
@@ -1368,12 +1370,14 @@ namespace umbraco.cms.businesslogic.web
 
             string pathExp = childrenOnly ? Path + ",%" : Path;
 
-            IRecordsReader dr = SqlHelper.ExecuteReader(String.Format(SqlOptimizedForPreview, pathExp));
-            while (dr.Read())
-                nodes.Add(new CMSPreviewNode(dr.GetInt("id"), dr.GetGuid("versionId"), dr.GetInt("parentId"), dr.GetShort("level"), dr.GetInt("sortOrder"), dr.GetString("xml"), !dr.GetBoolean("published")));
-            dr.Close();
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader dr = sqlHelper.ExecuteReader(String.Format(SqlOptimizedForPreview, pathExp)))
+            {
+                while (dr.Read())
+                    nodes.Add(new CMSPreviewNode(dr.GetInt("id"), dr.GetGuid("versionId"), dr.GetInt("parentId"), dr.GetShort("level"), dr.GetInt("sortOrder"), dr.GetString("xml"), !dr.GetBoolean("published")));
 
-            return nodes;
+                return nodes;
+            }
         }
 
         public override XmlNode ToPreviewXml(XmlDocument xd)
@@ -1539,21 +1543,29 @@ namespace umbraco.cms.businesslogic.web
         [MethodImpl(MethodImplOptions.Synchronized)]
         private void saveXml(XmlNode x)
         {
-            bool exists = (SqlHelper.ExecuteScalar<int>("SELECT COUNT(nodeId) FROM cmsContentXml WHERE nodeId=@nodeId",
-                                            SqlHelper.CreateParameter("@nodeId", Id)) != 0);
-            string sql = exists ? "UPDATE cmsContentXml SET xml = @xml WHERE nodeId=@nodeId"
-                                : "INSERT INTO cmsContentXml(nodeId, xml) VALUES (@nodeId, @xml)";
-            SqlHelper.ExecuteNonQuery(sql,
-                                      SqlHelper.CreateParameter("@nodeId", Id),
-                                      SqlHelper.CreateParameter("@xml", x.OuterXml));
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                bool exists = (sqlHelper.ExecuteScalar<int>(
+                                   "SELECT COUNT(nodeId) FROM cmsContentXml WHERE nodeId=@nodeId",
+                                   sqlHelper.CreateParameter("@nodeId", Id)) != 0);
+                string sql = exists ? "UPDATE cmsContentXml SET xml = @xml WHERE nodeId=@nodeId"
+                                    : "INSERT INTO cmsContentXml(nodeId, xml) VALUES (@nodeId, @xml)";
+           
+                sqlHelper.ExecuteNonQuery(sql,
+                    sqlHelper.CreateParameter("@nodeId", Id),
+                    sqlHelper.CreateParameter("@xml", x.OuterXml));
+            }
         }
 
         private XmlNode importXml()
         {
             XmlDocument xmlDoc = new XmlDocument();
-            XmlReader xmlRdr = SqlHelper.ExecuteXmlReader(string.Format(
-                                                       "select xml from cmsContentXml where nodeID = {0}", Id));
-            xmlDoc.Load(xmlRdr);
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                using(var xmlRdr = sqlHelper.ExecuteXmlReader(string.Format(
+                                                            "select xml from cmsContentXml where nodeID = {0}", Id)))
+                    xmlDoc.Load(xmlRdr);
+            }
 
             return xmlDoc.FirstChild;
         }

--- a/src/umbraco.cms/businesslogic/web/DocumentType.cs
+++ b/src/umbraco.cms/businesslogic/web/DocumentType.cs
@@ -307,11 +307,12 @@ namespace umbraco.cms.businesslogic.web
                 foreach (var currentContentTypeId in currentContentTypeIds)
                 {
                     //get all the content item ids of the current content type
-                    using (var dr = SqlHelper.ExecuteReader(@"SELECT DISTINCT cmsDocument.nodeId FROM cmsDocument
+                    using (var sqlHelper = Application.SqlHelper)
+                    using (var dr = sqlHelper.ExecuteReader(@"SELECT DISTINCT cmsDocument.nodeId FROM cmsDocument
                                                         INNER JOIN cmsContent ON cmsContent.nodeId = cmsDocument.nodeId
                                                         INNER JOIN cmsContentType ON cmsContent.contentType = cmsContentType.nodeId
                                                         WHERE cmsContentType.nodeId = @contentTypeId AND cmsDocument.published = 1",
-                                                            SqlHelper.CreateParameter("@contentTypeId", currentContentTypeId)))
+                                                            sqlHelper.CreateParameter("@contentTypeId", currentContentTypeId)))
                     {
                         while (dr.Read())
                         {
@@ -321,8 +322,9 @@ namespace umbraco.cms.businesslogic.web
                     }
 
                     //lookup the child content types if there are any and add the ids to the content type ids array
-                    using (var reader = SqlHelper.ExecuteReader("SELECT childContentTypeId FROM cmsContentType2ContentType WHERE parentContentTypeId=@contentTypeId",
-                                                                SqlHelper.CreateParameter("@contentTypeId", currentContentTypeId)))
+                    using (var sqlHelper = Application.SqlHelper)
+                    using (var reader = sqlHelper.ExecuteReader("SELECT childContentTypeId FROM cmsContentType2ContentType WHERE parentContentTypeId=@contentTypeId",
+                                                                sqlHelper.CreateParameter("@contentTypeId", currentContentTypeId)))
                     {
                         while (reader.Read())
                         {
@@ -396,15 +398,17 @@ namespace umbraco.cms.businesslogic.web
                 foreach (var currentContentTypeId in currentContentTypeIds)
                 {
                     //Remove all items from the cmsContentXml table that are of this current content type
-                    SqlHelper.ExecuteNonQuery(@"DELETE FROM cmsContentXml WHERE nodeId IN
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery(@"DELETE FROM cmsContentXml WHERE nodeId IN
                                         (SELECT DISTINCT cmsContent.nodeId FROM cmsContent 
                                             INNER JOIN cmsContentType ON cmsContent.contentType = cmsContentType.nodeId 
                                             WHERE cmsContentType.nodeId = @contentTypeId)",
-                                              SqlHelper.CreateParameter("@contentTypeId", currentContentTypeId));
+                                              sqlHelper.CreateParameter("@contentTypeId", currentContentTypeId));
 
                     //lookup the child content types if there are any and add the ids to the content type ids array
-                    using (var reader = SqlHelper.ExecuteReader("SELECT childContentTypeId FROM cmsContentType2ContentType WHERE parentContentTypeId=@contentTypeId",
-                                                                SqlHelper.CreateParameter("@contentTypeId", currentContentTypeId)))
+                    using (var sqlHelper = Application.SqlHelper)
+                    using (var reader = sqlHelper.ExecuteReader("SELECT childContentTypeId FROM cmsContentType2ContentType WHERE parentContentTypeId=@contentTypeId",
+                                                                sqlHelper.CreateParameter("@contentTypeId", currentContentTypeId)))
                     {                        
                         while (reader.Read())
                         {

--- a/src/umbraco.cms/businesslogic/workflow/Notification.cs
+++ b/src/umbraco.cms/businesslogic/workflow/Notification.cs
@@ -39,9 +39,8 @@ namespace umbraco.cms.businesslogic.workflow
         public char ActionId { get; private set; }
 
         /// <summary>
-        /// Gets the SQL helper.
+        /// Unused, please do not use
         /// </summary>
-        /// <value>The SQL helper.</value>
         [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {

--- a/src/umbraco.datalayer/SqlHelpers/MySql/MySqlInstaller.cs
+++ b/src/umbraco.datalayer/SqlHelpers/MySql/MySqlInstaller.cs
@@ -116,7 +116,8 @@ namespace umbraco.DataLayer.SqlHelpers.MySql
         /// <returns>The MySQL major version number</returns>
         protected virtual int GetMySqlVersion()
         {
-            return int.Parse(SqlHelper.ExecuteScalar<string>("SELECT SUBSTRING(VERSION(),1,1)"));
+            using (var sqlHelper = SqlHelper)
+                return int.Parse(sqlHelper.ExecuteScalar<string>("SELECT SUBSTRING(VERSION(),1,1)"));
         }
 
         #endregion

--- a/src/umbraco.datalayer/Utility/Installer/DefaultInstallerUtility.cs
+++ b/src/umbraco.datalayer/Utility/Installer/DefaultInstallerUtility.cs
@@ -197,7 +197,8 @@ namespace umbraco.DataLayer.Utility.Installer
                 {
                     if(v.ExpectedRows > -1)
                     {
-                        using (var reader = SqlHelper.ExecuteReader(v.Sql))
+                        using (var sqlHelper = SqlHelper)
+                        using (var reader = sqlHelper.ExecuteReader(v.Sql))
                         {
                             var rowCount = 0;
                             while (reader.Read())
@@ -209,7 +210,8 @@ namespace umbraco.DataLayer.Utility.Installer
                     }
                     else
                     {
-                        SqlHelper.ExecuteNonQuery(v.Sql);
+                        using (var sqlHelper = SqlHelper)
+                            sqlHelper.ExecuteNonQuery(v.Sql);
                     }
 
                     //if (!String.IsNullOrEmpty(v.Table) && !String.IsNullOrEmpty(v.Field) && !String.IsNullOrEmpty(v.Value))
@@ -251,7 +253,8 @@ namespace umbraco.DataLayer.Utility.Installer
             {
                 string rawStatement = statement.Trim();
                 if (rawStatement.Length > 0)
-                    SqlHelper.ExecuteNonQuery(rawStatement);
+                    using (var sqlHelper = SqlHelper)
+                        sqlHelper.ExecuteNonQuery(rawStatement);
             }
         }
 

--- a/src/umbraco.editorControls/BaseDataType.cs
+++ b/src/umbraco.editorControls/BaseDataType.cs
@@ -7,26 +7,30 @@ namespace umbraco.editorControls
 {
     [Obsolete("IDataType and all other references to the legacy property editors are no longer used this will be removed from the codebase in future versions")]
     public abstract class BaseDataType
-	{
-		private int _datatypedefinitionid;
-		private string _datafield = "";
-		private DBTypes _DBType;
+    {
+        private int _datatypedefinitionid;
+        private string _datafield = "";
+        private DBTypes _DBType;
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }
         }
 
-		public BaseDataType()
-		{}
+        public BaseDataType()
+        { }
 
-		#region IDataType Members
-		public abstract  Guid Id {get;}
-		public abstract string DataTypeName{get;}
-		public abstract interfaces.IDataEditor DataEditor{get;}
-		public abstract interfaces.IDataPrevalue PrevalueEditor {get;}
-		public abstract interfaces.IData Data{get;}
-		
+        #region IDataType Members
+        public abstract Guid Id { get; }
+        public abstract string DataTypeName { get; }
+        public abstract interfaces.IDataEditor DataEditor { get; }
+        public abstract interfaces.IDataPrevalue PrevalueEditor { get; }
+        public abstract interfaces.IData Data { get; }
+
 		public int DataTypeDefinitionId {
 			set {
 				_datatypedefinitionid = value;
@@ -44,53 +48,57 @@ namespace umbraco.editorControls
 				return _DBType;
 			}
 			set {
-				_DBType = value;
-				 SqlHelper.ExecuteNonQuery("update cmsDataType set dbType = '" + value.ToString() + "' where nodeId = @datadefinitionid",
-                     SqlHelper.CreateParameter("@datadefinitionid",_datatypedefinitionid)).ToString();
-				
-			}
-		}
-		// Umbraco legacy - get the datafield - the columnname of the cmsPropertyData table
-		// where to find the data, since it's configurable - there is no way of telling if
-		// its a bit, nvarchar, ntext or datetime field.
-		// get it by lookup the value associated to the datatypedefinition id.
-		public string DataFieldName 
-		{
+                _DBType = value;
+                using (var sqlHelper = Application.SqlHelper)
+				 sqlHelper.ExecuteNonQuery("update cmsDataType set dbType = '" + value.ToString() + "' where nodeId = @datadefinitionid",
+                     sqlHelper.CreateParameter("@datadefinitionid",_datatypedefinitionid)).ToString();
+            }
+        }
+        // Umbraco legacy - get the datafield - the columnname of the cmsPropertyData table
+        // where to find the data, since it's configurable - there is no way of telling if
+        // its a bit, nvarchar, ntext or datetime field.
+        // get it by lookup the value associated to the datatypedefinition id.
+        public string DataFieldName
+        {
 			get {
-				if (_datafield == "") 
-				{
-					string dbtypestr = SqlHelper.ExecuteScalar<string>("select dbType from cmsDataType where nodeId = @datadefinitionid",
-                        SqlHelper.CreateParameter("@datadefinitionid",_datatypedefinitionid));
-					DBTypes DataTypeSQLType = (DBTypes) Enum.Parse(typeof(DBTypes),dbtypestr,true);
-					_DBType = DataTypeSQLType;
-					switch (DataTypeSQLType) 
-					{
-						case DBTypes.Date :
-							_datafield = "dataDate";
-							break;
-						case DBTypes.Integer :
-							_datafield = "DataInt";
-							break;
-						case DBTypes.Ntext :
-							_datafield = "dataNtext";
-							break;
-						case DBTypes.Nvarchar :
-							_datafield = "dataNvarchar";
-							break;
-					}
-					return _datafield;
-				}
-				return _datafield;
-			}
-		}
-		#endregion
-	}
+                if (_datafield == "")
+                {
+                    using (var sqlHelper = Application.SqlHelper)
+                    {
+                        string dbtypestr = sqlHelper.ExecuteScalar<string>("select dbType from cmsDataType where nodeId = @datadefinitionid",
+                                sqlHelper.CreateParameter("@datadefinitionid", _datatypedefinitionid));
+                        DBTypes DataTypeSQLType = (DBTypes) Enum.Parse(typeof(DBTypes), dbtypestr, true);
+
+                        _DBType = DataTypeSQLType;
+                        switch (DataTypeSQLType)
+                        {
+                            case DBTypes.Date:
+                                _datafield = "dataDate";
+                                break;
+                            case DBTypes.Integer:
+                                _datafield = "DataInt";
+                                break;
+                            case DBTypes.Ntext:
+                                _datafield = "dataNtext";
+                                break;
+                            case DBTypes.Nvarchar:
+                                _datafield = "dataNvarchar";
+                                break;
+                        }
+                    }
+                    return _datafield;
+                }
+                return _datafield;
+            }
+        }
+        #endregion
+    }
     [Obsolete("IDataType and all other references to the legacy property editors are no longer used this will be removed from the codebase in future versions")]
-    public enum DBTypes 
-	{
-		Integer,
-		Date,
-		Nvarchar,
-		Ntext
-	}
+    public enum DBTypes
+    {
+        Integer,
+        Date,
+        Nvarchar,
+        Ntext
+    }
 }

--- a/src/umbraco.editorControls/DefaultData.cs
+++ b/src/umbraco.editorControls/DefaultData.cs
@@ -6,96 +6,105 @@ using umbraco.DataLayer;
 namespace umbraco.editorControls
 {
     [Obsolete("Use umbraco.cms.businesslogic.datatype.DefaultData instead")]
-	public class DefaultData : interfaces.IData
-	{
-		private int _propertyId;
-		private object _value;
-		protected BaseDataType _dataType;
+    public class DefaultData : interfaces.IData
+    {
+        private int _propertyId;
+        private object _value;
+        protected BaseDataType _dataType;
 
-        public static ISqlHelper SqlHelper
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
+        protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }
         }
-        
+
 		public DefaultData(BaseDataType DataType) {
-			_dataType = DataType;
-		}
+            _dataType = DataType;
+        }
 
-		#region IData Members
+        #region IData Members
 
-		public virtual System.Xml.XmlNode ToXMl(System.Xml.XmlDocument d)
-		{
-			if (this._dataType.DBType == DBTypes.Ntext) 
-				return d.CreateCDataSection(this.Value.ToString());
-			return d.CreateTextNode(Value.ToString());
-		}
-		
-		public object Value 
-		{
-			get 
-			{
-				return _value;
-			}
-			set 
-			{
-				// Try to set null values if possible
-				try 
-				{
-					if (value == null)
-						SqlHelper.ExecuteNonQuery("update cmsPropertyData set "+ _dataType.DataFieldName +" = NULL where id = " + _propertyId);
-					else
-						SqlHelper.ExecuteNonQuery("update cmsPropertyData set "+ _dataType.DataFieldName +" = @value where id = " + _propertyId, SqlHelper.CreateParameter("@value", value) );
-					_value = value;
-				} 
-				catch (Exception e)
-				{
+        public virtual System.Xml.XmlNode ToXMl(System.Xml.XmlDocument d)
+        {
+            if (this._dataType.DBType == DBTypes.Ntext)
+                return d.CreateCDataSection(this.Value.ToString());
+            return d.CreateTextNode(Value.ToString());
+        }
+
+        public object Value
+        {
+            get
+            {
+                return _value;
+            }
+            set
+            {
+                // Try to set null values if possible
+                try
+                {
+                    if (value == null)
+                        using (var sqlHelper = Application.SqlHelper)
+						    sqlHelper.ExecuteNonQuery("update cmsPropertyData set "+ _dataType.DataFieldName +" = NULL where id = " + _propertyId);
+                    else
+                        using (var sqlHelper = Application.SqlHelper)
+						    sqlHelper.ExecuteNonQuery("update cmsPropertyData set "+ _dataType.DataFieldName +" = @value where id = " + _propertyId, sqlHelper.CreateParameter("@value", value) );
+                    _value = value;
+                }
+                catch (Exception e)
+                {
 					LogHelper.Error(typeof(DefaultData), "Error updating item: " + e.ToString(), e);
-					
+
 					if (value==null) value ="";
-					SqlHelper.ExecuteNonQuery("update cmsPropertyData set "+ _dataType.DataFieldName +" = @value where id = " + _propertyId, SqlHelper.CreateParameter("@value", value) );
+                    using (var sqlHelper = Application.SqlHelper)
+                        sqlHelper.ExecuteNonQuery("update cmsPropertyData set "+ _dataType.DataFieldName +" = @value where id = " + _propertyId, sqlHelper.CreateParameter("@value", value) );
 					_value = value;
 				}
+            }
+        }
 
-			}
-		}
-
-		public virtual void MakeNew(int PropertyId)
-		{
-			// this default implementation of makenew does not do anything sínce 
-			// it uses the default datastorage of umbraco, and the row is already populated by the "property" object
-			// If the datatype needs to have a default value, inherit this class and override this method.
-		}
+        public virtual void MakeNew(int PropertyId)
+        {
+            // this default implementation of makenew does not do anything sínce 
+            // it uses the default datastorage of umbraco, and the row is already populated by the "property" object
+            // If the datatype needs to have a default value, inherit this class and override this method.
+        }
 
 		public void Delete() {
-			// this default implementation of delete does not do anything sínce 
-			// it uses the default datastorage of umbraco, and the row is already deleted by the "property" object
-		}
+            // this default implementation of delete does not do anything sínce 
+            // it uses the default datastorage of umbraco, and the row is already deleted by the "property" object
+        }
 
-		public int PropertyId
-		{
+        public int PropertyId
+        {
 			get {
-				return _propertyId;
-			}
-			set
-			{
-				_propertyId = value;
-				_value = SqlHelper.ExecuteScalar<object>("Select " + _dataType.DataFieldName + " from cmsPropertyData where id = " + value);
-			}
-		}
+                return _propertyId;
+            }
+            set
+            {
+                _propertyId = value;
+                using (var sqlHelper = Application.SqlHelper)
+				    _value = sqlHelper.ExecuteScalar<object>("Select " + _dataType.DataFieldName + " from cmsPropertyData where id = " + value);
+            }
+        }
 
-		// TODO: clean up Legacy - these are needed by the wysiwyeditor, in order to feed the richtextholder with version and nodeid
-		// solution, create a new version of the richtextholder, which does not depend on these.
+        // TODO: clean up Legacy - these are needed by the wysiwyeditor, in order to feed the richtextholder with version and nodeid
+        // solution, create a new version of the richtextholder, which does not depend on these.
 		public Guid Version {
 			get {
-				return new Guid(SqlHelper.ExecuteScalar<string>("Select versionId from cmsPropertyData where id = " + PropertyId).ToString());
-			}
-		}
+                using (var sqlHelper = Application.SqlHelper)
+                    return new Guid(sqlHelper.ExecuteScalar<string>("Select versionId from cmsPropertyData where id = " + PropertyId).ToString());
+            }
+        }
 
 		public int NodeId {
 			get {
-				return SqlHelper.ExecuteScalar<int>("Select contentNodeid from cmsPropertyData where id = " + PropertyId);
+                using (var sqlHelper = Application.SqlHelper)
+                    return sqlHelper.ExecuteScalar<int>("Select contentNodeid from cmsPropertyData where id = " + PropertyId);
 			}
 		}
-		#endregion
-	}	
+        #endregion
+    }
 }

--- a/src/umbraco.editorControls/DefaultDataKeyValue.cs
+++ b/src/umbraco.editorControls/DefaultDataKeyValue.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using umbraco.BusinessLogic;
 using Umbraco.Core.Logging;
 
 namespace umbraco.editorControls
@@ -27,16 +28,16 @@ namespace umbraco.editorControls
                 // Don't query if there's nothing to query for..
                 if (string.IsNullOrWhiteSpace(Value.ToString()) == false)
                 {
-                    var dr = SqlHelper.ExecuteReader(string.Format("Select [value] from cmsDataTypeprevalues where id in ({0})", SqlHelper.EscapeString(Value.ToString())));
-
-                    while (dr.Read())
+                    using (var sqlHelper = Application.SqlHelper)
+                    using (var dr = sqlHelper.ExecuteReader(string.Format("Select [value] from cmsDataTypeprevalues where id in ({0})", sqlHelper.EscapeString(Value.ToString()))))
                     {
-                        value += value.Length == 0
-                            ? dr.GetString("value")
-                            : string.Format(",{0}", dr.GetString("value"));
+                        while (dr.Read())
+                        {
+                            value += value.Length == 0
+                                ? dr.GetString("value")
+                                : string.Format(",{0}", dr.GetString("value"));
+                        }
                     }
-
-                    dr.Close();
                 }
             }
             catch (Exception ex)

--- a/src/umbraco.editorControls/KeyValuePrevalueEditor.cs
+++ b/src/umbraco.editorControls/KeyValuePrevalueEditor.cs
@@ -14,72 +14,77 @@ using System.Web.UI.HtmlControls;
 [assembly: System.Web.UI.WebResource("umbraco.editorControls.KeyValuePrevalueEditor.css", "text/css")]
 namespace umbraco.editorControls
 {
-	/// <summary>
-	/// Summary description for KeyValuePrevalueEditor.
-	/// </summary>
+    /// <summary>
+    /// Summary description for KeyValuePrevalueEditor.
+    /// </summary>
 
     [ClientDependency(ClientDependencyType.Javascript, "Jeditable/jquery.jeditable.js", "UmbracoClient")]
     [Obsolete("IDataType and all other references to the legacy property editors are no longer used this will be removed from the codebase in future versions")]
     public class KeyValuePrevalueEditor : System.Web.UI.WebControls.PlaceHolder, interfaces.IDataPrevalue
-	{
-	
-		// UI controls
-		public System.Web.UI.WebControls.DropDownList _dropdownlist;
-		public TextBox _textbox;
+    {
+
+        // UI controls
+        public System.Web.UI.WebControls.DropDownList _dropdownlist;
+        public TextBox _textbox;
         private TextBox _tbhidden;
         public umbraco.uicontrols.PropertyPanel pp1 = new umbraco.uicontrols.PropertyPanel();
         public umbraco.uicontrols.PropertyPanel pp2 = new umbraco.uicontrols.PropertyPanel();
-				
-		private Hashtable DeleteButtons = new Hashtable();
 
-		// referenced datatype
-		private cms.businesslogic.datatype.BaseDataType _datatype;
+        private Hashtable DeleteButtons = new Hashtable();
 
+        // referenced datatype
+        private cms.businesslogic.datatype.BaseDataType _datatype;
+
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         protected static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }
         }
 
-		public KeyValuePrevalueEditor(cms.businesslogic.datatype.BaseDataType DataType) 
-		{
-			// state it knows its datatypedefinitionid
-			_datatype = DataType;
+        public KeyValuePrevalueEditor(cms.businesslogic.datatype.BaseDataType DataType)
+        {
+            // state it knows its datatypedefinitionid
+            _datatype = DataType;
 
             setupChildControls();
-            
+
             // Bootstrap delete.
 			if (System.Web.HttpContext.Current.Request["delete"] != null) {
-				DeletePrevalue(int.Parse(System.Web.HttpContext.Current.Request["delete"]));
-			}
-			
-		}
-		
-		private void DeletePrevalue(int id) {
-			SqlHelper.ExecuteNonQuery("delete from cmsDataTypePreValues where id = " + id);
-		}
+                DeletePrevalue(int.Parse(System.Web.HttpContext.Current.Request["delete"]));
+            }
 
-		private void setupChildControls() 
-		{
-			_dropdownlist = new DropDownList();
-			_dropdownlist.ID = "dbtype";
-			
-			_textbox = new TextBox();
-			_textbox.ID = "AddValue";
+        }
+
+		private void DeletePrevalue(int id) {
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("delete from cmsDataTypePreValues where id = " + id);
+        }
+
+        private void setupChildControls()
+        {
+            _dropdownlist = new DropDownList();
+            _dropdownlist.ID = "dbtype";
+
+            _textbox = new TextBox();
+            _textbox.ID = "AddValue";
 
             _tbhidden = new TextBox();
             _tbhidden.Attributes.Add("style", "display:none;");
             _tbhidden.CssClass = "valuesHiddenInput";
 
-			// put the childcontrols in context - ensuring that
-			// the viewstate is persisted etc.
-			this.Controls.Add(_dropdownlist);
-			this.Controls.Add(_textbox);
+            // put the childcontrols in context - ensuring that
+            // the viewstate is persisted etc.
+            this.Controls.Add(_dropdownlist);
+            this.Controls.Add(_textbox);
             this.Controls.Add(_tbhidden);
 
-			_dropdownlist.Items.Add(DBTypes.Date.ToString());
-			_dropdownlist.Items.Add(DBTypes.Integer.ToString());
-			_dropdownlist.Items.Add(DBTypes.Ntext.ToString());
-			_dropdownlist.Items.Add(DBTypes.Nvarchar.ToString());
+            _dropdownlist.Items.Add(DBTypes.Date.ToString());
+            _dropdownlist.Items.Add(DBTypes.Integer.ToString());
+            _dropdownlist.Items.Add(DBTypes.Ntext.ToString());
+            _dropdownlist.Items.Add(DBTypes.Nvarchar.ToString());
         }
 
         protected override void OnInit(EventArgs e) {
@@ -103,26 +108,26 @@ namespace umbraco.editorControls
 
         }
 
-		protected override void OnLoad(EventArgs e)
-		{
-			base.OnLoad (e);
-        
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+
             if (!Page.IsPostBack)
-			{
-				_dropdownlist.SelectedValue = _datatype.DBType.ToString();
+            {
+                _dropdownlist.SelectedValue = _datatype.DBType.ToString();
 
-			}
+            }
 
-            
-		}
-		
-		public Control Editor 
-		{
-			get
-			{
-				return this;
-			}
-		}
+
+        }
+
+        public Control Editor
+        {
+            get
+            {
+                return this;
+            }
+        }
 
 		public void Save() 
 		{
@@ -141,13 +146,14 @@ namespace umbraco.editorControls
 
                         if (row.Split('|').Length == 2 &&  int.TryParse(row.Split('|')[0], out id) && row.Split('|')[1].Length > 0)
                         {
-
-                            IParameter[] SqlParams = new IParameter[] {
-								SqlHelper.CreateParameter("@value",row.Split('|')[1]),
-								SqlHelper.CreateParameter("@sortorder",so),
-                                SqlHelper.CreateParameter("@id",id)};
-                            SqlHelper.ExecuteNonQuery("update cmsDataTypePreValues set [value] = @value, sortorder = @sortorder where id = @id", SqlParams);
-
+                            using (var sqlHelper = Application.SqlHelper)
+                            {
+                                IParameter[] SqlParams = new IParameter[] {
+                                sqlHelper.CreateParameter("@value",row.Split('|')[1]),
+                                sqlHelper.CreateParameter("@sortorder",so),
+                                sqlHelper.CreateParameter("@id",id)};
+                                sqlHelper.ExecuteNonQuery("update cmsDataTypePreValues set [value] = @value, sortorder = @sortorder where id = @id", SqlParams);
+                            }
                         }
 
                         so++;
@@ -165,25 +171,29 @@ namespace umbraco.editorControls
 
                 try
                 {
-                    so = SqlHelper.ExecuteScalar<int>("select max(sortorder) from cmsDataTypePreValues where datatypenodeid = @dtdefid",
-                        SqlHelper.CreateParameter("@dtdefid", _datatype.DataTypeDefinitionId));
+                    using (var sqlHelper = Application.SqlHelper)
+                        so = sqlHelper.ExecuteScalar<int>("select max(sortorder) from cmsDataTypePreValues where datatypenodeid = @dtdefid",
+                            sqlHelper.CreateParameter("@dtdefid", _datatype.DataTypeDefinitionId));
                     so++;
                 }
                 catch { }
 
-				IParameter[] SqlParams = new IParameter[] {
-								SqlHelper.CreateParameter("@value",_textbox.Text),
-								SqlHelper.CreateParameter("@dtdefid",_datatype.DataTypeDefinitionId),
-                                SqlHelper.CreateParameter("@so",so)};
-				SqlHelper.ExecuteNonQuery("insert into cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) values (@dtdefid,@value,@so,'')",SqlParams);
+                using (var sqlHelper = Application.SqlHelper)
+                {
+                    IParameter[] SqlParams = new IParameter[] {
+                                    sqlHelper.CreateParameter("@value",_textbox.Text),
+                                    sqlHelper.CreateParameter("@dtdefid",_datatype.DataTypeDefinitionId),
+                                    sqlHelper.CreateParameter("@so",so)};
+                    sqlHelper.ExecuteNonQuery("insert into cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) values (@dtdefid,@value,@so,'')", SqlParams);
+                }
 				_textbox.Text = "";
 
                 ScriptManager.GetCurrent(Page).SetFocus(_textbox);
 			}
 		}
 
-		protected override void Render(HtmlTextWriter writer)
-		{
+        protected override void Render(HtmlTextWriter writer)
+        {
             writer.Write("<div class='propertyItem'><div class='propertyItemheader'>" + ui.Text("dataBaseDatatype") + "</div>");
             _dropdownlist.RenderControl(writer);
             writer.Write("<br style='clear: both'/></div>");
@@ -206,24 +216,25 @@ namespace umbraco.editorControls
 
             _tbhidden.RenderControl(writer);
 
-        
+
         }
 
-		public SortedList Prevalues {
-			get
+        public SortedList Prevalues {
+            get
             {
-                
                 SortedList retval = new SortedList();
-				IRecordsReader dr = SqlHelper.ExecuteReader(
-					"Select id, [value] from cmsDataTypePreValues where DataTypeNodeId = "
-					+ _datatype.DataTypeDefinitionId + " order by sortorder");
-				
-				while (dr.Read())
-					retval.Add(dr.GetInt("id"), dr.GetString("value"));
-				dr.Close();
-				return retval;
-			}
-		}
+                using (var sqlHelper = Application.SqlHelper)
+                using (IRecordsReader dr = sqlHelper.ExecuteReader(
+                   "Select id, [value] from cmsDataTypePreValues where DataTypeNodeId = "
+                    + _datatype.DataTypeDefinitionId + " order by sortorder"))
+                {
+                    while (dr.Read())
+                        retval.Add(dr.GetInt("id"), dr.GetString("value"));
+
+                    return retval;
+                }
+            }
+        }
 
         public List<KeyValuePair<int, String>> PrevaluesAsKeyValuePairList
         {
@@ -232,15 +243,18 @@ namespace umbraco.editorControls
 
                 List<KeyValuePair<int, String>> items = new List<KeyValuePair<int, String>>();
 
-                IRecordsReader dr = SqlHelper.ExecuteReader(
-                    "Select id, [value] from cmsDataTypePreValues where DataTypeNodeId = "
-                    + _datatype.DataTypeDefinitionId + " order by sortorder");
-
-                while (dr.Read())
-                    items.Add(new KeyValuePair<int, string>(dr.GetInt("id"), dr.GetString("value")));
-                dr.Close();
+                using (var sqlHelper = Application.SqlHelper)
+                {
+                    using (IRecordsReader dr = sqlHelper.ExecuteReader(
+                        "Select id, [value] from cmsDataTypePreValues where DataTypeNodeId = "
+                        + _datatype.DataTypeDefinitionId + " order by sortorder"))
+                    {
+                        while (dr.Read())
+                            items.Add(new KeyValuePair<int, string>(dr.GetInt("id"), dr.GetString("value")));
+                    }
+                }
                 return items;
             }
         }
-	}
+    }
 }

--- a/src/umbraco.editorControls/PickerRelations/PickerRelationsDataEditor.cs
+++ b/src/umbraco.editorControls/PickerRelations/PickerRelationsDataEditor.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-
+using umbraco.BusinessLogic;
 using umbraco.cms.businesslogic.datatype; // DefaultData
 using umbraco.cms.businesslogic.property; // Property
 using umbraco.cms.businesslogic.relation; // RelationType
@@ -77,10 +77,13 @@ namespace umbraco.editorControls.PickerRelations
         {
             get
             {
-                return uQuery.GetUmbracoObjectType(
-                        uQuery.SqlHelper.ExecuteScalar<Guid>(
-                            "SELECT nodeObjectType FROM umbracoNode WHERE id = @id",
-                            uQuery.SqlHelper.CreateParameter("@id", this.CurrentContentId)));
+                using (var sqlHelper = Application.SqlHelper)
+                {
+                    var guid = sqlHelper.ExecuteScalar<Guid>(
+                        "SELECT nodeObjectType FROM umbracoNode WHERE id = @id",
+                        sqlHelper.CreateParameter("@id", this.CurrentContentId));
+                    return uQuery.GetUmbracoObjectType(guid);
+                }
             }
         }
 

--- a/src/umbraco.editorControls/PickerRelations/PickerRelationsEventHandler.cs
+++ b/src/umbraco.editorControls/PickerRelations/PickerRelationsEventHandler.cs
@@ -229,15 +229,16 @@ namespace umbraco.editorControls.PickerRelations
 
 			getRelationsSql += " AND comment = '" + instanceIdentifier + "'";
 
-			using (IRecordsReader relations = uQuery.SqlHelper.ExecuteReader(getRelationsSql))
+            using (var sqlHelper = Application.SqlHelper)
+            using (IRecordsReader relations = sqlHelper.ExecuteReader(getRelationsSql))
 			{
 				//clear data
 				Relation relation;
-				while (relations.Read())
+			    while (relations.Read())
 				{
-					relation = new Relation(relations.GetInt("id"));
+				    relation = new Relation(relations.GetInt("id"));
 
-					// TODO: [HR] check to see if an instance identifier is used
+				    // TODO: [HR] check to see if an instance identifier is used
 					relation.Delete();
 				}
 			}

--- a/src/umbraco.editorControls/SettingControls/Pickers/Field.cs
+++ b/src/umbraco.editorControls/SettingControls/Pickers/Field.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using umbraco.BusinessLogic;
 using umbraco.DataLayer;
 using umbraco.cms.businesslogic.datatype;
 
@@ -40,11 +41,16 @@ namespace umbraco.editorControls.SettingControls.Pickers
 
             string fieldSql = "select distinct alias from cmsPropertyType order by alias";
 
-            IRecordsReader dataTypes = umbraco.BusinessLogic.Application.SqlHelper.ExecuteReader(fieldSql);
-            ddl.DataTextField = "alias";
-            ddl.DataValueField = "alias";
-            ddl.DataSource = dataTypes;
-            ddl.DataBind();
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                using (IRecordsReader dataTypes = sqlHelper.ExecuteReader(fieldSql))
+                {
+                    ddl.DataTextField = "alias";
+                    ddl.DataValueField = "alias";
+                    ddl.DataSource = dataTypes;
+                    ddl.DataBind();
+                }
+            }
 
             foreach (string s in preValuesSource)
             {

--- a/src/umbraco.editorControls/imagecropper/PrevalueEditor.cs
+++ b/src/umbraco.editorControls/imagecropper/PrevalueEditor.cs
@@ -331,11 +331,13 @@ namespace umbraco.editorControls.imagecropper
 
             string data = String.Format("{0}|{1}", generalData, templateData);
 
-            SqlHelper.ExecuteNonQuery("delete from cmsDataTypePreValues where datatypenodeid = @dtdefid",
-                                      SqlHelper.CreateParameter("@dtdefid", _dataType.DataTypeDefinitionId));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("delete from cmsDataTypePreValues where datatypenodeid = @dtdefid", 
+                    sqlHelper.CreateParameter("@dtdefid", _dataType.DataTypeDefinitionId));
 
-            SqlHelper.ExecuteNonQuery("insert into cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) values (@dtdefid,@value,0,'')",
-                                      SqlHelper.CreateParameter("@dtdefid", _dataType.DataTypeDefinitionId), SqlHelper.CreateParameter("@value", data));
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("insert into cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) values (@dtdefid,@value,0,'')",
+                    sqlHelper.CreateParameter("@dtdefid", _dataType.DataTypeDefinitionId), sqlHelper.CreateParameter("@value", data));
         }
 
         protected override void Render(HtmlTextWriter writer)
@@ -409,23 +411,25 @@ namespace umbraco.editorControls.imagecropper
         {
             get
             {
-                object conf =
-                    SqlHelper.ExecuteScalar<object>("select value from cmsDataTypePreValues where datatypenodeid = @datatypenodeid",
-                                                    SqlHelper.CreateParameter("@datatypenodeid", _dataType.DataTypeDefinitionId));
+                using (var sqlHelper = Application.SqlHelper) { 
+                    object conf =
+                    sqlHelper.ExecuteScalar<object>("select value from cmsDataTypePreValues where datatypenodeid = @datatypenodeid",
+                                                    sqlHelper.CreateParameter("@datatypenodeid", _dataType.DataTypeDefinitionId));
 
-                if (conf != null)
-                    return conf.ToString();
-
+                    if (conf != null)
+                        return conf.ToString();
+                }
                 return string.Empty;
             }
         }
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         public static ISqlHelper SqlHelper
         {
-            get
-            {
-                return Application.SqlHelper;
-            }
+            get { return Application.SqlHelper; }
         }
     }
 }

--- a/src/umbraco.editorControls/macrocontainer/PrevalueEditor.cs
+++ b/src/umbraco.editorControls/macrocontainer/PrevalueEditor.cs
@@ -153,9 +153,10 @@ namespace umbraco.editorControls.macrocontainer
             {
                 if (_configuration == null)
                 {
-                return Application.SqlHelper.ExecuteScalar<string>(
+                using (var sqlHelper = Application.SqlHelper)
+                return sqlHelper.ExecuteScalar<string>(
                         "select value from cmsDataTypePreValues where datatypenodeid = @datatypenodeid",
-                        Application.SqlHelper.CreateParameter("@datatypenodeid", Datatype.DataTypeDefinitionId));
+                        sqlHelper.CreateParameter("@datatypenodeid", Datatype.DataTypeDefinitionId));
                 }
                 else
                 {
@@ -279,10 +280,12 @@ namespace umbraco.editorControls.macrocontainer
         /// </summary>
         public void Save()
         {
-       
-            Application.SqlHelper.ExecuteNonQuery(
-                "delete from cmsDataTypePreValues where datatypenodeid = @dtdefid",
-                Application.SqlHelper.CreateParameter("@dtdefid", Datatype.DataTypeDefinitionId));
+
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                sqlHelper.ExecuteNonQuery("delete from cmsDataTypePreValues where datatypenodeid = @dtdefid", 
+                    sqlHelper.CreateParameter("@dtdefid", Datatype.DataTypeDefinitionId));
+            }
 
             StringBuilder config = new StringBuilder();
             config.Append(GetSelectedMacosFromCheckList());
@@ -299,12 +302,10 @@ namespace umbraco.editorControls.macrocontainer
             int.TryParse(_txtPreferedWidth.Text, out prefwidth);
             config.Append(prefwidth);
 
-            Application.SqlHelper.ExecuteNonQuery(
-                "insert into cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) values (@dtdefid,@value,0,'')",
-                Application.SqlHelper.CreateParameter("@dtdefid", Datatype.DataTypeDefinitionId), Application.SqlHelper.CreateParameter("@value", config.ToString()));
-
+            using (var sqlHelper = Application.SqlHelper)
+                sqlHelper.ExecuteNonQuery("insert into cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) values (@dtdefid,@value,0,'')",
+                    sqlHelper.CreateParameter("@dtdefid", Datatype.DataTypeDefinitionId), sqlHelper.CreateParameter("@value", config.ToString()));
         }
         #endregion
-
     }
 }

--- a/src/umbraco.editorControls/memberpicker/memberPicker.cs
+++ b/src/umbraco.editorControls/memberpicker/memberPicker.cs
@@ -57,23 +57,25 @@ namespace umbraco.editorControls
 		protected override void OnInit(EventArgs e)
 		{
 			base.OnInit (e);
-			IRecordsReader dropdownData = Application.SqlHelper.ExecuteReader("select id, text from umbracoNode where nodeObjectType = '39EB0F98-B348-42A1-8662-E7EB18487560' order by text");
-			base.DataValueField = "id";
-			base.DataTextField = "text";
-			base.DataSource = dropdownData;
-			base.DataBind();
-			base.Items.Insert(0, new ListItem(ui.Text("choose") + "...",""));
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                using (IRecordsReader dropdownData = sqlHelper.ExecuteReader("select id, text from umbracoNode where nodeObjectType = '39EB0F98-B348-42A1-8662-E7EB18487560' order by text")) 
+                { 
+                    base.DataValueField = "id";
+                    base.DataTextField = "text";
+                    base.DataSource = dropdownData;
+                    base.DataBind();
+                    base.Items.Insert(0, new ListItem(ui.Text("choose") + "...", ""));
 
-            base.SelectedValue = _data.Value != null ? _data.Value.ToString() : "";
-
-			// Iterate on the control items and mark fields by match them with the Text property!
-			//foreach(ListItem li in base.Items) 
-			//{
-			//	if ((","+base.SelectedValue+",").IndexOf(","+li.Value.ToString()+",") > -1)
-			//		li.Selected = true;
-			//}
-
-			dropdownData.Close();
+                    base.SelectedValue = _data.Value != null ? _data.Value.ToString() : "";
+                }
+                // Iterate on the control items and mark fields by match them with the Text property!
+                //foreach(ListItem li in base.Items) 
+                //{
+                //	if ((","+base.SelectedValue+",").IndexOf(","+li.Value.ToString()+",") > -1)
+                //		li.Selected = true;
+                //}
+            }
 		}
 	
 		/// <summary> 

--- a/src/umbraco.editorControls/tinymce/tinyMCEPreValueConfigurator.cs
+++ b/src/umbraco.editorControls/tinymce/tinyMCEPreValueConfigurator.cs
@@ -13,8 +13,8 @@ namespace umbraco.editorControls.tinymce
     [Obsolete("IDataType and all other references to the legacy property editors are no longer used this will be removed from the codebase in future versions")]
     public class tinyMCEPreValueConfigurator : System.Web.UI.WebControls.PlaceHolder, interfaces.IDataPrevalue
     {
-		// UI controls
-		private CheckBoxList _editorButtons;
+        // UI controls
+        private CheckBoxList _editorButtons;
         private CheckBox _enableRightClick;
         private DropDownList _dropdownlist;
         private CheckBoxList _advancedUsersList;
@@ -27,27 +27,32 @@ namespace umbraco.editorControls.tinymce
         private RegularExpressionValidator _widthValidator = new RegularExpressionValidator();
         private RegularExpressionValidator _heightValidator = new RegularExpressionValidator();
         private RegularExpressionValidator _maxImageWidthValidator = new RegularExpressionValidator();
-				
-		// referenced datatype
-		private cms.businesslogic.datatype.BaseDataType _datatype;
+
+        // referenced datatype
+        private cms.businesslogic.datatype.BaseDataType _datatype;
         private string _selectedButtons = "";
         private string _advancedUsers = "";
         private string _stylesheets = "";
 
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
         public static ISqlHelper SqlHelper
         {
             get { return Application.SqlHelper; }
         }
 
-        public tinyMCEPreValueConfigurator(cms.businesslogic.datatype.BaseDataType DataType) 
-		{
-			// state it knows its datatypedefinitionid
-			_datatype = DataType;
-			setupChildControls();
-		}
-		
-		private void setupChildControls() 
-		{
+
+        public tinyMCEPreValueConfigurator(cms.businesslogic.datatype.BaseDataType DataType)
+        {
+            // state it knows its datatypedefinitionid
+            _datatype = DataType;
+            setupChildControls();
+        }
+
+        private void setupChildControls()
+        {
             _dropdownlist = new DropDownList();
             _dropdownlist.ID = "dbtype";
             _dropdownlist.Items.Add(DBTypes.Date.ToString());
@@ -61,7 +66,7 @@ namespace umbraco.editorControls.tinymce
             _editorButtons.CellPadding = 3;
 
             _enableRightClick = new CheckBox();
-		    _enableRightClick.ID = "enableRightClick";
+            _enableRightClick.ID = "enableRightClick";
 
             _advancedUsersList = new CheckBoxList();
             _advancedUsersList.ID = "advancedUsersList";
@@ -76,14 +81,14 @@ namespace umbraco.editorControls.tinymce
             _maxImageWidth.ID = "maxImageWidth";
 
             // put the childcontrols in context - ensuring that
-			// the viewstate is persisted etc.
+            // the viewstate is persisted etc.
             Controls.Add(_dropdownlist);
             Controls.Add(_enableRightClick);
             Controls.Add(_editorButtons);
             Controls.Add(_advancedUsersList);
             Controls.Add(_stylesheetList);
             Controls.Add(_width);
-		    Controls.Add(_widthValidator);
+            Controls.Add(_widthValidator);
             Controls.Add(_height);
             Controls.Add(_heightValidator);
             Controls.Add(_showLabel);
@@ -91,11 +96,11 @@ namespace umbraco.editorControls.tinymce
             Controls.Add(_maxImageWidthValidator);
             //            Controls.Add(_fullWidth);
 
-		}
-		
-		protected override void OnLoad(EventArgs e)
-		{
-			base.OnLoad (e);
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
             // add ids to controls
             _width.ID = "width";
             _height.ID = "height";
@@ -104,19 +109,19 @@ namespace umbraco.editorControls.tinymce
             // initialize validators
             _widthValidator.ValidationExpression = "0*[1-9][0-9]*";
             _widthValidator.ErrorMessage = ui.Text("errorHandling", "errorIntegerWithoutTab", ui.Text("width"), new BasePages.BasePage().getUser());
-		    _widthValidator.Display = ValidatorDisplay.Dynamic;
+            _widthValidator.Display = ValidatorDisplay.Dynamic;
             _widthValidator.ControlToValidate = _width.ID;
             _heightValidator.ValidationExpression = "0*[1-9][0-9]*";
             _heightValidator.ErrorMessage = ui.Text("errorHandling", "errorIntegerWithoutTab", ui.Text("height"), new BasePages.BasePage().getUser());
             _heightValidator.ControlToValidate = _height.ID;
             _heightValidator.Display = ValidatorDisplay.Dynamic;
             _maxImageWidthValidator.ValidationExpression = "0*[1-9][0-9]*";
-            _maxImageWidthValidator.ErrorMessage = ui.Text("errorHandling", "errorIntegerWithoutTab","'" +  ui.Text("rteMaximumDefaultImgSize") + "'", new BasePages.BasePage().getUser());
+            _maxImageWidthValidator.ErrorMessage = ui.Text("errorHandling", "errorIntegerWithoutTab", "'" + ui.Text("rteMaximumDefaultImgSize") + "'", new BasePages.BasePage().getUser());
             _maxImageWidthValidator.ControlToValidate = _maxImageWidth.ID;
             _maxImageWidthValidator.Display = ValidatorDisplay.Dynamic;
-            
+
             if (!Page.IsPostBack)
-			{
+            {
                 if (Configuration != null)
                 {
                     string[] config = Configuration.Split("|".ToCharArray());
@@ -133,13 +138,13 @@ namespace umbraco.editorControls.tinymce
 
                         if (config.Length > 4 && config[4].Split(',').Length > 1)
                         {
-//                        if (config[3] == "1")
-//                            _fullWidth.Checked = true;
-//                        else
-//                        {
+                            //                        if (config[3] == "1")
+                            //                            _fullWidth.Checked = true;
+                            //                        else
+                            //                        {
                             _width.Text = config[4].Split(',')[0];
                             _height.Text = config[4].Split(',')[1];
-//                        }
+                            //                        }
                         }
 
                         // if width and height are empty or lower than 0 then set default sizes:
@@ -166,7 +171,7 @@ namespace umbraco.editorControls.tinymce
                     IDictionaryEnumerator ide = tinyMCEConfiguration.SortedCommands.GetEnumerator();
                     while (ide.MoveNext())
                     {
-                        tinyMCECommand cmd = (tinyMCECommand) ide.Value;
+                        tinyMCECommand cmd = (tinyMCECommand)ide.Value;
                         ListItem li =
                             new ListItem(
                                 string.Format("<img src=\"{0}\" class=\"tinymceIcon\" alt=\"{1}\" />&nbsp;", cmd.Icon,
@@ -198,25 +203,25 @@ namespace umbraco.editorControls.tinymce
                     }
                 }
 
-			    // Mark the current db type
+                // Mark the current db type
                 _dropdownlist.SelectedValue = _datatype.DBType.ToString();
-                    
-            }
-		}
-		
-		public Control Editor 
-		{
-			get
-			{
-				return this;
-			}
-		}
 
-		public virtual void Save() 
-		{
+            }
+        }
+
+        public Control Editor
+        {
+            get
+            {
+                return this;
+            }
+        }
+
+        public virtual void Save()
+        {
             _datatype.DBType = (cms.businesslogic.datatype.DBTypes)Enum.Parse(typeof(cms.businesslogic.datatype.DBTypes), _dropdownlist.SelectedValue, true);
 
-			// Generate data-string
+            // Generate data-string
             string data = ",";
 
             foreach (ListItem li in _editorButtons.Items)
@@ -238,43 +243,39 @@ namespace umbraco.editorControls.tinymce
 
             data += "|";
 
-            
-		    data += "0|";
-            /*
-            if (_fullWidth.Checked)
-                data += "1|";
-            else
-                data += "0|";
-            */
+            data += "0|";
 
             data += _width.Text + "," + _height.Text + "|";
 
             foreach (ListItem li in _stylesheetList.Items)
                 if (li.Selected)
                     data += li.Value + ",";
-		    data += "|";
+
+            data += "|";
             data += _showLabel.Checked.ToString() + "|";
             data += _maxImageWidth.Text + "|";
 
-
-            // If the add new prevalue textbox is filled out - add the value to the collection.
-			IParameter[] SqlParams = new IParameter[] {
-										    SqlHelper.CreateParameter("@value",data),
-											SqlHelper.CreateParameter("@dtdefid",_datatype.DataTypeDefinitionId)};
-			SqlHelper.ExecuteNonQuery("delete from cmsDataTypePreValues where datatypenodeid = @dtdefid",SqlParams);
-            // we need to populate the parameters again due to an issue with SQL CE
-            SqlParams = new IParameter[] {
-										    SqlHelper.CreateParameter("@value",data),
-											SqlHelper.CreateParameter("@dtdefid",_datatype.DataTypeDefinitionId)};
-			SqlHelper.ExecuteNonQuery("insert into cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) values (@dtdefid,@value,0,'')",SqlParams);
+            using (var sqlHelper = Application.SqlHelper)
+            {
+                // If the add new prevalue textbox is filled out - add the value to the collection.
+                IParameter[] SqlParams = new IParameter[] {
+                                                sqlHelper.CreateParameter("@value",data),
+                                                sqlHelper.CreateParameter("@dtdefid",_datatype.DataTypeDefinitionId)};
+                sqlHelper.ExecuteNonQuery("delete from cmsDataTypePreValues where datatypenodeid = @dtdefid", SqlParams);
+                // we need to populate the parameters again due to an issue with SQL CE
+                SqlParams = new IParameter[] {
+                                                sqlHelper.CreateParameter("@value",data),
+                                                sqlHelper.CreateParameter("@dtdefid",_datatype.DataTypeDefinitionId)};
+                sqlHelper.ExecuteNonQuery("insert into cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) values (@dtdefid,@value,0,'')", SqlParams);
+            }
 		}
 
-		protected override void Render(HtmlTextWriter writer)
-		{
-			writer.WriteLine("<table>");
+        protected override void Render(HtmlTextWriter writer)
+        {
+            writer.WriteLine("<table>");
             writer.WriteLine("<tr><th>" + ui.Text("editdatatype", "dataBaseDatatype") + ":</th><td>");
-			_dropdownlist.RenderControl(writer);
-			writer.Write("</td></tr>");
+            _dropdownlist.RenderControl(writer);
+            writer.Write("</td></tr>");
             writer.Write("<tr><th>" + ui.Text("editdatatype", "rteButtons") + ":</th><td>");
             _editorButtons.RenderControl(writer);
             writer.Write("</td></tr>");
@@ -287,7 +288,7 @@ namespace umbraco.editorControls.tinymce
             writer.Write("<tr><th>" + ui.Text("editdatatype", "rteEnableAdvancedSettings") + ":</th><td>");
             _advancedUsersList.RenderControl(writer);
             writer.Write("</td></tr>");
-            writer.Write("<tr><th>"); 
+            writer.Write("<tr><th>");
             //"Size:</th><td>Maximum width and height: ");
             //            _fullWidth.RenderControl(writer);
 
@@ -309,20 +310,21 @@ namespace umbraco.editorControls.tinymce
             writer.Write("</table>");
         }
 
-		public string Configuration 
-		{
-			get 
-			{
+        public string Configuration
+        {
+            get
+            {
                 try
                 {
-                    return SqlHelper.ExecuteScalar<string>("select value from cmsDataTypePreValues where datatypenodeid = @datatypenodeid", SqlHelper.CreateParameter("@datatypenodeid", _datatype.DataTypeDefinitionId));
+                    using (var sqlHelper = Application.SqlHelper)
+                        return sqlHelper.ExecuteScalar<string>("select value from cmsDataTypePreValues where datatypenodeid = @datatypenodeid", sqlHelper.CreateParameter("@datatypenodeid", _datatype.DataTypeDefinitionId));
                 }
                 catch
                 {
                     return "";
                 }
-			}
-		}
+            }
+        }
 
-	}
+    }
 }

--- a/src/umbraco.editorControls/userControlWrapper/usercontrolPrevalueEditor.cs
+++ b/src/umbraco.editorControls/userControlWrapper/usercontrolPrevalueEditor.cs
@@ -21,200 +21,204 @@ namespace umbraco.editorControls.userControlGrapper
 {
     [Obsolete("IDataType and all other references to the legacy property editors are no longer used this will be removed from the codebase in future versions")]
     public class usercontrolPrevalueEditor : System.Web.UI.WebControls.PlaceHolder, umbraco.interfaces.IDataPrevalue
-	{
-		public ISqlHelper SqlHelper
-		{
-			get { return Application.SqlHelper; }
-		}
+    {
+        /// <summary>
+        /// Unused, please do not use
+        /// </summary>
+        [Obsolete("Obsolete, For querying the database use the new UmbracoDatabase object ApplicationContext.Current.DatabaseContext.Database", false)]
+        public static ISqlHelper SqlHelper
+        {
+            get { return Application.SqlHelper; }
+        }
 
-		#region IDataPrevalue Members
+        #region IDataPrevalue Members
 
-		// referenced datatype
-		private umbraco.cms.businesslogic.datatype.BaseDataType _datatype;
+        // referenced datatype
+        private umbraco.cms.businesslogic.datatype.BaseDataType _datatype;
 
-		private DropDownList _dropdownlist;
-		private DropDownList _dropdownlistUserControl;
-		private PlaceHolder _phSettings;
+        private DropDownList _dropdownlist;
+        private DropDownList _dropdownlistUserControl;
+        private PlaceHolder _phSettings;
 
-		private Dictionary<string, DataEditorSettingType> dtSettings = new Dictionary<string, DataEditorSettingType>();
+        private Dictionary<string, DataEditorSettingType> dtSettings = new Dictionary<string, DataEditorSettingType>();
 
-		public usercontrolPrevalueEditor(umbraco.cms.businesslogic.datatype.BaseDataType DataType) 
-		{
-			// state it knows its datatypedefinitionid
-			_datatype = DataType;
-			setupChildControls();
+        public usercontrolPrevalueEditor(umbraco.cms.businesslogic.datatype.BaseDataType DataType)
+        {
+            // state it knows its datatypedefinitionid
+            _datatype = DataType;
+            setupChildControls();
 
-		}
-		
-		private void setupChildControls() 
-		{
-			_dropdownlist = new DropDownList();
-			_dropdownlist.ID = "dbtype";
-			_dropdownlist.Items.Add(DBTypes.Date.ToString());
-			_dropdownlist.Items.Add(DBTypes.Integer.ToString());
-			_dropdownlist.Items.Add(DBTypes.Ntext.ToString());
-			_dropdownlist.Items.Add(DBTypes.Nvarchar.ToString());
-			
-			_dropdownlistUserControl = new DropDownList();
-			_dropdownlistUserControl.ID = "usercontrol";
+        }
 
-			_phSettings = new PlaceHolder();
-			_phSettings.ID = "settings";
+        private void setupChildControls()
+        {
+            _dropdownlist = new DropDownList();
+            _dropdownlist.ID = "dbtype";
+            _dropdownlist.Items.Add(DBTypes.Date.ToString());
+            _dropdownlist.Items.Add(DBTypes.Integer.ToString());
+            _dropdownlist.Items.Add(DBTypes.Ntext.ToString());
+            _dropdownlist.Items.Add(DBTypes.Nvarchar.ToString());
 
-			// put the childcontrols in context - ensuring that
-			// the viewstate is persisted etc.
-			Controls.Add(_dropdownlist);
-			Controls.Add(_dropdownlistUserControl);
-			Controls.Add(_phSettings);
+            _dropdownlistUserControl = new DropDownList();
+            _dropdownlistUserControl.ID = "usercontrol";
 
-			// populate the usercontrol dropdown
-			_dropdownlistUserControl.Items.Add(new ListItem(ui.Text("choose"), ""));
-			populateUserControls( IOHelper.MapPath( SystemDirectories.UserControls) );
+            _phSettings = new PlaceHolder();
+            _phSettings.ID = "settings";
 
-		   
-		}
+            // put the childcontrols in context - ensuring that
+            // the viewstate is persisted etc.
+            Controls.Add(_dropdownlist);
+            Controls.Add(_dropdownlistUserControl);
+            Controls.Add(_phSettings);
 
-		private void populateUserControls(string path)
-		{
-			DirectoryInfo di = new DirectoryInfo(path);
+            // populate the usercontrol dropdown
+            _dropdownlistUserControl.Items.Add(new ListItem(ui.Text("choose"), ""));
+            populateUserControls(IOHelper.MapPath(SystemDirectories.UserControls));
+
+
+        }
+
+        private void populateUserControls(string path)
+        {
+            DirectoryInfo di = new DirectoryInfo(path);
             if (di.Exists == false) return;
 
-			foreach (FileInfo uc in di.GetFiles("*.ascx"))
-			{
+            foreach (FileInfo uc in di.GetFiles("*.ascx"))
+            {
                 string ucRoot = IOHelper.MapPath(SystemDirectories.UserControls);
 
-				_dropdownlistUserControl.Items.Add(
+                _dropdownlistUserControl.Items.Add(
 
                     new ListItem(SystemDirectories.UserControls +
                             uc.FullName.Substring(ucRoot.Length).Replace(IOHelper.DirSepChar, '/'))
 
-					/*
-					new ListItem( 
-						uc.FullName.Substring( uc.FullName.IndexOf(root), uc.FullName.Length - uc.FullName.IndexOf(root)).Replace(IOHelper.DirSepChar, '/'))
-					  */  
-						);
+                        /*
+                        new ListItem( 
+                            uc.FullName.Substring( uc.FullName.IndexOf(root), uc.FullName.Length - uc.FullName.IndexOf(root)).Replace(IOHelper.DirSepChar, '/'))
+                          */
+                        );
 
-			}
-			foreach (DirectoryInfo dir in di.GetDirectories())
-				populateUserControls(dir.FullName);
-		}
+            }
+            foreach (DirectoryInfo dir in di.GetDirectories())
+                populateUserControls(dir.FullName);
+        }
 
-		public Control Editor
-		{
-			get
-			{
-				return this;
-			}
-		}
-
-
-		protected override void OnLoad(EventArgs e)
-		{
-			base.OnLoad(e);
-			if (!Page.IsPostBack)
-			{
-				string config = Configuration;
-				if (config != "")
-				{
-					_dropdownlistUserControl.SelectedValue = config;
-
-					
-				}
-				_dropdownlist.SelectedValue = _datatype.DBType.ToString();
+        public Control Editor
+        {
+            get
+            {
+                return this;
+            }
+        }
 
 
-				
-			}
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            if (!Page.IsPostBack)
+            {
+                string config = Configuration;
+                if (config != "")
+                {
+                    _dropdownlistUserControl.SelectedValue = config;
 
-			//check for settings
-			if (!string.IsNullOrEmpty(Configuration))
-				LoadSetttings(Configuration);
-		   
 
-		}
+                }
+                _dropdownlist.SelectedValue = _datatype.DBType.ToString();
 
-		private Dictionary<string, DataEditorSetting> GetSettings(Type t)
-		{
-			Dictionary<string, DataEditorSetting> settings = new Dictionary<string, DataEditorSetting>();
 
-			foreach (System.Reflection.PropertyInfo p in t.GetProperties())
-			{
 
-				object[] o = p.GetCustomAttributes(typeof(DataEditorSetting), true);
+            }
 
-				if (o.Length > 0)
-					settings.Add(p.Name, (DataEditorSetting)o[0]);
-			}
-			return settings;
-		}
+            //check for settings
+            if (!string.IsNullOrEmpty(Configuration))
+                LoadSetttings(Configuration);
 
-		private bool HasSettings(Type t)
-		{
-			bool hasSettings = false;
-			foreach (System.Reflection.PropertyInfo p in t.GetProperties())
-			{
-				object[] o = p.GetCustomAttributes(typeof(DataEditorSetting), true);
 
-				if (o.Length > 0)
-				{
-					hasSettings = true;
-					break;
-				}
-			}
+        }
 
-			return hasSettings;
-		}
+        private Dictionary<string, DataEditorSetting> GetSettings(Type t)
+        {
+            Dictionary<string, DataEditorSetting> settings = new Dictionary<string, DataEditorSetting>();
 
-		private void LoadSetttings(string fileName)
-		{
+            foreach (System.Reflection.PropertyInfo p in t.GetProperties())
+            {
+
+                object[] o = p.GetCustomAttributes(typeof(DataEditorSetting), true);
+
+                if (o.Length > 0)
+                    settings.Add(p.Name, (DataEditorSetting)o[0]);
+            }
+            return settings;
+        }
+
+        private bool HasSettings(Type t)
+        {
+            bool hasSettings = false;
+            foreach (System.Reflection.PropertyInfo p in t.GetProperties())
+            {
+                object[] o = p.GetCustomAttributes(typeof(DataEditorSetting), true);
+
+                if (o.Length > 0)
+                {
+                    hasSettings = true;
+                    break;
+                }
+            }
+
+            return hasSettings;
+        }
+
+        private void LoadSetttings(string fileName)
+        {
             // due to legacy, some user controls may not have the tilde start
             if (fileName.StartsWith("~/"))
                 fileName = fileName.Substring(2);
 
-			if (System.IO.File.Exists(IOHelper.MapPath("~/" + fileName)))
-			{
-			  
-				UserControl oControl = (UserControl)this.Page.LoadControl(@"~/" + fileName);
+            if (System.IO.File.Exists(IOHelper.MapPath("~/" + fileName)))
+            {
 
-				Type type = oControl.GetType();
+                UserControl oControl = (UserControl)this.Page.LoadControl(@"~/" + fileName);
 
-
-				Dictionary<string, DataEditorSetting> settings = GetSettings(type);
-
-				foreach (KeyValuePair<string, DataEditorSetting> kv in settings)
-				{
-					DataEditorSettingType dst = kv.Value.GetDataEditorSettingType();
-					dtSettings.Add(kv.Key, dst);
-
-					DataEditorPropertyPanel panel = new DataEditorPropertyPanel();
-					panel.Text = kv.Value.GetName();
-					panel.Text += "<br/><small>" + kv.Value.description + "</small>";
+                Type type = oControl.GetType();
 
 
-					if (HasSettings(type))
-					{
-						DataEditorSettingsStorage ss = new DataEditorSettingsStorage();
+                Dictionary<string, DataEditorSetting> settings = GetSettings(type);
 
-						List<Setting<string, string>> s = ss.GetSettings(_datatype.DataTypeDefinitionId);
-						ss.Dispose();
+                foreach (KeyValuePair<string, DataEditorSetting> kv in settings)
+                {
+                    DataEditorSettingType dst = kv.Value.GetDataEditorSettingType();
+                    dtSettings.Add(kv.Key, dst);
 
-						if (s.Find(set => set.Key == kv.Key).Value != null)
-							dst.Value = s.Find(set => set.Key == kv.Key).Value;
+                    DataEditorPropertyPanel panel = new DataEditorPropertyPanel();
+                    panel.Text = kv.Value.GetName();
+                    panel.Text += "<br/><small>" + kv.Value.description + "</small>";
 
-					}
 
-					panel.Controls.Add(dst.RenderControl(kv.Value));
+                    if (HasSettings(type))
+                    {
+                        DataEditorSettingsStorage ss = new DataEditorSettingsStorage();
 
-					Label invalid = new Label();
-					invalid.Attributes.Add("style", "color:#8A1F11");
-					invalid.ID = "lbl" + kv.Key;
-					panel.Controls.Add(invalid);
+                        List<Setting<string, string>> s = ss.GetSettings(_datatype.DataTypeDefinitionId);
+                        ss.Dispose();
 
-					_phSettings.Controls.Add(panel);
-					
-				}
-			}
-		}
+                        if (s.Find(set => set.Key == kv.Key).Value != null)
+                            dst.Value = s.Find(set => set.Key == kv.Key).Value;
+
+                    }
+
+                    panel.Controls.Add(dst.RenderControl(kv.Value));
+
+                    Label invalid = new Label();
+                    invalid.Attributes.Add("style", "color:#8A1F11");
+                    invalid.ID = "lbl" + kv.Key;
+                    panel.Controls.Add(invalid);
+
+                    _phSettings.Controls.Add(panel);
+
+                }
+            }
+        }
 
 		public void Save()
 		{
@@ -247,23 +251,25 @@ namespace umbraco.editorControls.userControlGrapper
 				// Generate data-string
 				string data = _dropdownlistUserControl.SelectedValue;
 
-				// If the add new prevalue textbox is filled out - add the value to the collection.
-				IParameter[] SqlParams = new IParameter[]
-											 {
-												 SqlHelper.CreateParameter("@value", data),
-												 SqlHelper.CreateParameter("@dtdefid", _datatype.DataTypeDefinitionId)
-											 };
-				SqlHelper.ExecuteNonQuery("delete from cmsDataTypePreValues where datatypenodeid = @dtdefid", SqlParams);
-				// we need to populate the parameters again due to an issue with SQL CE
-				SqlParams = new IParameter[]
-								{
-									SqlHelper.CreateParameter("@value", data),
-									SqlHelper.CreateParameter("@dtdefid", _datatype.DataTypeDefinitionId)
-								};
-				SqlHelper.ExecuteNonQuery(
-					"insert into cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) values (@dtdefid,@value,0,'')",
-					SqlParams);
-
+                // If the add new prevalue textbox is filled out - add the value to the collection.
+                using (var sqlHelper = Application.SqlHelper)
+                {
+                    IParameter[] SqlParams = new IParameter[]
+                                                 {
+                                                     sqlHelper.CreateParameter("@value", data),
+                                                     sqlHelper.CreateParameter("@dtdefid", _datatype.DataTypeDefinitionId)
+                                                 };
+                    sqlHelper.ExecuteNonQuery("delete from cmsDataTypePreValues where datatypenodeid = @dtdefid", SqlParams);
+                    // we need to populate the parameters again due to an issue with SQL CE
+                    SqlParams = new IParameter[]
+                                    {
+                                        sqlHelper.CreateParameter("@value", data),
+                                        sqlHelper.CreateParameter("@dtdefid", _datatype.DataTypeDefinitionId)
+                                    };
+                    sqlHelper.ExecuteNonQuery(
+                        "insert into cmsDataTypePreValues (datatypenodeid,[value],sortorder,alias) values (@dtdefid,@value,0,'')",
+                        SqlParams);
+                }
 
 				//settings
 
@@ -290,35 +296,36 @@ namespace umbraco.editorControls.userControlGrapper
 			}
 		}
 
-		protected override void Render(HtmlTextWriter writer)
-		{
-			writer.WriteLine("<div class=\"propertyItem\">");
-			writer.WriteLine("<div class=\"propertyItemheader\">Database datatype</div>");
-			writer.WriteLine("<div class=\"propertyItemContent\">");
-			_dropdownlist.RenderControl(writer);
-			writer.Write("</div></div>");
+        protected override void Render(HtmlTextWriter writer)
+        {
+            writer.WriteLine("<div class=\"propertyItem\">");
+            writer.WriteLine("<div class=\"propertyItemheader\">Database datatype</div>");
+            writer.WriteLine("<div class=\"propertyItemContent\">");
+            _dropdownlist.RenderControl(writer);
+            writer.Write("</div></div>");
 
-			writer.WriteLine("<div class=\"propertyItem\">");
-			writer.WriteLine("<div class=\"propertyItemheader\">Usercontrol:</div>");
-			writer.WriteLine("<div class=\"propertyItemContent\">");
-			_dropdownlistUserControl.RenderControl(writer);
-			writer.Write("</div></div>");
+            writer.WriteLine("<div class=\"propertyItem\">");
+            writer.WriteLine("<div class=\"propertyItemheader\">Usercontrol:</div>");
+            writer.WriteLine("<div class=\"propertyItemContent\">");
+            _dropdownlistUserControl.RenderControl(writer);
+            writer.Write("</div></div>");
 
-			_phSettings.RenderControl(writer);
-		}
+            _phSettings.RenderControl(writer);
+        }
 
 		public string Configuration
 		{
 			get
 			{
-				object conf =
-					SqlHelper.ExecuteScalar<object>("select value from cmsDataTypePreValues where datatypenodeid = @datatypenodeid",
-											SqlHelper.CreateParameter("@datatypenodeid", _datatype.DataTypeDefinitionId));
-				if (conf != null)
-					return conf.ToString();
-				else
-					return "";
-
+                using (var sqlHelper = Application.SqlHelper) { 
+                    object conf =
+					    sqlHelper.ExecuteScalar<object>("select value from cmsDataTypePreValues where datatypenodeid = @datatypenodeid",
+											    sqlHelper.CreateParameter("@datatypenodeid", _datatype.DataTypeDefinitionId));
+				    if (conf != null)
+					    return conf.ToString();
+				    else
+					    return "";
+                }
 			}
 		}
 


### PR DESCRIPTION
…into using blocks

To review, make sure that all usages of `SqlHelper`, `ExecuteReader` and `ExecuteXmlReader` are in a `using` block. There's a few exceptions like the `ExecuteReader` in `Log.cs` but all others should be done.

I've not refactored any other code, on purpose, to make this easier to merge. My hands were itching, for sure... 

In Github, make sure to [add `?w=1` to the querystring (or just click here)](https://github.com/umbraco/Umbraco-CMS/pull/1637/files?w=1) to filter out whitespace differences.

In VS finding usages should look something lie this for `ExecuteXmlReader`:

![image](https://cloud.githubusercontent.com/assets/304656/20641938/52c55084-b403-11e6-9484-c6c15b7dc2c7.png)


For `ExecuteReader`:

![image](https://cloud.githubusercontent.com/assets/304656/20641933/4137d97c-b403-11e6-8eb4-c13f1e99011c.png)


And for For `SqlHelper`:

![image](https://cloud.githubusercontent.com/assets/304656/20641925/1e19f682-b403-11e6-8540-f9e8d1b6b71e.png)


