### PR TITLE
Tweaks to RelatedLinks

### DIFF
--- a/src/Umbraco.Web/Models/RelatedLink.cs
+++ b/src/Umbraco.Web/Models/RelatedLink.cs
@@ -1,8 +1,11 @@
-﻿﻿namespace Umbraco.Web.Models
+﻿﻿using Umbraco.Core.Models;
+
+namespace Umbraco.Web.Models
 {
-	public class RelatedLink : RelatedLinkBase
-	{
-		public int? Id { get; internal set; }
-		internal bool IsDeleted { get; set; }
-	}
+    public class RelatedLink : RelatedLinkBase
+    {
+        public int? Id { get; internal set; }
+        internal bool IsDeleted { get; set; }
+        public IPublishedContent Content { get; set; }
+    }
 }

--- a/src/Umbraco.Web/Models/RelatedLinkBase.cs
+++ b/src/Umbraco.Web/Models/RelatedLinkBase.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using Umbraco.Core.Models;
 
 namespace Umbraco.Web.Models
 {
@@ -15,7 +14,5 @@ namespace Umbraco.Web.Models
         public bool IsInternal { get; set; }
         [JsonProperty("type")]
         public RelatedLinkType Type { get; set; }
-        [JsonIgnore]
-        public IPublishedContent Content { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/RelatedLinksEditorValueConvertor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/RelatedLinksEditorValueConvertor.cs
@@ -104,6 +104,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                 {
                     relatedLink.Id = contentId;
                     relatedLink = CreateLink(relatedLink);
+                    relatedLink.Content = UmbracoContext.Current.ContentCache.GetById(contentId);
                 }
                 else
                 {


### PR DESCRIPTION
Moved Content property from RelatedLinkBase to RelatedLink and populated Content property for non UDI RelatedLink editor

FYI If someone wants to create RelatedLinks using the C# they can create a model that inherits from RelatedLinkBase e.g.

    public class RelatedLinkData : RelatedLinkBase
    {
        [JsonProperty("internal")]
        public int? Internal { get; set; }
        [JsonProperty("edit")]
        public bool Edit { get; set; }
        [JsonProperty("internalName")]
        public string InternalName { get; set; }
        [JsonProperty("title")]
        public string Title { get; set; }
    }