### PR TITLE
Feature Request: Double Click Content Node to Expand

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -36,7 +36,7 @@ angular.module("umbraco.directives")
         // this will greatly improve performance since there's potentially a lot of nodes being rendered = a LOT of watches!
 
         template: '<li ng-class="{\'current\': (node == currentNode), \'has-children\': node.hasChildren}" on-right-click="altSelect(node, $event)">' +
-            '<div ng-class="getNodeCssClass(node)" ng-swipe-right="options(node, $event)" >' +
+            '<div ng-class="getNodeCssClass(node)" ng-swipe-right="options(node, $event)" ng-dblclick="load(node)" >' +
             //NOTE: This ins element is used to display the search icon if the node is a container/listview and the tree is currently in dialog
             //'<ins ng-if="tree.enablelistviewsearch && node.metaData.isContainer" class="umb-tree-node-search icon-search" ng-click="searchNode(node, $event)" alt="searchAltText"></ins>' + 
             '<ins ng-class="{\'icon-navigation-right\': !node.expanded || node.metaData.isContainer, \'icon-navigation-down\': node.expanded && !node.metaData.isContainer}" ng-click="load(node)">&nbsp;</ins>' +


### PR DESCRIPTION
Doube-clicking a tree item now expands or collapses a node. It basically does what clicking the triangle left of the node would do. Only difference is the ng-click will fire regardless as well, which will select the node upon double-clicking it.

This works in all sections, not just the Content section.
