### PR TITLE
Fixed Serialization issue in ValidatePasswordResetCodeModel

### DIFF
--- a/src/Umbraco.Web/Models/ValidatePasswordResetCodeModel.cs
+++ b/src/Umbraco.Web/Models/ValidatePasswordResetCodeModel.cs
@@ -1,8 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 
 namespace Umbraco.Web.Models
 {
+    [Serializable]
     [DataContract(Name = "validatePasswordReset", Namespace = "")]
     public class ValidatePasswordResetCodeModel
     {


### PR DESCRIPTION
Added [Serializable] Attribute and using System; to allow ValidatePasswordResetCodeModel to be serialized to TempData on password reset validation when Umbraco is running in SQLServer or ASPStateServer Session State Modes