### PR TITLE
Fixes U4-9678 - XPath Syntax Parser slowdown

### DIFF
--- a/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
+++ b/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
@@ -60,7 +60,7 @@ namespace Umbraco.Core.Xml
                 return -1;
             });
 
-            const string rootXpath = "descendant::*[@id={0}]";
+            const string rootXpath = "id({0})";
 
             //parseable items:
             var vars = new Dictionary<string, Func<string, string>>();


### PR DESCRIPTION
Swaps out the base XPath from `"descendant::*[@id={0}]"` to `"id({0})"` - making use of the content-cache's XML DTD ID index.

http://issues.umbraco.org/issue/U4-9678

This will perform better on larger content-trees.