### PR TITLE
Added Danish translation for "remove" in "general"

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -461,6 +461,7 @@
     <key alias="recycleBin">Papirkurv</key>
     <key alias="recycleBinEmpty">Din papirkurv er tom</key>
     <key alias="remaining">Mangler</key>
+    <key alias="remove">Fjern</key>
     <key alias="rename">Omdøb</key>
     <key alias="renew">Forny</key>
     <key alias="required" version="7.0">Påkrævet</key>


### PR DESCRIPTION
The Danish translation is missing in both 7.6 and 7.7 beta. The label is used by the new content picker (and probably other parts of Umbraco as well):

![image](https://user-images.githubusercontent.com/3634580/30523147-64c23ce0-9bdc-11e7-9a48-8d2de93fce72.png)