### PR TITLE
Adjust z-index of umb-overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -2,7 +2,7 @@
     position: fixed;
     overflow: hidden;
     background: @white;
-    z-index: 996660;
+    z-index: 9900;
     animation: fadeIn 0.2s;
     box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
 }


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10291

Just a minor change, so login overlay (z-index: 10000) has higher z-index than `umb-overlay`, e.g. when session is timed out.