### PR TITLE
Extra check before assigning value to currentColor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
@@ -15,7 +15,7 @@ function ColorPickerController($scope) {
 
     $scope.toggleItem = function (color) {
 
-        var currentColor = $scope.model.value.hasOwnProperty("value")
+        var currentColor = ($scope.model.value && $scope.model.value.hasOwnProperty("value"))
             ? $scope.model.value.value
             : $scope.model.value;
 


### PR DESCRIPTION
In version 7.7.7 with the latest version of LeBlender (1.0.9.2), colorpickers will throw a javascript error in console. Applying this small check will resolve that issue.
ref: https://our.umbraco.org/forum/contributing-to-umbraco-cms/88890-color-picker-cannot-read-property-hasownproperty-of-null