### PR TITLE
U4-10161 - Update localization of email

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -263,7 +263,7 @@
     <key alias="recycleBinIsEmpty">Papirkurven er nu tom</key>
     <key alias="recycleBinWarning">Når elementer slettes fra papirkurven, slettes de for altid</key>
     <key alias="regexSearchError"><![CDATA[<a target='_blank' href='http://regexlib.com'>regexlib.com</a>'s webservice oplever i øjeblikket problemer, vi ikke har kontrol over. Beklager ulejligheden. ]]></key>
-    <key alias="regexSearchHelp">Søg efter et regulært udtryk for at tilføje validering til et formularfelt. Eksempel: 'email', 'zip-code', 'url'</key>
+    <key alias="regexSearchHelp">Søg efter et regulært udtryk for at tilføje validering til et formularfelt. Eksempel: 'e-mail', 'zip-code', 'url'</key>
     <key alias="removeMacro">Fjern makro</key>
     <key alias="requiredField">Obligatorisk</key>
     <key alias="sitereindexed">Sitet er genindekseret</key>
@@ -321,7 +321,8 @@
     <key alias="search">Søg...</key>
     <key alias="filter">Filtrer...</key>
     <key alias="enterTags">Indtast nøgleord (tryk på Enter efter hvert nøgleord)...</key>
-    <key alias="usernameHint">Dit brugernavn er typisk din e-mail adresse</key>
+    <key alias="email">Indtast din e-mail</key>
+    <key alias="usernameHint">Dit brugernavn er typisk din e-mailadresse</key>
   </area>
   <area alias="editcontenttype">
     <key alias="allowAtRoot" version="7.2">Tillad på rodniveau</key>
@@ -421,7 +422,7 @@
     <key alias="edit">Rediger</key>
     <key alias="edited">Redigeret</key>
     <key alias="elements">Elementer</key>
-    <key alias="email">Email</key>
+    <key alias="email">E-mail</key>
     <key alias="error">Fejl</key>
     <key alias="findDocument">Find</key>
     <key alias="height">Højde</key>
@@ -456,7 +457,7 @@
     <key alias="pleasewait">Et øjeblik...</key>
     <key alias="previous">Forrige</key>
     <key alias="properties">Egenskaber</key>
-    <key alias="reciept">Email der skal modtage indhold af formular</key>
+    <key alias="reciept">E-mail der skal modtage indhold af formular</key>
     <key alias="recycleBin">Papirkurv</key>
     <key alias="recycleBinEmpty">Din papirkurv er tom</key>
     <key alias="remaining">Mangler</key>
@@ -1268,7 +1269,7 @@ Mange hilsner fra Umbraco robotten
   </area>
   <area alias="validation">
     <key alias="validation">Validation</key>
-    <key alias="validateAsEmail">Valider som email</key>
+    <key alias="validateAsEmail">Valider som e-mail</key>
     <key alias="validateAsNumber">Valider som tal</key>
     <key alias="validateAsUrl">Valider som Url</key>
     <key alias="enterCustomValidation">...eller indtast din egen validering</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -263,7 +263,7 @@
     <key alias="recycleBinIsEmpty">Papirkurven er nu tom</key>
     <key alias="recycleBinWarning">Når elementer slettes fra papirkurven, slettes de for altid</key>
     <key alias="regexSearchError"><![CDATA[<a target='_blank' href='http://regexlib.com'>regexlib.com</a>'s webservice oplever i øjeblikket problemer, vi ikke har kontrol over. Beklager ulejligheden. ]]></key>
-    <key alias="regexSearchHelp">Søg efter et regulært udtryk for at tilføje validering til et formularfelt. Eksempel: 'e-mail', 'zip-code', 'url'</key>
+    <key alias="regexSearchHelp">Søg efter et regulært udtryk for at tilføje validering til et formularfelt. Eksempel: 'e-mail', 'postnr.', 'url'</key>
     <key alias="removeMacro">Fjern makro</key>
     <key alias="requiredField">Obligatorisk</key>
     <key alias="sitereindexed">Sitet er genindekseret</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -351,8 +351,8 @@
     <key alias="filter">Type to filter...</key>
     <key alias="enterTags">Type to add tags (press enter after each tag)...</key>
     <key alias="email">Enter your email</key>
+    <key alias="usernameHint">Your username is usually your email</key>
   </area>
-
   <area alias="editcontenttype">
     <key alias="allowAtRoot" version="7.2">Allow at root</key>
     <key alias="allowAtRootDesc" version="7.2">Only Content Types with this checked can be created at the root level of Content and Media trees</key>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10161

I have updated missing translation of email placeholder text. Furthermore email address is one word in Danish and I think it is much common to write `email` with a dash in Danish.
E.g. https://support.google.com/accounts/answer/40560?hl=da