### PR TITLE
Add .editorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root=true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{cs,cshtml}]
+indent_size = 4


### PR DESCRIPTION
I've added a .editorconfig file to enforce whitespace rules. This has long been a awesome plugin for Visual Studio 2015 but it's now built into Visual Studio 2017 which is even more awesome! https://blogs.msdn.microsoft.com/dotnet/2016/12/15/code-style-configuration-in-the-vs2017-rc-update/

While this is a fairly common .editorconfig file for C# projects you may wish to change it for Umbraco.

Additionally it should be recommend that all IDE's being used for Core contribution (Sublime etc) install a EditorConfig plugin, it supports pretty much every IDE there is! http://editorconfig.org/#download