### PR TITLE
Added possibilty to ignore collisions from an IContentFinder (U4-10345)

### DIFF
--- a/src/Umbraco.Web/Routing/PublishedContentRequest.cs
+++ b/src/Umbraco.Web/Routing/PublishedContentRequest.cs
@@ -614,6 +614,9 @@ namespace Umbraco.Web.Routing
             set { _headers = value; }
         }
 
-
+        /// <summary>
+        /// Gets of sets a value indicating whether the Umbraco Backoffice should ignore a collision for this request.
+        /// </summary>
+        public bool IgnorePublishedContentCollisions { get; set; }
     }
 }

--- a/src/Umbraco.Web/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Web/Routing/UrlProviderExtensions.cs
@@ -78,7 +78,7 @@ namespace Umbraco.Web.Routing
                 {
                     urls.Add(ui.Text("content", "routeError", "(error)", umbracoContext.Security.CurrentUser));
                 }
-                else if (pcr.PublishedContent.Id != content.Id)
+                else if (pcr.IgnorePublishedContentCollisions == false && pcr.PublishedContent.Id != content.Id)
                 {
                     var o = pcr.PublishedContent;
                     string s;


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10345

Since 7.5.6 or something a check has been added to Umbraco to let a backoffice user know a certain node collides with another node, which is perfectly reasonable :)

However, especially when combining the power of `IUrlProvider` and `IContentFinder` to separate view from presentation, but still keep "Content Picker"-compatible links, the check is somewhat flawed. Even though it doesn't actually break routing, it does break the possibility to copy URLs from the Properties-tab, which is very inconvenient for the end-user.

This PR adds an `IgnorePublishedContentCollisions` property to the `PublishedContentRequest`, allowing an `IContentPicker` to let Umbraco know this may seem like a collision, but in reality, we really know what we are doing and wish to ignore it.

PS. Aside of this issue, I have to mention that the `if (o == null)` line inside the check we're trying to skip is unnecessary and can never happen, as we already make sure PublishedContent is not null in the initial if-statement. On top of that, even if `HasPublishedContent` fails to do its job, we would already have an exception before it even reaches this line because of the `pcr.PublishedContent.Id != content.Id` part before it (more specifically: trying to get an Id from a null-object).