### PR TITLE
Fixed an error preventing URLs from being inserted in RTE/TinyMCE

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
+++ b/src/Umbraco.Web.UI.Client/lib/tinymce/plugins/umbracolink/plugin.min.js
@@ -209,6 +209,7 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
                         else if (data.id) {
                             a["data-id"] = data.id;
                         }
+                        return a;
                     }
 
                     function insertLink() {
@@ -229,7 +230,7 @@ tinymce.PluginManager.add('umbracolink', function(editor) {
 
     				//if we have an id, it must be a locallink:id, aslong as the isMedia flag is not set
                     if (id && (angular.isUndefined(data.isMedia) || !data.isMedia)){
-                        
+
                         href = "/{localLink:" + id + "}";
 
                         insertLink();


### PR DESCRIPTION
I recently noticed it was no longer possible to create URL's in RTE.

`createElemAttributes()` was not returning the variable holding the actual URL, causing null errors in downstream code.