### PR TITLE
Start node -> Startnode

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1481,7 +1481,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="permissionsGranularHelp">Sæt rettigheder for specifikke noder</key>
     <key alias="profile">Profil</key>
     <key alias="searchAllChildren">Søg alle 'børn'</key>
-    <key alias="startnode">Start node</key>
+    <key alias="startnode">Startnode</key>
     <key alias="stateActive">Aktiv</key>
     <key alias="stateAll">Alle</key>
     <key alias="stateDisabled">Deaktiveret</key>


### PR DESCRIPTION
Everywhere except this particular key, "start node" is spelled "startnode"