### PR TITLE
U4-10333 Invite user needs extensibility points to work with Umbraco Cloud when no SMTP is set

### DIFF
--- a/build/UmbracoVersion.txt
+++ b/build/UmbracoVersion.txt
@@ -1,3 +1,3 @@
 # Usage: on line 2 put the release version, on line 3 put the version comment (example: beta)
 7.7.0
-beta003
+beta004

--- a/build/UmbracoVersion.txt
+++ b/build/UmbracoVersion.txt
@@ -1,3 +1,3 @@
 # Usage: on line 2 put the release version, on line 3 put the version comment (example: beta)
 7.7.0
-beta004
+beta005

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -12,4 +12,4 @@ using System.Resources;
 [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyFileVersion("7.7.0")]
-[assembly: AssemblyInformationalVersion("7.7.0-beta004")]
+[assembly: AssemblyInformationalVersion("7.7.0-beta005")]

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -12,4 +12,4 @@ using System.Resources;
 [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyFileVersion("7.7.0")]
-[assembly: AssemblyInformationalVersion("7.7.0-beta003")]
+[assembly: AssemblyInformationalVersion("7.7.0-beta004")]

--- a/src/Umbraco.Core/Configuration/UmbracoVersion.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoVersion.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Core.Configuration
         /// Gets the version comment (like beta or RC).
         /// </summary>
         /// <value>The version comment.</value>
-        public static string CurrentComment { get { return "beta004"; } }
+        public static string CurrentComment { get { return "beta005"; } }
 
         // Get the version of the umbraco.dll by looking at a class in that dll
         // Had to do it like this due to medium trust issues, see: http://haacked.com/archive/2010/11/04/assembly-location-and-medium-trust.aspx

--- a/src/Umbraco.Core/Configuration/UmbracoVersion.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoVersion.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Core.Configuration
         /// Gets the version comment (like beta or RC).
         /// </summary>
         /// <value>The version comment.</value>
-        public static string CurrentComment { get { return "beta003"; } }
+        public static string CurrentComment { get { return "beta004"; } }
 
         // Get the version of the umbraco.dll by looking at a class in that dll
         // Had to do it like this due to medium trust issues, see: http://haacked.com/archive/2010/11/04/assembly-location-and-medium-trust.aspx

--- a/src/Umbraco.Core/EmailSender.cs
+++ b/src/Umbraco.Core/EmailSender.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mail;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Routing;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Events;
+
+namespace Umbraco.Core
+{
+    /// <summary>
+    /// A utility class for sending emails
+    /// </summary>
+    public class EmailSender : IEmailSender
+    {
+        //TODO: This should encapsulate a BackgroundTaskRunner with a queue to send these emails!
+
+        private readonly bool _enableEvents;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public EmailSender() : this(false)
+        {
+        }
+
+        internal EmailSender(bool enableEvents)
+        {
+            _enableEvents = enableEvents;
+        }
+
+        private static readonly Lazy<bool> SmtpConfigured = new Lazy<bool>(() => GlobalSettings.HasSmtpServerConfigured(HttpRuntime.AppDomainAppVirtualPath));
+
+        /// <summary>
+        /// Sends the message non-async
+        /// </summary>
+        /// <param name="message"></param>
+        public void Send(MailMessage message)
+        {
+            if (SmtpConfigured.Value == false && _enableEvents)
+            {
+                OnSendEmail(new SendEmailEventArgs(message));
+            }
+            else
+            {
+                using (var client = new SmtpClient())
+                {
+                    client.Send(message);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sends the message async
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        public async Task SendAsync(MailMessage message)
+        {
+            if (SmtpConfigured.Value == false && _enableEvents)
+            {
+                OnSendEmail(new SendEmailEventArgs(message));
+            }
+            else
+            {
+                using (var client = new SmtpClient())
+                {
+                    if (client.DeliveryMethod == SmtpDeliveryMethod.Network)
+                    {
+                        await client.SendMailAsync(message);
+                    }
+                    else
+                    {
+                        client.Send(message);
+                    }
+                }
+            }            
+        }
+
+        /// <summary>
+        /// Returns true if the application should be able to send a required application email
+        /// </summary>
+        /// <remarks>
+        /// We assume this is possible if either an event handler is registered or an smtp server is configured
+        /// </remarks>
+        internal static bool CanSendRequiredEmail
+        {
+            get { return EventHandlerRegistered || SmtpConfigured.Value; }
+        }
+
+        /// <summary>
+        /// returns true if an event handler has been registered
+        /// </summary>
+        internal static bool EventHandlerRegistered
+        {
+            get { return SendEmail != null; }
+        }
+        
+        /// <summary>
+        /// An event that is raised when no smtp server is configured if events are enabled
+        /// </summary>
+        internal static event EventHandler<SendEmailEventArgs> SendEmail;
+
+        private static void OnSendEmail(SendEmailEventArgs e)
+        {
+            var handler = SendEmail;
+            if (handler != null) handler(null, e);
+        }
+    }
+}

--- a/src/Umbraco.Core/Events/SendEmailEventArgs.cs
+++ b/src/Umbraco.Core/Events/SendEmailEventArgs.cs
@@ -3,25 +3,13 @@ using System.Net.Mail;
 
 namespace Umbraco.Core.Events
 {
-    public class SendEmailEventArgs : EventArgs
+    internal class SendEmailEventArgs : EventArgs
     {
-        public SmtpClient Smtp { get; private set; }
         public MailMessage Message { get; private set; }
-
-        ///// <summary>
-        ///// A flag indicating that the mail sending was handled by an event handler
-        ///// </summary>
-        //public bool SendingHandledExternally { get; set; }
 
         public SendEmailEventArgs(MailMessage message)
         {
             Message = message;
-        }
-
-        public SendEmailEventArgs(SmtpClient smtp, MailMessage message)
-        {
-            Smtp = smtp;
-            Message = message;
-        }
+        }        
     }
 }

--- a/src/Umbraco.Core/Events/SendEmailEventArgs.cs
+++ b/src/Umbraco.Core/Events/SendEmailEventArgs.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Net.Mail;
+
+namespace Umbraco.Core.Events
+{
+    public class SendEmailEventArgs : EventArgs
+    {
+        public SmtpClient Smtp { get; private set; }
+        public MailMessage Message { get; private set; }
+
+        ///// <summary>
+        ///// A flag indicating that the mail sending was handled by an event handler
+        ///// </summary>
+        //public bool SendingHandledExternally { get; set; }
+
+        public SendEmailEventArgs(MailMessage message)
+        {
+            Message = message;
+        }
+
+        public SendEmailEventArgs(SmtpClient smtp, MailMessage message)
+        {
+            Smtp = smtp;
+            Message = message;
+        }
+    }
+}

--- a/src/Umbraco.Core/IEmailSender.cs
+++ b/src/Umbraco.Core/IEmailSender.cs
@@ -1,0 +1,13 @@
+﻿using System.Net.Mail;
+using System.Threading.Tasks;
+
+namespace Umbraco.Core
+{
+    /// <summary>
+    /// Simple abstraction to send an email message
+    /// </summary>
+    public interface IEmailSender
+    {
+        Task SendAsync(MailMessage message);
+    }
+}

--- a/src/Umbraco.Core/Security/UmbracoEmailMessage.cs
+++ b/src/Umbraco.Core/Security/UmbracoEmailMessage.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNet.Identity;
+
+namespace Umbraco.Core.Security
+{
+    /// <summary>
+    /// A custom implementation for IdentityMessage that allows the customization of how an email is sent
+    /// </summary>
+    internal class UmbracoEmailMessage : IdentityMessage
+    {
+        public IEmailSender MailSender { get; private set; }
+
+        public UmbracoEmailMessage(IEmailSender mailSender)
+        {
+            MailSender = mailSender;
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -348,14 +348,17 @@
     <Compile Include="Deploy\Direction.cs" />
     <Compile Include="Deploy\IFileType.cs" />
     <Compile Include="Deploy\IFileTypeCollection.cs" />
+    <Compile Include="EmailSender.cs" />
     <Compile Include="Events\EventDefinitionFilter.cs" />
     <Compile Include="Events\IDeletingMediaFilesEventArgs.cs" />
     <Compile Include="Events\ScopeEventDispatcherBase.cs" />
     <Compile Include="Events\ScopeLifespanMessagesFactory.cs" />
+    <Compile Include="Events\SendEmailEventArgs.cs" />
     <Compile Include="Events\SupersedeEventAttribute.cs" />
     <Compile Include="Exceptions\ConnectionException.cs" />
     <Compile Include="HashCodeHelper.cs" />
     <Compile Include="HashGenerator.cs" />
+    <Compile Include="IEmailSender.cs" />
     <Compile Include="IHttpContextAccessor.cs" />
     <Compile Include="Models\EntityBase\EntityPath.cs" />
     <Compile Include="Models\EntityBase\IDeletableEntity.cs" />
@@ -688,6 +691,7 @@
     <Compile Include="Security\EmailService.cs" />
     <Compile Include="Security\MembershipProviderPasswordValidator.cs" />
     <Compile Include="Security\OwinExtensions.cs" />
+    <Compile Include="Security\UmbracoEmailMessage.cs" />
     <Compile Include="Security\UserAwareMembershipProviderPasswordHasher.cs" />
     <Compile Include="SemVersionExtensions.cs" />
     <Compile Include="Serialization\NoTypeConverterJsonConverter.cs" />

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -50,24 +50,31 @@
             "selected": true
         };
 
-        //don't set this if no email is configured
-        if (Umbraco.Sys.ServerVariables.umbracoSettings.emailServerConfigured) {
+        //don't show the invite button if no email is configured
+        if (Umbraco.Sys.ServerVariables.umbracoSettings.showUserInvite) {
             vm.defaultButton = {
                 labelKey: "user_inviteUser",
-                handler: function () {
+                handler: function() {
                     vm.setUsersViewState('inviteUser');
                 }
             };
+            vm.subButtons = [
+                {
+                    labelKey: "user_createUser",
+                    handler: function () {
+                        vm.setUsersViewState('createUser');
+                    }
+                }
+            ];
         }
-
-        vm.subButtons = [
-            {
+        else {
+            vm.defaultButton = {
                 labelKey: "user_createUser",
                 handler: function () {
                     vm.setUsersViewState('createUser');
                 }
-            }
-        ];
+            };
+        }
 
         vm.toggleFilter = toggleFilter;
         vm.setUsersViewState = setUsersViewState;

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -289,7 +289,7 @@ namespace Umbraco.Web.Editors
                         {"cssPath", IOHelper.ResolveUrl(SystemDirectories.Css).TrimEnd('/')},
                         {"allowPasswordReset", UmbracoConfig.For.UmbracoSettings().Security.AllowPasswordReset},
                         {"loginBackgroundImage",  UmbracoConfig.For.UmbracoSettings().Content.LoginBackgroundImage},
-                        {"emailServerConfigured", GlobalSettings.HasSmtpServerConfigured(_httpContext.Request.ApplicationPath)},
+                        {"showUserInvite", EmailSender.CanSendRequiredEmail},
                     }
                 },
                 {

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -345,9 +345,8 @@ namespace Umbraco.Web.Editors
             {
                 throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, ModelState));
             }
-
-            var hasSmtp = GlobalSettings.HasSmtpServerConfigured(RequestContext.VirtualPathRoot);
-            if (hasSmtp == false)
+            
+            if (EmailSender.CanSendRequiredEmail == false)
             {
                 throw new HttpResponseException(
                     Request.CreateNotificationValidationErrorResponse("No Email server is configured"));
@@ -442,12 +441,15 @@ namespace Umbraco.Web.Editors
                 UserExtensions.GetUserCulture(to.Language, Services.TextService),
                 new[] { userDisplay.Name, from, message, inviteUri.ToString() });
 
-            await UserManager.EmailService.SendAsync(new IdentityMessage
-            {
-                Body = emailBody,
-                Destination = userDisplay.Email,
-                Subject = emailSubject
-            });
+            await UserManager.EmailService.SendAsync(
+                //send the special UmbracoEmailMessage which configures it's own sender
+                //to allow for events to handle sending the message if no smtp is configured
+                new UmbracoEmailMessage(new EmailSender(true))
+                {
+                    Body = emailBody,
+                    Destination = userDisplay.Email,
+                    Subject = emailSubject
+                });
 
         }
 

--- a/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
@@ -67,7 +67,7 @@ namespace Umbraco.Web.HealthCheck.NotificationMethods
 
             var subject = _textService.Localize("healthcheck/scheduledHealthCheckEmailSubject");
 
-            using (var client = new SmtpClient())
+            var mailSender = new EmailSender();
             using (var mailMessage = new MailMessage(UmbracoConfig.For.UmbracoSettings().Content.NotificationEmailAddress,
                 RecipientEmail,
                 string.IsNullOrEmpty(subject) ? "Umbraco Health Check Status" : subject,
@@ -77,14 +77,7 @@ namespace Umbraco.Web.HealthCheck.NotificationMethods
                              && message.Contains("<") && message.Contains("</")
             })
             {
-                if (client.DeliveryMethod == SmtpDeliveryMethod.Network)
-                {
-                    await client.SendMailAsync(mailMessage);
-                }
-                else
-                {
-                    client.Send(mailMessage);
-                }
+                await mailSender.SendAsync(mailMessage);
             }
         }
     }

--- a/src/Umbraco.Web/Security/Identity/AppBuilderExtensions.cs
+++ b/src/Umbraco.Web/Security/Identity/AppBuilderExtensions.cs
@@ -90,7 +90,8 @@ namespace Umbraco.Web.Security.Identity
                     appContext.Services.UserService,
                     appContext.Services.EntityService,
                     appContext.Services.ExternalLoginService,
-                    userMembershipProvider));
+                    userMembershipProvider,
+                    UmbracoConfig.For.UmbracoSettings().Content));
             
             app.SetBackOfficeUserManagerType<BackOfficeUserManager, BackOfficeIdentityUser>();
 
@@ -119,7 +120,8 @@ namespace Umbraco.Web.Security.Identity
                 (options, owinContext) => BackOfficeUserManager.Create(
                     options,
                     customUserStore,
-                    userMembershipProvider));
+                    userMembershipProvider,
+                    UmbracoConfig.For.UmbracoSettings().Content));
 
             app.SetBackOfficeUserManagerType<BackOfficeUserManager, BackOfficeIdentityUser>();
 

--- a/src/Umbraco.Web/umbraco.presentation/library.cs
+++ b/src/Umbraco.Web/umbraco.presentation/library.cs
@@ -1614,6 +1614,7 @@ namespace umbraco
         {
             try
             {
+                var mailSender = new EmailSender();
                 using (var mail = new MailMessage())
                 {
                     mail.From = new MailAddress(fromMail.Trim());
@@ -1622,8 +1623,7 @@ namespace umbraco
                     mail.Subject = subject;
                     mail.IsBodyHtml = isHtml;
                     mail.Body = body;
-                    using (var smtpClient = new SmtpClient())
-                        smtpClient.Send(mail);
+                    mailSender.Send(mail);
                 }
             }
             catch (Exception ee)

--- a/src/umbraco.cms/businesslogic/translation/Translation.cs
+++ b/src/umbraco.cms/businesslogic/translation/Translation.cs
@@ -59,6 +59,7 @@ namespace umbraco.cms.businesslogic.translation
                 {
                     try
                     {
+                        var mailSender = new EmailSender();
                         using (var mail = new MailMessage())
                         {
                             mail.From = new MailAddress(user.Email.Trim());
@@ -66,8 +67,7 @@ namespace umbraco.cms.businesslogic.translation
                             mail.Subject = ui.Text("translation", "mailSubject", subjectVars, translator); ;
                             mail.IsBodyHtml = false;
                             mail.Body = ui.Text("translation", "mailBody", bodyVars, translator); ;
-                            using (var smtpClient = new SmtpClient())
-                                smtpClient.Send(mail);
+                            mailSender.Send(mail);
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
This does a few things:

* New EmailSender (IEmailSender) to manage sending emails via SMTP
* Updates most other places that use SMTP directly to use EmailSender
* Updates Umbraco's ASP.NET Identity Email Service to use EmailSender and makes these objects more unit testable - which leads to creating new ctor's and factory methods for the BackOfficeUserManager - but I've just obsoleted the existing ones (no breaking changes)
* Creates an internal sub class of IdentityMessage which we can supply a custom IEmailSender to be used to send the message, in the case of the user invite email, this special IEmailSender will have events turned on
* Changes the UI to show the invite button if the EmailSender detects that either the event is subscribed to, or an SMTP server is configured