### PR TITLE
Fixes VirtualPath being null on template creation

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/TemplateRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/TemplateRepository.cs
@@ -270,12 +270,11 @@ namespace Umbraco.Core.Persistence.Repositories
 
             // once content has been set, "template on disk" are not "on disk" anymore
             template.Content = content;
+            SetVirtualPath(template);
 
             if (dto.Design == content) return;
             dto.Design = content;
             Database.Update(dto); // though... we don't care about the db value really??!!
-
-            SetVirtualPath(template);
         }
 
         protected override void PersistDeletedItem(ITemplate entity)


### PR DESCRIPTION
This is related to task deploy-245 - we always see this issue when a DocumentType with Template or just a Template is created and subscribing to the TemplateSaved event.