### PR TITLE
Temp u4 10626

### DIFF
--- a/src/Umbraco.Core/ApplicationContext.cs
+++ b/src/Umbraco.Core/ApplicationContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
 using System.Threading;
 using Umbraco.Core.Configuration;
@@ -280,7 +281,9 @@ namespace Umbraco.Core
 	    // ReSharper disable once InconsistentNaming
 	    internal string _umbracoApplicationUrl;
 
-	    internal string _umbracoApplicationDeploymentId;
+        internal List<string> _umbracoApplicationDomains = new List<string>();
+
+        internal string _umbracoApplicationDeploymentId;
 
         private Lazy<bool> _configured;
         internal MainDom MainDom { get; private set; }

--- a/src/Umbraco.Core/ApplicationContext.cs
+++ b/src/Umbraco.Core/ApplicationContext.cs
@@ -280,6 +280,8 @@ namespace Umbraco.Core
 	    // ReSharper disable once InconsistentNaming
 	    internal string _umbracoApplicationUrl;
 
+	    internal string _umbracoApplicationDeploymentId;
+
         private Lazy<bool> _configured;
         internal MainDom MainDom { get; private set; }
 

--- a/src/Umbraco.Core/ApplicationContext.cs
+++ b/src/Umbraco.Core/ApplicationContext.cs
@@ -260,13 +260,21 @@ namespace Umbraco.Core
         /// - http://issues.umbraco.org/issue/U4-5728
         /// - http://issues.umbraco.org/issue/U4-5391
         /// </remarks>
-        internal string UmbracoApplicationUrl
+        public string UmbracoApplicationUrl
         {
             get
             {
                 ApplicationUrlHelper.EnsureApplicationUrl(this);
                 return _umbracoApplicationUrl;
             }
+        }
+
+        /// <summary>
+        /// Resets the url.
+        /// </summary>
+        public void ResetUmbracoApplicationUrl()
+        {
+            _umbracoApplicationUrl = null;
         }
 
 	    // ReSharper disable once InconsistentNaming

--- a/src/Umbraco.Core/Sync/ApplicationUrlHelper.cs
+++ b/src/Umbraco.Core/Sync/ApplicationUrlHelper.cs
@@ -3,6 +3,7 @@ using System.Web;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.IO;
+using Umbraco.Core.Logging;
 using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Core.Sync
@@ -46,8 +47,14 @@ namespace Umbraco.Core.Sync
         // settings: for unit tests only
         internal static void EnsureApplicationUrl(ApplicationContext appContext, HttpRequestBase request = null, IUmbracoSettingsSection settings = null)
         {
-            // if initialized, return
-            if (appContext._umbracoApplicationUrl != null) return;
+            // if initialized and on the same DeploymentId, return
+            var deplayomentId = Environment.ExpandEnvironmentVariables("%WEBSITE_SITE_NAME%");
+            if (appContext._umbracoApplicationUrl != null && appContext._umbracoApplicationDeploymentId == deplayomentId) return;
+
+            if (appContext._umbracoApplicationDeploymentId != deplayomentId)
+                LogHelper.Info(typeof(ApplicationUrlHelper), $"DeploymentId changed: {deplayomentId}");
+
+            appContext._umbracoApplicationDeploymentId = deplayomentId;
 
             var logger = appContext.ProfilingLogger.Logger;
 


### PR DESCRIPTION
Pull request to U4-10626 issue.

**Summary of Changes**
I store a list of detected Application Urls.

When a request from not listed domain appears _umbracoApplicationUrl is updated.

Now, after swap in Azure Envirament, ApplicationUrl is updated. Thanks to that, when adding a new Umbraco user, the invitation email contains correct activation url.