### PR TITLE
U4-10252: Slider property editor initial values not used when equal (range enabled)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -127,7 +127,7 @@
                 var i2 = parseFloat($scope.model.config.initVal2);
                 sliderVal = [
                     isNaN(i1) ? $scope.model.config.minVal : (i1 >= $scope.model.config.minVal ? i1 : $scope.model.config.minVal),
-                    isNaN(i2) ? $scope.model.config.maxVal : (i2 > i1 ? (i2 <= $scope.model.config.maxVal ? i2 : $scope.model.config.maxVal) : $scope.model.config.maxVal)
+                    isNaN(i2) ? $scope.model.config.maxVal : (i2 >= i1 ? (i2 <= $scope.model.config.maxVal ? i2 : $scope.model.config.maxVal) : $scope.model.config.maxVal)
                 ];
             }
             else {


### PR DESCRIPTION
Umbraco.Slider property editor did not use the correct initial values
when range was enabled and both values were equal: http://issues.umbraco.org/issue/U4-10252.

_Keeping my first Umbraco pull request to a bare minimum code change_ 😇