### PR TITLE
Fixed U4-9800 by changing how folders are retrieved from API

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
@@ -420,47 +420,6 @@ function mediaResource($q, $http, umbDataFormatter, umbRequestHelper) {
 
         /**
           * @ngdoc method
-          * @name umbraco.resources.mediaResource#getChildFolders
-          * @methodOf umbraco.resources.mediaResource
-          *
-          * @description
-          * Retrieves all media children with types used as folders.
-          * Uses the convention of looking for media items with mediaTypes ending in
-          * *Folder so will match "Folder", "bannerFolder", "secureFolder" etc,
-          * 
-          * NOTE: This will return a max of 500 folders, if more is required it needs to be paged
-          * 
-          * ##usage
-          * <pre>
-          * mediaResource.getChildFolders(1234)
-          *    .then(function(data) {
-          *        alert('folders');
-          *    });
-          * </pre> 
-          *
-          * @param {int} parentId Id of the media item to query for child folders    
-          * @returns {Promise} resourcePromise object.
-          *
-          */
-        getChildFolders: function (parentId) {
-            if (!parentId) {
-                parentId = -1;
-            }
-
-            //NOTE: This will return a max of 500 folders, if more is required it needs to be paged
-            return umbRequestHelper.resourcePromise(
-                  $http.get(
-                        umbRequestHelper.getApiUrl(
-                              "mediaApiBaseUrl",
-                              "GetChildFolders",
-                            {
-                                id: parentId
-                            })),
-                  'Failed to retrieve child folders for media item ' + parentId);
-        },
-
-        /**
-          * @ngdoc method
           * @name umbraco.resources.mediaResource#emptyRecycleBin
           * @methodOf umbraco.resources.mediaResource
           *

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/grid/grid.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/grid/grid.listviewlayout.controller.js
@@ -47,7 +47,6 @@
       }
 
       function filterOutFolders(items) {
-
           var newArray = [];
 
           if(items && items.length ) {

--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -151,51 +151,6 @@ namespace Umbraco.Web.Editors
         }
 
         /// <summary>
-        /// Returns media items known to be of a "Folder" type
-        /// </summary>
-        /// <param name="id"></param>
-        /// <returns></returns>
-        [Obsolete("This is no longer used and shouldn't be because it performs poorly when there are a lot of media items")]
-        [FilterAllowedOutgoingMedia(typeof(IEnumerable<ContentItemBasic<ContentPropertyBasic, IMedia>>))]
-        public IEnumerable<ContentItemBasic<ContentPropertyBasic, IMedia>> GetChildFolders(int id = -1)
-        {
-            //we are only allowing a max of 500 to be returned here, if more is required it needs to be paged
-            var result = GetChildFolders(id, 1, 500);
-            return result.Items;
-        }
-
-        /// <summary>
-        /// Returns a paged result of media items known to be of a "Folder" type
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="pageNumber"></param>
-        /// <param name="pageSize"></param>
-        /// <returns></returns>
-        public PagedResult<ContentItemBasic<ContentPropertyBasic, IMedia>> GetChildFolders(int id, int pageNumber, int pageSize)
-        {
-            //Suggested convention for folder mediatypes - we can make this more or less complicated as long as we document it...
-            //if you create a media type, which has an alias that ends with ...Folder then its a folder: ex: "secureFolder", "bannerFolder", "Folder"
-            var folderTypes = Services.ContentTypeService
-                .GetAllMediaTypes()
-                .Where(x => x.Alias.EndsWith("Folder"))
-                .Select(x => x.Id)
-                .ToArray();
-
-            if (folderTypes.Length == 0)
-            {
-                return new PagedResult<ContentItemBasic<ContentPropertyBasic, IMedia>>(0, pageNumber, pageSize);
-            }
-
-            long total;
-            var children = Services.MediaService.GetPagedChildren(id, pageNumber - 1, pageSize, out total, "Name", Direction.Ascending, true, null, folderTypes.ToArray());
-            
-            return new PagedResult<ContentItemBasic<ContentPropertyBasic, IMedia>>(total, pageNumber, pageSize)
-            {
-                Items = children.Select(Mapper.Map<IMedia, ContentItemBasic<ContentPropertyBasic, IMedia>>)
-            };
-        }
-
-        /// <summary>
         /// Returns the root media objects
         /// </summary>
         [FilterAllowedOutgoingMedia(typeof(IEnumerable<ContentItemBasic<ContentPropertyBasic, IMedia>>))]


### PR DESCRIPTION
List layout (which does not have that problem) is obtaining items through a call to ContentController, and then differentiating between files and folders.

Grid Layout on the other hand was retrieving all the items from the ContentController as well (this includes folders), then filtering the items which are not folders. The folders where obtained from the MediaController.

I made the listview.controller, to get the folders from the ContentController by filtering them in the same matter as the files were.