### PR TITLE
U4-288 - Allow relative urls in sheduled tasks

### DIFF
--- a/src/Umbraco.Web/Scheduling/ScheduledTasks.cs
+++ b/src/Umbraco.Web/Scheduling/ScheduledTasks.cs
@@ -63,6 +63,10 @@ namespace Umbraco.Web.Scheduling
         {
             using (var wc = new HttpClient())
             {
+                if (Uri.TryCreate(_appContext.UmbracoApplicationUrl, UriKind.Absolute, out var baseUri))
+                {
+                    wc.BaseAddress = baseUri;
+                }
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
 
                 //TODO: pass custom the authorization header, currently these aren't really secured!


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
http://issues.umbraco.org/issue/U4-288

Uses the UmbracoApplicationUrl as the base url for sheduled task requests, in case the  sheduled task is a relative url.
