### PR TITLE
Add events for handling rendered data by application tree controller

### DIFF
--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -14,6 +14,7 @@ using Umbraco.Web.WebApi.Filters;
 using Constants = Umbraco.Core.Constants;
 
 using umbraco;
+using Umbraco.Core.Events;
 
 namespace Umbraco.Web.Trees
 {
@@ -21,6 +22,8 @@ namespace Umbraco.Web.Trees
     [PluginController("UmbracoTrees")]
     public class ApplicationTreeController : UmbracoAuthorizedApiController
     {
+        public static event TypedEventHandler<ApplicationTreeController, ApplicationTreeRenderingEventArgs> ApplicationTreeNodeRendering;
+
         /// <summary>
         /// Returns the tree nodes for an application
         /// </summary>
@@ -72,6 +75,9 @@ namespace Umbraco.Web.Trees
 
             var multiTree = SectionRootNode.CreateMultiTreeSectionRoot(rootId, collection);
             multiTree.Name = ui.Text("sections", application);
+
+            ApplicationTreeNodeRendering?.Invoke(this, new ApplicationTreeRenderingEventArgs(application, tree, queryStrings, multiTree));
+
             return multiTree;
         }
 

--- a/src/Umbraco.Web/Trees/ApplicationTreeRenderingEventArgs.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeRenderingEventArgs.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Formatting;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Web.Models.Trees;
+
+namespace Umbraco.Web.Trees
+{
+    public class ApplicationTreeRenderingEventArgs : EventArgs
+    {
+        public string Application { get; }
+        public string Tree { get; }
+        public FormDataCollection QueryStrings { get; }
+        public SectionRootNode SectionRootNode { get; }
+
+        public ApplicationTreeRenderingEventArgs(string application, string tree, FormDataCollection queryStrings, SectionRootNode root)
+        {
+            Application = application;
+            Tree = tree;
+            QueryStrings = queryStrings;
+            SectionRootNode = root;
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -491,6 +491,7 @@
     <Compile Include="Models\Mapping\PropertyTypeGroupResolver.cs" />
     <Compile Include="Security\Identity\PreviewAuthenticationMiddleware.cs" />
     <Compile Include="SingletonHttpContextAccessor.cs" />
+    <Compile Include="Trees\ApplicationTreeRenderingEventArgs.cs" />
     <Compile Include="Trees\UserTreeController.cs" />
     <Compile Include="Suspendable.cs" />
     <Compile Include="Trees\ContentBlueprintTreeController.cs" />


### PR DESCRIPTION
There is the need to hide some application trees. The reason I created this pull request is somehow to satisfy one of the 3 points which I enumerated here:

https://our.umbraco.org/forum/developing-packages/87713-custom-section-tree-node-route-path-takes-from-view-folder#comment-280533

This could allow to develop a plugin for non CRUD entities (or entities which they have more contextual meaning that simply objects)