### PR TITLE
MultipleTextStringValueConverter - moved the newline delimiters to be a static reusable array

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultipleTextStringValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultipleTextStringValueConverter.cs
@@ -13,6 +13,8 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
     [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]
     public class MultipleTextStringValueConverter : PropertyValueConverterBase
     {
+        private static readonly string[] NewLineDelimiters = new[] { "\r\n", "\r", "\n" };
+
         public override bool IsConverter(PublishedPropertyType propertyType)
         {
             return Constants.PropertyEditors.MultipleTextstringAlias.Equals(propertyType.PropertyEditorAlias);
@@ -53,7 +55,7 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
             // Fall back on normal behaviour
             if (values.Any() == false)
             {
-                return sourceString.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+                return sourceString.Split(NewLineDelimiters, StringSplitOptions.None);
             }
 
             return values.ToArray();


### PR DESCRIPTION
In `MultipleTextStringValueConverter`, I've moved the newline delimiters to be a static reusable array to prevent the allocation every time this is called. This will make @JimBobSquarePants happier 😸 

This is an amendment for PR #2399 - with reference to issue U4-8712
<http://issues.umbraco.org/issue/U4-8712>