### PR TITLE
U4-10528 - Add better function to get initials from name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbavatar.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbavatar.directive.js
@@ -66,9 +66,13 @@ Use this directive to render an avatar.
 
             function getNameInitials(name) {
                 if(name) {
-                    var initials = name.match(/\b\w/g) || [];
-                    initials = ((initials.shift() || '') + (initials.pop() || '')).toUpperCase();
-                    return initials;
+                    var names = name.split(' '),
+                        initials = names[0].substring(0, 1);
+
+                    if (names.length > 1) {
+                        initials += names[names.length - 1].substring(0, 1);
+                    }
+                    return initials.toUpperCase();
                 }
                 return null;
             }


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10528

This PR add a better function to get initials from name. The existing function is similar to this one https://stackoverflow.com/a/33076482/1693918 but it doesn't work with special characters like Danish `æ`, `ø` and `å`.. or characters like `ü` and `é`.
It will simple ignore these characters and go to next character in the string. Try for example with this regex tester: https://regex101.com/
E.g. try some of these names: https://stackoverflow.com/a/28373431/1693918

_Éric Ígor_
Before: RG
Now: ÉÍ

_Chris O'Donnell_
Before: CD
Now: CO

This Angular 2 component here https://angularscript.com/universal-avatar-component-angular-2-avatar/ also seem to work like the above examples.
https://angularscript.com/universal-avatar-component-angular-2-avatar/
https://github.com/HaithemMosbahi/ngx-avatar
Demo link: https://stackblitz.com/edit/ngx-avatar-demo ( try change some of the names in this file https://stackblitz.com/edit/ngx-avatar-demo?file=app%2Fapp.component.html )

![image](https://user-images.githubusercontent.com/2919859/31520981-1ef6e3b6-afa8-11e7-909f-2abb95d78f29.png)

I have instead used this function: https://stackoverflow.com/a/33076323/1693918

![image](https://user-images.githubusercontent.com/2919859/31521035-4b6b4324-afa8-11e7-818c-351a27a3b305.png)

Maybe also consider if some characters should be excluded, e.g. `,` `.` `:` ;` ` `_` etc.
![image](https://user-images.githubusercontent.com/2919859/31521783-1b02c358-afab-11e7-9dc2-8b6e861833d2.png)

The old method did exclude `,`, `.`  and `@` but not in this new method. Maybe there is a better regex for this to handle initials of names, but exclude special characters like these?

![image](https://user-images.githubusercontent.com/2919859/31521841-57c436b4-afab-11e7-9a61-20e0c3431c5e.png) ![image](https://user-images.githubusercontent.com/2919859/31521945-c5583c52-afab-11e7-9ed0-04363b7036e9.png)

