### PR TITLE
Fix for U4-10549 RTE memory usage

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
@@ -366,6 +366,9 @@ angular.module("umbraco.directives")
                             // element might still be there even after the modal has been hidden.
                             scope.$on('$destroy', function () {
                                 unsubscribe();
+								if (tinyMceEditor !== undefined && tinyMceEditor != null) {
+									tinyMceEditor.destroy()
+								}
                             });
 
                         });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -374,6 +374,9 @@ angular.module("umbraco")
                 // element might still be there even after the modal has been hidden.
                 $scope.$on('$destroy', function () {
                     unsubscribe();
+					if (tinyMceEditor !== undefined && tinyMceEditor != null) {
+						tinyMceEditor.destroy()
+					}
                 });
             });
         });


### PR DESCRIPTION
This fix destroys tinyMceEditor when the directive/controller gets destroyed.

My testing has shown a significant memory usage reduction. I am no longer able to get Chrome to use 4GB. The memory usage still increases, but I think that must be other parts of Umbraco.

Tested on 7.7.6 on the default starterkit.

http://issues.umbraco.org/issue/U4-10549