### PR TITLE
U4-11020 Deleting a member group that is part of a Public Access feat…

### DIFF
--- a/src/Umbraco.Tests/UI/LegacyDialogTests.cs
+++ b/src/Umbraco.Tests/UI/LegacyDialogTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using Umbraco.Core;
 using Umbraco.Web.UI;
 using umbraco;
 using umbraco.BusinessLogic;
 using umbraco.interfaces;
+using Umbraco.Web.umbraco.presentation.umbraco.create;
 
 namespace Umbraco.Tests.UI
 {

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/MemberGroupTasks.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/MemberGroupTasks.cs
@@ -22,8 +22,7 @@ namespace Umbraco.Web.umbraco.presentation.umbraco.create
             // only built-in roles can be deleted
             if (Member.IsUsingUmbracoRoles())
             {
-                Roles.DeleteRole(Alias);
-                roleDeleted = true;
+                roleDeleted = Roles.DeleteRole(Alias);
             }
 
             // Need to delete the member group from any content item that has it assigned in public access settings

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/MemberGroupTasks.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/MemberGroupTasks.cs
@@ -1,24 +1,17 @@
-using System;
-using System.Data;
 using System.Linq;
 using System.Web.Security;
-using Umbraco.Web.UI;
 using umbraco.BusinessLogic;
-using umbraco.DataLayer;
-using umbraco.BasePages;
-using Umbraco.Core.IO;
 using umbraco.cms.businesslogic.member;
-using Umbraco.Core;
-using Umbraco.Web;
+using Umbraco.Web.UI;
 
-namespace umbraco
+namespace Umbraco.Web.umbraco.presentation.umbraco.create
 {
     public class MemberGroupTasks : LegacyDialogTask
     {
         public override bool PerformSave()
         {
             Roles.CreateRole(Alias);
-            _returnUrl = string.Format("members/EditMemberGroup.aspx?id={0}", System.Web.HttpContext.Current.Server.UrlEncode(Alias));
+            _returnUrl = $"members/EditMemberGroup.aspx?id={System.Web.HttpContext.Current.Server.UrlEncode(Alias)}";
             return true;
         }
 
@@ -29,7 +22,7 @@ namespace umbraco
             // only built-in roles can be deleted
             if (Member.IsUsingUmbracoRoles())
             {
-                MemberGroup.GetByName(Alias).delete();
+                Roles.DeleteRole(Alias);
                 roleDeleted = true;
             }
 
@@ -54,14 +47,8 @@ namespace umbraco
 
         private string _returnUrl = "";
 
-        public override string ReturnUrl
-        {
-            get { return _returnUrl; }
-        }
+        public override string ReturnUrl => _returnUrl;
 
-        public override string AssignedApp
-        {
-            get { return DefaultApps.member.ToString(); }
-        }
+        public override string AssignedApp => DefaultApps.member.ToString();
     }
 }


### PR DESCRIPTION
…ure, from the system, does not also remove the corresponding rows from the umbracoAccessRule table.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->
http://issues.umbraco.org/issue/U4-11020


<!-- Thanks for contributing to Umbraco CMS! -->
