### PR TITLE
Fix for: U4-10444 - External Logins have stopped working since the 7.…

### DIFF
--- a/src/Umbraco.Core/Models/Identity/BackOfficeIdentityUser.cs
+++ b/src/Umbraco.Core/Models/Identity/BackOfficeIdentityUser.cs
@@ -42,6 +42,14 @@ namespace Umbraco.Core.Models.Identity
 
         private BackOfficeIdentityUser()
         {
+            _startMediaIds = new int[] { };
+            _startContentIds = new int[] { };
+            _groups = new IReadOnlyUserGroup[] { };
+            _allowedSections = new string[] { };
+            _culture = Configuration.GlobalSettings.DefaultUILanguage;
+            _groups = new IReadOnlyUserGroup[0];
+            _roles = new ObservableCollection<IdentityUserRole<string>>();
+            _roles.CollectionChanged += _roles_CollectionChanged;
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Core/Security/BackOfficeUserStore.cs
@@ -124,12 +124,15 @@ namespace Umbraco.Core.Security
             var found = _userService.GetUserById(asInt.Result);
             if (found != null)
             {
+                // we have to remember whether Logins property is dirty, since the UpdateMemberProperties will reset it.
+                var isLoginsPropertyDirty = user.IsPropertyDirty("Logins");
+
                 if (UpdateMemberProperties(found, user))
                 {
                     _userService.Save(found);
                 }
 
-                if (user.IsPropertyDirty("Logins"))
+                if (isLoginsPropertyDirty)
                 {
                     var logins = await GetLoginsAsync(user);
                     _externalLoginService.SaveUserLogins(found.Id, logins);


### PR DESCRIPTION
Fix for: U4-10444 - External Logins have stopped working since the 7.7.1 update when using auto linking.

See http://issues.umbraco.org/issue/U4-10444 for details