### PR TITLE
U4-8886 - TinyMCE - highlight media picker toolbar icon when image selected

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -87,6 +87,7 @@ function tinyMceService(dialogService, $log, imageHelper, $http, $timeout, macro
             editor.addButton('umbmediapicker', {
                 icon: 'custom icon-picture',
                 tooltip: 'Media Picker',
+                stateSelector: 'img',
                 onclick: function () {
 
                     var selectedElm = editor.selection.getNode(),


### PR DESCRIPTION
Quick attempt at fix for [U4-8886](http://issues.umbraco.org/issue/U4-8886)

![image](https://user-images.githubusercontent.com/1396376/30074137-566d0cda-923e-11e7-8870-45b2372db448.png)

