### PR TITLE
U4-10029Umbraco.ReplaceLineBreaksForHtml should return an IHtmlString

### DIFF
--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/TextString.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/TextString.cshtml
@@ -1,22 +1,23 @@
 @model dynamic
 @using Umbraco.Web.Templates
-
-@if (Model.editor.config.markup != null)
-{
-    string markup = Model.editor.config.markup.ToString();
-
+@{
     var UmbracoHelper = new UmbracoHelper(UmbracoContext.Current);
-    
-    markup = markup.Replace("#value#", UmbracoHelper.ReplaceLineBreaksForHtml(Model.value.ToString()));
-    markup = markup.Replace("#style#", Model.editor.config.style.ToString());
+    if (Model.editor.config.markup != null)
+    {
+        string markup = Model.editor.config.markup.ToString();
 
-    <text>
-        @Html.Raw(markup)
-    </text>
-}
-else
-{
-    <text>
-        <div style="@Model.editor.config.style">@Model.value</div>
-    </text>
+
+        markup = markup.Replace("#value#", UmbracoHelper.ReplaceLineBreaksForHtml(Model.value.ToString()).ToString());
+        markup = markup.Replace("#style#", Model.editor.config.style.ToString());
+
+        <text>
+            @Html.Raw(markup)
+        </text>
+    }
+    else
+    {
+        <text>
+            <div style="@Model.editor.config.style">@UmbracoHelper.ReplaceLineBreaksForHtml(Model.value)</div>
+        </text>
+    }
 }

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/TextString.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/TextString.cshtml
@@ -1,11 +1,13 @@
-﻿@model dynamic
+@model dynamic
 @using Umbraco.Web.Templates
 
 @if (Model.editor.config.markup != null)
 {
     string markup = Model.editor.config.markup.ToString();
 
-    markup = markup.Replace("#value#", Model.value.ToString());
+    var UmbracoHelper = new UmbracoHelper(UmbracoContext.Current);
+    
+    markup = markup.Replace("#value#", UmbracoHelper.ReplaceLineBreaksForHtml(Model.value.ToString()));
     markup = markup.Replace("#style#", Model.editor.config.style.ToString());
 
     <text>

--- a/src/Umbraco.Web/HtmlStringUtilities.cs
+++ b/src/Umbraco.Web/HtmlStringUtilities.cs
@@ -21,9 +21,9 @@ namespace Umbraco.Web
         /// </summary>
         /// <param name="text">The text.</param>
         /// <returns>The text with text line breaks replaced with html linebreaks (<br/>)</returns>
-        public string ReplaceLineBreaksForHtml(string text)
+        public HtmlString ReplaceLineBreaksForHtml(string text)
         {
-            return text.Replace("\n", "<br/>\n");
+            return new HtmlString(text.Replace("\n", "<br/>\n"));
         }
 
         public HtmlString StripHtmlTags(string html, params string[] tags)

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -1066,9 +1066,9 @@ namespace Umbraco.Web
 		/// </summary>
 		/// <param name="text">The text.</param>
 		/// <returns>The text with text line breaks replaced with html linebreaks (<br/>)</returns>
-		public string ReplaceLineBreaksForHtml(string text)
+		public IHtmlString ReplaceLineBreaksForHtml(string text)
 		{
-            return _stringUtilities.ReplaceLineBreaksForHtml(text);
+            		return _stringUtilities.ReplaceLineBreaksForHtml(text);
 		}
 
 		/// <summary>

--- a/src/Umbraco.Web/umbraco.presentation/library.cs
+++ b/src/Umbraco.Web/umbraco.presentation/library.cs
@@ -992,7 +992,7 @@ namespace umbraco
         /// <returns>The text with text line breaks replaced with html linebreaks (<br/>)</returns>
         public static string ReplaceLineBreaks(string text)
         {
-        	return GetUmbracoHelper().ReplaceLineBreaksForHtml(text);
+        	return GetUmbracoHelper().ReplaceLineBreaksForHtml(text).ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
I'm a bit unsure if it's ok for the method in src/Umbraco.Web/umbraco.presentation/library.cs to return IHtmlString, so I converted that one to a string.