### PR TITLE
U4-9374 Navigation panel header and editor panel header don't line up properly in Firefox

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -22,8 +22,12 @@
 .umb-editor-header {
 	background: @gray-10;
 	border-bottom: 1px solid @purple-l3;
-	flex: 0 0 99px;
 	position: relative;
+
+    @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {  
+        /* IE10+ specific styles go here */  
+        flex: 0 0 99px;
+    }
 }
 
 .umb-editor-header__actions-menu {


### PR DESCRIPTION
This fixes an issue where the navigation panel header and editor panel header don't line up properly in Firefox (1px shift) due to the use of the `flex` CSS property on the `.umb-editor-header` element. Also see issue [U4-9374](http://issues.umbraco.org/issue/U4-9374). I believe the `flex` property is only needed for IE10+, hence the suggested CSS fix.