### PR TITLE
U4-9945 - Fix vertical separator color and height of icon in custom section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -30,7 +30,7 @@ ul.sections li img.icon-section {
 	transition: all .3s linear;
 
     &, &:before {
-        line-height: 20px; /* set line-height to ensure all icons use same line-height */
+        line-height: 20px !important; /* set line-height to ensure all icons use same line-height */
     }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -7,7 +7,7 @@ ul.sections {
 	background: @purple;
 	height: 100%;
 	width: 80px;
-    border-right: 1px solid @purple;
+    border-right: 1px solid @purple-d1;
 }
 
 ul.sections li {
@@ -22,13 +22,16 @@ ul.sections li [class^="icon-"],
 ul.sections li [class*=" icon-"],
 ul.sections li img.icon-section {
 	font-size: 30px;
-    line-height: 20px; /* set line-height to ensure all icons use same line-height */
     display: inline-block;
 	margin: 1px 0 0 0;
 	color: @purple-l2;
 	-webkit-transition: all .3s linear;
 	-moz-transition: all .3s linear;
 	transition: all .3s linear;
+
+    &, &:before {
+        line-height: 20px; /* set line-height to ensure all icons use same line-height */
+    }
 }
 
 ul.sections:hover li [class^="icon-"], 
@@ -168,7 +171,7 @@ ul.sections-tray {
 	width: 80px;
 
     & > li:first-child > a {
-        border-top: 1px solid @purple;
+        border-top: 1px solid @purple-d1;
     }
 
     & > li {


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-9945

This fix the color of the vertical separator between the sections, when collapsed and then expanding the additional sections.

It also add line-height to `:before` in the icon in custom section, e.g. for uCommerce. This might need `!important` if the injected css is added later and since the custom font icons not always has same base line-height, e.g. when generation a custom icon from https://icomoon.io/app

![image](https://user-images.githubusercontent.com/2919859/27968394-21c3a08c-6347-11e7-98d3-3e3598f2b00f.png)
