### PR TITLE
password field on Installer now has a show/hide button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -2,6 +2,8 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
     
     $scope.passwordPattern = /.*/;
     $scope.installer.current.model.subscribeToNewsLetter = true;
+    $scope.pwInputType = "password";
+    $scope.showPassword = false;
     
     if ($scope.installer.current.model.minNonAlphaNumericLength > 0) {
         var exp = "";
@@ -11,7 +13,7 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
         //replace duplicates
         exp = exp.replace(".*.*", ".*");            
         $scope.passwordPattern = new RegExp(exp);
-    }
+    };
 
 	$scope.validateAndInstall = function(){
 			installerService.install();
@@ -21,6 +23,16 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
 			if(this.myForm.$valid){
 				installerService.forward();
 			}
-	};
+    };
+
+    $scope.toggleShowPassword = function () {
+        //$scope.showPassword = !$scope.showPassword;
+        if ($scope.showPassword) {
+            $scope.pwInputType = "text";
+        }
+        else {
+            $scope.pwInputType = "password";
+        }
+    };
 	
 });

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -27,13 +27,14 @@
 					<label class="control-label" for="password">Password</label>
 					<div class="controls">
 						<!-- why isn't this masked: http://www.nngroup.com/articles/stop-password-masking/ -->
-					    <input type="text" name="installer.current.model.password" 
-					           ng-minlength="{{installer.current.model.minCharLength}}" 
-					           ng-pattern="passwordPattern"
-					           autocorrect="off"
-					           autocapitalize="off"
-					           autocomplete="off"
-                               required 
+                        <!-- why this should maybe be optional: http://passwordmasking.com/ -->
+                        <input type="{{pwInputType}}" name="installer.current.model.password"
+                               ng-minlength="{{installer.current.model.minCharLength}}"
+                               ng-pattern="passwordPattern"
+                               autocorrect="off"
+                               autocapitalize="off"
+                               autocomplete="off"
+                               required
                                ng-model="installer.current.model.password" id="password" />
 					    <small class="inline-help">At least {{installer.current.model.minCharLength}} characters long</small>
 					    
@@ -41,8 +42,14 @@
 					        At least {{installer.current.model.minNonAlphaNumericLength}} symbol{{installer.current.model.minNonAlphaNumericLength > 1 ? 's' : ''}}
 					    </small>
 					</div>
+                    
 				</div>
-
+                <div class="control-group">
+                    <div class="controls">
+                        <input type="checkbox" ng-click="toggleShowPassword()" ng-model="showPassword"/>
+                        Show password
+                    </div>
+                </div> 
 
 				<div class="control-group">
 					<div class="controls">


### PR DESCRIPTION
Changes the installer password field's default behaviour to hidden, adds a "show password"

from 
![image](https://user-images.githubusercontent.com/7046713/32500449-5d05a730-c3cd-11e7-91b4-ac3ccbcf0ee4.png)

to 
![image](https://user-images.githubusercontent.com/7046713/32500479-7728dbf0-c3cd-11e7-98b4-7f772b9d38ad.png)

