### PR TITLE
U4-10495 - Install and customize buttons disabled

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -18,7 +18,7 @@
 				<div class="control-group">
 					<label class="control-label" for="email">Email</label>
 					<div class="controls">
-						<input type="email" id="email" name="email" placeholder="you@example.com" required ng-model="installer.current.model.email" val-email />
+						<input type="email" id="email" name="email" placeholder="you@example.com" val-email required ng-model="installer.current.model.email" />
 						<small class="inline-help">Your email will be used as your login</small>
 					</div>
 				</div>


### PR DESCRIPTION
This has been broken since the input type was changed from text to email.

Moving the val-email attribute before required attribute fixes this, as discussed in
https://github.com/umbraco/Umbraco-CMS/pull/2215:

> "required needed to be AFTER val-email. The other way around and Angular validation kicks in, which is the wrong validation."