### PR TITLE
Strongly typed grid framework

### DIFF
--- a/src/Umbraco.Core/Models/GridAttributesBase.cs
+++ b/src/Umbraco.Core/Models/GridAttributesBase.cs
@@ -1,0 +1,50 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Umbraco.Core.Models
+{
+    public abstract class GridAttributesBase : IGridAttributes
+    {
+        /// <summary>
+        /// Gets or sets the con dfig.
+        /// </summary>
+        /// <value>
+        /// The con dfig.
+        /// </value>
+        [JsonProperty("config")]
+        public JToken Config { get; set; }
+
+        /// <summary>
+        /// Gets or sets the styles.
+        /// </summary>
+        /// <value>
+        /// The styles.
+        /// </value>
+        [JsonProperty("styles")]
+        public JToken Styles { get; set; }
+
+        /// <summary>
+        /// Gets the attributes.
+        /// </summary>
+        /// <returns></returns>
+        public Dictionary<string, string> GetAttributes()
+        {
+            var attributes = new Dictionary<string, string>();
+            if (Config != null)
+            {
+                attributes = Config.ToObject<JObject>().Properties().ToDictionary(p => p.Name, p => p.Value.ToString());
+            }
+
+            if (Styles == null) return attributes;
+
+            var cssValues = Styles.ToObject<JObject>().Properties().Select(p => string.Format("{0}:{1}", p.Name, p.Value.ToString()));
+            if (Styles.ToObject<JObject>().Properties().Any())
+            {
+                attributes.Add("style", string.Join(";", cssValues));
+            }
+            return attributes;
+        }
+    }
+}

--- a/src/Umbraco.Core/Models/GridValue.cs
+++ b/src/Umbraco.Core/Models/GridValue.cs
@@ -1,7 +1,7 @@
-using System;
-using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
 
 namespace Umbraco.Core.Models
 {
@@ -19,67 +19,115 @@ namespace Umbraco.Core.Models
         public class GridSection
         {
             [JsonProperty("grid")]
-            public string Grid { get; set; }
+            public int Grid { get; set; }
+
+            [JsonProperty("allowAll")]
+            public bool AllowAll { get; set; }
 
             [JsonProperty("rows")]
             public IEnumerable<GridRow> Rows { get; set; }
         }
 
-        public class GridRow
+        public class GridRow : GridAttributesBase
         {
+            [JsonProperty("label")]
+            public string Label { get; set; }
+
             [JsonProperty("name")]
             public string Name { get; set; }
-
-            [JsonProperty("id")]
-            public Guid Id { get; set; }
 
             [JsonProperty("areas")]
             public IEnumerable<GridArea> Areas { get; set; }
 
-            [JsonProperty("styles")]
-            public JToken Styles { get; set; }
+            [JsonProperty("hasConfig")]
+            public bool HasConfig { get; set; }
 
-            [JsonProperty("config")]
-            public JToken Config { get; set; }
+            [JsonProperty("id")]
+            public Guid Id { get; set; }
+
+            [JsonProperty("active")]
+            public bool Active { get; set; }
         }
 
-        public class GridArea
+        public class GridArea : GridAttributesBase
         {
             [JsonProperty("grid")]
             public string Grid { get; set; }
 
+            [JsonProperty("allowAll")]
+            public bool AllowAll { get; set; }
+
+            [JsonProperty("allowed")]
+            public List<string> Allowed { get; set; }
+
+            [JsonProperty("hasConfig")]
+            public bool HasConfig { get; set; }
+
             [JsonProperty("controls")]
             public IEnumerable<GridControl> Controls { get; set; }
 
-            [JsonProperty("styles")]
-            public JToken Styles { get; set; }
-
-            [JsonProperty("config")]
-            public JToken Config { get; set; }
+            [JsonProperty("active")]
+            public bool Active { get; set; }
         }
 
-        public class GridControl
+        public class GridControl : GridAttributesBase
         {
             [JsonProperty("value")]
             public JToken Value { get; set; }
 
             [JsonProperty("editor")]
             public GridEditor Editor { get; set; }
-
-            [JsonProperty("styles")]
-            public JToken Styles { get; set; }
-
-            [JsonProperty("config")]
-            public JToken Config { get; set; }
         }
 
         public class GridEditor
         {
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
             [JsonProperty("alias")]
             public string Alias { get; set; }
 
             [JsonProperty("view")]
             public string View { get; set; }
+
+            [JsonProperty("render")]
+            public string Render { get; set; }
+
+            [JsonProperty("icon")]
+            public string Icon { get; set; }
+
+            [JsonProperty("config")]
+            public GridConfig Config { get; set; }
+        }
+
+        public class GridConfig
+        {
+            [JsonProperty("style")]
+            public string Style { get; set; }
+
+            [JsonProperty("markup")]
+            public string Markup { get; set; }
+
+            [JsonProperty("allowedDocTypes")]
+            public List<string> AllowedDocTypes { get; set; }
+
+            [JsonProperty("nameTemplate")]
+            public string NameTemplate { get; set; }
+
+            [JsonProperty("enablePreview")]
+            public bool? EnablePreview { get; set; }
+
+            [JsonProperty("viewPath")]
+            public string ViewPath { get; set; }
+
+            [JsonProperty("previewViewPath")]
+            public string PreviewViewPath { get; set; }
+
+            [JsonProperty("previewCssFilePath")]
+            public string PreviewCssFilePath { get; set; }
+
+            [JsonProperty("previewJsFilePath")]
+            public string PreviewJsFilePath { get; set; }
         }
     }
 }

--- a/src/Umbraco.Core/Models/IGridAttributes.cs
+++ b/src/Umbraco.Core/Models/IGridAttributes.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace Umbraco.Core.Models
+{
+    public interface IGridAttributes
+    {
+        /// <summary>
+        /// Gets or sets the configuration.
+        /// </summary>
+        /// <value>
+        /// The configuration.
+        /// </value>
+        [JsonProperty("config")]
+        JToken Config { get; set; }
+
+        /// <summary>
+        /// Gets or sets the styles.
+        /// </summary>
+        /// <value>
+        /// The styles.
+        /// </value>
+        [JsonProperty("styles")]
+        JToken Styles { get; set; }
+
+        /// <summary>
+        /// Gets the attributes.
+        /// </summary>
+        /// <returns></returns>
+        Dictionary<string, string> GetAttributes();
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -344,6 +344,8 @@
     <Compile Include="HashCodeHelper.cs" />
     <Compile Include="IHttpContextAccessor.cs" />
     <Compile Include="Models\EntityBase\IDeletableEntity.cs" />
+    <Compile Include="Models\GridAttributesBase.cs" />
+    <Compile Include="Models\IGridAttributes.cs" />
     <Compile Include="Models\IUserControl.cs" />
     <Compile Include="Models\PublishedContent\PublishedContentTypeConverter.cs" />
     <Compile Include="Models\UserControl.cs" />

--- a/src/Umbraco.Web/GridFrameworks/Bootstrap2FluidGrid.cs
+++ b/src/Umbraco.Web/GridFrameworks/Bootstrap2FluidGrid.cs
@@ -1,0 +1,29 @@
+﻿namespace Umbraco.Web.GridFrameworks
+{
+    public class Bootstrap2FluidGrid : UmbracoGridFramework
+    {
+        /// <summary>
+        /// Gets the container CSS class.
+        /// </summary>
+        /// <value>
+        /// The container CSS class.
+        /// </value>
+        public override string ContainerCssClass { get { return "container-fluid"; } }
+
+        /// <summary>
+        /// Gets the row CSS class.
+        /// </summary>
+        /// <value>
+        /// The row CSS class.
+        /// </value>
+        public override string RowCssClass { get { return "row-fluid"; } }
+
+        /// <summary>
+        /// Gets the column CSS class pre text.
+        /// </summary>
+        /// <value>
+        /// The column CSS class pre text.
+        /// </value>
+        public override string ColumnCssClassPreText { get { return "span"; } }
+    }
+}

--- a/src/Umbraco.Web/GridFrameworks/Bootstrap2Grid.cs
+++ b/src/Umbraco.Web/GridFrameworks/Bootstrap2Grid.cs
@@ -1,0 +1,13 @@
+﻿namespace Umbraco.Web.GridFrameworks
+{
+    public class Bootstrap2Grid : UmbracoGridFramework
+    {
+        /// <summary>
+        /// Gets the column CSS class pre text.
+        /// </summary>
+        /// <value>
+        /// The column CSS class pre text.
+        /// </value>
+        public override string ColumnCssClassPreText { get { return "span"; } }
+    }
+}

--- a/src/Umbraco.Web/GridFrameworks/Bootstrap3FluidGrid.cs
+++ b/src/Umbraco.Web/GridFrameworks/Bootstrap3FluidGrid.cs
@@ -1,0 +1,29 @@
+﻿namespace Umbraco.Web.GridFrameworks
+{
+    public class Bootstrap3FluidGrid : UmbracoGridFramework
+    {
+        /// <summary>
+        /// Gets the container CSS class.
+        /// </summary>
+        /// <value>
+        /// The container CSS class.
+        /// </value>
+        public override string ContainerCssClass { get { return "container-fluid"; } }
+
+        /// <summary>
+        /// Gets the row CSS class.
+        /// </summary>
+        /// <value>
+        /// The row CSS class.
+        /// </value>
+        public override string RowCssClass { get { return "row-fluid"; } }
+
+        /// <summary>
+        /// Gets the column CSS class pre text.
+        /// </summary>
+        /// <value>
+        /// The column CSS class pre text.
+        /// </value>
+        public override string ColumnCssClassPreText { get { return "col-md-"; } }
+    }
+}

--- a/src/Umbraco.Web/GridFrameworks/Bootstrap3Grid.cs
+++ b/src/Umbraco.Web/GridFrameworks/Bootstrap3Grid.cs
@@ -1,0 +1,13 @@
+﻿namespace Umbraco.Web.GridFrameworks
+{
+    public class Bootstrap3Grid : UmbracoGridFramework
+    {
+        /// <summary>
+        /// Gets the column CSS class pre text.
+        /// </summary>
+        /// <value>
+        /// The column CSS class pre text.
+        /// </value>
+        public override string ColumnCssClassPreText { get { return "col-md-"; } }
+    }
+}

--- a/src/Umbraco.Web/GridFrameworks/GridHelper.cs
+++ b/src/Umbraco.Web/GridFrameworks/GridHelper.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using Umbraco.Core.Models;
+using Umbraco.Web.Mvc;
+
+namespace Umbraco.Web.GridFrameworks
+{
+    internal static class GridHelper
+    {
+        /// <summary>
+        /// Gets the div wrapper.
+        /// </summary>
+        /// <param name="cssClassName">Name of the CSS class.</param>
+        /// <returns></returns>
+        internal static HtmlTagWrapper GetDivWrapper(string cssClassName)
+        {
+            var div = new HtmlTagWrapper("div");
+            div.AddClassName(cssClassName);
+            return div;
+        }
+
+        /// <summary>
+        /// Gets the div wrapper.
+        /// </summary>
+        /// <param name="element">The attributes.</param>
+        /// <returns></returns>
+        internal static HtmlTagWrapper GetDivWrapper(IGridAttributes element)
+        {
+            var tagWrapper = new HtmlTagWrapper("div");
+            var attr = element.GetAttributes();
+            if (attr.Any())
+            {
+                tagWrapper.ReflectAttributesFromAnonymousType(element);
+            }
+            return tagWrapper;
+        }
+    }
+}

--- a/src/Umbraco.Web/GridFrameworks/UmbracoGridFramework.cs
+++ b/src/Umbraco.Web/GridFrameworks/UmbracoGridFramework.cs
@@ -1,0 +1,200 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+using System.Web.Mvc.Html;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+
+namespace Umbraco.Web.GridFrameworks
+{
+    public abstract class UmbracoGridFramework : IGridFramework
+    {
+        /// <summary>
+        /// Gets the grid value.
+        /// </summary>
+        /// <value>
+        /// The grid value.
+        /// </value>
+        public GridValue GridValue { get; set; }
+
+        /// <summary>
+        /// Gets the grid CSS class.
+        /// </summary>
+        /// <value>
+        /// The grid CSS class.
+        /// </value>
+        public virtual string GridCssClass { get { return "umb-grid"; } }
+
+        /// <summary>
+        /// Gets the container CSS class.
+        /// </summary>
+        /// <value>
+        /// The container CSS class.
+        /// </value>
+        public virtual string ContainerCssClass { get { return "container"; } }
+
+        /// <summary>
+        /// Gets the section CSS class.
+        /// </summary>
+        /// <value>
+        /// The section CSS class.
+        /// </value>
+        public virtual string SectionCssClass { get { return "grid-section"; } }
+
+        /// <summary>
+        /// Gets the row CSS class.
+        /// </summary>
+        /// <value>
+        /// The row CSS class.
+        /// </value>
+        public virtual string RowCssClass { get { return "row"; } }
+
+        /// <summary>
+        /// Gets the column CSS class.
+        /// </summary>
+        /// <value>
+        /// The column CSS class.
+        /// </value>
+        public virtual string ColumnCssClass { get { return "column"; } }
+
+        /// <summary>
+        /// Gets the column CSS class pre text.
+        /// </summary>
+        /// <value>
+        /// The column CSS class pre text.
+        /// </value>
+        public abstract string ColumnCssClassPreText { get; }
+
+        /// <summary>
+        /// Gets the partial views path.
+        /// </summary>
+        /// <value>
+        /// The partial views path.
+        /// </value>
+        public virtual string PartialViewsPath { get { return "grid/editors/"; } }
+
+        /// <summary>
+        /// Gets the section HTML.
+        /// </summary>
+        /// <param name="html">The HTML.</param>
+        /// <param name="sectionIndex">Index of the section.</param>
+        /// <returns></returns>
+        public IHtmlString GetSectionHtml(HtmlHelper html, int sectionIndex)
+        {
+            Mandate.That<ArgumentNullException>(HasGridValue);
+            var section = GridValue.Sections.ToList()[sectionIndex];
+            var singleSection = section.Grid < 12;
+            var columnDiv = GridHelper.GetDivWrapper(singleSection ? SectionCssClass : ColumnCssClassPreText + section.Grid);
+            if (singleSection == false)
+            {
+                columnDiv.AddClassName(ColumnCssClass);
+            }
+            foreach (var rowHtml in section.Rows.Select(gridRow => GetRowHtml(html, gridRow, singleSection)))
+            {
+                columnDiv.AddChild(rowHtml.ToHtmlString());
+            }
+            return columnDiv.ToHtml();
+        }
+
+        /// <summary>
+        /// Gets the sections HTML.
+        /// </summary>
+        /// <param name="html">The HTML.</param>
+        /// <returns></returns>
+        public IHtmlString GetSectionsHtml(HtmlHelper html)
+        {
+            Mandate.That<ArgumentNullException>(HasGridValue);
+            var sectionsDiv = GridHelper.GetDivWrapper(RowCssClass);
+            sectionsDiv.AddClassName("clearfix");
+
+            foreach (var columHtml in GridValue.Sections.Select(section => GetSectionHtml(html, GridValue.Sections.IndexOf(section))))
+            {
+                var sectionDiv = GridHelper.GetDivWrapper(SectionCssClass);
+                sectionDiv.AddChild(columHtml.ToHtmlString());
+                sectionsDiv.AddChild(sectionDiv);
+            }
+
+            var containerDiv = GridHelper.GetDivWrapper(ContainerCssClass);
+            return containerDiv.AddChild(sectionsDiv).ToHtml();
+        }
+
+        /// <summary>
+        /// Gets the row HTML.
+        /// </summary>
+        /// <param name="html">The HTML.</param>
+        /// <param name="row">The grid row.</param>
+        /// <param name="wrapInContainer">if set to <c>true</c> [single column].</param>
+        /// <returns></returns>
+        public IHtmlString GetRowHtml(HtmlHelper html, GridValue.GridRow row, bool wrapInContainer)
+        {
+            Mandate.That<ArgumentNullException>(row != null);
+            var rowDiv = GridHelper.GetDivWrapper(RowCssClass);
+            rowDiv.AddClassName("clearfix");
+
+            foreach (var area in row.Areas)
+            {
+                rowDiv.AddChild(GetAreaHtml(html, area).ToHtmlString());
+            }
+
+            var rowDivWrapper = GridHelper.GetDivWrapper(row);
+            rowDivWrapper.AddChild(
+                wrapInContainer
+                    ? GridHelper.GetDivWrapper(ContainerCssClass).AddChild(rowDiv)
+                    : rowDiv
+            );
+            return rowDivWrapper.ToHtml();
+        }
+
+        /// <summary>
+        /// Gets the area HTML.
+        /// </summary>
+        /// <param name="html">The HTML.</param>
+        /// <param name="area">The area.</param>
+        /// <returns></returns>
+        public IHtmlString GetAreaHtml(HtmlHelper html, GridValue.GridArea area)
+        {
+            Mandate.That<ArgumentNullException>(area != null);
+            var areaDivWrapper = GridHelper.GetDivWrapper(area);
+
+            // Render all the controls to HtmlStrings
+            foreach (var control in area.Controls.Where(c => c != null && c.Editor != null && c.Editor.View != null))
+            {
+                areaDivWrapper.AddChild(GetControlHtml(html, control).ToHtmlString());
+            }
+
+            var areaColumnDiv = GridHelper.GetDivWrapper(ColumnCssClassPreText + area.Grid);
+            areaColumnDiv.AddClassName(ColumnCssClass);
+            areaColumnDiv.AddChild(areaDivWrapper);
+            return areaColumnDiv.ToHtml();
+        }
+
+        /// <summary>
+        /// Gets the control HTML.
+        /// </summary>
+        /// <param name="html">The HTML.</param>
+        /// <param name="control">The control.</param>
+        /// <returns></returns>
+        public virtual IHtmlString GetControlHtml(HtmlHelper html, GridValue.GridControl control)
+        {
+            var view = (control.Editor.Render ?? control.Editor.View).Replace(".html", ".cshtml");
+            if (view.Contains("/") == false)
+            {
+                view = PartialViewsPath + view;
+            }
+            return html.Partial(view, JToken.FromObject(control));
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance has grid value.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance has grid value; otherwise, <c>false</c>.
+        /// </value>
+        public bool HasGridValue
+        {
+            get { return GridValue != null; }
+        }
+    }
+}

--- a/src/Umbraco.Web/IGridFramework.cs
+++ b/src/Umbraco.Web/IGridFramework.cs
@@ -1,0 +1,121 @@
+﻿using System.Web;
+using System.Web.Mvc;
+using Umbraco.Core.Models;
+
+namespace Umbraco.Web
+{
+    public interface IGridFramework
+    {
+        /// <summary>
+        /// Gets the grid value.
+        /// </summary>
+        /// <value>
+        /// The grid value.
+        /// </value>
+        GridValue GridValue { get; set; }
+
+        /// <summary>
+        /// Gets the grid CSS class.
+        /// </summary>
+        /// <value>
+        /// The grid CSS class.
+        /// </value>
+        string GridCssClass { get; }
+
+        /// <summary>
+        /// Gets the container CSS class.
+        /// </summary>
+        /// <value>
+        /// The container CSS class.
+        /// </value>
+        string ContainerCssClass { get; }
+
+        /// <summary>
+        /// Gets the section CSS class.
+        /// </summary>
+        /// <value>
+        /// The section CSS class.
+        /// </value>
+        string SectionCssClass { get; }
+
+        /// <summary>
+        /// Gets the row CSS class.
+        /// </summary>
+        /// <value>
+        /// The row CSS class.
+        /// </value>
+        string RowCssClass { get; }
+
+        /// <summary>
+        /// Gets the column CSS class.
+        /// </summary>
+        /// <value>
+        /// The column CSS class.
+        /// </value>
+        string ColumnCssClass { get; }
+
+        /// <summary>
+        /// Gets the column CSS class pre text.
+        /// </summary>
+        /// <value>
+        /// The column CSS class pre text.
+        /// </value>
+        string ColumnCssClassPreText { get; }
+
+        /// <summary>
+        /// Gets the partial views path.
+        /// </summary>
+        /// <value>
+        /// The partial views path.
+        /// </value>
+        string PartialViewsPath { get; }
+
+        /// <summary>
+        /// Gets the section HTML.
+        /// </summary>
+        /// <param name="html">The HTML.</param>
+        /// <param name="sectionIndex">Index of the section.</param>
+        /// <returns></returns>
+        IHtmlString GetSectionHtml(HtmlHelper html, int sectionIndex);
+
+        /// <summary>
+        /// Gets the sections HTML.
+        /// </summary>
+        /// <param name="html">The HTML.</param>
+        /// <returns></returns>
+        IHtmlString GetSectionsHtml(HtmlHelper html);
+
+        /// <summary>
+        /// Gets the row HTML.
+        /// </summary>
+        /// <param name="html">The HTML.</param>
+        /// <param name="row">The grid row.</param>
+        /// <param name="wrapInContainer">if set to <c>true</c> [wrap in container].</param>
+        /// <returns></returns>
+        IHtmlString GetRowHtml(HtmlHelper html, GridValue.GridRow row, bool wrapInContainer);
+
+        /// <summary>
+        /// Gets the area HTML.
+        /// </summary>
+        /// <param name="html">The HTML.</param>
+        /// <param name="area">The area.</param>
+        /// <returns></returns>
+        IHtmlString GetAreaHtml(HtmlHelper html, GridValue.GridArea area);
+
+        /// <summary>
+        /// Gets the control HTML.
+        /// </summary>
+        /// <param name="html">The HTML.</param>
+        /// <param name="control">The control.</param>
+        /// <returns></returns>
+        IHtmlString GetControlHtml(HtmlHelper html, GridValue.GridControl control);
+
+        /// <summary>
+        /// Gets a value indicating whether this instance has grid value.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance has grid value; otherwise, <c>false</c>.
+        /// </value>
+        bool HasGridValue { get; }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -314,6 +314,12 @@
     <Compile Include="Editors\ParameterSwapControllerActionSelector.cs" />
     <Compile Include="Editors\CodeFileController.cs" />
     <Compile Include="Extensions\UdiExtensions.cs" />
+    <Compile Include="GridFrameworks\Bootstrap2FluidGrid.cs" />
+    <Compile Include="GridFrameworks\Bootstrap2Grid.cs" />
+    <Compile Include="GridFrameworks\Bootstrap3FluidGrid.cs" />
+    <Compile Include="GridFrameworks\Bootstrap3Grid.cs" />
+    <Compile Include="GridFrameworks\GridHelper.cs" />
+    <Compile Include="GridFrameworks\UmbracoGridFramework.cs" />
     <Compile Include="HealthCheck\Checks\Config\AbstractConfigCheck.cs" />
     <Compile Include="HealthCheck\Checks\Config\AcceptableConfiguration.cs" />
     <Compile Include="HealthCheck\Checks\Config\ConfigurationService.cs" />
@@ -341,6 +347,7 @@
     <Compile Include="HealthCheck\IHealthCheckResolver.cs" />
     <Compile Include="HealthCheck\StatusResultType.cs" />
     <Compile Include="HealthCheck\Checks\DataIntegrity\XmlDataIntegrityHealthCheck.cs" />
+    <Compile Include="IGridFramework.cs" />
     <Compile Include="IHttpContextAccessor.cs" />
     <Compile Include="Models\ContentEditing\ContentRedirectUrl.cs" />
     <Compile Include="Models\ContentEditing\GetAvailableCompositionsFilter.cs" />


### PR DESCRIPTION
Removed the need for separate grid partials and moves them into strongly typed classes.
Expands the GridValue classes.

Grid editor partials can now use a strongly typed GridControl model instead of dynamic
