### PR TITLE
"Set date" and "Clear date" in the new Info tab can now be localized

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -107,14 +107,14 @@
                                     <div class="date-wrapper__date">{{node.releaseDate | amDateFormat:'dddd'}} {{node.releaseDate | amDateFormat:'HH:mm'}}</div>
                                 </div>
 
-                                <a href="" ng-if="!node.releaseDate" class="bold" style="color: #00aea2; text-decoration: underline;">Set date</a>                                                    
+                                <a href="" ng-if="!node.releaseDate" class="bold" style="color: #00aea2; text-decoration: underline;"><localize key="content_setDate">Set date</localize></a>                                                    
                                 
                             </div>
 
                         </umb-date-time-picker>
                         
                         <a ng-if="node.releaseDate" ng-click="clearPublishDate()" href="" style="text-decoration: underline;">
-                            <small>Clear date</small>
+                            <small><localize key="content_removeDate">Clear date</localize></small>
                         </a>
 
                     </div>
@@ -139,14 +139,14 @@
                                     <div class="date-wrapper__date">{{node.removeDate | amDateFormat:'dddd'}} {{node.removeDate | amDateFormat:'HH:mm'}}</div>
                                 </div>
 
-                                <a href="" ng-if="!node.removeDate" class="bold" style="color: #00aea2; text-decoration: underline;">Set date</a>
+                                <a href="" ng-if="!node.removeDate" class="bold" style="color: #00aea2; text-decoration: underline;"><localize key="content_setDate">Set date</localize></a>
 
                             </div>
 
                         </umb-date-time-picker>
 
                         <a ng-if="node.removeDate" ng-click="clearUnpublishDate()" href="" style="text-decoration: underline;">
-                            <small>Clear date</small>
+                            <small><localize key="content_removeDate">Clear date</localize></small>
                         </a>
                     </div>
 

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -194,6 +194,7 @@
     <key alias="releaseDate">Udgivelsesdato</key>
     <key alias="unpublishDate">Dato for Fortryd udgivelse</key>
     <key alias="removeDate">Fjern dato</key>
+    <key alias="setDate">Vælg dato</key>
     <key alias="sortDone">Sorteringsrækkefølgen er opdateret</key>
     <key alias="sortHelp">For at sortere, træk siderne eller klik på en af kolonnehovederne. Du kan vælge flere sider ved at holde "shift" eller "control" nede mens du vælger.</key>
     <key alias="statistics">Statistik</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -198,6 +198,7 @@
         <key alias="releaseDate">Publish at</key>
         <key alias="unpublishDate">Unpublish at</key>
         <key alias="removeDate">Clear Date</key>
+        <key alias="setDate">Set date</key>
         <key alias="sortDone">Sortorder is updated</key>
         <key alias="sortHelp">To sort the nodes, simply drag the nodes or click one of the column headers. You can select multiple nodes by holding the "shift" or "control" key while selecting</key>
         <key alias="statistics">Statistics</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -201,6 +201,7 @@
         <key alias="releaseDate">Publish at</key>
         <key alias="unpublishDate">Unpublish at</key>
         <key alias="removeDate">Clear Date</key>
+        <key alias="setDate">Set date</key>
         <key alias="sortDone">Sortorder is updated</key>
         <key alias="sortHelp">To sort the nodes, simply drag the nodes or click one of the column headers. You can select multiple nodes by holding the "shift" or "control" key while selecting</key>
         <key alias="statistics">Statistics</key>


### PR DESCRIPTION
Spend waaaay to long figuring out I had to edit the `dev-v7.8` branch :confused:

As part of the new **Scheduled Publishing** box, editors can set a publish date - and thereafter also clear the date again. The labels for **Set date** and **Clear date** were hardcoded. This pull request fixes that.

For **Clear date**, I've used the existing translation for `removeDate`. I couldn't find an existing translation for **Set date**, so I've introduced a new `setDate` translation, which have been added to both `en.xml` and `en_us.xml`.

I've also added a Danish translation for **Set date**. It isn't an exact translation, as **Set date** would be **Sæt dato**. I've gone with **Vælg dato** instead (which is more a translations of **Select date**), as I think this is a more suitable translation for Danish.


![image](https://user-images.githubusercontent.com/3634580/32691939-d50939e6-c70f-11e7-802d-46a87520b901.png)
