### PR TITLE
U4-11124 - Prevents deleting a default language (API Controller & Service Layers)

### DIFF
--- a/src/Umbraco.Web/Editors/LanguageController.cs
+++ b/src/Umbraco.Web/Editors/LanguageController.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Web.Http;
 using Umbraco.Core.Persistence;
 using Umbraco.Web.Models;
@@ -56,6 +59,13 @@ namespace Umbraco.Web.Editors
             {
                 throw new EntityNotFoundException(id, $"Could not find language by id: '{id}'.");
             }
+
+            if (language.IsDefaultVariantLanguage)
+            {
+                var message = $"Language with id '{id}' is currently set to 'default' and can not be deleted.";
+                throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, message));
+            }
+
             Services.LocalizationService.Delete(language);
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
http://issues.umbraco.org/issue/U4-11124

This adds checks to ensure the Umbraco backoffice editor that uses the APIController prevents users deleting a language that is marked as default.

In addition, if users are using the raw API/Services layer and try to delete a language that is marked as default it will also throw.
