### PR TITLE
U4-10464: Fixes selecting multiple list view items when item ID is int.MaxValue

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
@@ -269,7 +269,8 @@
             var isSelected = false;
             for (var i = 0; selection.length > i; i++) {
                 var selectedItem = selection[i];
-                if (item.id === selectedItem.id || item.key === selectedItem.key) {
+                // if item.id is 2147483647 (int.MaxValue) use item.key
+                if ((item.id !== 2147483647 && item.id === selectedItem.id) || item.key === selectedItem.key) {
                     isSelected = true;
                 }
             }
@@ -294,7 +295,8 @@
         function deselectItem(item, selection) {
             for (var i = 0; selection.length > i; i++) {
                 var selectedItem = selection[i];
-                if (item.id === selectedItem.id) {
+                // if item.id is 2147483647 (int.MaxValue) use item.key
+                if ((item.id !== 2147483647 && item.id === selectedItem.id) || item.key === selectedItem.key) {
                     selection.splice(i, 1);
                     item.selected = false;
                 }
@@ -366,7 +368,7 @@
                 var item = items[i];
 
                 if (checkbox.checked) {
-                    selection.push({ id: item.id });
+                    selection.push({ id: item.id, key: item.key });
                 } else {
                     clearSelection = true;
                 }
@@ -405,7 +407,8 @@
                 for (var selectedIndex = 0; selection.length > selectedIndex; selectedIndex++) {
                     var selectedItem = selection[selectedIndex];
 
-                    if (item.id === selectedItem.id) {
+                    // if item.id is 2147483647 (int.MaxValue) use item.key
+                    if ((item.id !== 2147483647 && item.id === selectedItem.id) || item.key === selectedItem.key) {
                         numberOfSelectedItem++;
                     }
                 }


### PR DESCRIPTION
Fixes selecting multiple items from a list view when the items don't have valid IDs, and therefore all fallback to int.MaxValue (2147483647). Currently it is only possible to select one item, any further attempts at selecting does nothing.

This affects all versions since v7.6.5 when my change was introduced to take note of item keys as a fallback to the integer based IDs for items in list view.

I submitted a fix for deleting items in listview as part of U4-9934 which was released in v7.6.5. However, I failed to notice a further issue with selecting multiple items in list view when the items are relying on keys instead of IDs.

To fix this I have implemented the ID / key checks on the other methods within listviewhelper.service.js