### PR TITLE
U4-10363 417 missing token error due to invalid cookie name

### DIFF
--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -212,6 +212,7 @@
     <Compile Include="Collections\DeepCloneableListTests.cs" />
     <Compile Include="Web\Controllers\BackOfficeControllerUnitTests.cs" />
     <Compile Include="DelegateExtensionsTests.cs" />
+    <Compile Include="Web\HttpCookieExtensionsTests.cs" />
     <Compile Include="Web\Mvc\RenderIndexActionSelectorAttributeTests.cs" />
     <Compile Include="Persistence\Repositories\AuditRepositoryTest.cs" />
     <Compile Include="Persistence\Repositories\DomainRepositoryTest.cs" />

--- a/src/Umbraco.Tests/Web/HttpCookieExtensionsTests.cs
+++ b/src/Umbraco.Tests/Web/HttpCookieExtensionsTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Umbraco.Core;
+using Umbraco.Web;
+
+namespace Umbraco.Tests.Web
+{
+    [TestFixture]
+    public class HttpCookieExtensionsTests
+    {
+        [TestCase("hello=world;cookies=are fun;", "hello", "world", true)]
+        [TestCase("HELlo=world;cookies=are fun", "hello", "world", true)]
+        [TestCase("HELlo= world;cookies=are fun", "hello", "world", true)]
+        [TestCase("HELlo =world;cookies=are fun", "hello", "world", true)]
+        [TestCase("hello = world;cookies=are fun;", "hello", "world", true)]
+        [TestCase("hellos=world;cookies=are fun", "hello", "world", false)]
+        [TestCase("hello=world;cookies?=are fun?", "hello", "world", true)]
+        [TestCase("hel?lo=world;cookies=are fun?", "hel?lo", "world", true)]
+        public void Get_Cookie_Value_From_HttpRequestHeaders(string cookieHeaderVal, string cookieName, string cookieVal, bool matches)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://test.com");
+            var requestHeaders = request.Headers;
+            requestHeaders.Add("Cookie", cookieHeaderVal);
+
+            var valueFromHeader = requestHeaders.GetCookieValue(cookieName);
+
+            if (matches)
+            {
+                Assert.IsNotNull(valueFromHeader);
+                Assert.AreEqual(cookieVal, valueFromHeader);
+            }
+            else
+            {
+                Assert.IsNull(valueFromHeader);
+            }                
+        }
+    }
+}

--- a/src/Umbraco.Web/HttpCookieExtensions.cs
+++ b/src/Umbraco.Web/HttpCookieExtensions.cs
@@ -28,26 +28,23 @@ namespace Umbraco.Web
         /// </remarks>
         public static string GetCookieValue(this HttpRequestHeaders requestHeaders, string cookieName)
         {
-            var cookieRequestHeader = requestHeaders
-                .Where(h => h.Key.Equals("Cookie", StringComparison.InvariantCultureIgnoreCase))
-                .ToArray();
-
-            if (cookieRequestHeader.Length == 0)
-                return null;
-
-            var cookiesHeader = cookieRequestHeader[0];
-            
-            var cookiesHeaderValue = cookiesHeader.Value.FirstOrDefault();
-            if (cookiesHeaderValue == null)
-                return null;
-
-            var cookieCollection = cookiesHeaderValue.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
-            foreach (var cookieNameValue in cookieCollection)
+            foreach (var header in requestHeaders)
             {
-                var parts = cookieNameValue.Split(new[] {'='}, StringSplitOptions.RemoveEmptyEntries);
-                if (parts.Length != 2) continue;
-                if (parts[0].Trim().InvariantEquals(cookieName))
-                    return parts[1].Trim();
+                if (header.Key.Equals("Cookie", StringComparison.InvariantCultureIgnoreCase) == false)
+                    continue;
+                
+                var cookiesHeaderValue = header.Value.FirstOrDefault();
+                if (cookiesHeaderValue == null)
+                    return null;
+
+                var cookieCollection = cookiesHeaderValue.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var cookieNameValue in cookieCollection)
+                {
+                    var parts = cookieNameValue.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length != 2) continue;
+                    if (parts[0].Trim().Equals(cookieName, StringComparison.InvariantCultureIgnoreCase))
+                        return parts[1].Trim();
+                }
             }
 
             return null;

--- a/src/Umbraco.Web/HttpCookieExtensions.cs
+++ b/src/Umbraco.Web/HttpCookieExtensions.cs
@@ -17,6 +17,43 @@ namespace Umbraco.Web
     internal static class HttpCookieExtensions
     {
         /// <summary>
+        /// Retrieves an individual cookie from the cookies collection
+        /// </summary>
+        /// <param name="requestHeaders"></param>
+        /// <param name="cookieName"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Adapted from: https://stackoverflow.com/a/29057304/5018 because there's an issue with .NET WebApi cookie parsing logic 
+        /// when using requestHeaders.GetCookies() when an invalid cookie name is present.
+        /// </remarks>
+        public static string GetCookieValue(this HttpRequestHeaders requestHeaders, string cookieName)
+        {
+            var cookieRequestHeader = requestHeaders
+                .Where(h => h.Key.Equals("Cookie", StringComparison.InvariantCultureIgnoreCase))
+                .ToArray();
+
+            if (cookieRequestHeader.Length == 0)
+                return null;
+
+            var cookiesHeader = cookieRequestHeader[0];
+            
+            var cookiesHeaderValue = cookiesHeader.Value.FirstOrDefault();
+            if (cookiesHeaderValue == null)
+                return null;
+
+            var cookieCollection = cookiesHeaderValue.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var cookieNameValue in cookieCollection)
+            {
+                var parts = cookieNameValue.Split(new[] {'='}, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length != 2) continue;
+                if (parts[0].Trim().InvariantEquals(cookieName))
+                    return parts[1].Trim();
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Removes the cookie from the request and the response if it exists
         /// </summary>
         /// <param name="http"></param>

--- a/src/Umbraco.Web/WebApi/Filters/AngularAntiForgeryHelper.cs
+++ b/src/Umbraco.Web/WebApi/Filters/AngularAntiForgeryHelper.cs
@@ -107,41 +107,13 @@ namespace Umbraco.Web.WebApi.Filters
         /// <returns></returns>
         public static bool ValidateHeaders(HttpRequestHeaders requestHeaders, out string failedReason)
         {
-            var cookieToken = GetCookie(requestHeaders, CsrfValidationCookieName);
+            var cookieToken = requestHeaders.GetCookieValue(CsrfValidationCookieName);
 
             return ValidateHeaders(
                 requestHeaders.ToDictionary(x => x.Key, x => x.Value).ToArray(),
                 cookieToken == null ? null : cookieToken,
                 out failedReason);
         }
-
-        /// <summary>
-        /// Retrieves an individual cookie from the cookies collection
-        /// Adapted from: https://stackoverflow.com/a/29057304/5018
-        /// </summary>
-        /// <param name="requestHeaders"></param>
-        /// <param name="cookieName"></param>
-        /// <returns></returns>
-        private static string GetCookie(HttpRequestHeaders requestHeaders, string cookieName)
-        {
-            var cookieRequestHeader = requestHeaders.Where(h => h.Key.Equals("Cookie", StringComparison.InvariantCultureIgnoreCase)).ToArray();
-            if (cookieRequestHeader.Any() == false)
-                return null;
-
-            var cookiesHeader = cookieRequestHeader.FirstOrDefault();
-            if (cookiesHeader.Value == null)
-                return null;
-
-            var cookiesHeaderValue = cookiesHeader.Value.FirstOrDefault();
-            if (cookiesHeaderValue == null)
-                return null;
-
-            var cookieCollection = cookiesHeaderValue.Split(';');
-            var cookiePair = cookieCollection.FirstOrDefault(c => c.Trim().StartsWith(cookieName, StringComparison.InvariantCultureIgnoreCase));
-            if (cookiePair == null)
-                return null;
-
-            return cookiePair.Trim().Substring(cookieName.Length + 1);
-        }
+        
     }
 }

--- a/src/Umbraco.Web/WebApi/Filters/AngularAntiForgeryHelper.cs
+++ b/src/Umbraco.Web/WebApi/Filters/AngularAntiForgeryHelper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
-using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Web.Helpers;
 using Umbraco.Core;
@@ -29,8 +27,6 @@ namespace Umbraco.Web.WebApi.Filters
         /// The header name that angular uses to pass in the token to validate the cookie
         /// </summary>
         public const string AngularHeadername = "X-XSRF-TOKEN";
-
-        
 
         /// <summary>
         /// Returns 2 tokens - one for the cookie value and one that angular should set as the header value
@@ -68,8 +64,8 @@ namespace Umbraco.Web.WebApi.Filters
             return true;
         }
 
-        internal static bool ValidateHeaders(            
-            KeyValuePair<string, IEnumerable<string>>[] requestHeaders, 
+        internal static bool ValidateHeaders(
+            KeyValuePair<string, IEnumerable<string>>[] requestHeaders,
             string cookieToken,
             out string failedReason)
         {
@@ -86,7 +82,7 @@ namespace Umbraco.Web.WebApi.Filters
                 .Select(z => z.Value)
                 .SelectMany(z => z)
                 .FirstOrDefault();
-            
+
             // both header and cookie must be there
             if (cookieToken == null || headerToken == null)
             {
@@ -111,15 +107,41 @@ namespace Umbraco.Web.WebApi.Filters
         /// <returns></returns>
         public static bool ValidateHeaders(HttpRequestHeaders requestHeaders, out string failedReason)
         {
-            var cookieToken = requestHeaders
-                .GetCookies()
-                .Select(c => c[CsrfValidationCookieName])
-                .FirstOrDefault();
+            var cookieToken = GetCookie(requestHeaders, CsrfValidationCookieName);
 
             return ValidateHeaders(
                 requestHeaders.ToDictionary(x => x.Key, x => x.Value).ToArray(),
-                cookieToken == null ? null : cookieToken.Value,
+                cookieToken == null ? null : cookieToken,
                 out failedReason);
+        }
+
+        /// <summary>
+        /// Retrieves an individual cookie from the cookies collection
+        /// Adapted from: https://stackoverflow.com/a/29057304/5018
+        /// </summary>
+        /// <param name="requestHeaders"></param>
+        /// <param name="cookieName"></param>
+        /// <returns></returns>
+        private static string GetCookie(HttpRequestHeaders requestHeaders, string cookieName)
+        {
+            var cookieRequestHeader = requestHeaders.Where(h => h.Key.Equals("Cookie", StringComparison.InvariantCultureIgnoreCase)).ToArray();
+            if (cookieRequestHeader.Any() == false)
+                return null;
+
+            var cookiesHeader = cookieRequestHeader.FirstOrDefault();
+            if (cookiesHeader.Value == null)
+                return null;
+
+            var cookiesHeaderValue = cookiesHeader.Value.FirstOrDefault();
+            if (cookiesHeaderValue == null)
+                return null;
+
+            var cookieCollection = cookiesHeaderValue.Split(';');
+            var cookiePair = cookieCollection.FirstOrDefault(c => c.Trim().StartsWith(cookieName, StringComparison.InvariantCultureIgnoreCase));
+            if (cookiePair == null)
+                return null;
+
+            return cookiePair.Trim().Substring(cookieName.Length + 1);
         }
     }
 }


### PR DESCRIPTION
Manually parse the cookie header instead of using the buggy extension method

http://issues.umbraco.org/issue/U4-10363