### PR TITLE
U4-10225: Notification banner floats above context menu

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/application/grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/application/grid.less
@@ -70,7 +70,7 @@ body {
 
 #leftcolumn {
   height: 100%;
-  z-index: 20;
+  z-index: 1100;
   width: 80px;
   float: left;
   position: absolute;


### PR DESCRIPTION
http://issues.umbraco.org/issue/U4-10225

This bumps the z-index of #leftcolumn, so the notifications don't get in the way.