### PR TITLE
Temp U4-11123 - Sets Language Root Tree Node to use custom UI

### DIFF
--- a/src/Umbraco.Web/Trees/LanguageTreeController.cs
+++ b/src/Umbraco.Web/Trees/LanguageTreeController.cs
@@ -19,78 +19,31 @@ namespace Umbraco.Web.Trees
     [CoreTree]
     public class LanguageTreeController : TreeController
     {
-        /// <summary>
-        /// The method called to render the contents of the tree structure
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="queryStrings">
-        /// All of the query string parameters passed from jsTree
-        /// </param>
-        /// <remarks>
-        /// We are allowing an arbitrary number of query strings to be pased in so that developers are able to persist custom data from the front-end
-        /// to the back end to be used in the query for model data.
-        /// </remarks>
         protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
         {
-            var nodes = new TreeNodeCollection();
+            //We don't have any child nodes & only use the root node to load a custom UI
+            return new TreeNodeCollection();
+        }
 
-            if (id == Constants.System.Root.ToInvariantString())
-            {
-                var languages = Services.LocalizationService.GetAllLanguages();
-                foreach (var language in languages)
-                {
-                    nodes.Add(
-                        CreateTreeNode(
-                            language.Id.ToString(CultureInfo.InvariantCulture), "-1", queryStrings, language.CultureInfo.DisplayName, "icon-flag-alt", false,
-                            //TODO: Rebuild the language editor in angular, then we dont need to have this at all (which is just a path to the legacy editor)
-                            "/" + queryStrings.GetValue<string>("application") + "/framed/" +
-                            Uri.EscapeDataString("settings/editLanguage.aspx?id=" + language.Id)));
-                }
-            }
-
-            return nodes;
+        protected override MenuItemCollection GetMenuForNode(string id, FormDataCollection queryStrings)
+        {
+            //We don't have any menu item options (such as create/delete/reload) & only use the root node to load a custom UI
+            return null;
         }
 
         /// <summary>
-        /// Returns the menu structure for the node
+        /// Helper method to create a root model for a tree
         /// </summary>
-        /// <param name="id"></param>
-        /// <param name="queryStrings"></param>
         /// <returns></returns>
-        protected override MenuItemCollection GetMenuForNode(string id, FormDataCollection queryStrings)
+        protected override TreeNode CreateRootNode(FormDataCollection queryStrings)
         {
-            var menu = new MenuItemCollection();
+            var root = base.CreateRootNode(queryStrings);
 
-            if (id == Constants.System.Root.ToInvariantString())
-            {
-                //Create the normal create action
-                menu.Items.Add<ActionNew>(Services.TextService.Localize("actions", ActionNew.Instance.Alias))
-                    //Since we haven't implemented anything for languages in angular, this needs to be converted to
-                    //use the legacy format
-                    .ConvertLegacyMenuItem(null, "initlanguages", queryStrings.GetValue<string>("application"));
+            //this will load in a custom UI instead of the dashboard for the root node
+            root.RoutePath = string.Format("{0}/{1}/{2}", Constants.Applications.Settings, Constants.Trees.Languages, "overview");
+            root.Icon = "icon-flag-alt";
 
-                //refresh action
-                menu.Items.Add<RefreshNode, ActionRefresh>(Services.TextService.Localize("actions", ActionRefresh.Instance.Alias), true);
-
-                return menu;
-            }
-
-            var lang = Services.LocalizationService.GetLanguageById(int.Parse(id));
-            if (lang == null) return new MenuItemCollection();
-
-            //add delete option for all languages
-            menu.Items.Add<ActionDelete>(Services.TextService.Localize("actions", ActionDelete.Instance.Alias))
-                //Since we haven't implemented anything for languages in angular, this needs to be converted to
-                //use the legacy format
-                .ConvertLegacyMenuItem(new EntitySlim
-                {
-                    Id = lang.Id,
-                    Level = 1,
-                    ParentId = -1,
-                    Name = lang.CultureInfo.DisplayName
-                }, "language", queryStrings.GetValue<string>("application"));
-
-            return menu;
+            return root;
         }
     }
 }

--- a/src/Umbraco.Web/Trees/LanguageTreeController.cs
+++ b/src/Umbraco.Web/Trees/LanguageTreeController.cs
@@ -1,14 +1,7 @@
-using System;
-using System.Globalization;
 using System.Net.Http.Formatting;
-using Umbraco.Core;
-using Umbraco.Core.Services;
-using Umbraco.Core.Models;
-using Umbraco.Core.Models.Entities;
 using Umbraco.Web.Models.Trees;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi.Filters;
-using Umbraco.Web._Legacy.Actions;
 using Constants = Umbraco.Core.Constants;
 
 namespace Umbraco.Web.Trees


### PR DESCRIPTION


### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
* Sets language tree root node with flag icon that child items had & sets the route for a custom UI
* Removes child tree items as we will now use new UI to manage them
* Removes menu items (as no need for create, refresh, delete etc)

http://issues.umbraco.org/issue/U4-11123