### PR TITLE
Contribution guidelines moved to .github directory

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to the Umbraco CMS
+
+We're really glad you're reading this - [#h5yr](http://h5yr.com)! People like you can contribute and help us make Umbraco CMS even greater! The following descriptions provide you information on how you can contribute to different parts of the project. 
+
+Remember that contribution is not just `code` but can also be:
+- constructive discussion and [issues reports](issues.umbraco.org)
+- contribution to documentation
+- providing translations to language files
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change. 
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. **Fork** the repository
+2. **Clone** the fork to your local machine
+3. **Build** & **Run** the solution
+4. Create new **branch** with a proper name and then make changes
+5. **Commit** & **Push** to your fork
+6. Submit a **Pull Request**
+
+At this point, you're waiting on us. We like to at least comment on, if not accept, pull requests as soon as possible. We may also suggest some changes, improvements or alternatives to proposed solution. It's not the end yet!
+
+## Coding Conventions
+
+When developing new `Class Libraries` we will be adhereing as closely as possible to the official guidelines as proposed by Microsoft -http://msdn.microsoft.com/en-us/library/ms229042.aspx
+
+Another good reference is "Framework Design Guidelines: Conventions, Idioms, and Patterns for Reusable .NET Libraries" book by Krzysztof Cwalina and Brad Abrams.
+
+Resharper settings are included with the solution, so developers can cleanup code in a consistent manner.
+
+A special note about whitespace is in order. Usage should follow Visual Studio defaults which is 4 spaces for pretty much everything except for XML, which uses 2 spaces instead (again, this is the Visual Studio defaults).
+
+## Detailed Resources
+
+### [First Timers](FIRST_TIMERS.md)
+
+This is a place for you if the journey with contributing to Open Source is just beginning. We're a friendly bunch however and want you to be successful without bureaucracy. If you're just looking for a quick guide on how to get started then follow steps here.
+
+### [Core Contribution Guidelines](CORE_CONTRIBUTION_GUIDELINES.md)
+
+Would you like to contribute to the Umbraco project? The best way to get started is to first read the information in this section which provides the guidelines for contribution to the Core.
+
+### [Documentation Contribution](DOCUMENTATION_CONTRIBUTION.md)
+
+Documentation is an important part of the Umbraco project. That's why we have a dedicated project devoted just to that. Find out how you can contribute to the Documentation project.
+
+### [Issues and Features Requests](ISSUES_AND_FEATURES_REQUESTS.md)
+
+Report any bugs or suggest features on our issue tracker. It's as same important as coding solutions for them, so please be as detailed as you can. Find out how to report them in a way that helps us to help you!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We're really glad you're reading this - [#h5yr](http://h5yr.com)! People like you can contribute and help us make Umbraco CMS even greater! The following descriptions provide you information on how you can contribute to different parts of the project. 
 
 Remember that contribution is not just `code` but can also be:
-- constructive discussion and [issues reports](issues.umbraco.org)
+- constructive discussion and [issues reports](http://issues.umbraco.org)
 - contribution to documentation
 - providing translations to language files
 

--- a/.github/CORE _CONTRIBUTION_GUIDELINES.md
+++ b/.github/CORE _CONTRIBUTION_GUIDELINES.md
@@ -1,0 +1,164 @@
+# Guidelines for Core Contribution
+
+This document contains the proposed plan of action for how to approach involvement of the community and the continued development of the Umbraco v4 core.
+
+## Roles in the HQ
+
+The roles occupied by HQ staff members are as follows:
+
+**Umbraco Core:**
+- Shannon Deminick
+- Sebastiaan Janssen
+- Mads Rasmussen
+- Rune Strand
+- Simon Busborg
+- Claus Jensen
+- Stéphane Gay
+
+**Product Owner:**
+- Niels Hartvig
+
+**Scrum master / Project Manager:**
+- Sebastiaan Janssen
+
+**Documentation Project Owner:**
+- Rune Strand
+
+## Core team process
+
+Umbraco HQ uses the Scrum process in order to establish a fixed team that can build up a velocity helping us improve as a development team - both in regards to the amount of tasks (story points) that can be completed within a Sprint and with regards to planning a release (Sprint).
+
+The idea is to have 4 x two week Sprints that over a 8 week period results in a release - either Major or Minor release. The type of release shouldn't matter as ultimately it is about having a deliverable as the end result. At the end of each Sprint will be a working product, which combined makes up a deliverable (eg. a release).
+Patch releases will appear every 4 weeks and will only contain bug fixes, a patch released is planned for a certain date but if there's a pressing need to do a release then this can happen at any time. The next patch release will then be scheduled for 4 weeks after that again. 
+
+The roles include a Product Owner, Scrum Master and Scrum team(s).
+
+The Product Owner will create a backlog of prioritized items, which are pulled into the Sprints during planning. Seeing as we are creating a long term road map, some tasks will be predefined, but it's important to note that the scrum team has to commit to these tasks before the road map is valid.
+
+The road map might contain loosely defined tasks, which need to be made concrete for a given Sprint. It might also be necessary to pull in additional tasks if the road map does not contain enough tasks for the team to work on.
+
+The planning process will occur on a monthly basis after each release.
+
+The backlog of items/tasks are open to both the Scrum team(s) and outside contributors. Before tasks can be pulled from the backlog to a Sprint it should be approved by the Scrum master, as they are the one with the overview.
+
+There will be one fixed Scrum team consisting of HQ Core developers that will be the main drivers of the road map. Aside from this, contributors can form their own teams and work on tasks (features, bug fixes etc) as agreed upon with the Scrum master.
+
+Contributors can of course also work individually and their contributions (pull requests) will be assessed and if accepted merged according to how it fits the current plan (road map) and Sprint log.
+
+To the extent it's possible the Product Owner should write User Stories for new features, whereas bug fixes and other smaller tasks will remain a simple description of the task at hand.
+
+The team will gradually start to add story points to the tasks in a Sprint during Sprint planning, so we can start recording the fixed team's velocity. This will however take some time to implement, so we should not stress to spend time on writing user stories and assigning story points - this is a process that will evolve over time.
+
+## Adoption of SemVer (www.semver.org)
+
+Versioning is an important aspect of the project as it should clearly communicate with the community information about each release and where each release fits on the road map. The easy and obvious choice is to use Semantic Versioning, which is a well defined set of rules for when to change version number based major, minor and patch changes.
+
+Using this semantic versioning will also help in terms of the road map, as it will be clear when there is a need to change major and minor numbers based on the tasks being implemented for a specific release. Below is the two most important rules, which should be considered when planning the road map.
+
+"Minor version Y (x.Y.z | x > 0) MUST be incremented if new, backwards compatible functionality is introduced to the public API. It MUST be incremented if any public API functionality is marked as deprecated. It MAY be incremented if substantial new functionality or improvements are introduced within the private code. It MAY include patch level changes. Patch version MUST be reset to 0 when minor version is incremented."
+
+"Major version X (X.y.z | X > 0) MUST be incremented if any backwards incompatible changes are introduced to the public API. It MAY include minor and patch level changes. Patch and minor version MUST be reset to 0 when major version is incremented."
+
+Semantic versioning will also be used for nuget packages, so we can provide pre-release packages for testing - ie. Umbraco.4.8.0-beta.nupkg.
+
+## Approving features and breaking changes - RFC
+
+Whenever the Core team or contributors want to implement a new "larger" feature or introduce breaking changes, a 'request for comments' should be submitted to the Core mailing list detailing the proposed changes and/or additions.
+
+**An RFC should at best and to the extent of the proposed changes contain the following:**
+
+- Documentation
+  - Why should the proposed changes be implemented in the Core?
+  - How should it be integrated?
+  - What are the consequences of the proposed changes - will it break or deprecate anything meaning major or minor release?
+- Proof of concept or pseudo code if it makes sense
+- Await feedback and assess whether to go ahead or rethink the proposed changes.
+
+## Working with branches
+
+Each major release (4, 6, 7, etc...) has 2 branches: 'master-x' and 'dev-x' named according to the major version. (i.e. master-v7 and dev-v7).
+
+The 'master-x' branch is the baseline branch for a given major version and is the stable version of the current release. The 'dev-x' branch is the current development branch for a given major version. Any time a new version of Umbraco is released, the 'dev-x' branch will be tagged at the revision of the release with the release name and merged in to the 'master-x' branch.
+
+If you are creating pull requests, you should do so on the 'dev-'x branch. If you want to work with the latest stable released code, you should clone the 'master-x' branch.
+
+New features for Umbraco will normally be done on a feature/WIP (work in progress) branch that will be branched from the 'dev-x' branch and merged back in when that feature is complete. Feature branches should be named accordingly and prefixed with the 'dev-x' branch it was created from. i.e. dev-v7-LocalizationService
+
+When working on "normal" tasks or bug fixes, they should be committed to the 'dev-x' branch along with clear notes in the comments about the task or bug that the commit address'. ie. 
+
+Fixes: U4-97 Enable RTE label as default
+
+All developers should commit early, commit often and make sure to push changes to the remote repository - inspired by http://www.codinghorror.com/blog/2008/08/check-in-early-check-in-often.html
+
+When working on features or bug fixes in a fork the targeted branch should be used. Eg. when working on a feature for version 7.2.0 then commit changes to that branch. Also make sure to get the fork up-to-date before submitting a pull request, so that merging conflicts and the possibility that the pull request is rejected can be avoided.
+
+## Contributing to the Umbraco Core
+
+Direct commit access to the source code repository is limited to the Core team. This rule is enforced to ensure the stability of the core and to ensure that velocity is maintained and releases are not affected by code containing errors. Contributors should fork the project and send patches or pull requests, which will be reviewed by the Scrum master and Core team before being committed to the main branch/repository.
+
+As Contributors and Contribution teams start to learn the development workflow they may be granted access to commit to the main repository, and will be governed by the same guidelines for working with branches as the Core team.
+
+**The flow for contributing new features or bug fixes is as follows:**
+
+1. Contact the Scrum master / Project manager from Umbraco HQ with a note about what you wish to work on.
+2. Once agreement on when this addition/improvement fits in, fork the repository and start working.
+3. Work is implemented in the branch that corresponds to the release that the work is targeted at.
+4. When work is complete, update the fork from the main branch and ensure all code is working and tested. Once satisfied send a patch / pull request.
+5. Once the contribution has been reviewed by the Core team it will either be merged into the main repository or rejected with reasoning.
+
+All contributors should consider writing unit tests for the code they are implementing - whenever it makes sense. It is not a must to write unit tests, but it is encouraged for new features and bug fixes that are not "100%" UI centric.
+
+Umbraco fully respects that contributors have limited time, and might not be able to work on features or bug fixes within a fixed timeframe. We will therefore be as flexible as possible with regards to the above flow of contributing.
+
+## (Naming) Conventions
+
+When developing new Class Libraries we will be adhereing as closely as possible to the official guidelines as proposed by Microsoft -http://msdn.microsoft.com/en-us/library/ms229042.aspx
+
+Another good reference is "Framework Design Guidelines: Conventions, Idioms, and Patterns for Reusable .NET Libraries" book by Krzysztof Cwalina and Brad Abrams
+
+Resharper settings are included with the solution, so developers can cleanup code in a consistent manner.
+
+A special note about `whitespace` is in order. Usage should follow Visual Studio defaults which is **4 spaces** for pretty much everything except for XML, which uses **2 spaces** instead (again, this is the Visual Studio defaults).
+
+## Reviews of code contributions
+
+These are the things that will be looked at before your patch/pull request can be accepted.
+
+- Is there a Issue ID attached?
+- For non-major releases:
+  - The workitem shouldn't introduce breaking API changes (results of API call changes, method signature changes)
+  - Any large behavioral changes should be avoided for anything except for major release
+- Are the coding standards followed?
+  - [Coding standards guidelines documentation](https://our.umbraco.org/documentation/Development-Guidelines/Coding-Standards/)
+- Does the code compile and work? 
+  - Unit tests to verify that the code works
+  - Otherwise: communicate, make sure the reviewer knows what the code is supposed to do
+- Does it add value?
+  - For example: is this not solving something that might be slated for a release in the near future (i.e. should we spend time on this now if it's going to change within 2 months?)
+  - But also: is this really something we want in the core? If you're not sure, before you start writing code, make sure to post to the core dev mailing list to see if you're on the right path 
+- Any security implications? Think about:
+  - Data Validation
+  - Authentication
+  - Session Management
+  - Authorization
+  - Cryptography
+  - Consult OWASP when in doubt
+
+## Release naming conventions
+
+Umbraco releases should be named as follows (according to SemVer) for consistency.
+
+**Source code repository:**
+- UmbracoCms.7.7.0.zip
+- UmbracoCms.7.7.0-beta.zip (for pre-release)
+- UmbracoCms.Source.7.7.0.zip
+- UmbracoCms.WebPI.7.7.0.zip
+
+**Nightlies:**
+- UmbracoCms.7.7.0-build.297 (where 297 is the build number - AssemblyVersion 7.7.0.297)
+
+**Nuget:**
+- UmbracoCms.7.7.0.nupkg
+- UmbracoCms.7.7.0-beta.nupkg (for pre-release)
+- UmbracoCms.Core.7.7.0.nupkg
+- UmbracoCms.SqlCE.7.7.0.nupkg

--- a/.github/DOCUMENTATION_CONTRIBUTION.md
+++ b/.github/DOCUMENTATION_CONTRIBUTION.md
@@ -1,0 +1,11 @@
+# Contribute to the Documentation
+
+Documentation is a major part of the Umbraco project as it allows users and developers to come to grips with ins and outs of the system.  There is nothing more frustrating than trying to understand an API or feature when there is no official documentation explaining how it works! This was one of the reasons why the documentation project was created.  By helping contribute to the documentation project you are not only helping those that currently use Umbraco, but also the multitude of developers who are new to the platform.
+
+The scope of this project is to provide overviews of concepts, tutorials, example code, and links to API references. It is always a work in progress, and we welcome valuable contributions from anyone willing to help. For details on how to contribute, see further down this page.
+
+The documentation project lives at GitHub which provides an effective way of managing project documentation. 
+
+To browse the documentation at **GitHub** visit: https://github.com/umbraco/UmbracoDocs.
+
+To contribute, follow the general contribution guidelines and we're waiting for your PRs!

--- a/.github/FIRST_TIMERS.md
+++ b/.github/FIRST_TIMERS.md
@@ -34,11 +34,11 @@ If you want to see the process done with GitHub client for Windows, watch
 
 Once the repository is cloned on your local machine, open the folder where you cloned it to and go into the "build" folder. From there you can run `build.bat` file. 
 
-This will set up everything for you and runs MSBuild and the Grunt build for you. Don't worry if you have no idea what that all means, it's all automatic and should look something like on the video [here](https://www.youtube.com/watch?v=nZHQeB3mCzo).
+This will set up everything for you and runs MSBuild and the Gulp build for you. Don't worry if you have no idea what that all means, it's all automatic and should look something like on the video [here](https://www.youtube.com/watch?v=nZHQeB3mCzo).
 
 Now that everything is set up for you, go into the "src" folder and open `umbraco.sln` in Visual Studio. 
 
-Once that loads you can hit **F5** or press the **"Play" button** to start the solution. 
+Once that loads set the startup project to **Umbraco.Web.UI** and hit **F5** or press the **"Play" button** to start the solution. 
 
 After a few minutes, you will see the Umbraco installer which will guide you through setting up a new Umbraco website. The process is exactly the same as for the standard Umbraco installation. You can preview it on the video [here](https://www.youtube.com/watch?v=7CMdRf-fxlg).
 

--- a/.github/FIRST_TIMERS.md
+++ b/.github/FIRST_TIMERS.md
@@ -1,0 +1,75 @@
+# First Timers
+
+We hear sometimes that people find it difficult to wrap their head around the contribution guidelines we have. This page shows you how to get started in small steps. The lengthy documentation we'll save for you to read another day. Get started, do something, instead of being paralyzed in fear of doing it wrong. Don't worry, we're a friendly bunch and love to help.
+
+## Pull Request Process
+
+1. **Fork** the repository
+2. **Clone** the fork to your local machine
+3. **Build** & **Run** the solution
+4. Create new **branch** with a proper name and then make changes
+5. **Commit** & **Push** to your fork
+6. Submit a **Pull Request**
+
+## Fork the repository
+
+The first thing to do is go to https://github.com/umbraco/Umbraco-CMS and click the "Fork" button at the top right. This copies the Umbraco repository into your own account so you can start editing in a safe environment.
+
+![Forking the repo](https://our.umbraco.org/media/7514491/2016-06-21_132516.png?width=958&height=524)
+
+After clicking the "Fork" button you'll have to wait a few seconds and the repository will land on your GitHub account.
+
+## Clone the fork to your local machine
+
+You can follow the instructions on GitHub to get the repository cloned to your local machine. If you have GitHub for Windows installed this should be easy with the click of "Open in Desktop".
+
+![Cloning the repo](https://our.umbraco.org/media/7514492/2016-06-21_133506.png?width=456&height=196)
+
+If you have any other Git client installed, copy the URL and past it into the clone dialog of your preferred Git client. 
+
+If you want to see the process done with GitHub client for Windows, watch 
+[this video](http://www.youtube.com/watch?v=BhzOoyvCDcU).
+
+## Build & run the solution
+
+Once the repository is cloned on your local machine, open the folder where you cloned it to and go into the "build" folder. From there you can run `build.bat` file. 
+
+This will set up everything for you and runs MSBuild and the Grunt build for you. Don't worry if you have no idea what that all means, it's all automatic and should look something like on the video [here](https://www.youtube.com/watch?v=nZHQeB3mCzo).
+
+Now that everything is set up for you, go into the "src" folder and open `umbraco.sln` in Visual Studio. 
+
+Once that loads you can hit **F5** or press the **"Play" button** to start the solution. 
+
+After a few minutes, you will see the Umbraco installer which will guide you through setting up a new Umbraco website. The process is exactly the same as for the standard Umbraco installation. You can preview it on the video [here](https://www.youtube.com/watch?v=7CMdRf-fxlg).
+
+Once this site is running you can start changing the code in Umbraco anywhere you need to change it. When you're done changing, hit **F5 / the "Play" button**, verify that your fix worked in the Umbraco site that you now have and then it's time to commit your changes.
+
+## Create new branch and make changes
+
+First of all, make sure to create a new branch from the proper development branch (e.g. `dev-v7` for Umbraco 7 development). This ensures that you can work on multiple pull requests at once. Otherwise you'd have to wait for us to evaluate the PR first and merge it in before you can do anything else. 
+
+It's a great idea to name the branch after the issue your fixing on the issue tracker. If you're working on issue U4-7879 then create a branch named U4-7879.
+
+![Create new branch](https://our.umbraco.org/media/7514493/2016-06-21_151310.png?width=579&height=228)
+
+Then you can commit your changes. Make sure to commit to the correct branch.
+
+![Commit your changes](https://our.umbraco.org/media/7514494/2016-06-21_151415.png?width=1000&height=622.5328947368421)
+
+Finally, you can push your changes. In the GitHub for Windows app this is called "Sync" (top right) in other git applications it's usually called "Push". This pushes the changes to your personal copy of the Umbraco repository after which you're ready to send a pull request.
+
+## Submit a Pull Request
+
+If you go to your fork on GitHub you can switch to the branch you've just created. From that branch you can press the "Compare & pull request" button.
+
+![Submit a Pull Request](https://our.umbraco.org/media/7514496/2016-06-21_152345.png?width=996&height=221)
+
+You'll be asked to give a description after which you can open the pull request. You can follow our [Pull Request Template](PULL_REQUEST_TEMPLATE.md) to make it clear and descriptive. **Remember this is the start of a conversation, you can open a pull request with some example code and ask us how to continue.** If you already have working code that's great too, we can and will give you feedback on the pull request.
+
+You will then be redirected to an overview screen where you will also see the build status. Each pull request will be automatically built for you on our build server so that we know it builds and the unit tests still work.
+
+![PR comments](https://our.umbraco.org/media/7514498/2016-06-21_152737.png?width=784&height=565)
+
+## That's it!
+
+Again, we might ask questions or ask you to correct something. This is easy: make the corrections in this branch an push them to your fork again. The pull request automatically updates with the additional commit so we can review it again. If all is well, we'll merge the code and your commits are forever part of Umbraco!

--- a/.github/ISSUES_AND_FEATURES_REQUESTS.md
+++ b/.github/ISSUES_AND_FEATURES_REQUESTS.md
@@ -1,0 +1,69 @@
+# Issues and Features Requests
+
+Umbraco is great! But sometimes there are issues that need to be resolved, or features that you would like added to make it that much greaterer...erer. To help us make Umbraco better, the Core team needs your help and you can do this through well crafted bug reports and feature requests.  The following information are tips on how you can submit a well written bug report.
+
+## Where do I submit a bug report?
+
+To submit a bug report visit http://issues.umbraco.org
+
+Before you are able to submit new issues you will need to be a registered user. Once you are registered create new issues by clicking the Create Issue link aat to the top of the screen. This will reveal the following form: http://issues.umbraco.org/dashboard#newissue=yes
+
+Please try and make sure that your bug report or feature request follows this format for the title.
+
+[Feature Request], [version], [descriptive title]
+
+An example issue report: [ISSUE_TEMPLATE.md](ISSUE_TEMPLATE.md).
+
+A list of existing issues can be found here: http://issues.umbraco.org/issues
+
+Please note: **The more information you can give us, the better it helps the Core team assign a priority to your issue.**
+
+## Writing a good bug report
+
+Writing a good bug report helps us to identify issues quicker and ultimately provide you with a more stable Umbraco. The following tips will help you write a good bug report.
+
+**1. Identify that it's actually a bug**
+
+    Sometimes you're just doing it wrong but thinking it's a bug.  Make sure that what you are experiencing is actually a bug and that it can be repeated.
+
+**2. Don't create duplicate tickets**
+
+    Try to find out if someone else has already reported the issue. You can search the existing issues here.  If they have why not add to their report that you are experiencing the same issue, also providing any additional information you have over and above their report that could help solve the problem.
+
+**3. Provide the step-by-step**
+
+    Work out the steps it takes to create the bug and write them down as accurately as you can.  Maybe even consider recording a Screenr if you think that it would help.
+
+**4. Version is important**
+
+    Make sure you tell us what version of Umbraco you are using as you might be experiencing the bug with that bleeding edge nightly because the code is not finished yet :)
+
+**5. Write descriptive titles**
+
+    Within reason try and make your ticket title reveal as much as possible. Doesn't need to be a novel, just be descriptive.  E.g.
+4.8.0 Unable to insert anchors in TinyMCE in chrome.
+This provides quite a bit of information straight away :)
+
+**6. Copy any error text into the report**
+
+    Saying "It's broken! fix it!" is not going to help you or anyone.  Even if you don't know what caused the error most of the time there will be some sort of error message or error page displayed that you can either screenshot or copy into the report to help the Core team diagnose the issue.
+
+**7. Explain your environment**
+
+    We don't mean that you sit at a wooden desk, and have a small pot plant that you have named Jerry.  We mean things that might help us work out the issue like, the site is running in medium trust, it's a shared host, it's IIS6, it's SQL Server, the browser is IE6 etc  Any information that you can provide about the environment that you have Umbraco running in can help with the diagnosis.
+
+**8. Code references help**
+
+    If you are one of those people who have the Umbraco Source on your machine and are capable of debugging, why not give us the code reference to where the issue is, or better yet why not fix it yourself and submit a pull request!
+
+**9. Expected behaviour**
+
+    If you know what the expected behaviour should be let us know because we may not see it the way you do.  It can help us understand how you expect to work with that feature.
+
+**10. Report each issue separately**
+
+    Do not send us ten issue in a single bug report.  Send us one issue per ticket. This helps us to delegate the issues out to the right developers and also saves us a bunch of busy work splitting your ticket into smaller workable chunks.
+
+**11. Feature requests are not bugs**
+
+    Just because the system doesn't have the feature you want, doesn't mean its a bug.  Make sure you label feature requests as such so they don't get mixed up in the bug hunt.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+Your report will have a greater chance of being addressed if you can give us clear steps to reproduce the issue, please answer the following questions in as much detail as possible:
+
+### What did you do?
+
+### What did you expect to happen?
+
+### What actually happened?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Pull Request for Issue # .
+
+### Summary of Changes
+
+### Testing Instructions
+
+### Expected Result
+
+### Actual Result
+
+### Documentation Changes Required


### PR DESCRIPTION
Pull Request for issue [#U4-10619](http://issues.umbraco.org/issue/U4-10619).

### Summary of Changes

After short talk with Sebastian we decided that we can switch from keeping this documentation on content pages on Our into proper Github docs. After it'll be merged the URLs / paths should be updated on Our.

So I've moved the documentation for the contribution process from the Our content page into proper and suggested CONTRIBUTION.md file displayed for all possible future contributors on Github.

I've also added some additional files like PR template and Issue report template.

Some of the legacy sections were removed and some of them requires HQ's attention for sure, but at summary - it's a huge step forward.

### Documentation Changes Required

It's a documentation change itself :)