### PR TITLE
A few fixes for the Danish translation

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1442,7 +1442,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="documentType">Dokumenttype</key>
     <key alias="editors">Redaktør</key>
     <key alias="excerptField">Uddragsfelt</key>
-    <key alias="failedPasswordAttempts">Fejlet loginforsøg</key>
+    <key alias="failedPasswordAttempts">Fejlede loginforsøg</key>
     <key alias="goToProfile">Gå til brugerprofil</key>
     <key alias="groupsHelp">Tilføj grupper for at tildele adgang og tilladelser</key>
     <key alias="inviteAnotherUser">Invitér anden bruger</key>
@@ -1450,7 +1450,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="language">Sprog</key>
     <key alias="languageHelp">Indstil det sprog, du vil se i menuer og dialoger</key>
     <key alias="lastLockoutDate">Seneste låst ude dato</key>
-    <key alias="lastLogin">Senest login</key>
+    <key alias="lastLogin">Seneste login</key>
     <key alias="lastPasswordChangeDate">Kodeord sidst ændret</key>
     <key alias="loginname">Brugernavn</key>
     <key alias="mediastartnode">Startnode i mediearkivet</key>


### PR DESCRIPTION
**Fejlet loginforsøg** should be **Fejlede loginforsøg**, and **Senest login** should be **Seneste login**.