### PR TITLE
Removed unnecessary &nbsp;

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.html
@@ -8,7 +8,7 @@
                 <a href="" ng-click="createMediaType()" umb-auto-focus>
                     <i class="large icon-item-arrangement"></i>
                     <span class="menu-label">
-                        <localize key="general_new">New</localize>&nbsp;
+                        <localize key="general_new">New</localize>
                         <localize key="content_mediatype">Media type</localize>
                     </span>
                 </a>


### PR DESCRIPTION
The `&nbsp;` is not needed as the line break gives the necessary spacing. Having both `&nbsp;` and the line break creates a double space.

![image](https://user-images.githubusercontent.com/3634580/35234294-e8a77b60-ffa0-11e7-9366-6cb88adae4fc.png)

#flueknepper