### PR TITLE
U4-10228: Overflowing text in group dropdown in permissions menu

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/rights.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/rights.html
@@ -26,7 +26,7 @@
                         Add permissions for...
                         <span class="caret" style="margin-left: 10px;"></span>
                     </a>
-                    <ul class="dropdown-menu" style="width: 100%;">
+                    <ul class="dropdown-menu">
                         <li ng-repeat="group in vm.availableUserGroups | filter:{selected: '!true'}">
                             <a href="" ng-click="vm.editPermissions(group)" prevent-default>
                                 <i class="{{group.icon}}"></i>


### PR DESCRIPTION
Removes inline width on dropdown for groups.

There is a possibility that the dropdown now can overflow the context menu, since it doesn't have a max-width. I'm unsure if the context menu has the same width at all breakpoints, so didn't want to set a max-width on the dropdown.