### PR TITLE
Turns out when we empty the recycle bin we weren't removing associate…

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
@@ -636,9 +636,12 @@ namespace Umbraco.Core.Persistence.Repositories
             {
                 //In order to update the ContentVersion we need to retrieve its primary key id
                 var contentVerDto = Database.SingleOrDefault<ContentVersionDto>("WHERE VersionId = @Version", new { Version = entity.Version });
-                contentVersionDto.Id = contentVerDto.Id;
-
-                Database.Update(contentVersionDto);
+                if (contentVerDto != null)
+                {
+                    contentVersionDto.Id = contentVerDto.Id;
+                    Database.Update(contentVersionDto);
+                }
+                
                 Database.Update(dto);
             }
 

--- a/src/Umbraco.Core/Persistence/Repositories/RecycleBinRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/RecycleBinRepository.cs
@@ -42,6 +42,7 @@ namespace Umbraco.Core.Persistence.Repositories
             //Construct and execute delete statements for all trashed items by 'nodeObjectType'
             var deletes = new List<string>
             {
+                FormatDeleteStatement("cmsTask", "nodeId"),
                 FormatDeleteStatement("umbracoUser2NodeNotify", "nodeId"),
                 FormatDeleteStatement("umbracoUser2NodePermission", "nodeId"),
                 @"DELETE FROM umbracoAccessRule WHERE umbracoAccessRule.accessId IN (


### PR DESCRIPTION
…d cmsTask info. This also adds a null check since a SingleOrDefault call can return null. I've only seen this cause a problem when there is corrupt data but it should still be checked.