### PR TITLE
U4-9573 PublicAccess - Ensure correct ordering on join

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/PublicAccessRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/PublicAccessRepository.cs
@@ -69,7 +69,8 @@ namespace Umbraco.Core.Persistence.Repositories
             sql.Select("*")
                 .From<AccessDto>(SqlSyntax)
                 .LeftJoin<AccessRuleDto>(SqlSyntax)
-                .On<AccessDto, AccessRuleDto>(SqlSyntax, left => left.Id, right => right.AccessId);
+                .On<AccessDto, AccessRuleDto>(SqlSyntax, left => left.Id, right => right.AccessId)
+                .OrderBy(new string[] { "umbracoAccess.id" });
 
             return sql;
         }


### PR DESCRIPTION
Ensured the correct order on JOIN for the subsequent mapping on AccessDto and AccessRuleDto.