### PR TITLE
U4-10845 MNTP value-converter - trashed content causes database lookups

### DIFF
--- a/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
@@ -117,6 +117,7 @@ namespace Umbraco.Web.Cache
             LegacyMediaPickerPropertyConverter.ClearCaches();
             SliderValueConverter.ClearCaches();
             MediaPickerPropertyConverter.ClearCaches();
+            MultiNodeTreePickerPropertyConverter.ClearCaches();
 
 
             base.Refresh(jsonPayload);


### PR DESCRIPTION
If the first ID in the MNTP value is a trashed content node, then the `ConvertSourceToObject` method would check if the ID is a media or member node, both of these incur a database call.

This can cause a detrimental performance impact on the website.

This patch uses the `startNode.type` prevalue to detect the node type, (e.g. Content, Media or Member).
The prevalue is cached in a private `ConcurrentDictionary` and refreshed using the `DataTypeCacheRefresher` event.
> _This follows the same caching-pattern as the Slider, Tags and MediaPicker value-converters._

<http://issues.umbraco.org/issue/U4-10845>