### PR TITLE
Allow leading whitespace in textstring prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/textstring.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/textstring.html
@@ -1,1 +1,1 @@
-<input type="text" ng-model="model.value" class="umb-editor umb-textstring" />
+<input type="text" ng-model="model.value" ng-trim="false" class="umb-editor umb-textstring" />


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-9585

This fix allow leading whitespace in textstring prevalue editor aswell like it is allowed in textstring property editor since merge of this PR https://github.com/umbraco/Umbraco-CMS/pull/534

After save of datatype - the blue marking indicate whitespace.

![image](https://cloud.githubusercontent.com/assets/2919859/23529792/3815ed10-ff9f-11e6-80d2-b46f84d261df.png)
