### PR TITLE
U4-10242 - Remove bottom margin of subtitle paragraph

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -28,13 +28,13 @@
     font-size: @fontSizeLarge;
     color: @black;
     font-weight: bold;
-
     margin: 7px 0;
 }
 
 .umb-overlay .umb-overlay__subtitle {
     font-size: @fontSizeSmall;
     color: @gray-3;
+    margin: 0;
 }
 
 .umb-overlay .umb-overlay-container {


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10242

Remove bottom margin of subtitle in overlay header to align with background, when there only is a singline text in subtitle.