### PR TITLE
U4-10461 - Format dates using culture of current backoffice user

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function UserEditController($scope, $timeout, $location, $routeParams, formHelper, usersResource, contentEditingHelper, localizationService, notificationsService, mediaHelper, Upload, umbRequestHelper, usersHelper, authResource, dateHelper) {
+    function UserEditController($scope, $timeout, $location, $routeParams, formHelper, usersResource, userService, contentEditingHelper, localizationService, notificationsService, mediaHelper, Upload, umbRequestHelper, usersHelper, authResource, dateHelper) {
 
         var vm = this;
 
@@ -92,7 +92,7 @@
             });
         }
         
-        function getLocalDate(date, format) {
+        function getLocalDate(date, culture, format) {
             if(date) {
                 var dateVal;
                 var serverOffset = Umbraco.Sys.ServerVariables.application.serverTimeOffset;
@@ -105,7 +105,7 @@
                     dateVal = moment(date, "YYYY-MM-DD HH:mm:ss");
                 }
 
-                return dateVal.format(format);
+                return dateVal.locale(culture).format(format);
             }
         }
 
@@ -393,11 +393,14 @@
         }
 
         function formatDatesToLocal(user) {
-            user.formattedLastLogin = getLocalDate(user.lastLoginDate, "MMMM Do YYYY, HH:mm");
-            user.formattedLastLockoutDate = getLocalDate(user.lastLockoutDate, "MMMM Do YYYY, HH:mm");
-            user.formattedCreateDate = getLocalDate(user.createDate, "MMMM Do YYYY, HH:mm");
-            user.formattedUpdateDate = getLocalDate(user.updateDate, "MMMM Do YYYY, HH:mm");
-            user.formattedLastPasswordChangeDate = getLocalDate(user.lastPasswordChangeDate, "MMMM Do YYYY, HH:mm");
+            // get current backoffice user and format dates
+            userService.getCurrentUser().then(function (currentUser) {
+                user.formattedLastLogin = getLocalDate(user.lastLoginDate, currentUser.locale, "LLL");
+                user.formattedLastLockoutDate = getLocalDate(user.lastLockoutDate, currentUser.locale, "LLL");
+                user.formattedCreateDate = getLocalDate(user.createDate, currentUser.locale, "LLL");
+                user.formattedUpdateDate = getLocalDate(user.updateDate, currentUser.locale, "LLL");
+                user.formattedLastPasswordChangeDate = getLocalDate(user.lastPasswordChangeDate, currentUser.locale, "LLL");
+            });
         }
 
         init();

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function UsersController($scope, $timeout, $location, usersResource, userGroupsResource, localizationService, contentEditingHelper, usersHelper, formHelper, notificationsService, dateHelper) {
+    function UsersController($scope, $timeout, $location, usersResource, userGroupsResource, userService, localizationService, contentEditingHelper, usersHelper, formHelper, notificationsService, dateHelper) {
 
         var vm = this;
         var localizeSaving = localizationService.localize("general_saving");
@@ -583,7 +583,10 @@
                         dateVal = moment(user.lastLoginDate, "YYYY-MM-DD HH:mm:ss");
                     }
 
-                    user.formattedLastLogin = dateVal.format("MMMM Do YYYY, HH:mm");
+                    // get current backoffice user and format date
+                    userService.getCurrentUser().then(function (currentUser) {
+                        user.formattedLastLogin = dateVal.locale(currentUser.locale).format("LLL");
+                    });
                 }
             });
         }


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10461

I have formatted dates in the new user management using culture of current backoffice user like in datepicker: https://github.com/umbraco/Umbraco-CMS/blob/5397f2c53acbdeb0805e1fe39fda938f571d295a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js#L121 which used formats available in lib/moment/moment-with-locales.js

Path from Umbraco install: /umbraco/lib/moment/moment-with-locales.js

Now the dateformat is correct for a backoffice user with Danish culture.

![image](https://user-images.githubusercontent.com/2919859/30786880-7c38f390-a17d-11e7-88aa-f558650b5e5c.png)

![image](https://user-images.githubusercontent.com/2919859/30786888-9dcc2d10-a17d-11e7-9e3a-a8c7276bd9a8.png)

And a different format for e.g. English (en-US):

![image](https://user-images.githubusercontent.com/2919859/30786997-01b061fa-a180-11e7-8e8c-b48d1afe18fe.png)

![image](https://user-images.githubusercontent.com/2919859/30786988-d2a4b6f4-a17f-11e7-91a6-3736ab2bec0f.png)

Other parts of the missing localization has been added in PR https://github.com/umbraco/Umbraco-CMS/pull/2210