### PR TITLE
Revised fix for issue: U4-9489 - Just fix logResource.js parameters

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/log.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/log.resource.js
@@ -67,7 +67,7 @@ function logResource($q, $http, umbRequestHelper) {
                    umbRequestHelper.getApiUrl(
                        "logApiBaseUrl",
                        "GetCurrentUserLog",
-                       [{ logtype: type, sinceDate: since }])),
+                       [{ logtype: type}, {sinceDate: since }])),
                'Failed to retrieve log data for current user of type ' + type + ' since ' + since);
         },
 
@@ -98,7 +98,7 @@ function logResource($q, $http, umbRequestHelper) {
                    umbRequestHelper.getApiUrl(
                        "logApiBaseUrl",
                        "GetLog",
-                       [{ logtype: type, sinceDate: since }])),
+                       [{ logtype: type}, {sinceDate: since }])),
                'Failed to retrieve log data of type ' + type + ' since ' + since);
         }
     };

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -47,17 +47,15 @@ function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogServ
                 return _.map(queryStrings, function (item) {
                     var key = null;
                     var val = null;
-                    var encodedQueryStrings = [];
-                    // can be multiple parameters passed via array
                     for (var k in item) {
                         key = k;
                         val = item[k];
-                        encodedQueryStrings.push(encodeURIComponent(key) + "=" + encodeURIComponent(val));
-                     }
+                        break;
+                    }
                     if (key === null || val === null) {
                         throw "The object in the array was not formatted as a key/value pair";
-                    }                  
-                    return encodedQueryStrings.join("&");
+                    }
+                    return encodeURIComponent(key) + "=" + encodeURIComponent(val);
                 }).join("&");
             }
             else if (angular.isObject(queryStrings)) {


### PR DESCRIPTION
The logResource was incorrectly passing an array of a single dictionary item containing sinceDate and logType parameters to the GetCurrentUserLog api endpoint, which is only expecting either a dictionary OR an array of key value pairs...

... so this PR changes the way these values are passed, eg an array of key value pairs and replaces the previous PR, which crazily changed the GetCurrentUserLog endpoint to accept an array of a single dictionary... but it shouldn't !