### PR TITLE
U4-9387: Umbraco v7.5.x: Package Icon doesn't appear on Installed Packages screen when an icon URL is populated

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packager/views/installed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packager/views/installed.html
@@ -12,8 +12,8 @@
                 <div class="umb-package-list__item" ng-repeat="installedPackage in vm.installedPackages">
 
                     <div class="umb-package-list__item-icon">
-                        <i ng-if="!installedPackage.icon" class="icon-box"></i>
-                        <img ng-if="installedPackage.icon" ng-src="{{installedPackage.icon}}" />
+                        <i ng-if="!installedPackage.iconUrl" class="icon-box"></i>
+                        <img ng-if="installedPackage.iconUrl" ng-src="{{installedPackage.iconUrl}}" />
                     </div>
 
                     <div class="umb-package-list__item-content">


### PR DESCRIPTION
Minor HTML update which now properly shows the icon URL of a installed package if one is present in the API called of GetInstalled().

Related YouTrack issue [link here](http://issues.umbraco.org/issue/U4-9387).