### PR TITLE
Fixes U4-4090 - by preserved line breaks in property descriptions...

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/filters/preserveNewLineInHtml.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/preserveNewLineInHtml.filter.js
@@ -1,0 +1,12 @@
+/**
+* @ngdoc filter
+* @name umbraco.filters.preserveNewLineInHtml
+* @description 
+* Used when rendering a string as HTML (i.e. with ng-bind-html) to convert line-breaks to <br /> tags
+**/
+angular.module("umbraco.filters").filter('preserveNewLineInHtml', function () {
+  return function (text) {
+    return text.replace(/\n/g, '<br />');
+  }
+});
+	

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -11,7 +11,7 @@
                     <span ng-if="property.validation.mandatory">
                         <strong class="umb-control-required">*</strong>
                     </span>
-                    <small ng-bind-html="property.description"></small>
+                    <small ng-bind-html="property.description | preserveNewLineInHtml"></small>
                 </label>
 
                 <div class="controls" ng-transclude>


### PR DESCRIPTION
...when rendering in content area (converting newlines to `<br />` tags