### PR TITLE
Use correct stream seek enum

### DIFF
--- a/src/Umbraco.Core/IO/PhysicalFileSystem.cs
+++ b/src/Umbraco.Core/IO/PhysicalFileSystem.cs
@@ -122,7 +122,7 @@ namespace Umbraco.Core.IO
             Directory.CreateDirectory(Path.GetDirectoryName(fullPath)); // ensure it exists
 
             if (stream.CanSeek)
-                stream.Seek(0, 0);
+                stream.Seek(0, SeekOrigin.Begin);
 
             using (var destination = (Stream)File.Create(fullPath))
                 stream.CopyTo(destination);

--- a/src/Umbraco.Core/Media/ImageHelper.cs
+++ b/src/Umbraco.Core/Media/ImageHelper.cs
@@ -236,7 +236,7 @@ namespace Umbraco.Core.Media
                     using (var ms = new MemoryStream())
                     {
                         bp.Save(ms, codec, ep);
-                        ms.Seek(0, 0);
+                        ms.Seek(0, SeekOrigin.Begin);
 
                         fs.AddFile(predictableThumbnailName, ms);
                         fs.AddFile(predictableThumbnailNameJpg, ms);
@@ -247,7 +247,7 @@ namespace Umbraco.Core.Media
                     using (var ms = new MemoryStream())
                     {
                         bp.Save(ms, codec, ep);
-                        ms.Seek(0, 0);
+                        ms.Seek(0, SeekOrigin.Begin);
 
                         fs.AddFile(newFileName, ms);
                     }

--- a/src/Umbraco.Core/Models/ContentExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentExtensions.cs
@@ -545,7 +545,7 @@ namespace Umbraco.Core.Models
             if (supportsResizing)
             {
                 //get the original image from the original stream
-                if (fileStream.CanSeek) fileStream.Seek(0, 0);
+                if (fileStream.CanSeek) fileStream.Seek(0, SeekOrigin.Begin);
                 using (var originalImage = Image.FromStream(fileStream))
                 {
                     var additionalSizes = new List<int>();


### PR DESCRIPTION
Updates any instances of `Stream.Seek(long offset, SeekOrigin origin)` to use the correct enum.