### PR TITLE
U4-9454: Added in Twitter OEmbed configuration

### DIFF
--- a/src/Umbraco.Web.UI/config/EmbeddedMedia.Release.config
+++ b/src/Umbraco.Web.UI/config/EmbeddedMedia.Release.config
@@ -116,4 +116,10 @@
   <provider name="Twitgoo" type="Umbraco.Web.Media.EmbedProviders.Twitgoo, umbraco">
     <urlShemeRegex><![CDATA[twitgoo\.com/]]></urlShemeRegex>
   </provider>
+  <!-- Twitter settings -->
+  <provider name="Twitter" type="Umbraco.Web.Media.EmbedProviders.OEmbedJson, umbraco">
+    <urlShemeRegex><![CDATA[twitter\.com/]]></urlShemeRegex>
+    <apiEndpoint><![CDATA[https://publish.twitter.com/oembed]]></apiEndpoint>
+    <requestParams type="Umbraco.Web.Media.EmbedProviders.Settings.Dictionary, umbraco"></requestParams>
+  </provider>
 </embed>

--- a/src/Umbraco.Web.UI/config/EmbeddedMedia.config
+++ b/src/Umbraco.Web.UI/config/EmbeddedMedia.config
@@ -116,4 +116,10 @@
   <provider name="Twitgoo" type="Umbraco.Web.Media.EmbedProviders.Twitgoo, umbraco">
     <urlShemeRegex><![CDATA[twitgoo\.com/]]></urlShemeRegex>
   </provider>
+  <!-- Twitter settings -->
+  <provider name="Twitter" type="Umbraco.Web.Media.EmbedProviders.OEmbedJson, umbraco">
+    <urlShemeRegex><![CDATA[twitter\.com/]]></urlShemeRegex>
+    <apiEndpoint><![CDATA[https://publish.twitter.com/oembed]]></apiEndpoint>
+    <requestParams type="Umbraco.Web.Media.EmbedProviders.Settings.Dictionary, umbraco"></requestParams>
+  </provider>
 </embed>


### PR DESCRIPTION
As described on the [related YouTrack ticket](http://issues.umbraco.org/issue/U4-9454) Twitter would be a great addition to the Umbraco Core oembed service.

Thanks to the versatility of this endpoint it not only supports single tweets but timelines, moments & lists too. 