### PR TITLE
Check if user is admin to show propertyAlias regardless of debug status

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
@@ -4,27 +4,30 @@
 * @restrict E
 **/
 angular.module("umbraco.directives")
-    .directive('umbProperty', function (umbPropEditorHelper) {
+    .directive('umbProperty', function (umbPropEditorHelper, userService) {
         return {
             scope: {
                 property: "="
             },
             transclude: true,
             restrict: 'E',
-            replace: true,        
+            replace: true,
             templateUrl: 'views/components/property/umb-property.html',
-            link: function(scope) {
-                scope.propertyAlias = Umbraco.Sys.ServerVariables.isDebuggingEnabled === true ? scope.property.alias : null;
+            link: function (scope) {
+                userService.getCurrentUser().then(function (u) {
+                    var isAdmin = u.userGroups.indexOf('admin') !== -1;
+                    scope.propertyAlias = (Umbraco.Sys.ServerVariables.isDebuggingEnabled === true || isAdmin) ? scope.property.alias : null;
+                });
             },
             //Define a controller for this directive to expose APIs to other directives
             controller: function ($scope, $timeout) {
-               
+
                 var self = this;
 
                 //set the API properties/methods
-                
+
                 self.property = $scope.property;
-                self.setPropertyError = function(errorMsg) {
+                self.setPropertyError = function (errorMsg) {
                     $scope.property.propertyErrorMessage = errorMsg;
                 };
             }


### PR DESCRIPTION
uDuf Hackathon goodness!

Feature request from this issue: issues.umbraco.org/issue/U4-10116

Makes use of the getCurrentUser() method of the userService to query the userGroups property of the current user.

Thanks Shannon for the pointer towards the right method!