### PR TITLE
U4-9558 - Media upload whitelist

### DIFF
--- a/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
@@ -141,6 +141,12 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
             get { return GetOptionalDelimitedElement("disallowedUploadFiles", new[] {"ashx", "aspx", "ascx", "config", "cshtml", "vbhtml", "asmx", "air", "axd"}); }
         }
 
+        [ConfigurationProperty("allowedUploadFiles")]
+        internal CommaDelimitedConfigurationElement AllowedUploadFiles
+        {
+            get { return GetOptionalDelimitedElement("allowedUploadFiles", new string[0]); }
+        }
+
         [ConfigurationProperty("cloneXmlContent")]
         internal InnerTextConfigurationElement<bool> CloneXmlContent
         {
@@ -307,6 +313,11 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         IEnumerable<string> IContentSection.DisallowedUploadFiles
         {
             get { return DisallowedUploadFiles; }
+        }
+
+        IEnumerable<string> IContentSection.AllowedUploadFiles
+        {
+            get { return AllowedUploadFiles; }
         }
 
         bool IContentSection.CloneXmlContent

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/ContentSectionExtensions.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/ContentSectionExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Linq;
+
+namespace Umbraco.Core.Configuration.UmbracoSettings
+{
+    public static class ContentSectionExtensions
+    {
+        /// <summary>
+        /// Determines if file extension is allowed for upload based on (optional) white list and black list
+        /// held in settings.
+        /// Allow upload if extension is whitelisted OR if there is no whitelist and extension is NOT blacklisted.
+        /// </summary>
+        public static bool IsFileAllowedForUpload(this IContentSection contentSection, string extension)
+        {
+            return contentSection.AllowedUploadFiles.Any(x => x.InvariantEquals(extension)) ||
+                (contentSection.AllowedUploadFiles.Any() == false &&
+                contentSection.DisallowedUploadFiles.Any(x => x.InvariantEquals(extension)) == false);
+        }
+    }
+}

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
@@ -54,6 +54,8 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         
         IEnumerable<string> DisallowedUploadFiles { get; }
 
+        IEnumerable<string> AllowedUploadFiles { get; }
+
         bool CloneXmlContent { get; }
 
         bool GlobalPreviewStorageEnabled { get; }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Configuration\UmbracoSettings\ContentError404Collection.cs" />
     <Compile Include="Configuration\UmbracoSettings\ContentErrorPageElement.cs" />
     <Compile Include="Configuration\UmbracoSettings\ContentErrorsElement.cs" />
+    <Compile Include="Configuration\UmbracoSettings\ContentSectionExtensions.cs" />
     <Compile Include="Configuration\UmbracoSettings\ImagingAutoFillPropertiesCollection.cs" />
     <Compile Include="Configuration\UmbracoSettings\ImagingAutoFillUploadFieldElement.cs" />
     <Compile Include="Configuration\UmbracoSettings\ContentImagingElement.cs" />

--- a/src/Umbraco.Tests/Configurations/UmbracoSettings/ContentElementTests.cs
+++ b/src/Umbraco.Tests/Configurations/UmbracoSettings/ContentElementTests.cs
@@ -184,5 +184,13 @@ namespace Umbraco.Tests.Configurations.UmbracoSettings
         {
             Assert.IsTrue(SettingsSection.Content.AllowedUploadFiles.All(x => "jpg,gif,png".Split(',').Contains(x)));
         }
+
+        [Test]
+        public void IsFileAllowedForUpload_WithWhitelist()
+        {
+            Assert.IsTrue(SettingsSection.Content.IsFileAllowedForUpload("png"));
+            Assert.IsFalse(SettingsSection.Content.IsFileAllowedForUpload("bmp"));
+            Assert.IsFalse(SettingsSection.Content.IsFileAllowedForUpload("php"));
+        }
     }
 }

--- a/src/Umbraco.Tests/Configurations/UmbracoSettings/ContentElementTests.cs
+++ b/src/Umbraco.Tests/Configurations/UmbracoSettings/ContentElementTests.cs
@@ -178,5 +178,11 @@ namespace Umbraco.Tests.Configurations.UmbracoSettings
         {
             Assert.IsTrue(SettingsSection.Content.DisallowedUploadFiles.All(x => "ashx,aspx,ascx,config,cshtml,vbhtml,asmx,air,axd".Split(',').Contains(x)));
         }
+
+        [Test]
+        public void AllowedUploadFiles()
+        {
+            Assert.IsTrue(SettingsSection.Content.AllowedUploadFiles.All(x => "jpg,gif,png".Split(',').Contains(x)));
+        }
     }
 }

--- a/src/Umbraco.Tests/Configurations/UmbracoSettings/umbracoSettings.config
+++ b/src/Umbraco.Tests/Configurations/UmbracoSettings/umbracoSettings.config
@@ -100,6 +100,9 @@
     <!-- These file types will not be allowed to be uploaded via the upload control for media and content -->
     <disallowedUploadFiles>ashx,aspx,ascx,config,cshtml,vbhtml,asmx,air,axd</disallowedUploadFiles>
 
+    <!-- If completed, only the file extensions listed below will be allowed to be uploaded.  If empty, disallowedUploadFiles will apply to prevent upload of specific file extensions. -->
+    <allowedUploadFiles>jpg,png,gif</allowedUploadFiles>    
+
     <!-- Defines the default document type property used when adding properties in the back-office (if missing or empty, defaults to Textstring -->
     <defaultDocumentTypeProperty>Textstring</defaultDocumentTypeProperty>
   </content>

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -16,14 +16,32 @@ angular.module("umbraco")
             $scope.startNodeId = dialogOptions.startNodeId ? dialogOptions.startNodeId : -1;
             $scope.cropSize = dialogOptions.cropSize;
             $scope.lastOpenedNode = localStorageService.get("umbLastOpenedMediaNodeId");
+
+            var umbracoSettings = Umbraco.Sys.ServerVariables.umbracoSettings;
+            var allowedUploadFiles = mediaHelper.formatFileTypes(umbracoSettings.allowedUploadFiles);
             if ($scope.onlyImages) {
-                $scope.acceptedFileTypes = mediaHelper
-                    .formatFileTypes(Umbraco.Sys.ServerVariables.umbracoSettings.imageFileTypes);
+                // If whitelist provided, use just images from that
+                if (allowedUploadFiles !== '') {
+                    var allowedUploadFilesArray = allowedUploadFiles.Split(',');
+                    var allowedImageFiles = umbracoSettings.imageFileTypes.split(',').filter(function (n) {
+                        return allowedUploadFilesArray.indexOf(n) > -1;
+                    });
+                    $scope.acceptedFileTypes = allowedImageFiles;
+                } else {
+                    // If no whitelist, allow all images
+                    $scope.acceptedFileTypes = mediaHelper.formatFileTypes(umbracoSettings.imageFileTypes);
+                }
             } else {
-                $scope.acceptedFileTypes = !mediaHelper
-                    .formatFileTypes(Umbraco.Sys.ServerVariables.umbracoSettings.disallowedUploadFiles);
+                // Use whitelist of allowed file types if provided
+                if (allowedUploadFiles !== '') {
+                    $scope.acceptedFileTypes = allowedUploadFiles;
+                } else {
+                    // If no whitelist, we pass in a blacklist by adding ! to the file extensions, allowing everything EXCEPT for disallowedUploadFiles
+                    $scope.acceptedFileTypes = !mediaHelper.formatFileTypes(umbracoSettings.disallowedUploadFiles);
+                }
             }
-            $scope.maxFileSize = Umbraco.Sys.ServerVariables.umbracoSettings.maxFileSize + "KB";
+
+            $scope.maxFileSize = umbracoSettings.maxFileSize + "KB";
 
             $scope.model.selectedImages = [];
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -20,17 +20,7 @@ angular.module("umbraco")
             var umbracoSettings = Umbraco.Sys.ServerVariables.umbracoSettings;
             var allowedUploadFiles = mediaHelper.formatFileTypes(umbracoSettings.allowedUploadFiles);
             if ($scope.onlyImages) {
-                // If whitelist provided, use just images from that
-                if (allowedUploadFiles !== '') {
-                    var allowedUploadFilesArray = allowedUploadFiles.Split(',');
-                    var allowedImageFiles = umbracoSettings.imageFileTypes.split(',').filter(function (n) {
-                        return allowedUploadFilesArray.indexOf(n) > -1;
-                    });
-                    $scope.acceptedFileTypes = allowedImageFiles.join(',');
-                } else {
-                    // If no whitelist, allow all images
-                    $scope.acceptedFileTypes = mediaHelper.formatFileTypes(umbracoSettings.imageFileTypes);
-                }
+                $scope.acceptedFileTypes = mediaHelper.formatFileTypes(umbracoSettings.imageFileTypes);
             } else {
                 // Use whitelist of allowed file types if provided
                 if (allowedUploadFiles !== '') {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -26,7 +26,7 @@ angular.module("umbraco")
                     var allowedImageFiles = umbracoSettings.imageFileTypes.split(',').filter(function (n) {
                         return allowedUploadFilesArray.indexOf(n) > -1;
                     });
-                    $scope.acceptedFileTypes = allowedImageFiles;
+                    $scope.acceptedFileTypes = allowedImageFiles.join(',');
                 } else {
                     // If no whitelist, allow all images
                     $scope.acceptedFileTypes = mediaHelper.formatFileTypes(umbracoSettings.imageFileTypes);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
@@ -1,89 +1,96 @@
 (function () {
-   "use strict";
+    "use strict";
 
-   function ListViewListLayoutController($scope, listViewHelper, $location, mediaHelper, mediaTypeHelper) {
+    function ListViewListLayoutController($scope, listViewHelper, $location, mediaHelper, mediaTypeHelper) {
 
-      var vm = this;
+        var vm = this;
+        var umbracoSettings = Umbraco.Sys.ServerVariables.umbracoSettings;
 
-      vm.nodeId = $scope.contentId;
-        //we pass in a blacklist by adding ! to the file extensions, allowing everything EXCEPT for disallowedUploadFiles
-        vm.acceptedFileTypes = !mediaHelper.formatFileTypes(Umbraco.Sys.ServerVariables.umbracoSettings.disallowedUploadFiles);
-      vm.maxFileSize = Umbraco.Sys.ServerVariables.umbracoSettings.maxFileSize + "KB";
-      vm.activeDrag = false;
-      vm.isRecycleBin = $scope.contentId === '-21' || $scope.contentId === '-20';
-      vm.acceptedMediatypes = [];
+        vm.nodeId = $scope.contentId;
 
-      vm.selectItem = selectItem;
-      vm.clickItem = clickItem;
-      vm.selectAll = selectAll;
-      vm.isSelectedAll = isSelectedAll;
-      vm.isSortDirection = isSortDirection;
-      vm.sort = sort;
-      vm.dragEnter = dragEnter;
-      vm.dragLeave = dragLeave;
-      vm.onFilesQueue = onFilesQueue;
-      vm.onUploadComplete = onUploadComplete;
-
-      function activate() {
-
-        if ($scope.entityType === 'media') {
-          mediaTypeHelper.getAllowedImagetypes(vm.nodeId).then(function (types) {
-            vm.acceptedMediatypes = types;
-          });
+        // Use whitelist of allowed file types if provided
+        vm.acceptedFileTypes = mediaHelper.formatFileTypes(umbracoSettings.allowedUploadFiles);
+        if (vm.acceptedFileTypes === '') {
+            // If not provided, we pass in a blacklist by adding ! to the file extensions, allowing everything EXCEPT for disallowedUploadFiles
+            vm.acceptedFileTypes = !mediaHelper.formatFileTypes(umbracoSettings.disallowedUploadFiles);
         }
 
-      }
+        vm.maxFileSize = umbracoSettings.maxFileSize + "KB";
+        vm.activeDrag = false;
+        vm.isRecycleBin = $scope.contentId === '-21' || $scope.contentId === '-20';
+        vm.acceptedMediatypes = [];
 
-      function selectAll($event) {
-         listViewHelper.selectAllItems($scope.items, $scope.selection, $event);
-      }
+        vm.selectItem = selectItem;
+        vm.clickItem = clickItem;
+        vm.selectAll = selectAll;
+        vm.isSelectedAll = isSelectedAll;
+        vm.isSortDirection = isSortDirection;
+        vm.sort = sort;
+        vm.dragEnter = dragEnter;
+        vm.dragLeave = dragLeave;
+        vm.onFilesQueue = onFilesQueue;
+        vm.onUploadComplete = onUploadComplete;
 
-      function isSelectedAll() {
-         return listViewHelper.isSelectedAll($scope.items, $scope.selection);
-      }
+        function activate() {
 
-      function selectItem(selectedItem, $index, $event) {
-         listViewHelper.selectHandler(selectedItem, $index, $scope.items, $scope.selection, $event);
-      }
+            if ($scope.entityType === 'media') {
+                mediaTypeHelper.getAllowedImagetypes(vm.nodeId).then(function (types) {
+                    vm.acceptedMediatypes = types;
+                });
+            }
 
-      function clickItem(item) {
-         // if item.id is 2147483647 (int.MaxValue) use item.key
-         $location.path($scope.entityType + '/' +$scope.entityType + '/edit/' + (item.id === 2147483647 ? item.key : item.id));
-      }
+        }
 
-      function isSortDirection(col, direction) {
-         return listViewHelper.setSortingDirection(col, direction, $scope.options);
-      }
+        function selectAll($event) {
+            listViewHelper.selectAllItems($scope.items, $scope.selection, $event);
+        }
 
-      function sort(field, allow, isSystem) {
-         if (allow) {
-            $scope.options.orderBySystemField = isSystem;
-            listViewHelper.setSorting(field, allow, $scope.options);
+        function isSelectedAll() {
+            return listViewHelper.isSelectedAll($scope.items, $scope.selection);
+        }
+
+        function selectItem(selectedItem, $index, $event) {
+            listViewHelper.selectHandler(selectedItem, $index, $scope.items, $scope.selection, $event);
+        }
+
+        function clickItem(item) {
+            // if item.id is 2147483647 (int.MaxValue) use item.key
+            $location.path($scope.entityType + '/' + $scope.entityType + '/edit/' + (item.id === 2147483647 ? item.key : item.id));
+        }
+
+        function isSortDirection(col, direction) {
+            return listViewHelper.setSortingDirection(col, direction, $scope.options);
+        }
+
+        function sort(field, allow, isSystem) {
+            if (allow) {
+                $scope.options.orderBySystemField = isSystem;
+                listViewHelper.setSorting(field, allow, $scope.options);
+                $scope.getContent($scope.contentId);
+            }
+        }
+
+        // Dropzone upload functions
+        function dragEnter(el, event) {
+            vm.activeDrag = true;
+        }
+
+        function dragLeave(el, event) {
+            vm.activeDrag = false;
+        }
+
+        function onFilesQueue() {
+            vm.activeDrag = false;
+        }
+
+        function onUploadComplete() {
             $scope.getContent($scope.contentId);
-          }
-      }
+        }
 
-      // Dropzone upload functions
-      function dragEnter(el, event) {
-         vm.activeDrag = true;
-      }
+        activate();
 
-      function dragLeave(el, event) {
-         vm.activeDrag = false;
-      }
+    }
 
-      function onFilesQueue() {
-         vm.activeDrag = false;
-      }
+    angular.module("umbraco").controller("Umbraco.PropertyEditors.ListView.ListLayoutController", ListViewListLayoutController);
 
-      function onUploadComplete() { 
-         $scope.getContent($scope.contentId);
-      }
-
-      activate();
-
-   }
-
-angular.module("umbraco").controller("Umbraco.PropertyEditors.ListView.ListLayoutController", ListViewListLayoutController);
-
-}) ();
+})();

--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -102,6 +102,9 @@
     <!-- These file types will not be allowed to be uploaded via the upload control for media and content -->
     <disallowedUploadFiles>ashx,aspx,ascx,config,cshtml,vbhtml,asmx,air,axd,swf,xml,xhtml,html,htm,svg,php,htaccess</disallowedUploadFiles>
 
+    <!-- If completed, only the file extensions listed below will be allowed to be uploaded.  If empty, disallowedUploadFiles will apply to prevent upload of specific file extensions. -->
+    <allowedUploadFiles>jpg,txt,pdf</allowedUploadFiles>
+
     <!-- Defines the default document type property used when adding properties in the back-office (if missing or empty, defaults to Textstring -->
     <defaultDocumentTypeProperty>Textstring</defaultDocumentTypeProperty>
 

--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -103,7 +103,7 @@
     <disallowedUploadFiles>ashx,aspx,ascx,config,cshtml,vbhtml,asmx,air,axd,swf,xml,xhtml,html,htm,svg,php,htaccess</disallowedUploadFiles>
 
     <!-- If completed, only the file extensions listed below will be allowed to be uploaded.  If empty, disallowedUploadFiles will apply to prevent upload of specific file extensions. -->
-    <allowedUploadFiles>jpg,txt,pdf</allowedUploadFiles>
+    <allowedUploadFiles></allowedUploadFiles>
 
     <!-- Defines the default document type property used when adding properties in the back-office (if missing or empty, defaults to Textstring -->
     <defaultDocumentTypeProperty>Textstring</defaultDocumentTypeProperty>

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -393,6 +393,10 @@ namespace Umbraco.Web.Editors
                                 string.Join(",", UmbracoConfig.For.UmbracoSettings().Content.DisallowedUploadFiles)
                             },
                             {
+                                "allowedUploadFiles",
+                                string.Join(",", UmbracoConfig.For.UmbracoSettings().Content.AllowedUploadFiles)
+                            },
+                            {
                                 "maxFileSize",
                                 GetMaxRequestLength()
                             },

--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -33,6 +33,7 @@ using Umbraco.Core.Configuration;
 using Umbraco.Web.UI;
 using Notification = Umbraco.Web.Models.ContentEditing.Notification;
 using Umbraco.Core.Persistence;
+using Umbraco.Core.Configuration.UmbracoSettings;
 
 namespace Umbraco.Web.Editors
 {
@@ -723,7 +724,7 @@ namespace Umbraco.Web.Editors
                 var safeFileName = fileName.ToSafeFileName();
                 var ext = safeFileName.Substring(safeFileName.LastIndexOf('.') + 1).ToLower();
 
-                if (UmbracoConfig.For.UmbracoSettings().Content.DisallowedUploadFiles.Contains(ext) == false)
+                if (UmbracoConfig.For.UmbracoSettings().Content.IsFileAllowedForUpload(ext))
                 {
                     var mediaType = Constants.Conventions.MediaTypes.File;
 

--- a/src/Umbraco.Web/PropertyEditors/UploadFileTypeValidator.cs
+++ b/src/Umbraco.Web/PropertyEditors/UploadFileTypeValidator.cs
@@ -9,6 +9,7 @@ using Umbraco.Core.Configuration;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 using umbraco;
+using Umbraco.Core.Configuration.UmbracoSettings;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -42,11 +43,8 @@ namespace Umbraco.Web.PropertyEditors
         {
             if (fileName.IndexOf('.') <= 0) return false;
             var extension = Path.GetExtension(fileName).TrimStart(".");
-            
-            // Is valid if extension is whitelisted OR if there is no whitelist and extension is NOT blacklisted
-            return UmbracoConfig.For.UmbracoSettings().Content.AllowedUploadFiles.Any(x => x.InvariantEquals(extension)) ||
-                (UmbracoConfig.For.UmbracoSettings().Content.AllowedUploadFiles.Any() == false &&
-                UmbracoConfig.For.UmbracoSettings().Content.DisallowedUploadFiles.Any(x => x.InvariantEquals(extension)) == false);
+
+            return UmbracoConfig.For.UmbracoSettings().Content.IsFileAllowedForUpload(extension);
         }
 
     }

--- a/src/Umbraco.Web/PropertyEditors/UploadFileTypeValidator.cs
+++ b/src/Umbraco.Web/PropertyEditors/UploadFileTypeValidator.cs
@@ -42,7 +42,11 @@ namespace Umbraco.Web.PropertyEditors
         {
             if (fileName.IndexOf('.') <= 0) return false;
             var extension = Path.GetExtension(fileName).TrimStart(".");
-            return UmbracoConfig.For.UmbracoSettings().Content.DisallowedUploadFiles.Any(x => StringExtensions.InvariantEquals(x, extension)) == false;
+            
+            // Is valid if extension is whitelisted OR if there is no whitelist and extension is NOT blacklisted
+            return UmbracoConfig.For.UmbracoSettings().Content.AllowedUploadFiles.Any(x => x.InvariantEquals(extension)) ||
+                (UmbracoConfig.For.UmbracoSettings().Content.AllowedUploadFiles.Any() == false &&
+                UmbracoConfig.For.UmbracoSettings().Content.DisallowedUploadFiles.Any(x => x.InvariantEquals(extension)) == false);
         }
 
     }

--- a/src/umbraco.businesslogic/UmbracoSettings.cs
+++ b/src/umbraco.businesslogic/UmbracoSettings.cs
@@ -273,6 +273,14 @@ namespace umbraco
         }
 
         /// <summary>
+        /// File types that will be allowed to be uploaded via the content/media upload control
+        /// </summary>
+        public static IEnumerable<string> AllowedUploadFiles
+        {
+            get { return UmbracoConfig.For.UmbracoSettings().Content.AllowedUploadFiles; }
+        }
+
+        /// <summary>
         /// Gets the allowed image file types.
         /// </summary>
         /// <value>The allowed image file types.</value>

--- a/src/umbraco.editorControls/uploadfield/uploadField.cs
+++ b/src/umbraco.editorControls/uploadfield/uploadField.cs
@@ -91,7 +91,10 @@ namespace umbraco.editorControls
             //now check the file type
             var extension = Path.GetExtension(postedFile.FileName).TrimStart(".");
 
-            return UmbracoConfig.For.UmbracoSettings().Content.DisallowedUploadFiles.Any(x => x.InvariantEquals(extension)) == false;
+            // allow if extension is whitelisted OR if there is no whitelist and extension is NOT blacklisted
+            return UmbracoConfig.For.UmbracoSettings().Content.AllowedUploadFiles.Any(x => x.InvariantEquals(extension)) ||
+                (UmbracoConfig.For.UmbracoSettings().Content.AllowedUploadFiles.Any() == false &&
+                UmbracoConfig.For.UmbracoSettings().Content.DisallowedUploadFiles.Any(x => x.InvariantEquals(extension)) == false);
         }
 
         public string Text

--- a/src/umbraco.editorControls/uploadfield/uploadField.cs
+++ b/src/umbraco.editorControls/uploadfield/uploadField.cs
@@ -10,6 +10,7 @@ using Umbraco.Core.Configuration;
 using Umbraco.Core.IO;
 using umbraco.interfaces;
 using Umbraco.Core;
+using Umbraco.Core.Configuration.UmbracoSettings;
 using Content = umbraco.cms.businesslogic.Content;
 using Umbraco.Core;
 
@@ -91,10 +92,7 @@ namespace umbraco.editorControls
             //now check the file type
             var extension = Path.GetExtension(postedFile.FileName).TrimStart(".");
 
-            // allow if extension is whitelisted OR if there is no whitelist and extension is NOT blacklisted
-            return UmbracoConfig.For.UmbracoSettings().Content.AllowedUploadFiles.Any(x => x.InvariantEquals(extension)) ||
-                (UmbracoConfig.For.UmbracoSettings().Content.AllowedUploadFiles.Any() == false &&
-                UmbracoConfig.For.UmbracoSettings().Content.DisallowedUploadFiles.Any(x => x.InvariantEquals(extension)) == false);
+            return UmbracoConfig.For.UmbracoSettings().Content.IsFileAllowedForUpload(extension);
         }
 
         public string Text


### PR DESCRIPTION
As described in [issue](http://issues.umbraco.org/issue/U4-9558) this PR allows for Umbraco settings to contain an upload file extension whitelist.  If it's present, it's used to determine which files can be uploaded.  If not, it reverts back to the existing black list functionality.