### PR TITLE
U4-9599 - Fix caret in font size select

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -649,9 +649,19 @@
     clear: both;
 }
 
-.umb-grid .mce-btn button {
-    padding: 8px 6px;
-    line-height: inherit;
+.umb-grid .mce-btn {
+    button {
+        padding-top: 8px;
+        padding-bottom: 8px;
+        padding-left: 6px;
+        line-height: inherit;
+    }
+
+    &:not(.mce-menubtn) {
+        button {
+            padding-right: 6px;
+        }
+    }
 }
 
 .umb-grid .mce-toolbar {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -76,6 +76,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
                     icon.isCustom = false;
                     break;
                 case "styleselect":
+                case "fontsizeselect":
                     icon.name = "icon-list";
                     icon.isCustom = true;
                     break;


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-9599

This was also reported in http://issues.umbraco.org/issue/U4-7618 but I think this was never fixed for font size select.

Now it doesn't overwrite padding-right for `.mce-menubtn` which both "Format" and "Font Sizes" select dropdown has, but not the other buttons.

Before:
![image](https://cloud.githubusercontent.com/assets/2919859/23580739/796ba930-0107-11e7-9073-99df3b3b3e17.png)

After:
![image](https://cloud.githubusercontent.com/assets/2919859/23580740/925409ec-0107-11e7-8f8a-42ec0996d752.png)

It have also added an icon for `fontsizeselect` which used same icon as `styleselect` - just an icon the show it is an dropdownlist (list).

To test add the following to tinyMCEConfig.config

```
<command>
      <umbracoAlias>mcefontsizeselect</umbracoAlias>
      <name>Font size select</name>
      <icon>images/editor/fontsizeselect.gif</icon>
      <tinyMceCommand value="" userInterface="true" frontendCommand="fontsizeselect">fontsizeselect</tinyMceCommand>
      <priority>18</priority>
</command>
```

![image](https://cloud.githubusercontent.com/assets/2919859/23580810/d6803b1c-0108-11e7-994c-1e62ec7f460d.png)

This could also be included as default, but just not enabled.

It would also be great to add `<name>` element to docs here, but somehow the "Edit" button at the top just return 404 page. https://our.umbraco.org/documentation/reference/config/tinymceconfig/