### PR TITLE
Adding gitlink to the main Umbraco projects

### DIFF
--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\GitLink.3.0.0\build\GitLink.props" Condition="Exists('..\packages\GitLink.3.0.0\build\GitLink.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -15,6 +16,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -1583,6 +1586,14 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <Import Project="..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets" Condition="Exists('..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\GitLink.3.0.0\build\GitLink.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitLink.3.0.0\build\GitLink.props'))" />
+    <Error Condition="!Exists('..\packages\GitLink.3.0.0\build\GitLink.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitLink.3.0.0\build\GitLink.targets'))" />
+  </Target>
+  <Import Project="..\packages\GitLink.3.0.0\build\GitLink.targets" Condition="Exists('..\packages\GitLink.3.0.0\build\GitLink.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Umbraco.Core/packages.config
+++ b/src/Umbraco.Core/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoMapper" version="3.3.1" targetFramework="net45" />
+  <package id="GitLink" version="3.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net45" />
   <package id="ImageProcessor" version="2.5.3" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <Import Project="..\packages\GitLink.3.0.0\build\GitLink.props" Condition="Exists('..\packages\GitLink.3.0.0\build\GitLink.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <ProductVersion>9.0.30729</ProductVersion>
@@ -49,6 +50,9 @@
     <RestorePackages>true</RestorePackages>
     <MvcProjectUpgradeChecked>true</MvcProjectUpgradeChecked>
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\</OutputPath>
@@ -2440,4 +2444,12 @@ xcopy "$(ProjectDir)"..\packages\SqlServerCE.4.0.0.1\x86\*.* "$(TargetDir)x86\" 
     <Exec WorkingDirectory="$(ProjectDir)\..\..\build\" Command="BuildBelle.bat $(VersionNumber)" ConsoleToMSBuild="true" IgnoreExitCode="true" ContinueOnError="WarnAndContinue" />
   </Target>
   <Import Project="..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets" Condition="Exists('..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\GitLink.3.0.0\build\GitLink.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitLink.3.0.0\build\GitLink.props'))" />
+    <Error Condition="!Exists('..\packages\GitLink.3.0.0\build\GitLink.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitLink.3.0.0\build\GitLink.targets'))" />
+  </Target>
+  <Import Project="..\packages\GitLink.3.0.0\build\GitLink.targets" Condition="Exists('..\packages\GitLink.3.0.0\build\GitLink.targets')" />
 </Project>

--- a/src/Umbraco.Web.UI/packages.config
+++ b/src/Umbraco.Web.UI/packages.config
@@ -5,6 +5,7 @@
   <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net45" />
   <package id="dotless" version="1.5.2" targetFramework="net45" />
   <package id="Examine" version="0.1.83" targetFramework="net45" />
+  <package id="GitLink" version="3.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="ImageProcessor" version="2.5.3" targetFramework="net45" />
   <package id="ImageProcessor.Web" version="4.8.3" targetFramework="net45" />
   <package id="ImageProcessor.Web.Config" version="2.3.0" targetFramework="net45" />


### PR DESCRIPTION
Trying to debug Umbraco source code can be a pain, even with the symbol server support, because the source code drifts over time and you have to work out which commit to role back to so you're matching the symbols.

This PR adds [GitLink](https://github.com/GitTools/GitLink) to the Umbraco.Core and Umbraco.Core.UI projects (the ones distributed by NuGet) and _should_ then generate the appropriate symbols-to-GitHub linkage.

I wasn't able to test this locally (I wanted to generate the NuGet packages and test) because I can't get `built.bat` to work (I didn't have the right version of MSBuild in the expected location, it then wouldn't load the community tasks, then the Web Publishing tasks and eventually it just failed to find the web.config). I don't know if the artifacts are generated by a build server on a PR, but that'd be handy 😁.