### PR TITLE
U4-9254 - Added defaultSection to webroutingsection - used by routes.js

### DIFF
--- a/src/Umbraco.Core/Configuration/UmbracoSettings/IWebRoutingSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/IWebRoutingSection.cs
@@ -15,6 +15,8 @@
         string UrlProviderMode { get; }
 
         string UmbracoApplicationUrl { get; }
+
+        string defaultSection { get;  }
     }
 
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/IWebRoutingSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/IWebRoutingSection.cs
@@ -16,7 +16,7 @@
 
         string UmbracoApplicationUrl { get; }
 
-        string defaultSection { get;  }
+        string DefaultSection { get;  }
     }
 
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/WebRoutingElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/WebRoutingElement.cs
@@ -44,5 +44,11 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         {
             get { return (string)base["umbracoApplicationUrl"]; }
         }
+
+        [ConfigurationProperty("defaultSection", DefaultValue = "false")]
+        public string defaultSection
+        {
+            get { return (string)base["defaultSection"]; }
+        }
     }
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/WebRoutingElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/WebRoutingElement.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         }
 
         [ConfigurationProperty("defaultSection", DefaultValue = "false")]
-        public string defaultSection
+        public string DefaultSection
         {
             get { return (string)base["defaultSection"]; }
         }

--- a/src/Umbraco.Web.UI.Client/src/routes.js
+++ b/src/Umbraco.Web.UI.Client/src/routes.js
@@ -101,7 +101,7 @@ app.config(function ($routeProvider) {
             templateUrl: function (rp) {
                 if (rp.section.toLowerCase() === "default" || rp.section.toLowerCase() === "umbraco" || rp.section === "")
                 {
-                    rp.section = "content";
+                    rp.section = Umbraco.Sys.ServerVariables.umbracoSettings.defaultSection || "content";
                 }
 
                 rp.url = "dashboard.aspx?app=" + rp.section;

--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -291,8 +291,8 @@
         over and render its built-in error page. See MS doc for HttpResponseBase.TrySkipIisCustomErrors.
         The default value is false, for backward compatibility reasons, which means that IIS _will_ take
         over, and _prevent_ Umbraco 404 pages to show.
-      @internalRedirectPreservesTemplate
-        Default section when logging into to the umbraco backend. Default is content
+      @defaultSection
+        Default section when logging into to the umbraco backend. Default is 'content'
       @internalRedirectPreservesTemplate
         By default as soon as we're not displaying the initial document, we reset the template set by the
         finder or by the alt. template. Set this option to true to preserve the template set by the finder

--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -292,6 +292,8 @@
         The default value is false, for backward compatibility reasons, which means that IIS _will_ take
         over, and _prevent_ Umbraco 404 pages to show.
       @internalRedirectPreservesTemplate
+        Default section when logging into to the umbraco backend. Default is content
+      @internalRedirectPreservesTemplate
         By default as soon as we're not displaying the initial document, we reset the template set by the
         finder or by the alt. template. Set this option to true to preserve the template set by the finder
         or by the alt. template, in case of an internal redirect.
@@ -312,6 +314,7 @@
   -->
   <web.routing
     trySkipIisCustomErrors="false"
+    defaultSection="content"
     internalRedirectPreservesTemplate="false" disableAlternativeTemplates="false" disableFindContentByIdPath="false"
     umbracoApplicationUrl="">
   </web.routing>

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -381,7 +381,7 @@ namespace Umbraco.Web.Editors
                                 GetMaxRequestLength()
                             },
                             {"keepUserLoggedIn", UmbracoConfig.For.UmbracoSettings().Security.KeepUserLoggedIn},
-                            {"defaultSection", UmbracoConfig.For.UmbracoSettings().WebRouting.defaultSection},
+                            {"defaultSection", UmbracoConfig.For.UmbracoSettings().WebRouting.DefaultSection},
                             {"cssPath", IOHelper.ResolveUrl(SystemDirectories.Css).TrimEnd('/')},
                             {"allowPasswordReset", UmbracoConfig.For.UmbracoSettings().Security.AllowPasswordReset},
                         }

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -381,6 +381,7 @@ namespace Umbraco.Web.Editors
                                 GetMaxRequestLength()
                             },
                             {"keepUserLoggedIn", UmbracoConfig.For.UmbracoSettings().Security.KeepUserLoggedIn},
+                            {"defaultSection", UmbracoConfig.For.UmbracoSettings().WebRouting.defaultSection},
                             {"cssPath", IOHelper.ResolveUrl(SystemDirectories.Css).TrimEnd('/')},
                             {"allowPasswordReset", UmbracoConfig.For.UmbracoSettings().Security.AllowPasswordReset},
                         }


### PR DESCRIPTION
The default section to show should not be hardcoded!

We've made a custom dashboard for our editors and they do not like to click the section button each time the log in. They want it to be the standard/default view instead of content.

Let me know if the setting should be somewhere else :)