### PR TITLE
U4-11121 New LanguagesController (back office editor controller) for …

### DIFF
--- a/src/Umbraco.Web/Editors/LanguageController.cs
+++ b/src/Umbraco.Web/Editors/LanguageController.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Web.Http;
+using Umbraco.Core.Persistence;
+using Umbraco.Web.Models;
+using Umbraco.Web.Mvc;
+
+namespace Umbraco.Web.Editors
+{
+    /// <summary>
+    /// Backoffice controller supporting the dashboard for language administration.
+    /// </summary>
+    [PluginController("UmbracoApi")]
+    public class LanguageController : UmbracoAuthorizedJsonController
+    {
+        /// <summary>
+        /// Returns all cultures available for creating languages.
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet]
+        public IEnumerable<Culture> GetAllCultures()
+        {
+            return CultureInfo.GetCultures(CultureTypes.AllCultures)
+                .Select(x => new Culture {IsoCode = x.Name, Name = x.DisplayName});
+        }
+
+        /// <summary>
+        /// Returns all currently configured languages.
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet]
+        public IEnumerable<Language> GetAllLanguages()
+        {
+            var allLanguages = Services.LocalizationService.GetAllLanguages();
+
+            return allLanguages.Select(x => new Language
+            {
+                Id = x.Id,
+                IsoCode = x.IsoCode,
+                Name = x.CultureInfo.DisplayName,
+                IsDefaultVariantLanguage = x.IsDefaultVariantLanguage,
+                Mandatory = x.Mandatory
+            });
+        }
+        
+        /// <summary>
+        /// Deletes a language with a given ID
+        /// </summary>
+        [HttpDelete]
+        [HttpPost]
+        public void DeleteLanguage(int id)
+        {
+            var language = Services.LocalizationService.GetLanguageById(id);
+            if (language == null)
+            {
+                throw new EntityNotFoundException(id, $"Could not find language by id: '{id}'.");
+            }
+            Services.LocalizationService.Delete(language);
+        }
+
+        /// <summary>
+        /// Saves a bulk set of languages with default/mandatory settings and returns the full set of languages configured.
+        /// </summary>
+        [HttpPost]
+        public IEnumerable<Language> SaveLanguages(IEnumerable<Language> languages)
+        {
+            foreach (var l in languages)
+            {
+                var language = Services.LocalizationService.GetLanguageByIsoCode(l.IsoCode);
+                if (language == null)
+                {
+                    language = new Core.Models.Language(l.IsoCode);
+                }
+                language.Mandatory = l.Mandatory;
+                language.IsDefaultVariantLanguage = l.IsDefaultVariantLanguage;
+                Services.LocalizationService.Save(language);
+            }
+
+            return GetAllLanguages();
+        }
+    }
+}

--- a/src/Umbraco.Web/Models/Culture.cs
+++ b/src/Umbraco.Web/Models/Culture.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Web.Models
+{
+    public class Culture
+    {
+        public string IsoCode { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/Umbraco.Web/Models/Language.cs
+++ b/src/Umbraco.Web/Models/Language.cs
@@ -1,0 +1,13 @@
+﻿using System.Globalization;
+
+namespace Umbraco.Web.Models
+{
+    public class Language
+    {
+        public int Id { get; set; }
+        public string IsoCode { get; set; }
+        public string Name { get; set; }
+        public bool IsDefaultVariantLanguage { get; set; }
+        public bool Mandatory { get; set; }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Editors\EditorValidatorOfT.cs" />
     <Compile Include="Editors\FromJsonPathAttribute.cs" />
     <Compile Include="Editors\IsCurrentUserModelFilterAttribute.cs" />
+    <Compile Include="Editors\LanguageController.cs" />
     <Compile Include="Editors\ParameterSwapControllerActionSelector.cs" />
     <Compile Include="Editors\PasswordChanger.cs" />
     <Compile Include="Editors\TemplateController.cs" />
@@ -221,6 +222,8 @@
     <Compile Include="Models\ContentEditing\UserInvite.cs" />
     <Compile Include="Models\ContentEditing\UserProfile.cs" />
     <Compile Include="Models\ContentEditing\UserSave.cs" />
+    <Compile Include="Models\Culture.cs" />
+    <Compile Include="Models\Language.cs" />
     <Compile Include="Models\Mapping\ActionButtonsResolver.cs" />
     <Compile Include="Models\Mapping\CodeFileMapperProfile.cs" />
     <Compile Include="Models\Mapping\ContentTypeUdiResolver.cs" />


### PR DESCRIPTION
…persisting language changes

http://issues.umbraco.org/issue/U4-11121

### Description
Adding a `LanguageController` for use in the new language administration dashboard (angular).
- Getting current languages (those configured in the site)
- Getting available cultures (used when adding a new language to the site)
- Deleting a configured language
- Saving/updating a bulk set of languages
