### PR TITLE
Fixes U4-10899: Template circular dependency 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -516,9 +516,13 @@
             var availableMasterTemplates = [];
 
             // filter out the current template and the selected master template
-            angular.forEach(vm.templates, function(template){
-                if(template.alias !== vm.template.alias && template.alias !== vm.template.masterTemplateAlias) {
-                    availableMasterTemplates.push(template);
+            angular.forEach(vm.templates, function (template) {
+                if (template.alias !== vm.template.alias && template.alias !== vm.template.masterTemplateAlias) {
+                    var templatePathArray = template.path.split(',');
+                    // filter descendant templates of current template
+                    if (templatePathArray.indexOf(String(vm.template.id)) === -1) {
+                        availableMasterTemplates.push(template);
+                    }
                 }
             });
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-10899

### Description
To avoid creating circular dependencies when selecting master template, I have added a check to see if the template exists in current templates path. If so, it is a descendant of the current template and should not be available when choosing master template.



<!-- Thanks for contributing to Umbraco CMS! -->
