### PR TITLE
Fixes U4-8900 - XPath: "$current" on Multinodetreepicker gives error in Document Type editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -131,8 +131,11 @@ function contentPickerController($scope, dialogService, entityResource, editorSt
     }
 
 
-    //if we have a query for the startnode, we will use that. 
-    if ($scope.model.config.startNode.query) {
+    if ($routeParams.section === "settings" && $routeParams.tree === "documentTypes") {
+        //if the content-picker is being rendered inside the document-type editor, we don't need to process the startnode query
+        dialogOptions.startNodeId = -1;
+    } else if ($scope.model.config.startNode.query) {
+        //if we have a query for the startnode, we will use that.
         var rootId = $routeParams.id;
         entityResource.getByQuery($scope.model.config.startNode.query, rootId, "Document").then(function (ent) {
             dialogOptions.startNodeId = ent.id;


### PR DESCRIPTION
MNTP Content Picker - when rendering using the DocumentType Editor, querying for the 'startNodeId' is unrequired and could throw exceptions.

This patch checks if the property-editor is being rendered within the "settings" section and "documentType" tree, then it ignores making the request to for the "startNodeId" query.

This patch would resolve the following issues...

- [U4-7602](http://issues.umbraco.org/issue/U4-7602) - "7.4 Data Types with xpath queries specified caused Document Type edit/creation issues."
- [U4-8098](http://issues.umbraco.org/issue/U4-8098) - "Content Type editor can fail while rendering"
- [U4-8900](http://issues.umbraco.org/issue/U4-8900) - "XPath: "$current" on Multinodetreepicker gives error in Document Type editor"