### PR TITLE
Added web.config to fonts folder to allow for caching out of the box

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/fonts/web.config
+++ b/src/Umbraco.Web.UI.Client/src/assets/fonts/web.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <staticContent>
+      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="7.00:00:00" />
+    </staticContent>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11074

### Description
<!-- A description of the changes proposed in the pull-request -->

This additional file will cache the fonts used in the back office for 7 days.

<!-- Thanks for contributing to Umbraco CMS! -->
