### PR TITLE
Fixes  U4-9401 Double slashes in some Umbraco generated urls causes broken links

### DIFF
--- a/src/Umbraco.Web/UriUtility.cs
+++ b/src/Umbraco.Web/UriUtility.cs
@@ -70,7 +70,7 @@ namespace Umbraco.Web
 				if (!GlobalSettings.UseDirectoryUrls)
 					path += ".aspx";
                 else if (UmbracoConfig.For.UmbracoSettings().RequestHandler.AddTrailingSlash)
-					path += "/";
+				    path = path.EnsureEndsWith("/");
 			}
 
 			path = ToAbsolute(path);


### PR DESCRIPTION
Now uses `path.EnsureEndsWith("/")` instead of simply appending it without first checking there wasn't already a trailing slash.