### PR TITLE
U4-10184 - Fixed string splitting in MultipleTextStringValueConverter.

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultipleTextStringValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultipleTextStringValueConverter.cs
@@ -53,7 +53,7 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
             // Fall back on normal behaviour
             if (values.Any() == false)
             {
-                return sourceString.Split(Environment.NewLine.ToCharArray());
+                return sourceString.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
             }
 
             return values.ToArray();


### PR DESCRIPTION
It was wrongly splitting the string, because `Environment.NewLine.ToCharArray()` generates an array of two characters (`\r` and `\n`) which then splits the string on both characters.
So for example the string `Example 1\r\nExample 2` would be split into:
- "Example 1"
- ""
- "Example 2"

To fix this I have changed the string split to use `Environment.NewLine` as a whole string, which will correctly split the string and not end up with empty entries in the list.