### PR TITLE
Dev v7.8 - Fix for media picker overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -103,7 +103,7 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 	              $scope.model.target.udi = media.udi;
 	              $scope.model.target.isMedia = true;
 	              $scope.model.target.name = media.name;
-	              $scope.model.target.url = mediaHelper.resolveFile(media);
+	              $scope.model.target.url = media.image;
 
 	              $scope.mediaPickerOverlay.show = false;
 	              $scope.mediaPickerOverlay = null;


### PR DESCRIPTION
There's a bug with the media picker overlay.
If you search by name and then select one of the results, the picker fails to populate the Url and stops it from working.
This fixes it by using the .image property of the media model.