### PR TITLE
Fixed error label showing when you do a retry

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/database.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/database.controller.js
@@ -1,28 +1,35 @@
 angular.module("umbraco.install").controller("Umbraco.Installer.DataBaseController", function($scope, $http, installerService){
 	
 	$scope.checking = false;
+	$scope.invalidDbDns = false;
+			
 	$scope.dbs = [
-					{name: 'Microsoft SQL Server Compact (SQL CE)', id: 0},
-					{name: 'Microsoft SQL Server', id: 1},
-                    { name: 'Microsoft SQL Azure', id: 3 },
-                    { name: 'MySQL', id: 2 },
-					{name: 'Custom connection string', id: -1}];
+		{ name: 'Microsoft SQL Server Compact (SQL CE)', id: 0},
+		{ name: 'Microsoft SQL Server', id: 1},
+                { name: 'Microsoft SQL Azure', id: 3 },
+		{ name: 'MySQL', id: 2 },
+		{ name: 'Custom connection string', id: -1}
+	];
 
-	if(installerService.status.current.model.dbType === undefined){
+	if ( installerService.status.current.model.dbType === undefined ) {
 		installerService.status.current.model.dbType = 0;
 	}
 	
-    $scope.validateAndForward = function(){
-		if(!$scope.checking && this.myForm.$valid){
+    	$scope.validateAndForward = function(){
+		if ( !$scope.checking && this.myForm.$valid ) {
 		 	$scope.checking = true;
+			$scope.invalidDbDns = false;
+			
 			var model = installerService.status.current.model;
 
-			$http.post(Umbraco.Sys.ServerVariables.installApiBaseUrl + "PostValidateDatabaseConnection",
-				model).then(function(response){
+			$http.post(
+				Umbraco.Sys.ServerVariables.installApiBaseUrl + "PostValidateDatabaseConnection",
+				model ).then( function( response ) {
 					
-					if(response.data === "true"){
+					if ( response.data === "true" ) {
 						installerService.forward();	
-					}else{
+					}
+					else {
 						$scope.invalidDbDns = true;
 					}
 


### PR DESCRIPTION
Should be a nice and easy one, the bool for if the DB connection is valid or not is never cleared on when you do a retry.

http://issues.umbraco.org/issue/U4-9193