### PR TITLE
Fixes missing content type check.

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Interfaces/IContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Interfaces/IContentRepository.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Core.Persistence.Repositories
         /// <remarks>
         /// We require this on the repo because the IQuery{IContent} cannot supply the 'newest' parameter
         /// </remarks>
-        int CountPublished();
+        int CountPublished(string contentTypeAlias = null);
 
         /// <summary>
         /// Used to bulk update the permissions set for a content item. This will replace all permissions

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -62,7 +62,7 @@ namespace Umbraco.Core.Services
             using (var uow = UowProvider.GetUnitOfWork(readOnly: true))
             {
                 var repository = RepositoryFactory.CreateContentRepository(uow);
-                return repository.CountPublished();
+                return repository.CountPublished(contentTypeAlias);
             }
         }
 


### PR DESCRIPTION
The parameter is now passed through to the repository and works as expected.

For details of issue, see:

http://issues.umbraco.org/issue/U4-9613