### PR TITLE
U4-11161 fix for adding multiple items in a single content picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -66,6 +66,8 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         showOpenButton: false,
         showEditButton: false,
         showPathOnHover: false,
+        maxNumber: 1,
+        minNumber : 0,
         startNode: {
             query: "",
             type: "content",

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -28,7 +28,7 @@
             <localize key="general_add">Add</localize>
         </a>
 
-        <div class="umb-contentpicker__min-max-help">
+        <div class="umb-contentpicker__min-max-help" ng-if="model.config.multiPicker === true">
 
             <!-- Both min and max items -->
             <span ng-if="model.config.minNumber && model.config.maxNumber && model.config.minNumber !== model.config.maxNumber">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11161

### Description
<!-- A description of the changes proposed in the pull-request -->

Added minNumber and maxNumbers to default config in controller. This solves the issue with being able to add multiple items to the Content picker.

I also changed the view to only show the help when it's multiple picker

Tested other pickers like MNTP and media picker and they keep working

@madsrasmussen can you review this because I saw you added the help text
<!-- Thanks for contributing to Umbraco CMS! -->
