### PR TITLE
Added missing caption validation on edit

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.controller.js
@@ -76,9 +76,19 @@
                 $scope.model.value[idx].edit = true;
             };
 
+            $scope.canSaveEdit = function (idx) {
+                return $scope.model.value[idx].caption.trim() != "";
+            }
+
             $scope.saveEdit = function (idx) {
-                $scope.model.value[idx].title = $scope.model.value[idx].caption;
-                $scope.model.value[idx].edit = false;
+                if ($scope.model.value[idx].caption.trim() == "") {
+                    $scope.hasError = true;
+                    $event.preventDefault();
+                }
+                else {
+                    $scope.model.value[idx].title = $scope.model.value[idx].caption;
+                    $scope.model.value[idx].edit = false;
+                }
             };
 
             $scope.delete = function (idx) {               

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.html
@@ -50,7 +50,7 @@
                         <button type="button" class="btn btn-default" ng-click="delete($index)"><localize key="delete">Delete</localize></button>
                     </div>
                     <div class="btn-group" ng-show="link.edit" style="margin-left: 0;">
-                        <button type="button" class="btn btn-default" ng-click="saveEdit($index)"><localize key="buttons_save">Save</localize></button>
+                        <button type="button" class="btn btn-default" ng-disabled="!canSaveEdit($index)" ng-click="saveEdit($index)"><localize key="buttons_save">Save</localize></button>
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
Related link property editor caption is only required when adding.
It can be removed when editing.
It should have the same behavior.