### PR TITLE
Fix checkmark tree icon, when custom font icon is used for tree icon

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -240,6 +240,7 @@
 .umb-tree .umb-tree-node-checked i:before {
 	/*check box*/
     content: "\e165" !important;
+	font-family: inherit;
 }
 
 a.umb-options {


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10809

Fix checkmark tree icon, when custom font icon is used for tree icon, e.g. in UCommerce or other third party packages.

**Before**
![image](https://user-images.githubusercontent.com/2919859/34673344-324e6096-f482-11e7-84f8-6612939c059f.png)

**After**
![image](https://user-images.githubusercontent.com/2919859/34673369-4fc06e6c-f482-11e7-9e71-90df17c3b2d4.png)
