### PR TITLE
U4-9521 MediaService.GetPagedChildren should only get children and not descendants

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -578,11 +578,9 @@ namespace Umbraco.Core.Services
                 var repository = RepositoryFactory.CreateContentRepository(uow);
 
                 var query = Query<IContent>.Builder;
-                //if the id is System Root, then just get all
-                if (id != Constants.System.Root)
-                {
-                    query.Where(x => x.ParentId == id);
-                }
+                // always check for a parent - else it will also get decendants (and then you should use the GetPagedDescendants method)
+                query.Where(x => x.ParentId == id);
+
                 IQuery<IContent> filterQuery = null;
                 if (filter.IsNullOrWhiteSpace() == false)
                 {

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -457,7 +457,7 @@ namespace Umbraco.Core.Services
                 var repository = RepositoryFactory.CreateMediaRepository(uow);
 
                 var query = Query<IMedia>.Builder;
-                // always check for a parent - else it will also get decendants
+                // always check for a parent - else it will also get decendants (and then you should use the GetPagedDescendants method)
                 query.Where(x => x.ParentId == id);
 
                 IQuery<IMedia> filterQuery = null;

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -457,11 +457,9 @@ namespace Umbraco.Core.Services
                 var repository = RepositoryFactory.CreateMediaRepository(uow);
 
                 var query = Query<IMedia>.Builder;
-                //if the id is System Root, then just get all
-                if (id != Constants.System.Root)
-                {
-                    query.Where(x => x.ParentId == id);
-                }
+                // always check for a parent - else it will also get decendants
+                query.Where(x => x.ParentId == id);
+
                 IQuery<IMedia> filterQuery = null;
                 if (filter.IsNullOrWhiteSpace() == false)
                 {

--- a/src/Umbraco.Tests/Services/MediaServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MediaServiceTests.cs
@@ -145,6 +145,70 @@ namespace Umbraco.Tests.Services
             Assert.That(resolvedMedia.GetValue(Constants.Conventions.Media.File).ToString().Contains(mediaPath));
         }
 
+        [Test]
+        public void Can_Get_Paged_Children()
+        {
+            var mediaType = MockedContentTypes.CreateImageMediaType("Image2");
+            ServiceContext.ContentTypeService.Save(mediaType);
+            for (int i = 0; i < 10; i++)
+            {
+                var c1 = MockedMedia.CreateMediaImage(mediaType, -1);
+                ServiceContext.MediaService.Save(c1);
+            }
+
+            var service = ServiceContext.MediaService;
+
+            long total;
+            var entities = service.GetPagedChildren(-1, 0, 6, out total).ToArray();
+            Assert.That(entities.Length, Is.EqualTo(6));
+            Assert.That(total, Is.EqualTo(10));
+            entities = service.GetPagedChildren(-1, 1, 6, out total).ToArray();
+            Assert.That(entities.Length, Is.EqualTo(4));
+            Assert.That(total, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void Can_Get_Paged_Children_Dont_Get_Descendants()
+        {
+            var mediaType = MockedContentTypes.CreateImageMediaType("Image2");
+            ServiceContext.ContentTypeService.Save(mediaType);
+            // only add 9 as we also add a folder with children
+            for (int i = 0; i < 9; i++)
+            {
+                var m1 = MockedMedia.CreateMediaImage(mediaType, -1);
+                ServiceContext.MediaService.Save(m1);
+            }
+
+            var mediaTypeForFolder = MockedContentTypes.CreateImageMediaType("Folder2");
+            ServiceContext.ContentTypeService.Save(mediaTypeForFolder);
+            var mediaFolder = MockedMedia.CreateMediaFolder(mediaTypeForFolder, -1);
+            ServiceContext.MediaService.Save(mediaFolder);
+            for (int i = 0; i < 10; i++)
+            {
+                var m1 = MockedMedia.CreateMediaImage(mediaType, mediaFolder.Id);
+                ServiceContext.MediaService.Save(m1);
+            }
+
+            var service = ServiceContext.MediaService;
+
+            long total;
+            // children in root including the folder - not the descendants in the folder
+            var entities = service.GetPagedChildren(-1, 0, 6, out total).ToArray();
+            Assert.That(entities.Length, Is.EqualTo(6));
+            Assert.That(total, Is.EqualTo(10));
+            entities = service.GetPagedChildren(-1, 1, 6, out total).ToArray();
+            Assert.That(entities.Length, Is.EqualTo(4));
+            Assert.That(total, Is.EqualTo(10));
+
+            // children in folder
+            entities = service.GetPagedChildren(mediaFolder.Id, 0, 6, out total).ToArray();
+            Assert.That(entities.Length, Is.EqualTo(6));
+            Assert.That(total, Is.EqualTo(10));
+            entities = service.GetPagedChildren(mediaFolder.Id, 1, 6, out total).ToArray();
+            Assert.That(entities.Length, Is.EqualTo(4));
+            Assert.That(total, Is.EqualTo(10));
+        }
+
         private Tuple<IMedia, IMedia, IMedia, IMedia, IMedia> CreateTrashedTestMedia()
         {
             //Create and Save folder-Media -> 1050


### PR DESCRIPTION
MediaService.GetPagedChildren now only gets children even if parent id is root node instead of also getting descendants