### PR TITLE
Store GUIDs instead of IDs for pre value content picker

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/PreValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/PreValueEditor.cs
@@ -178,7 +178,7 @@ namespace Umbraco.Core.PropertyEditors
             return result;
         }
 
-        private void ConvertItemsToJsonIfDetected(IDictionary<string, object> result)
+        internal void ConvertItemsToJsonIfDetected(IDictionary<string, object> result)
         {
             //now we're going to try to see if any of the values are JSON, if they are we'll convert them to real JSON objects
             // so they can be consumed as real json in angular!

--- a/src/Umbraco.Web/PropertyEditors/ContentPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ContentPickerPropertyEditor.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Umbraco.Core;
+using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
@@ -33,17 +35,97 @@ namespace Umbraco.Web.PropertyEditors
 
         internal class ContentPickerPreValueEditor : PreValueEditor
         {
+            private const string _startNodeAlias = "startNodeId";
+
             [PreValueField("showOpenButton", "Show open button", "boolean")]
             public string ShowOpenButton { get; set; }
 
             [PreValueField("showEditButton", "Show edit button (this feature is in preview!)", "boolean")]
             public string ShowEditButton { get; set; }
-            
-            [PreValueField("startNodeId", "Start node", "treepicker")]
+
+            [PreValueField(_startNodeAlias, "Start node", "treepicker")]
             public int StartNodeId { get; set; }
 
             [PreValueField("showPathOnHover", "Show path when hovering items", "boolean")]
             public bool ShowPathOnHover { get; set; }
+
+            public override IDictionary<string, PreValue> ConvertEditorToDb(IDictionary<string, object> editorValue, PreValueCollection currentValue)
+            {
+                var processedEditorValues = new Dictionary<string, PreValue>();
+                foreach (var preval in editorValue)
+                {
+                    var processedPreVal = new KeyValuePair<string, PreValue>(preval.Key, preval.Value == null ? null : new PreValue(preval.Value.ToString()));
+                    if (preval.Key == _startNodeAlias && preval.Value != null)
+                    {
+                        int startNodeUniqueId;
+                        if (int.TryParse(preval.Value.ToString(), out startNodeUniqueId))
+                        {
+                            // look up the node
+                            var cs = ApplicationContext.Current.Services.ContentService;
+                            var contentNode = cs.GetById(startNodeUniqueId);
+                            if (contentNode != null)
+                            {
+                                processedPreVal = new KeyValuePair<string, PreValue>(preval.Key, new PreValue(contentNode.Key.ToString()));
+                            }
+                        }
+                    }
+                    processedEditorValues.Add(processedPreVal.Key, processedPreVal.Value);
+                }
+                return processedEditorValues;
+
+                }
+
+            public override IDictionary<string, object> ConvertDbToEditor(IDictionary<string, object> defaultPreVals, PreValueCollection persistedPreVals)
+            {
+                var defaultPreValCopy = new Dictionary<string, object>();
+                if (defaultPreVals != null)
+                {
+                    defaultPreValCopy = new Dictionary<string, object>(defaultPreVals);
+                }
+
+                //we just need to merge the dictionaries now, the persisted will replace default.
+                foreach (var item in persistedPreVals.PreValuesAsDictionary)
+                {
+                    //The persisted dictionary contains values of type PreValue which contain the ID and the Value, we don't care
+                    // about the Id, just the value so ignore the id.
+
+                    // the start node could be stored as a Guid, in that case we'll need to find its integer Id
+                    if (item.Key == _startNodeAlias)
+                    {
+                        Guid startNodeUniqueId;
+                        if (Guid.TryParse(item.Value.Value, out startNodeUniqueId))
+                        {
+                            // look up the node
+                            var cs = ApplicationContext.Current.Services.ContentService;
+                            var contentNode = cs.GetById(startNodeUniqueId);
+                            if (contentNode != null)
+                            {
+                                defaultPreValCopy[item.Key] = contentNode.Id.ToString();
+                            }
+                            else
+                            {
+                                // the content couldn't be found - revert to the start node for the user
+                                defaultPreValCopy[item.Key] = UmbracoContext.Current.Security.CurrentUser.StartContentId.ToString();
+                            }
+                        }
+                        else
+                        {
+                            defaultPreValCopy[item.Key] = item.Value.Value;
+                        }
+
+                    }
+                    else
+                    {
+                        defaultPreValCopy[item.Key] = item.Value.Value;
+                    }
+
+                }
+                //now we're going to try to see if any of the values are JSON, if they are we'll convert them to real JSON objects
+                // so they can be consumed as real json in angular!
+                base.ConvertItemsToJsonIfDetected(defaultPreValCopy);
+
+                return defaultPreValCopy;
+            }
         }
     }
 }


### PR DESCRIPTION
This change is 100% backwards compatible and will make the content pre-value editor for Data Types save Guids instead of Integer IDs. By overriding ConvertEditorToDb and ConvertDbToEditor methods in the PreValueEditor, we can automatically convert the GUID back to Integer when the service layers request the data, thus make it a data layer change only.

Following this we should update the media picker, etc as well.