### PR TITLE
U4-10609 - Fix missing end closing <div> in login screen

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
@@ -151,7 +151,8 @@
               <label><localize key="general_password">Password</localize></label>
               <div class="password-toggle">
                 <input type="password" ng-model="password" name="password" class="-full-width-input" localize="placeholder" placeholder="@placeholders_password" autocomplete="off" /><a ng-click="togglePassword()">Toggle</a>
-             </div>
+              </div>
+            </div>
 
             <div class="flex justify-between items-center">
               <button type="submit" class="btn btn-success" val-trigger-change="#login .form input"><localize key="general_login">Login</localize></button>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10609

Probably one of the smallest PR's, but a major impact on the UI caused by the missing end closing `<div>` tag.