### PR TITLE
U4-10445 - Fix IE issues with user boxes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-avatar.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-avatar.less
@@ -6,6 +6,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    margin: 0 auto;
     color: @black;
     font-weight: bold;
     font-size: 16px;

--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-cards.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-cards.less
@@ -11,6 +11,8 @@
     flex: 0 0 100%;
     max-width: 100%;
     display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
 }
 
 .umb-user-card:hover,


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10445

This fix issue in IE11 where avatar not was centered horizontally.
Furthermore it also fix issue, where longer text not was wrapped inside the user box size, e.g. "Migrated Section Access Group 1".

**Before**
![image](https://user-images.githubusercontent.com/2919859/30719700-c582d94a-9f24-11e7-84a9-d4ee2889acb0.png)

**After**
![image](https://user-images.githubusercontent.com/2919859/30719726-eaf80db2-9f24-11e7-9a38-a78cf403fef2.png)

I have also checked in Chrome and Firefox, where the boxes still looks great.