### PR TITLE
(uDuf) Prevent unsaved dialogue appearing when no changes made on FileUpload

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/nodirtycheck.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/nodirtycheck.directive.js
@@ -10,12 +10,12 @@ function noDirtyCheck() {
         require: 'ngModel',
         link: function (scope, elm, attrs, ctrl) {
 
-            elm.focus(function () {
-                scope.$watch(function() {
-                    ctrl.$pristine = false;
-                });
-            });
-
+            var alwaysFalse = {
+                    get: function () { return false; },
+                    set: function () { }
+                };
+            Object.defineProperty(ctrl, '$pristine', alwaysFalse);
+            Object.defineProperty(ctrl, '$dirty', alwaysFalse);
 
         }
     };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
@@ -130,6 +130,9 @@ function fileUploadController($scope, $element, $compile, imageHelper, fileManag
             // in the description of this controller, it states that this value isn't actually used for persistence,
             // but we need to set it so that the editor and the server can detect that it's been changed, and it is used for validation.
             $scope.model.value = { selectedFiles: newVal.trimEnd(",") };
+
+            //need to explicity setDirty here as file upload field can't track dirty & we can't use the fileCount (hidden field/model)
+            $scope.propertyForm.$setDirty();
         });
     });
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
@@ -31,6 +31,6 @@
         </ul>
     </div>
 
-    <input type="hidden" name="fileCount" ng-model="files.length" val-property-validator="validateMandatory"/>
+    <input type="hidden" name="fileCount" ng-model="files.length" val-property-validator="validateMandatory" no-dirty-check />
 
 </div>


### PR DESCRIPTION
Addresses this issue in media section (U4-9996) and content (U4-7484)

Three things changed:

* FileUpload has a hidden field for 'fileCount' which is updated in controller & this was causing the issue : added no-dirty-check attribute
* Changed the no-dirty-check directive so the instead of relying on 'onFocus' event to override dirty value it is always false (also should avoid confusion if setPristine is ever called) : see http://issues.umbraco.org/issue/U4-4902#comment=67-43816 and https://stackoverflow.com/questions/17089090/prevent-input-from-setting-form-dirty-angularjs
* Explicitly call $setDirty in fileupload Angular controller when a fileSelected event is fired.

