### PR TITLE
Remove console.log from slider property editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -92,7 +92,6 @@
         $scope.model.config.ticksPositions = _.map($scope.model.config.ticksPositions.split(','), function (item) {
             return parseInt(item.trim());
         });
-        console.log($scope.model.config.ticksPositions);
     }
 
     if (!$scope.model.config.ticksLabels) {


### PR DESCRIPTION
removed console.log statement from slider property editor controller

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11110

### Description
<!-- A description of the changes proposed in the pull-request -->

Removed console.log statement from controller of slider property editor


<!-- Thanks for contributing to Umbraco CMS! -->
