### PR TITLE
cursor remians default when no alias is given to the umb-control-grou…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -158,7 +158,6 @@
 @import "utilities/_spacing.less";
 @import "utilities/_text-align.less";
 @import "utilities/_width.less";
-@import "utilities/_cursor.less";
 
 //page specific styles
 @import "pages/document-type-editor.less";

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -158,6 +158,7 @@
 @import "utilities/_spacing.less";
 @import "utilities/_text-align.less";
 @import "utilities/_width.less";
+@import "utilities/_cursor.less";
 
 //page specific styles
 @import "pages/document-type-editor.less";

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -182,6 +182,14 @@ h5.-black {
   margin-left: 0;
 }
 
+label[for=""] {
+  cursor: default;
+}
+
+label:not([for]) {
+  cursor: default;
+}
+
 /* CONTROL VALIDATION */
 .umb-control-required {
     color: @controlRequiredColor;

--- a/src/Umbraco.Web.UI.Client/src/less/utilities/_cursor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/utilities/_cursor.less
@@ -1,0 +1,9 @@
+﻿/*
+
+    Cursor
+
+*/
+
+.cursorDefault {
+    cursor: default;
+}

--- a/src/Umbraco.Web.UI.Client/src/less/utilities/_cursor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/utilities/_cursor.less
@@ -1,9 +1,0 @@
-﻿/*
-
-    Cursor
-
-*/
-
-.cursorDefault {
-    cursor: default;
-}

--- a/src/Umbraco.Web.UI.Client/src/views/components/html/umb-control-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/html/umb-control-group.html
@@ -1,7 +1,7 @@
 <div class="umb-property">
     <div class="control-group umb-control-group" ng-class="{error: !formValid(), hidelabel:hideLabel=='true'}">
         <div class="umb-el-wrap">
-            <label ng-if="hideLabel!=='true'" class="control-label" for="{{alias}}">
+            <label ng-if="hideLabel!=='true'" class="control-label" ng-class="{cursorDefault: !alias}" for="{{alias}}">
                 <span ng-bind-html="labelstring"></span>
                 <span ng-if="required">
                     <strong class="umb-control-required">*</strong>

--- a/src/Umbraco.Web.UI.Client/src/views/components/html/umb-control-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/html/umb-control-group.html
@@ -1,7 +1,7 @@
 <div class="umb-property">
     <div class="control-group umb-control-group" ng-class="{error: !formValid(), hidelabel:hideLabel=='true'}">
         <div class="umb-el-wrap">
-            <label ng-if="hideLabel!=='true'" class="control-label" ng-class="{cursorDefault: !alias}" for="{{alias}}">
+            <label ng-if="hideLabel!=='true'" class="control-label" for="{{alias}}">
                 <span ng-bind-html="labelstring"></span>
                 <span ng-if="required">
                     <strong class="umb-control-required">*</strong>

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -8,14 +8,16 @@
 
             <umb-box-content class="block-form">
 
-                <umb-control-group label="@general_email" required="true">
+                <umb-control-group label="@general_email" required="true" alias="email">
 
                     <input type="email"
                            localize="placeholder"
                            placeholder="@placeholders_enteremail"
                            class="input-block-level"
                            ng-model="model.user.email"
-                           umb-auto-focus name="email"
+                           umb-auto-focus
+                           name="email"
+                           id="email"
                            val-email
                            required
                            val-server-field="Email" />


### PR DESCRIPTION
…p. Also added alias for the email field on the user details page

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixed [http://issues.umbraco.org/issue/U4-11040](http://issues.umbraco.org/issue/U4-11040)
Before:
![user-details-groups-label](https://user-images.githubusercontent.com/13035873/36902244-1c3e3336-1e2a-11e8-8db6-32509db6a8fa.gif)
After:
![user-details-groups-label-fix](https://user-images.githubusercontent.com/13035873/36902242-1c08a860-1e2a-11e8-88f8-54a64161055d.gif)


 I also added a missing alias to the email label on the user details page. 


Before:
![user-details-email-label](https://user-images.githubusercontent.com/13035873/36902418-acbe5242-1e2a-11e8-9ff0-57a204f825a7.gif)
After:
![user-details-email-label-fix](https://user-images.githubusercontent.com/13035873/36902450-c9b561b0-1e2a-11e8-8344-365a1f0656e9.gif)


<!-- Thanks for contributing to Umbraco CMS! -->
