### PR TITLE
Proposed patch for U4-10756 - Guid TypedContent performance

### DIFF
--- a/src/Umbraco.Web/PublishedContentQuery.cs
+++ b/src/Umbraco.Web/PublishedContentQuery.cs
@@ -231,6 +231,24 @@ namespace Umbraco.Web
 
         private IPublishedContent TypedDocumentById(Guid id, ContextualPublishedCache cache)
         {
+            // Check if the loopkup is empty, if so populate it [LK]
+            if (_guidToIntLoopkup.Count == 0)
+            {
+                // TODO: Remove the debug profile logger
+                using (ApplicationContext.Current.ProfilingLogger.DebugDuration<PublishedContentQuery>("Populate GUID/INT lookup"))
+                {
+                    // NOTE, using the `@nodeTypeAlias` attribute in the XPath as this was support in both legacy & new schemas
+                    var tmpNodes = cache.GetXPathNavigator().Select("//*[@nodeTypeAlias]");
+                    foreach (XPathNavigator tmpNode in tmpNodes)
+                    {
+                        if (int.TryParse(tmpNode.GetAttribute("id", string.Empty), out int tmpNodeId)
+                            && Guid.TryParse(tmpNode.GetAttribute("key", string.Empty), out Guid tmpNodeKey))
+                        {
+                            _guidToIntLoopkup[tmpNodeKey] = tmpNodeId;
+                        }
+                    }
+                }
+            }
 
             IPublishedContent doc;
 

--- a/src/Umbraco.Web/PublishedContentQuery.cs
+++ b/src/Umbraco.Web/PublishedContentQuery.cs
@@ -227,13 +227,10 @@ namespace Umbraco.Web
             return doc;
         }
 
-        private static ConcurrentDictionary<Guid, int> _guidToIntLoopkup;
+        private static readonly ConcurrentDictionary<Guid, int> _guidToIntLoopkup = new ConcurrentDictionary<Guid, int>();
 
         private IPublishedContent TypedDocumentById(Guid id, ContextualPublishedCache cache)
         {
-            // We create the lookup when we first need it
-            if (_guidToIntLoopkup == null)
-                _guidToIntLoopkup = new ConcurrentDictionary<Guid, int>();
 
             IPublishedContent doc;
 

--- a/src/Umbraco.Web/PublishedContentQuery.cs
+++ b/src/Umbraco.Web/PublishedContentQuery.cs
@@ -243,9 +243,7 @@ namespace Umbraco.Web
                 // If not, then we perform an inefficient XPath for the GUID
 
                 // todo: in v8, implement in a more efficient way
-                var legacyXml = UmbracoConfig.For.UmbracoSettings().Content.UseLegacyXmlSchema;
-                var xpath = legacyXml ? "//node[@key=$guid]" : "//*[@key=$guid]";
-                doc = cache.GetSingleByXPath(xpath, new XPathVariable("guid", id.ToString()));
+                doc = cache.GetSingleByXPath("//*[@key=$guid]", new XPathVariable("guid", id.ToString()));
 
                 // When we have the node, we add the GUID/INT value to the lookup
                 if (doc != null)

--- a/src/Umbraco.Web/PublishedContentQuery.cs
+++ b/src/Umbraco.Web/PublishedContentQuery.cs
@@ -247,7 +247,7 @@ namespace Umbraco.Web
 
                 // When we have the node, we add the GUID/INT value to the lookup
                 if (doc != null)
-                    _guidToIntLoopkup.TryAdd(id, doc.Id);
+                    _guidToIntLoopkup[id] = doc.Id;
             }
             else
             {


### PR DESCRIPTION
This is a proposal for a temporary workaround to issue U4-10756.

It uses a local static ConcurrentDictionary to store a lookup of Guid/int values.
- If the Guid isn't in the lookup, then the traditional XPath is used, which would add the resulting node ID (int) to the lookup.
- If the lookup contains the Guid, then the returned int value will be used to perform a more efficient retrieval.

<http://issues.umbraco.org/issue/U4-10854>

---

Note: I have also removed the `UseLegacyXmlSchema` check, see commit da11acd229f5c41c9e25282ce83aefa62a5c5c12 for notes.