### PR TITLE
U4-10688 Obsolete property editors showing

### DIFF
--- a/src/Umbraco.Core/CoreBootManager.cs
+++ b/src/Umbraco.Core/CoreBootManager.cs
@@ -461,7 +461,7 @@ namespace Umbraco.Core
                 ApplicationCache.RuntimeCache,
                 new ManifestParser(new DirectoryInfo(IOHelper.MapPath("~/App_Plugins")), ApplicationCache.RuntimeCache));
 
-            PropertyEditorResolver.Current = new PropertyEditorResolver(ServiceProvider, ProfilingLogger.Logger, () => PluginManager.ResolvePropertyEditors(), builder);
+            PropertyEditorResolver.Current = new PropertyEditorResolver(ServiceProvider, ProfilingLogger.Logger, () => PluginManager.ResolvePropertyEditors(), builder, UmbracoConfig.For.UmbracoSettings().Content);
             ParameterEditorResolver.Current = new ParameterEditorResolver(ServiceProvider, ProfilingLogger.Logger, () => PluginManager.ResolveParameterEditors(), builder);
 
             //setup the validators resolver with our predefined validators

--- a/src/Umbraco.Core/CoreBootManager.cs
+++ b/src/Umbraco.Core/CoreBootManager.cs
@@ -461,7 +461,7 @@ namespace Umbraco.Core
                 ApplicationCache.RuntimeCache,
                 new ManifestParser(new DirectoryInfo(IOHelper.MapPath("~/App_Plugins")), ApplicationCache.RuntimeCache));
 
-            PropertyEditorResolver.Current = new PropertyEditorResolver(ServiceProvider, ProfilingLogger.Logger, () => PluginManager.ResolvePropertyEditors(), builder, UmbracoConfig.For.UmbracoSettings().Content);
+            PropertyEditorResolver.Current = new PropertyEditorResolver(ServiceProvider, ProfilingLogger.Logger, () => PluginManager.ResolvePropertyEditors(), builder);
             ParameterEditorResolver.Current = new ParameterEditorResolver(ServiceProvider, ProfilingLogger.Logger, () => PluginManager.ResolveParameterEditors(), builder);
 
             //setup the validators resolver with our predefined validators

--- a/src/Umbraco.Core/PropertyEditors/PropertyEditorResolver.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyEditorResolver.cs
@@ -48,8 +48,10 @@ namespace Umbraco.Core.PropertyEditors
         private static List<PropertyEditor> SanitizeNames(List<PropertyEditor> editors)
         {
             var nestedContentEditorFromPackage = editors.FirstOrDefault(x => x.Alias == "Our.Umbraco.NestedContent");
-            if (nestedContentEditorFromPackage != null)
+            if (nestedContentEditorFromPackage != null) { 
                 nestedContentEditorFromPackage.Name = "(Obsolete) " + nestedContentEditorFromPackage.Name;
+                nestedContentEditorFromPackage.IsDeprecated = true;
+            }
             return editors;
 
         }

--- a/src/Umbraco.Core/PropertyEditors/PropertyEditorResolver.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyEditorResolver.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Umbraco.Core.Cache;
+using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.Logging;
 using Umbraco.Core.IO;
 using Umbraco.Core.Manifest;
@@ -39,10 +40,11 @@ namespace Umbraco.Core.PropertyEditors
             _unioned = new Lazy<List<PropertyEditor>>(() => Values.Union(builder.PropertyEditors).ToList());
         }
 
-        internal PropertyEditorResolver(IServiceProvider serviceProvider, ILogger logger, Func<IEnumerable<Type>> typeListProducerList, ManifestBuilder builder)
+        internal PropertyEditorResolver(IServiceProvider serviceProvider, ILogger logger, Func<IEnumerable<Type>> typeListProducerList, ManifestBuilder builder, IContentSection contentSection)
             : base(serviceProvider, logger, typeListProducerList, ObjectLifetimeScope.Application)
         {
-            _unioned = new Lazy<List<PropertyEditor>>(() => SanitizeNames(Values.Union(builder.PropertyEditors).ToList()));
+            _unioned = new Lazy<List<PropertyEditor>>(() => SanitizeNames(Values.Union(builder.PropertyEditors)
+                .Where(x=>x.IsDeprecated == false || contentSection != null && contentSection.ShowDeprecatedPropertyEditors).ToList()));
         }
 
         private static List<PropertyEditor> SanitizeNames(List<PropertyEditor> editors)

--- a/src/Umbraco.Core/PropertyEditors/PropertyEditorResolver.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyEditorResolver.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Umbraco.Core.Cache;
-using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.Logging;
 using Umbraco.Core.IO;
 using Umbraco.Core.Manifest;
@@ -40,11 +39,10 @@ namespace Umbraco.Core.PropertyEditors
             _unioned = new Lazy<List<PropertyEditor>>(() => Values.Union(builder.PropertyEditors).ToList());
         }
 
-        internal PropertyEditorResolver(IServiceProvider serviceProvider, ILogger logger, Func<IEnumerable<Type>> typeListProducerList, ManifestBuilder builder, IContentSection contentSection)
+        internal PropertyEditorResolver(IServiceProvider serviceProvider, ILogger logger, Func<IEnumerable<Type>> typeListProducerList, ManifestBuilder builder)
             : base(serviceProvider, logger, typeListProducerList, ObjectLifetimeScope.Application)
         {
-            _unioned = new Lazy<List<PropertyEditor>>(() => SanitizeNames(Values.Union(builder.PropertyEditors)
-                .Where(x=>x.IsDeprecated == false || contentSection != null && contentSection.ShowDeprecatedPropertyEditors).ToList()));
+            _unioned = new Lazy<List<PropertyEditor>>(() => SanitizeNames(Values.Union(builder.PropertyEditors).ToList()));
         }
 
         private static List<PropertyEditor> SanitizeNames(List<PropertyEditor> editors)

--- a/src/Umbraco.Web/Editors/DataTypeController.cs
+++ b/src/Umbraco.Web/Editors/DataTypeController.cs
@@ -20,6 +20,7 @@ using umbraco;
 using Constants = Umbraco.Core.Constants;
 using System.Net.Http;
 using System.Text;
+using Umbraco.Core.Configuration;
 
 namespace Umbraco.Web.Editors
 {
@@ -341,8 +342,10 @@ namespace Umbraco.Web.Editors
         public IDictionary<string, IEnumerable<DataTypeBasic>> GetGroupedPropertyEditors()
         {
             var datatypes = new List<DataTypeBasic>();
+            var showDeprecatedPropertyEditors = UmbracoConfig.For.UmbracoSettings().Content
+                .ShowDeprecatedPropertyEditors;
 
-            var propertyEditors = PropertyEditorResolver.Current.PropertyEditors;
+            var propertyEditors = PropertyEditorResolver.Current.PropertyEditors.Where(x=>x.IsDeprecated == false || showDeprecatedPropertyEditors);
             foreach (var propertyEditor in propertyEditors)
             {
                 var hasPrevalues = propertyEditor.PreValueEditor.Fields.Any();


### PR DESCRIPTION
Please be aware that if you do have obsolete property editors in use and set the setting "showDeprecatedPropertyEditors" to false you'll get an exception.