### PR TITLE
U4-11154 Nested content ncNodename filter support for media and member pickers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
@@ -9,11 +9,15 @@ var ncNodeNameCache = {
 
 angular.module("umbraco.filters").filter("ncNodeName", function (editorState, entityResource) {
 
-    return function (input) {
+    return function (input, entityType) {
 
         // Check we have a value at all
         if (input === "" || input.toString() === "0") {
             return "";
+        }
+
+        if (entityType === "") {
+            entityType = "Document";
         }
 
         var currentNode = editorState.getCurrent();
@@ -35,7 +39,7 @@ angular.module("umbraco.filters").filter("ncNodeName", function (editorState, en
         // make a load of requests while we wait for a response
         ncNodeNameCache.keys[input] = "Loading...";
 
-        entityResource.getById(input, "Document")
+        entityResource.getById(input, entityType)
             .then(function (ent) {
                 ncNodeNameCache.keys[input] = ent.name;
             });


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11154

### Description
It was already supported to use the node name of item picked with a content picker as name template in nested content. This was done by writing a angular expression using the ncNodeName filter eg. {{pickerAlias | ncNodeName}}

This PR adds support for media and member pickers as well
Now you can do {{pickerAlias | ncNodeName:'Media'}} for media pickers and {{pickerAlias | ncNodeName:'Member'}}

If the extra type parameter is omitted it will default to Document as entity type for backwards compability


