### PR TITLE
U4 9457: Added in Support for Facebook OEmbed

### DIFF
--- a/src/Umbraco.Core/Media/IEmbedProvider.cs
+++ b/src/Umbraco.Core/Media/IEmbedProvider.cs
@@ -4,6 +4,6 @@
     {
         bool SupportsDimensions { get; }
 
-        string GetMarkup(string url, int maxWidth = 0, int maxHeight = 0);
+        string GetMarkup(string url, string userAgent, int maxWidth = 0, int maxHeight = 0);
     }
 }

--- a/src/Umbraco.Web.UI/config/EmbeddedMedia.Release.config
+++ b/src/Umbraco.Web.UI/config/EmbeddedMedia.Release.config
@@ -116,4 +116,16 @@
   <provider name="Twitgoo" type="Umbraco.Web.Media.EmbedProviders.Twitgoo, umbraco">
     <urlShemeRegex><![CDATA[twitgoo\.com/]]></urlShemeRegex>
   </provider>
+    <!-- Facebook Video settings -->
+  <provider name="FacebookVideo" type="Umbraco.Web.Media.EmbedProviders.OEmbedJson, umbraco">
+    <urlShemeRegex><![CDATA[facebook\.com/((.*)/videos/|video.php)(\?(v|id)\=)?([0-9]+)/?]]></urlShemeRegex>
+    <apiEndpoint><![CDATA[https://www.facebook.com/plugins/video/oembed.json]]></apiEndpoint>
+    <requestParams type="Umbraco.Web.Media.EmbedProviders.Settings.Dictionary, umbraco"></requestParams>
+  </provider>
+  <!-- Facebook Post settings -->
+  <provider name="FacebookPost" type="Umbraco.Web.Media.EmbedProviders.OEmbedJson, umbraco">
+    <urlShemeRegex><![CDATA[facebook\.com/]]></urlShemeRegex>
+    <apiEndpoint><![CDATA[https://www.facebook.com/plugins/post/oembed.json]]></apiEndpoint>
+    <requestParams type="Umbraco.Web.Media.EmbedProviders.Settings.Dictionary, umbraco"></requestParams>
+  </provider>
 </embed>

--- a/src/Umbraco.Web.UI/config/EmbeddedMedia.config
+++ b/src/Umbraco.Web.UI/config/EmbeddedMedia.config
@@ -116,4 +116,16 @@
   <provider name="Twitgoo" type="Umbraco.Web.Media.EmbedProviders.Twitgoo, umbraco">
     <urlShemeRegex><![CDATA[twitgoo\.com/]]></urlShemeRegex>
   </provider>
+  <!-- Facebook Video settings -->
+  <provider name="FacebookVideo" type="Umbraco.Web.Media.EmbedProviders.OEmbedJson, umbraco">
+    <urlShemeRegex><![CDATA[facebook\.com/((.*)/videos/|video.php)(\?(v|id)\=)?([0-9]+)/?]]></urlShemeRegex>
+    <apiEndpoint><![CDATA[https://www.facebook.com/plugins/video/oembed.json]]></apiEndpoint>
+    <requestParams type="Umbraco.Web.Media.EmbedProviders.Settings.Dictionary, umbraco"></requestParams>
+  </provider>
+  <!-- Facebook Post settings -->
+  <provider name="FacebookPost" type="Umbraco.Web.Media.EmbedProviders.OEmbedJson, umbraco">
+    <urlShemeRegex><![CDATA[facebook\.com/]]></urlShemeRegex>
+    <apiEndpoint><![CDATA[https://www.facebook.com/plugins/post/oembed.json]]></apiEndpoint>
+    <requestParams type="Umbraco.Web.Media.EmbedProviders.Settings.Dictionary, umbraco"></requestParams>
+  </provider>
 </embed>

--- a/src/Umbraco.Web/Media/EmbedProviders/AbstractOEmbedProvider.cs
+++ b/src/Umbraco.Web/Media/EmbedProviders/AbstractOEmbedProvider.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Web.Media.EmbedProviders
         [ProviderSetting]
         public Dictionary<string, string> RequestParams{ get;set; }
 
-        public abstract string GetMarkup(string url, int maxWidth, int maxHeight);
+        public abstract string GetMarkup(string url, string userAgent, int maxWidth, int maxHeight);
 
         public virtual string BuildFullUrl(string url, int maxWidth, int maxHeight)
         {
@@ -49,23 +49,25 @@ namespace Umbraco.Web.Media.EmbedProviders
             return fullUrl.ToString();
         }
 
-        public virtual string DownloadResponse(string url)
+        public virtual string DownloadResponse(string url, string userAgent)
         {
             using (var webClient = new WebClient())
             {
+                webClient.Headers.Add("User-Agent", userAgent);
+
                 return webClient.DownloadString(url);
             }
         }
 
-        public virtual T GetJsonResponse<T>(string url) where T : class
+        public virtual T GetJsonResponse<T>(string url, string userAgent) where T : class
         {
-            var response = DownloadResponse(url);
+            var response = DownloadResponse(url, userAgent);
             return JsonConvert.DeserializeObject<T>(response);
         }
 
-        public virtual XmlDocument GetXmlResponse(string url)
+        public virtual XmlDocument GetXmlResponse(string url, string userAgent)
         {
-            var response = DownloadResponse(url);
+            var response = DownloadResponse(url, userAgent);
             var doc = new XmlDocument();
             doc.LoadXml(response);
 

--- a/src/Umbraco.Web/Media/EmbedProviders/AbstractProvider.cs
+++ b/src/Umbraco.Web/Media/EmbedProviders/AbstractProvider.cs
@@ -9,6 +9,6 @@ namespace Umbraco.Web.Media.EmbedProviders
             get { return true; }
         }
 
-        public abstract string GetMarkup(string url, int maxWidth, int maxHeight);
+        public abstract string GetMarkup(string url, string userAgent, int maxWidth, int maxHeight);
     }
 }

--- a/src/Umbraco.Web/Media/EmbedProviders/Flickr.cs
+++ b/src/Umbraco.Web/Media/EmbedProviders/Flickr.cs
@@ -8,10 +8,10 @@ namespace Umbraco.Web.Media.EmbedProviders
     [Obsolete("This is no longer used and will be removed from the codebase in the future, for Flickr, use the Umbraco.Web.Media.EmbedProviders.OEmbedPhoto provider")]
     public class Flickr : AbstractOEmbedProvider
     {
-        public override string GetMarkup(string url, int maxWidth, int maxHeight)
+        public override string GetMarkup(string url, string userAgent, int maxWidth, int maxHeight)
         {
             var flickrUrl = BuildFullUrl(url, maxWidth, maxHeight);
-            var doc = GetXmlResponse(flickrUrl);
+            var doc = GetXmlResponse(flickrUrl, userAgent);
 
             string imageUrl = doc.SelectSingleNode("/oembed/url").InnerText;
             string imageWidth = doc.SelectSingleNode("/oembed/width").InnerText;

--- a/src/Umbraco.Web/Media/EmbedProviders/OEmbedJson.cs
+++ b/src/Umbraco.Web/Media/EmbedProviders/OEmbedJson.cs
@@ -2,11 +2,11 @@
 {
     public class OEmbedJson : AbstractOEmbedProvider
     {
-        public override string GetMarkup(string url, int maxWidth, int maxHeight)
+        public override string GetMarkup(string url, string userAgent, int maxWidth, int maxHeight)
         {
             string requestUrl = BuildFullUrl(url, maxWidth, maxHeight);
 
-            var jsonResponse = GetJsonResponse<OEmbedResponse>(requestUrl);
+            var jsonResponse = GetJsonResponse<OEmbedResponse>(requestUrl, userAgent);
             return jsonResponse.GetHtml();
         }
     }

--- a/src/Umbraco.Web/Media/EmbedProviders/OEmbedPhoto.cs
+++ b/src/Umbraco.Web/Media/EmbedProviders/OEmbedPhoto.cs
@@ -5,11 +5,11 @@ namespace Umbraco.Web.Media.EmbedProviders
 {
     public class OEmbedPhoto : AbstractOEmbedProvider
     {
-        public override string GetMarkup(string url, int maxWidth, int maxHeight)
+        public override string GetMarkup(string url, string userAgent, int maxWidth, int maxHeight)
         {
             string requestUrl = BuildFullUrl(url, maxWidth, maxHeight);
 
-            XmlDocument doc = GetXmlResponse(requestUrl);
+            XmlDocument doc = GetXmlResponse(requestUrl, userAgent);
             string imageUrl = GetXmlProperty(doc, "/oembed/url");
             string imageWidth = GetXmlProperty(doc, "/oembed/width");
             string imageHeight = GetXmlProperty(doc, "/oembed/height");

--- a/src/Umbraco.Web/Media/EmbedProviders/OEmbedVideo.cs
+++ b/src/Umbraco.Web/Media/EmbedProviders/OEmbedVideo.cs
@@ -4,11 +4,11 @@ namespace Umbraco.Web.Media.EmbedProviders
 {
     public class OEmbedVideo : AbstractOEmbedProvider
     {
-        public override string GetMarkup(string url, int maxWidth, int maxHeight)
+        public override string GetMarkup(string url, string userAgent, int maxWidth, int maxHeight)
         {
             string requestUrl = BuildFullUrl(url, maxWidth, maxHeight);
 
-            XmlDocument doc = GetXmlResponse(requestUrl);
+            XmlDocument doc = GetXmlResponse(requestUrl, userAgent);
             return GetXmlProperty(doc, "/oembed/html");
         }
     }

--- a/src/Umbraco.Web/Media/EmbedProviders/Twitgoo.cs
+++ b/src/Umbraco.Web/Media/EmbedProviders/Twitgoo.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Web.Media.EmbedProviders
             get { return false; }
         }
 
-        public override string GetMarkup(string url, int maxWidth, int maxHeight)
+        public override string GetMarkup(string url, string userAgent, int maxWidth, int maxHeight)
         {
             var web = new HtmlWeb();
             var doc = web.Load(url);

--- a/src/Umbraco.Web/PropertyEditors/RteEmbedController.cs
+++ b/src/Umbraco.Web/PropertyEditors/RteEmbedController.cs
@@ -27,6 +27,7 @@ namespace Umbraco.Web.PropertyEditors
         public Result GetEmbed(string url, int width, int height)
         {
             var result = new Result();
+            var userAgent = Request.Headers.UserAgent.ToString();
 
             //todo cache embed doc
             var xmlConfig = new XmlDocument();
@@ -64,7 +65,7 @@ namespace Umbraco.Web.PropertyEditors
                     }
                     try
                     {
-                        result.Markup = prov.GetMarkup(url, width, height);
+                        result.Markup = prov.GetMarkup(url, userAgent, width, height);
                         result.Status = Status.Success;
                     }
                     catch(Exception ex)

--- a/src/Umbraco.Web/WebServices/EmbedMediaService.cs
+++ b/src/Umbraco.Web/WebServices/EmbedMediaService.cs
@@ -24,6 +24,7 @@ namespace Umbraco.Web.WebServices
                 throw new UnauthorizedAccessException("You must be logged in to use this service");
             
             var url = HttpContext.Current.Request.Form["url"];
+            var userAgent = HttpContext.Current.Request.UserAgent;
             var width = int.Parse(HttpContext.Current.Request.Form["width"]);
             var height = int.Parse(HttpContext.Current.Request.Form["height"]);
 
@@ -65,7 +66,7 @@ namespace Umbraco.Web.WebServices
                     }
                     try
                     {
-                        result.Markup = prov.GetMarkup(url, width, height);
+                        result.Markup = prov.GetMarkup(url, userAgent, width, height);
                         result.Status = Status.Success;
                     }
                     catch


### PR DESCRIPTION
As described on the related [YouTrack ticket](http://issues.umbraco.org/issue/U4-9457) Facebook would be a great addition to the Umbraco Core oembed service. However as it currently stands a User Agent is required to be sent so Facebook will return JSON.

I've made structural changes to the IEmbedProvider classes to allow this. Not entirely sure if this is a bit heavy handed. Any feedback would be appreciated! :)