### PR TITLE
U4-8879 - Create button on member and media list view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -58,23 +58,26 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
       items: []
    };
 
-   $scope.currentNodePermissions = {}
+   //when this is null, we don't check permissions
+   $scope.currentNodePermissions = null;
 
-   //Just ensure we do have an editorState
-   if (editorState.current) {
-      //Fetch current node allowed actions for the current user
-      //This is the current node & not each individual child node in the list
-      var currentUserPermissions = editorState.current.allowedActions;
+   if ($scope.entityType === "content") {
+       //Just ensure we do have an editorState
+       if (editorState.current) {
+           //Fetch current node allowed actions for the current user
+           //This is the current node & not each individual child node in the list
+           var currentUserPermissions = editorState.current.allowedActions;
 
-      //Create a nicer model rather than the funky & hard to remember permissions strings
-      $scope.currentNodePermissions = {
-         "canCopy": _.contains(currentUserPermissions, 'O'), //Magic Char = O
-         "canCreate": _.contains(currentUserPermissions, 'C'), //Magic Char = C
-         "canDelete": _.contains(currentUserPermissions, 'D'), //Magic Char = D
-         "canMove": _.contains(currentUserPermissions, 'M'), //Magic Char = M                
-         "canPublish": _.contains(currentUserPermissions, 'U'), //Magic Char = U
-         "canUnpublish": _.contains(currentUserPermissions, 'U'), //Magic Char = Z (however UI says it can't be set, so if we can publish 'U' we can unpublish)
-      };
+           //Create a nicer model rather than the funky & hard to remember permissions strings
+           $scope.currentNodePermissions = {
+               "canCopy": _.contains(currentUserPermissions, 'O'), //Magic Char = O
+               "canCreate": _.contains(currentUserPermissions, 'C'), //Magic Char = C
+               "canDelete": _.contains(currentUserPermissions, 'D'), //Magic Char = D
+               "canMove": _.contains(currentUserPermissions, 'M'), //Magic Char = M                
+               "canPublish": _.contains(currentUserPermissions, 'U'), //Magic Char = U
+               "canUnpublish": _.contains(currentUserPermissions, 'U'), //Magic Char = Z (however UI says it can't be set, so if we can publish 'U' we can unpublish)
+           };
+       }
    }
 
    //when this is null, we don't check permissions

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -10,7 +10,7 @@
 
            <umb-editor-sub-header-content-left>
 
-               <umb-editor-sub-header-section ng-if="(listViewAllowedTypes && listViewAllowedTypes.length > 0 && !isAnythingSelected()) && currentNodePermissions.canCreate">
+               <umb-editor-sub-header-section ng-if="(listViewAllowedTypes && listViewAllowedTypes.length > 0 && !isAnythingSelected()) && (currentNodePermissions == null || currentNodePermissions.canCreate)">
                    <div class="btn-group" ng-show="listViewAllowedTypes.length > 1">
                        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
                            <localize key="actions_create">Create</localize>


### PR DESCRIPTION
The button has been missing from Members and Media since 7.4.1, because of the added node permissions check. `editorState.current.allowedActions ` is empty on Members/Media.
