### PR TITLE
U4-9760 - Master Templates & Tree Bug

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -67,7 +67,8 @@
 }
 
 .login-overlay .form input[type="text"], 
-.login-overlay .form input[type="password"] {
+.login-overlay .form input[type="password"],
+.login-overlay .form input[type="email"] {
     height: 36px;
     padding-left: 10px;
     padding-right: 10px;

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -60,10 +60,14 @@
                 // sync tree
                 // if master template alias has changed move the node to it's new location
                 if(oldMasterTemplateAlias !== vm.template.masterTemplateAlias) {
+                
+                    //Only do this if we are not on the initial create route param - /-1?create=true
+                    if ($routeParams.create === false) {
 
-                    // move node to new location in tree
-                    //first we need to remove the node that we're working on
-                    treeService.removeNode(vm.page.menu.currentNode);
+                        // move node to new location in tree
+                        //first we need to remove the node that we're working on
+                        treeService.removeNode(vm.page.menu.currentNode);
+                    }
                     
                     // update stored alias to the new one so the node won't move again unless the alias is changed again
                     oldMasterTemplateAlias = vm.template.masterTemplateAlias;

--- a/src/Umbraco.Web/Editors/TemplateController.cs
+++ b/src/Umbraco.Web/Editors/TemplateController.cs
@@ -137,10 +137,15 @@ namespace Umbraco.Web.Editors
                             foreach (var childTemplate in templateHasChildren)
                             {
                                 //template ID to find
-                                var templateIDInPath = "," + display.Id + ",";
+                                var templateIdInPath = "," + display.Id + ",";
+                                
+                                if (string.IsNullOrEmpty(childTemplate.Path))
+                                {
+                                    continue;
+                                }
 
                                 //Find position in current comma seperate string path (so we get the correct children path)
-                                var positionInPath = childTemplate.Path.IndexOf(templateIDInPath) + templateIDInPath.Length;
+                                var positionInPath = childTemplate.Path.IndexOf(templateIdInPath) + templateIdInPath.Length;
 
                                 //Get the substring of the child & any children (descendants it may have too)
                                 var childTemplatePath = childTemplate.Path.Substring(positionInPath);

--- a/src/Umbraco.Web/Editors/TemplateController.cs
+++ b/src/Umbraco.Web/Editors/TemplateController.cs
@@ -105,8 +105,7 @@ namespace Umbraco.Web.Editors
             {
                 throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, ModelState));
             }
-
-
+            
             if (display.Id > 0)
             {
                 // update
@@ -131,8 +130,29 @@ namespace Umbraco.Web.Editors
                         }else
                         {
                             template.SetMasterTemplate(master);
-                        }
 
+                            //After updating the master - ensure we update the path property if it has any children already assigned
+                            var templateHasChildren = Services.FileService.GetTemplateDescendants(display.Id);
+
+                            foreach (var childTemplate in templateHasChildren)
+                            {
+                                //template ID to find
+                                var templateIDInPath = "," + display.Id + ",";
+
+                                //Find position in current comma seperate string path (so we get the correct children path)
+                                var positionInPath = childTemplate.Path.IndexOf(templateIDInPath) + templateIDInPath.Length;
+
+                                //Get the substring of the child & any children (descendants it may have too)
+                                var childTemplatePath = childTemplate.Path.Substring(positionInPath);
+
+                                //As we are updating the template to be a child of a master
+                                //Set the path to the master's path + its current template id + the current child path substring
+                                childTemplate.Path = master.Path + "," + display.Id + "," + childTemplatePath;
+
+                                //Save the children with the updated path
+                                Services.FileService.SaveTemplate(childTemplate);
+                            }
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
When we create a brand new template & set a master template we were removing the entire tree for templates - this adds in a check to not do the remove of the old node if its a brand new template we are creating