### PR TITLE
Nested Content should use the new turquoise/purple colors as the rest of the backoffice

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -31,13 +31,13 @@
 
 .nested-content__item--active:not(.nested-content__item--single)
 {
-    background: #f8f8f8;
+    background: @gray-10;
 }
 
 .nested-content__item.ui-sortable-placeholder
 {
-    background: #f8f8f8;
-    border: 1px dashed #d9d9d9;
+    background: @gray-10;
+    border-bottom: 1px dashed @purple-l3;
     visibility: visible !important;
     height: 55px;
     margin-top: -1px;
@@ -56,7 +56,7 @@
 .nested-content__header-bar
 {
     padding: 15px 20px;
-    border-bottom: 1px dashed #e0e0e0;
+    border-bottom: 1px dashed @purple-l3;
     text-align: right;
     cursor: pointer;
     background-color: white;
@@ -113,8 +113,8 @@
 .nested-content__icon--active
 {
     color: white;
-    background: #2e8aea;
-    border-color: #2e8aea;
+    background: @turquoise-d1;
+    border-color: @turquoise-d1;
     text-decoration: none;
 }
 
@@ -146,7 +146,7 @@
 
 .nested-content__content
 {
-    border-bottom: 1px dashed #e0e0e0;
+    border-bottom: 1px dashed @purple-l3;
 }
 
 .nested-content__content .umb-control-group {
@@ -165,7 +165,7 @@
     clear: both;
     font-size: 14px;
     color: #555;
-    background: #f8f8f8;
+    background: @gray-10;
     border-radius: 15px;
 }
 


### PR DESCRIPTION
Umbraco 7.6 introduced new colors for the backoffice, where the gray colors became slightly darker, and the blue color became turquoise instead.

However even though Nested Content was added to the core after the color change, Nested Content still uses the old colors. I've tried to rectify that with this commit.

How it looks now:

![image](https://user-images.githubusercontent.com/3634580/35300270-3996ce26-0088-11e8-98a3-160197e330c9.png)

How it looks after with this pull request:

![image](https://user-images.githubusercontent.com/3634580/35300306-50077070-0088-11e8-8d48-33366db6e29d.png)
