### PR TITLE
U4-11133 - Fix access check for Unpublish button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -243,10 +243,11 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, notifica
                 }
 
 
-                //if we are not creating, then we should add unpublish too,
+                // if we are not creating, then we should add unpublish too,
                 // so long as it's already published and if the user has access to publish
+                // and the user has access to unpublish (may have been removed via Event)
                 if (!args.create) {
-                    if (args.content.publishDate && _.contains(args.content.allowedActions, "Z")) {
+                    if (args.content.publishDate && _.contains(args.content.allowedActions, "U") && _.contains(args.content.allowedActions, "Z")) {
                         buttons.subButtons.push(createButtonDefinition("Z"));
                     }
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -246,7 +246,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, notifica
                 //if we are not creating, then we should add unpublish too,
                 // so long as it's already published and if the user has access to publish
                 if (!args.create) {
-                    if (args.content.publishDate && _.contains(args.content.allowedActions, "U")) {
+                    if (args.content.publishDate && _.contains(args.content.allowedActions, "Z")) {
                         buttons.subButtons.push(createButtonDefinition("Z"));
                     }
                 }


### PR DESCRIPTION
See [U4-11133](http://issues.umbraco.org/issue/U4-11133)  - the logic to show the Unpublish button was checking for "Publish" (U) permission rather than "Unpublish" (Z).

