### PR TITLE
U4-9451 Package installation custom user control is not displayed aft…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/user.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/user.service.js
@@ -204,7 +204,7 @@ angular.module('umbraco.services')
                         //when it's successful, return the user data
                         setCurrentUser(data);
 
-                        var result = { user: data, authenticated: true, lastUserId: lastUserId };
+                        var result = { user: data, authenticated: true, lastUserId: lastUserId, loginType: "credentials" };
 
                         //broadcast a global event
                         eventsService.emit("app.authenticated", result);
@@ -232,7 +232,7 @@ angular.module('umbraco.services')
                     authResource.getCurrentUser()
                         .then(function (data) {
 
-                            var result = { user: data, authenticated: true, lastUserId: lastUserId };
+                            var result = { user: data, authenticated: true, lastUserId: lastUserId, loginType: "implicit" };
 
                             //TODO: This is a mega backwards compatibility hack... These variables SHOULD NOT exist in the server variables
                             // since they are not supposed to be dynamic but I accidentally added them there in 7.1.5 IIRC so some people might

--- a/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
@@ -8,7 +8,7 @@
  * The main application controller
  * 
  */
-function MainController($scope, $rootScope, $location, $routeParams, $timeout, $http, $log, appState, treeService, notificationsService, userService, navigationService, historyService, updateChecker, assetsService, eventsService, umbRequestHelper, tmhDynamicLocale) {
+function MainController($scope, $rootScope, $location, $routeParams, $timeout, $http, $log, appState, treeService, notificationsService, userService, navigationService, historyService, updateChecker, assetsService, eventsService, umbRequestHelper, tmhDynamicLocale, localStorageService) {
 
     //the null is important because we do an explicit bool check on this in the view
     //the avatar is by default the umbraco logo    
@@ -81,6 +81,14 @@ function MainController($scope, $rootScope, $location, $routeParams, $timeout, $
             $location.path("/").search("");
             historyService.removeAll();
             treeService.clearCache();
+
+            //if the user changed, clearout local storage too - could contain sensitive data
+            localStorageService.clearAll();
+        }
+
+        //if this is a new login (i.e. the user entered credentials), then clear out local storage - could contain sensitive data
+        if (data.loginType === "credentials") {            
+            localStorageService.clearAll();
         }
 
         //Load locale file

--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -13,11 +13,7 @@ app.run(['userService', '$log', '$rootScope', '$location', 'navigationService', 
 
         /** Listens for authentication and checks if our required assets are loaded, if/once they are we'll broadcast a ready event */
         eventsService.on("app.authenticated", function(evt, data) {
-
-            //Removes all stored LocalStorage browser items - that may contain sensitive data
-            //So if a machine or computer is shared and a new user logs in, we clear out the previous persons localStorage items
-            localStorageService.clearAll();
-
+            
             assetsService._loadInitAssets().then(function() {
                 appState.setGlobalState("isReady", true);
 


### PR DESCRIPTION
Package installation custom user control is not displayed after a package is installed

Changes:

* We were clearing the localStorage when the browser refreshed so it didn't know where to redirect
* This was due to not knowing that the app.authenticated event fires when the browser reloads - not always when it's an explicit login
* To fix, move the logic to clear this with the other logic that clears other data when a user changes and added a loginType of either "credentials" or "implicit" so we know if it's a new login or an authentication based on a refresh