### PR TITLE
U4 10727 - If nodes with an empty name exist, it's not possible to empty recycle bin

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/SimilarNodeName.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/SimilarNodeName.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Core.Persistence.Repositories
                 var name = Name;
 
 				// cater for instances where node has no name.
-				if(name.Length == 0)
+				if(string.IsNullOrWhiteSpace(name))
 				{
 					return _numPos;
  				}
@@ -112,7 +112,7 @@ namespace Umbraco.Core.Persistence.Repositories
                 }
             }
 
-            return uniqueing ? string.Concat(nodeName, " (", uniqueNumber.ToString(), ")") : nodeName;
+            return uniqueing || string.IsNullOrWhiteSpace(nodeName) ? string.Concat(nodeName, " (", uniqueNumber.ToString(), ")") : nodeName;
         }
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/SimilarNodeName.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/SimilarNodeName.cs
@@ -20,6 +20,12 @@ namespace Umbraco.Core.Persistence.Repositories
 
                 var name = Name;
 
+				// cater for instances where node has no name.
+				if(name.Length == 0)
+				{
+					return _numPos;
+ 				}
+
                 if (name[name.Length - 1] != ')')
                     return _numPos = -1;
 

--- a/src/Umbraco.Tests/Persistence/Repositories/SimilarNodeNameTests.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/SimilarNodeNameTests.cs
@@ -25,6 +25,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         [TestCase("Kilo", "Golf (2)", +1)]
         [TestCase("Kilo (1)", "Golf (2)", +1)]
 		[TestCase("", "", 0)]
+		[TestCase(null, null, 0)]
 		public void ComparerTest(string name1, string name2, int expected)
         {
             var comparer = new SimilarNodeName.Comparer();
@@ -77,7 +78,9 @@ namespace Umbraco.Tests.Persistence.Repositories
         [TestCase(0, "Alpha", "Alpha (3)")]
         [TestCase(0, "Kilo (1)", "Kilo (1) (1)")] // though... we might consider "Kilo (2)"
         [TestCase(6, "Kilo (1)", "Kilo (1)")] // because of the id
-        public void Test(int nodeId, string nodeName, string expected)
+		[TestCase(0, "", " (1)")]
+		[TestCase(0, null, " (1)")]
+		public void Test(int nodeId, string nodeName, string expected)
         {
             var names = new[]
             {

--- a/src/Umbraco.Tests/Persistence/Repositories/SimilarNodeNameTests.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/SimilarNodeNameTests.cs
@@ -24,7 +24,8 @@ namespace Umbraco.Tests.Persistence.Repositories
         [TestCase("Alpha (10)", "Alpha (2)", +1)] // this is the real stuff
         [TestCase("Kilo", "Golf (2)", +1)]
         [TestCase("Kilo (1)", "Golf (2)", +1)]
-        public void ComparerTest(string name1, string name2, int expected)
+		[TestCase("", "", 0)]
+		public void ComparerTest(string name1, string name2, int expected)
         {
             var comparer = new SimilarNodeName.Comparer();
 


### PR DESCRIPTION
Adds null checking for node names when deleting a node/emptying recycle bin. If a node for some reason has the name set to either an empty string or null, the node is given a name using the same process used to ensure unique names are used.

For example

```
null or ""
```
becomes
```
" (1)"
```

I have also added some tests for SimilarNodeName to cater for null or "" values.