### PR TITLE
Fix incorrect namespace in deprecated class messages

### DIFF
--- a/src/umbraco.businesslogic/Exceptions/FileSecurityException.cs
+++ b/src/umbraco.businesslogic/Exceptions/FileSecurityException.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace umbraco.businesslogic.Exceptions
 {
-	[Obsolete("This class has been superceded by Umbraco.Core.UI.FileSecurityException")]
+	[Obsolete("This class has been superceded by Umbraco.Core.IO.FileSecurityException")]
 	public class FileSecurityException : Umbraco.Core.IO.FileSecurityException
     {
         public FileSecurityException()

--- a/src/umbraco.businesslogic/IO/SystemFiles.cs
+++ b/src/umbraco.businesslogic/IO/SystemFiles.cs
@@ -10,7 +10,7 @@ using System.Web;
 namespace umbraco.IO
 {
 
-	[Obsolete("Use Umbraco.Core.UI.SystemFiles instead")]
+	[Obsolete("Use Umbraco.Core.IO.SystemFiles instead")]
 	public class SystemFiles
 	{
         [Obsolete("This file is no longer used and should not be accessed!")]


### PR DESCRIPTION
Obsolete warning messages for the deprecated classes `umbraco.businesslogic.Exceptions.FileSecurityException` and `umbraco.IO.SystemFiles` both pointed to the updated classes in the `Umbraco.Core.UI` namespace.

Since `Umbraco.Core.UI` does not exist, I assume this was a typo and should actually be `Umbraco.Core.IO` which does contain the superseding classes as expected.

Caused a little confusion recently when I was upgrading an older project to Umbraco 7.6! 😄

Thanks!