### PR TITLE
Triggers the save button to momentarily show an error icon

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -185,6 +185,8 @@
 
             $scope.page.buttonGroupState = "success";
 
+          }, function(err) {
+            $scope.page.buttonGroupState = 'error';
           });
       }
 


### PR DESCRIPTION
Related to http://issues.umbraco.org/issue/U4-7757

When attempting to unpublish a content node, but the unpublishing fails (eg. if the event is cancelled), there is no indication that the request failed.

With this commit, an error icon (the white cross) is shown momentarily - in the same way if saving fails.

![image](https://user-images.githubusercontent.com/3634580/34228351-a91e40ee-e5d0-11e7-8a09-60bb3876b7c5.png)

There is however a small issue if the next request fails as well, as the button state isn't reverted to `init`, and there error icon therefore isn't shown. This appears to be a general issue, as the regular "Save and publish" action works the same way.
