### PR TITLE
U4-9656 Fixes UmbracoContentIndexer's PerformIndexAll paging issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ build/ui-docs.zip
 build/csharp-docs.zip
 build/msbuild.log
 .vs/
+/src/Umbraco.Web.UI/js

--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,3 @@ build/ui-docs.zip
 build/csharp-docs.zip
 build/msbuild.log
 .vs/
-/src/Umbraco.Web.UI/js

--- a/src/UmbracoExamine/UmbracoMemberIndexer.cs
+++ b/src/UmbracoExamine/UmbracoMemberIndexer.cs
@@ -173,7 +173,7 @@ namespace UmbracoExamine
                         {
                             long totalContent;
                             var result = _memberService.GetPagedXmlEntries(pIndex, pSize, out totalContent).ToArray();
-                            return new Tuple<long, XElement[]>(totalContent, result);
+                            return new Tuple<long, int, XElement[]>(totalContent, result.Length, result);
                         },
                         i => _memberService.GetById(i));
                 }


### PR DESCRIPTION
Fixes UmbracoContentIndexer's PerformIndexAll paging issue when needing to short circuit if the parent is unpublished so not to include the child in the xml cache. The filtered list was lowering the page item count therefore not publishing more that one page.