### PR TITLE
Quick and very dirty fix for preview being partially visible when not logged in

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/canvasdesigner/canvasdesigner.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/canvasdesigner/canvasdesigner.controller.js
@@ -7,6 +7,9 @@ var app = angular.module("Umbraco.canvasdesigner", ['colorpicker', 'ui.slider', 
 
 .controller("Umbraco.canvasdesignerController", function ($scope, $http, $window, $timeout, $location, dialogService) {
 
+    if (typeof(Umbraco) === "undefined") {
+        window.location.href = '/umbraco';
+    }
     var isInit = $location.search().init;
     if (isInit === "true") {
         //do not continue, this is the first load of this new window, if this is passed in it means it's been


### PR DESCRIPTION


### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11134

### Description
<!-- A description of the changes proposed in the pull-request -->
It seems to preview runs a seperate angular app than the rest of the backoffice and not all security checks are in place.

Fixed this very dirty by checking on Umbraco namespace, which is not defined in when not logged in. If not defined just change the browser location to login screen.

If somebody can give me pointers how to fix this correctly I can apply a better fix

<!-- Thanks for contributing to Umbraco CMS! -->
