### PR TITLE
Make unit testing easier

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentModelFactoryResolver.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentModelFactoryResolver.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Core.Models.PublishedContent
         /// Initializes a new instance of the <see cref="PublishedContentModelFactoryResolver"/>.
         /// </summary>
         /// <remarks>The resolver is created by the <c>WebBootManager</c> and thus the constructor remains internal.</remarks>
-        internal PublishedContentModelFactoryResolver()
+        public PublishedContentModelFactoryResolver()
             : base()
         { }
 
@@ -20,7 +20,7 @@ namespace Umbraco.Core.Models.PublishedContent
         /// </summary>
         /// <param name="factory">The factory.</param>
         /// <remarks>The resolver is created by the <c>WebBootManager</c> and thus the constructor remains internal.</remarks>
-        internal PublishedContentModelFactoryResolver(IPublishedContentModelFactory factory)
+        public PublishedContentModelFactoryResolver(IPublishedContentModelFactory factory)
             : base(factory)
         { }
 

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
@@ -187,7 +187,7 @@ namespace Umbraco.Core.Models.PublishedContent
 
         // for unit tests - changing the callback must reset the cache obviously
         private static Func<string, PublishedContentType> _getPublishedContentTypeCallBack;
-        internal static Func<string, PublishedContentType> GetPublishedContentTypeCallback
+        public static Func<string, PublishedContentType> GetPublishedContentTypeCallback
         {
             get { return _getPublishedContentTypeCallBack; }
             set


### PR DESCRIPTION
By making these two visibility changes, we can now write integration tests against umbraco, which we are using to test our migration to ditto works.

`[Category("Integration")]
    [TestFixture, RequiresSTA]
    [DatabaseTestBehavior(DatabaseBehavior.NoDatabasePerFixture)] // This does require a database but we are telling umbraco not to spin up an sqllite one.
    public abstract class BaseMappingTest<TModel> : BaseRoutingTest where TModel : class
    {

        [SetUp]
        public override void Initialize()
        {
            base.Initialize();
            PublishedContentType.GetPublishedContentTypeCallback = null;
        }

        protected TModel Entity;
        public abstract int ItemId { get; }

        protected override string GetDbConnectionString()
        {
            return @"Server=tcp:xx.database.windows.net,1433;Database=xx;User ID=xx@xx;Password=xx";
        }

        protected override string GetDbProviderName()
        {
            return "System.Data.SqlClient";
        }

    


        [SetUp]
        public virtual void SetUp()
        {
            var content = GetRoutingContext("/", 0, setUmbracoContextCurrent: true).UmbracoContext.ContentCache.GetById(ItemId);

            Entity = content.As<TModel>();
        }

        protected override string GetXmlContent(int templateId)
        {
            return File.ReadAllText("..\\..\\App_Data\\umbraco.config");
        }

        [Test]
        public void Entity_NotNull()
        {
            Entity.Should().NotBeNull();
        }

        protected void VerifyList<T>(IEnumerable<T> list, int expectedCount)
        {
            list.Should().NotBeNull();
            var arr = list.ToArray();
            arr.Count().Should().Be(expectedCount);

            foreach (var entity in arr)
            {
                entity.Should().NotBeNull();
                entity.Should().BeAssignableTo<T>();
            }
        }
    }`

Example test:

`[Category("Integration")]
    [TestFixture, RequiresSTA]
    [DatabaseTestBehavior(DatabaseBehavior.NoDatabasePerFixture)]
    public class CarouselModelMappingTests : BaseMappingTest<CarouselModel>
    {
        public override int ItemId => 2217;

        
        [Test]
        public void Entity_Slides_HaveCopy()
        {
            Entity.Slides.ToList().First().Copy.Should().NotBeEmpty();
        }
    }`

