### PR TITLE
Visual improvements to Nested Content (U4-10742)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
@@ -9,6 +9,13 @@ var ncNodeNameCache = {
 
 angular.module("umbraco.filters").filter("ncNodeName", function (editorState, entityResource) {
 
+    function formatLabel(firstNodeName, totalNodes) {
+        return totalNodes <= 1
+            ? firstNodeName
+            // If there is more than one item selected, append the additional number of items selected to hint that
+            : firstNodeName + " (+" + (totalNodes - 1) + ")";
+    }
+
     return function (input) {
 
         // Check we have a value at all
@@ -31,7 +38,7 @@ angular.module("umbraco.filters").filter("ncNodeName", function (editorState, en
 
         // See if there is a value in the cache and use that
         if (ncNodeNameCache.keys[lookupId]) {
-            return ncNodeNameCache.keys[lookupId];
+            return formatLabel(ncNodeNameCache.keys[lookupId], ids.length);
         }
 
         // No value, so go fetch one 
@@ -47,13 +54,12 @@ angular.module("umbraco.filters").filter("ncNodeName", function (editorState, en
         entityResource.getById(lookupId, type)
             .then(
                 function (ent) {
-                    // If there is more than one item selected, append ", ..." to the header to hint that
-                    ncNodeNameCache.keys[lookupId] = ent.name + (ids.length > 1 ? ", ..." : "");
+                    ncNodeNameCache.keys[lookupId] = ent.name;
                 }
             );
 
         // Return the current value for now
-        return ncNodeNameCache.keys[lookupId];
+        return formatLabel(ncNodeNameCache.keys[lookupId], ids.length);
     };
 
 }).filter("ncRichtext", function () {

--- a/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
@@ -62,7 +62,7 @@ angular.module("umbraco.filters").filter("ncNodeName", function (editorState, en
         return formatLabel(ncNodeNameCache.keys[lookupId], ids.length);
     };
 
-}).filter("ncRichtext", function () {
+}).filter("ncRichText", function () {
     return function(input) {
         return $("<div/>").html(input).text();
     };

--- a/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
@@ -7,7 +7,7 @@ var ncNodeNameCache = {
     keys: {}
 };
 
-angular.module("umbraco.filters").filter("ncNodeName", function (editorState, entityResource, $q) {
+angular.module("umbraco.filters").filter("ncNodeName", function (editorState, entityResource) {
 
     return function (input) {
 

--- a/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
@@ -35,13 +35,19 @@ angular.module("umbraco.filters").filter("ncNodeName", function (editorState, en
         // make a load of requests while we wait for a response
         ncNodeNameCache.keys[input] = "Loading...";
 
-        entityResource.getById(input, "Document")
-            .then(function (ent) {
-                ncNodeNameCache.keys[input] = ent.name;
-            });
+        entityResource.getById(input, input.indexOf("umb://media/") === 0 ? "Media" : "Document")
+            .then(
+                function (ent) {
+                    ncNodeNameCache.keys[input] = ent.name;
+                }
+            );
 
         // Return the current value for now
         return ncNodeNameCache.keys[input];
     };
 
+}).filter("ncRichtext", function (editorState, entityResource) {
+    return function(input) {
+        return $("<div/>").html(input).text();
+    };
 });

--- a/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
@@ -39,7 +39,12 @@ angular.module("umbraco.filters").filter("ncNodeName", function (editorState, en
         // make a load of requests while we wait for a response
         ncNodeNameCache.keys[lookupId] = "Loading...";
 
-        entityResource.getById(lookupId, lookupId.indexOf("umb://media/") === 0 ? "Media" : "Document")
+        var type = lookupId.indexOf("umb://media/") === 0
+            ? "Media"
+            : lookupId.indexOf("umb://member/") === 0
+                ? "Member"
+                : "Document";
+        entityResource.getById(lookupId, type)
             .then(
                 function (ent) {
                     // If there is more than one item selected, append ", ..." to the header to hint that

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -67,8 +67,7 @@
     -o-user-select: none;
 }
 
-.nested-content__heading
-{
+.nested-content__heading {
     line-height: 20px;
     position: relative;
 
@@ -86,12 +85,12 @@
 
     .nested-content__item-name
     {
-        max-height: 40px;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        display: -webkit-box;
-        overflow: hidden;
+        max-height: 20px;
         text-align: left;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: block;
     }
 }
 
@@ -105,10 +104,9 @@
 
     position: absolute;
     right: 0px;
-    top: 0px;
+    top: 2px;
     background-color: white;
     padding: 5px;
-    height: 75%;
 
     &:before
     {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -69,26 +69,62 @@
 
 .nested-content__heading
 {
-    float: left;
     line-height: 20px;
-}
+    position: relative;
 
-.nested-content__heading i
-{
-    vertical-align: text-top;
-    color: #999; /* same icon color as the icons in the item type picker */
-    margin-right: 10px;
+    &.-with-icon
+    {
+        padding-left: 20px;
+    }
+
+    i
+    {
+        color: #999; /* same icon color as the icons in the item type picker */
+        position: absolute;
+        left: 0;
+    }
+
+    .nested-content__item-name
+    {
+        max-height: 40px;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        display: -webkit-box;
+        overflow: hidden;
+        text-align: left;
+    }
 }
 
 .nested-content__icons
 {
-    margin: -6px 0;
     opacity: 0;
 
     transition: opacity .15s ease-in-out;
    -moz-transition: opacity .15s ease-in-out;
    -webkit-transition: opacity .15s ease-in-out;
+
+    position: absolute;
+    right: 0px;
+    top: 0px;
+    background-color: white;
+    padding: 5px;
+    height: 75%;
+
+    &:before
+    {
+        content: ' ';
+        position: absolute;
+        display: block;
+        width: 30px;
+        left: -30px;
+        top: 0;
+        bottom: 0;
+        background: -webkit-linear-gradient(90deg, rgba(255,255,255,0), white);
+        background: -moz-linear-gradient(90deg, rgba(255,255,255,0), white);
+        background: linear-gradient(90deg, rgba(255,255,255,0), white);
+    }
 }
+
 
 .nested-content__header-bar:hover .nested-content__icons,
 .nested-content__item--active > .nested-content__header-bar .nested-content__icons

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -9,7 +9,7 @@
 
                 <div class="nested-content__header-bar" ng-click="$parent.editNode($index)" ng-hide="$parent.singleMode">
 
-                    <div class="nested-content__heading"><i ng-if="showIcons" class="icon" ng-class="$parent.getIcon($index)"></i><span ng-bind="$parent.getName($index)"></span></div>
+                    <div class="nested-content__heading" ng-class="{'-with-icon': showIcons}"><i ng-if="showIcons" class="icon" ng-class="$parent.getIcon($index)"></i><span class="nested-content__item-name" ng-bind="$parent.getName($index)"></span></div>
 
                     <div class="nested-content__icons">
                         <a class="nested-content__icon nested-content__icon--edit" title="{{editIconTitle}}" ng-class="{ 'nested-content__icon--active' : $parent.realCurrentNode.id == node.id }" ng-click="$parent.editNode($index); $event.stopPropagation();" ng-show="$parent.maxItems > 1" prevent-default>


### PR DESCRIPTION
As outlined in [U4-10742](http://issues.umbraco.org/issue/U4-10742), Nested Content breaks visually when using anything but very basic properties with very short values as label templates.

This PR proposes limiting the text to only one line (with an ellipsis text overflow), thus ensuring a harmonic look in all cases. 

Additionally the PR introduces support for media, member and multitreenode pickers as well as richtext editors in the built-in filters for handling label templates. 

I'm attaching before and after images of various scenarios that are handled by this PR. 

Note that this is not a complete fix for U4-10742, as it calls for support for all built-in property editors. But it goes a long way for supporting more cases than is currently. 

If this PR is accepted, the [Nested Content documentation](https://our.umbraco.org/Documentation/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Nested-Content) should be updated with info on how to use these filters - the current (and now updated) `ncNodeName` and the new `ncRichtext`.

### Using richtext as label template
![richtext](https://user-images.githubusercontent.com/7405322/36497314-40a03d8c-173b-11e8-9819-df68f04de28b.png)

### Using textarea as label template
![textarea](https://user-images.githubusercontent.com/7405322/36497320-45835654-173b-11e8-9447-c76e6d770f3e.png)

### Using media picker as label template
![media picker](https://user-images.githubusercontent.com/7405322/36497326-4c56c5e2-173b-11e8-9943-172eb179ca9b.png)

### Using media picker with multiselect as label template
![media picker multiple](https://user-images.githubusercontent.com/7405322/36497330-4f7b385c-173b-11e8-81ca-8db77fff2760.png)

### Using multinode treepicker as label template
![multinode treepicker](https://user-images.githubusercontent.com/7405322/36497331-5393931c-173b-11e8-902f-93d7814b186d.png)

### Using member picker as label template
![member picker](https://user-images.githubusercontent.com/7405322/36497335-562d816e-173b-11e8-92eb-41df962c4418.png)
