### PR TITLE
Fix NullReferenceException when HttpContext is not available

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/GridValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/GridValueConverter.cs
@@ -40,12 +40,13 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
 
                     //TODO: Change all singleton access to use ctor injection in v8!!!
                     //TODO: That would mean that property value converters would need to be request lifespan, hrm....
+                    bool isDebug = HttpContext.Current != null && HttpContext.Current.IsDebuggingEnabled;
                     var gridConfig = UmbracoConfig.For.GridConfig(
                         ApplicationContext.Current.ProfilingLogger.Logger,
                         ApplicationContext.Current.ApplicationCache.RuntimeCache,
                         new DirectoryInfo(IOHelper.MapPath(SystemDirectories.AppPlugins)),
                         new DirectoryInfo(IOHelper.MapPath(SystemDirectories.Config)),
-                        HttpContext.Current.IsDebuggingEnabled);
+                        isDebug);
                     
                     var sections = GetArray(obj, "sections");
                     foreach (var section in sections.Cast<JObject>())


### PR DESCRIPTION
This method currently throws a NullReferenceException in contexts where HttpContext.Current is null. This would happen in e.g. background threads. As HttpContext is only used to set an isDebug flag, it seems more sensible to not throw in cases without an HttpContext, but simply set isDebug to false instead. If this is not acceptable behavior, could we perhaps look at something other than HttpContext.Current.IsDebuggingEnabled to decide whether isDebug should be set?