### PR TITLE
U4 9934: Fixes deleting members in list view using custom membership provider

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
@@ -269,12 +269,12 @@
             var isSelected = false;
             for (var i = 0; selection.length > i; i++) {
                 var selectedItem = selection[i];
-                if (item.id === selectedItem.id) {
+                if (item.id === selectedItem.id || item.key === selectedItem.key) {
                     isSelected = true;
                 }
             }
             if (!isSelected) {
-                selection.push({ id: item.id });
+                selection.push({ id: item.id, key: item.key });
                 item.selected = true;
             }
         }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -20,8 +20,7 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
       getListResultsCallback = contentResource.getPagedResults;
       deleteItemCallback = contentResource.deleteByKey;
       getIdCallback = function (selected) {
-         var selectedKey = getItemKey(selected.id);
-         return selectedKey;
+         return selected.key;
       };
       createEditUrlCallback = function (item) {
          return "/" + $scope.entityType + "/" + $scope.entityType + "/edit/" + item.key + "?page=" + $scope.options.pageNumber + "&listName=" + $scope.contentId;
@@ -648,15 +647,6 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
             return "general_username";
       }
       return alias;
-   }
-
-   function getItemKey(itemId) {
-      for (var i = 0; i < $scope.listViewResultSet.items.length; i++) {
-         var item = $scope.listViewResultSet.items[i];
-         if (item.id === itemId) {
-            return item.key;
-         }
-      }
    }
 
    //GO!


### PR DESCRIPTION
Fixes deleting members from the members section list view when using custom ASP.NET membership provider rather than an Umbraco membership provider.

Previously when selecting a member in the list view to delete this was finding members by id - now this uses they key property from model instead. This is necessary because when using an ASP.NET membership provider the id for every member is set to int.MaxValue (2147483647) and therefore it always deletes the first member in the list.

Affects all versions since Umbraco 7.3 as far as I can tell, but is actively affecting us in the latest Umbraco 7.5.14