### PR TITLE
U4-10463: Fixes Backoffice opening custom section on login instead of content section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/routes.js
+++ b/src/Umbraco.Web.UI.Client/src/routes.js
@@ -10,10 +10,10 @@ app.config(function ($routeProvider) {
             /** Checks that the user is authenticated, then ensures that are requires assets are loaded */
             isAuthenticatedAndReady: function ($q, userService, $route, assetsService, appState) {
                 var deferred = $q.defer();
+                var routeParams = $route.current.params;
 
                 //don't need to check if we've redirected to login and we've already checked auth
-                if (!$route.current.params.section
-                    && ($route.current.params.check === false || $route.current.params.check === "false")) {
+                if (!routeParams.section && (routeParams.check === false || routeParams.rpcheck === "false")) {
                     deferred.resolve(true);
                     return deferred.promise;
                 }
@@ -31,10 +31,14 @@ app.config(function ($routeProvider) {
                             userService.getCurrentUser({ broadcastEvent: broadcast }).then(function (user) {
                                 //is auth, check if we allow or reject
                                 if (isRequired) {
+                                    if (routeParams.section.toLowerCase() === "default" || routeParams.section.toLowerCase() === "umbraco" || routeParams.section === "") {
+                                        routeParams.section = "content";
+                                    }
+
                                     // U4-5430, Benjamin Howarth
                                     // We need to change the current route params if the user only has access to a single section
                                     // To do this we need to grab the current user's allowed sections, then reject the promise with the correct path.
-                                    if (user.allowedSections.indexOf($route.current.params.section) > -1) {
+                                    if (user.allowedSections.indexOf(routeParams.section) > -1) {
                                         //this will resolve successfully so the route will continue
                                         deferred.resolve(true);
                                     } else {
@@ -102,10 +106,6 @@ app.config(function ($routeProvider) {
             template: "<div ng-include='templateUrl'></div>",
             //This controller will execute for this route, then we can execute some code in order to set the template Url
             controller: function ($scope, $route, $routeParams, $location, sectionService) {
-                if ($routeParams.section.toLowerCase() === "default" || $routeParams.section.toLowerCase() === "umbraco" || $routeParams.section === "") {
-                    $routeParams.section = "content";
-                }
-
                 //We are going to check the currently loaded sections for the user and if the section we are navigating
                 //to has a custom route path we'll use that 
                 sectionService.getSectionsForUser().then(function(sections) {


### PR DESCRIPTION
We have a custom backoffice section and since upgrading to Umbraco 7.7 the user is directed to that custom section rather than the content section when logging in. This happens because the backoffice defaults to the first available section, in alphabetical order - e.g. a custom section with an alias of "acustomsection" will load instead of "content".

When handling a routing request in the backoffice the Angular routing uses a resolve function called "canRoute" to determine if the user has permission to access the section trying to be loaded - this function is called before anything else happens, such as loading templates or controllers for the route. If the section being loaded isn't in the list of allowed sections for that user, the routing request is intercepted and the user is redirected to the first available section in alphabetical order. See: https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Web.UI.Client/src/routes.js#L37

The fix for U4-10227 caused this issue with this change: https://github.com/umbraco/Umbraco-CMS/pull/2120/files#diff-071d0ca68f9a7399d3ec7c7126e5e81dR104

Previously the "section" routeParam would already have been set before "canRoute" was called, including handling of empty / default section values, within the templateUrl function. The empty / default handling logic has now been moved to a controller which is called after the "canRoute" function and therefore the user is always redirected to the first available section.

To fix this I have moved the empty / default check on the section routeParams into the resolve function where it probably should have been in the first place...