### PR TITLE
U4-10088 - Add option for List View to change the tab name

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesResolver.cs
@@ -172,6 +172,11 @@ namespace Umbraco.Web.Models.Mapping
             //add the entity type to the config
             listViewConfig["entityType"] = entityType;
 
+            //Override Tab Label if tabName is provided
+            if (listViewConfig.ContainsKey("tabName") && !String.IsNullOrWhiteSpace(listViewConfig["tabName"].ToString())) {
+                listViewTab.Label = listViewConfig["tabName"].ToString();
+            }
+
             var listViewProperties = new List<ContentPropertyDisplay>();
             listViewProperties.Add(new ContentPropertyDisplay
             {

--- a/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
@@ -51,6 +51,9 @@ namespace Umbraco.Web.PropertyEditors
 
         internal class ListViewPreValueEditor : PreValueEditor
         {
+            [PreValueField("tabName", "Tab Name", "textstring", Description = "The name of the tab that the list of child items will be displayed")]
+            public int TabName { get; set; }
+
             [PreValueField("displayAtTabNumber", "Display At Tab Number", "number", Description = "Which tab position that the list of child items will be displayed")]
             public int DisplayAtTabNumber { get; set; }
 


### PR DESCRIPTION
This adds a new option in the List View configuration that allows you to override the "Child Items" name for the tab that is used by the List View.

**Settings Preview**
![List View Settings](https://user-images.githubusercontent.com/6951262/27930800-eec46c5c-6265-11e7-90d5-29677f857d7a.png)


**Display Preview**
![List View Display](https://user-images.githubusercontent.com/6951262/27930832-0806816e-6266-11e7-933a-aa452881941d.png)
