### PR TITLE
Manage redirects from a content item's Info tab - issues: 8925 & 10669

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/redirecturls.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/redirecturls.resource.js
@@ -40,6 +40,32 @@
                         { searchTerm: searchTerm, page: pageIndex, pageSize: pageSize })),
                 'Failed to retrieve data for searching redirect urls');
         }
+        /**
+   * @ngdoc function
+   * @name umbraco.resources.redirectUrlResource#getRedirectsForContentItem
+   * @methodOf umbraco.resources.redirectUrlResource
+   * @function
+   *
+   * @description
+   * Used to retrieve RedirectUrls for a specific item of content for Information tab
+   * ##usage
+   * <pre>
+   * redirectUrlsResource.getRedirectsForContentItem("udi:123456")
+   *    .then(function(response) {
+   *
+   *    });
+   * </pre>
+   * @param {String} contentUdi identifier for the content item to retrieve redirects for
+   */
+        function getRedirectsForContentItem(contentUdi) {
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "redirectUrlManagementApiBaseUrl",
+                        "RedirectUrlsForContentItem",
+                        { contentUdi: contentUdi })),
+                'Failed to retrieve redirects for content: ' + contentUdi);
+        }
 
         function getEnableState() {
 
@@ -50,7 +76,7 @@
                         "GetEnableState")),
                 'Failed to retrieve data to check if the 301 redirect is enabled');
         }
-
+     
         /**
          * @ngdoc function
          * @name umbraco.resources.redirectUrlResource#deleteRedirectUrl
@@ -107,7 +133,8 @@
             searchRedirectUrls: searchRedirectUrls,
             deleteRedirectUrl: deleteRedirectUrl,
             toggleUrlTracker: toggleUrlTracker,
-            getEnableState: getEnableState
+            getEnableState: getEnableState,
+            getRedirectsForContentItem: getRedirectsForContentItem
         };
 
         return resource;

--- a/src/Umbraco.Web.UI.Client/src/common/resources/redirecturls.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/redirecturls.resource.js
@@ -40,7 +40,7 @@
                         { searchTerm: searchTerm, page: pageIndex, pageSize: pageSize })),
                 'Failed to retrieve data for searching redirect urls');
         }
-        /**
+   /**
    * @ngdoc function
    * @name umbraco.resources.redirectUrlResource#getRedirectsForContentItem
    * @methodOf umbraco.resources.redirectUrlResource
@@ -102,7 +102,32 @@
                         "DeleteRedirectUrl", { id: id })),
                 'Failed to remove redirect');
         }
-
+        /**
+       * @ngdoc function
+       * @name umbraco.resources.redirectUrlResource#createRedirectUrl
+       * @methodOf umbraco.resources.redirectUrlResource
+       * @function
+       *
+       * @description
+       * Called to create a manual redirect
+       * ##usage
+       * <pre>
+       * redirectUrlsResource.createRedirectUrl("/myrelative/niceurl","umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2")
+       *    .then(function() {
+       *
+       *    });
+       * </pre>
+        * @param {String} url relative url to redirect from
+       * @param {String} id Udi of the Content Item to redirect to
+       */
+        function createRedirectUrl(url, id) {
+            return umbRequestHelper.resourcePromise(
+                $http.post(
+                    umbRequestHelper.getApiUrl(
+                        "redirectUrlManagementApiBaseUrl",
+                        "CreateRedirectUrl", { url: url, id: id })),
+                'Failed to create redirect');
+        }
         /**
          * @ngdoc function
          * @name umbraco.resources.redirectUrlResource#toggleUrlTracker
@@ -132,6 +157,7 @@
         var resource = {
             searchRedirectUrls: searchRedirectUrls,
             deleteRedirectUrl: deleteRedirectUrl,
+            createRedirectUrl: createRedirectUrl,
             toggleUrlTracker: toggleUrlTracker,
             getEnableState: getEnableState,
             getRedirectsForContentItem: getRedirectsForContentItem

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlmanagementoverlay/redirecturlmanagementoverlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlmanagementoverlay/redirecturlmanagementoverlay.controller.js
@@ -1,0 +1,148 @@
+/**
+ * @ngdoc controller
+ * @name Umbraco.Editors.DocumentType.RedirectUrlManagement
+ * @function
+ *
+ * @description
+ * The controller for the redirect url management overlay dialog
+ */
+function RedirectUrlManagementOverlay($scope, $http, notificationsService, redirectUrlsResource, localizationService, navigationService) {
+
+    var vm = this;
+
+    vm.status = {
+        loading: false,
+        loaded: false,
+        hasRedirects: false,
+        currentContentItem: null
+    };
+    vm.data = {
+        redirects: [],
+        redirectFromUrl: ''
+    }
+
+
+    vm.addRedirect = addRedirect;
+    vm.removeRedirect = removeRedirect;
+
+    function removeRedirect(redirectToDelete) {
+        
+        localizationService.localize("redirectUrls_confirmRemove", [redirectToDelete.originalUrl, vm.status.currentContentItem.name]).then(function (value) {
+            var toggleConfirm = confirm(value);
+            var deletedRedirectUrl = redirectToDelete.url;
+            if (toggleConfirm) {
+                redirectUrlsResource.deleteRedirectUrl(redirectToDelete.redirectId).then(function () {
+                    var index = vm.data.redirects.indexOf(redirectToDelete);
+                    vm.data.redirects.splice(index, 1);
+                    //close the dialog
+                    $scope.submit({ redirectAction: "Remove",actionSuccess: true, statusMessage: "deleted '" + deletedRedirectUrl + "'"});
+             
+                }, function (error) {
+                    //close the dialog
+                    $scope.submit({
+                        redirectAction: "Remove",actionSuccess: false, statusMessage: "error deleting '" + deletedRedirectUrl + "'", error: error });
+                });
+            }
+        });
+
+    }
+    function checkUrl(url) {
+        //this could do with some thought, perhaps should be 'somewhere' else more reusable
+        //also probably more thought given to rules
+        //also how best to localize the text of  these messages
+        var validUrlStatus = {
+            isValidUrl: false,
+            statusMessage: 'InValid Url',
+            url: url
+        };
+        if (url.length > 0) {
+            //assume will be valid
+            validUrlStatus.isValidUrl = true;
+            validUrlStatus.statusMessage = "Valid Url";
+            if (url.length < 3) {
+                validUrlStatus.statusMessage = "'Url to Redirect From' must be a little longer than maybe 2 chars?";
+                validUrlStatus.isValidUrl = false;
+            }
+            // only relative urls, like the tracker? or does the tracker add the domain if one is set?
+            if (url.startsWith('http')) {
+                validUrlStatus.statusMessage = "'Url to Redirect From' must be relative, and start with a leading /, not http or https";
+                validUrlStatus.isValidUrl = false;
+            }
+            if (!url.startsWith('/')) {
+                validUrlStatus.statusMessage = "'Url to Redirect From' must be relative, and start with a leading /";
+                validUrlStatus.isValidUrl = false;
+            }
+            // you can't have any spaces in the url
+            if (url.indexOf(' ') >= 0) {
+                validUrlStatus.statusMessage = "'Url to Redirect From' cannot contain whitespace";
+                validUrlStatus.isValidUrl = false;
+            }
+            // Url has a file extension eg /oldpage.asp ?
+            // we don't want to use this mechnism for redirect hundreds of old system urls, that's more of a rewrite rule thing, create a static rewrite map if necessary
+            // so not really thinking this through but can we safely disallow any url with . in it?
+            if (url.indexOf('.') >= 0) {
+                validUrlStatus.statusMessage = "'Url to Redirect From' cannot contain a dot/full stop - this is just for handling simple renames";
+                validUrlStatus.isValidUrl = false;
+            }
+             //Other things still to consider...
+                // Url contains invalid characters?    
+                // Url already exists in dashboard and redirects somewhere else - do we replace the entry already there? or error?
+                // Url is a redirect to itself
+            // the core redirectservice is adding a slash on the end, (regardless of  useTrailingSlash value - so we're stripping the trailing slash here...
+            if (url.endsWith('/')) {
+                validUrlStatus.url = url.slice(0, -1);
+            }
+        }
+        return validUrlStatus;
+    }
+    function addRedirect() {
+        //check if url is in a valid format
+        //eg relative, without the 'protocol' and without extension
+        //probably a clever regex here..
+        // or a redirectUrlCheckService...
+
+        var urlStatus = checkUrl(vm.data.redirectFromUrl);
+
+        if (urlStatus.isValidUrl) {
+            //Add Service to add a Url?
+            redirectUrlsResource.createRedirectUrl(urlStatus.url, vm.status.currentContentItem.udi).then(function (data) {
+                console.log(data);
+                //close the dialog
+                $scope.submit({ redirectAction: "Create", actionSuccess: true, statusMessage: "Redirect '" + vm.data.redirectFromUrl + "' added" });
+
+            }, function (error) {
+                //close the dialog
+                $scope.submit({ redirectAction: "Create", actionSuccess: false, statusMessage: urlStatus.statusMessage, error: error });
+            });        
+          
+        }
+        else {
+            $scope.submit({ redirectAction: "Create", actionSuccess: false, statusMessage: urlStatus.statusMessage });
+        }
+    };
+
+    function getRedirects(udi) {
+
+        vm.status.loading = true;
+        redirectUrlsResource.getRedirectsForContentItem(udi)
+            .then(function (data) {
+                console.log(data);
+                vm.data.redirects = data.searchResults;
+                vm.status.hasRedirects = (typeof data.searchResults !== 'undefined' && data.searchResults.length > 0);
+                vm.status.loading = false;
+                vm.status.loaded = true;
+            });
+    }
+
+    function init() {
+        // go off and get all redirects for this node
+        vm.status.currentContentItem = $scope.dialogData;
+        getRedirects($scope.dialogData.udi);
+        vm.data.redirectFromUrl = '';
+    }
+
+    init();
+
+}
+
+angular.module("umbraco").controller("Umbraco.Overlays.RedirectUrlManagementOverlay", RedirectUrlManagementOverlay);

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlmanagementoverlay/redirecturlmanagementoverlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlmanagementoverlay/redirecturlmanagementoverlay.html
@@ -1,0 +1,52 @@
+<div ng-controller="Umbraco.Overlays.RedirectUrlManagementOverlay as vm">
+
+    <div class="umb-dialog-body">
+        <div class="umb-pane">
+            <h3 class="title"><localize key="redirectUrls_redirectUrlManagement">Redirect Url Management</localize></h3>
+        </div>
+        <umb-load-indicator ng-if="vm.status.loading">
+        </umb-load-indicator>
+        <div ng-show="vm.status.hasRedirects" class="umb-pane">
+            <div class="umb-table">
+                <div class="umb-table-head">
+                    <div class="umb-table-row">
+
+                        <div class="umb-table-cell  not-fixed flx-s1 flx-g1 flx-b4">
+                            Redirected Url
+                        </div>
+                        <div class="umb-table-cell">
+
+                        </div>
+                    </div>
+                </div>
+                <div class="umb-table-body">
+                    <div class="umb-table-row -solid" ng-repeat="redirectUrl in vm.data.redirects">
+                        <div class="umb-table-cell  not-fixed flx-s1 flx-g1 flx-b4">
+                            <a href="{{redirectUrl.originalUrl}}"><i ng-class="value.icon" class="icon-out"></i> {{redirectUrl.originalUrl}}</a>
+                        </div>
+                        <div class="umb-table-cell">
+                            <button type="button" class="umb-era-button umb-button--s -red" ng-click="vm.removeRedirect(redirectUrl)"><localize key="redirectUrls_removeButton">Remove</localize></button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div ng-show="vm.status.loaded && !vm.status.hasRedirects" class="umb-pane">
+            <localize key="redirectUrls_noRedirects"></localize>
+        </div>
+        <div class="umb-pane">
+            <h3 class="subhead">Add redirect</h3>
+         
+            <form class="form" novalidate>
+                <div class="umb-el-wrap">
+                    <label class="control-label">Url to redirect from:</label>
+                    <input type="text" class="form-control" ng-model="vm.data.redirectFromUrl" prevent-enter-submit no-dirty-check />
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
+        <a class="btn btn-link" ng-click="close()"><localize key="general_cancel">Cancel</localize></a> <button ng-show="vm.data.redirectFromUrl.length > 3" class="btn btn-primary" ng-click="vm.addRedirect()">Add Redirect</button>
+    </div>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -25,26 +25,21 @@
                 <div style="position: relative;">
                     <div ng-if="loadingRedirectUrls" style="background: rgba(255, 255, 255, 0.8); position: absolute; top: 0; left: 0; right: 0; bottom: 0;"></div>
                     <umb-load-indicator ng-if="loadingRedirectUrls"></umb-load-indicator>
-                    <!--<ul class="nav nav-stacked" style="margin-bottom: 0;" ng-show="hasRedirects">
-                        <li ng-repeat="redirectUrl in redirectUrls">
-                            <a href="{{redirectUrl.originalUrl}}"><i ng-class="value.icon" class="icon-out"></i> {{redirectUrl.originalUrl}}</a> <button type="button" class="umb-era-button umb-button--s -red" ng-click="removeRedirect(redirectUrl)"><localize key="redirectUrls_removeButton">Remove</localize></button>
-                        </li>
-                        </ul>-->
-                        <div class="umb-table" ng-show="hasRedirects" style="border:none">
-                            <div class="umb-table-body" style="border:none">
-                                <div class="umb-table-row -solid" ng-repeat="redirectUrl in redirectUrls"  style="border-top:none">
-                                    <div class="umb-table-cell  not-fixed flx-s1 flx-g1 flx-b4">
-                                        <a href="{{redirectUrl.originalUrl}}"><i ng-class="value.icon" class="icon-out"></i> {{redirectUrl.originalUrl}}</a>
-                                    </div>
-                                    <div class="umb-table-cell">
-                                  
-                                        <button type="button" class="umb-era-button umb-button--s -red" ng-click="removeRedirect(redirectUrl)"><localize key="redirectUrls_removeButton">Remove</localize></button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+  
                     <div ng-show="!hasRedirects && !loadingRedirectUrls"><localize key="redirectUrls_noRedirects"></localize></div>
-</div>                  
+                    <ul ng-show="hasRedirects" class="nav nav-stacked" style="margin-bottom: 0;">
+                        <li ng-repeat="redirectUrl in redirectUrls">
+                            <a  href="{{redirectUrl.originalUrl}}" target="_blank">
+                                <i ng-class="value.icon" class="icon-out"></i>
+                                <span>{{redirectUrl.originalUrl}}</span>
+                            </a>
+                            </li>
+                        </ul>
+                               
+      
+                    <div><a class="btn pull-right" style="text-align:right" ng-click="showRedirectOverlay()">Manage Redirects</a></div>
+                    <br class="clearfix" />
+</div>                 
 </umb-box-content>
         </umb-box>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -19,6 +19,34 @@
                 </ul>
             </umb-box-content>
         </umb-box>
+        <umb-box data-element="node-info-redirects">
+            <umb-box-header title-key="redirectUrls_redirectUrlManagement"></umb-box-header>
+            <umb-box-content class="block-form">
+                <div style="position: relative;">
+                    <div ng-if="loadingRedirectUrls" style="background: rgba(255, 255, 255, 0.8); position: absolute; top: 0; left: 0; right: 0; bottom: 0;"></div>
+                    <umb-load-indicator ng-if="loadingRedirectUrls"></umb-load-indicator>
+                    <!--<ul class="nav nav-stacked" style="margin-bottom: 0;" ng-show="hasRedirects">
+                        <li ng-repeat="redirectUrl in redirectUrls">
+                            <a href="{{redirectUrl.originalUrl}}"><i ng-class="value.icon" class="icon-out"></i> {{redirectUrl.originalUrl}}</a> <button type="button" class="umb-era-button umb-button--s -red" ng-click="removeRedirect(redirectUrl)"><localize key="redirectUrls_removeButton">Remove</localize></button>
+                        </li>
+                        </ul>-->
+                        <div class="umb-table" ng-show="hasRedirects" style="border:none">
+                            <div class="umb-table-body" style="border:none">
+                                <div class="umb-table-row -solid" ng-repeat="redirectUrl in redirectUrls"  style="border-top:none">
+                                    <div class="umb-table-cell  not-fixed flx-s1 flx-g1 flx-b4">
+                                        <a href="{{redirectUrl.originalUrl}}"><i ng-class="value.icon" class="icon-out"></i> {{redirectUrl.originalUrl}}</a>
+                                    </div>
+                                    <div class="umb-table-cell">
+                                  
+                                        <button type="button" class="umb-era-button umb-button--s -red" ng-click="removeRedirect(redirectUrl)"><localize key="redirectUrls_removeButton">Remove</localize></button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    <div ng-show="!hasRedirects && !loadingRedirectUrls"><localize key="redirectUrls_noRedirects"></localize></div>
+</div>                  
+</umb-box-content>
+        </umb-box>
 
         <umb-box data-element="node-info-history">
             <umb-box-header title-key="general_history"></umb-box-header>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
@@ -1337,6 +1337,7 @@
     <key alias="enableUrlTracker">啟動網址追蹤器</key>
     <key alias="originalUrl">原本網址</key>
     <key alias="redirectedTo">轉址成</key>
+    <key alias="redirectUrlManagement">Redirect Url Management</key>
     <key alias="noRedirects">沒有任何轉址</key>
     <key alias="noRedirectsDescription">當發佈後的頁面改名或移動時，會自動轉址至新網頁。</key>
     <key alias="removeButton">移除</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1559,6 +1559,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="enableUrlTracker">Slå URL tracker til</key>
     <key alias="originalUrl">Original URL</key>
     <key alias="redirectedTo">Viderestillet til</key>
+    <key alias="redirectUrlManagement">Redirect Url Management</key>
     <key alias="noRedirects">Der er ikke lavet nogen viderestillinger</key>
     <key alias="noRedirectsDescription">Når en udgivet side bliver omdøbt eller flyttet, vil en viderestilling automatisk blive lavet til den nye side.</key>
     <key alias="removeButton">Fjern</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2086,11 +2086,12 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
         <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status</key>
     </area>
-    <area alias="redirectUrls">
+    <area alias="redirectUrls">        
         <key alias="disableUrlTracker">Disable URL tracker</key>
         <key alias="enableUrlTracker">Enable URL tracker</key>
         <key alias="originalUrl">Original URL</key>
         <key alias="redirectedTo">Redirected To</key>
+        <key alias="redirectUrlManagement">Redirect Url Management</key>
         <key alias="noRedirects">No redirects have been made</key>
         <key alias="noRedirectsDescription">When a published page gets renamed or moved a redirect will automatically be made to the new page.</key>
         <key alias="removeButton">Remove</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2094,6 +2094,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="enableUrlTracker">Enable URL tracker</key>
         <key alias="originalUrl">Original URL</key>
         <key alias="redirectedTo">Redirected To</key>
+        <key alias="redirectUrlManagement">Redirect Url Management</key>
         <key alias="noRedirects">No redirects have been made</key>
         <key alias="noRedirectsDescription">When a published page gets renamed or moved a redirect will automatically be made to the new page.</key>
         <key alias="removeButton">Remove</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -1607,6 +1607,7 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="enableUrlTracker">Activer URL tracker</key>
     <key alias="originalUrl">URL original</key>
     <key alias="redirectedTo">Redirigé Vers</key>
+    <key alias="redirectUrlManagement">Redirect Url Management</key>
     <key alias="noRedirects">Aucune redirection n'a été créée</key>
     <key alias="noRedirectsDescription">Lorsqu'une page publiée est renommée ou déplacée, une redirection sera automatiquement créée vers la nouvelle page.</key>
     <key alias="removeButton">Supprimer</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -1432,6 +1432,7 @@ Om een vertalingstaak te sluiten, ga aub naar het detailoverzicht en klik op de 
     <key alias="enableUrlTracker">URL tracker aanzetten</key>
     <key alias="originalUrl">Originele URL</key>
     <key alias="redirectedTo">Doorgestuurd naar</key>
+    <key alias="redirectUrlManagement">Redirect Url Management</key>
     <key alias="noRedirects">Er zijn geen redirects</key>
     <key alias="noRedirectsDescription">Er wordt automatisch een redirect aangemaakt als een gepubliceerde pagina hernoemd of verplaatst wordt.</key>
     <key alias="removeButton">Verwijder</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -1682,6 +1682,7 @@ Naciśnij przycisk <strong>instaluj</strong>, aby zainstalować bazę danych Umb
     <key alias="enableUrlTracker">Włącz śledzenie URL</key>
     <key alias="originalUrl">Oryginalny URL</key>
     <key alias="redirectedTo">Przekierowane do</key>
+    <key alias="redirectUrlManagement">Redirect Url Management</key>
     <key alias="noRedirects">Nie stworzono żadnych przekierowań</key>
     <key alias="noRedirectsDescription">Kiedy nazwa opublikowanej strony zostanie zmieniona lub zostanie ona przeniesiona, zostanie stworzone automatyczne przekierowanie na nową stronę.</key>
     <key alias="removeButton">Usuń</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -1213,6 +1213,7 @@
     <key alias="enableUrlTracker">Запустить отслеживание URL</key>
     <key alias="originalUrl">Первоначальный URL</key>
     <key alias="redirectedTo">Перенаправлен в</key>
+    <key alias="redirectUrlManagement">Redirect Url Management</key>
     <key alias="noRedirects">На данный момент нет ни одного перенаправления</key>
     <key alias="noRedirectsDescription">Если опубликованный документ переименовывается или меняет свое расположение в дереве, а следовательно, меняется адрес (URL), автоматически создается перенаправление на новое местоположение этого документа.</key>
     <key alias="removeButton">Удалить</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -1606,6 +1606,7 @@
     <key alias="enableUrlTracker">启用 url 跟踪程序</key>
     <key alias="originalUrl">原始网址</key>
     <key alias="redirectedTo">已重定向至</key>
+    <key alias="redirectUrlManagement">Redirect Url Management</key>
     <key alias="noRedirects">未进行重定向</key>
     <key alias="noRedirectsDescription">当已发布的页重命名或移动时, 将自动对新页进行重定向。</key>
     <key alias="removeButton">删除</key>

--- a/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
+++ b/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
@@ -88,7 +88,45 @@ namespace Umbraco.Web.Editors
             redirectUrlService.Delete(id);
             return Ok();
         }
+        /// <summary>
+        /// Creates a redirect in the Redirect Url Tracking table for a particular relative Url to a specific content item identified by Udi
+        /// </summary>
+        /// <param name="url">Relative url to redirect from</param>
+        /// <param name="id">Udi of content item to redirect to</param>
+        /// <returns></returns>
+        [HttpPost]
+        public IHttpActionResult CreateRedirectUrl(string url, string id)
+        {
+            if (String.IsNullOrEmpty(url)){
+                //should we be validating this url here, to make sure people not passing http or /oldsystem.php style urls, this is just for nice vanity redirects, or Url changes not tracked
+                return BadRequest("Missing RedirectFromUrl");
+            }
+            var redirectUrlService = Services.RedirectUrlService;
+            Guid contentKey = default(Guid);
+            if (!String.IsNullOrEmpty(id))
+            {
+                GuidUdi guidIdi;
+                contentKey = GuidUdi.TryParse(id, out guidIdi) ? guidIdi.Guid : default(Guid);
+            }
+            try
+            {
+                if (contentKey != Guid.Empty)
+                {
+                    redirectUrlService.Register(url, contentKey);
+                    return Ok();
+                }
+                else
+                {
+                    return BadRequest(id + " not a valid Guid Udi");
+                }
+             
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
 
+        }
         [HttpPost]
         public IHttpActionResult ToggleUrlTracker(bool disable)
         {

--- a/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
+++ b/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
@@ -12,6 +12,7 @@ using Umbraco.Web.Models.ContentEditing;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
 using File = System.IO.File;
+using Umbraco.Core;
 
 namespace Umbraco.Web.Editors
 {
@@ -57,7 +58,29 @@ namespace Umbraco.Web.Editors
             return searchResult;
 
         }
-
+        /// <summary>
+        /// This lists the RedirectUrls for a particular content item
+        /// Do we need to consider paging here?
+        /// </summary>
+        /// <param name="contentUdi">Udi of content item to retrieve RedirectUrls for</param>
+        /// <returns></returns>
+        [HttpGet]
+        public RedirectUrlSearchResult RedirectUrlsForContentItem(string contentUdi)
+        {
+            var redirectsResult = new RedirectUrlSearchResult();
+            GuidUdi guidIdi;
+            var contentKey = GuidUdi.TryParse(contentUdi, out guidIdi) ? guidIdi.Guid : default(Guid);
+            //hmm what to do if this doesn't parse as a Guid?
+            var redirectUrlService = Services.RedirectUrlService;
+            var redirects = redirectUrlService.GetContentRedirectUrls(contentKey);
+            redirectsResult.SearchResults = Mapper.Map<IEnumerable<ContentRedirectUrl>>(redirects).ToArray();
+            //now map the Content/published - don't need to do this? - not displaying the target Url on the info tab, no need to retrieve in the same was as on the dashboard
+            //not doing paging 'yet'
+            redirectsResult.TotalCount = redirects.Count();
+            redirectsResult.CurrentPage = 1;
+            redirectsResult.PageCount = 1;
+            return redirectsResult;
+        }
         [HttpPost]
         public IHttpActionResult DeleteRedirectUrl(Guid id)
         {


### PR DESCRIPTION
### Prerequisites

- [Y] I have written a descriptive pull-request title
- [Y ] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

See: http://issues.umbraco.org/issue/U4-10669
&
http://issues.umbraco.org/issue/U4-8925

### Description
<!-- A description of the changes proposed in the pull-request -->
I've blogged a little bit about redirects here: http://tooorangey.co.uk/posts/301-redirection-in-umbraco-it-s-a-rum-do/

This PR, would list redirects from the Redirect Url Management table on the Info tab of a content item, and provide a 'Manage Redirects' button, that will open a dialog and allow redirects to be removed for the current content item. Additionally, and controversially new redirects to the content item can be added from this dialog, but only 'relative' urls, that can be existingly created by renaming content, as some editors already do!

There is a previous PR: https://github.com/umbraco/Umbraco-CMS/pull/2452 that just lists the redirects on the info tab, without the ability to manage them from a dialog...

<!-- Thanks for contributing to Umbraco CMS! -->
