### PR TITLE
Adds the Digibiz Advanced Media Picker datatype

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/LegacyPropertyEditorIdToAliasConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/LegacyPropertyEditorIdToAliasConverter.cs
@@ -145,7 +145,8 @@ namespace Umbraco.Core.PropertyEditors
             //Not being converted - convert to label
             CreateMap(Guid.Parse(Constants.PropertyEditors.DictionaryPicker), Constants.PropertyEditors.NoEditAlias);
             CreateMap(Guid.Parse(Constants.PropertyEditors.UmbracoUserControlWrapper), Constants.PropertyEditors.NoEditAlias);
-            
+            //Old Digibiz Advanced Media Picker
+            CreateMap(Guid.Parse(Constants.PropertyEditors.DigibizAdvancedMediaPicker), Constants.PropertyEditors.NoEditAlias);            
             
         }
 


### PR DESCRIPTION
If not present, the packages from the previous versions of Umbraco using that data type will fail.

PS: Probably this is not the best way to propose a pull request, please forgive and take in consideration the two pull requests in order to allow the packages that include the old "Digibiz Advanced Media Picker" to import the data. Thanks!