### PR TITLE
Allow for SMTP username and password to be optionally defined as AppSettings

### DIFF
--- a/src/Umbraco.Core/Security/EmailService.cs
+++ b/src/Umbraco.Core/Security/EmailService.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Core.Security
     {
         public async Task SendAsync(IdentityMessage message)
         {
-            using (var client = new SmtpClient())
+            using (var client = new SmtpClientExtended())
             using (var mailMessage = new MailMessage())
             {
                 mailMessage.Body = message.Body;

--- a/src/Umbraco.Core/Services/NotificationService.cs
+++ b/src/Umbraco.Core/Services/NotificationService.cs
@@ -609,7 +609,7 @@ namespace Umbraco.Core.Services
         {
             ThreadPool.QueueUserWorkItem(state =>
             {
-                var s = new SmtpClient();
+                var s = new SmtpClientExtended();
                 try
                 {
                     _logger.Debug<NotificationService>("Begin processing notifications.");
@@ -627,7 +627,7 @@ namespace Umbraco.Core.Services
                             {
                                 _logger.Error<NotificationService>("An error occurred sending notification", ex);
                                 s.Dispose();
-                                s = new SmtpClient();
+                                s = new SmtpClientExtended();
                             }
                             finally
                             {
@@ -651,7 +651,7 @@ namespace Umbraco.Core.Services
         }
 
         // for tests
-        internal static Action<SmtpClient, MailMessage, ILogger> Sendmail;
+        internal static Action<SmtpClientExtended, MailMessage, ILogger> Sendmail;
             //= (_, msg, logger) => logger.Debug<NotificationService>("Email " + msg.To.ToString());
 
         #endregion

--- a/src/Umbraco.Core/SmtpClientExtended.cs
+++ b/src/Umbraco.Core/SmtpClientExtended.cs
@@ -1,0 +1,26 @@
+﻿using System.Net;
+using System.Net.Mail;
+using System.Web.Configuration;
+
+namespace Umbraco.Core
+{
+    //
+    // Summary:
+    //     Extends SmtpClient to check for authentication settings stored in AppSettings
+    internal class SmtpClientExtended : SmtpClient
+    {
+        public SmtpClientExtended()
+        {
+            var smtpUserName = WebConfigurationManager.AppSettings["smtpUserName"];
+            var smtpPassword = WebConfigurationManager.AppSettings["smtpPassword"];
+
+            if (string.IsNullOrEmpty(smtpUserName) == false && string.IsNullOrEmpty(smtpPassword) == false)
+            {
+                this.UseDefaultCredentials = false;
+
+                var networkCredentials = new NetworkCredential(smtpUserName, smtpPassword);
+                this.Credentials = networkCredentials;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -673,6 +673,7 @@
     <Compile Include="Services\OperationStatusType.cs" />
     <Compile Include="Services\ScopeRepositoryService.cs" />
     <Compile Include="Services\TaskService.cs" />
+    <Compile Include="SmtpClientExtended.cs" />
     <Compile Include="Strings\Css\StylesheetHelper.cs" />
     <Compile Include="Models\IPartialView.cs" />
     <Compile Include="Persistence\DatabaseSchemaHelper.cs" />

--- a/src/Umbraco.Web/umbraco.presentation/library.cs
+++ b/src/Umbraco.Web/umbraco.presentation/library.cs
@@ -1612,7 +1612,7 @@ namespace umbraco
                     mail.Subject = subject;
                     mail.IsBodyHtml = isHtml;
                     mail.Body = body;
-                    using (var smtpClient = new SmtpClient())
+                    using (var smtpClient = new SmtpClientExtended())
                         smtpClient.Send(mail);
                 }
             }

--- a/src/umbraco.cms/businesslogic/translation/Translation.cs
+++ b/src/umbraco.cms/businesslogic/translation/Translation.cs
@@ -66,7 +66,7 @@ namespace umbraco.cms.businesslogic.translation
                             mail.Subject = ui.Text("translation", "mailSubject", subjectVars, translator); ;
                             mail.IsBodyHtml = false;
                             mail.Body = ui.Text("translation", "mailBody", bodyVars, translator); ;
-                            using (var smtpClient = new SmtpClient())
+                            using (var smtpClient = new SmtpClientExtended())
                                 smtpClient.Send(mail);
                         }
                     }


### PR DESCRIPTION
This PR is to allow the environment to handle the app settings such as you have with Azure Web App, Application settings.

The SMTP password is now the only remaining credential that has to be stored physically in web.config on Azure Web App using Application Settings.

I'm not sure about what the AppSetting names should be, I've gone with smtpUserName and smtpPassword but could be smtp:UserName, umbracoSmtpUserName etc....