### PR TITLE
Updated colorpicker datatype to be usable as a style/setting on grid datatype

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
@@ -13,28 +13,39 @@ function ColorPickerController($scope) {
         initActiveColor();
     }
 
-    $scope.toggleItem = function (color) {
+     $scope.toggleItem = function (color) {
+           
 
-        var currentColor = $scope.model.value.hasOwnProperty("value")
-            ? $scope.model.value.value
-            : $scope.model.value;
+            var currentColor = $scope.model.hasOwnProperty('value') ?
+               ( $scope.model.value.hasOwnProperty('value') ? $scope.model.value.value : $scope.model.value)
+                : "";
+            var newColor;
+            if (currentColor === color.value) {
+               // deselect
+                $scope.model.value = $scope.model.useLabel ? {
+                    value: '',
+                    label: ''
+                } : '';
+                newColor = '';
+            } else {
+                
+                // select
+                $scope.model.value = $scope.model.useLabel
+                    ? {
+                        value: color.value,
+                        label: color.label
+                    }
+                    : (color.hasOwnProperty('value') ? color.value : color);
+                newColor = color.hasOwnProperty('value') ? color.value : color;
+            }
+       
 
-        var newColor;
-        if (currentColor === color.value) {
-            // deselect
-            $scope.model.value = $scope.model.useLabel ? { value: "", label: "" } : "";
-            newColor = "";
-        }
-        else {
-            // select
-            $scope.model.value = $scope.model.useLabel ? { value: color.value, label: color.label } : color.value;
-            newColor = color.value;
-        }
+             if ($scope.propertyForm.hasOwnProperty('modelValue')) {
+                // this is required to re-validate
+                $scope.propertyForm.modelValue.$setViewValue(newColor);
+            }
 
-        // this is required to re-validate
-        $scope.propertyForm.modelValue.$setViewValue(newColor);
-    };
-
+         };
     // Method required by the valPropertyValidator directive (returns true if the property editor has at least one color selected)
     $scope.validateMandatory = function () {
         var isValid = !$scope.model.validation.mandatory || (


### PR DESCRIPTION
If you use the colorpicker as a style or setting it dosnt work unless this fix is applied, because it works abit differently when its a style then as a standalone datatype.

Try with a setting/style like this:
[{
    "label": "Baggrundsfarve",
    "description": "Sæt en baggrundsfarve på rækken",
    "key": "background-color",
    "view": "colorpicker",
    "prevalues": [
      "#627991",
      "#a9c2d9",
      "#ccc9b0",
      "#8f5368",
      "#8f9f84",
      "#c8ccb5",
      "#3e424d",
      "#df791e",
      "#259ff4",
      "#bb0000"
    ]
  }
]
![image](https://user-images.githubusercontent.com/1286043/34941621-ce867b5c-f9f4-11e7-95b9-22a3f68a9c57.png)
