### PR TITLE
U4-10008 - New danish translation for "Preview" - button

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -89,8 +89,8 @@
     <key alias="saveAndPublish">Gem og udgiv</key>
     <key alias="saveToPublish">Gem og send til udgivelse</key>
     <key alias="saveListView">Gem listevisning</key>
-    <key alias="showPage">Se siden</key>
-    <key alias="showPageDisabled">Preview er deaktiveret fordi der ikke er nogen skabelon tildelt</key>
+    <key alias="showPage">Forhåndsvisning</key>
+    <key alias="showPageDisabled">Forhåndsvisning er deaktiveret fordi der ikke er nogen skabelon tildelt</key>
     <key alias="styleChoose">Vælg formattering</key>
     <key alias="styleShow">Vis koder</key>
     <key alias="tableInsert">Indsæt tabel</key>


### PR DESCRIPTION
Hi all at HQ :)

I have created this issue U4-10008 and then this pull request since with some new danish translation, since we have had some customers that wasn't aware that "Se siden" only was a preview, because "Se siden" does not directly tell that this is only a preview. :)