### PR TITLE
Adds missing swedish translation for document type without template

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -171,6 +171,7 @@
     <key alias="noDocumentTypes"><![CDATA[Det finns inga giltiga dokumenttyper tillgängliga. Du måste aktivera dessa under sektionen inställningar och under <strong>"dokumenttyper"</strong>.]]></key>
     <key alias="noMediaTypes"><![CDATA[Det finns inga giltiga mediatyper tillgängliga. Du måste aktivera dessa under sektionen inställningar och under <strong>"mediatyper"</strong>.]]></key>
     <key alias="updateData">Välj typ och rubrik</key>
+    <key alias="documentTypeWithoutTemplate">Dokumenttyp utan sidmall</key>
   </area>
   <area alias="dashboard">
     <key alias="browser">Surfa på din webbplats</key>


### PR DESCRIPTION
I found a translation that was missing for the Swedish language in the document type create tab under Settings:

![image](https://cloud.githubusercontent.com/assets/2542686/23706747/beabc394-040f-11e7-89e0-70a270dd2d7a.png)
