### PR TITLE
Updating sv.xml with correct translation

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -87,7 +87,7 @@
     <key alias="selectCurrentFolder">Välj aktuell mapp</key>
     <key alias="showPage">Förhandsgranska</key>
     <key alias="showPageDisabled">Förhandsgranskning är avstängt på grund av att det inte finns någon mall tilldelad</key>
-    <key alias="somethingElse">Ångra</key>
+    <key alias="somethingElse">Annat</key>
     <key alias="styleChoose">Välj stil</key>
     <key alias="styleShow">Visa stil</key>
     <key alias="tableInsert">Infoga tabell</key>


### PR DESCRIPTION
Fixing the Swedish translation for "Something else". "Ångra" as it says today means "regret" or "undo" which is not what the button is supposed to indicate. I changed it to "Ändra" which means "Change", which is a way more fitting translation. 