### PR TITLE
U4-10013 Umbraco.MediaPicker value converter does not understand ints

### DIFF
--- a/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
@@ -114,7 +114,7 @@ namespace Umbraco.Web.Cache
             });
 
             TagsValueConverter.ClearCaches();
-            MultipleMediaPickerPropertyConverter.ClearCaches();
+            LegacyMediaPickerPropertyConverter.ClearCaches();
             SliderValueConverter.ClearCaches();
             MediaPickerPropertyConverter.ClearCaches();
 

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/LegacyMediaPickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/LegacyMediaPickerPropertyConverter.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="MultipleMediaPickerPropertyConverter.cs" company="Umbraco">
+// <copyright file="LegacyMediaPickerPropertyConverter.cs" company="Umbraco">
 //   Umbraco
 // </copyright>
 // <summary>
@@ -24,20 +24,20 @@ using Umbraco.Core.Services;
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
     /// <summary>
-    /// The multiple media picker property value converter.
+    /// The multiple media picker and double legacy media picker property value converter, should be deleted for v8
     /// </summary>
     [DefaultPropertyValueConverter(typeof(MustBeStringValueConverter))]
-    public class MultipleMediaPickerPropertyConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    public class LegacyMediaPickerPropertyConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
     {
         private readonly IDataTypeService _dataTypeService;
 
         //TODO: Remove this ctor in v8 since the other one will use IoC
-        public MultipleMediaPickerPropertyConverter()
+        public LegacyMediaPickerPropertyConverter()
             : this(ApplicationContext.Current.Services.DataTypeService)
         {
         }
 
-        public MultipleMediaPickerPropertyConverter(IDataTypeService dataTypeService)
+        public LegacyMediaPickerPropertyConverter(IDataTypeService dataTypeService)
         {
             if (dataTypeService == null) throw new ArgumentNullException("dataTypeService");
             _dataTypeService = dataTypeService;
@@ -57,6 +57,12 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             if (UmbracoConfig.For.UmbracoSettings().Content.EnablePropertyValueConverters)
             {
                 return propertyType.PropertyEditorAlias.Equals(Constants.PropertyEditors.MultipleMediaPickerAlias);
+            }
+
+            if (UmbracoConfig.For.UmbracoSettings().Content.EnablePropertyValueConverters)
+            {
+                // this is the double legacy media picker, it can pick only single media items
+                return propertyType.PropertyEditorAlias.Equals(Constants.PropertyEditors.MediaPickerAlias);
             }
             return false;
         }
@@ -109,7 +115,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                             ApplicationContext.Current.Services.DataTypeService.GetDataTypeDefinitionById(
                                 propertyType.DataTypeId).Name);
 
-                    LogHelper.Warn<MultipleMediaPickerPropertyConverter>(error);
+                    LogHelper.Warn<LegacyMediaPickerPropertyConverter>(error);
                     throw new Exception(error);
                 }
             }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerPropertyConverter.cs
@@ -126,10 +126,6 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             if (propertyType.PropertyEditorAlias.Equals(Constants.PropertyEditors.MediaPicker2Alias))
                 return true;
 
-            if (UmbracoConfig.For.UmbracoSettings().Content.EnablePropertyValueConverters)
-            {
-                return propertyType.PropertyEditorAlias.Equals(Constants.PropertyEditors.MediaPickerAlias);
-            }
             return false;
         }
 

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -411,7 +411,7 @@
     <Compile Include="PropertyEditors\ValueConverters\MediaPickerPropertyConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\MemberPickerPropertyConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\MultiNodeTreePickerPropertyConverter.cs" />
-    <Compile Include="PropertyEditors\ValueConverters\MultipleMediaPickerPropertyConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\LegacyMediaPickerPropertyConverter.cs" />
     <Compile Include="PublishedContentQueryExtensions.cs" />
     <Compile Include="Routing\RedirectTrackingEventHandler.cs" />
     <Compile Include="Editors\RedirectUrlManagementController.cs" />


### PR DESCRIPTION
Switches Umbraco.MediaPicker (double legacy) to being converted by MultipleMediaPickerPropertyConverter so that it actually works

Renames MultipleMediaPickerPropertyConverter to LegacyMediaPickerPropertyConverter (delete for v8)