### PR TITLE
add log if request to ScheduledPublishController fails without exception

### DIFF
--- a/src/Umbraco.Web/Scheduling/ScheduledPublishing.cs
+++ b/src/Umbraco.Web/Scheduling/ScheduledPublishing.cs
@@ -92,7 +92,9 @@ namespace Umbraco.Web.Scheduling
 
                         if (result.IsSuccessStatusCode)
                         {
-                            LogHelper.Debug<ScheduledPublishing>(() => "Request successfully send to url = " + url);
+                            LogHelper.Debug<ScheduledPublishing>(
+                                () => string.Format(
+                                    "Request successfully sent to url = \"{0}\". ", url));
                         }
                         else
                         {

--- a/src/Umbraco.Web/Scheduling/ScheduledPublishing.cs
+++ b/src/Umbraco.Web/Scheduling/ScheduledPublishing.cs
@@ -88,6 +88,20 @@ namespace Umbraco.Web.Scheduling
                         }
 
                         var result = await wc.SendAsync(request, token);
+                        var content = await result.Content.ReadAsStringAsync();
+
+                        if (result.IsSuccessStatusCode)
+                        {
+                            LogHelper.Debug<ScheduledPublishing>(() => "Request successfully send to url = " + url);
+                        }
+                        else
+                        {
+                            var msg = string.Format(
+                                    "Request failed with status code \"{0}\". Request content = \"{1}\".",
+                                    result.StatusCode, content);
+                            var ex = new HttpRequestException(msg);
+                            LogHelper.Error<ScheduledPublishing>(msg, ex);
+                        }
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
I have a problem with Scheduled Publishing on Azure and while I was trouble shooting it, I've discovered that this class fails silently if there is no exception, but http response has not-success Status Code.
If you have any comments please let me know.

more about my problem here : https://our.umbraco.org/forum/using-umbraco-and-getting-started/85795-scheduled-publishing-doesnt-work