### PR TITLE
Wrap text in umb-node-preview component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
@@ -37,6 +37,7 @@
 .umb-node-preview__content {
     flex: 1 1 auto;
     margin-right: 25px;
+    overflow: hidden;
 }
 
 .umb-node-preview__name {
@@ -48,6 +49,13 @@
     font-size: 12px;
     line-height: 1.5em;
     color: @gray-3;
+}
+
+.umb-node-preview__name,
+.umb-node-preview__description {
+    /*text-overflow: ellipsis;
+    overflow: hidden;*/
+    word-wrap: break-word;
 }
 
 .umb-node-preview__actions {


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10703

This ensure text inside `umb-node-preview` is wrapped instead of pushing action links outside screen, when it is used in overlay/dialog, e.g. when using Multi Url Picker or other pickers in LeBlender and when text of name and description might be too long.

It could also use these lines with `text-overflow: ellipsis;`, but it I think that might work best if it only has a single line in name and description, e.g. by adding `max-height: 1.5em`.

https://github.com/bjarnef/Umbraco-CMS/blob/3c98d9d2e146e9046ef7fe6f7c6869c4390c4433/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less#L56-L57

**Before**
![image](https://user-images.githubusercontent.com/2919859/33034645-c48cc02c-ce28-11e7-8249-8cc91230611b.png)


**After**
![image](https://user-images.githubusercontent.com/2919859/33034600-a344d774-ce28-11e7-93cb-802463a516d5.png)
