### PR TITLE
U4-10791 - Fix collapsed columns listview settings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.controller.js
@@ -96,6 +96,10 @@ function includePropsPreValsController($rootScope, $scope, localizationService, 
         cursor: 'move',
         items: '> tr',
         tolerance: 'pointer',
+        forcePlaceholderSize: true,
+        start: function(e, ui){
+            ui.placeholder.height(ui.item.height());
+        },
         update: function (e, ui) {
             
             // Get the new and old index for the moved element (using the text as the identifier)

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.controller.js
@@ -77,14 +77,14 @@ function includePropsPreValsController($rootScope, $scope, localizationService, 
 
     // Return a helper with preserved width of cells
     var fixHelper = function (e, ui) {
-        var h = ui.clone();
-
-        h.children().each(function () {
-            $(this).width($(this).width());            
+        ui.children().each(function () {
+            $(this).width($(this).width());
         });
-        h.css("background-color", "lightgray");
 
-        return h;
+        var row = ui.clone();
+        row.css("background-color", "lightgray");
+
+        return row;
     };
 
     $scope.sortableOptions = {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
@@ -20,7 +20,7 @@
                     <td style="width:100px;"></td>
                 </tr>
             </thead>
-            <tbody ui-sortable="sortableOptions">
+            <tbody ui-sortable="sortableOptions" ng-model="model.value">
                 <tr ng-repeat="val in model.value">
                     <td>
                         <i class="icon icon-navigation handle"></i>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10791

The fix the collapsed columns in listview settings, when sorting the columns.
There is also a demo about this issue here:
https://paulund.co.uk/fixed-width-sortable-tables

**Before**
![image](https://user-images.githubusercontent.com/2919859/34448111-e37bfca6-ecea-11e7-8b11-e4a1ac2d1717.png)

**After**
![image](https://user-images.githubusercontent.com/2919859/34448133-0dc34fd2-eceb-11e7-9036-88dd0fa11cd9.png)
