### PR TITLE
Adds the Digibiz Advanced Media Picker datatype

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -419,7 +419,13 @@ namespace Umbraco.Core
             /// Alias for the email address property editor
             /// </summary>
             public const string EmailAddressAlias = "Umbraco.EmailAddress";
-
+            
+	    /// <summary>
+            /// Guid for the XPath Digibiz Advanced Media Picker datatype.
+            /// </summary>
+            [Obsolete("GUIDs are no longer used to reference Property Editors, use the Alias constant instead. This will be removed in future versions")]
+            public const string DigibizAdvancedMediaPicker = "EF94C406-9E83-4058-A780-0375624BA7CA"; 
+		
             public static class PreValueKeys
             {
                 /// <summary>


### PR DESCRIPTION
If not present, the packages from the previous versions of Umbraco using that data type will fail.