### PR TITLE
U4-10503 Umbraco plugins cache files should be stored in the same local temp location as the umbraco xml cache file

### DIFF
--- a/src/Umbraco.Core/PluginManager.cs
+++ b/src/Umbraco.Core/PluginManager.cs
@@ -489,7 +489,8 @@ namespace Umbraco.Core
                     break;
                 case LocalTempStorage.Default:
                 default:
-                    pluginHashFilePath =  Path.Combine(_pluginListFilePath, "umbraco-plugins." + NetworkHelper.FileSafeMachineName + ".hash");
+                    var tempFolder = IOHelper.MapPath("~/App_Data/TEMP/PluginCache");
+                    pluginHashFilePath =  Path.Combine(tempFolder, "umbraco-plugins." + NetworkHelper.FileSafeMachineName + ".hash");
                     break;
             }
 

--- a/src/Umbraco.Core/PluginManager.cs
+++ b/src/Umbraco.Core/PluginManager.cs
@@ -343,7 +343,7 @@ namespace Umbraco.Core
             {
                 return ReadCache();
             }
-            catch
+            catch (Exception ex)
             {
                 try
                 {
@@ -503,8 +503,7 @@ namespace Umbraco.Core
 
         internal void UpdateCache()
         {
-            // note
-            // at the moment we write the cache to disk every time we update it. ideally we defer the writing
+            // TODO: at the moment we write the cache to disk every time we update it. ideally we defer the writing
             // since all the updates are going to happen in a row when Umbraco starts. that being said, the
             // file is small enough, so it is not a priority.
             WriteCache();
@@ -520,7 +519,7 @@ namespace Umbraco.Core
                 {
                     return new FileStream(path, fileMode, fileAccess, fileShare);
                 }
-                catch
+                catch (Exception ex)
                 {
                     if (--attempts == 0)
                         throw;

--- a/src/Umbraco.Core/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Core/Sync/DatabaseServerMessenger.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Core.Sync
         private bool _syncing;
         private bool _released;
         private readonly ProfilingLogger _profilingLogger;
-        private Lazy<string> _distCacheFilePath = new Lazy<string>(GetDistCacheFilePath);
+        private readonly Lazy<string> _distCacheFilePath = new Lazy<string>(GetDistCacheFilePath);
 
         protected DatabaseServerMessengerOptions Options { get; private set; }
         protected ApplicationContext ApplicationContext { get { return _appContext; } }

--- a/src/Umbraco.Tests/Models/ContentTests.cs
+++ b/src/Umbraco.Tests/Models/ContentTests.cs
@@ -20,7 +20,7 @@ using Umbraco.Tests.TestHelpers.Entities;
 namespace Umbraco.Tests.Models
 {
     [TestFixture]
-    public class ContentTests : BaseUmbracoConfigurationTest
+    public class ContentTests : BaseUmbracoApplicationTest
     {
         [SetUp]
         public void Init()

--- a/src/Umbraco.Tests/TestHelpers/BaseUmbracoApplicationTest.cs
+++ b/src/Umbraco.Tests/TestHelpers/BaseUmbracoApplicationTest.cs
@@ -119,24 +119,11 @@ namespace Umbraco.Tests.TestHelpers
         }
 
         /// <summary>
-        /// By default this returns false which means the plugin manager will not be reset so it doesn't need to re-scan
-        /// all of the assemblies. Inheritors can override this if plugin manager resetting is required, generally needs
-        /// to be set to true if the SetupPluginManager has been overridden.
-        /// </summary>
-        protected virtual bool PluginManagerResetRequired
-        {
-            get { return false; }
-        }
-
-        /// <summary>
         /// Inheritors can resset the plugin manager if they choose to on teardown
         /// </summary>
         protected virtual void ResetPluginManager()
         {
-            if (PluginManagerResetRequired)
-            {
-                PluginManager.Current = null;
-            }
+            PluginManager.Current = null;
         }        
 
         protected virtual CacheHelper CreateCacheHelper()
@@ -185,26 +172,23 @@ namespace Umbraco.Tests.TestHelpers
         /// </summary>
         protected virtual void SetupPluginManager()
         {
-            if (PluginManager.Current == null || PluginManagerResetRequired)
+            PluginManager.Current = new PluginManager(
+                new ActivatorServiceProvider(),
+                CacheHelper.RuntimeCache, ProfilingLogger, false)
             {
-                PluginManager.Current = new PluginManager(
-                    new ActivatorServiceProvider(),
-                    CacheHelper.RuntimeCache, ProfilingLogger, false)
+                AssembliesToScan = new[]
                 {
-                    AssembliesToScan = new[]
-                    {
-                        Assembly.Load("Umbraco.Core"),
-                        Assembly.Load("umbraco"),
-                        Assembly.Load("Umbraco.Tests"),
-                        Assembly.Load("businesslogic"),
-                        Assembly.Load("cms"),
-                        Assembly.Load("controls"),
-                        Assembly.Load("umbraco.editorControls"),
-                        Assembly.Load("umbraco.MacroEngines"),
-                        Assembly.Load("umbraco.providers"),
-                    }
-                };
-            }
+                    Assembly.Load("Umbraco.Core"),
+                    Assembly.Load("umbraco"),
+                    Assembly.Load("Umbraco.Tests"),
+                    Assembly.Load("businesslogic"),
+                    Assembly.Load("cms"),
+                    Assembly.Load("controls"),
+                    Assembly.Load("umbraco.editorControls"),
+                    Assembly.Load("umbraco.MacroEngines"),
+                    Assembly.Load("umbraco.providers"),
+                }
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
This ensures the DistCache file uses the same configured temp location as the plugin cache files and that the App_Data/Temp/PluginCache folder is not eagerly created