### PR TITLE
U4-10260 - Umbraco.7.7 beta - NestedContent with ModelsBuilder disabled throws error

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentPublishedPropertyTypeExtensions.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentPublishedPropertyTypeExtensions.cs
@@ -108,7 +108,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                             i,
                             preview);
 
-                        if (PublishedContentModelFactoryResolver.HasCurrent)
+                        if (PublishedContentModelFactoryResolver.HasCurrent && PublishedContentModelFactoryResolver.Current.HasValue)
                         {
                             // Let the current model factory create a typed model to wrap our model
                             content = PublishedContentModelFactoryResolver.Current.Factory.CreateModel(content);


### PR DESCRIPTION
Nested Content with ModelsBuilder disabled will throw a null-reference exception.

The fix is to check if the `Current` instance has a `Value`.

For more details, see ticket: http://issues.umbraco.org/issue/U4-10260