### PR TITLE
LinkPicker overlay: Added property for hiding the target option

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -22,6 +22,8 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 	        selectedSearchResults: []
 	    };
 
+            $scope.showTarget = $scope.model.hideTarget !== true;
+
 	    if (dialogOptions.currentTarget) {
 	        $scope.model.target = dialogOptions.currentTarget;
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
@@ -17,7 +17,7 @@
             ng-model="model.target.name" />
     </umb-control-group>
 
-    <umb-control-group label="@content_target">
+    <umb-control-group ng-if="showTarget" label="@content_target">
         <label class="checkbox no-indent">
             <input type="checkbox" ng-model="model.target.target" ng-true-value="_blank" ng-false-value="" /> <localize key="defaultdialogs_openInNewWindow">Opens the linked document in a new window or tab</localize>
         </label>


### PR DESCRIPTION
Since there might be use cases where the target option doesn't make sense, this pull request makes it possible to hide the target option through a `hideTarget` property in the overlay model.

Corresponding issue can be found here: http://issues.umbraco.org/issue/U4-9541