### PR TITLE
U4-9318 Examine indexes inherited unpublished nodes on index rebuild

### DIFF
--- a/src/UmbracoExamine/UmbracoContentIndexer.cs
+++ b/src/UmbracoExamine/UmbracoContentIndexer.cs
@@ -419,6 +419,8 @@ namespace UmbracoExamine
                         pageIndex++;
                     } while (content.Length == pageSize);
 
+                    notPublished.Clear();
+
                     break;
                 case IndexTypes.Media:
                     var mediaParentId = -1;

--- a/src/UmbracoExamine/UmbracoContentIndexer.cs
+++ b/src/UmbracoExamine/UmbracoContentIndexer.cs
@@ -142,7 +142,7 @@ namespace UmbracoExamine
             _userService = userService;
             _contentTypeService = contentTypeService;
         }
-
+        
         #endregion
 
         #region Constants & Fields
@@ -365,7 +365,7 @@ namespace UmbracoExamine
         /// <summary>
         /// This is a static query, it's parameters don't change so store statically
         /// </summary>
-        private static readonly IQuery<IContent> PublishedQuery = Query<IContent>.Builder.Where(x => x.Published == true);
+        private IQuery<IContent> _publishedQuery;
 
         protected override void PerformIndexAll(string type)
         {
@@ -393,8 +393,13 @@ namespace UmbracoExamine
                         }
                         else
                         {
+                            if (_publishedQuery == null)
+                            {
+                                _publishedQuery = Query<IContent>.Builder.Where(x => x.Published == true);
+                            }
+
                             //add the published filter
-                            descendants = _contentService.GetPagedDescendants(contentParentId, pageIndex, pageSize, out total, "Path", Direction.Ascending, true, PublishedQuery);
+                            descendants = _contentService.GetPagedDescendants(contentParentId, pageIndex, pageSize, out total, "Path", Direction.Ascending, true, _publishedQuery);
                         }                        
 
                         //if specific types are declared we need to post filter them


### PR DESCRIPTION
This also reduces allocations since we don't need to create a new serializer for every doc. To fix the unpublishing we sort the paged results by level and track each explicitly unpublished item path and ensure it's not added to the index , then we check each other non explicitly unpublished item to check if it exists underneath any tracked unpublished nodes and if so we don't publish them either.