### PR TITLE
U4-8395 - adds updateNodeData call to parent node when children are loaded from apis

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
@@ -254,6 +254,7 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
             this.removeChildNodes(args.node);
             args.node.loading = true;
 
+            var self = this;
             return this.getChildren(args)
                 .then(function(data) {
 
@@ -263,6 +264,10 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
                     if (args.node.children && args.node.children.length > 0) {
                         args.node.expanded = true;
                         args.node.hasChildren = true;
+                    }
+
+                    if (angular.isFunction(args.node.updateNodeData)) {
+                        args.node.updateNodeData();
                     }
                     return data;
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
@@ -264,11 +264,13 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
                     if (args.node.children && args.node.children.length > 0) {
                         args.node.expanded = true;
                         args.node.hasChildren = true;
+
+                        //make sure to update the UI with the new values
+                        if (angular.isFunction(args.node.updateNodeData)) {
+                            args.node.updateNodeData();
+                        }
                     }
 
-                    if (angular.isFunction(args.node.updateNodeData)) {
-                        args.node.updateNodeData();
-                    }
                     return data;
 
                 }, function(reason) {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-8395

### Description
The angular views aren't updated for parent nodes when the child nodes are loaded from the tree controller. The hasChildren property of the parent is explicitly set to false when the children are removed, and that's the state that is still reflected on the tree once the load is complete. Adding a call to the node.updateNodeData() within the return fixes the issue. 


<!-- Thanks for contributing to Umbraco CMS! -->
