### PR TITLE
U4-10779 Allow Members tree to work independently of Member Types tree 

### DIFF
--- a/src/Umbraco.Web/Editors/MemberTypeController.cs
+++ b/src/Umbraco.Web/Editors/MemberTypeController.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Web.Editors
     /// An API controller used for dealing with content types
     /// </summary>
     [PluginController("UmbracoApi")]
-    [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]    
+    [UmbracoTreeAuthorize(new string[] { Constants.Trees.MemberTypes, Constants.Trees.Members})]    
     public class MemberTypeController : ContentTypeControllerBase
     {
         /// <summary>
@@ -48,6 +48,7 @@ namespace Umbraco.Web.Editors
 
         private readonly MembershipProvider _provider;
 
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
         public MemberTypeDisplay GetById(int id)
         {
             var ct = Services.MemberTypeService.Get(id);
@@ -67,6 +68,7 @@ namespace Umbraco.Web.Editors
         /// <returns></returns>
         [HttpDelete]
         [HttpPost]
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
         public HttpResponseMessage DeleteById(int id)
         {
             var foundType = Services.MemberTypeService.Get(id);
@@ -93,6 +95,8 @@ namespace Umbraco.Web.Editors
         /// be looked up via the db, they need to be passed in.
         /// </param>
         /// <returns></returns>
+
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
         public HttpResponseMessage GetAvailableCompositeMemberTypes(int contentTypeId,
             [FromUri]string[] filterContentTypes,
             [FromUri]string[] filterPropertyTypes)
@@ -106,6 +110,7 @@ namespace Umbraco.Web.Editors
             return Request.CreateResponse(result);
         }
 
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
         public MemberTypeDisplay GetEmpty()
         {
             var ct = new MemberType(-1);
@@ -129,6 +134,7 @@ namespace Umbraco.Web.Editors
             return Enumerable.Empty<ContentTypeBasic>();
         }
 
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
         public MemberTypeDisplay PostSave(MemberTypeSave contentTypeSave)
         {
             var savedCt = PerformPostSave<IMemberType, MemberTypeDisplay, MemberTypeSave, MemberPropertyTypeBasic>(


### PR DESCRIPTION
Allow Members tree to work independently of Member Types tree by giving it permission to access the MemberType.GetAllTypes Method