### PR TITLE
U4-11113 - Remove umb-pane from dialog to avoid additional padding

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/move.html
@@ -1,4 +1,4 @@
-<div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.DataType.MoveController">
+<div class="umb-dialog" ng-controller="Umbraco.Editors.DataType.MoveController">
 
     <div class="umb-dialog-body">
         <div class="umb-pane">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
@@ -1,4 +1,4 @@
-<div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.DocumentTypes.CopyController">
+<div class="umb-dialog" ng-controller="Umbraco.Editors.DocumentTypes.CopyController">
 
     <div class="umb-dialog-body">
         <div class="umb-pane">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
@@ -1,4 +1,4 @@
-<div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.DocumentTypes.MoveController">
+<div class="umb-dialog" ng-controller="Umbraco.Editors.DocumentTypes.MoveController">
 
     <div class="umb-dialog-body">
         <div class="umb-pane">

--- a/src/Umbraco.Web.UI.Client/src/views/media/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/move.html
@@ -1,56 +1,55 @@
 <div ng-controller="Umbraco.Editors.Media.MoveController">
-<div class="umb-dialog-body" ng-cloak>
-	<div class="umb-pane">
+    <div class="umb-dialog-body" ng-cloak>
+	    <div class="umb-pane">
 
-		<div ng-show="error">
-			<div class="alert alert-error">
-				<div><strong>{{error.errorMsg}}</strong></div>
-				<div>{{error.data.message}}</div>
+		    <div ng-show="error">
+			    <div class="alert alert-error">
+				    <div><strong>{{error.errorMsg}}</strong></div>
+				    <div>{{error.data.message}}</div>
+                </div>
             </div>
-        </div>
 
-		<div ng-show="success">
-			<div class="alert alert-success">
-				<strong>{{currentNode.name}}</strong> was moved underneath <strong>{{target.name}}</strong>
-			</div>
-			<button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
-		</div>
+		    <div ng-show="success">
+			    <div class="alert alert-success">
+				    <strong>{{currentNode.name}}</strong> was moved underneath <strong>{{target.name}}</strong>
+			    </div>
+			    <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
+		    </div>
 
-		<p class="abstract" ng-hide="success">
-            <localize key="actions_chooseWhereToMove">Choose where to move</localize>
-            <strong>{{currentNode.name}}</strong>
-            <localize key="actions_toInTheTreeStructureBelow">to in the tree structure below</localize>
-        </p>
+		    <p class="abstract" ng-hide="success">
+                <localize key="actions_chooseWhereToMove">Choose where to move</localize>
+                <strong>{{currentNode.name}}</strong>
+                <localize key="actions_toInTheTreeStructureBelow">to in the tree structure below</localize>
+            </p>
 
-		<div ng-hide="success">
+		    <div ng-hide="success">
             
-			<div ng-hide="miniListView">
-				<umb-tree
-					section="media"
-				    hideheader="{{treeModel.hideHeader}}"
-					hideoptions="true"
-					isdialog="true"
-					eventhandler="dialogTreeEventHandler"
-					enablelistviewexpand="true"
-					enablecheckboxes="true">
-				</umb-tree>
-			</div>
+			    <div ng-hide="miniListView">
+				    <umb-tree
+					    section="media"
+				        hideheader="{{treeModel.hideHeader}}"
+					    hideoptions="true"
+					    isdialog="true"
+					    eventhandler="dialogTreeEventHandler"
+					    enablelistviewexpand="true"
+					    enablecheckboxes="true">
+				    </umb-tree>
+			    </div>
 
-			<umb-mini-list-view
-				ng-if="miniListView"
-				node="miniListView"
-				entity-type="Media"
-				on-select="selectListViewNode(node)"
-				on-close="closeMiniListView()">
-			</umb-mini-list-view>
+			    <umb-mini-list-view
+				    ng-if="miniListView"
+				    node="miniListView"
+				    entity-type="Media"
+				    on-select="selectListViewNode(node)"
+				    on-close="closeMiniListView()">
+			    </umb-mini-list-view>
 
-		</div>
-	</div>
-</div>
+		    </div>
+	    </div>
+    </div>
 
-
-<div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-	<a class="btn btn-link" ng-click="nav.hideDialog()"><localize key="general_cancel">Cancel</localize></a>
-	<button class="btn btn-primary" ng-click="move()"><localize key="actions_move">Move</localize></button>
-</div>
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
+	    <a class="btn btn-link" ng-click="nav.hideDialog()"><localize key="general_cancel">Cancel</localize></a>
+	    <button class="btn btn-primary" ng-click="move()"><localize key="actions_move">Move</localize></button>
+    </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
@@ -1,4 +1,4 @@
-<div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.MediaTypes.CopyController">
+<div class="umb-dialog" ng-controller="Umbraco.Editors.MediaTypes.CopyController">
 
     <div class="umb-dialog-body">
         <div class="umb-pane">

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
@@ -1,4 +1,4 @@
-<div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.MediaTypes.MoveController">
+<div class="umb-dialog" ng-controller="Umbraco.Editors.MediaTypes.MoveController">
 
     <div class="umb-dialog-body">
         <div class="umb-pane">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11113

### Description
I have remove umb-pane from mainly the "Move" and "Copy" dialogs to remove the additional padding in the dialog, because either `umb-pane` directive/component or the class `umb-pane` is used inside the dialog. Basically the `.umb-pane` class add `margin: 30px 20px;` but it doesn't seem to be consistent when it is used in dialog - sometimes on the dialog container, sometimes inside the dialog.

Maybe just add the padding to `umb-dialog-body`, so you don't have to add `umb-pane` class to a dialog container (or a container inside that), or `umb-pane` directives inside the dialog.

**Before**
![image](https://user-images.githubusercontent.com/2919859/37569863-84c15314-2ae8-11e8-8c42-215d5a11a2f2.png)

**After**
![image](https://user-images.githubusercontent.com/2919859/37569874-9f3ac8ec-2ae8-11e8-95d0-0542785fdace.png)

