### PR TITLE
U4-11123 (Take 2) Updates Language Tree to not show having children or right click menu

### DIFF
--- a/src/Umbraco.Web/Trees/LanguageTreeController.cs
+++ b/src/Umbraco.Web/Trees/LanguageTreeController.cs
@@ -35,6 +35,8 @@ namespace Umbraco.Web.Trees
             //this will load in a custom UI instead of the dashboard for the root node
             root.RoutePath = string.Format("{0}/{1}/{2}", Constants.Applications.Settings, Constants.Trees.Languages, "overview");
             root.Icon = "icon-flag-alt";
+            root.HasChildren = false;
+            root.MenuUrl = null;
 
             return root;
         }


### PR DESCRIPTION


### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description

http://issues.umbraco.org/issue/U4-11123

* Makes sure to set no child nodes & menu url
* Removes the child arrow for tree items
* Removes the 3 dots for the context menu item that had nothing in it
