### PR TITLE
U4-9489 - dictonaryToQueryString only returns first dictionary item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/log.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/log.resource.js
@@ -68,7 +68,7 @@ function logResource($q, $http, umbRequestHelper) {
                        "logApiBaseUrl",
                        "GetCurrentUserLog",
                        [{ logtype: type, sinceDate: since }])),
-               'Failed to retrieve user data for id ' + id);
+               'Failed to retrieve log data for current user of type ' + type + ' since ' + since);
         },
 
         /**
@@ -99,7 +99,7 @@ function logResource($q, $http, umbRequestHelper) {
                        "logApiBaseUrl",
                        "GetLog",
                        [{ logtype: type, sinceDate: since }])),
-               'Failed to retrieve user data for id ' + id);
+               'Failed to retrieve log data of type ' + type + ' since ' + since);
         }
     };
 }

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -47,15 +47,17 @@ function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogServ
                 return _.map(queryStrings, function (item) {
                     var key = null;
                     var val = null;
+                    var encodedQueryStrings = [];
+                    // can be multiple parameters passed via array
                     for (var k in item) {
                         key = k;
                         val = item[k];
-                        break;
-                    }
+                        encodedQueryStrings.push(encodeURIComponent(key) + "=" + encodeURIComponent(val));
+                     }
                     if (key === null || val === null) {
                         throw "The object in the array was not formatted as a key/value pair";
-                    }
-                    return encodeURIComponent(key) + "=" + encodeURIComponent(val);
+                    }                  
+                    return encodedQueryStrings.join("&");
                 }).join("&");
             }
             else if (angular.isObject(queryStrings)) {


### PR DESCRIPTION
umbraco.services umbRequestHelper dictionaryToQueryString helper method only returns the first item when passed an array of several parameters

Basically only the first item in a dictionary object is getting parsed, preventing some of the logResource methods to work.

This fixes it by looping through each key value pair to build the querystring to send to the api endpoint

not sure if there is a more elegant fix though

Issue is here: http://issues.umbraco.org/issue/U4-9489