### PR TITLE
Creating a new content node using Content Templates (Blueprints) always places node at root.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -418,14 +418,14 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
                   'Failed to retrieve data for empty content item type ' + alias);
         },
 
-        getBlueprintScaffold: function (blueprintId) {
+        getBlueprintScaffold: function (parentId, blueprintId) {
 
           return umbRequestHelper.resourcePromise(
             $http.get(
               umbRequestHelper.getApiUrl(
                 "contentApiBaseUrl",
-                "GetEmpty",
-                [{ blueprintId: blueprintId }])),
+                      "GetEmpty",
+                      [{ blueprintId: blueprintId }, { parentId: parentId}])),
             'Failed to retrieve blueprint for id ' + blueprintId);
         },
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -12,7 +12,7 @@ function ContentEditController($scope, $routeParams, contentResource) {
     return contentResource.getScaffold($routeParams.id, $routeParams.doctype);
   }
   function scaffoldBlueprint() {
-    return contentResource.getBlueprintScaffold($routeParams.blueprintId);
+      return contentResource.getBlueprintScaffold($routeParams.id, $routeParams.blueprintId);
   }
 
   $scope.contentId = $routeParams.id;

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -315,7 +315,7 @@ namespace Umbraco.Web.Editors
         }
 
         [OutgoingEditorModelEvent]
-        public ContentItemDisplay GetEmpty(int blueprintId)
+        public ContentItemDisplay GetEmpty(int blueprintId, int parentId)
         {
             var blueprint = Services.ContentService.GetBlueprintById(blueprintId);
             if (blueprint == null)
@@ -325,6 +325,7 @@ namespace Umbraco.Web.Editors
 
             blueprint.Id = 0;
             blueprint.Name = string.Empty;
+            blueprint.ParentId = parentId;
 
             var mapped = Mapper.Map<ContentItemDisplay>(blueprint);
 


### PR DESCRIPTION
http://issues.umbraco.org/issue/U4-10326