### PR TITLE
U4-9571: Legacy icons look weird

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -40,7 +40,7 @@
 .umb-tree li.current > div i.icon,
 .umb-tree li.current > div ins {
 	color: white !important;
-	background: @blue;
+	background-color: @blue;
 	border-color: @blue;
 }
 .umb-tree li.root > div {


### PR DESCRIPTION
"background" is overriding "background-repeat" and "background-position" causing legacy icons (like uCommerces') to be offset

more info: http://issues.umbraco.org/issue/U4-9571