### PR TITLE
(uDuf) Prevent "unsaved" warning when no changes on MarkDown Editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
@@ -46,6 +46,7 @@ function MarkdownEditorController($scope, $element, assetsService, dialogService
                 // init the md editor after this digest because the DOM needs to be ready first
                 // so run the init on a timeout
                 $timeout(function () {
+                    $scope.markdownEditorInitComplete = false;
                     var converter2 = new Markdown.Converter();
                     var editor2 = new Markdown.Editor(converter2, "-" + $scope.model.alias);
                     editor2.run();
@@ -59,7 +60,12 @@ function MarkdownEditorController($scope, $element, assetsService, dialogService
                     editor2.hooks.set("onPreviewRefresh", function () {
                         // We must manually update the model as there is no way to hook into the markdown editor events without exstensive edits to the library.
                         if ($scope.model.value !== $("textarea", $element).val()) {
-                            angularHelper.getCurrentForm($scope).$setDirty();
+                            if ($scope.markdownEditorInitComplete) {
+                                //only set dirty after init load to avoid "unsaved" dialogue when we don't want it
+                                angularHelper.getCurrentForm($scope).$setDirty();
+                            } else {
+                                $scope.markdownEditorInitComplete = true;
+                            }
                             $scope.model.value = $("textarea", $element).val();
                         }
                     });


### PR DESCRIPTION
Fixes issue where "unsaved changes" dialogue appears when no changes actually made.

Affects MarkDown Editor property type only (note that http://issues.umbraco.org/issue/U4-7484# also refers to a similar issue with Upload File type which is not addressed in the PR).