### PR TITLE
U4-11053 Removed .ToUpper from L214

### DIFF
--- a/src/umbraco.datalayer/SqlParser.cs
+++ b/src/umbraco.datalayer/SqlParser.cs
@@ -199,8 +199,8 @@ namespace umbraco.DataLayer
                 // String start?
                 if (query[currentPos] == StringDelimiter)
                 {
-                    // append part before string, uppercased
-                    replacedQuery.Append(query.Substring(partStartPos, currentPos - partStartPos).ToUpper());
+                    // append part before string, uppercased - Removed .ToUpper() to fix linux MySQL table name issue
+                    replacedQuery.Append(query.Substring(partStartPos, currentPos - partStartPos));
 
                     // append string, case unchanged
                     int endStringPos = FindStringEndPosition(query, currentPos);

--- a/src/umbraco.datalayer/SqlParser.cs
+++ b/src/umbraco.datalayer/SqlParser.cs
@@ -210,7 +210,7 @@ namespace umbraco.DataLayer
                     currentPos = partStartPos = endStringPos;
                 }
             }
-            // append remainder of the query, uppercased
+            // append remainder of the query, uppercased - 4/3/2018 Removed .ToUpper() to fix linux MySQl table name case issue U4-11053
             replacedQuery.Append(query.Substring(partStartPos));
 
             return replacedQuery.ToString();

--- a/src/umbraco.datalayer/SqlParser.cs
+++ b/src/umbraco.datalayer/SqlParser.cs
@@ -211,7 +211,7 @@ namespace umbraco.DataLayer
                 }
             }
             // append remainder of the query, uppercased
-            replacedQuery.Append(query.Substring(partStartPos).ToUpper());
+            replacedQuery.Append(query.Substring(partStartPos));
 
             return replacedQuery.ToString();
         }


### PR DESCRIPTION
Removed the Upper Case conversion of table names on L214

As per my issue on the tracker:
http://issues.umbraco.org/issue/U4-11053

It resolved 1 issue if using a linux MySQL database