### PR TITLE
Fix for ImageCropDataSet.GetCropUrl causing YSOD with null alias

### DIFF
--- a/src/Umbraco.Web/Models/ImageCropDataSet.cs
+++ b/src/Umbraco.Web/Models/ImageCropDataSet.cs
@@ -33,10 +33,14 @@ namespace Umbraco.Web.Models
 
         public string GetCropUrl(string alias, bool useCropDimensions = true, bool useFocalPoint = false, string cacheBusterValue = null)
         {
-
+            if (string.IsNullOrEmpty(alias))
+            {
+                return null;
+            }
+            
             var crop = Crops.GetCrop(alias);
 
-            if (crop == null && string.IsNullOrEmpty(alias) == false)
+            if (crop == null)
             {
                 return null;
             }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [ ] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->
Returns null if alias is null to avoid YSOD if someone tries accessing an asset that didn't resolve


e.g. ```Umbraco.TypedMedia(0).GetCropUrl(/*params*/)```


<!-- Thanks for contributing to Umbraco CMS! -->
