### PR TITLE
Uduf-Hackathon U4-5366

### DIFF
--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -832,32 +832,21 @@ namespace Umbraco.Core.Services
             foreach (var element in structureElement.Elements("DocumentType"))
             {
                 var alias = element.Value;
-                if (_importedContentTypes.ContainsKey(alias))
+
+                var allowedChild = _importedContentTypes.ContainsKey(alias) ? _importedContentTypes[alias] : _contentTypeService.GetContentType(alias);
+                if (allowedChild == null)
                 {
-                    var allowedChild = _importedContentTypes[alias];
-                    if (allowedChild == null || allowedChildren.Any(x => x.Id.IsValueCreated && x.Id.Value == allowedChild.Id)) continue;
+                    _logger.Warn<PackagingService>(
+                    string.Format(
+                        "Packager: Error handling DocumentType structure. DocumentType with alias '{0}' could not be found and was not added to the structure for '{1}'.",
+                        alias, contentType.Alias));
 
-                    allowedChildren.Add(new ContentTypeSort(new Lazy<int>(() => allowedChild.Id), sortOrder, allowedChild.Alias));
-                    sortOrder++;
+                    continue;
                 }
-                else
-                {
-                    // DocumentType was not in imported or dependant types, try to get from ContentTypeService
-                    var allowedChild = _contentTypeService.GetContentType(alias);
-                    if (allowedChild == null)
-                    {
-                        _logger.Warn<PackagingService>(
-                        string.Format(
-                            "Packager: Error handling DocumentType structure. DocumentType with alias '{0}' could not be found and was not added to the structure for '{1}'.",
-                            alias, contentType.Alias));
+                if (allowedChildren.Any(x => x.Id.IsValueCreated && x.Id.Value == allowedChild.Id)) continue;
 
-                        continue;
-                    }
-                    if (allowedChildren.Any(x => x.Id.IsValueCreated && x.Id.Value == allowedChild.Id)) continue;
-
-                    allowedChildren.Add(new ContentTypeSort(new Lazy<int>(() => allowedChild.Id), sortOrder, allowedChild.Alias));
-                    sortOrder++;
-                }
+                allowedChildren.Add(new ContentTypeSort(new Lazy<int>(() => allowedChild.Id), sortOrder, allowedChild.Alias));
+                sortOrder++;
             }
 
             contentType.AllowedContentTypes = allowedChildren;

--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -842,10 +842,19 @@ namespace Umbraco.Core.Services
                 }
                 else
                 {
-                    _logger.Warn<PackagingService>(
-                    string.Format(
-                        "Packager: Error handling DocumentType structure. DocumentType with alias '{0}' could not be found and was not added to the structure for '{1}'.",
-                        alias, contentType.Alias));
+                    // DocumentType was not in imported or dependant types, try to get from ContentTypeService
+                    var allowedChild = _contentTypeService.GetContentType(alias);
+                    if (allowedChild == null)
+                    {
+                        _logger.Warn<PackagingService>(
+                        string.Format(
+                            "Packager: Error handling DocumentType structure. DocumentType with alias '{0}' could not be found and was not added to the structure for '{1}'.",
+                            alias, contentType.Alias));
+                    }
+                    if (allowedChildren.Any(x => x.Id.IsValueCreated && x.Id.Value == allowedChild.Id)) continue;
+
+                    allowedChildren.Add(new ContentTypeSort(new Lazy<int>(() => allowedChild.Id), sortOrder, allowedChild.Alias));
+                    sortOrder++;
                 }
             }
 

--- a/src/Umbraco.Core/Services/PackagingService.cs
+++ b/src/Umbraco.Core/Services/PackagingService.cs
@@ -850,6 +850,8 @@ namespace Umbraco.Core.Services
                         string.Format(
                             "Packager: Error handling DocumentType structure. DocumentType with alias '{0}' could not be found and was not added to the structure for '{1}'.",
                             alias, contentType.Alias));
+
+                        continue;
                     }
                     if (allowedChildren.Any(x => x.Id.IsValueCreated && x.Id.Value == allowedChild.Id)) continue;
 


### PR DESCRIPTION
When importing document types, only document types part of the import were added as allowed child node types. Changed code also uses ContentTypeService to find existing document types by alias and adds them as allowed child node type.

http://issues.umbraco.org/issue/U4-5366