### PR TITLE
Fixes U4-10004 - validation of provided healthcheck fix value

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/healthcheck.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/healthcheck.controller.js
@@ -130,6 +130,10 @@
                 }
             }
         }
+
+        $scope.parseRegex = function (regexAsString) {
+            return new RegExp(regexAsString);
+        }
     }
 
     angular.module("umbraco").controller("Umbraco.Dashboard.HealthCheckController", HealthCheckController);

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/healthcheck.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/healthcheck.html
@@ -101,7 +101,11 @@
 
                                         <div ng-if="action.valueRequired">
                                             <div><label class="bold">Set new value:</label></div>
-                                            <input name="providedValue" type="text" ng-model="action.providedValue" required val-email/>
+                                            <div ng-switch on="action.providedValueValidation">
+                                                <input ng-switch-when="email" name="providedValue" type="text" ng-model="action.providedValue" required val-email />
+                                                <input ng-switch-when="regex" name="providedValue" type="text" ng-model="action.providedValue" required ng-pattern="parseRegex(action.providedValueValidationRegex)" />
+                                                <input ng-switch-default name="providedValue" type="text" ng-model="action.providedValue" required />
+                                            </div>
                                         </div>
 
                                         <button

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/AbstractConfigCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/AbstractConfigCheck.cs
@@ -7,7 +7,6 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Web.HealthCheck.Checks.Config
 {
-
     public abstract class AbstractConfigCheck : HealthCheck
     {
         private readonly ConfigurationService _configurationService;
@@ -42,6 +41,22 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
         /// Gets the comparison type for checking the value.
         /// </summary>
         public abstract ValueComparisonType ValueComparisonType { get; }
+
+        /// <summary>
+        /// Indicates validation method for provided value
+        /// </summary>
+        public virtual ProvidedValueValidation ProvidedValueValidation
+        {
+            get { return ProvidedValueValidation.None; }
+        }
+
+        /// <summary>
+        /// If provided value validation requires a regex, it's provided here
+        /// </summary>
+        public virtual string ProvidedValueValidationRegex
+        {
+            get { return string.Empty; }
+        }
 
         protected AbstractConfigCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
         {
@@ -154,6 +169,12 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
                 Name = _textService.Localize("healthcheck/rectifyButton"),
                 ValueRequired = CanRectifyWithValue,
             };
+
+            if (rectifyAction.ValueRequired)
+            {
+                rectifyAction.ProvidedValueValidation = ProvidedValueValidation.ToString().ToLower();
+                rectifyAction.ProvidedValueValidationRegex = ProvidedValueValidationRegex;
+            }
 
             var resultMessage = string.Format(CheckErrorMessage, FileName, XPath, Values, CurrentValue);
             return new[]

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/NotificationEmailCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/NotificationEmailCheck.cs
@@ -31,6 +31,11 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
             get { return ValueComparisonType.ShouldNotEqual; }
         }
 
+        public override ProvidedValueValidation ProvidedValueValidation
+        {
+            get { return ProvidedValueValidation.Email; }
+        }
+
         public override IEnumerable<AcceptableConfiguration> Values
         {
             get

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/ProvidedValueValidation.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/ProvidedValueValidation.cs
@@ -1,0 +1,9 @@
+﻿namespace Umbraco.Web.HealthCheck.Checks.Config
+{
+    public enum ProvidedValueValidation
+    {
+        None,
+        Email,
+        Regex
+    }
+}

--- a/src/Umbraco.Web/HealthCheck/HealthCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/HealthCheck.cs
@@ -54,8 +54,5 @@ namespace Umbraco.Web.HealthCheck
         /// <param name="action"></param>
         /// <returns></returns>
         public abstract HealthCheckStatus ExecuteAction(HealthCheckAction action);
-
-        //TODO: What else?
-
     }
 }

--- a/src/Umbraco.Web/HealthCheck/HealthCheckAction.cs
+++ b/src/Umbraco.Web/HealthCheck/HealthCheckAction.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Umbraco.Core.Services;
+using Umbraco.Web.HealthCheck.Checks.Config;
 
 namespace Umbraco.Web.HealthCheck
 {
@@ -69,6 +70,18 @@ namespace Umbraco.Web.HealthCheck
         /// </summary>
         [DataMember(Name = "valueRequired")]
         public bool ValueRequired { get; set; }
+
+        /// <summary>
+        /// Indicates if a value required, how it is validated
+        /// </summary>
+        [DataMember(Name = "providedValueValidation")]
+        public string ProvidedValueValidation { get; set; }
+
+        /// <summary>
+        /// Indicates if a value required, and is validated by a regex, what the regex to use is
+        /// </summary>
+        [DataMember(Name = "providedValueValidationRegex")]
+        public string ProvidedValueValidationRegex { get; set; }
 
         /// <summary>
         /// Provides a value to rectify the issue

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -323,6 +323,7 @@
     <Compile Include="HealthCheck\Checks\Config\TrySkipIisCustomErrorsCheck.cs" />
     <Compile Include="HealthCheck\Checks\Config\CustomErrorsCheck.cs" />
     <Compile Include="HealthCheck\Checks\Config\TraceCheck.cs" />
+    <Compile Include="HealthCheck\Checks\Config\ProvidedValueValidation.cs" />
     <Compile Include="HealthCheck\Checks\Config\ValueComparisonType.cs" />
     <Compile Include="HealthCheck\Checks\Config\CompilationDebugCheck.cs" />
     <Compile Include="HealthCheck\Checks\Services\SmtpCheck.cs" />


### PR DESCRIPTION
This PR removes hard-coded email validation for the healthcheck provided value (which isn't appropriate for all checks).  And makes validation more flexible, supporting none, email and regex.  This reinstates the existing behaviour of the "Notification Email Settings" check.

Review points:

Possibly there's a better way to apply the different validation attributes than the `ng-switch` method I've used here?