### PR TITLE
Fixed the xmldoc for UserService.Delete

### DIFF
--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -228,9 +228,9 @@ namespace Umbraco.Core.Services
         }
 
         /// <summary>
-        /// Deletes an <see cref="IUser"/>
+        /// Disables an <see cref="IUser"/>
         /// </summary>
-        /// <param name="membershipUser"><see cref="IUser"/> to Delete</param>
+        /// <param name="membershipUser"><see cref="IUser"/> to disable</param>
         public void Delete(IUser membershipUser)
         {
             //disable


### PR DESCRIPTION
I've corrected the xmldoc a bit as the `Delete(IUser membershipUser)` just disables the user - it doesn't actually delete the user in the database.