### PR TITLE
U4-10440 - Fix image cropper z-index with focal point behind sticky bar

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -2,7 +2,7 @@
     position: fixed;
     overflow: hidden;
     background: @white;
-    z-index: 7500;
+    z-index: @zindexUmbOverlay;
     animation: fadeIn 0.2s;
     box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays/umb-overlay-backdrop.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays/umb-overlay-backdrop.less
@@ -3,7 +3,7 @@
    width: 100%;
    height: 100%;
    background-color: rgba(255, 255, 255, 0.50);
-   z-index: 2000;
+   z-index: @zindexOverlayBackdrop;
    top: 0;
    left: 0;
    animation: fadeIn 0.2s;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -304,7 +304,7 @@ ul.color-picker li a  {
   top: 0;
   left: 0;
   cursor: move;
-  z-index: 6001;
+  z-index: @zindexCropperOverlay;
   position: absolute;
 }
 
@@ -331,7 +331,7 @@ ul.color-picker li a  {
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 5999;
+  z-index: @zindexCropperOverlay - 1;
   -moz-opacity: .75;
   opacity: .75;
   filter: alpha(opacity=7);

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -438,6 +438,7 @@ ul.color-picker li a  {
         top: 3px;
         right: 3px;
         cursor: pointer;
+        z-index: 1;
     }
 
     .umb-close-cropper:hover {

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -230,6 +230,12 @@
 @zindexModalBackdrop:     1040;
 @zindexModal:             1050;
 
+@zindexUmbOverlay:        7500;
+@zindexOverlayBackdrop:   2000;
+
+// Sticky bar has a z-index of "500", which is set from javascript in directive
+// so set z-index of cropper should be lower to be behind sticky bar.
+@zindexCropperOverlay:    499;
 
 // Sprite icons path
 // -------------------------


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10440

The sticky bar get a z-index of 500 from the `umbStickyBar` directive:
https://github.com/umbraco/Umbraco-CMS/blob/9badb35c054ecc91630b69b1b6753c78427cb4a6/src/Umbraco.Web.UI.Client/src/common/directives/components/umbstickybar.directive.js#L131

This part of the css could be moved to `-umb-sticky-bar` class, so the directive just toggle (or add/remove) this class.
https://github.com/umbraco/Umbraco-CMS/blob/9badb35c054ecc91630b69b1b6753c78427cb4a6/src/Umbraco.Web.UI.Client/src/common/directives/components/umbstickybar.directive.js#L129-L133

and then in variables.less have:
```
@zindexUmbStickyBar:      500;
@zindexCropperOverlay:    @zindexUmbStickyBar - 1;
```

This affect that both focal point and close icon is on top of stickybar, e.g. if ImageCropper is placed below a grid editor or in media section.

![image](https://user-images.githubusercontent.com/2919859/30655177-7a494094-9e30-11e7-9ab7-bfe74d2e689d.png)

![image](https://user-images.githubusercontent.com/2919859/30655345-f21e6f40-9e30-11e7-9410-6c2e1a2f1e16.png)

To review:

- Ensure focal point is behind sticky bar
- Ensure crops is dragable in "crop mode".
- Ensure close button in "crop mode" is behind sticky bar