### PR TITLE
U4-9237 Validate application parameter when getting application trees

### DIFF
--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -34,11 +34,7 @@ namespace Umbraco.Web.Trees
         [HttpQueryStringFilter("queryStrings")]
         public async Task<SectionRootNode> GetApplicationTrees(string application, string tree, FormDataCollection queryStrings, bool onlyInitialized = true)
         {
-            // define valid application pattern
-            // only letters, numbers, hyphens, underscores
-            Regex validRegex = new Regex("^[a-zA-Z0-9_-]*$");
-
-            if (validRegex.IsMatch(application) == false) throw new HttpRequestValidationException();
+            application = application.CleanForXss();
 
             if (string.IsNullOrEmpty(application)) throw new HttpResponseException(HttpStatusCode.NotFound);
 

--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Web.Trees
             //find all tree definitions that have the current application alias
             var appTrees = Services.ApplicationTreeService.GetApplicationTrees(application, onlyInitialized).ToArray();
 
-            if (string.IsNullOrEmpty(tree) == false || appTrees.Length == 1)
+            if (string.IsNullOrEmpty(tree) == false || appTrees.Length == 1 || appTrees.Any() == false)
             {
                 var apptree = string.IsNullOrEmpty(tree) == false 
                     ? appTrees.SingleOrDefault(x => x.Alias == tree)

--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -3,7 +3,9 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http.Formatting;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Web;
 using System.Web.Http;
 using Umbraco.Core;
 using Umbraco.Core.Models;
@@ -32,6 +34,12 @@ namespace Umbraco.Web.Trees
         [HttpQueryStringFilter("queryStrings")]
         public async Task<SectionRootNode> GetApplicationTrees(string application, string tree, FormDataCollection queryStrings, bool onlyInitialized = true)
         {
+            // define valid application pattern
+            // only letters, numbers, hyphens, underscores
+            Regex validRegex = new Regex("^[a-zA-Z0-9_-]*$");
+
+            if (validRegex.IsMatch(application) == false) throw new HttpRequestValidationException();
+
             if (string.IsNullOrEmpty(application)) throw new HttpResponseException(HttpStatusCode.NotFound);
 
             var rootId = Constants.System.Root.ToString(CultureInfo.InvariantCulture);


### PR DESCRIPTION
Added a regex check to ensure that the `application` parameter doesn't contain potentially dangerous characters. I'm not 100% sure what should count as a valid character in this case but went for letters, numbers, hyphens, and underscores. Wouldn't think you'd need anything else in a tree but please correct me if I'm mistaken.

Ultimately, I'm not convinced that there's a huge security flaw with the XPath injection (I'm unable to find evidence of any danger this introduces other than exposing some tree names but I'm not expert on the matter) here but better to whitelist characters and play it safe.

Original issues: http://issues.umbraco.org/issue/U4-9237