### PR TITLE
Update "Element hinzufügen" (Add grid element)

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -859,7 +859,7 @@ Wenn Sie sich für Runway entscheiden, können Sie optional Blöcke nutzen, die 
   <area alias="grid">
     <key alias="insertControl">Element hinzufügen</key>
     <key alias="addRows">Zeilenlayout auswählen</key>
-    <key alias="addElement">Einfach auf &lt;i class="icon icon-add blue"&gt;&lt;/i&gt; klicken, um das erste Element anzulegen</key>
+    <key alias="addElement">Element mit &lt;i class="icon icon-add blue"&gt;&lt;/i&gt; hinzufügen</key>
     <key alias="dropElement">Drop content</key>
     <key alias="clickToEmbed">Klicken, um Inhalt einzubetten</key>
     <key alias="clickToInsertImage">Klicken, um Abbildung einzufügen</key>


### PR DESCRIPTION
Key no longer used for first element exclusively for ages. New label just hints the (+) as button to add an element (being it the first one or not) -- very generic and thus hopefully future proof.