### PR TITLE
Fix for U4-10012 - Examine only reindexes first 10,000 media when filtering by node types

### DIFF
--- a/src/UmbracoExamine/UmbracoContentIndexer.cs
+++ b/src/UmbracoExamine/UmbracoContentIndexer.cs
@@ -610,13 +610,14 @@ namespace UmbracoExamine
 
                 //if specific types are declared we need to post filter them
                 //TODO: Update the service layer to join the cmsContentType table so we can query by content type too
+                var filteredElements = xElements;
                 if (IndexerData.IncludeNodeTypes.Any())
                 {
                     var includeNodeTypeIds = contentTypes.Where(x => IndexerData.IncludeNodeTypes.Contains(x.Alias)).Select(x => x.Id);
-                    xElements = xElements.Where(elm => includeNodeTypeIds.Contains(elm.AttributeValue<int>("nodeType"))).ToArray();
+                    filteredElements = xElements.Where(elm => includeNodeTypeIds.Contains(elm.AttributeValue<int>("nodeType"))).ToArray();
                 }
 
-                foreach (var element in xElements)
+                foreach (var element in filteredElements)
                 {
                     if (element.Attribute("icon") == null)
                     {
@@ -624,7 +625,7 @@ namespace UmbracoExamine
                     }
                 }
 
-                AddNodesToIndex(xElements, type);
+                AddNodesToIndex(filteredElements, type);
                 pageIndex++;
             } while (xElements.Length == pageSize);
         }


### PR DESCRIPTION
The check if there is another page is comparing the number of items with the page size, when filtering by node types the number of items is reduced so most likely it will never go onto any subsequent page