### PR TITLE
Added missing Danish translation for "searchNoResult" in "general

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -467,6 +467,7 @@
     <key alias="retry">Prøv igen</key>
     <key alias="rights">Rettigheder</key>
     <key alias="search">Søg</key>
+    <key alias="searchNoResult">Beklager, vi kan ikke finde det, du leder efter.</key>
     <key alias="server">Server</key>
     <key alias="show">Vis</key>
     <key alias="showPageOnSend">Hvilken side skal vises efter at formularen er sendt</key>


### PR DESCRIPTION
Used in Umbraco's list views when the search query doesn't match any items.

I took the liberty to add a period at the end of the sentence, as I believe that is more correct (the English sentence doesn't have a period at the end).

![image](https://user-images.githubusercontent.com/3634580/30524581-033f4376-9bf7-11e7-8427-1574360dc9a6.png)

![image](https://user-images.githubusercontent.com/3634580/30524601-531b6fc8-9bf7-11e7-8542-fb6cda82f1bd.png)

