### PR TITLE
U4-10639 - Fix square "add" button in imagepicker prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -283,7 +283,7 @@ ul.color-picker li a  {
 
 .umb-sortable-thumbnails .umb-sortable-thumbnails__wrapper {
     width: 120px;
-    height: 100px;
+    height: 114px;
     overflow: hidden;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -281,6 +281,12 @@ ul.color-picker li a  {
     display: block;
 }
 
+.umb-sortable-thumbnails .umb-sortable-thumbnails__wrapper {
+    width: 120px;
+    height: 100px;
+    overflow: hidden;
+}
+
 .umb-sortable-thumbnails .umb-sortable-thumbnails__actions {
     position: absolute;
     bottom: 10px;
@@ -308,6 +314,7 @@ ul.color-picker li a  {
     justify-content: center;
     align-items: center;
     margin-left: 5px;
+    text-decoration: none;
 }
 
 .umb-sortable-thumbnails .umb-sortable-thumbnails__action.-red {

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/imagepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/imagepicker.controller.js
@@ -4,7 +4,6 @@ function imageFilePickerController($scope) {
         $scope.mediaPickerOverlay = {
             view: "mediapicker",
             disableFolderSelect: true,
-            disableFolderSelect: true,
             onlyImages: true,
             show: true,
             submit: function (model) {

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/imagepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/imagepicker.controller.js
@@ -1,20 +1,26 @@
 function imageFilePickerController($scope) {
 
-    $scope.pick = function() {
-        $scope.mediaPickerDialog = {};
-        $scope.mediaPickerDialog.view = "mediapicker";
-        $scope.mediaPickerDialog.show = true;
-
-        $scope.mediaPickerDialog.submit = function(model) {
-            $scope.model.value = model.selectedImages[0].image;
-            $scope.mediaPickerDialog.show = false;
-            $scope.mediaPickerDialog = null;
+    $scope.add = function() {
+        $scope.mediaPickerOverlay = {
+            view: "mediapicker",
+            disableFolderSelect: true,
+            disableFolderSelect: true,
+            onlyImages: true,
+            show: true,
+            submit: function (model) {
+                $scope.model.value = model.selectedImages[0].image;
+                $scope.mediaPickerOverlay.show = false;
+                $scope.mediaPickerOverlay = null;
+            },
+            close: function () {
+                $scope.mediaPickerOverlay.show = false;
+                $scope.mediaPickerOverlay = null;
+            }
         };
+    };
 
-        $scope.mediaPickerDialog.close = function(oldModel) {
-            $scope.mediaPickerDialog.show = false;
-            $scope.mediaPickerDialog = null;
-        };
+    $scope.remove = function () {
+        $scope.model.value = null;
     };
 
 }

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/imagepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/imagepicker.html
@@ -1,19 +1,28 @@
 <div ng-controller="Umbraco.PrevalueEditors.ImageFilePickerController" class="umb-editor umb-mediapicker">
-    <ul class="umb-sortable-thumbnails">
-        <li>
-            <img ng-src="{{model.value}}" alt="" ng-show="model.value">
-            <a href class="picked-image" ng-click="model.value = null" ng-show="model.value"><i class="icon icon-delete"></i></a>
+
+    <ul class="umb-sortable-thumbnails" ng-if="model.value">
+        <li class="umb-sortable-thumbnails__wrapper">
+            <img ng-src="{{model.value}}" alt="">
+
+            <div class="umb-sortable-thumbnails__actions">
+                <!--<a class="umb-sortable-thumbnails__action" href="" ng-click="goToItem(image)">
+                    <i class="icon icon-edit"></i>
+                </a>-->
+                <a class="umb-sortable-thumbnails__action -red" href="" ng-click="remove()">
+                    <i class="icon icon-delete"></i>
+                </a>
+            </div>
         </li>
     </ul>
 
-    <a href ng-click="pick()" class="umb-mediapicker add-link" ng-hide="model.value">
+    <a href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': !model.value }" ng-hide="model.value" prevent-default>
         <i class="icon icon-add large"></i>
     </a>
 
     <umb-overlay
-      ng-if="mediaPickerDialog.show"
-      model="mediaPickerDialog"
-      view="mediaPickerDialog.view"
+      ng-if="mediaPickerOverlay.show"
+      model="mediaPickerOverlay"
+      view="mediaPickerOverlay.view"
       position="right">
     </umb-overlay>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -19,6 +19,8 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
             $scope.images = [];
             $scope.ids = [];
 
+            $scope.isMultiPicker = multiPicker;
+
             if ($scope.model.value) {
                 var ids = $scope.model.value.split(',');
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -4,7 +4,7 @@
     <p ng-if="(images|filter:{trashed:true}).length > 1"><localize key="mediaPicker_pickedTrashedItems"></localize></p>
 
     <div class="flex error">
-        <ul ui-sortable="sortableOptions" ng-model="images" class="umb-sortable-thumbnails">
+        <ul ui-sortable="sortableOptions" ng-model="images" ng-if="images.length > 0" class="umb-sortable-thumbnails">
             <li class="umb-sortable-thumbnails__wrapper" ng-repeat="image in images">
 
                 <!-- IMAGE -->
@@ -30,8 +30,8 @@
                 </div>
 
             </li>
-
         </ul>
+
         <a href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': images.length === 0}" ng-if="showAdd()" prevent-default>
             <i class="icon icon-add large"></i>
         </a>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -5,7 +5,7 @@
 
     <div class="flex error">
         <ul ui-sortable="sortableOptions" ng-model="images" class="umb-sortable-thumbnails">
-            <li style="width: 120px; height: 100px; overflow: hidden;" ng-repeat="image in images">
+            <li class="umb-sortable-thumbnails__wrapper" ng-repeat="image in images">
 
                 <!-- IMAGE -->
                 <img ng-class="{'trashed': image.trashed}" ng-src="{{image.thumbnail}}" alt="" ng-show="image.thumbnail" title="{{image.trashed ? 'Trashed: ' + image.name : image.name}}" />

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -2,7 +2,7 @@
 
     <p ng-if="(images|filter:{trashed:true}).length == 1"><localize key="mediaPicker_pickedTrashedItem"></localize></p>
     <p ng-if="(images|filter:{trashed:true}).length > 1"><localize key="mediaPicker_pickedTrashedItems"></localize></p>
-
+    
     <div class="flex error">
         <ul ui-sortable="sortableOptions" ng-model="images" ng-if="images.length > 0" class="umb-sortable-thumbnails">
             <li class="umb-sortable-thumbnails__wrapper" ng-repeat="image in images">
@@ -32,7 +32,7 @@
             </li>
         </ul>
 
-        <a href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': images.length === 0}" ng-if="showAdd()" prevent-default>
+        <a href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': (images.length === 0 || isMultiPicker)}" ng-if="showAdd()" prevent-default>
             <i class="icon icon-add large"></i>
         </a>
     </div>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10639

This PR fix the issue where the "add" button in imagepicker prevalue editor no longer was a square.
Furthermore it was also an issue with the selected image not was visible because it unlike media picker property editor didn't had the inline css (I have moved these inline styles, so it can be reused on both media picker and imagepicker prevalue editor).

I have also made the imagepicker prevalue editor a bit more consistent with media picker property editor, e.g. the actions (edit, delete). However it doesn't have an edit button, since it only store the image url in model value (should it store an object or udi in future versions maybe?).

Finally I have also disabled folder select and set onlyImages to true.

**Before**
![image](https://user-images.githubusercontent.com/2919859/32457193-8183bcd2-c328-11e7-9451-5bb812fd999c.png)

**After**
![image](https://user-images.githubusercontent.com/2919859/32457222-b0432a9e-c328-11e7-9873-07c348df8547.png)

Test:
- Image "add link" is square in mediapicker property editor and imagepicker prevalue editor
- Image can be added and removed in mediapicker editor and imagepicker prevalue editor
- Test imagepicker and mediapicker prevalue editor on grid row/column

```
{
    "label": "Background image",
    "description": "Choose an image",
    "key": "background-image",
    "view": "imagepicker",
    "modifier": "url('{0}')"
}
```

```
{
    "label": "Background image",
    "description": "Choose an image",
    "key": "background-image",
    "view": "mediapicker",
    "modifier": "url('{0}')"
}
```