### PR TITLE
U4-9435 Fix breaking change made in U4-9312

### DIFF
--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -262,7 +262,7 @@ namespace Umbraco.Web.Editors
                             },
                             {
                                 "mediaTypeApiBaseUrl", Url.GetUmbracoApiServiceBaseUrl<MediaTypeController>(
-                                    controller => controller.GetAllowedChildren("0"))
+                                    controller => controller.GetAllowedChildren(0))
                             },
                             {
                                 "macroApiBaseUrl", Url.GetUmbracoApiServiceBaseUrl<MacroController>(

--- a/src/Umbraco.Web/Editors/MediaTypeController.cs
+++ b/src/Umbraco.Web/Editors/MediaTypeController.cs
@@ -13,6 +13,7 @@ using Umbraco.Web.WebApi;
 using Umbraco.Core.Services;
 using Umbraco.Core.Models.EntityBase;
 using System;
+using System.Web.Http.Controllers;
 
 namespace Umbraco.Web.Editors
 {
@@ -26,8 +27,21 @@ namespace Umbraco.Web.Editors
     [PluginController("UmbracoApi")]
     [UmbracoTreeAuthorize(Constants.Trees.MediaTypes)]
     [EnableOverrideAuthorization]
+    [MediaTypeControllerControllerConfigurationAttribute]
     public class MediaTypeController : ContentTypeControllerBase
     {
+        /// <summary>
+        /// Configures this controller with a custom action selector
+        /// </summary>
+        private class MediaTypeControllerControllerConfigurationAttribute : Attribute, IControllerConfiguration
+        {
+            public void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+            {
+                controllerSettings.Services.Replace(typeof(IHttpActionSelector), new ParameterSwapControllerActionSelector(
+                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetAllowedChildren", "contentId", typeof(int), typeof(Guid))));
+            }
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -172,26 +186,11 @@ namespace Umbraco.Web.Editors
 
 
         /// <summary>
-        /// Returns the allowed child content type objects for the content item id passed in
+        /// Returns the allowed child content type objects for the content item id passed in - based on an INT id
         /// </summary>
         /// <param name="contentId"></param>
         [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
-        public IEnumerable<ContentTypeBasic> GetAllowedChildren(string contentId)
-        {
-            Guid idGuid = Guid.Empty;
-            int idInt;
-            if (Guid.TryParse(contentId, out idGuid)) { 
-                var entity = ApplicationContext.Services.EntityService.GetByKey(idGuid);
-                return GetAllowedChildrenInternal(entity.Id);
-            } else if (int.TryParse(contentId, out idInt))
-            {
-                return GetAllowedChildrenInternal(idInt);
-            }
-
-            throw new HttpResponseException(HttpStatusCode.NotFound);
-        }
-
-        private IEnumerable<ContentTypeBasic> GetAllowedChildrenInternal(int contentId)
+        public IEnumerable<ContentTypeBasic> GetAllowedChildren(int contentId)
         {
             if (contentId == Constants.System.RecycleBinContent)
                 return Enumerable.Empty<ContentTypeBasic>();
@@ -229,6 +228,22 @@ namespace Umbraco.Web.Editors
             }
 
             return basics;
+        }
+
+        /// <summary>
+        /// Returns the allowed child content type objects for the content item id passed in - based on a GUID id
+        /// </summary>
+        /// <param name="contentId"></param>
+        [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
+        public IEnumerable<ContentTypeBasic> GetAllowedChildren(Guid contentId)
+        {
+            var entity = ApplicationContext.Services.EntityService.GetByKey(contentId);
+            if (entity != null)
+            {
+                return GetAllowedChildren(entity.Id);
+            }
+
+            throw new HttpResponseException(HttpStatusCode.NotFound);
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Editors/ParameterSwapControllerActionSelector.cs
+++ b/src/Umbraco.Web/Editors/ParameterSwapControllerActionSelector.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using System.Web;
+using System.Web.Http.Controllers;
+using Umbraco.Core;
+
+namespace Umbraco.Web.Editors
+{
+    /// <summary>
+    /// This is used to auto-select specific actions on controllers that would otherwise be ambiguous based on a single parameter type
+    /// </summary>
+    /// <remarks>
+    /// As an example, lets say we have 2 methods: GetChildren(int id) and GetChildren(Guid id), by default Web Api won't allow this since
+    /// it won't know what to select, but if this Tuple is passed in new Tuple{string, string}("GetChildren", "id")
+    /// </remarks>
+    internal class ParameterSwapControllerActionSelector : ApiControllerActionSelector
+    {
+        private readonly ParameterSwapInfo[] _actions;
+
+        /// <summary>
+        /// Constructor accepting a list of action name + parameter name
+        /// </summary>
+        /// <param name="actions"></param>
+        public ParameterSwapControllerActionSelector(params ParameterSwapInfo[] actions)
+        {
+            _actions = actions;
+        }
+        public override HttpActionDescriptor SelectAction(HttpControllerContext controllerContext)
+        {
+            var found = _actions.FirstOrDefault(x => controllerContext.Request.RequestUri.GetLeftPart(UriPartial.Path).InvariantEndsWith(x.ActionName));
+
+            if (found != null)
+            {
+                var id = HttpUtility.ParseQueryString(controllerContext.Request.RequestUri.Query).Get(found.ParamName);
+
+                if (id != null)
+                {
+                    var idTypes = found.SupportedTypes;
+
+                    foreach (var idType in idTypes)
+                    {
+                        var converted = id.TryConvertTo(idType);
+                        if (converted)
+                        {
+                            var method = MatchByType(idType, controllerContext, found);
+                            if (method != null)
+                                return method;
+                        }
+                    }                   
+                }
+            }
+            return base.SelectAction(controllerContext);
+        }
+
+        private static ReflectedHttpActionDescriptor MatchByType(Type idType, HttpControllerContext controllerContext, ParameterSwapInfo found)
+        {
+            var controllerType = controllerContext.Controller.GetType();
+            var methods = controllerType.GetMethods().Where(info => info.Name == found.ActionName).ToArray();
+            if (methods.Length > 1)
+            {
+                //choose the one that has the parameter with the T type
+                var method = methods.FirstOrDefault(x => x.GetParameters().FirstOrDefault(p => p.Name == found.ParamName && p.ParameterType == idType) != null);
+
+                return new ReflectedHttpActionDescriptor(controllerContext.ControllerDescriptor, method);
+            }
+            return null;
+        }
+
+        internal class ParameterSwapInfo
+        {
+            public string ActionName { get; private set; }
+            public string ParamName { get; private set; }
+            public Type[] SupportedTypes { get; private set; }
+
+            public ParameterSwapInfo(string actionName, string paramName, params Type[] supportedTypes)
+            {
+                ActionName = actionName;
+                ParamName = paramName;
+                SupportedTypes = supportedTypes;
+            }
+        }
+
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Editors\EditorValidationResolver.cs" />
     <Compile Include="Editors\EditorValidator.cs" />
     <Compile Include="Editors\GravatarController.cs" />
+    <Compile Include="Editors\ParameterSwapControllerActionSelector.cs" />
     <Compile Include="HealthCheck\Checks\Config\AbstractConfigCheck.cs" />
     <Compile Include="HealthCheck\Checks\Config\AcceptableConfiguration.cs" />
     <Compile Include="HealthCheck\Checks\Config\ConfigurationService.cs" />


### PR DESCRIPTION
Updates MediaController and MediaTypeController to have the same method signature supporting both INT and GUID with a custom action selector to handle the ambiguity

