### PR TITLE
U4-9261 Feature Request: add name to image cropper as multilingual

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
@@ -2,7 +2,7 @@
 //with a specified callback, this callback will receive an object with a selection on it
 angular.module('umbraco')
     .controller("Umbraco.PropertyEditors.ImageCropperController",
-    function ($rootScope, $routeParams, $scope, $log, mediaHelper, cropperHelper, $timeout, editorState, umbRequestHelper, fileManager, angularHelper) {
+	function ($rootScope, $routeParams, $scope, $log, mediaHelper, cropperHelper, $timeout, editorState, umbRequestHelper, fileManager, angularHelper, localizationService) {
 
         var config = angular.copy($scope.model.config);
         $scope.imageIsLoaded = false;
@@ -33,8 +33,27 @@ angular.module('umbraco')
             $scope.imageSrc = $scope.model.value.src;
         }
 
+        $scope.setDisplayName = function (crop) {
+          if (crop.name.startsWith("@")) {
+              localizationService.localize(crop.name.substring(1)).then(function (value) {
+                  if (value !== "") {
+                    crop.displayName = value;
+                  } else {
+                    crop.displayName = crop.name;
+                  }
+              });
+          } else {
+              crop.displayName = crop.name;
+          }
+        };
 
-        //crop a specific crop
+        if ($scope.model.value.crops) {
+            _.each($scope.model.value.crops, function(crop) {
+                  $scope.setDisplayName(crop);
+            });
+        }
+
+	      //crop a specific crop
         $scope.crop = function (crop) {
             $scope.currentCrop = crop;
             $scope.currentPoint = undefined;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
@@ -59,7 +59,7 @@
                      </umb-image-thumbnail>
 
                     <div class="crop-information">
-                        <span class="crop-name crop-text">{{value.alias}}</span>
+                        <span class="crop-name crop-text">{{value.displayName || value.alias}}</span>
                         <span class="crop-size crop-text">{{value.width}}px x {{value.height}}px</span>
                     </div>
                 </li>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -1,11 +1,26 @@
 angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesController",
-	function ($scope, $timeout) {
+	function ($scope, $timeout, localizationService) {
 
 	    if (!$scope.model.value) {
 	        $scope.model.value = [];
-	    }
-
-	    $scope.remove = function (item, evt) {
+		}
+		$scope.setDisplayName = function (crop) {
+		  if (crop.name.startsWith("@")) {
+		    localizationService.localize(crop.name.substring(1)).then(function (value) {
+		      if (value !== "") {
+		        crop.displayName = value;
+		      } else {
+		        crop.displayName = crop.name;
+		      }
+		    });
+		  } else {
+		    crop.displayName = crop.name;
+		  }
+	  };
+	    _.each($scope.model.value, function (crop) {
+	      $scope.setDisplayName(crop);
+	    });
+	  $scope.remove = function (item, evt) {
 	        evt.preventDefault();
 	        $scope.model.value = _.reject($scope.model.value, function (x) {
 	            return x.alias === item.alias;
@@ -25,10 +40,10 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	    $scope.add = function (evt) {
 	        evt.preventDefault();
 
-	        if ($scope.newItem && $scope.newItem.alias && 
-                angular.isNumber($scope.newItem.width) && angular.isNumber($scope.newItem.height) &&
-                $scope.newItem.width > 0 && $scope.newItem.height > 0) {
-
+	        if ($scope.newItem && $scope.newItem.name && $scope.newItem.alias && 
+             angular.isNumber($scope.newItem.width) && angular.isNumber($scope.newItem.height) &&
+	           $scope.newItem.width > 0 && $scope.newItem.height > 0) {
+	              $scope.setDisplayName($scope.newItem);
 	            var exists = _.find($scope.model.value, function (item) { return $scope.newItem.alias === item.alias; });
 	            if (!exists) {
 	                $scope.model.value.push($scope.newItem);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -9,7 +9,7 @@
                 <a href=""><i class="icon icon-delete red hover-show pull-right" ng-click="remove(node, $event)"></i></a>
                 <i class="icon icon-picture handle hover-hide"></i>
 
-                <a href prevent-default ng-click="edit(node, $event)">{{node.alias}}</a>
+                <a href prevent-default ng-click="edit(node, $event)">{{node.displayName || node.alias}}</a>
                 <br /><small>{{node.width}}px &times; {{node.height}}px</small>
             </li>
         </ul>
@@ -18,10 +18,16 @@
     <div class="form" ng-show="newItem">
         <h4><localize key="imagecropper_defineCrop">Define crop</localize></h4>
         <p>
-            <localize key="imagecropper_defineCropDescription">Give the crop an alias and it's default width and height</localize>.
+            <localize key="imagecropper_defineCropDescription">Give the crop a name, an alias and its default width and height</localize>.
         </p>
 
         <div class="control-group">
+            <label><localize key="general_name">Name</localize></label>
+            <input name="newItem.name" type="text"
+                   ng-model="newItem.name" val-highlight="{{hasError}}" />
+        </div>
+
+      <div class="control-group">
             <label><localize key="general_alias">Alias</localize></label>
             <input name="newItem.alias" type="text"
                    ng-model="newItem.alias" val-highlight="{{hasError}}" />

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -21,11 +21,15 @@
             <localize key="imagecropper_defineCropDescription">Give the crop a name, an alias and its default width and height</localize>.
         </p>
 
-        <div class="control-group">
-            <label><localize key="general_name">Name</localize></label>
-            <input name="newItem.name" type="text"
-                   ng-model="newItem.name" val-highlight="{{hasError}}" />
-        </div>
+      <div class="control-group">
+        <label><localize key="general_name">Name</localize></label>
+        <input name="newItem.name" type="text" 
+               ng-model="newItem.name" val-highlight="{{hasError}}"/>
+        <br />
+        <small>
+          <localize key="imagecropper_nameDescription">Use @ as prefix to utilize localization keys</localize>.
+        </small>
+      </div>
 
       <div class="control-group">
             <label><localize key="general_alias">Alias</localize></label>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -960,7 +960,7 @@ To manage your website, simply open the Umbraco back office and start adding con
   <area alias="imagecropper">
     <key alias="reset">Reset</key>
     <key alias="defineCrop">Define crop</key>
-    <key alias="defineCropDescription">Give the crop an alias and its default width and height</key>
+    <key alias="defineCropDescription">Give the crop a name, an alias and its default width and height</key>
     <key alias="saveCrop">Save crop</key>
     <key alias="addCrop">Add new crop</key>
   </area>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -963,6 +963,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="defineCropDescription">Give the crop a name, an alias and its default width and height</key>
     <key alias="saveCrop">Save crop</key>
     <key alias="addCrop">Add new crop</key>
+    <key alias="nameDescription">Use @ as prefix to utilize localization keys, if no area is given, the "general" area will be used.</key>
   </area>
   <area alias="rollback">
     <key alias="currentVersion">Current version</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -958,6 +958,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="defineCropDescription">Give the crop a name, an alias and its default width and height</key>
     <key alias="saveCrop">Save crop</key>
     <key alias="addCrop">Add new crop</key>
+    <key alias="nameDescription">Use @ as prefix to utilize localization keys, if no area is given, the "general" area will be used.</key>
   </area>
   <area alias="rollback">
     <key alias="currentVersion">Current version</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -955,7 +955,7 @@ To manage your website, simply open the Umbraco back office and start adding con
   <area alias="imagecropper">
     <key alias="reset">Reset</key>
     <key alias="defineCrop">Define crop</key>
-    <key alias="defineCropDescription">Give the crop an alias and its default width and height</key>
+    <key alias="defineCropDescription">Give the crop a name, an alias and its default width and height</key>
     <key alias="saveCrop">Save crop</key>
     <key alias="addCrop">Add new crop</key>
   </area>


### PR DESCRIPTION
- Added a Name property
- Added functionality to use the xml localization files to add localizations for the crop name, if no translation prefix (@, as it works in other parts of umbraco) is added, the name of the crop is displayed.
- Modified translations for en and en-US
- Added description text to clarify usage of the name property