### PR TITLE
U4-9374 Navigation panel header and editor panel header don't line up properly in Firefox

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -356,7 +356,7 @@
 .umb-panel-header-content-wrapper {
   display: flex;
   flex-direction: column;
-  height: 100px;
+  height: 99px;
   padding: 0 20px;
 }
 


### PR DESCRIPTION
The .umb-panel-header-content-wrapper was 1 pixel higher than the parent .umb-panel-header, now both heights are 99px.