### PR TITLE
"Select editor" items shouldn't have a max height

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/card.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/card.less
@@ -97,7 +97,6 @@
 	text-align: center;
 
 	width: 100px;
-	height: 105px;
 
 	box-sizing: border-box;
 }
@@ -115,6 +114,7 @@
 	width: 100%;
 	height: 100%;
 	border-radius: 3px;
+    padding-bottom: 5px;
 }
 
 


### PR DESCRIPTION
The `<li>` making up each item currently has a max height of 105 pixels, which is a bit to low - even for some of the build in editors, and as a result the text is cropped.

If we remove the max height entirely, the items on each row (due to `display: flex;`) will adjust to their own desired height of that row. If we add a small padding at the bottom of the `<a>` element as well, it looks a lot better.

![image](https://user-images.githubusercontent.com/3634580/35235812-7ec353ae-ffa5-11e7-861e-b9c205e0ce3c.png)