### PR TITLE
U4-9430 Fix

### DIFF
--- a/src/Umbraco.Web/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Web/Routing/UrlProviderExtensions.cs
@@ -68,7 +68,7 @@ namespace Umbraco.Web.Routing
             else
             {
                 // test for collisions
-                var uri = new Uri(url.TrimEnd('/'), UriKind.RelativeOrAbsolute);
+                var uri = UriUtility.UriToUmbraco(new Uri(url.TrimEnd('/'), UriKind.RelativeOrAbsolute));
                 if (uri.IsAbsoluteUri == false) uri = uri.MakeAbsolute(UmbracoContext.Current.CleanedUmbracoUrl);
                 var pcr = new PublishedContentRequest(uri, UmbracoContext.Current.RoutingContext, UmbracoConfig.For.UmbracoSettings().WebRouting, s => Roles.Provider.GetRolesForUser(s));
                 pcr.Engine.TryRouteRequest();


### PR DESCRIPTION
I applied Tom Fulton's fix for U4-9430 from https://github.com/tomfulton/Umbraco-CMS/commit/ba670586eba14092e6f1d20ee5e9aceb93e05f23. It runs the URL through the UriToUmbraco method which strips off the Virtual Directory prefix that is causing this problem. It works when I tested. I'm submitting this pull request myself since Tom hasn't responded to prodding to do it and it's important this make it into the base.