### PR TITLE
Allow Members tree to work independently of Member Types tree

### DIFF
--- a/src/Umbraco.Web/Editors/MediaTypeController.cs
+++ b/src/Umbraco.Web/Editors/MediaTypeController.cs
@@ -1,82 +1,63 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Web.Security;
 using AutoMapper;
+using Umbraco.Core;
 using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+using Umbraco.Core.Security;
 using Umbraco.Web.Models.ContentEditing;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi.Filters;
 using Constants = Umbraco.Core.Constants;
 using System.Web.Http;
 using System.Net;
-using System.Net.Http;
-using Umbraco.Web.WebApi;
-using Umbraco.Core.Services;
-using Umbraco.Core.Models.EntityBase;
+using Umbraco.Core.PropertyEditors;
 using System;
-using System.ComponentModel;
-using System.Web.Http.Controllers;
-using Umbraco.Core;
+using System.Net.Http;
+using ContentType = System.Net.Mime.ContentType;
 
 namespace Umbraco.Web.Editors
 {
-    //TODO:  We'll need to be careful about the security on this controller, when we start implementing
-    // methods to modify content types we'll need to enforce security on the individual methods, we
-    // cannot put security on the whole controller because things like GetAllowedChildren are required for content editing.
-
+    
     /// <summary>
     /// An API controller used for dealing with content types
     /// </summary>
     [PluginController("UmbracoApi")]
-    [UmbracoTreeAuthorize(Constants.Trees.MediaTypes)]
-    [EnableOverrideAuthorization]
-    [MediaTypeControllerControllerConfiguration]
-    public class MediaTypeController : ContentTypeControllerBase
+    [UmbracoTreeAuthorize(new string[] { Constants.Trees.MemberTypes, Constants.Trees.Members})]    
+    public class MemberTypeController : ContentTypeControllerBase
     {
-        /// <summary>
-        /// Configures this controller with a custom action selector
-        /// </summary>
-        private class MediaTypeControllerControllerConfigurationAttribute : Attribute, IControllerConfiguration
-        {
-            public void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
-            {
-                controllerSettings.Services.Replace(typeof(IHttpActionSelector), new ParameterSwapControllerActionSelector(
-                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetAllowedChildren", "contentId", typeof(int), typeof(Guid), typeof(Udi), typeof(string))));
-            }
-        }
-
         /// <summary>
         /// Constructor
         /// </summary>
-        public MediaTypeController()
+        public MemberTypeController()
             : this(UmbracoContext.Current)
         {
+            _provider = Core.Security.MembershipProviderExtensions.GetMembersMembershipProvider();
         }
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="umbracoContext"></param>
-        public MediaTypeController(UmbracoContext umbracoContext)
+        public MemberTypeController(UmbracoContext umbracoContext)
             : base(umbracoContext)
         {
-
+            _provider = Core.Security.MembershipProviderExtensions.GetMembersMembershipProvider();
         }
 
-        public int GetCount()
-        {
-            return Services.ContentTypeService.CountContentTypes();
-        }
+        private readonly MembershipProvider _provider;
 
-        [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
-        public MediaTypeDisplay GetById(int id)
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
+        public MemberTypeDisplay GetById(int id)
         {
-            var ct = Services.ContentTypeService.GetMediaType(id);
+            var ct = Services.MemberTypeService.Get(id);
             if (ct == null)
             {
                 throw new HttpResponseException(HttpStatusCode.NotFound);
             }
 
-            var dto = Mapper.Map<IMediaType, MediaTypeDisplay>(ct);
+            var dto = Mapper.Map<IMemberType, MemberTypeDisplay>(ct);
             return dto;
         }
 
@@ -87,39 +68,39 @@ namespace Umbraco.Web.Editors
         /// <returns></returns>
         [HttpDelete]
         [HttpPost]
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
         public HttpResponseMessage DeleteById(int id)
         {
-            var foundType = Services.ContentTypeService.GetMediaType(id);
+            var foundType = Services.MemberTypeService.Get(id);
             if (foundType == null)
             {
                 throw new HttpResponseException(HttpStatusCode.NotFound);
             }
 
-            Services.ContentTypeService.Delete(foundType, Security.CurrentUser.Id);
+            Services.MemberTypeService.Delete(foundType, Security.CurrentUser.Id);
             return Request.CreateResponse(HttpStatusCode.OK);
         }
 
         /// <summary>
         /// Returns the avilable compositions for this content type
-        /// This has been wrapped in a dto instead of simple parameters to support having multiple parameters in post request body
         /// </summary>
-        /// <param name="filter.contentTypeId"></param>
-        /// <param name="filter.ContentTypes">
+        /// <param name="contentTypeId"></param>
+        /// <param name="filterContentTypes">
         /// This is normally an empty list but if additional content type aliases are passed in, any content types containing those aliases will be filtered out
         /// along with any content types that have matching property types that are included in the filtered content types
         /// </param>
-        /// <param name="filter.PropertyTypes">
+        /// <param name="filterPropertyTypes">
         /// This is normally an empty list but if additional property type aliases are passed in, any content types that have these aliases will be filtered out.
         /// This is required because in the case of creating/modifying a content type because new property types being added to it are not yet persisted so cannot
         /// be looked up via the db, they need to be passed in.
         /// </param>
-        /// <param name="filter">
-        /// Filter applied when resolving compositions</param>
         /// <returns></returns>
-        [HttpPost]
-        public HttpResponseMessage GetAvailableCompositeMediaTypes(GetAvailableCompositionsFilter filter)
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
+        public HttpResponseMessage GetAvailableCompositeMemberTypes(int contentTypeId,
+            [FromUri]string[] filterContentTypes,
+            [FromUri]string[] filterPropertyTypes)
         {
-            var result = PerformGetAvailableCompositeContentTypes(filter.ContentTypeId, UmbracoObjectTypes.MediaType, filter.FilterContentTypes, filter.FilterPropertyTypes)
+            var result = PerformGetAvailableCompositeContentTypes(contentTypeId, UmbracoObjectTypes.MemberType, filterContentTypes, filterPropertyTypes)
                 .Select(x => new
                 {
                     contentType = x.Item1,
@@ -128,11 +109,13 @@ namespace Umbraco.Web.Editors
             return Request.CreateResponse(result);
         }
 
-        public MediaTypeDisplay GetEmpty(int parentId)
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
+        public MemberTypeDisplay GetEmpty()
         {
-            var ct = new MediaType(parentId) {Icon = "icon-picture"};
+            var ct = new MemberType(-1);
+            ct.Icon = "icon-user";
 
-            var dto = Mapper.Map<IMediaType, MediaTypeDisplay>(ct);
+            var dto = Mapper.Map<IMemberType, MemberTypeDisplay>(ct);
             return dto;
         }
 
@@ -140,188 +123,33 @@ namespace Umbraco.Web.Editors
         /// <summary>
         /// Returns all member types
         /// </summary>
-        public IEnumerable<ContentTypeBasic> GetAll()
+        /// 
+        [UmbracoTreeAuthorize(new [] { Constants.Trees.Members, Constants.Trees.MemberTypes})]
+        public IEnumerable<ContentTypeBasic> GetAllTypes()
         {
-
-            return Services.ContentTypeService.GetAllMediaTypes()
-                               .Select(Mapper.Map<IMediaType, ContentTypeBasic>);
+            if (_provider.IsUmbracoMembershipProvider())
+            {
+                return Services.MemberTypeService.GetAll()
+                               .Select(Mapper.Map<IMemberType, ContentTypeBasic>);    
+            }
+            return Enumerable.Empty<ContentTypeBasic>();
         }
 
-        /// <summary>
-        /// Deletes a document type container wth a given ID
-        /// </summary>
-        /// <param name="id"></param>
-        /// <returns></returns>
-        [HttpDelete]
-        [HttpPost]
-        public HttpResponseMessage DeleteContainer(int id)
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
+        public MemberTypeDisplay PostSave(MemberTypeSave contentTypeSave)
         {
-            Services.ContentTypeService.DeleteMediaTypeContainer(id, Security.CurrentUser.Id);
+            var savedCt = PerformPostSave<IMemberType, MemberTypeDisplay, MemberTypeSave, MemberPropertyTypeBasic>(
+                contentTypeSave:            contentTypeSave,
+                getContentType:             i => Services.MemberTypeService.Get(i),
+                saveContentType:            type => Services.MemberTypeService.Save(type));
 
-            return Request.CreateResponse(HttpStatusCode.OK);
-        }
-
-        public HttpResponseMessage PostCreateContainer(int parentId, string name)
-        {
-            var result = Services.ContentTypeService.CreateMediaTypeContainer(parentId, name, Security.CurrentUser.Id);
-
-            return result
-                ? Request.CreateResponse(HttpStatusCode.OK, result.Result) //return the id
-                : Request.CreateNotificationValidationErrorResponse(result.Exception.Message);
-        }
-
-        public HttpResponseMessage PostRenameContainer(int id, string name)
-        {
-            
-            var result = Services.ContentTypeService.RenameMediaTypeContainer(id, name, Security.CurrentUser.Id);
-
-            return result
-                ? Request.CreateResponse(HttpStatusCode.OK, result.Result) //return the id
-                : Request.CreateNotificationValidationErrorResponse(result.Exception.Message);
-        }
-
-        public MediaTypeDisplay PostSave(MediaTypeSave contentTypeSave)
-        {
-            var savedCt = PerformPostSave<IMediaType, MediaTypeDisplay, MediaTypeSave, PropertyTypeBasic>(
-                contentTypeSave:        contentTypeSave,
-                getContentType:         i => Services.ContentTypeService.GetMediaType(i),
-                saveContentType:        type => Services.ContentTypeService.Save(type));
-
-            var display = Mapper.Map<MediaTypeDisplay>(savedCt);
+            var display = Mapper.Map<MemberTypeDisplay>(savedCt);
 
             display.AddSuccessNotification(
-                            Services.TextService.Localize("speechBubbles/mediaTypeSavedHeader"),
+                            Services.TextService.Localize("speechBubbles/memberTypeSavedHeader"),
                             string.Empty);
 
             return display;
-        }
-
-
-        #region GetAllowedChildren
-        /// <summary>
-        /// Returns the allowed child content type objects for the content item id passed in - based on an INT id
-        /// </summary>
-        /// <param name="contentId"></param>
-        [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
-        public IEnumerable<ContentTypeBasic> GetAllowedChildren(int contentId)
-        {
-            if (contentId == Constants.System.RecycleBinContent)
-                return Enumerable.Empty<ContentTypeBasic>();
-
-            IEnumerable<IMediaType> types;
-            if (contentId == Constants.System.Root)
-            {
-                types = Services.ContentTypeService.GetAllMediaTypes().ToList();
-
-                //if no allowed root types are set, just return everything
-                if (types.Any(x => x.AllowedAsRoot))
-                    types = types.Where(x => x.AllowedAsRoot);
-            }
-            else
-            {
-                var contentItem = Services.MediaService.GetById(contentId);
-                if (contentItem == null)
-                {
-                    return Enumerable.Empty<ContentTypeBasic>();
-                }
-
-                var ids = contentItem.ContentType.AllowedContentTypes.Select(x => x.Id.Value).ToArray();
-
-                if (ids.Any() == false) return Enumerable.Empty<ContentTypeBasic>();
-
-                types = Services.ContentTypeService.GetAllMediaTypes(ids).ToList();
-            }
-
-            var basics = types.Select(Mapper.Map<IMediaType, ContentTypeBasic>).ToList();
-
-            foreach (var basic in basics)
-            {
-                basic.Name = TranslateItem(basic.Name);
-                basic.Description = TranslateItem(basic.Description);
-            }
-
-            return basics.OrderBy(x => x.Name);
-        }
-
-        /// <summary>
-        /// Returns the allowed child content type objects for the content item id passed in - based on a GUID id
-        /// </summary>
-        /// <param name="contentId"></param>
-        [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
-        public IEnumerable<ContentTypeBasic> GetAllowedChildren(Guid contentId)
-        {
-            var entity = ApplicationContext.Services.EntityService.GetByKey(contentId);
-            if (entity != null)
-            {
-                return GetAllowedChildren(entity.Id);
-            }
-
-            throw new HttpResponseException(HttpStatusCode.NotFound);
-        }
-
-        /// <summary>
-        /// Returns the allowed child content type objects for the content item id passed in - based on a UDI id
-        /// </summary>
-        /// <param name="contentId"></param>
-        [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
-        public IEnumerable<ContentTypeBasic> GetAllowedChildren(Udi contentId)
-        {
-            var guidUdi = contentId as GuidUdi;
-            if (guidUdi != null)
-            {
-                var entity = ApplicationContext.Services.EntityService.GetByKey(guidUdi.Guid);
-                if (entity != null)
-                {
-                    return GetAllowedChildren(entity.Id);
-                }
-            }
-
-            throw new HttpResponseException(HttpStatusCode.NotFound);
-        }
-
-        [Obsolete("Do not use this method, use either the overload with INT, GUID or UDI instead, this will be removed in future versions")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
-        public IEnumerable<ContentTypeBasic> GetAllowedChildren(string contentId)
-        {
-            foreach (var type in new[] { typeof(int), typeof(Guid) })
-            {
-                var parsed = contentId.TryConvertTo(type);
-                if (parsed)
-                {
-                    //oooh magic! will auto select the right overload
-                    return GetAllowedChildren((dynamic)parsed.Result);
-                }
-            }
-
-            throw new HttpResponseException(HttpStatusCode.NotFound);
-        } 
-        #endregion
-
-        /// <summary>
-        /// Move the media type
-        /// </summary>
-        /// <param name="move"></param>
-        /// <returns></returns>
-        public HttpResponseMessage PostMove(MoveOrCopy move)
-        {
-            return PerformMove(
-                move,
-                getContentType: i => Services.ContentTypeService.GetMediaType(i),
-                doMove: (type, i) => Services.ContentTypeService.MoveMediaType(type, i));
-        }
-
-        /// <summary>
-        /// Copy the media type
-        /// </summary>
-        /// <param name="copy"></param>
-        /// <returns></returns>
-        public HttpResponseMessage PostCopy(MoveOrCopy copy)
-        {
-            return PerformCopy(
-                copy,
-                getContentType: i => Services.ContentTypeService.GetMediaType(i),
-                doCopy: (type, i) => Services.ContentTypeService.CopyMediaType(type, i));
         }
     }
 }


### PR DESCRIPTION
Allow Members tree to work independently of Member Types tree by giving it permission to access the MemberType.GetAllTypes Method