### PR TITLE
U4-9793 - Fixed "insert link" not working with non-image media items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
@@ -207,6 +207,8 @@ function mediaHelper(umbRequestHelper) {
                         }
                     }
                 }
+            }else if (mediaItem.image) {
+              result = mediaItem.image;
             }
             return result;            
         },


### PR DESCRIPTION
Tested with a multitude of different file-types, ranging from PDF to PowerPoints on a 7.6.5.