### PR TITLE
U4-9598: Deeply foldered content is not correctly indexed

### DIFF
--- a/src/UmbracoExamine/UmbracoContentIndexer.cs
+++ b/src/UmbracoExamine/UmbracoContentIndexer.cs
@@ -585,9 +585,12 @@ namespace UmbracoExamine
             var contentTypes = getContentTypes();
             var icons = contentTypes.ToDictionary(x => x.Id, y => y.Icon);
 
+            // total number of pages must be calculated below on the first iteration
+            var numPages = 0;
+
             do
             {
-                long total;
+                long total = 0;
                 if (parentId == -1)
                 {
                     var pagedElements = getPagedXmlEntries("-1", pageIndex, pageSize);
@@ -608,6 +611,11 @@ namespace UmbracoExamine
                     }
                 }
 
+                if (numPages == 0)
+                {
+                    numPages = (int)Math.Ceiling(total / (decimal)pageSize);
+                }
+
                 //if specific types are declared we need to post filter them
                 //TODO: Update the service layer to join the cmsContentType table so we can query by content type too
                 if (IndexerData.IncludeNodeTypes.Any())
@@ -626,7 +634,7 @@ namespace UmbracoExamine
 
                 AddNodesToIndex(xElements, type);
                 pageIndex++;
-            } while (xElements.Length == pageSize);
+            } while (pageIndex < numPages);
         }
 
         internal static IEnumerable<XElement> GetSerializedContent(


### PR DESCRIPTION
Fixed an ExamineManagement reindexing bug for indexes with supportUnpublished=true. For sites with more than 10,000 published content nodes, the first 10,000 node page would index correctly. Subsequent pages of nodes wouldn't be reindexed if any of the first 10,000 nodes are filtered out due to unpublished parents. This affected deeply nested nodes first and foremost because those nodes are indexed in the later pages.

**Steps to reproduce:**
1) Set up a site with more than 10,000 published content nodes
2) Focus your attention on the most deeply foldered nodes in the site. These will be the first nodes to fail to be indexed when you rebuild the indexes via the Examine Management Dashboard.
3) Save and Publish one of the deeply foldered nodes. Use the Examine Management Dashboard to confirm that your deeply foldered node is indexed in the External Indexer.
4) Rebuild the External Indexer with the Examine Management Dashboard. Confirm that the deeply foldered node has been removed from the index

