### PR TITLE
Hackathon: U4-10941 Name should be before Label when adding grid row configurations

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
@@ -10,14 +10,14 @@
           data for any existing content that is based on this configuration.</p>
           <p><strong>Modifying only the label will not result in data loss.</strong></p>
       </div>
+
+       <umb-control-group label="@general_name">
+           <input type="text" ng-model="currentRow.name" />
+       </umb-control-group>
        
        <umb-control-group label="@general_label">
            <input type="text" ng-model="currentRow.label" placeholder="Overrides name" />
        </umb-control-group>
-
-      <umb-control-group label="@general_name">
-          <input type="text" ng-model="currentRow.name" />
-      </umb-control-group>
 
       <div class="uSky-templates-template"
            style="margin: 0; width: 350px; position: relative;">


### PR DESCRIPTION
Full issue here: [http://issues.umbraco.org/issue/U4-10941](http://issues.umbraco.org/issue/U4-10941). I kept it simple and just swapped the field order.