### PR TITLE
U4-10769 - Fix listviewhelper to work without key property on objects

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
@@ -281,7 +281,6 @@
                 if (item.key) {
                     obj.key = item.key;
                 }
-                console.log("obj", obj);
 
                 selection.push(obj);
                 item.selected = true;

--- a/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
@@ -270,12 +270,20 @@
             for (var i = 0; selection.length > i; i++) {
                 var selectedItem = selection[i];
                 // if item.id is 2147483647 (int.MaxValue) use item.key
-                if ((item.id !== 2147483647 && item.id === selectedItem.id) || item.key === selectedItem.key) {
+                if ((item.id !== 2147483647 && item.id === selectedItem.id) || (item.key && item.key === selectedItem.key)) {
                     isSelected = true;
                 }
             }
             if (!isSelected) {
-                selection.push({ id: item.id, key: item.key });
+                var obj = {
+                    id: item.id
+                };
+                if (item.key) {
+                    obj.key = item.key;
+                }
+                console.log("obj", obj);
+
+                selection.push(obj);
                 item.selected = true;
             }
         }
@@ -296,7 +304,7 @@
             for (var i = 0; selection.length > i; i++) {
                 var selectedItem = selection[i];
                 // if item.id is 2147483647 (int.MaxValue) use item.key
-                if ((item.id !== 2147483647 && item.id === selectedItem.id) || item.key === selectedItem.key) {
+                if ((item.id !== 2147483647 && item.id === selectedItem.id) || (item.key && item.key === selectedItem.key)) {
                     selection.splice(i, 1);
                     item.selected = false;
                 }
@@ -366,9 +374,15 @@
             for (var i = 0; i < items.length; i++) {
 
                 var item = items[i];
+                var obj = {
+                    id: item.id
+                };
+                if (item.key) {
+                    obj.key = item.key
+                }
 
                 if (checkbox.checked) {
-                    selection.push({ id: item.id, key: item.key });
+                    selection.push(obj);
                 } else {
                     clearSelection = true;
                 }
@@ -408,7 +422,7 @@
                     var selectedItem = selection[selectedIndex];
 
                     // if item.id is 2147483647 (int.MaxValue) use item.key
-                    if ((item.id !== 2147483647 && item.id === selectedItem.id) || item.key === selectedItem.key) {
+                    if ((item.id !== 2147483647 && item.id === selectedItem.id) || (item.key && item.key === selectedItem.key)) {
                         numberOfSelectedItem++;
                     }
                 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-table.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-table.less
@@ -93,7 +93,7 @@ input.umb-table__input {
     cursor: pointer;
     font-size: 14px;
     position: relative;
-    min-height: 32px;
+    min-height: 52px;
     &:hover {
         background-color: @gray-10;
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-10769

### Description
This fixes listviewhelper, so it doesn't require `key` property on object when used in combination with e.g. `umb-table`.

Previously before this change and when the objects didn't contain an unique `key` property (e.g. a Guid), then when you selected only one element, it set the checkbox "select all" to checked and the selection/deselection of items didn't worked as expected.

To reproduce/test this:

Add the following to /config/dashboard config:

```
<section alias="ApoWelcomeDashboard">
    <access>
        <deny>translator</deny>
    </access>
    <areas>
        <area>content</area>
    </areas>
    <tab caption="Order Management">
      <control>
        /app_plugins/MyDashboards/OrderManagement/views/bom.dashboard.html
      </control>
    </tab>
  </section>
```

Add the following folder `MyDashboards` to `/App_Plugins` folder:
[MyDashboards.zip](https://github.com/umbraco/Umbraco-CMS/files/1823193/MyDashboards.zip)

In `/App_Plugins/MyDashboards/OrderManagement/resources/bom.resource.js` try change between these lines:

```
return $http.get("/App_Plugins/MyDashboards/OrderManagement/resources/orders1.json");
//return $http.get("/App_Plugins/MyDashboards/OrderManagement/resources/orders2.json");
```

`orders1.json` contains the json without `key` property and the `orders2.json` contains the object with a key property (Guid).

listviewhelper didn't work correct with orders1.json because of the required `key` property, but orders2.json works because it has unique values for key property.

With the updates in this PR orders1.json also work.

I have also increase the minimum height of the table row, so in case an icon doesn't exist or isn't found the table row height doesn't "jump" on selection (checkmark icon is set) and therefore more consistent.

![image](https://user-images.githubusercontent.com/2919859/37571986-a9501618-2b04-11e8-8f5a-d7f32f915964.png)

![image](https://user-images.githubusercontent.com/2919859/37571999-c4e4eb56-2b04-11e8-98cb-cbb9835d5676.png)

Some thing to consider/improve:
- Make it possible to change label of "Name" column, e.g. "Order Number".
- Set datatype of custom columns to be sorted, e.g. string, int, decimal/double/float, datetime etc. In this example the Order Number is sorted as string - maybe specify an datatype and value for sorting since you might want the text/label to be different.