### PR TITLE
Fixes U4-10851 - Unzip Umbraco packages into a flat structure

### DIFF
--- a/src/umbraco.cms/businesslogic/Packager/Installer.cs
+++ b/src/umbraco.cms/businesslogic/Packager/Installer.cs
@@ -763,7 +763,21 @@ namespace umbraco.cms.businesslogic.packager
             if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
             Directory.CreateDirectory(tempDir);
 
-            ZipFile.ExtractToDirectory(zipName, tempDir);
+            //Have to open zip & get each entry & unzip to flatten
+            //Some Umbraco packages are nested in another folder, where others have all the files at the root
+            using (var archive = ZipFile.OpenRead(zipName))
+            {
+                foreach (var entry in archive.Entries)
+                {
+                    //Name will be empty if it's a folder
+                    //Otherwise its the filename - where FullName will include any nested folders too
+                    if (string.IsNullOrEmpty(entry.Name) == false)
+                    {
+                        var fullPath = Path.Combine(tempDir, entry.Name);
+                        entry.ExtractToFile(fullPath);
+                    }
+                }
+            }
 
             if (deleteFile)
             {


### PR DESCRIPTION
Unzip Umbraco packages into a flat structure, so it supports packages that have files at the root, along with some packages that have the files nested insider another guid folder