### PR TITLE
U4-10357 Redirect manager not affected by user content start node

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Interfaces/IRedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Interfaces/IRedirectUrlRepository.cs
@@ -76,5 +76,16 @@ namespace Umbraco.Core.Persistence.Repositories
         /// <param name="total">The total count of redirect urls.</param>
         /// <returns>The redirect urls.</returns>
         IEnumerable<IRedirectUrl> SearchUrls(string searchTerm, long pageIndex, int pageSize, out long total);
+
+        /// <summary>
+        /// Searches for all redirect urls that contain a given search term in their URL property.
+        /// </summary>
+        /// <param name="rootContentId">The content unique identifier.</param>
+        /// <param name="searchTerm">The term to search for.</param>
+        /// <param name="pageIndex">The page index.</param>
+        /// <param name="pageSize">The page size.</param>
+        /// <param name="total">The total count of redirect urls.</param>
+        /// <returns>The redirect urls.</returns>
+        IEnumerable<IRedirectUrl> SearchUrls(int rootContentId, string searchTerm, long pageIndex, int pageSize, out long total);
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/RedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/RedirectUrlRepository.cs
@@ -205,6 +205,18 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
 
             var rules = result.Items.Select(Map);
             return rules;
-        }     
+        }
+
+        public IEnumerable<IRedirectUrl> SearchUrls(int rootContentId, string searchTerm, long pageIndex, int pageSize, out long total)
+        {
+            var sql = GetBaseQuery(false)
+                .Where(string.Format("{0}.{1} LIKE @url AND {2}.{3} LIKE @path", SqlSyntax.GetQuotedTableName("umbracoRedirectUrl"), SqlSyntax.GetQuotedColumnName("Url"), SqlSyntax.GetQuotedTableName("umbracoNode"),SqlSyntax.GetQuotedColumnName("path")), new { url = "%" + searchTerm.Trim().ToLowerInvariant() + "%", path = "%," + rootContentId + ",%" })
+                .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc, SqlSyntax);
+            var result = Database.Page<RedirectUrlDto>(pageIndex + 1, pageSize, sql);
+            total = Convert.ToInt32(result.TotalItems);
+
+            var rules = result.Items.Select(Map);
+            return rules;
+        }
     }
 }

--- a/src/Umbraco.Core/Services/IRedirectUrlService.cs
+++ b/src/Umbraco.Core/Services/IRedirectUrlService.cs
@@ -82,5 +82,16 @@ namespace Umbraco.Core.Services
         /// <param name="total">The total count of redirect urls.</param>
         /// <returns>The redirect urls.</returns>
         IEnumerable<IRedirectUrl> SearchRedirectUrls(string searchTerm, long pageIndex, int pageSize, out long total);
+
+        /// <summary>
+        /// Searches for all redirect urls that contain a given search term in their URL property.
+        /// </summary>
+        /// <param name="rootContentId">The content unique identifier.</param>
+        /// <param name="searchTerm">The term to search for.</param>
+        /// <param name="pageIndex">The page index.</param>
+        /// <param name="pageSize">The page size.</param>
+        /// <param name="total">The total count of redirect urls.</param>
+        /// <returns>The redirect urls.</returns>
+        IEnumerable<IRedirectUrl> SearchRedirectUrls(int rootContentId, string searchTerm, long pageIndex, int pageSize, out long total);
     }
 }

--- a/src/Umbraco.Core/Services/RedirectUrlService.cs
+++ b/src/Umbraco.Core/Services/RedirectUrlService.cs
@@ -123,5 +123,16 @@ namespace Umbraco.Core.Services
                 return rules;
             }
         }
+
+        public IEnumerable<IRedirectUrl> SearchRedirectUrls(int rootContentId, string searchTerm, long pageIndex, int pageSize, out long total)
+        {
+            using (var uow = UowProvider.GetUnitOfWork())
+            {
+                var repo = RepositoryFactory.CreateRedirectUrlRepository(uow);
+                var rules = repo.SearchUrls(rootContentId, searchTerm, pageIndex, pageSize, out total);
+                uow.Commit();
+                return rules;
+            }
+        }
     }
 }

--- a/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
+++ b/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
@@ -35,13 +35,27 @@ namespace Umbraco.Web.Editors
         [HttpGet]
         public RedirectUrlSearchResult SearchRedirectUrls(string searchTerm, int page = 0, int pageSize = 10)
         {
+            var user = Security.CurrentUser;
+            var userIsAdmin = user.IsAdmin();
+            var startContentId = user.StartContentId;
+
             var searchResult = new RedirectUrlSearchResult();
             var redirectUrlService = Services.RedirectUrlService;
             long resultCount;
+            IEnumerable<IRedirectUrl> redirects;
 
-            var redirects = string.IsNullOrWhiteSpace(searchTerm) 
-                ? redirectUrlService.GetAllRedirectUrls(page, pageSize, out resultCount)
-                : redirectUrlService.SearchRedirectUrls(searchTerm, page, pageSize, out resultCount);
+            if (userIsAdmin)
+            {
+                redirects = string.IsNullOrWhiteSpace(searchTerm)
+                    ? redirectUrlService.GetAllRedirectUrls(page, pageSize, out resultCount)
+                    : redirectUrlService.SearchRedirectUrls(searchTerm, page, pageSize, out resultCount);
+            }
+            else
+            {
+                redirects = string.IsNullOrWhiteSpace(searchTerm)
+                    ? redirectUrlService.GetAllRedirectUrls(startContentId, page, pageSize, out resultCount)
+                    : redirectUrlService.SearchRedirectUrls(startContentId, searchTerm, page, pageSize, out resultCount);
+            }
 
             searchResult.SearchResults = Mapper.Map<IEnumerable<ContentRedirectUrl>>(redirects).ToArray();
             //now map the Content/published url

--- a/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
+++ b/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
@@ -35,28 +35,16 @@ namespace Umbraco.Web.Editors
         [HttpGet]
         public RedirectUrlSearchResult SearchRedirectUrls(string searchTerm, int page = 0, int pageSize = 10)
         {
-            var user = Security.CurrentUser;
-            var userIsAdmin = user.IsAdmin();
-            var startContentId = user.StartContentId;
+            var startContentId = Security.CurrentUser.StartContentId;
 
             var searchResult = new RedirectUrlSearchResult();
             var redirectUrlService = Services.RedirectUrlService;
             long resultCount;
-            IEnumerable<IRedirectUrl> redirects;
 
-            if (userIsAdmin)
-            {
-                redirects = string.IsNullOrWhiteSpace(searchTerm)
-                    ? redirectUrlService.GetAllRedirectUrls(page, pageSize, out resultCount)
-                    : redirectUrlService.SearchRedirectUrls(searchTerm, page, pageSize, out resultCount);
-            }
-            else
-            {
-                redirects = string.IsNullOrWhiteSpace(searchTerm)
+            var redirects = string.IsNullOrWhiteSpace(searchTerm)
                     ? redirectUrlService.GetAllRedirectUrls(startContentId, page, pageSize, out resultCount)
                     : redirectUrlService.SearchRedirectUrls(startContentId, searchTerm, page, pageSize, out resultCount);
-            }
-
+            
             searchResult.SearchResults = Mapper.Map<IEnumerable<ContentRedirectUrl>>(redirects).ToArray();
             //now map the Content/published url
             foreach (var result in searchResult.SearchResults)


### PR DESCRIPTION
Redirect URL management now shows redirects based on what content you have access to.
Also created an overload for SearchRedirectUrls which takes rootContentId as argument.

This will only work for versions with just one start node.