### PR TITLE
Adds unit tests for U4-9458 UmbracoExamine performance optimizations

### DIFF
--- a/build/NuSpecs/UmbracoCms.Core.nuspec
+++ b/build/NuSpecs/UmbracoCms.Core.nuspec
@@ -28,17 +28,17 @@
       <dependency id="MySql.Data" version="[6.9.8, 7.0.0)" />
       <dependency id="xmlrpcnet" version="[2.5.0, 3.0.0)" />
       <dependency id="ClientDependency" version="[1.9.2, 2.0.0)" />
-      <dependency id="ClientDependency-Mvc5" version="[1.8.0, 2.0.0)" />
+      <dependency id="ClientDependency-Mvc5" version="[1.8.0.0, 2.0.0)" />
 	  <!-- AutoMapper can not be updated due to: https://github.com/AutoMapper/AutoMapper/issues/373#issuecomment-127644405 -->
       <dependency id="AutoMapper" version="[3.3.1, 4.0.0)" />
       <dependency id="Newtonsoft.Json" version="[6.0.8, 10.0.0)" />
-      <dependency id="Examine" version="[0.1.80, 1.0.0)" />
+      <dependency id="Examine" version="[0.1.81, 1.0.0)" />
       <dependency id="ImageProcessor" version="[2.5.2, 3.0.0)" />
       <dependency id="ImageProcessor.Web" version="[4.8.2, 5.0.0)" />
       <dependency id="semver" version="[1.1.2, 2.0.0)" />
       <dependency id="UrlRewritingNet" version="[2.0.7, 3.0.0)" />	  
 	  <!-- Markdown can not be updated due to: https://github.com/hey-red/markdownsharp/issues/71#issuecomment-233585487 -->
-      <dependency id="Markdown" version="[1.14.4, 2.0.0)" />	  
+      <dependency id="Markdown" version="[1.14.7, 2.0.0)" />	  
     </dependencies>
   </metadata>
   <files>

--- a/src/Umbraco.Tests/Dependencies/NuGet.cs
+++ b/src/Umbraco.Tests/Dependencies/NuGet.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xml.Serialization;
+using NUnit.Framework;
+using Umbraco.Tests.TestHelpers;
+
+namespace Umbraco.Tests.Dependencies
+{
+    [TestFixture]
+    public class NuGet
+    {
+        [Test]
+        public void NuGet_Package_Versions_Are_The_Same_In_All_Package_Config_Files()
+        {
+            var packagesAndVersions = GetNuGetPackagesInSolution();
+            Assert.IsTrue(packagesAndVersions.Any());
+
+            var failTest = false;
+            foreach (var package in packagesAndVersions.OrderBy(x => x.ConfigFilePath))
+            {
+                var matchingPackages = packagesAndVersions.Where(x => string.Equals(x.PackageName, package.PackageName, StringComparison.InvariantCultureIgnoreCase));
+                foreach (var matchingPackage in matchingPackages)
+                {
+                    if (package.PackageVersion == matchingPackage.PackageVersion)
+                        continue;
+
+                    Debug.WriteLine("Package '{0}' with version {1} in {2} doesn't match with version {3} in {4}",
+                        package.PackageName, package.PackageVersion, package.ConfigFilePath,
+                        matchingPackage.PackageVersion, matchingPackage.ConfigFilePath);
+                    failTest = true;
+                }
+            }
+
+            Assert.IsFalse(failTest);
+        }
+
+        [Test]
+        public void NuSpec_File_Matches_Installed_Dependencies()
+        {
+            var solutionDirectory = GetSolutionDirectory();
+            Assert.NotNull(solutionDirectory);
+            Assert.NotNull(solutionDirectory.Parent);
+
+            var nuSpecPath = solutionDirectory.Parent.FullName + "\\build\\NuSpecs\\";
+            Assert.IsTrue(Directory.Exists(nuSpecPath));
+
+            var packagesAndVersions = GetNuGetPackagesInSolution();
+            var failTest = false;
+
+            var nuSpecFiles = Directory.GetFiles(nuSpecPath);
+            foreach (var fileName in nuSpecFiles.Where(x => x.EndsWith("nuspec")))
+            {
+                var serializer = new XmlSerializer(typeof(NuSpec));
+                using (var reader = new StreamReader(fileName))
+                {
+                    var nuspec = (NuSpec)serializer.Deserialize(reader);
+                    var dependencies = nuspec.MetaData.dependencies;
+
+                    //UmbracoCms.Core has version "[$version$]" - ignore
+                    foreach (var dependency in dependencies.Where(x => x.Id != "UmbracoCms.Core"))
+                    {
+                        var dependencyVersionRange = dependency.Version.Replace("[", string.Empty).Replace("(", string.Empty).Split(',');
+                        var dependencyMinimumVersion = dependencyVersionRange.First().Trim();
+                        
+                        var matchingPackages = packagesAndVersions.Where(x => string.Equals(x.PackageName, dependency.Id,
+                                        StringComparison.InvariantCultureIgnoreCase)).ToList();
+                        if (matchingPackages.Any() == false)
+                            continue;
+
+                        // NuGet_Package_Versions_Are_The_Same_In_All_Package_Config_Files test 
+                        // guarantees that all packages have one version, solutionwide, so it's okay to take First() here
+                        if (dependencyMinimumVersion != matchingPackages.First().PackageVersion)
+                        {
+                            Debug.WriteLine("NuSpec dependency '{0}' with minimum version {1} in doesn't match with version {2} in the solution",
+                                dependency.Id, dependencyMinimumVersion, matchingPackages.First().PackageVersion);
+                            failTest = true;
+                        }
+                    }
+                }
+            }
+
+            Assert.IsFalse(failTest);
+        }
+
+        private List<PackageVersionMatcher> GetNuGetPackagesInSolution()
+        {
+            var packagesAndVersions = new List<PackageVersionMatcher>();
+            var solutionDirectory = GetSolutionDirectory();
+            if (solutionDirectory == null)
+                return packagesAndVersions;
+
+            var packageConfigFiles = new List<FileInfo>();
+            var packageDirectories =
+                solutionDirectory.GetDirectories().Where(x =>
+                            x.Name.StartsWith("Umbraco.Tests") == false &&
+                            x.Name.StartsWith("Umbraco.MSBuild.Tasks") == false).ToArray();
+
+            foreach (var directory in packageDirectories)
+            {
+                var packagesFiles = directory.EnumerateFiles("packages.config");
+                packageConfigFiles.AddRange(packagesFiles);
+            }
+
+            foreach (var file in packageConfigFiles)
+            {
+                //read all and de-duplicate packages
+                var serializer = new XmlSerializer(typeof(PackageConfigEntries));
+                using (var reader = new StreamReader(file.FullName))
+                {
+                    var packages = (PackageConfigEntries)serializer.Deserialize(reader);
+                    packagesAndVersions.AddRange(packages.Package.Select(package =>
+                        new PackageVersionMatcher
+                        {
+                            PackageName = package.Id,
+                            PackageVersion = package.Version,
+                            ConfigFilePath = file.FullName
+                        }));
+                }
+            }
+            return packagesAndVersions;
+        }
+
+        private DirectoryInfo GetSolutionDirectory()
+        {
+            var testsDirectory = new FileInfo(TestHelper.MapPathForTest("~/"));
+            if (testsDirectory.Directory == null)
+                return null;
+            if (testsDirectory.Directory.Parent == null || testsDirectory.Directory.Parent.Parent == null)
+                return null;
+            var solutionDirectory = testsDirectory.Directory.Parent.Parent.Parent;
+            return solutionDirectory;
+        }
+    }
+
+    public class PackageVersionMatcher
+    {
+        public string ConfigFilePath { get; set; }
+        public string PackageName { get; set; }
+        public string PackageVersion { get; set; }
+    }
+
+    [XmlType(AnonymousType = true)]
+    [XmlRoot(Namespace = "", IsNullable = false, ElementName = "packages")]
+    public class PackageConfigEntries
+    {
+        [XmlElement("package")]
+        public PackagesPackage[] Package { get; set; }
+    }
+
+    [XmlType(AnonymousType = true, TypeName = "package")]
+    public class PackagesPackage
+    {
+        [XmlAttribute(AttributeName = "id")]
+        public string Id { get; set; }
+
+        [XmlAttribute(AttributeName = "version")]
+        public string Version { get; set; }
+    }
+    
+
+    [XmlType(AnonymousType = true, Namespace = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd")]
+    [XmlRoot(Namespace = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd", IsNullable = false, ElementName = "package")]
+    public class NuSpec
+    {
+        [XmlElement("metadata")]
+        public Metadata MetaData { get; set; }
+    }
+    
+    [XmlType(AnonymousType = true, Namespace = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd", TypeName = "metadata")]
+    public class Metadata
+    {
+        [XmlArrayItem("dependency", IsNullable = false)]
+        //TODO: breaks when renamed to capital D
+        public Dependency[] dependencies { get; set; }
+    }
+
+    [XmlType(AnonymousType = true, Namespace = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd", TypeName = "dependencies")]
+    public class Dependency
+    {
+        [XmlAttribute(AttributeName = "id")]
+        public string Id { get; set; }
+        
+        [XmlAttribute(AttributeName = "version")]
+        public string Version { get; set; }
+    }
+
+}

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -154,6 +154,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Dependencies\NuGet.cs" />
     <Compile Include="Migrations\MigrationIssuesTests.cs" />
     <Compile Include="Persistence\BulkDataReaderTests.cs" />
     <Compile Include="Persistence\Migrations\MigrationStartupHandlerTests.cs" />


### PR DESCRIPTION
More info: http://issues.umbraco.org/issue/U4-9458#comment=67-34596

First tests loops over all the packages in each packages.config file to make sure that when we update a dependency in the core that we do it in each Visual Studio project.

The second test loops over all the dependencies we require when people install the UmbracoCms NuGet package and compares them with the installed packages in Visual Studio. It will fail and log what failed if they do not match. This way we can never forget to update a dependency in the NuSpec files any more.