### PR TITLE
U4-9373 Fix for duplicate dashboards after upgrading

### DIFF
--- a/build/NuSpecs/tools/Dashboard.config.install.xdt
+++ b/build/NuSpecs/tools/Dashboard.config.install.xdt
@@ -41,16 +41,6 @@
         views/dashboard/developer/examinemanagement.html
       </control>
     </tab>
-    <tab caption="Health Check" xdt:Transform="InsertIfMissing" xdt:Locator="Match(caption)">
-      <control>
-        views/dashboard/developer/healthcheck.html
-      </control>
-    </tab>
-    <tab caption="Redirect URL Management" xdt:Transform="InsertIfMissing" xdt:Locator="Match(caption)">
-      <control>
-        views/dashboard/developer/redirecturls.html
-      </control>
-    </tab>	
   </section>
   
   <section alias="StartupMediaDashboardSection" xdt:Locator="Match(alias)" xdt:Transform="InsertIfMissing">
@@ -79,5 +69,27 @@
   <section alias="StartupDashboardSection">
 	<tab caption="Change Password" xdt:Locator="Match(caption)" xdt:Transform="Remove" />
 	<tab caption="Last Edits" xdt:Locator="Match(caption)" xdt:Transform="Remove" />
+  </section>
+
+  <section alias="RedirectUrlManagement" xdt:Locator="Match(alias)" xdt:Transform="InsertIfMissing">
+    <areas>
+      <area>content</area>
+    </areas>
+    <tab caption="Redirect URL Management">
+      <control>
+        views/dashboard/developer/redirecturls.html
+      </control>
+    </tab>
+  </section>
+
+  <section alias="UmbracoHealthCheck" xdt:Locator="Match(alias)" xdt:Transform="InsertIfMissing">
+    <areas>
+      <area>developer</area>
+    </areas>
+    <tab caption="Health Check">
+      <control>
+        views/dashboard/developer/healthcheck.html
+      </control>
+    </tab>
   </section>
 </dashBoard>


### PR DESCRIPTION
[U4-9373](http://issues.umbraco.org/issue/U4-9373)

After upgrading Umbraco a second healthcheck dashboard and the redirect dashboard is added to the Developer section.