### PR TITLE
Fixes "Content Picker 2 can search outside of it's selected start node"

### DIFF
--- a/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
+++ b/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
@@ -208,6 +208,10 @@ namespace Umbraco.Web.Search
             if (sb == null) throw new ArgumentNullException("sb");
             if (entityService == null) throw new ArgumentNullException("entityService");
 
+            Udi udi;
+            Udi.TryParse(searchFrom, true, out udi);
+            searchFrom = udi == null ? searchFrom : entityService.GetIdForUdi(udi).Result.ToString();
+
             int searchFromId;
             var entityPath = int.TryParse(searchFrom, out searchFromId) && searchFromId > 0
                 ? entityService.GetAllPaths(objectType, searchFromId).FirstOrDefault()


### PR DESCRIPTION
umbtreesearchbox.directive.js used to take a nodeId to perform the search, today that is not the case anymore as we pass a udi. I added a check in UmbracotreeSearcher.cs which will attempt to get a node id from the udi which fixes the issue.

http://issues.umbraco.org/issue/U4-10876