### PR TITLE
Add default gitattributes and cleanup editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,16 @@
-root=true
+# editorconfig.org
 
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
 [*]
-end_of_line = lf
+insert_final_newline = true
 indent_style = space
 indent_size = 4
-trim_trailing_whitespace = true
 
-[*.{cs,cshtml,csx,vb,vbx,vbhtml,fs,fsx,txt,ps1,sql}]
-indent_size = 4
+# Trim trailing whitespace, limited support.
+# https://github.com/editorconfig/editorconfig/wiki/Property-research:-Trim-trailing-spaces
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,49 @@
+*.doc  diff=astextplain
+*.DOC	diff=astextplain
+*.docx	diff=astextplain
+*.DOCX	diff=astextplain
+*.dot	diff=astextplain
+*.DOT	diff=astextplain
+*.pdf	diff=astextplain
+*.PDF	diff=astextplain
+*.rtf	diff=astextplain
+*.RTF	diff=astextplain
+
+*.jpg  	binary
+*.png 	binary
+*.gif 	binary
+
+*.cs text=auto diff=csharp 
+*.vb text=auto
+*.c text=auto
+*.cpp text=auto
+*.cxx text=auto
+*.h text=auto
+*.hxx text=auto
+*.py text=auto
+*.rb text=auto
+*.java text=auto
+*.html text=auto
+*.htm text=auto
+*.css text=auto
+*.scss text=auto
+*.sass text=auto
+*.less text=auto
+*.js text=auto
+*.lisp text=auto
+*.clj text=auto
+*.sql text=auto
+*.php text=auto
+*.lua text=auto
+*.m text=auto
+*.asm text=auto
+*.erl text=auto
+*.fs text=auto
+*.fsx text=auto
+*.hs text=auto
+
+*.csproj text=auto merge=union 
+*.vbproj text=auto merge=union 
+*.fsproj text=auto merge=union 
+*.dbproj text=auto merge=union 
+*.sln text=auto eol=crlf merge=union 


### PR DESCRIPTION
This PR does some housekeeping to fix issues I was having with continuing line endings messages when working with the repository using the default Visual Studio settings.

1. Adds a [`.gitattributes`](https://www.git-scm.com/docs/gitattributes) file to handle line endings. This file is the default one generated by GitHub. It checks in using Linux line endings and checks out with Windows.
2. Removed the duplicate instructions from `.editorconfig` and removed the line endings instruction that were messing with Visual Studio since we now use the  `.gitattributes` to handle this way.
3. Added comment to `.editorconfig` to clarify behaviour.