### PR TITLE
U4-10446 - Fix IE issues with action button in tree

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -157,8 +157,8 @@
 
 .umb-tree li > div a:not(.umb-options) {
 	padding: 6px 0;
-	width: 100%;
 	display: flex;
+    flex: 1 1 100%;
 }
 
 .umb-tree li > div:hover a:not(.umb-options) {

--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -119,6 +119,7 @@
 
 .umb-tree div > a.umb-options {
 	visibility: hidden;
+    flex: 1 0 auto;
 }
 .umb-tree div:hover > a.umb-options {
 	visibility: visible;


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10446

Issue in IE11 with squeezed action button (dots).
![image](https://user-images.githubusercontent.com/2919859/30720879-a2ae3aea-9f29-11e7-8bcd-aae687caf051.png)

The tree menu items in IE11 has additional padding (as on touch devices) apparently because body has the class touch. Not sure if that is because my laptop screen support touch and IE somehow detect that. However that is not part of this issue/PR.

![image](https://user-images.githubusercontent.com/2919859/30721043-60c62862-9f2a-11e7-8c8f-c10e378db722.png)

Issue in IE10, where action button was pushed out of tree section, because of `width:100%`
![image](https://user-images.githubusercontent.com/2919859/30721203-33c948fc-9f2b-11e7-80f0-2af27850b232.png)

Now it looks like this in both IE10 and IE11.
![image](https://user-images.githubusercontent.com/2919859/30721262-8264afa6-9f2b-11e7-9869-ee7d17f3f96d.png)
