### PR TITLE
U4-10152 - Fix typo in localization of placeholder text

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/iconpicker.html
@@ -7,7 +7,7 @@
                        style="width: 100%"
                        ng-model="searchTerm"
                        class="umb-search-field search-query input-block-level"
-                       localize="plceholder"
+                       localize="placeholder"
                        placeholder="@placeholders_filter"
                        no-dirty-check>
             </div>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10152

Just fixing a minor typo in localization of placeholder text in icon picker.
The icon picker should probably at some point be updated to match icon picker for e.g. document type, media type and member type icon picker, which has the header and drawer. I also think some other overlays is inconsistent when using the service in the controller compared to using the umb-* directives/components which was added in 7.4.
I have another issue about that over here: http://issues.umbraco.org/issue/U4-8093