### PR TITLE
U4-10842 LegacyMediaPickerPropertyConverter null-reference check

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/LegacyMediaPickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/LegacyMediaPickerPropertyConverter.cs
@@ -85,6 +85,9 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         /// </returns>
         public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
         {
+            if (source == null)
+                return null;
+
             if (IsMultipleDataType(propertyType.DataTypeId, propertyType.PropertyEditorAlias))
             {
                 var nodeIds =


### PR DESCRIPTION
If a selected media node has been trashed on the source environment, when Deploy comes to transfer the node ID, because it can't transfer the media dependency, the node ID value is set to `null`.

This causes an issue for the `LegacyMediaPickerPropertyConverter` and `ConvertDataToSource` throws a null-reference exception.

This patch adds in a null-reference check for the `source` value.

<http://issues.umbraco.org/issue/U4-10842>