### PR TITLE
U4-4441 Fix: TinyMCE overlay was showing in front of login overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -5,7 +5,7 @@
     width: 100%;
     height: 100%;
     position: absolute;
-    z-index: 10000;
+    z-index: 65537;
     top: 0;
     left: 0;
     margin: 0 !important;


### PR DESCRIPTION
Proposed increase of .login-overlay z-index so that it shows in front of TinyMCE's 'Source code' modal dialog.