### PR TITLE
U4-9448 Slave Front End server requires write access to database when…

### DIFF
--- a/src/Umbraco.Web/Cache/PageCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/PageCacheRefresher.cs
@@ -74,7 +74,7 @@ namespace Umbraco.Web.Cache
         public override void Remove(int id)
         {
             ApplicationContext.Current.ApplicationCache.ClearPartialViewCache();
-            content.Instance.ClearDocumentCache(id);
+            content.Instance.ClearDocumentCache(id, false);
             DistributedCache.Instance.ClearAllMacroCacheOnCurrentServer();
             DistributedCache.Instance.ClearXsltCacheOnCurrentServer();
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
@@ -95,7 +95,7 @@ namespace Umbraco.Web.Cache
         public override void Remove(IContent instance)
         {
             ApplicationContext.Current.ApplicationCache.ClearPartialViewCache();
-            content.Instance.ClearDocumentCache(new Document(instance));
+            content.Instance.ClearDocumentCache(new Document(instance), false);
             XmlPublishedContent.ClearRequest();
             DistributedCache.Instance.ClearAllMacroCacheOnCurrentServer();
             DistributedCache.Instance.ClearXsltCacheOnCurrentServer();

--- a/src/Umbraco.Web/umbraco.presentation/content.cs
+++ b/src/Umbraco.Web/umbraco.presentation/content.cs
@@ -395,6 +395,11 @@ namespace umbraco
 
         public virtual void ClearDocumentCache(int documentId)
         {
+            ClearDocumentCache(documentId, true);
+        }
+
+        internal virtual void ClearDocumentCache(int documentId, bool removeDbXmlEntry)
+        {
             // Get the document
             Document d;
             try
@@ -408,7 +413,7 @@ namespace umbraco
                 ClearDocumentXmlCache(documentId);
                 return;
             }
-            ClearDocumentCache(d);
+            ClearDocumentCache(d, removeDbXmlEntry);
         }
 
         /// <summary>
@@ -416,7 +421,8 @@ namespace umbraco
         /// This means the node gets unpublished from the website.
         /// </summary>
         /// <param name="doc">The document</param>
-        internal void ClearDocumentCache(Document doc)
+        /// <param name="removeDbXmlEntry"></param>
+        internal void ClearDocumentCache(Document doc, bool removeDbXmlEntry)
         {
             var e = new DocumentCacheEventArgs();
             FireBeforeClearDocumentCache(doc, e);
@@ -424,7 +430,15 @@ namespace umbraco
             if (!e.Cancel)
             {
                 XmlNode x;
-                
+
+                //Hack: this is here purely for backwards compat if someone for some reason is using the 
+                // ClearDocumentCache(int documentId) method and expecting it to remove the xml
+                if (removeDbXmlEntry)
+                {
+                    // remove from xml db cache
+                    doc.XmlRemoveFromDB();
+                }
+
                 // clear xml cache
                 ClearDocumentXmlCache(doc.Id);
 

--- a/src/Umbraco.Web/umbraco.presentation/content.cs
+++ b/src/Umbraco.Web/umbraco.presentation/content.cs
@@ -424,10 +424,7 @@ namespace umbraco
             if (!e.Cancel)
             {
                 XmlNode x;
-
-                // remove from xml db cache
-                doc.XmlRemoveFromDB();
-
+                
                 // clear xml cache
                 ClearDocumentXmlCache(doc.Id);
 


### PR DESCRIPTION
… master performs unpublish

This removes the additional SQL call made by the legacy `content.ClearDocumentCache` to remove the xml structure from the cmsContentXml table - in all cases in Umbraco Core, this XML structure will already be removed because this is taken care of at the service/repository level. I've made the code 100% backwards compat, the cache refreshers pass in 'false' to the internal `ClearDocumentCache` methods so that no DB writing occurs.