### PR TITLE
U4-10478: Bugfix where it would throw an IndexOutOfBounds 

### DIFF
--- a/src/Umbraco.Tests/Web/Mvc/HtmlStringUtilitiesTests.cs
+++ b/src/Umbraco.Tests/Web/Mvc/HtmlStringUtilitiesTests.cs
@@ -22,5 +22,40 @@ namespace Umbraco.Tests.Web.Mvc
             var expected = "<div><h1>hello world</h1><p>hello world<br />hello world<br />hello world<br />hello world</p></div>";
             Assert.AreEqual(expected, output);
         }
+
+        [Test]
+        public void TruncateWithElipsis()
+        {
+            var output = _htmlStringUtilities.Truncate("hello world", 5, true, false).ToString();
+            var expected = "hello&hellip;";
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void TruncateWithoutElipsis()
+        {
+            var output = _htmlStringUtilities.Truncate("hello world", 5, false, false).ToString();
+            var expected = "hello";
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void TruncateShorterWordThanHellip()
+        {
+            //http://issues.umbraco.org/issue/U4-10478
+            var output = _htmlStringUtilities.Truncate("hi", 5, true, false).ToString();
+            var expected = "hi";
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void TruncateAndRemoveSpaceBetweenHellipAndWord()
+        {
+            var output = _htmlStringUtilities.Truncate("hello world", 6 /* hello plus space */, true, false).ToString();
+            var expected = "hello&hellip;";
+            Assert.AreEqual(expected, output);
+        }
+
+
     }
 }

--- a/src/Umbraco.Web/HtmlStringUtilities.cs
+++ b/src/Umbraco.Web/HtmlStringUtilities.cs
@@ -92,6 +92,8 @@ namespace Umbraco.Web
 
             using (var outputms = new MemoryStream())
             {
+                bool lengthReached = false;
+
                 using (var outputtw = new StreamWriter(outputms))
                 {
                     using (var ms = new MemoryStream())
@@ -106,7 +108,6 @@ namespace Umbraco.Web
                             using (TextReader tr = new StreamReader(ms))
                             {
                                 bool isInsideElement = false,
-                                    lengthReached = false,
                                     insideTagSpaceEncountered = false,
                                     isTagClose = false;
 
@@ -254,10 +255,15 @@ namespace Umbraco.Web
 
                         //Check to see if there is an empty char between the hellip and the output string
                         //if there is, remove it
-                        if (string.IsNullOrWhiteSpace(firstTrim) == false)
+                        if (addElipsis && lengthReached && string.IsNullOrWhiteSpace(firstTrim) == false)
                         {
                             result = firstTrim[firstTrim.Length - hellip.Length - 1] == ' ' ? firstTrim.Remove(firstTrim.Length - hellip.Length - 1, 1) : firstTrim;
                         }
+                        else
+                        {
+                            result = firstTrim;
+                        }
+
                         return new HtmlString(result);
                     }
                 }


### PR DESCRIPTION
when passing a word shorter than &hellip; to Truncate it would throw an IndexOutOfBounds exception and crash. Now checks whether the input wanted an elipsis and also if it reached the end (because in that case the &hellip; was added to the string and thus, would be able to count with the length of it without stepping outside).