### PR TITLE
New Danish translation for "Dato for Fortryd udgivelse"

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -200,7 +200,7 @@
     <key alias="titleOptional">Titel (valgfri)</key>
     <key alias="altTextOptional">Alternativ tekst (valgfri)</key>
     <key alias="type">Type</key>
-    <key alias="unPublish">Fortryd udgivelse</key>
+    <key alias="unPublish">Afpublicér</key>
     <key alias="updateDate">Sidst redigeret</key>
     <key alias="updateDateDesc" version="7.0">Tidspunkt for seneste redigering</key>
     <key alias="uploadClear">Fjern fil</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -26,7 +26,7 @@
     <key alias="notify">Notificeringer</key>
     <key alias="protect">Offentlig adgang</key>
     <key alias="publish">Udgiv</key>
-    <key alias="unpublish">Fortryd udgivelse</key>
+    <key alias="unpublish">Afpublicér</key>
     <key alias="refreshNode">Genindlæs elementer</key>
     <key alias="republish">Genudgiv hele sitet</key>
     <key alias="rename" version="7.3.0">Omdøb</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -192,7 +192,7 @@
     <key alias="publish">Udgivet</key>
     <key alias="publishStatus">Udgivelsesstatus</key>
     <key alias="releaseDate">Udgivelsesdato</key>
-    <key alias="unpublishDate">Dato for afpublisering</key>
+    <key alias="unpublishDate">Afpubliceringsdato</key>
     <key alias="removeDate">Fjern dato</key>
     <key alias="sortDone">Sorteringsrækkefølgen er opdateret</key>
     <key alias="sortHelp">For at sortere, træk siderne eller klik på en af kolonnehovederne. Du kan vælge flere sider ved at holde "shift" eller "control" nede mens du vælger.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -192,7 +192,7 @@
     <key alias="publish">Udgivet</key>
     <key alias="publishStatus">Udgivelsesstatus</key>
     <key alias="releaseDate">Udgivelsesdato</key>
-    <key alias="unpublishDate">Dato for Fortryd udgivelse</key>
+    <key alias="unpublishDate">Dato for afpublisering</key>
     <key alias="removeDate">Fjern dato</key>
     <key alias="sortDone">Sorteringsrækkefølgen er opdateret</key>
     <key alias="sortHelp">For at sortere, træk siderne eller klik på en af kolonnehovederne. Du kan vælge flere sider ved at holde "shift" eller "control" nede mens du vælger.</key>


### PR DESCRIPTION
I've always felt that the Danish translation for the unpublish date could be improved a bit, as "fortryd" is best translated to "undo". Technically it may me correct, but I think "Afpubliceringsdato" is much better - it also matches "Udgivelsesdato" for the publish date.

As a bonus, it also takes up slightly less space in the UI.

![image](https://user-images.githubusercontent.com/3634580/32691315-09d511cc-c706-11e7-91e9-b240d41b7370.png)

A little side node, I've also renamed "Fortryd udgivelse" to "Afpublicér" in relation to the save button.

![image](https://user-images.githubusercontent.com/3634580/32691395-4e4c8136-c707-11e7-841e-743958dfaf27.png)

I feel this is a better translations as well, but perhaps you can take it up with some of the Danes at the HQ. A downside to renaming this is of course that Danish editors now will se another text than what they're used to.

Another downside to using "Afpublicér" is the Danish translation for "Publish" is "Udgiv" rather than "Publicér". But I still think "Afpublicér" instead of "Fortryd udgivelse" will make more sense ;)

