### PR TITLE
U4-11052 - Enabled IntegerValueConverter to handle `Int64` source values

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/IntegerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/IntegerValueConverter.cs
@@ -15,23 +15,7 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
 
         public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
         {
-            if (source == null)
-                return default(int);
-
-            // in the database an integer is an integer
-            if (source is int)
-                return source;
-
-            if (source is long)
-                return Convert.ToInt32(source);
-
-            // in XML an integer is a string
-            int i;
-            if (source is string && int.TryParse((string)source, out i))
-                return i;
-
-            // default value is zero
-            return default(int);
+            return source.TryConvertTo<int>().Result;
         }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/IntegerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/IntegerValueConverter.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.Models.PublishedContent;
+﻿using System;
+using Umbraco.Core.Models.PublishedContent;
 
 namespace Umbraco.Core.PropertyEditors.ValueConverters
 {
@@ -14,19 +15,23 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
 
         public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
         {
-            if (source == null) return 0;
-
-            // in XML an integer is a string
-            var sourceString = source as string;
-            if (sourceString != null)
-            {
-                int i;
-                return (int.TryParse(sourceString, out i)) ? i : 0;
-            }
+            if (source == null)
+                return default(int);
 
             // in the database an integer is an integer
+            if (source is int)
+                return source;
+
+            if (source is long)
+                return Convert.ToInt32(source);
+
+            // in XML an integer is a string
+            int i;
+            if (source is string && int.TryParse((string)source, out i))
+                return i;
+
             // default value is zero
-            return (source is int) ? source : 0;
+            return default(int);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11052

### Description
<!-- A description of the changes proposed in the pull-request -->

I've modified the ordering of the `ConvertDataToSource` logic, so that `int` and `long` value-types are checked first (for quick exits), and also (hopefully) simplified the `string` check.

Also swapped out `0` with `default(int)`, but I guess this is a matter of taste :-)

<!-- Thanks for contributing to Umbraco CMS! -->
