### PR TITLE
Updated ReplaceLineBreaksForHtml to include \r

### DIFF
--- a/src/Umbraco.Web/HtmlStringUtilities.cs
+++ b/src/Umbraco.Web/HtmlStringUtilities.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Web;
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 
 namespace Umbraco.Web
@@ -23,7 +24,7 @@ namespace Umbraco.Web
         /// <returns>The text with text line breaks replaced with html linebreaks (<br/>)</returns>
         public string ReplaceLineBreaksForHtml(string text)
         {
-            return text.Replace("\n", "<br/>\n");
+            return Regex.Replace(text, @"(\r\n?|\n)", "<br />$0");
         }
 
         public HtmlString StripHtmlTags(string html, params string[] tags)


### PR DESCRIPTION
I was surprised when this method did not replace a `\r` character with an HTML break. I have updated it to not only replace `\n`, but also `\r\n` and just `\r`.

I think these cases should be considered because of [this SO thread](https://stackoverflow.com/questions/4824621/is-a-new-line-n-or-r-n).

The updated code will not replace `\n\r` with one break but with two.

I used [this SO answer](https://stackoverflow.com/a/8196219/2963111) to update the method.

```
[TestMethod]
public void ReplaceLineBreaksForHtmlTest()
{
    var result = Umbraco.ReplaceLineBreaksForHtml("foo\rbar\nbaz\r\nbiff\n\r");

    Assert.AreEqual(result, "foo<br />\rbar<br />\nbaz<br />\r\nbiff<br />\n<br />\r");
}
```