### PR TITLE
U4-7757 Show notifications if server returns status 400 and data has notifications

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -4,6 +4,17 @@
 * @description A helper object used for sending requests to the server
 **/
 function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogService, notificationsService, eventsService) {
+    function showFailureNotifications(data, status) {
+        var i;
+
+        if (status >= 400 && data && data.notifications && data.notifications.length) {
+            for (i = 0; i < data.notifications.length; i++) {
+                notificationsService.showNotification(data.notifications[i]);
+            }
+        }
+
+    }
+
     return {
 
         /**
@@ -24,7 +35,7 @@ function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogServ
             if (!virtualPath.startsWith("~/")) {
                 throw "The path " + virtualPath + " is not a virtual path";
             }
-            if (!Umbraco.Sys.ServerVariables.application.applicationPath) { 
+            if (!Umbraco.Sys.ServerVariables.application.applicationPath) {
                 throw "No applicationPath defined in Umbraco.ServerVariables.application.applicationPath";
             }
             return Umbraco.Sys.ServerVariables.application.applicationPath + virtualPath.trimStart("~/");
@@ -42,7 +53,7 @@ function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogServ
          * @param {Array} queryStrings An array of key/value pairs
          */
         dictionaryToQueryString: function (queryStrings) {
-            
+
             if (angular.isArray(queryStrings)) {
                 return _.map(queryStrings, function (item) {
                     var key = null;
@@ -63,7 +74,7 @@ function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogServ
                 //this allows for a normal object to be passed in (ie. a dictionary)
                 return decodeURIComponent($.param(queryStrings));
             }
-            
+
             throw "The queryString parameter is not an array or object of key value pairs";
         },
 
@@ -168,7 +179,10 @@ function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogServ
                         //show a simple error notification                         
                         notificationsService.error("Server error", "Contact administrator, see log for full details.<br/><i>" + result.errorMsg + "</i>");
                     }
-                    
+
+                }
+                else {
+                    showFailureNotifications(data, status);
                 }
 
                 //return an error object including the error message for UI
@@ -249,7 +263,7 @@ function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogServ
                         // do this since it's very hacky/difficult to catch this on the server
                         if (typeof data !== "undefined" && typeof data.indexOf === "function" && data.indexOf("Maximum request length exceeded") >= 0) {
                             notificationsService.error("Server error", "The uploaded file was too large, check with your site administrator to adjust the maximum size allowed");
-                        }                        
+                        }
                         else if (Umbraco.Sys.ServerVariables["isDebuggingEnabled"] === true) {
                             //show a ysod dialog
                             eventsService.emit('app.ysod',
@@ -262,16 +276,19 @@ function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogServ
                             //show a simple error notification                         
                             notificationsService.error("Server error", "Contact administrator, see log for full details.<br/><i>" + data.ExceptionMessage + "</i>");
                         }
-                        
+
                     }
-                    
+                    else {
+                        showFailureNotifications(data, status);
+                    }
+
                     //return an error object including the error message for UI
                     deferred.reject({
                         errorMsg: 'An error occurred',
                         data: data,
                         status: status
                     });
-                   
+
 
                 });
 


### PR DESCRIPTION
Showing notifications if any for any response with status 400 >= x <500.

Ref. event hooks cancelling stuff discussed here:  
http://issues.umbraco.org/issue/U4-7757

There might be controllers actually handling rejected promises, but it seems to me it's too risky to leave that up to implementors. I'm sure the original intent was doing something like this?
Dunno if it can be "just pulled" since there might be duplicate warnings now. But I'd say this is better than just leaving operations hanging when controllers are hard-coded to respond with 400 for cancellations and validation errors.