### PR TITLE
U4-10864 add button when search returns no results, to clear the search

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/controllers/search.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/search.controller.js
@@ -14,7 +14,6 @@ function SearchController($scope, searchService, $log, $location, navigationServ
     $scope.isSearching = false;
     $scope.selectedResult = -1;
 
-
     $scope.navigateResults = function (ev) {
         //38: up 40: down, 13: enter
 
@@ -34,12 +33,14 @@ function SearchController($scope, searchService, $log, $location, navigationServ
         }
     };
 
-
     var group = undefined;
     var groupIndex = -1;
     var itemIndex = -1;
     $scope.selectedItem = undefined;
 
+    $scope.clearSearch = function () {
+        $scope.searchTerm = null;
+    };
 
     function iterateResults(up) {
         //default group

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -35,10 +35,14 @@
 
           <umb-load-indicator ng-if="isSearching"></umb-load-indicator>
 
-          <umb-empty-state
-            ng-if="!hasResults && !isSearching"
-            position="center">
-            <localize key="general_searchNoResult"></localize>
+          <umb-empty-state ng-if="!hasResults && !isSearching" position="center">
+              <localize key="general_searchNoResult"></localize>
+              <br/>
+              <button type="button" class="btn umb-button__button btn-info umb-button--" ng-click="clearSearch()" hotkey="" hotkey-when-hidden="">
+                  <span class="umb-button__content">
+                      <localize key="general_clearSearch" class="ng-isolate-scope ng-scope ng-binding">Clear Search</localize>
+                  </span>
+              </button>
           </umb-empty-state>
 
           <ul class="umb-tree" ng-if="!isSearching && hasResults">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -604,6 +604,7 @@
         <key alias="rights">Permissions</key>
         <key alias="search">Search</key>
         <key alias="searchNoResult">Sorry, we can not find what you are looking for</key>
+        <key alias="clearSearch">Clear search</key>
         <key alias="noItemsInList">No items have been added</key>
         <key alias="server">Server</key>
         <key alias="show">Show</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -604,6 +604,7 @@
         <key alias="rights">Permissions</key>
         <key alias="search">Search</key>
         <key alias="searchNoResult">Sorry, we can not find what you are looking for</key>
+        <key alias="clearSearch">Clear search</key>
         <key alias="noItemsInList">No items have been added</key>
         <key alias="server">Server</key>
         <key alias="show">Show</key>


### PR DESCRIPTION
Added a button if the main search doesn't return anything. Clicking the button will clear the input, which returns you back to the tree view.

<img width="601" alt="screen shot 2018-01-23 at 09 23 09" src="https://user-images.githubusercontent.com/7428078/35267735-24538e82-001f-11e8-99d5-0cc9ea538fd9.png">
