### PR TITLE
U4-9491 Back Office Property Editor to highlight mandatory fields to user

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/variables.less
@@ -246,6 +246,9 @@
 @infoBackground:          #d9edf7;
 @infoBorder:              darken(spin(@infoBackground, -10), 7%);
 
+// Property / Control States
+// -------------------------
+@controlRequiredColor:     #ee5f5b;
 
 // Tooltips and popovers
 // -------------------------

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -156,6 +156,11 @@ h5.-black {
   margin-left: 0;
 }
 
+/* CONTROL VALIDATION */
+.umb-control-required {
+    color: @controlRequiredColor;
+}
+
 .controls-row {
   padding-bottom: 5px;
   margin-left: 240px;

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -1,13 +1,16 @@
 <div class="umb-property">
     <ng-form name="propertyForm">
-        <div class="control-group umb-control-group" ng-class="{hidelabel:property.hideLabel}" >
-            
+        <div class="control-group umb-control-group" ng-class="{hidelabel:property.hideLabel}">
+
             <val-property-msg property="property"></val-property-msg>
-            
+
             <div class="umb-el-wrap">
-                
+
                 <label class="control-label" ng-hide="property.hideLabel" for="{{property.alias}}" ng-attr-title="{{propertyAlias}}">
                     {{property.label}}
+                    <strong ng-if="property.validation.mandatory">
+                        <span class="red">&nbsp;*&nbsp;</span>
+                    </strong>
                     <small ng-bind-html="property.description"></small>
                 </label>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -8,9 +8,9 @@
 
                 <label class="control-label" ng-hide="property.hideLabel" for="{{property.alias}}" ng-attr-title="{{propertyAlias}}">
                     {{property.label}}
-                    <strong ng-if="property.validation.mandatory">
-                        <span class="red">&nbsp;*&nbsp;</span>
-                    </strong>
+                    <span ng-if="property.validation.mandatory">
+                        <strong class="umb-control-required">*</strong>
+                    </span>
                     <small ng-bind-html="property.description"></small>
                 </label>
 


### PR DESCRIPTION
u4-9491 Added an asterisk with appropriate css class to the property editor next to the label in the back office to indicate to the user that the field is mandatory before saving. This is more intuitive to the user to see what fields need filling in before submitting. This was implemented in our solution which is used by hundreds of back end users.