### PR TITLE
U4-8712 MultipleTextstring value newline delimiter changes

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultipleTextStringValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultipleTextStringValueConverter.cs
@@ -53,7 +53,7 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
             // Fall back on normal behaviour
             if (values.Any() == false)
             {
-                return sourceString.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+                return sourceString.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             }
 
             return values.ToArray();


### PR DESCRIPTION
<http://issues.umbraco.org/issue/U4-8712>

PR #2185 goes towards resolving this, but doesn't handle the impromptu switch between the `\r\n` and `\n` newline delimiters when republishing a content node.

Using an explicit array of newline chars will resolve this, e.g. `Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None)`

This also resolves issue <http://issues.umbraco.org/issue/U4-9360>

---

As for why the underlying switch from `\r\n` to `\n` happens when republishing a node, is still an unknown to me. Let's consider this a workaround patch.