### PR TITLE
Fix U4-10272 Health Check Notification Methods (such as core email) that don't have configuration cause all notifications to fail

### DIFF
--- a/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Web.HealthCheck.NotificationMethods
         public EmailNotificationMethod(bool enabled, bool failureOnly, HealthCheckNotificationVerbosity verbosity,
                 string recipientEmail)
             : this(enabled, failureOnly, verbosity, recipientEmail, ApplicationContext.Current.Services.TextService)
-        {            
+        {
         }
 
         /// <summary>
@@ -39,13 +39,13 @@ namespace Umbraco.Web.HealthCheck.NotificationMethods
             : base(enabled, failureOnly, verbosity)
         {
             if (textService == null) throw new ArgumentNullException("textService");
-            if (string.IsNullOrWhiteSpace(recipientEmail)) throw new ArgumentException("Value cannot be null or whitespace.", "recipientEmail");
+            if (enabled && string.IsNullOrWhiteSpace(recipientEmail)) throw new ArgumentException("Value cannot be null or whitespace.", "recipientEmail");
             _textService = textService;
             RecipientEmail = recipientEmail;
             Verbosity = verbosity;
         }
 
-        public string RecipientEmail { get; private set; }        
+        public string RecipientEmail { get; private set; }
 
         public async Task SendAsync(HealthCheckResults results)
         {

--- a/src/Umbraco.Web/HealthCheck/NotificationMethods/IHealthCheckNotificatationMethod.cs
+++ b/src/Umbraco.Web/HealthCheck/NotificationMethods/IHealthCheckNotificatationMethod.cs
@@ -4,6 +4,7 @@ namespace Umbraco.Web.HealthCheck.NotificationMethods
 {
     public interface IHealthCheckNotificatationMethod
     {
+        bool Enabled { get; }
         Task SendAsync(HealthCheckResults results);
     }
 }

--- a/src/Umbraco.Web/Scheduling/HealthCheckNotifier.cs
+++ b/src/Umbraco.Web/Scheduling/HealthCheckNotifier.cs
@@ -64,8 +64,8 @@ namespace Umbraco.Web.Scheduling
                 var results = new HealthCheckResults(checks);
                 results.LogResults();
 
-                // Send using registered notification methods
-                var registeredNotificationMethods = HealthCheckNotificationMethodResolver.Current.NotificationMethods;
+                // Send using registered notification methods that are enabled
+                var registeredNotificationMethods = HealthCheckNotificationMethodResolver.Current.NotificationMethods.Where(x => x.Enabled);
                 foreach (var notificationMethod in registeredNotificationMethods)
                 {
                     await notificationMethod.SendAsync(results);


### PR DESCRIPTION
Fix so that health check notifications without config don't cause all notification methods to fail