### PR TITLE
U4-9377 It is possible to create/save entities with a blank names by …

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2192,6 +2192,11 @@ namespace Umbraco.Core.Services
                 }
             }
 
+            if (string.IsNullOrWhiteSpace(content.Name))
+            {
+                throw new ArgumentException("Cannot save content with empty name.");
+            }
+
             using (new WriteLock(Locker))
             {
                 var uow = UowProvider.GetUnitOfWork();

--- a/src/Umbraco.Core/Services/ContentTypeService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeService.cs
@@ -719,8 +719,13 @@ namespace Umbraco.Core.Services
         /// <param name="userId">Optional id of the user saving the ContentType</param>
         public void Save(IContentType contentType, int userId = 0)
         {
-	        if (SavingContentType.IsRaisedEventCancelled(new SaveEventArgs<IContentType>(contentType), this))
-				return;
+            if (SavingContentType.IsRaisedEventCancelled(new SaveEventArgs<IContentType>(contentType), this))
+                return;
+
+            if (string.IsNullOrWhiteSpace(contentType.Name))
+            {
+                throw new ArgumentException("Cannot save content type with empty name.");
+            }
 
             using (new WriteLock(Locker))
             {

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -361,8 +361,13 @@ namespace Umbraco.Core.Services
         /// <param name="userId">Id of the user issueing the save</param>
         public void Save(IDataTypeDefinition dataTypeDefinition, int userId = 0)
         {
-	        if (Saving.IsRaisedEventCancelled(new SaveEventArgs<IDataTypeDefinition>(dataTypeDefinition), this)) 
-				return;
+            if (Saving.IsRaisedEventCancelled(new SaveEventArgs<IDataTypeDefinition>(dataTypeDefinition), this)) 
+                return;
+
+            if (string.IsNullOrWhiteSpace(dataTypeDefinition.Name))
+            {
+                throw new ArgumentException("Cannot save datatype with empty name.");
+            }
 
             var uow = UowProvider.GetUnitOfWork();
             using (var repository = RepositoryFactory.CreateDataTypeDefinitionRepository(uow))

--- a/src/Umbraco.Core/Services/MacroService.cs
+++ b/src/Umbraco.Core/Services/MacroService.cs
@@ -142,19 +142,24 @@ namespace Umbraco.Core.Services
         /// <param name="userId">Optional Id of the user deleting the macro</param>
         public void Save(IMacro macro, int userId = 0)
         {
-	        if (Saving.IsRaisedEventCancelled(new SaveEventArgs<IMacro>(macro), this)) 
-				return;
-	        
-			var uow = UowProvider.GetUnitOfWork();
-	        using (var repository = RepositoryFactory.CreateMacroRepository(uow))
-	        {
-		        repository.AddOrUpdate(macro);
-		        uow.Commit();
+            if (Saving.IsRaisedEventCancelled(new SaveEventArgs<IMacro>(macro), this))
+                return;
 
-		        Saved.RaiseEvent(new SaveEventArgs<IMacro>(macro, false), this);
-	        }
+            if (string.IsNullOrWhiteSpace(macro.Name))
+            {
+                throw new ArgumentException("Cannot save macro with empty name.");
+            }
 
-	        Audit(AuditType.Save, "Save Macro performed by user", userId, -1);
+            var uow = UowProvider.GetUnitOfWork();
+            using (var repository = RepositoryFactory.CreateMacroRepository(uow))
+            {
+                repository.AddOrUpdate(macro);
+                uow.Commit();
+
+                Saved.RaiseEvent(new SaveEventArgs<IMacro>(macro, false), this);
+            }
+
+            Audit(AuditType.Save, "Save Macro performed by user", userId, -1);
         }
 
         ///// <summary>

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -837,7 +837,11 @@ namespace Umbraco.Core.Services
                 {
                     return OperationStatus.Cancelled(evtMsgs);
                 }
+            }
 
+            if (string.IsNullOrWhiteSpace(media.Name))
+            {
+                throw new ArgumentException("Cannot save media with empty name.");
             }
 
             var uow = UowProvider.GetUnitOfWork();

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -978,6 +978,11 @@ namespace Umbraco.Core.Services
                 }
             }
 
+            if (string.IsNullOrWhiteSpace(entity.Name))
+            {
+                throw new ArgumentException("Cannot save member with empty name.");
+            }
+
             var uow = UowProvider.GetUnitOfWork();
             using (var repository = RepositoryFactory.CreateMemberRepository(uow))
             {

--- a/src/Umbraco.Core/Services/MemberTypeService.cs
+++ b/src/Umbraco.Core/Services/MemberTypeService.cs
@@ -78,6 +78,11 @@ namespace Umbraco.Core.Services
             if (Saving.IsRaisedEventCancelled(new SaveEventArgs<IMemberType>(memberType), this))
                 return;
 
+            if (string.IsNullOrWhiteSpace(memberType.Name))
+            {
+                throw new ArgumentException("Cannot save MemberType with empty name.");
+            }
+
             using (new WriteLock(Locker))
             {
                 var uow = UowProvider.GetUnitOfWork();

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -125,6 +125,11 @@ namespace Umbraco.Core.Services
         {
             if (userType == null) throw new ArgumentNullException("userType");
 
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                throw new ArgumentException("Cannot create user with empty username.");
+            }
+
             //TODO: PUT lock here!!
 
             var uow = UowProvider.GetUnitOfWork();
@@ -312,6 +317,15 @@ namespace Umbraco.Core.Services
                     return;
             }
 
+            if (string.IsNullOrWhiteSpace(entity.Username))
+            {
+                throw new ArgumentException("Cannot save user with empty username.");
+            }
+            if (string.IsNullOrWhiteSpace(entity.Name))
+            {
+                throw new ArgumentException("Cannot save user with empty name.");
+            }
+
             var uow = UowProvider.GetUnitOfWork();
             using (var repository = RepositoryFactory.CreateUserRepository(uow))
             {
@@ -353,6 +367,14 @@ namespace Umbraco.Core.Services
             {
                 foreach (var member in entities)
                 {
+                    if (string.IsNullOrWhiteSpace(member.Username))
+                    {
+                        throw new ArgumentException("Cannot save user with empty username.");
+                    }
+                    if (string.IsNullOrWhiteSpace(member.Name))
+                    {
+                        throw new ArgumentException("Cannot save user with empty name.");
+                    }
                     repository.AddOrUpdate(member);
                 }
                 //commit the whole lot in one go

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -669,6 +669,17 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Cannot_Save_Content_With_Empty_Name()
+        {
+            // Arrange
+            var contentService = ServiceContext.ContentService;
+            var content = new Content(string.Empty, -1, ServiceContext.ContentTypeService.GetContentType("umbTextpage"));
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => contentService.Save(content));
+        }
+
+        [Test]
         public void Can_Get_Content_By_Id()
         {
             // Arrange

--- a/src/Umbraco.Tests/Services/ContentTypeServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentTypeServiceTests.cs
@@ -718,6 +718,16 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Cannot_Save_ContentType_With_Empty_Name()
+        {
+            // Arrange
+            var contentType = MockedContentTypes.CreateSimpleContentType("contentType", string.Empty);
+            
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => ServiceContext.ContentTypeService.Save(contentType));
+        }
+
+        [Test]
         public void Cannot_Rename_PropertyType_Alias_On_Composition_Which_Would_Cause_Conflict_In_Other_Composition()
         {
             /*

--- a/src/Umbraco.Tests/Services/DataTypeServiceTests.cs
+++ b/src/Umbraco.Tests/Services/DataTypeServiceTests.cs
@@ -221,5 +221,18 @@ namespace Umbraco.Tests.Services
             Assert.AreEqual("preVal1", preVals.PreValuesAsArray.First().Value);
             Assert.AreEqual("preVal2", preVals.PreValuesAsArray.Last().Value);            
         }
+
+        [Test]
+        public void Cannot_Save_DataType_With_Empty_Name()
+        {
+            // Arrange
+            var dataTypeService = ServiceContext.DataTypeService;
+
+            // Act
+            var dataTypeDefinition = new DataTypeDefinition(-1, "Test.TestEditor") { Name = string.Empty, DatabaseType = DataTypeDatabaseType.Ntext };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => dataTypeService.Save(dataTypeDefinition));
+        }
     }
 }

--- a/src/Umbraco.Tests/Services/MacroServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MacroServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Core;
@@ -215,6 +216,17 @@ namespace Umbraco.Tests.Services
             result1 = macroService.GetById(result1.Id);
             Assert.AreEqual(2, result1.Properties.Count());
 
+        }
+
+        [Test]
+        public void Cannot_Save_Macro_With_Empty_Name()
+        {
+            // Arrange
+            var macroService = ServiceContext.MacroService;
+            var macro = new Macro("test", string.Empty, scriptPath: "~/Views/MacroPartials/Test.cshtml", cacheDuration: 1234);
+            
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => macroService.Save(macro));
         }
 
         //[Test]

--- a/src/Umbraco.Tests/Services/MediaServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MediaServiceTests.cs
@@ -82,6 +82,19 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Cannot_Save_Media_With_Empty_Name()
+        {
+            // Arrange
+            var mediaService = ServiceContext.MediaService;
+            var mediaType = MockedContentTypes.CreateVideoMediaType();
+            ServiceContext.ContentTypeService.Save(mediaType);
+            var media = mediaService.CreateMedia(string.Empty, -1, "video");
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => mediaService.Save(media));
+        }
+
+        [Test]
         public void Ensure_Content_Xml_Created()
         {
             var mediaService = ServiceContext.MediaService;

--- a/src/Umbraco.Tests/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberServiceTests.cs
@@ -185,6 +185,18 @@ namespace Umbraco.Tests.Services
             Assert.AreEqual(2, membersInRole.Count());
         }
 
+        [Test]
+        public void Cannot_Save_Member_With_Empty_Name()
+        {
+            IMemberType memberType = MockedContentTypes.CreateSimpleMemberType();
+            ServiceContext.MemberTypeService.Save(memberType);
+            IMember member = MockedMember.CreateSimpleMember(memberType, string.Empty, "test@test.com", "pass", "test");
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => ServiceContext.MemberService.Save(member));
+            
+        }
+
         [TestCase("MyTestRole1", "test1", StringPropertyMatchType.StartsWith, 1)]
         [TestCase("MyTestRole1", "test", StringPropertyMatchType.StartsWith, 3)]
         [TestCase("MyTestRole1", "test1", StringPropertyMatchType.Exact, 1)]

--- a/src/Umbraco.Tests/Services/MemberTypeServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberTypeServiceTests.cs
@@ -173,6 +173,16 @@ namespace Umbraco.Tests.Services
             }
         }
 
+        [Test]
+        public void Cannot_Save_MemberType_With_Empty_Name()
+        {
+            // Arrange
+            IMemberType memberType = MockedContentTypes.CreateSimpleMemberType("memberTypeAlias", string.Empty);
+            
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => ServiceContext.MemberTypeService.Save(memberType));
+        }
+
         //[Test]
         //public void Can_Save_MemberType_Structure_And_Create_A_Member_Based_On_It()
         //{

--- a/src/Umbraco.Tests/Services/UserServiceTests.cs
+++ b/src/Umbraco.Tests/Services/UserServiceTests.cs
@@ -491,6 +491,43 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Cannot_Create_User_With_Empty_Username()
+        {
+            // Arrange
+            var userService = ServiceContext.UserService;
+            var userType = userService.GetUserTypeByAlias("admin");
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => userService.CreateUserWithIdentity(string.Empty, "john@umbraco.io", userType));
+        }
+
+        [Test]
+        public void Cannot_Save_User_With_Empty_Username()
+        {
+            // Arrange
+            var userService = ServiceContext.UserService;
+            var userType = userService.GetUserTypeByAlias("admin");
+            var user = userService.CreateUserWithIdentity("John Doe", "john@umbraco.io", userType);
+            user.Username = string.Empty;
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => userService.Save(user));
+        }
+
+        [Test]
+        public void Cannot_Save_User_With_Empty_Name()
+        {
+            // Arrange
+            var userService = ServiceContext.UserService;
+            var userType = userService.GetUserTypeByAlias("admin");
+            var user = userService.CreateUserWithIdentity("John Doe", "john@umbraco.io", userType);
+            user.Name = string.Empty;
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => userService.Save(user));
+        }
+
+        [Test]
         public void Get_By_Profile_Username()
         {
             // Arrange


### PR DESCRIPTION
…using the services directly

ensuring that when trying to save an entity with an empty name, directly through a service, an exception will be thrown.