### PR TITLE
U4-10281 - Fix maxchars javascript errors on macro parameter editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.controller.js
@@ -1,4 +1,15 @@
-function textAreaController($rootScope, $scope, $log) {
+function textAreaController($scope) {
+
+    // macro parameter editor doesn't contains a config object,
+    // so we create a new one to hold any properties 
+    if (!$scope.model.config) {
+        $scope.model.config = {};
+    }
+
+    if (!$scope.model.config.maxChars) {
+        $scope.model.config.maxChars = false;
+    }
+
     $scope.model.maxlength = false;
     if($scope.model.config.maxChars) {
         $scope.model.maxlength = true;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.controller.js
@@ -1,4 +1,15 @@
-function textboxController($rootScope, $scope, $log) {
+function textboxController($scope) {
+
+    // macro parameter editor doesn't contains a config object,
+    // so we create a new one to hold any properties 
+    if (!$scope.model.config) {
+        $scope.model.config = {};
+    }
+
+    if (!$scope.model.config.maxChars) {
+        $scope.model.config.maxChars = false;
+    }
+
     $scope.model.maxlength = false;
     if($scope.model.config.maxChars) {
         $scope.model.maxlength = true;


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10281

When using textstring or textarea as parameters on a macro and then inserting a macro from the template editor "insert -> macro" action, it returns javascript errors.

![image](https://user-images.githubusercontent.com/2919859/29284692-07a33f84-812c-11e7-978f-a70cce11570f.png)

It is because config object doesn't exist in this case (not sure why) and therefore when accessing any properties on config object will fails, when the property editor is used as a parameter editor.

![image](https://user-images.githubusercontent.com/2919859/29284680-ff072e76-812b-11e7-9a7e-45b6afd001de.png)

Should parameter editors always return a "config" property, which has an object?

I have added a fix for this, but would probably be better if it always exists, so you don't have to check for this in each property editor, which might be used as a macro parameter editor.