### PR TITLE
U4-11155 fixed error when creating member groups

### DIFF
--- a/src/Umbraco.Tests/UI/LegacyDialogTests.cs
+++ b/src/Umbraco.Tests/UI/LegacyDialogTests.cs
@@ -5,7 +5,6 @@ using Umbraco.Web.UI;
 using umbraco;
 using umbraco.BusinessLogic;
 using umbraco.interfaces;
-using Umbraco.Web.umbraco.presentation.umbraco.create;
 
 namespace Umbraco.Tests.UI
 {

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/create/MemberGroupTasks.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/create/MemberGroupTasks.cs
@@ -2,9 +2,10 @@ using System.Linq;
 using System.Web.Security;
 using umbraco.BusinessLogic;
 using umbraco.cms.businesslogic.member;
+using Umbraco.Web;
 using Umbraco.Web.UI;
 
-namespace Umbraco.Web.umbraco.presentation.umbraco.create
+namespace umbraco
 {
     public class MemberGroupTasks : LegacyDialogTask
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11155

### Description
Reverted the namespace change in this commit https://github.com/umbraco/Umbraco-CMS/commit/0d2df4de811fbbd5760e0ef70adf0abcf8da326c

Now creating works again



<!-- Thanks for contributing to Umbraco CMS! -->
