### PR TITLE
U4-10231 Avatar is slightly off center

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -87,9 +87,10 @@ ul.sections li.avatar a {
 	border: none
 }
 
-ul.sections li.avatar a img {
+ul.sections li.avatar a div {
 	border-radius: 50%;
 	width: 30px;
+    margin:0 auto;
 }
 
 ul.sections li.avatar a span {


### PR DESCRIPTION
A div has been introduced, and is aligning the avatar to the left of the 40x40 block.

This moves the sizing and border-radius to the surrounding div, and adds a margin to center it.