### PR TITLE
U4-10160 - MediaPickerPropertyConverter returns an empty Udi array

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerPropertyConverter.cs
@@ -201,7 +201,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                 }
             }
 
-            return source;
+            return null;
         }
 
         private static readonly ConcurrentDictionary<int, bool> Storages = new ConcurrentDictionary<int, bool>();


### PR DESCRIPTION
When no media items is selected the MediaPickerPropertyConverter is returning an empty array of the Udi object. That will throw an error because we expect to get an IPublishedContent or List<IPublishedContent>.