### PR TITLE
U4-10966 -  Single/Multiple Media Picker is messed up when dragging images

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -282,8 +282,8 @@ ul.color-picker li a  {
 }
 
 .umb-sortable-thumbnails .umb-sortable-thumbnails__wrapper {
-    width: 120px;
-    height: 114px;
+    width: 124px;
+    height: 124px;
     overflow: hidden;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -298,6 +298,10 @@ ul.color-picker li a  {
     visibility: hidden;
 }
 
+.umb-sortable-thumbnails:not(.ui-sortable-disabled) > li:not(.unsortable) {
+    cursor: move;
+}
+
 .umb-sortable-thumbnails li:hover .umb-sortable-thumbnails__actions  {
     opacity: 1;
     visibility: visible;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -298,9 +298,11 @@ ul.color-picker li a  {
     visibility: hidden;
 }
 
-.umb-sortable-thumbnails:not(.ui-sortable-disabled) > li:not(.unsortable) {
-    cursor: move;
-}
+.umb-sortable-thumbnails.ui-sortable:not(.ui-sortable-disabled) {
+    > li:not(.unsortable) {
+        cursor: move;
+    }
+} 
 
 .umb-sortable-thumbnails li:hover .umb-sortable-thumbnails__actions  {
     opacity: 1;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -243,7 +243,7 @@ ul.color-picker li a  {
 
 .umb-mediapicker .umb-sortable-thumbnails li {
     flex-direction: column;
-    margin: 0 5px 0 0;
+    margin: 0 5px 5px 0;
     padding: 5px;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -137,7 +137,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
 
        $scope.sortableOptions = {
            disabled: !$scope.isMultiPicker,
-           items: "li:not(.unsortable)",
+           items: "li:not(.add-wrapper)",
            cancel: ".unsortable",
            update: function(e, ui) {
                var r = [];

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -141,8 +141,8 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
            cancel: ".unsortable",
            update: function(e, ui) {
                var r = [];
-               //TODO: Instead of doing this with a half second delay would be better to use a watch like we do in the
-               // content picker. THen we don't have to worry about setting ids, render models, models, we just set one and let the
+               // TODO: Instead of doing this with a half second delay would be better to use a watch like we do in the
+               // content picker. Then we don't have to worry about setting ids, render models, models, we just set one and let the
                // watch do all the rest.
                 $timeout(function(){
                     angular.forEach($scope.images, function(value, key) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -136,6 +136,8 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
        };
 
        $scope.sortableOptions = {
+           items: "li:not(.unsortable)",
+           cancel: ".unsortable",
            update: function(e, ui) {
                var r = [];
                //TODO: Instead of doing this with a half second delay would be better to use a watch like we do in the

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -136,6 +136,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
        };
 
        $scope.sortableOptions = {
+           disabled: !$scope.isMultiPicker,
            items: "li:not(.unsortable)",
            cancel: ".unsortable",
            update: function(e, ui) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -30,7 +30,7 @@
                 </div>
 
             </li>
-            <li class="unsortable" ng-if="showAdd()">
+            <li class="add-wrapper unsortable" ng-if="showAdd()">
                 <a href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': (images.length === 0 || isMultiPicker)}" prevent-default>
                     <i class="icon icon-add large"></i>
                 </a>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -3,7 +3,7 @@
     <p ng-if="(images|filter:{trashed:true}).length == 1"><localize key="mediaPicker_pickedTrashedItem"></localize></p>
     <p ng-if="(images|filter:{trashed:true}).length > 1"><localize key="mediaPicker_pickedTrashedItems"></localize></p>
     
-    <div class="flex error">
+    <div class="flex flex-wrap error">
         <ul ui-sortable="sortableOptions" ng-model="images" class="umb-sortable-thumbnails">
             <li class="umb-sortable-thumbnails__wrapper" ng-repeat="image in images track by $index">
 
@@ -30,8 +30,8 @@
                 </div>
 
             </li>
-            <li style="border: none;">
-                <a href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': (images.length === 0 || isMultiPicker)}" ng-if="showAdd()" prevent-default>
+            <li class="unsortable" ng-if="showAdd()">
+                <a href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': (images.length === 0 || isMultiPicker)}" prevent-default>
                     <i class="icon icon-add large"></i>
                 </a>
             </li>


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/U4-10966

The single/multiple media picker is messed up, when dragging the items and the `<li>` element wrapper is visible when the media picker only allows a single item to be picked.

I have added `cancel: ".unsortable"` which ensure the "add"-button can't be dragged. Furthermore I have added `items: "li:not(.add-wrapper)"` to the "add"-button `<li>` element which ensure the "add" button is last item even when you try to drag images to the right of the "add"-button.
Inspired from this 👍 https://stackoverflow.com/a/9000467/1693918

Finally the sortable is diabled when media picker not is multiple. Check out this codepen demo https://codepen.io/thgreasi/pen/pBbvF

It seems to work well when I change the Media/Image Picker between Single/Multiple items.