### PR TITLE
fix to UmbracoRequireHttps attribute to account for proxys or load balancers

### DIFF
--- a/src/Umbraco.Web/Mvc/UmbracoRequireHttpsAttribute.cs
+++ b/src/Umbraco.Web/Mvc/UmbracoRequireHttpsAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Mvc;
+﻿using System;
+using System.Web.Mvc;
 using GlobalSettings = Umbraco.Core.Configuration.GlobalSettings;
 
 namespace Umbraco.Web.Mvc
@@ -30,7 +31,19 @@ namespace Umbraco.Web.Mvc
             // If umbracoSSL is set, let base method handle checking for HTTPS.  Otherwise, we don't care.
             if (GlobalSettings.UseSSL)
             {
-                base.OnAuthorization(filterContext);
+                if (filterContext == null)
+                  throw new ArgumentNullException("filterContext");
+
+                if (filterContext.HttpContext.Request.IsSecureConnection)
+                  return;
+
+                if (string.Equals(filterContext.HttpContext.Request.Headers["X-Forwarded-Proto"], "https", StringComparison.OrdinalIgnoreCase))
+                  return;
+
+                if (filterContext.HttpContext.Request.IsLocal)
+                  return;
+                
+                base.HandleNonHttpsRequest(filterContext);
             }
         }
 


### PR DESCRIPTION
Had issues building project so unable to fully test.
Resolves following issues
http://issues.umbraco.org/issue/U4-9229
http://issues.umbraco.org/issue/U4-6493
http://issues.umbraco.org/issue/U4-5842 (may have been resolved previously?)

Requires testing, should be fairly simple 
`curl -X GET -H "X-Forwarded-Proto: https" -H "Cache-Control: no-cache" "http://localhost:7511/umbraco"`.