### PR TITLE
Switch to use TLS when initiating raw HttpWebRequests

### DIFF
--- a/src/Umbraco.Web/Editors/GravatarController.cs
+++ b/src/Umbraco.Web/Editors/GravatarController.cs
@@ -26,20 +26,29 @@ namespace Umbraco.Web.Editors
             var user = userService.GetUserById(UmbracoContext.Security.CurrentUser.Id);
             var gravatarHash = user.Email.ToMd5();
             var gravatarUrl = "https://www.gravatar.com/avatar/" + gravatarHash;
-           
-            // Test if we can reach this URL, will fail when there's network or firewall errors
-            var request = (HttpWebRequest)WebRequest.Create(gravatarUrl);
-            // Require response within 10 seconds
-            request.Timeout = 10000;
-            try
-            {
-                using ((HttpWebResponse)request.GetResponse()) { }
-            }
-            catch (Exception)
-            {
-                // There was an HTTP or other error, return an null instead
-                return null;
-            }
+
+			var activeProtocol = ServicePointManager.SecurityProtocol;
+			try
+			{
+				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+				// Test if we can reach this URL, will fail when there's network or firewall errors
+				var request = (HttpWebRequest)WebRequest.Create(gravatarUrl);
+				// Require response within 10 seconds
+				request.Timeout = 10000;
+				try
+				{
+					using ((HttpWebResponse)request.GetResponse()) { }
+				}
+				catch (Exception)
+				{
+					// There was an HTTP or other error, return an null instead
+					return null;
+				}
+			}
+			finally
+			{
+				ServicePointManager.SecurityProtocol = activeProtocol;
+			}
 
             return gravatarUrl;
         }

--- a/src/Umbraco.Web/umbraco.presentation/library.cs
+++ b/src/Umbraco.Web/umbraco.presentation/library.cs
@@ -1500,35 +1500,44 @@ namespace umbraco
             return xp.Select("/");
         }
 
-        /// <summary>
-        /// Fetches a xml file from the specified url.
-        /// the Url can be a local url or even from a remote server.
-        /// </summary>
-        /// <param name="Url">The URL.</param>
-        /// <returns>The xml file as a XpathNodeIterator</returns>
-        public static XPathNodeIterator GetXmlDocumentByUrl(string Url)
-        {
-            XmlDocument xmlDoc = new XmlDocument();
-            WebRequest request = WebRequest.Create(Url);
-            try
-            {
-                WebResponse response = request.GetResponse();
-                Stream responseStream = response.GetResponseStream();
-                XmlTextReader reader = new XmlTextReader(responseStream);
+		/// <summary>
+		/// Fetches a xml file from the specified url.
+		/// the Url can be a local url or even from a remote server.
+		/// </summary>
+		/// <param name="Url">The URL.</param>
+		/// <returns>The xml file as a XpathNodeIterator</returns>
+		public static XPathNodeIterator GetXmlDocumentByUrl(string Url)
+		{
+			var activeProtocol = ServicePointManager.SecurityProtocol;
+			try
+			{
+				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+				XmlDocument xmlDoc = new XmlDocument();
+				WebRequest request = WebRequest.Create(Url);
+				try
+				{
+					WebResponse response = request.GetResponse();
+					Stream responseStream = response.GetResponseStream();
+					XmlTextReader reader = new XmlTextReader(responseStream);
 
-                xmlDoc.Load(reader);
+					xmlDoc.Load(reader);
 
-                response.Close();
-                responseStream.Close();
-            }
-            catch (Exception err)
-            {
-                xmlDoc.LoadXml(string.Format("<error url=\"{0}\">{1}</error>",
-                                             HttpContext.Current.Server.HtmlEncode(Url), err));
-            }
-            XPathNavigator xp = xmlDoc.CreateNavigator();
-            return xp.Select("/");
-        }
+					response.Close();
+					responseStream.Close();
+				}
+				catch (Exception err)
+				{
+					xmlDoc.LoadXml(string.Format("<error url=\"{0}\">{1}</error>",
+												 HttpContext.Current.Server.HtmlEncode(Url), err));
+				}
+				XPathNavigator xp = xmlDoc.CreateNavigator();
+				return xp.Select("/");
+			}
+			finally
+			{
+				ServicePointManager.SecurityProtocol = activeProtocol;
+			}
+		}
 
         /// <summary>
         /// Gets the XML document by URL Cached.

--- a/src/Umbraco.Web/umbraco.presentation/publishingService.cs
+++ b/src/Umbraco.Web/umbraco.presentation/publishingService.cs
@@ -77,19 +77,28 @@ namespace umbraco.presentation
 
 		private static bool GetTaskByHttp(string url)
 		{
-			var myHttpWebRequest = (HttpWebRequest)WebRequest.Create(url);
+			var activeProtocol = ServicePointManager.SecurityProtocol;
+			try
+			{
+				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+				var myHttpWebRequest = (HttpWebRequest)WebRequest.Create(url);
 
-            try
-            {
-                using (var myHttpWebResponse = (HttpWebResponse)myHttpWebRequest.GetResponse())
-                {
-                    return myHttpWebResponse.StatusCode == HttpStatusCode.OK;
-                }
-            }
-            catch (Exception ex)
-            {
-                LogHelper.Error<publishingService>("Error sending url request for scheduled task", ex);
-            }
+				try
+				{
+					using (var myHttpWebResponse = (HttpWebResponse)myHttpWebRequest.GetResponse())
+					{
+						return myHttpWebResponse.StatusCode == HttpStatusCode.OK;
+					}
+				}
+				catch (Exception ex)
+				{
+					LogHelper.Error<publishingService>("Error sending url request for scheduled task", ex);
+				}
+			}
+			finally
+			{
+				ServicePointManager.SecurityProtocol = activeProtocol;
+			}
 
 		    return false;
 		}

--- a/src/umbraco.cms/businesslogic/Packager/Repositories/Repository.cs
+++ b/src/umbraco.cms/businesslogic/Packager/Repositories/Repository.cs
@@ -195,44 +195,39 @@ namespace umbraco.cms.businesslogic.packager.repositories
 
         public bool HasConnection()
         {
-
             string strServer = this.RepositoryUrl;
 
-            try
-            {
-
-                HttpWebRequest reqFP = (HttpWebRequest) HttpWebRequest.Create(strServer);
+			var activeProtocol = ServicePointManager.SecurityProtocol;
+			try
+			{
+				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+				HttpWebRequest reqFP = (HttpWebRequest) HttpWebRequest.Create(strServer);
                 HttpWebResponse rspFP = (HttpWebResponse) reqFP.GetResponse();
 
                 if (HttpStatusCode.OK == rspFP.StatusCode)
                 {
-
                     // HTTP = 200 - Internet connection available, server online
                     rspFP.Close();
 
                     return true;
-
                 }
                 else
                 {
-
                     // Other status - Server or connection not available
-
                     rspFP.Close();
 
                     return false;
-
                 }
-
             }
             catch (WebException)
             {
-
                 // Exception - connection not available
-
                 return false;
-
             }
+			finally
+			{
+				ServicePointManager.SecurityProtocol = activeProtocol;
+			}
         }
         
 


### PR DESCRIPTION
Enforce the use of TLS protocol, rather than deprecated SSL. Prevents potential security issues when routing via 3rd party DNS proxies that may have SSL disabled