### PR TITLE
U4-10762 Fix issue with empty name when registering new members from …

### DIFF
--- a/build/NuSpecs/UmbracoCms.nuspec
+++ b/build/NuSpecs/UmbracoCms.nuspec
@@ -17,7 +17,7 @@
     <dependencies>
       <dependency id="UmbracoCms.Core" version="[$version$]" />
       <dependency id="Newtonsoft.Json" version="[10.0.2, 11.0.0)" />
-      <dependency id="Umbraco.ModelsBuilder" version="[3.0.7, 4.0.0)" />
+      <dependency id="Umbraco.ModelsBuilder" version="[3.0.8, 4.0.0)" />
       <dependency id="Microsoft.AspNet.SignalR.Core" version="[2.2.1, 3.0.0)" />
 	  <dependency id="ImageProcessor.Web.Config" version="[2.3.1, 3.0.0)" />
     </dependencies>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -340,8 +340,8 @@
       <Name>umbraco.providers</Name>
     </ProjectReference>
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="Umbraco.ModelsBuilder, Version=3.0.7.99, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Umbraco.ModelsBuilder.3.0.7\lib\Umbraco.ModelsBuilder.dll</HintPath>
+    <Reference Include="Umbraco.ModelsBuilder, Version=3.0.8.100, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Umbraco.ModelsBuilder.3.0.8\lib\Umbraco.ModelsBuilder.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Umbraco.Web.UI/packages.config
+++ b/src/Umbraco.Web.UI/packages.config
@@ -37,5 +37,5 @@
   <package id="SqlServerCE" version="4.0.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />
-  <package id="Umbraco.ModelsBuilder" version="3.0.7" targetFramework="net45" />
+  <package id="Umbraco.ModelsBuilder" version="3.0.8" targetFramework="net45" />
 </packages>

--- a/src/Umbraco.Web/Controllers/UmbRegisterController.cs
+++ b/src/Umbraco.Web/Controllers/UmbRegisterController.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Linq;
 using System.Web.Mvc;
 using System.Web.Security;
-using umbraco.BusinessLogic;
-using umbraco.cms.businesslogic.member;
 using Umbraco.Core;
-using Umbraco.Core.Security;
 using Umbraco.Web.Models;
 using Umbraco.Web.Mvc;
 
@@ -19,6 +15,13 @@ namespace Umbraco.Web.Controllers
             if (ModelState.IsValid == false)
             {
                 return CurrentUmbracoPage();
+            }
+
+            // U4-10762 Server error with "Register Member" snippet (Cannot save member with empty name)
+            // If name field is empty, add the email address instead
+            if (string.IsNullOrEmpty(model.Name) && string.IsNullOrEmpty(model.Email) == false)
+            {
+                model.Name = model.Email;
             }
 
             MembershipCreateStatus status;
@@ -36,7 +39,6 @@ namespace Umbraco.Web.Controllers
                         return Redirect(model.RedirectUrl);
                     }
                     //redirect to current page by default
-                    
                     return RedirectToCurrentUmbracoPage();
                 case MembershipCreateStatus.InvalidUserName:
                     ModelState.AddModelError((model.UsernameIsEmail || model.Username == null)


### PR DESCRIPTION
…snippet

I've added some extra code to replace an empty Name field with the email address from the form, when used in a macro snippet.

Tested on a vanilla 7.6.12 installation.