### PR TITLE
U4-10849 [uDuf] fixed Umbraco user field "User Last updated" and "last locke…

### DIFF
--- a/src/Umbraco.Core/Models/Identity/BackOfficeIdentityUser.cs
+++ b/src/Umbraco.Core/Models/Identity/BackOfficeIdentityUser.cs
@@ -121,12 +121,21 @@ namespace Umbraco.Core.Models.Identity
         }
 
         /// <summary>
+        /// LastPasswordChangeDateUtc so we can track changes to it
+        /// </summary>
+        public override DateTime? LastPasswordChangeDateUtc
+        {
+            get { return _lastPasswordChangeDateUtc; }
+            set { _tracker.SetPropertyValueAndDetectChanges(value, ref _lastPasswordChangeDateUtc, Ps.Value.LastPasswordChangeDateUtcSelector); }
+        }
+
+        /// <summary>
         /// Override LastLoginDateUtc so we can track changes to it
         /// </summary>
         public override DateTime? LastLoginDateUtc
         {
             get { return _lastLoginDateUtc; }
-            set { _tracker.SetPropertyValueAndDetectChanges(value, ref _lastLoginDateUtc, Ps.Value.LastLoginDateUtcSelector); }            
+            set { _tracker.SetPropertyValueAndDetectChanges(value, ref _lastLoginDateUtc, Ps.Value.LastLoginDateUtcSelector); }
         }
 
         /// <summary>
@@ -392,6 +401,7 @@ namespace Umbraco.Core.Models.Identity
             public readonly PropertyInfo EmailSelector = ExpressionHelper.GetPropertyInfo<BackOfficeIdentityUser, string>(x => x.Email);
             public readonly PropertyInfo UserNameSelector = ExpressionHelper.GetPropertyInfo<BackOfficeIdentityUser, string>(x => x.UserName);
             public readonly PropertyInfo LastLoginDateUtcSelector = ExpressionHelper.GetPropertyInfo<BackOfficeIdentityUser, DateTime?>(x => x.LastLoginDateUtc);
+            public readonly PropertyInfo LastPasswordChangeDateUtcSelector = ExpressionHelper.GetPropertyInfo<BackOfficeIdentityUser, DateTime?>(x => x.LastPasswordChangeDateUtc);
             public readonly PropertyInfo EmailConfirmedSelector = ExpressionHelper.GetPropertyInfo<BackOfficeIdentityUser, bool>(x => x.EmailConfirmed);
             public readonly PropertyInfo NameSelector = ExpressionHelper.GetPropertyInfo<BackOfficeIdentityUser, string>(x => x.Name);
             public readonly PropertyInfo AccessFailedCountSelector = ExpressionHelper.GetPropertyInfo<BackOfficeIdentityUser, int>(x => x.AccessFailedCount);
@@ -419,6 +429,7 @@ namespace Umbraco.Core.Models.Identity
         private int _id;
         private bool _hasIdentity = false;
         private DateTime? _lastLoginDateUtc;
+        private DateTime? _lastPasswordChangeDateUtc;
         private bool _emailConfirmed;
         private string _name;
         private int _accessFailedCount;

--- a/src/Umbraco.Core/Models/Identity/IdentityModelMappings.cs
+++ b/src/Umbraco.Core/Models/Identity/IdentityModelMappings.cs
@@ -19,6 +19,7 @@ namespace Umbraco.Core.Models.Identity
                 })
                 .ConstructUsing(user => new BackOfficeIdentityUser(user.Id, user.Groups))
                 .ForMember(user => user.LastLoginDateUtc, expression => expression.MapFrom(user => user.LastLoginDate.ToUniversalTime()))
+                .ForMember(user => user.LastPasswordChangeDateUtc, expression => expression.MapFrom(user => user.LastPasswordChangeDate.ToUniversalTime()))
                 .ForMember(user => user.Email, expression => expression.MapFrom(user => user.Email))
                 .ForMember(user => user.EmailConfirmed, expression => expression.MapFrom(user => user.EmailConfirmedDate.HasValue))
                 .ForMember(user => user.Id, expression => expression.MapFrom(user => user.Id))

--- a/src/Umbraco.Core/Models/Identity/IdentityUser.cs
+++ b/src/Umbraco.Core/Models/Identity/IdentityUser.cs
@@ -84,6 +84,12 @@ namespace Umbraco.Core.Models.Identity
         public virtual DateTime? LockoutEndDateUtc { get; set; }
 
         /// <summary>
+        /// DateTime in UTC when the password was last changed.
+        /// 
+        /// </summary>
+        public virtual DateTime? LastPasswordChangeDateUtc { get; set; }
+
+        /// <summary>
         /// Is lockout enabled for this user
         /// 
         /// </summary>

--- a/src/Umbraco.Core/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Core/Security/BackOfficeUserManager.cs
@@ -457,6 +457,7 @@ namespace Umbraco.Core.Security
         /// </remarks>
         protected override async Task<IdentityResult> UpdatePassword(IUserPasswordStore<T, int> passwordStore, T user, string newPassword)
         {
+            user.LastPasswordChangeDateUtc = DateTime.UtcNow;
             var userAwarePasswordHasher = PasswordHasher as IUserAwarePasswordHasher<BackOfficeIdentityUser, int>;
             if (userAwarePasswordHasher == null)
                 return await base.UpdatePassword(passwordStore, user, newPassword);

--- a/src/Umbraco.Core/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Core/Security/BackOfficeUserStore.cs
@@ -622,7 +622,7 @@ namespace Umbraco.Core.Security
         private bool UpdateMemberProperties(IUser user, BackOfficeIdentityUser identityUser)
         {
             var anythingChanged = false;
-            
+
             //don't assign anything if nothing has changed as this will trigger the track changes of the model
 
             if (identityUser.IsPropertyDirty("LastLoginDateUtc")
@@ -631,6 +631,13 @@ namespace Umbraco.Core.Security
             {
                 anythingChanged = true;
                 user.LastLoginDate = identityUser.LastLoginDateUtc.Value.ToLocalTime();
+            }
+            if (identityUser.IsPropertyDirty("LastPasswordChangeDateUtc")
+                || (user.LastPasswordChangeDate != default(DateTime) && identityUser.LastPasswordChangeDateUtc.HasValue == false)
+                || identityUser.LastPasswordChangeDateUtc.HasValue && user.LastPasswordChangeDate.ToUniversalTime() != identityUser.LastPasswordChangeDateUtc.Value)
+            {
+                anythingChanged = true;
+                user.LastPasswordChangeDate = identityUser.LastPasswordChangeDateUtc.Value.ToLocalTime();
             }
             if (identityUser.IsPropertyDirty("EmailConfirmed")
                 || (user.EmailConfirmedDate.HasValue && user.EmailConfirmedDate.Value != default(DateTime) && identityUser.EmailConfirmed == false)


### PR DESCRIPTION
Fixed Umbraco user field "User Last updated" and "last locked date" not updating after password change / account locking.
http://issues.umbraco.org/issue/U4-10849

This seems to be a duplicate of http://issues.umbraco.org/issue/U4-10819 

The fix is addressing the issue at a level of the UserManager so it should cover all instances of password changes.