### PR TITLE
U4-9335 UmbracoExamine needs to ignore the useTempStorage option if a…

### DIFF
--- a/src/UmbracoExamine/BaseUmbracoIndexer.cs
+++ b/src/UmbracoExamine/BaseUmbracoIndexer.cs
@@ -162,6 +162,10 @@ namespace UmbracoExamine
 
             base.Initialize(name, config);
 
+            //NOTES: useTempStorage is obsolete, tempStorageDirectory is obsolete, both have been superceded by Examine Core's IDirectoryFactory
+            //       tempStorageDirectory never actually got finished in Umbraco Core but accidentally got shipped (it's only enabled on the searcher
+            //       and not the indexer). So this whole block is just legacy
+
             //detect if a dir factory has been specified, if so then useTempStorage will not be used (deprecated)
             if (config["directoryFactory"] == null && config["useTempStorage"] != null)
             {

--- a/src/UmbracoExamine/BaseUmbracoIndexer.cs
+++ b/src/UmbracoExamine/BaseUmbracoIndexer.cs
@@ -162,7 +162,8 @@ namespace UmbracoExamine
 
             base.Initialize(name, config);
 
-            if (config["useTempStorage"] != null)
+            //detect if a dir factory has been specified, if so then useTempStorage will not be used (deprecated)
+            if (config["directoryFactory"] == null && config["useTempStorage"] != null)
             {
                 var fsDir = base.GetLuceneDirectory() as FSDirectory;
                 if (fsDir != null)

--- a/src/UmbracoExamine/LocalStorage/AzureLocalStorageDirectory.cs
+++ b/src/UmbracoExamine/LocalStorage/AzureLocalStorageDirectory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.IO;
 using System.Web;
 using Umbraco.Core;
@@ -9,6 +10,8 @@ namespace UmbracoExamine.LocalStorage
     /// <summary>
     /// When running on Azure websites, we can use the local user's storage space
     /// </summary>
+    [Obsolete("This has been superceded by IDirectoryFactory in Examine Core and should not be used")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class AzureLocalStorageDirectory : ILocalStorageDirectory
     {
         public DirectoryInfo GetLocalStorageDirectory(NameValueCollection config, string configuredPath)

--- a/src/UmbracoExamine/LocalStorage/CodeGenLocalStorageDirectory.cs
+++ b/src/UmbracoExamine/LocalStorage/CodeGenLocalStorageDirectory.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.IO;
 using System.Web;
 
@@ -11,6 +13,8 @@ namespace UmbracoExamine.LocalStorage
     /// This is the default implementation - but it comes with it's own limitations - the CodeGen folder is cleared whenever new
     /// DLLs are changed in the /bin folder (among other circumstances) which means the index would be re-synced (or rebuilt) there.
     /// </remarks>
+    [Obsolete("This has been superceded by IDirectoryFactory in Examine Core and should not be used")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class CodeGenLocalStorageDirectory : ILocalStorageDirectory
     {
         public DirectoryInfo GetLocalStorageDirectory(NameValueCollection config, string configuredPath)

--- a/src/UmbracoExamine/UmbracoExamineSearcher.cs
+++ b/src/UmbracoExamine/UmbracoExamineSearcher.cs
@@ -73,7 +73,8 @@ namespace UmbracoExamine
 
             base.Initialize(name, config);
 
-            if (config != null && config["useTempStorage"] != null)
+            //detect if a dir factory has been specified, if so then useTempStorage will not be used (deprecated)
+            if (config != null && config["directoryFactory"] == null && config["useTempStorage"] != null)
             {
                 //Use the temp storage directory which will store the index in the local/codegen folder, this is useful
                 // for websites that are running from a remove file server and file IO latency becomes an issue

--- a/src/UmbracoExamine/UmbracoExamineSearcher.cs
+++ b/src/UmbracoExamine/UmbracoExamineSearcher.cs
@@ -73,6 +73,10 @@ namespace UmbracoExamine
 
             base.Initialize(name, config);
 
+            //NOTES: useTempStorage is obsolete, tempStorageDirectory is obsolete, both have been superceded by Examine Core's IDirectoryFactory
+            //       tempStorageDirectory never actually got finished in Umbraco Core but accidentally got shipped (it's only enabled on the searcher
+            //       and not the indexer). So this whole block is just legacy
+
             //detect if a dir factory has been specified, if so then useTempStorage will not be used (deprecated)
             if (config != null && config["directoryFactory"] == null && config["useTempStorage"] != null)
             {


### PR DESCRIPTION
…n IDirectoryFactory config option is supplied by the indexer