### PR TITLE
U4-10439 Email validation in installer, User and Member editor need t…

### DIFF
--- a/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
@@ -195,6 +195,12 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
             get { return GetOptionalTextElement("loginBackgroundImage", string.Empty); }
         }
 
+        [ConfigurationProperty("emailRegex")]
+        internal InnerTextConfigurationElement<string> EmailRegex
+        {
+            get { return GetOptionalTextElement("emailRegex", "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"); }
+        }
+
         string IContentSection.NotificationEmailAddress
         {
             get { return Notifications.NotificationEmailAddress; }
@@ -357,6 +363,11 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         string IContentSection.LoginBackgroundImage
         {
             get { return LoginBackgroundImage; }
+        }
+
+        string IContentSection.EmailRegex
+        {
+            get { return EmailRegex; }
         }
     }
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
@@ -198,7 +198,9 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         [ConfigurationProperty("emailRegex")]
         internal InnerTextConfigurationElement<string> EmailRegex
         {
-            get { return GetOptionalTextElement("emailRegex", "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"); }
+            // If this default needs to be updated then remember to also update
+            // val-email.spec.js - unfortunately the unit test seems to need a hardcoded regex
+            get { return GetOptionalTextElement("emailRegex", "^[a-z0-9!#$%&\'*+\\/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"); }
         }
 
         string IContentSection.NotificationEmailAddress

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
@@ -75,5 +75,7 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         bool EnablePropertyValueConverters { get; }
 
         string LoginBackgroundImage { get; }
+
+        string EmailRegex { get; }
     }
 }

--- a/src/Umbraco.Core/Security/MembershipProviderBase.cs
+++ b/src/Umbraco.Core/Security/MembershipProviderBase.cs
@@ -8,6 +8,7 @@ using System.Web;
 using System.Web.Configuration;
 using System.Web.Hosting;
 using System.Web.Security;
+using Umbraco.Core.Configuration;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 
@@ -677,10 +678,7 @@ namespace Umbraco.Core.Security
 
         internal static bool IsEmailValid(string email)
         {
-            const string pattern = @"^(?!\.)(""([^""\r\\]|\\[""\r\\])*""|"
-                                   + @"([-a-z0-9!#$%&'*+/=?^_`{|}~]|(?<!\.)\.)*)(?<!\.)"
-                                   + @"@[a-z0-9][\w\.-]*[a-z0-9]\.[a-z][a-z\.]*[a-z]$";
-
+            var pattern = UmbracoConfig.For.UmbracoSettings().Content.EmailRegex;
             return Regex.IsMatch(email, pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
         }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valemail.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valemail.directive.js
@@ -47,8 +47,8 @@ function valEmail(valEmailExpression) {
 angular.module('umbraco.directives.validation')
     .directive("valEmail", valEmail)
     .factory('valEmailExpression', function () {
-        //NOTE: This is the fixed regex which is part of the newer angular
+        var emailRegex = new RegExp(Umbraco.Sys.ServerVariables.umbracoSettings.emailRegex, "i");
         return {
-            EMAIL_REGEXP: /^[a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i
+            EMAIL_REGEXP: /^[^@\s]+@[^@\s]+\.[^@\s]+$/i
         };
     });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valemail.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valemail.directive.js
@@ -49,6 +49,6 @@ angular.module('umbraco.directives.validation')
     .factory('valEmailExpression', function () {
         var emailRegex = new RegExp(Umbraco.Sys.ServerVariables.umbracoSettings.emailRegex, "i");
         return {
-            EMAIL_REGEXP: /^[^@\s]+@[^@\s]+\.[^@\s]+$/i
+            EMAIL_REGEXP: emailRegex
         };
     });

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -18,7 +18,7 @@
 				<div class="control-group">
 					<label class="control-label" for="email">Email</label>
 					<div class="controls">
-						<input type="text" id="email" name="email" placeholder="you@example.com" required ng-model="installer.current.model.email" val-email />
+						<input type="email" id="email" name="email" placeholder="you@example.com" required ng-model="installer.current.model.email" val-email />
 						<small class="inline-help">Your email will be used as your login</small>
 					</div>
 				</div>

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.html
@@ -32,7 +32,7 @@
                                     <umb-control-group label="@general_email" required="true">
 
                                         <input
-                                            type="text"
+                                            type="email"
                                             localize="placeholder"
                                             placeholder="@placeholders_enteremail"
                                             class="input-block-level"

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.html
@@ -38,8 +38,8 @@
                                             class="input-block-level"
                                             ng-model="vm.user.email"
                                             umb-auto-focus name="email" 
-                                            required
                                             val-email
+                                            required
                                             val-server-field="Email" />
                                         <span class="help-inline" val-msg-for="email" val-toggle-msg="required"><localize key="general_required">Required</localize></span>
                                         <span class="help-inline" val-msg-for="email" val-toggle-msg="valServerField"></span>                                        

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.html
@@ -18,7 +18,7 @@
                 </umb-load-indicator>
 
                 <div ng-if="!vm.loading" class="umb-packages-view-wrapper" style="padding: 0;">
-
+                
                     <div class="umb-package-details">
 
                         <div class="umb-package-details__main-content">
@@ -30,17 +30,19 @@
                                 <umb-box-content class="block-form">
 
                                     <umb-control-group label="@general_email" required="true">
-                                        <input 
-                                            type="email" 
-                                            localize="placeholder" 
-                                            placeholder="@placeholders_enteremail" 
-                                            class="input-block-level" 
+
+                                        <input
+                                            type="text"
+                                            localize="placeholder"
+                                            placeholder="@placeholders_enteremail"
+                                            class="input-block-level"
                                             ng-model="vm.user.email"
                                             umb-auto-focus name="email" 
-                                            required 
+                                            required
+                                            val-email
                                             val-server-field="Email" />
                                         <span class="help-inline" val-msg-for="email" val-toggle-msg="required"><localize key="general_required">Required</localize></span>
-                                        <span class="help-inline" val-msg-for="email" val-toggle-msg="valServerField"></span>
+                                        <span class="help-inline" val-msg-for="email" val-toggle-msg="valServerField"></span>                                        
                                     </umb-control-group>
 
                                     <umb-control-group label="@general_username" ng-if="!vm.usernameIsEmail" required="true">
@@ -51,7 +53,7 @@
                                             class="input-block-level" 
                                             ng-model="vm.user.username"
                                             umb-auto-focus name="username" 
-                                            required 
+                                            required
                                             val-server-field="Username" />
                                         <span class="help-inline" val-msg-for="username" val-toggle-msg="required"><localize key="general_required">Required</localize></span>
                                         <span class="help-inline" val-msg-for="username" val-toggle-msg="valServerField"></span>

--- a/src/Umbraco.Web.UI.Client/test/unit/common/directives/val-email.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/directives/val-email.spec.js
@@ -27,7 +27,8 @@
             expect(valEmailExpression.EMAIL_REGEXP.test('a@3b.c')).toBe(true);
             expect(valEmailExpression.EMAIL_REGEXP.test('a@b')).toBe(true);
             expect(valEmailExpression.EMAIL_REGEXP.test('abc@xyz.financial')).toBe(true);
-            
+            expect(valEmailExpression.EMAIL_REGEXP.test('admin@c.pizza')).toBe(true);
+            expect(valEmailExpression.EMAIL_REGEXP.test('admin+gmail-syntax@c.pizza')).toBe(true);            
         });
     });
 

--- a/src/Umbraco.Web.UI/umbraco/Install/Views/Index.cshtml
+++ b/src/Umbraco.Web.UI/umbraco/Install/Views/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@using Umbraco.Web
+﻿@using Umbraco.Core.Configuration
+@using Umbraco.Web
 @using Umbraco.Web.Install.Controllers
 @{
     Layout = null;
@@ -66,6 +67,8 @@
             "installApiBaseUrl": "@ViewBag.InstallApiBaseUrl",
             "umbracoBaseUrl": "@ViewBag.UmbracoBaseFolder"
         };
+        Umbraco.Sys.ServerVariables.umbracoSettings = {};
+        Umbraco.Sys.ServerVariables.umbracoSettings.emailRegex = "@(UmbracoConfig.For.UmbracoSettings().Content.EmailRegex)";
     </script>
     <script src="lib/rgrove-lazyload/lazyload.js"></script>
     <script src="js/install.loader.js"></script>

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -287,6 +287,7 @@ namespace Umbraco.Web.Editors
                         },
                         {"keepUserLoggedIn", UmbracoConfig.For.UmbracoSettings().Security.KeepUserLoggedIn},
                         {"usernameIsEmail", UmbracoConfig.For.UmbracoSettings().Security.UsernameIsEmail},
+                        {"emailRegex", UmbracoConfig.For.UmbracoSettings().Content.EmailRegex},
                         {"cssPath", IOHelper.ResolveUrl(SystemDirectories.Css).TrimEnd('/')},
                         {"allowPasswordReset", UmbracoConfig.For.UmbracoSettings().Security.AllowPasswordReset},
                         {"loginBackgroundImage",  UmbracoConfig.For.UmbracoSettings().Content.LoginBackgroundImage},


### PR DESCRIPTION
…o be the same

http://issues.umbraco.org/issue/U4-10455

So a few things going on here:
1. The main problem here is that we're using the wrong regex in the Users section, our email validation directive was just using something that's outdated. That has been updated now (`valemail.directive.js`).
2. The email directive that was specifically built for this exact problem was not used, so an even more wrong regex was used, adding `val-email` in user.html fixes that. For `val-email` to actually work, this input needs to be of type `text` instead of `email`. Note I had to update the directive a little by instantiating a new Regex object, info in this SO reply: https://stackoverflow.com/a/874722/5018 (it wraps the configured regex in `/` and `/i` - just like it was before)
3. There was a different regex validation defined in `MembershipProviderBase` - I know it shouldn't be used any more, but while it is.. it's using the same validation now
4. I've made this regex configurable now, in case we want to allow people to make it more or less strict. I haven't added it to the config file but it's an option if we ever really need it, I think most people should be able to happily use the default.

