### PR TITLE
Remove negative marginfrom grid re-order bar.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -206,3 +206,7 @@
     position: relative;
     transform: translate(-50%, -25%);
 }
+
+.nested-content__content .umb-editor-sub-header {
+    margin-top: 0;
+}


### PR DESCRIPTION
Issue U4-10529 : When you have a grid item inside a nested content item, the re-order bar overlays the field above.

this PR just removes the negative margin from the grid-reorder items bar, when it is inside a nested content item. 

it still works when you scroll to the top, but it doesn't block the field above - when not scrolled. 