### PR TITLE
TinyMCE - oneTimeClick, changes the target of the floatpanel query

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
@@ -169,7 +169,7 @@ angular.module('umbraco.directives')
                 }
 
                 // ignore clicks in tinyMCE dropdown(floatpanel)
-                var floatpanel = $(el).parents(".mce-floatpanel");
+                var floatpanel = $(event.target).parents(".mce-floatpanel");
                 if (floatpanel.length === 1) {
                     return;
                 }


### PR DESCRIPTION
As outlined in ticket [U4-9524](http://issues.umbraco.org/issue/U4-9524), if the "Formats" dropdown on the TinyMCE editor used, then the RTE is destroyed, the "floatpanel" element still exists in the DOM.

If the RTE is re-created, and the "Formats" dropdown selected again, this will force the editor control to close (and not apply the formatting).

This fix is to workaround the orphaned "floatpanel" elements in the DOM, by changing the target of the jQuery selector from `el` to `event.target`.

e.g. `el` would equal the tag-name ("span"), _bit too generic_,, whereas `event.target` would be the "Formats" menu item element.