### PR TITLE
U4-9516 - New SQLRetryPolicy setting to manually set the applications retry policy

### DIFF
--- a/src/Umbraco.Core/Configuration/UmbracoSettings/DataElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/DataElement.cs
@@ -1,0 +1,18 @@
+﻿using System.Configuration;
+
+namespace Umbraco.Core.Configuration.UmbracoSettings
+{
+    internal class DataElement : UmbracoConfigurationElement, IDataSection
+    {
+        [ConfigurationProperty("SQLRetryPolicy")]
+        internal InnerTextConfigurationElement<SQLRetryPolicyBehaviour> SQLRetryPolicy
+        {
+            get { return GetOptionalTextElement("SQLRetryPolicy", SQLRetryPolicyBehaviour.Default); }
+        }
+
+        public SQLRetryPolicyBehaviour SQLRetryPolicyBehaviour
+        {
+            get { return SQLRetryPolicy; }
+        }
+    }
+}

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/IDataSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/IDataSection.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Umbraco.Core.Configuration.UmbracoSettings
+{
+    public interface IDataSection : IUmbracoConfigurationSection
+    {
+        SQLRetryPolicyBehaviour SQLRetryPolicyBehaviour { get; }
+    }
+}

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/IUmbracoSettingsSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/IUmbracoSettingsSection.cs
@@ -29,5 +29,7 @@
         IWebRoutingSection WebRouting { get; }
 
         IScriptingSection Scripting { get; }
+
+        IDataSection Data { get; }
     }
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/UmbracoSettingsSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/UmbracoSettingsSection.cs
@@ -127,7 +127,13 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         {
             get { return (ScriptingElement)this["scripting"]; }
         }
-        
+
+        [ConfigurationProperty("data")]
+        internal DataElement Data
+        {
+            get { return (DataElement)this["data"]; }
+        }
+
         IContentSection IUmbracoSettingsSection.Content
         {
             get { return Content; }
@@ -196,6 +202,11 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         IScriptingSection IUmbracoSettingsSection.Scripting
         {
             get { return Scripting; }
+        }
+
+        IDataSection IUmbracoSettingsSection.Data
+        {
+            get { return Data; }
         }
     }
 }

--- a/src/Umbraco.Core/Persistence/FaultHandling/RetryPolicyFactory.cs
+++ b/src/Umbraco.Core/Persistence/FaultHandling/RetryPolicyFactory.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.Persistence.FaultHandling.Strategies;
+﻿using Umbraco.Core.Configuration;
+using Umbraco.Core.Persistence.FaultHandling.Strategies;
 
 namespace Umbraco.Core.Persistence.FaultHandling
 {
@@ -9,10 +10,20 @@ namespace Umbraco.Core.Persistence.FaultHandling
     {
         public static RetryPolicy GetDefaultSqlConnectionRetryPolicyByConnectionString(string connectionString)
         {
-            //Is this really the best way to determine if the database is an Azure database?
-            return connectionString.Contains("database.windows.net")
-                       ? GetDefaultSqlAzureConnectionRetryPolicy()
-                       : GetDefaultSqlConnectionRetryPolicy();
+            var sqlRetryPolicyBehaviour = UmbracoConfig.For.UmbracoSettings().Data.SQLRetryPolicyBehaviour;
+            switch (sqlRetryPolicyBehaviour)
+            {
+                case SQLRetryPolicyBehaviour.Basic:
+                    return GetDefaultSqlConnectionRetryPolicy();
+                case SQLRetryPolicyBehaviour.Azure:
+                    return GetDefaultSqlAzureConnectionRetryPolicy();
+                case SQLRetryPolicyBehaviour.Default:
+                default:
+                    //Is this really the best way to determine if the database is an Azure database?
+                    return connectionString.Contains("database.windows.net")
+                               ? GetDefaultSqlAzureConnectionRetryPolicy()
+                               : GetDefaultSqlConnectionRetryPolicy();
+            }
         }
 
         public static RetryPolicy GetDefaultSqlConnectionRetryPolicy()
@@ -32,10 +43,20 @@ namespace Umbraco.Core.Persistence.FaultHandling
 
         public static RetryPolicy GetDefaultSqlCommandRetryPolicyByConnectionString(string connectionString)
         {
-            //Is this really the best way to determine if the database is an Azure database?
-            return connectionString.Contains("database.windows.net")
-                       ? GetDefaultSqlAzureCommandRetryPolicy()
-                       : GetDefaultSqlCommandRetryPolicy();
+            var sqlRetryPolicyBehaviour = UmbracoConfig.For.UmbracoSettings().Data.SQLRetryPolicyBehaviour;
+            switch (sqlRetryPolicyBehaviour)
+            {
+                case SQLRetryPolicyBehaviour.Basic:
+                    return GetDefaultSqlCommandRetryPolicy();
+                case SQLRetryPolicyBehaviour.Azure:
+                    return GetDefaultSqlAzureCommandRetryPolicy();
+                case SQLRetryPolicyBehaviour.Default:
+                default:
+                    //Is this really the best way to determine if the database is an Azure database?
+                    return connectionString.Contains("database.windows.net")
+                               ? GetDefaultSqlAzureCommandRetryPolicy()
+                               : GetDefaultSqlCommandRetryPolicy();
+            }
         }
 
         public static RetryPolicy GetDefaultSqlCommandRetryPolicy()

--- a/src/Umbraco.Core/SQLRetryPolicyBehaviour.cs
+++ b/src/Umbraco.Core/SQLRetryPolicyBehaviour.cs
@@ -1,0 +1,22 @@
+﻿namespace Umbraco.Core
+{
+    public enum SQLRetryPolicyBehaviour
+    {
+        /// <summary>
+        /// Default umbraco behavior 
+        /// - Chooses retry behaviour based on whether or not an Azure connection is detected
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Minimal transient network error detection for retries. The default for non-cloud installations
+        /// </summary>
+        Basic,
+
+        /// <summary>
+        /// Suitable for cloud installations of Umbraco where transient network errors are more common 
+        /// - Azure transient network error detection for retries
+        /// </summary>
+        Azure
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -214,10 +214,12 @@
     <Compile Include="Configuration\UmbracoSettings\CharCollection.cs" />
     <Compile Include="Configuration\UmbracoSettings\CharElement.cs" />
     <Compile Include="Configuration\CommaDelimitedConfigurationElement.cs" />
+    <Compile Include="Configuration\UmbracoSettings\DataElement.cs" />
     <Compile Include="Configuration\UmbracoSettings\ContentElement.cs" />
     <Compile Include="Configuration\UmbracoSettings\ContentError404Collection.cs" />
     <Compile Include="Configuration\UmbracoSettings\ContentErrorPageElement.cs" />
     <Compile Include="Configuration\UmbracoSettings\ContentErrorsElement.cs" />
+    <Compile Include="Configuration\UmbracoSettings\IDataSection.cs" />
     <Compile Include="Configuration\UmbracoSettings\ImagingAutoFillPropertiesCollection.cs" />
     <Compile Include="Configuration\UmbracoSettings\ImagingAutoFillUploadFieldElement.cs" />
     <Compile Include="Configuration\UmbracoSettings\ContentImagingElement.cs" />
@@ -350,6 +352,7 @@
     <Compile Include="Logging\LoggingEventContext.cs" />
     <Compile Include="Logging\LoggingEventHelper.cs" />
     <Compile Include="Logging\RingBuffer.cs" />
+    <Compile Include="SQLRetryPolicyBehaviour.cs" />
     <Compile Include="MainDom.cs" />
     <Compile Include="Logging\OwinLogger.cs" />
     <Compile Include="Logging\OwinLoggerFactory.cs" />

--- a/src/Umbraco.Tests/Configurations/UmbracoSettings/DataElementDefaultTests.cs
+++ b/src/Umbraco.Tests/Configurations/UmbracoSettings/DataElementDefaultTests.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace Umbraco.Tests.Configurations.UmbracoSettings
+{
+    [TestFixture]
+    public class DataElementDefaultTests : UmbracoSettingsTests
+    {
+        protected override bool TestingDefaults
+        {
+            get { return true; }
+        }
+
+        [Test]
+        public void SQLRetryPolicyBehaviour()
+        {
+            Assert.AreEqual(Core.SQLRetryPolicyBehaviour.Default, SettingsSection.Data.SQLRetryPolicyBehaviour);
+        }
+    }
+}

--- a/src/Umbraco.Tests/Configurations/UmbracoSettings/DataElementTests.cs
+++ b/src/Umbraco.Tests/Configurations/UmbracoSettings/DataElementTests.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Umbraco.Core;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Configuration.UmbracoSettings;
+
+namespace Umbraco.Tests.Configurations.UmbracoSettings
+{
+    [TestFixture]
+    public class DataElementTests : UmbracoSettingsTests
+    {
+        [Test]
+        public void SQLRetryPolicyBehaviour()
+        {
+            Assert.AreEqual(Core.SQLRetryPolicyBehaviour.Azure, SettingsSection.Data.SQLRetryPolicyBehaviour);
+        }
+    }
+}

--- a/src/Umbraco.Tests/Configurations/UmbracoSettings/umbracoSettings.config
+++ b/src/Umbraco.Tests/Configurations/UmbracoSettings/umbracoSettings.config
@@ -260,4 +260,7 @@
     internalRedirectPreservesTemplate="false">
   </web.routing>
 
+  <data>
+    <SQLRetryPolicy>Azure</SQLRetryPolicy>
+  </data>
 </settings>

--- a/src/Umbraco.Tests/TestHelpers/SettingsForTests.cs
+++ b/src/Umbraco.Tests/TestHelpers/SettingsForTests.cs
@@ -43,6 +43,7 @@ namespace Umbraco.Tests.TestHelpers
             var help = new Mock<IHelpSection>();
             var routing = new Mock<IWebRoutingSection>();
             var scripting = new Mock<IScriptingSection>();
+            var data = new Mock<IDataSection>();
 
             settings.Setup(x => x.Content).Returns(content.Object);
             settings.Setup(x => x.Security).Returns(security.Object);
@@ -58,6 +59,7 @@ namespace Umbraco.Tests.TestHelpers
             settings.Setup(x => x.Help).Returns(help.Object);
             settings.Setup(x => x.WebRouting).Returns(routing.Object);
             settings.Setup(x => x.Scripting).Returns(scripting.Object);
+            settings.Setup(x => x.Data).Returns(data.Object);
 
             //Now configure some defaults - the defaults in the config section classes do NOT pertain to the mocked data!!
             settings.Setup(x => x.Content.UseLegacyXmlSchema).Returns(false);

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -154,6 +154,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configurations\UmbracoSettings\DataElementDefaultTests.cs" />
+    <Compile Include="Configurations\UmbracoSettings\DataElementTests.cs" />
     <Compile Include="Dependencies\NuGet.cs" />
     <Compile Include="Migrations\MigrationIssuesTests.cs" />
     <Compile Include="Persistence\BulkDataReaderTests.cs" />

--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -316,4 +316,13 @@
     umbracoApplicationUrl="">
   </web.routing>
 
+  <data>
+    <!-- How Umbraco should detect transient network issues and then retry. Can be one of the following values:
+         - default - Chooses retry behaviour based on whether or not an Azure connection is detected. Historial Umbraco behaviour.
+         - basic   - Minimal transient network error detection for retries.
+         - azure   - Suitable for cloud installations of Umbraco where transient network errors are more common
+    -->
+    <SQLRetryPolicy>default</SQLRetryPolicy>
+  </data>
+
 </settings>


### PR DESCRIPTION
This is for http://issues.umbraco.org/issue/U4-9516

The idea is to provide an optional config setting to allow a developer to select the Azure based retry policy when using a cloud platform other than Azure rather than Umbraco forcing a particular policy. This will allow them to to take advantage of the additional transient errors it detects in order to retry the corresponding SQL and therefore reduce unnecessary errors that happen in cloud based applications due to transient network issues.