### PR TITLE
U4-10793 - add password toggle to installer step

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -9,18 +9,18 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
             exp += ".*[\\W].*";
         }
         //replace duplicates
-        exp = exp.replace(".*.*", ".*");            
+        exp = exp.replace(".*.*", ".*");
         $scope.passwordPattern = new RegExp(exp);
-    }
+    };
 
 	$scope.validateAndInstall = function(){
-			installerService.install();
+        installerService.install();
 	};
 
 	$scope.validateAndForward = function(){
-			if(this.myForm.$valid){
-				installerService.forward();
-			}
+		if(this.myForm.$valid){
+			installerService.forward();
+		}
 	};
 	
 });

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -14,7 +14,7 @@
 						<input type="text" id="name" name="name" placeholder="Full name" required ng-model="installer.current.model.name" />
 					</div>
 				</div>
-
+                
 				<div class="control-group">
 					<label class="control-label" for="email">Email</label>
 					<div class="controls">
@@ -27,14 +27,15 @@
 					<label class="control-label" for="password">Password</label>
 					<div class="controls">
 						<!-- why isn't this masked: http://www.nngroup.com/articles/stop-password-masking/ -->
-					    <input type="text" name="installer.current.model.password" 
+					    <input type="password" name="installer.current.model.password" id="password"
+                               ng-model="installer.current.model.password"
 					           ng-minlength="{{installer.current.model.minCharLength}}" 
 					           ng-pattern="passwordPattern"
 					           autocorrect="off"
 					           autocapitalize="off"
 					           autocomplete="off"
                                required 
-                               ng-model="installer.current.model.password" id="password" />
+                               umb-password-toggle />
 					    <small class="inline-help">At least {{installer.current.model.minCharLength}} characters long</small>
 					    
 					    <small ng-if="installer.current.model.minNonAlphaNumericLength > 0" class="inline-help">
@@ -47,11 +48,10 @@
 				<div class="control-group">
 					<div class="controls">
 						<label>
-							<input
-								type="checkbox" 
-								id="subscribeToNewsLetter" 
-								name="subscribeToNewsLetter"
-							    ng-model="installer.current.model.subscribeToNewsLetter" /> 
+							<input type="checkbox" 
+								   id="subscribeToNewsLetter" 
+								   name="subscribeToNewsLetter"
+							       ng-model="installer.current.model.subscribeToNewsLetter" /> 
 							Keep me updated on Umbraco Versions, Security Bulletins and Community News
 						</label>
 					</div>

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -116,6 +116,7 @@
 @import "components/umb-package-local-install.less";
 @import "components/umb-lightbox.less";
 @import "components/umb-avatar.less";
+@import "components/umb-password-toggle.less";
 @import "components/umb-progress-bar.less";
 @import "components/umb-querybuilder.less";
 @import "components/umb-pagination.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-password-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-password-toggle.less
@@ -1,0 +1,36 @@
+﻿.password-toggle {
+    position: relative;
+    display: block;
+    user-select: none;
+
+    input::-ms-clear, input::-ms-reveal {
+        display: none;
+    }
+
+    a {
+        opacity: .5;
+        cursor: pointer;
+        display: inline-block;
+        position: absolute;
+        height: 1px;
+        width: 40px;
+        height: 100%;
+        font-size: 0;
+        background-repeat: no-repeat;
+        background-size: 50%;
+        background-position: center;
+        top: 0;
+        margin-top: 0;
+        margin-left: -40px;
+        z-index: 1;
+        -webkit-tap-highlight-color: transparent;
+    }
+
+    [type="text"] + a {
+        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='%23444' d='M29.6.4C29 0 28 0 27.4.4L21 6.8c-1.4-.5-3-.8-5-.8C9 6 3 10 0 16c1.3 2.6 3 4.8 5.4 6.5l-5 5c-.5.5-.5 1.5 0 2 .3.4.7.5 1 .5s1 0 1.2-.4l27-27C30 2 30 1 29.6.4zM13 10c1.3 0 2.4 1 2.8 2L12 15.8c-1-.4-2-1.5-2-2.8 0-1.7 1.3-3 3-3zm-9.6 6c1.2-2 2.8-3.5 4.7-4.7l.7-.2c-.4 1-.6 2-.6 3 0 1.8.6 3.4 1.6 4.7l-2 2c-1.6-1.2-3-2.7-4-4.4zM24 13.8c0-.8 0-1.7-.4-2.4l-10 10c.7.3 1.6.4 2.4.4 4.4 0 8-3.6 8-8z'/%3E%3Cpath fill='%23444' d='M26 9l-2.2 2.2c2 1.3 3.6 3 4.8 4.8-1.2 2-2.8 3.5-4.7 4.7-2.7 1.5-5.4 2.3-8 2.3-1.4 0-2.6 0-3.8-.4L10 25c2 .6 4 1 6 1 7 0 13-4 16-10-1.4-2.8-3.5-5.2-6-7z'/%3E%3C/svg%3E");
+    }
+
+    [type="password"] + a {
+        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='%23444' d='M16 6C9 6 3 10 0 16c3 6 9 10 16 10s13-4 16-10c-3-6-9-10-16-10zm8 5.3c1.8 1.2 3.4 2.8 4.6 4.7-1.2 2-2.8 3.5-4.7 4.7-3 1.5-6 2.3-8 2.3s-6-.8-8-2.3C6 19.5 4 18 3 16c1.5-2 3-3.5 5-4.7l.6-.2C8 12 8 13 8 14c0 4.5 3.5 8 8 8s8-3.5 8-8c0-1-.3-2-.6-2.6l.4.3zM16 13c0 1.7-1.3 3-3 3s-3-1.3-3-3 1.3-3 3-3 3 1.3 3 3z'/%3E%3C/svg%3E");
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/less/installer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/installer.less
@@ -13,6 +13,8 @@
 @import "../../lib/bootstrap/less/thumbnails.less";
 @import "../../lib/bootstrap/less/media.less";
 
+// Umbraco Components
+@import "components/umb-password-toggle.less";
 
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
   display: none !important;

--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -121,37 +121,9 @@
 }
 
 .password-toggle {
-    position: relative;
-    display: block;
-    user-select: none;
-
-    input::-ms-clear, input::-ms-reveal {
-        display: none;
-    }
-
     a {
-        opacity: .5;
-        cursor: pointer;
-        display: inline-block;
-        position: absolute;
-        height: 1px;
-        width: 45px;
-        height: 75%;
-        font-size: 0;
-        background-repeat: no-repeat;
-        background-size: 50%;
-        background-position: center;
-        top: 0;
+        margin-top: -5px;
         margin-left: -45px;
-        z-index: 1;
-        -webkit-tap-highlight-color: transparent;
-    }
-
-    [type="text"] + a {
-        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='%23444' d='M29.6.4C29 0 28 0 27.4.4L21 6.8c-1.4-.5-3-.8-5-.8C9 6 3 10 0 16c1.3 2.6 3 4.8 5.4 6.5l-5 5c-.5.5-.5 1.5 0 2 .3.4.7.5 1 .5s1 0 1.2-.4l27-27C30 2 30 1 29.6.4zM13 10c1.3 0 2.4 1 2.8 2L12 15.8c-1-.4-2-1.5-2-2.8 0-1.7 1.3-3 3-3zm-9.6 6c1.2-2 2.8-3.5 4.7-4.7l.7-.2c-.4 1-.6 2-.6 3 0 1.8.6 3.4 1.6 4.7l-2 2c-1.6-1.2-3-2.7-4-4.4zM24 13.8c0-.8 0-1.7-.4-2.4l-10 10c.7.3 1.6.4 2.4.4 4.4 0 8-3.6 8-8z'/%3E%3Cpath fill='%23444' d='M26 9l-2.2 2.2c2 1.3 3.6 3 4.8 4.8-1.2 2-2.8 3.5-4.7 4.7-2.7 1.5-5.4 2.3-8 2.3-1.4 0-2.6 0-3.8-.4L10 25c2 .6 4 1 6 1 7 0 13-4 16-10-1.4-2.8-3.5-5.2-6-7z'/%3E%3C/svg%3E");
-    }
-
-    [type="password"] + a {
-        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='%23444' d='M16 6C9 6 3 10 0 16c3 6 9 10 16 10s13-4 16-10c-3-6-9-10-16-10zm8 5.3c1.8 1.2 3.4 2.8 4.6 4.7-1.2 2-2.8 3.5-4.7 4.7-3 1.5-6 2.3-8 2.3s-6-.8-8-2.3C6 19.5 4 18 3 16c1.5-2 3-3.5 5-4.7l.6-.2C8 12 8 13 8 14c0 4.5 3.5 8 8 8s8-3.5 8-8c0-1-.3-2-.6-2.6l.4.3zM16 13c0 1.7-1.3 3-3 3s-3-1.3-3-3 1.3-3 3-3 3 1.3 3 3z'/%3E%3C/svg%3E");
+        width: 45px;
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
@@ -1,4 +1,4 @@
-﻿<div ng-controller="Umbraco.Dialogs.LoginController">
+<div ng-controller="Umbraco.Dialogs.LoginController">
 
   <div id="login" class="umb-modalcolumn umb-dialog" ng-class="{'show-validation': loginForm.$invalid}" ng-cloak konami-code="activateKonamiMode()">
 
@@ -149,9 +149,7 @@
 
             <div class="control-group" ng-class="{error: loginForm.password.$invalid}">
               <label><localize key="general_password">Password</localize></label>
-              <div class="password-toggle">
-                <input type="password" ng-model="password" name="password" class="-full-width-input" localize="placeholder" placeholder="@placeholders_password" autocomplete="off" /><a ng-click="togglePassword()">Toggle</a>
-              </div>
+              <input type="password" ng-model="password" name="password" class="-full-width-input" localize="placeholder" placeholder="@placeholders_password" autocomplete="off" umb-password-toggle />
             </div>
 
             <div class="flex justify-between items-center">

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
@@ -149,7 +149,14 @@
 
             <div class="control-group" ng-class="{error: loginForm.password.$invalid}">
               <label><localize key="general_password">Password</localize></label>
-              <input type="password" ng-model="password" name="password" class="-full-width-input" localize="placeholder" placeholder="@placeholders_password" autocomplete="off" umb-password-toggle />
+              <input type="password" ng-model="password" name="password" 
+                     class="-full-width-input"
+                     localize="placeholder"
+                     placeholder="@placeholders_password" 
+                     autocorrect="off"
+                     autocapitalize="off"
+                     autocomplete="off"
+                     umb-password-toggle />
             </div>
 
             <div class="flex justify-between items-center">


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10793

I have created a new PR for the existing PR here https://github.com/umbraco/Umbraco-CMS/pull/2311 but instead using `umb-password-toggle` component/directive so it is consistent with login screen.

I have also moved the styles for password toggle to a separate less file, so it can be used in other part of the UI like the other Umbraco components.

Furthermore I have also disabled `autocorrect` and `autocapitalize` in login screen, so it is consistent with password in installer step.

However I have a minor issue, when I have added the `umb-password-toggle` to the input and it has `ng-pattern` I get the following console error.
https://docs.angularjs.org/error/ngPattern/noregexp

![image](https://user-images.githubusercontent.com/2919859/34454726-b2134106-ed71-11e7-9d44-d2d49c695e96.png)

I could fix the console error by changing `ng-pattern="passwordPattern"` to `ng-pattern="{{passwordPattern}}"`, but it doesn't seem to work correct, since the form is valid with just a single character in password.