### PR TITLE
Line breaks for property help text - U4-10002

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -149,6 +149,7 @@ h5.-black {
   font-size: 12px;
   color: @gray-6;
   line-height: 1.5em;
+  white-space: pre-line;
   padding-top: 5px;
 }
 .umb-nolabel .controls {


### PR DESCRIPTION
Adds line breaks to property help text on a node.
Fixes http://issues.umbraco.org/issue/U4-10002.