### PR TITLE
U4-10702 - Update Umb-modal icon to be consistent with other icons

### DIFF
--- a/src/Umbraco.Web.UI.Client/Web.config
+++ b/src/Umbraco.Web.UI.Client/Web.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.5"/>
+    <httpRuntime targetFramework="4.5"/>
+  </system.web>
+</configuration>

--- a/src/Umbraco.Web.UI.Client/src/less/modals.less
+++ b/src/Umbraco.Web.UI.Client/src/less/modals.less
@@ -181,7 +181,7 @@
 	width: 640px !important;
 }
 .umb-modal i {
-  font-size: 14px;
+  font-size: 20px;
 } 
 .umb-modal .breadcrumb {
 	background: none;


### PR DESCRIPTION
A Simple change of font size for the modal icon. 

To reproduce, add a content picker with "Show open button" set in the doctype settings. Then in the page, select a node and then click the "Open" Button