### PR TITLE
Added translations for labels when creating a new partial view

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -185,8 +185,10 @@
     <key alias="noDocumentTypes" version="7.0"><![CDATA[Der kunne ikke findes nogen tilladte dokument typer. Du skal tillade disse i indstillinger under <strong>"dokument typer"</strong>.]]></key>
     <key alias="noMediaTypes" version="7.0"><![CDATA[Der kunne ikke findes nogen tilladte media typer. Du skal tillade disse i indstillinger under <strong>"media typer"</strong>.]]></key>
     <key alias="documentTypeWithoutTemplate">Dokumenttype uden skabelon</key>
+    <key alias="newEmptyPartialView">Ny tom partial view</key>
     <key alias="newFolder">Ny mappe</key>
     <key alias="newDataType">Ny datatype</key>
+    <key alias="newPartialViewFromSnippet">Ny partial view fra snippet</key>
   </area>
   <area alias="dashboard">
     <key alias="browser">Til dit website</key>


### PR DESCRIPTION
I think "partial view" and "snippet" still makes sense in Danish, so I've only translated the text around it.

![image](https://user-images.githubusercontent.com/3634580/30524540-0ddf7db0-9bf6-11e7-8087-da288bd1a60e.png)
