### PR TITLE
U4-10435 Unable to Change Username (Reverts After Save)

### DIFF
--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -550,7 +550,7 @@ namespace Umbraco.Web.Editors
 
             // if the found user has his email for username, we want to keep this synced when changing the email.
             // we have already cross-checked above that the email isn't colliding with anything, so we can safely assign it here.
-            if (found.Username == found.Email && userSave.Username != userSave.Email)
+            if (UmbracoConfig.For.UmbracoSettings().Security.UsernameIsEmail && found.Username == found.Email && userSave.Username != userSave.Email)
             {
                 userSave.Username = userSave.Email;
             }


### PR DESCRIPTION
http://issues.umbraco.org/issue/U4-10435

When UserNameIsEmail is false, don't force the username to become the email address.