### PR TITLE
U4-9648 Remove the relevant query rather than the first one in list.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/querybuilder/querybuilder.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/querybuilder/querybuilder.controller.js
@@ -122,9 +122,14 @@
             query.filters.push({});
         }
 
-        function trashFilter(query) {
-            query.filters.splice(query, 1);
-
+        function trashFilter(query, filter) {
+            for (var i = 0; i < query.filters.length; i++)
+            {
+                if (query.filters[i] == filter)
+                {
+                    query.filters.splice(i, 1);
+                }
+            }
             //if we remove the last one, add a new one to generate ui for it.
             if (query.filters.length == 0) {
                 query.filters.push({});

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/querybuilder/querybuilder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/querybuilder/querybuilder.html
@@ -91,7 +91,7 @@
 					<i class="icon-add"></i>
 				</a>
 
-				<a href ng-click="vm.trashFilter(vm.query)">
+				<a href ng-click="vm.trashFilter(vm.query, filter)">
 					<i class="icon-trash"></i>
 				</a>
 


### PR DESCRIPTION
Trying to fix http://issues.umbraco.org/issue/U4-9648
Works for me but not sure if this is most effective way to do it in JS? Feel free to feedback if it's not!

Passing in the filter item to be deleted to the JS controller trashFilter method so we can delete the one with correct index rather than just the first one as it was doing previously.