### PR TITLE
U4-5139 Error uploading a file when filename contains comma

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
@@ -118,7 +118,7 @@ function fileUploadController($scope, $element, $compile, imageHelper, fileManag
             for (var i = 0; i < args.files.length; i++) {
                 //save the file object to the scope's files collection
                 $scope.files.push({ alias: $scope.model.alias, file: args.files[i] });
-                newVal += args.files[i].name + ",";
+                newVal += args.files[i].name.replace(',','-') + ",";
             }
 
             //this is required to re-validate


### PR DESCRIPTION
Uploading a file with a comma in it resulted in an error (because server side there was a split on the comma character). The comma later was replaced with a dash, so it's safe to replace it before sending it to the server.