### PR TITLE
Checking whether a request is over HTTPS before handling non HTTPS request

### DIFF
--- a/src/Umbraco.Web/Mvc/UmbracoRequireHttpsAttribute.cs
+++ b/src/Umbraco.Web/Mvc/UmbracoRequireHttpsAttribute.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Web.Mvc
         protected override void HandleNonHttpsRequest(AuthorizationContext filterContext)
         {
             // If umbracoUseSSL is set, let base method handle redirect.  Otherwise, we don't care.
-            if (GlobalSettings.UseSSL)
+            if (GlobalSettings.UseSSL && request.RequestUri.Scheme != Uri.UriSchemeHttps)
             {
                 base.HandleNonHttpsRequest(filterContext);
             }
@@ -33,7 +33,5 @@ namespace Umbraco.Web.Mvc
                 base.OnAuthorization(filterContext);
             }
         }
-
-
     }
 }


### PR DESCRIPTION
If a request is over SSL then we don't need to handle the request as a non SSL request.

This is necessary as HandleNonHttpsRequest just redirects to https without checking whether the original request was over https and causes a redirect loop.