### PR TITLE
U4-9142 - Multiple Related Links pickers on same Document Type not working

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/relatedlinks/relatedlinks.controller.js
@@ -86,6 +86,10 @@
             };
 
             $scope.add = function ($event) {
+				if (!angular.isArray($scope.model.value)) {
+                  $scope.model.value = [];
+				}
+				
                 if ($scope.newCaption == "") {
                     $scope.hasError = true;
                 } else {


### PR DESCRIPTION
Checking if $scope.model.value is an array on the add method.