### PR TITLE
U4-9265 Facilitate Translation of Dashboard Tab Captions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dashboard.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dashboard.controller.js
@@ -20,8 +20,19 @@ function DashboardController($scope, $routeParams, dashboardResource, localizati
     });
     
     dashboardResource.getDashboard($routeParams.section).then(function(tabs){
-   		$scope.dashboard.tabs = tabs;
-         $scope.page.loading = false;
+      $scope.dashboard.tabs = tabs;
+      if ($scope.dashboard.tabs) {
+        _.each($scope.dashboard.tabs, function (tab) {
+          if (tab.label.startsWith("@")) {
+            localizationService.localize(tab.label.substring(1)).then(function (value) {
+              if (value !== "") {
+                tab.label = value;
+              }
+            });
+          }
+        });
+      }
+      $scope.page.loading = false;
     });
 }
 


### PR DESCRIPTION
Added functionality to translate dashboard tab captions by prefixing them with '@' and using the standard group_key syntax.

To test (assuming clean install):
1. Change /Config/Dashboard.config for the content dashboard, change the tab caption attribute "Get Started" to use a translation key, e.g. @dashboard_getStarted
2. In /Config/Lang/en-GB.user.xml add the following XML:
```
  <area alias="dashboard">
    <key alias="getStarted">Get Shorty</key>
  </area>
```
3. Restart site and reload the content 
4. The "Get Started" Dashboard in the Content section now reads "Get Shorty".