### PR TITLE
U4-9890 - Grid error when existing grid no longer matches new config

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -705,7 +705,7 @@ angular.module("umbraco")
                     $scope.addRow(section, section.$allowedLayouts[0]);
                 }
             } else {
-				var refinedRows = [];
+                var refinedRows = [];
 				
                 _.each(section.rows, function (row, index) {
                     if (!row.$initialized) {
@@ -718,8 +718,8 @@ angular.module("umbraco")
                     }
                 });
 				
-				//set original section.rows to the rows that were successfully initialized
-				section.rows = refinedRows;
+                //set original section.rows to the rows that were successfully initialized
+                section.rows = refinedRows;
 
                 //if there is more than one row added - hide row add tools
                 $scope.showRowConfigurations = false;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -705,20 +705,23 @@ angular.module("umbraco")
                     $scope.addRow(section, section.$allowedLayouts[0]);
                 }
             } else {
-                _.forEach(section.rows, function (row, index) {
+				var refinedRows = [];
+				
+                _.each(section.rows, function (row, index) {
                     if (!row.$initialized) {
                         var initd = $scope.initRow(row);
 
-                        //if init fails, remove
-                        if (!initd) {
-                            section.rows.splice(index, 1);
-                        } else {
-                            section.rows[index] = initd;
+                        //we only want rows that successfully initialized
+                        if (initd) {
+                            refinedRows.push(initd);
                         }
                     }
                 });
+				
+				//set original section.rows to the rows that were successfully initialized
+				section.rows = refinedRows;
 
-                // if there is more than one row added - hide row add tools
+                //if there is more than one row added - hide row add tools
                 $scope.showRowConfigurations = false;
             }
         };


### PR DESCRIPTION
When a grid configuration is changed inside the CMS back end, any existing layouts actually end up breaking the display of the grid. This is because the code was splicing from the array it is iterating on which forces row to be undefined and thus $initialized property causes an error.