### PR TITLE
change newsletter subscribe to default for installation process - GDPR Compliance

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -1,7 +1,7 @@
 angular.module("umbraco.install").controller("Umbraco.Install.UserController", function($scope, installerService) {
     
     $scope.passwordPattern = /.*/;
-    $scope.installer.current.model.subscribeToNewsLetter = true;
+    $scope.installer.current.model.subscribeToNewsLetter = false;
     
     if ($scope.installer.current.model.minNonAlphaNumericLength > 0) {
         var exp = "";


### PR DESCRIPTION
references issue: 

http://issues.umbraco.org/issue/U4-11007

Newsletter subscribe should be defaulted to false during the installation process to comply with GDPR.