### PR TITLE
U4-6695 Adds InternalsVisibleTo("Umbraco.UnitTesting.Adapter")

### DIFF
--- a/src/Umbraco.Core/Properties/AssemblyInfo.cs
+++ b/src/Umbraco.Core/Properties/AssemblyInfo.cs
@@ -39,7 +39,6 @@ using System.Security.Permissions;
 [assembly: InternalsVisibleTo("UmbracoExamine")]
 
 [assembly: InternalsVisibleTo("Concorde.Sync")]
-[assembly: InternalsVisibleTo("Umbraco.VisualStudio")]
 [assembly: InternalsVisibleTo("Umbraco.Courier.Core")]
 [assembly: InternalsVisibleTo("Umbraco.Courier.Persistence")]
 
@@ -53,3 +52,7 @@ using System.Security.Permissions;
 
 //allow this to be mocked in our unit tests
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
+//allow custom unit-testing code to access internals through custom adapters
+[assembly: InternalsVisibleTo("Umbraco.VisualStudio")]          // backwards compat.
+[assembly: InternalsVisibleTo("Umbraco.UnitTesting.Adapter")]   // new, more imperative name

--- a/src/Umbraco.Web/Properties/AssemblyInfo.cs
+++ b/src/Umbraco.Web/Properties/AssemblyInfo.cs
@@ -38,7 +38,6 @@ using System.Security;
 [assembly: InternalsVisibleTo("Umbraco.Deploy")]
 [assembly: InternalsVisibleTo("Umbraco.Deploy.UI")]
 [assembly: InternalsVisibleTo("Umbraco.Deploy.Cloud")]
-[assembly: InternalsVisibleTo("Umbraco.VisualStudio")]
 [assembly: InternalsVisibleTo("Umbraco.ModelsBuilder")]
 [assembly: InternalsVisibleTo("Umbraco.ModelsBuilder.AspNet")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
@@ -47,3 +46,7 @@ using System.Security;
 [assembly: InternalsVisibleTo("Umbraco.Forms.Core.Providers")]
 [assembly: InternalsVisibleTo("Umbraco.Forms.Web")]
 
+
+//allow custom unit-testing code to access internals through custom adapters
+[assembly: InternalsVisibleTo("Umbraco.VisualStudio")]          // backwards compat.
+[assembly: InternalsVisibleTo("Umbraco.UnitTesting.Adapter")]   // new, more imperative name


### PR DESCRIPTION
Adds InternalsVisibleTo("Umbraco.UnitTesting.Adapter") for more imperative exposure to custom unit test adapters.