### PR TITLE
Extended HttpsCheck healthcheck to check for expiring SSL certificate

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1474,8 +1474,10 @@ To manage your website, simply open the Umbraco back office and start adding con
 	  <key alias="xmlDataIntegrityCheckMedia">Media - Total XML: %0%, Total: %1%, Total invalid: %2%</key>
 	  <key alias="xmlDataIntegrityCheckContent">Content - Total XML: %0%, Total published: %1%, Total invalid: %2%</key>
 
-	  <key alias="httpsCheckValidCertificate">Your site certificate was marked as valid.</key>
+	  <key alias="httpsCheckValidCertificate">Your website's certificate is valid.</key>
 	  <key alias="httpsCheckInvalidCertificate">Certificate validation error: '%0%'</key>
+    <key alias="httpsCheckExpiredCertificate">Your website's SSL certificate has expired.</key>
+    <key alias="httpsCheckExpiringCertificate">Your website's SSL certificate is expiring in %0% days.</key>
 	  <key alias="httpsCheckInvalidUrl">Error pinging the URL %0% - '%1%'</key>
 	  <key alias="httpsCheckIsCurrentSchemeHttps">You are currently %0% viewing the site using the HTTPS scheme.</key>
 	  <key alias="httpsCheckConfigurationRectifyNotPossible">The appSetting 'umbracoUseSSL' is set to 'false' in your web.config file. Once you access this site using the HTTPS scheme, that should be set to 'true'.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1469,8 +1469,10 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="xmlDataIntegrityCheckMedia">Media - Total XML: %0%, Total: %1%, Total invalid: %2%</key>
     <key alias="xmlDataIntegrityCheckContent">Content - Total XML: %0%, Total published: %1%, Total invalid: %2%</key>
 
-    <key alias="httpsCheckValidCertificate">Your site certificate was marked as valid.</key>
+    <key alias="httpsCheckValidCertificate">Your website's certificate is valid.</key>
     <key alias="httpsCheckInvalidCertificate">Certificate validation error: '%0%'</key>
+    <key alias="httpsCheckExpiredCertificate">Your website's SSL certificate has expired.</key>
+    <key alias="httpsCheckExpiringCertificate">Your website's SSL certificate is expiring in %0% days.</key>   
     <key alias="httpsCheckInvalidUrl">Error pinging the URL %0% - '%1%'</key>
     <key alias="httpsCheckIsCurrentSchemeHttps">You are currently %0% viewing the site using the HTTPS scheme.</key>
     <key alias="httpsCheckConfigurationRectifyNotPossible">The appSetting 'umbracoUseSSL' is set to 'false' in your web.config file. Once you access this site using the HTTPS scheme, that should be set to 'true'.</key>

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Security.Cryptography.X509Certificates;
 using System.Web;
 using Umbraco.Core.IO;
 using Umbraco.Core.Services;
@@ -53,7 +54,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         private HealthCheckStatus CheckForValidCertificate()
         {
             var message = string.Empty;
-            var success = false;
+            StatusResultType result;
             var url = HealthCheckContext.HttpContext.Request.Url;
 
             // Attempt to access the site over HTTPS to see if it HTTPS is supported 
@@ -65,7 +66,37 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             try
             {
                 var response = (HttpWebResponse)request.GetResponse();
-                success = response.StatusCode == HttpStatusCode.OK;
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    // Got a valid response, check now for if certificate expiring within 14 days
+                    // Hat-tip: https://stackoverflow.com/a/15343898/489433
+                    const int NumberOfDaysForExpiryWarning = 14;
+                    var cert = request.ServicePoint.Certificate;
+                    var cert2 = new X509Certificate2(cert);
+                    var expirationDate = cert2.NotAfter;
+
+                    var daysToExpiry = (int)Math.Floor((cert2.NotAfter - DateTime.Now).TotalDays);
+                    if (daysToExpiry <= 0)
+                    {
+                        result = StatusResultType.Error;
+                        message = _textService.Localize("healthcheck/httpsCheckExpiredCertificate");
+                    }
+                    else if (daysToExpiry < NumberOfDaysForExpiryWarning)
+                    {
+                        result = StatusResultType.Warning;
+                        message = _textService.Localize("healthcheck/httpsCheckExpiringCertificate", new[] { daysToExpiry.ToString() });
+                    }
+                    else
+                    {
+                        result = StatusResultType.Success;
+                        message = _textService.Localize("healthcheck/httpsCheckValidCertificate");
+                    }
+                }
+                else
+                {
+                    result = StatusResultType.Error;
+                    message = _textService.Localize("healthcheck/httpsCheckInvalidUrl", new[] { address, response.StatusDescription });
+                }
             }
             catch (Exception ex)
             {
@@ -80,17 +111,16 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
                 {
                     message = _textService.Localize("healthcheck/httpsCheckInvalidUrl", new[] { address, ex.Message });
                 }
+
+                result = StatusResultType.Error;
             }
 
             var actions = new List<HealthCheckAction>();
 
-            if (success)
-                message = _textService.Localize("healthcheck/httpsCheckValidCertificate");
-
             return
                 new HealthCheckStatus(message)
                 {
-                    ResultType = success ? StatusResultType.Success : StatusResultType.Error,
+                    ResultType = result,
                     Actions = actions
                 };
         }


### PR DESCRIPTION
With this in place the check will return error if there's no SSL certificate and success if there is as before, but if the certificate is expiring in the next 14 days a the result will be a warning instead.