### PR TITLE
Switching between sections - select last node

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
@@ -3,7 +3,7 @@
 * @name umbraco.directives.directive:umbSections
 * @restrict E
 **/
-function sectionsDirective($timeout, $window, navigationService, treeService, sectionService, appState, eventsService, $location) {
+function sectionsDirective($timeout, $window, navigationService, treeService, sectionService, appState, eventsService, $location, historyService) {
     return {
         restrict: "E",    // restrict to an element
         replace: true,   // replace the html element with the template
@@ -161,7 +161,9 @@ function sectionsDirective($timeout, $window, navigationService, treeService, se
                     $location.path(section.routePath);
                 }
                 else {
-                    $location.path(section.alias).search('');
+                    var lastAccessed = historyService.getLastAccessedItemForSection(section.alias);
+                    var path = lastAccessed != null ? lastAccessed.link : section.alias;                  
+                    $location.path(path).search('');
                 }
 			    
 			};

--- a/src/Umbraco.Web.UI.Client/src/common/services/history.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/history.service.js
@@ -115,6 +115,27 @@ angular.module('umbraco.services')
 		 */
 		getCurrent: function(){
 			return nArray;
-		}
+        },
+
+        /**
+		 * @ngdoc method
+		 * @name umbraco.services.historyService#getLastAccessedItemForSection
+		 * @methodOf umbraco.services.historyService
+		 *
+		 * @description
+		 * Method to return the item that was last accessed in the given section
+		 *
+         * @param {string} sectionAlias Alias of the section to return the last accessed item for.
+		 */
+        getLastAccessedItemForSection: function (sectionAlias) {
+            for (var i = 0, len = nArray.length; i < len; i++) {
+                var item = nArray[i];
+                if (item.link.indexOf(sectionAlias + "/") === 0) {
+                    return item;
+                }
+            }
+
+            return null;
+        }
 	};
 });


### PR DESCRIPTION
When returning to a previously visited section, will open the last selected node within that section immediately again, if any.