### PR TITLE
Quick/simple fix for the stale variable

### DIFF
--- a/src/Umbraco.Web/Mvc/UmbracoVirtualNodeRouteHandler.cs
+++ b/src/Umbraco.Web/Mvc/UmbracoVirtualNodeRouteHandler.cs
@@ -15,10 +15,10 @@ namespace Umbraco.Web.Mvc
     {
         public IHttpHandler GetHttpHandler(RequestContext requestContext)
         {
-            var umbracoContext = UmbracoContext.Current;
-
-            var found = FindContent(requestContext, umbracoContext);
+            var found = FindContent(requestContext, UmbracoContext.Current);
             if (found == null) return new NotFoundHandler();
+            
+            var umbracoContext = UmbracoContext.Current;
             
             umbracoContext.PublishedContentRequest = new PublishedContentRequest(
                 umbracoContext.CleanedUmbracoUrl, umbracoContext.RoutingContext, 


### PR DESCRIPTION
The umbracoContext variable can hold a null reference to UmbracoContext.Current. 

If a request containing a file extension is passed through an UmbracoVirtualNodeRouteHandler, the UmbracoContext will be null, because a context is never created for urls containing extensions due to https://github.com/umbraco/Umbraco-CMS/blob/5397f2c53acbdeb0805e1fe39fda938f571d295a/src/Umbraco.Core/UriExtensions.cs#L143

A call can be made to EnsureContext in the overridden FindContent method, but the fresh context would never get picked up, instead the variable always contains a null reference, and an exception is then thrown on line 23