### PR TITLE
U4-4895 - Search within all properties when in List View mode

### DIFF
--- a/src/Umbraco.Core/Models/Content.cs
+++ b/src/Umbraco.Core/Models/Content.cs
@@ -270,6 +270,11 @@ namespace Umbraco.Core.Models
         public Guid PublishedVersionGuid { get; internal set; }
 
         /// <summary>
+        /// Gets or Sets the database stored "index" of keywords for searching on for the content
+        /// </summary>
+        public string SearchText { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the content has a published version.
         /// </summary>
         public bool HasPublishedVersion { get { return PublishedVersionGuid != default(Guid); } }

--- a/src/Umbraco.Core/Models/IContent.cs
+++ b/src/Umbraco.Core/Models/IContent.cs
@@ -85,5 +85,10 @@ namespace Umbraco.Core.Models
         /// Gets the unique identifier of the published version, if any.
         /// </summary>
         Guid PublishedVersionGuid { get; }
+
+        /// <summary>
+        /// Gets or Sets the database stored "index" of keywords for searching on for the content
+        /// </summary>
+        string SearchText { get; set; }
     }
 }

--- a/src/Umbraco.Core/Models/PropertyType.cs
+++ b/src/Umbraco.Core/Models/PropertyType.cs
@@ -28,6 +28,7 @@ namespace Umbraco.Core.Models
         private string _propertyEditorAlias;
         private DataTypeDatabaseType _dataTypeDatabaseType;
         private bool _mandatory;
+        private bool _searchable;
         private string _helpText;
         private int _sortOrder;
         private string _validationRegExp;
@@ -98,6 +99,7 @@ namespace Umbraco.Core.Models
             public readonly PropertyInfo PropertyEditorAliasSelector = ExpressionHelper.GetPropertyInfo<PropertyType, string>(x => x.PropertyEditorAlias);
             public readonly PropertyInfo DataTypeDatabaseTypeSelector = ExpressionHelper.GetPropertyInfo<PropertyType, DataTypeDatabaseType>(x => x.DataTypeDatabaseType);
             public readonly PropertyInfo MandatorySelector = ExpressionHelper.GetPropertyInfo<PropertyType, bool>(x => x.Mandatory);
+            public readonly PropertyInfo SearchableSelector = ExpressionHelper.GetPropertyInfo<PropertyType, bool>(x => x.Searchable);
             public readonly PropertyInfo HelpTextSelector = ExpressionHelper.GetPropertyInfo<PropertyType, string>(x => x.HelpText);
             public readonly PropertyInfo SortOrderSelector = ExpressionHelper.GetPropertyInfo<PropertyType, int>(x => x.SortOrder);
             public readonly PropertyInfo ValidationRegExpSelector = ExpressionHelper.GetPropertyInfo<PropertyType, string>(x => x.ValidationRegExp);
@@ -206,6 +208,16 @@ namespace Umbraco.Core.Models
         {
             get { return _mandatory; }
             set { SetPropertyValueAndDetectChanges(value, ref _mandatory, Ps.Value.MandatorySelector); }
+        }
+
+        /// <summary>
+        /// Gets of Sets the Boolean indicating whether the value for this PropertyType is searchable when filtered in the list view
+        /// </summary>
+        [DataMember]
+        public bool Searchable
+        {
+            get { return _searchable; }
+            set { SetPropertyValueAndDetectChanges(value, ref _searchable, Ps.Value.SearchableSelector); }
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Models/Rdbms/DocumentSearchDto.cs
+++ b/src/Umbraco.Core/Models/Rdbms/DocumentSearchDto.cs
@@ -1,0 +1,18 @@
+﻿using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
+
+namespace Umbraco.Core.Models.Rdbms
+{
+    [TableName("cmsDocumentSearch")]
+    [PrimaryKey("NodeId", autoIncrement = false)]
+    [ExplicitColumns]
+    internal class DocumentSearchDto
+    {
+        [Column("NodeId")]
+        [ForeignKey(typeof(NodeDto))]
+        public int NodeId { get; set; }
+
+        [Column("SearchText")]
+        public string SearchText { get; set; }
+    }
+}

--- a/src/Umbraco.Core/Models/Rdbms/PropertyTypeDto.cs
+++ b/src/Umbraco.Core/Models/Rdbms/PropertyTypeDto.cs
@@ -46,6 +46,10 @@ namespace Umbraco.Core.Models.Rdbms
         [NullSetting(NullSetting = NullSettings.Null)]
         public string ValidationRegExp { get; set; }
 
+        [Column("Searchable")]
+        [Constraint(Default = "0")]
+        public bool Searchable { get; set; }
+
         [Column("Description")]
         [NullSetting(NullSetting = NullSettings.Null)]
         [Length(2000)]

--- a/src/Umbraco.Core/Persistence/Factories/PropertyGroupFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/PropertyGroupFactory.cs
@@ -73,6 +73,7 @@ namespace Umbraco.Core.Persistence.Factories
                             propertyType.Key = typeDto.UniqueId;
                             propertyType.Name = typeDto.Name;
                             propertyType.Mandatory = typeDto.Mandatory;
+                            propertyType.Searchable = typeDto.Searchable;
                             propertyType.SortOrder = typeDto.SortOrder;
                             propertyType.ValidationRegExp = typeDto.ValidationRegExp;
                             propertyType.PropertyGroupId = new Lazy<int>(() => tempGroupDto.Id);
@@ -137,6 +138,7 @@ namespace Umbraco.Core.Persistence.Factories
                 DataTypeId = propertyType.DataTypeDefinitionId,
                 Description = propertyType.Description,
                 Mandatory = propertyType.Mandatory,
+                Searchable = propertyType.Searchable,
                 Name = propertyType.Name,
                 SortOrder = propertyType.SortOrder,
                 ValidationRegExp = propertyType.ValidationRegExp,

--- a/src/Umbraco.Core/Persistence/Mappers/ContentMapper.cs
+++ b/src/Umbraco.Core/Persistence/Mappers/ContentMapper.cs
@@ -57,6 +57,7 @@ namespace Umbraco.Core.Persistence.Mappers
                 CacheMap<Content, DocumentDto>(src => src.ExpireDate, dto => dto.ExpiresDate);
                 CacheMap<Content, DocumentDto>(src => src.ReleaseDate, dto => dto.ReleaseDate);
                 CacheMap<Content, DocumentDto>(src => src.Published, dto => dto.Published);
+                CacheMap<Content, DocumentSearchDto>(src => src.SearchText, dto => dto.SearchText);
                 //CacheMap<Content, DocumentDto>(src => src.Name, dto => dto.Alias);
                 //CacheMap<Content, DocumentDto>(src => src, dto => dto.Newest);
                 //CacheMap<Content, DocumentDto>(src => src.Template, dto => dto.TemplateId);

--- a/src/Umbraco.Core/Persistence/Mappers/PropertyTypeMapper.cs
+++ b/src/Umbraco.Core/Persistence/Mappers/PropertyTypeMapper.cs
@@ -39,6 +39,7 @@ namespace Umbraco.Core.Persistence.Mappers
                 CacheMap<PropertyType, PropertyTypeDto>(src => src.DataTypeDefinitionId, dto => dto.DataTypeId);
                 CacheMap<PropertyType, PropertyTypeDto>(src => src.Description, dto => dto.Description);
                 CacheMap<PropertyType, PropertyTypeDto>(src => src.Mandatory, dto => dto.Mandatory);
+                CacheMap<PropertyType, PropertyTypeDto>(src => src.Searchable, dto => dto.Searchable);
                 CacheMap<PropertyType, PropertyTypeDto>(src => src.Name, dto => dto.Name);
                 CacheMap<PropertyType, PropertyTypeDto>(src => src.SortOrder, dto => dto.SortOrder);
                 CacheMap<PropertyType, PropertyTypeDto>(src => src.ValidationRegExp, dto => dto.ValidationRegExp);

--- a/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenSevenZero/AddDocumentSearchTable.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenSevenZero/AddDocumentSearchTable.cs
@@ -1,0 +1,35 @@
+﻿using System.Data;
+using System.Linq;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenSevenZero
+{
+    [Migration("7.7.0", 100, Constants.System.UmbracoMigrationName)]
+    public class AddDocumentSearchTable : MigrationBase
+    {
+        public AddDocumentSearchTable(ISqlSyntaxProvider sqlSyntax, ILogger logger)
+            : base(sqlSyntax, logger)
+        { }
+
+        public override void Up()
+        {
+            var tables = SqlSyntax.GetTablesInSchema(Context.Database).ToArray();
+            if (tables.InvariantContains("cmsDocumentSearch") == false)
+            {
+                Create.Table("cmsDocumentSearch")
+                    .WithColumn("NodeId").AsInt32().PrimaryKey("PK_cmsDocumentSearch")
+                    .WithColumn("SearchText").AsString().NotNullable();
+
+                Create.ForeignKey("FK_cmsDocumentSearch_umbracoNode_id")
+                    .FromTable("cmsDocumentSearch").ForeignColumn("NodeId")
+                    .ToTable("umbracoNode").PrimaryColumn("id").OnDeleteOrUpdate(Rule.Cascade);
+            }
+        }
+
+        public override void Down()
+        {
+            // not implemented
+        }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenSevenZero/AddSearchablePropertyTypeColumn.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenSevenZero/AddSearchablePropertyTypeColumn.cs
@@ -1,0 +1,31 @@
+﻿using System.Data;
+using System.Linq;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenSevenZero
+{
+    [Migration("7.7.0", 110, Constants.System.UmbracoMigrationName)]
+    public class AddSearchablePropertyTypeColumn : MigrationBase
+    {
+        public AddSearchablePropertyTypeColumn(ISqlSyntaxProvider sqlSyntax, ILogger logger)
+            : base(sqlSyntax, logger)
+        { }
+
+        public override void Up()
+        {
+            //Don't exeucte if the column is already there
+            var columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToArray();
+
+            if (columns.Any(x => x.TableName.InvariantEquals("cmsPropertyType") && x.ColumnName.InvariantEquals("Searchable")) == false)
+            {
+                Create.Column("Searchable").OnTable("cmsPropertyType").AsBoolean().NotNullable().WithDefault(0);
+            }
+        }
+
+        public override void Down()
+        {
+            // not implemented
+        }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
@@ -126,14 +126,19 @@ namespace Umbraco.Core.Persistence.Repositories
         protected override Sql GetBaseQuery(BaseQueryType queryType)
         {
             var sql = new Sql();
-            sql.Select(queryType == BaseQueryType.Count ? "COUNT(*)" : (queryType == BaseQueryType.Ids ? "cmsDocument.nodeId" : "*"))
-                .From<DocumentDto>(SqlSyntax)
+            sql
+                .Select(
+                    queryType == BaseQueryType.Count
+                        ? "COUNT(*)"
+                        : (queryType == BaseQueryType.Ids ? "cmsDocument.nodeId" : "*")).From<DocumentDto>(SqlSyntax)
                 .InnerJoin<ContentVersionDto>(SqlSyntax)
                 .On<DocumentDto, ContentVersionDto>(SqlSyntax, left => left.VersionId, right => right.VersionId)
                 .InnerJoin<ContentDto>(SqlSyntax)
                 .On<ContentVersionDto, ContentDto>(SqlSyntax, left => left.NodeId, right => right.NodeId)
                 .InnerJoin<NodeDto>(SqlSyntax)
-                .On<ContentDto, NodeDto>(SqlSyntax, left => left.NodeId, right => right.NodeId);
+                .On<ContentDto, NodeDto>(SqlSyntax, left => left.NodeId, right => right.NodeId)
+                .LeftJoin<DocumentSearchDto>(SqlSyntax)
+                .On<DocumentDto, DocumentSearchDto>(SqlSyntax, left => left.NodeId, right => right.NodeId);
             //TODO: IF we want to enable querying on content type information this will need to be joined
             //.InnerJoin<ContentTypeDto>(SqlSyntax)
             //.On<ContentDto, ContentTypeDto>(SqlSyntax, left => left.ContentTypeId, right => right.NodeId, SqlSyntax);

--- a/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
@@ -892,6 +892,23 @@ order by umbracoNode.{2}, umbracoNode.parentID, umbracoNode.sortOrder",
         }
 
         /// <summary>
+        /// Adds/updates the database held list view filter "index" for the content item
+        /// </summary>
+        /// <param name="content"></param>
+        public void AddOrUpdateSearchText(IContent content)
+        {
+            Database.Delete<DocumentSearchDto>(content.Id);
+            if (string.IsNullOrEmpty(content.SearchText) == false)
+            {
+                Database.InsertOrUpdate(new DocumentSearchDto
+                {
+                    NodeId = content.Id,
+                    SearchText = content.SearchText
+                });
+            }
+        }
+
+        /// <summary>
         /// Gets paged content results
         /// </summary>
         /// <param name="query">Query to excute</param>

--- a/src/Umbraco.Core/Persistence/Repositories/ContentTypeBaseRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentTypeBaseRepository.cs
@@ -501,6 +501,7 @@ AND umbracoNode.id <> @id",
                 propType.Key = dto.UniqueId;
                 propType.Name = dto.Name;
                 propType.Mandatory = dto.Mandatory;
+                propType.Searchable = dto.Searchable;
                 propType.SortOrder = dto.SortOrder;
                 propType.ValidationRegExp = dto.ValidationRegExp;
                 propType.CreateDate = createDate;
@@ -1077,14 +1078,14 @@ AND umbracoNode.id <> @id",
                 // NOTE: MySQL requires a SELECT * FROM the inner union in order to be able to sort . lame.
 
                 var sqlBuilder = new StringBuilder(@"SELECT PG.contenttypeNodeId as contentTypeId,
-                            PT.ptUniqueId as ptUniqueID, PT.ptId, PT.ptAlias, PT.ptDesc,PT.ptMandatory,PT.ptName,PT.ptSortOrder,PT.ptRegExp,
+                            PT.ptUniqueId as ptUniqueID, PT.ptId, PT.ptAlias, PT.ptDesc,PT.ptMandatory,PT.ptSearchable,PT.ptName,PT.ptSortOrder,PT.ptRegExp,
                             PT.dtId,PT.dtDbType,PT.dtPropEdAlias,
                             PG.id as pgId, PG.uniqueID as pgKey, PG.sortorder as pgSortOrder, PG." + sqlSyntax.GetQuotedColumnName("text") + @" as pgText
                         FROM cmsPropertyTypeGroup as PG
                         LEFT JOIN
                         (
                             SELECT PT.uniqueID as ptUniqueId, PT.id as ptId, PT.Alias as ptAlias, PT." + sqlSyntax.GetQuotedColumnName("Description") + @" as ptDesc,
-                                    PT.mandatory as ptMandatory, PT.Name as ptName, PT.sortOrder as ptSortOrder, PT.validationRegExp as ptRegExp,
+                                    PT.mandatory as ptMandatory, PT.Searchable as ptSearchable, PT.Name as ptName, PT.sortOrder as ptSortOrder, PT.validationRegExp as ptRegExp,
                                     PT.propertyTypeGroupId as ptGroupId,
                                     DT.dbType as dtDbType, DT.nodeId as dtId, DT.propertyEditorAlias as dtPropEdAlias
                             FROM cmsPropertyType as PT
@@ -1098,7 +1099,7 @@ AND umbracoNode.id <> @id",
 
                         SELECT  PT.contentTypeId as contentTypeId,
                                 PT.uniqueID as ptUniqueID, PT.id as ptId, PT.Alias as ptAlias, PT." + sqlSyntax.GetQuotedColumnName("Description") + @" as ptDesc,
-                                PT.mandatory as ptMandatory, PT.Name as ptName, PT.sortOrder as ptSortOrder, PT.validationRegExp as ptRegExp,
+                                PT.mandatory as ptMandatory, PT.Searchable as ptSearchable, PT.Name as ptName, PT.sortOrder as ptSortOrder, PT.validationRegExp as ptRegExp,
                                 DT.nodeId as dtId, DT.dbType as dtDbType, DT.propertyEditorAlias as dtPropEdAlias,
                                 PG.id as pgId, PG.uniqueID as pgKey, PG.sortorder as pgSortOrder, PG." + sqlSyntax.GetQuotedColumnName("text") + @" as pgText
                         FROM cmsPropertyType as PT
@@ -1148,6 +1149,7 @@ AND umbracoNode.id <> @id",
                                     Id = row.ptId,
                                     Key = row.ptUniqueID,
                                     Mandatory = Convert.ToBoolean(row.ptMandatory),
+                                    Searchable = Convert.ToBoolean(row.ptSearchable),
                                     Name = row.ptName,
                                     PropertyGroupId = new Lazy<int>(() => group.GroupId, false),
                                     SortOrder = row.ptSortOrder,
@@ -1177,6 +1179,7 @@ AND umbracoNode.id <> @id",
                             Id = row.ptId,
                             Key = row.ptUniqueID,
                             Mandatory = Convert.ToBoolean(row.ptMandatory),
+                            Searchable = Convert.ToBoolean(row.ptSearchable),
                             Name = row.ptName,
                             PropertyGroupId = null,
                             SortOrder = row.ptSortOrder,

--- a/src/Umbraco.Core/Persistence/Repositories/Interfaces/IContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Interfaces/IContentRepository.cs
@@ -83,7 +83,10 @@ namespace Umbraco.Core.Persistence.Repositories
         /// <param name="xml"></param>
         void AddOrUpdatePreviewXml(IContent content, Func<IContent, XElement> xml);
 
-        
-        
+        /// <summary>
+        /// Used to add/update the database held list view filter "index" for the content item
+        /// </summary>
+        /// <param name="content"></param>
+        void AddOrUpdateSearchText(IContent content);
     }
 }

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -582,8 +582,11 @@ namespace Umbraco.Core.Services
                 IQuery<IContent> filterQuery = null;
                 if (filter.IsNullOrWhiteSpace() == false)
                 {
-                    filterQuery = Query<IContent>.Builder.Where(x => x.Name.Contains(filter));
+                    filterQuery = Query<IContent>.Builder
+                        .Where(x => x.Name.Contains(filter) ||
+                                    x.SearchText.Contains(filter));
                 }
+
                 return repository.GetPagedResultsByQuery(query, pageIndex, pageSize, out totalChildren, orderBy, orderDirection, orderBySystemField, filterQuery);
             }
         }

--- a/src/Umbraco.Core/Services/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/EntityXmlSerializer.cs
@@ -284,6 +284,7 @@ namespace Umbraco.Core.Services
                                                    new XElement("Tab", propertyGroup == null ? "" : propertyGroup.Name),
                                                    new XElement("Mandatory", propertyType.Mandatory.ToString()),
                                                    new XElement("Validation", propertyType.ValidationRegExp),
+                                                   new XElement("Searchable", propertyType.Searchable.ToString()),
                                                    new XElement("Description", new XCData(propertyType.Description)));
                 genericProperties.Add(genericProperty);
             }
@@ -403,6 +404,7 @@ namespace Umbraco.Core.Services
                                                    new XElement("SortOrder", propertyType.SortOrder),
                                                    new XElement("Mandatory", propertyType.Mandatory.ToString()),
                                                    propertyType.ValidationRegExp != null ? new XElement("Validation", propertyType.ValidationRegExp) : null,
+                                                   new XElement("Searchable", propertyType.Searchable.ToString()),
                                                    propertyType.Description != null ? new XElement("Description", new XCData(propertyType.Description)) : null);
                 
                 genericProperties.Add(genericProperty);

--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -810,6 +810,7 @@ namespace Umbraco.Core.Services
                     Description = (string)property.Element("Description"),
                     Mandatory = property.Element("Mandatory") != null ? property.Element("Mandatory").Value.ToLowerInvariant().Equals("true") : false,
                     ValidationRegExp = (string)property.Element("Validation"),
+                    Searchable = property.Element("Searchable") != null ? property.Element("Searchable").Value.ToLowerInvariant().Equals("true") : false,
                     SortOrder = sortOrder
                 };
 

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -345,6 +345,7 @@
     <Compile Include="IHttpContextAccessor.cs" />
     <Compile Include="Models\EntityBase\IDeletableEntity.cs" />
     <Compile Include="Models\PublishedContent\PublishedContentTypeConverter.cs" />
+    <Compile Include="Models\Rdbms\DocumentSearchDto.cs" />
     <Compile Include="OrderedHashSet.cs" />
     <Compile Include="Events\UninstallPackageEventArgs.cs" />
     <Compile Include="Models\GridValue.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -501,6 +501,8 @@
     <Compile Include="Persistence\Mappers\MigrationEntryMapper.cs" />
     <Compile Include="Persistence\Migrations\LocalMigrationContext.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionFourOneZero\AddPreviewXmlTable.cs" />
+    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenSevenZero\AddSearchablePropertyTypeColumn.cs" />
+    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenSevenZero\AddDocumentSearchTable.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenSixZero\AddLockObjects.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenSixZero\AddLockTable.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenFiveFive\UpdateAllowedMediaTypesAtRoot.cs" />

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -545,6 +545,7 @@
             property.dataTypeName = oldModel.property.dataTypeName;
             property.validation.mandatory = oldModel.property.validation.mandatory;
             property.validation.pattern = oldModel.property.validation.pattern;
+            property.searchable = oldModel.property.searchable;
             property.showOnMemberProfile = oldModel.property.showOnMemberProfile;
             property.memberCanEdit = oldModel.property.memberCanEdit;
 
@@ -593,7 +594,8 @@
           validation: {
             mandatory: false,
             pattern: null
-          }
+          },
+          searchable: false
         };
 
         // check if there already is an init property

--- a/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
@@ -608,7 +608,7 @@ function umbDataFormatter() {
                 });
 
                 var saveProperties = _.map(realProperties, function (p) {
-                    var saveProperty = _.pick(p, 'id', 'alias', 'description', 'validation', 'label', 'sortOrder', 'dataTypeId', 'groupId', 'memberCanEdit', 'showOnMemberProfile');
+                    var saveProperty = _.pick(p, 'id', 'alias', 'description', 'validation', 'searchable', 'label', 'sortOrder', 'dataTypeId', 'groupId', 'memberCanEdit', 'showOnMemberProfile');
                     return saveProperty;
                 });
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.html
@@ -86,7 +86,19 @@
 
    </div>
 
-   <div class="umb-control-group clearfix" ng-if="model.contentType === 'memberType'">
+  <div class="umb-control-group clearfix">
+
+    <h5><localize key="editcontenttype_searchOptions"></localize></h5>
+
+    <label class="checkbox no-indent">
+      <input type="checkbox" ng-model="model.property.searchable">
+      <localize key="editcontenttype_fieldIsSearchable"></localize>
+      <div><small><localize key="editcontenttype_fieldIsSearchableInfo"></localize></small></div>
+    </label>
+
+  </div>
+  
+  <div class="umb-control-group clearfix" ng-if="model.contentType === 'memberType'">
 
        <h5><localize key="general_rights"></localize></h5>
 

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -371,6 +371,9 @@
     <key alias="currentListViewDesc" version="7.2">The active list view data type</key>
     <key alias="createListView" version="7.2">Create custom list view</key>
     <key alias="removeListView" version="7.2">Remove custom list view</key>
+    <key alias="searchOptions">Search options</key>
+    <key alias="fieldIsSearchable">Field is searchable when content presented in a list view</key>
+    <key alias="fieldIsSearchableInfo">Take care when enabling this option. To ensure optimal list view performance it is best to enable only for content presented in a list view, and then just for fields with small amounts of text that are sensible for the editor to search on.</key>
   </area>
   <area alias="editdatatype">
     <key alias="addPrevalue">Add prevalue</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -370,6 +370,9 @@
     <key alias="currentListViewDesc" version="7.2">The active list view data type</key>
     <key alias="createListView" version="7.2">Create custom list view</key>
     <key alias="removeListView" version="7.2">Remove custom list view</key>
+    <key alias="searchOptions">Search options</key>
+    <key alias="fieldIsSearchable">Field is searchable when content presented in a list view</key>
+    <key alias="fieldIsSearchableInfo">Take care when enabling this option. To ensure optimal list view performance it is best to enable only for content presented in a list view, and then just for fields with small amounts of text that are sensible for the editor to search on.</key> 
   </area>
   <area alias="editdatatype">
     <key alias="addPrevalue">Add prevalue</key>

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -223,8 +223,9 @@ namespace Umbraco.Web.Editors
             if (pageNumber > 0 && pageSize > 0)
             {
                 children = Services.ContentService
-                 .GetPagedChildren(id, (pageNumber - 1), pageSize, out totalChildren
-                 , orderBy, orderDirection, orderBySystemField, filter).ToArray();
+                    .GetPagedChildren(id, (pageNumber - 1), pageSize, out totalChildren, 
+                        orderBy, orderDirection, orderBySystemField, filter)
+                    .ToArray();
             }
             else
             {

--- a/src/Umbraco.Web/Models/ContentEditing/PropertyTypeBasic.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/PropertyTypeBasic.cs
@@ -32,6 +32,9 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "validation")]
         public PropertyTypeValidation Validation { get; set; }
 
+        [DataMember(Name = "searchable")]
+        public bool Searchable { get; set; }
+
         [DataMember(Name = "label")]
         [Required]
         public string Label { get; set; }

--- a/src/Umbraco.Web/Models/Mapping/ContentTypeModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeModelMapper.cs
@@ -40,6 +40,7 @@ namespace Umbraco.Web.Models.Mapping
                 .ConstructUsing(basic => new PropertyType(applicationContext.Services.DataTypeService.GetDataTypeDefinitionById(basic.DataTypeId)))
                 .ForMember(type => type.ValidationRegExp, expression => expression.ResolveUsing(basic => basic.Validation.Pattern))
                 .ForMember(type => type.Mandatory, expression => expression.ResolveUsing(basic => basic.Validation.Mandatory))
+                .ForMember(type => type.Searchable, expression => expression.ResolveUsing(basic => basic.Searchable))
                 .ForMember(type => type.Name, expression => expression.ResolveUsing(basic => basic.Label))
                 .ForMember(type => type.DataTypeDefinitionId, expression => expression.ResolveUsing(basic => basic.DataTypeId))
                 .ForMember(type => type.DataTypeId, expression => expression.Ignore())
@@ -195,6 +196,7 @@ namespace Umbraco.Web.Models.Mapping
                 .ForMember(type => type.DataTypeId, expression => expression.Ignore())
                 .ForMember(type => type.Mandatory, expression => expression.MapFrom(display => display.Validation.Mandatory))
                 .ForMember(type => type.ValidationRegExp, expression => expression.MapFrom(display => display.Validation.Pattern))
+                .ForMember(type => type.Searchable, expression => expression.MapFrom(display => display.Searchable))
                 .ForMember(type => type.DataTypeDefinitionId, expression => expression.MapFrom(display => display.DataTypeId))
                 .ForMember(type => type.Name, expression => expression.MapFrom(display => display.Label));
 

--- a/src/Umbraco.Web/Models/Mapping/PropertyTypeGroupResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/PropertyTypeGroupResolver.cs
@@ -210,6 +210,7 @@ namespace Umbraco.Web.Models.Mapping
                     Description = p.Description,
                     Editor = p.PropertyEditorAlias,
                     Validation = new PropertyTypeValidation {Mandatory = p.Mandatory, Pattern = p.ValidationRegExp},
+                    Searchable = p.Searchable,
                     Label = p.Name,
                     View = propertyEditor.ValueEditor.View,
                     Config = propertyEditor.PreValueEditor.ConvertDbToEditor(propertyEditor.DefaultPreValues, preValues),


### PR DESCRIPTION
This PR implements [the suggestion made on the issue tracker](http://issues.umbraco.org/issue/U4-4895#comment=67-39798) for supporting the ability to search across selected properties on the list view (as well as the node name, which is the only current field used).

It works by:
 - Adding a checkbox to the editing of a property on a document type, indicating if it should be included in the search or not.  This gives the developer control of this, so only appropriate columns (i.e. containing text, but perhaps not very large fields) are chosen
 - On save of content serialises the text content of the selected properties into a new database table and field
 - On filter in the list view searches within this field

Just to be clear I've not done performance tests on this, but I suspect it'll be one of those that if used sensibly will be useful, but it's possible if the list view is particularly large and/or multiple large text columns are included, you could see some performance issues.