### PR TITLE
Consider the 'case' of the Member Group/Role Name when comparing...

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/MemberGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/MemberGroupRepository.cs
@@ -242,7 +242,7 @@ namespace Umbraco.Core.Persistence.Repositories
                .Where<NodeDto>(dto => dto.NodeObjectType == NodeObjectTypeId)
                .Where("umbracoNode." + SqlSyntax.GetQuotedColumnName("text") + " in (@names)", new { names = roleNames });
             var existingRoles = Database.Fetch<NodeDto>(existingSql).Select(x => x.Text);
-            var missingRoles = roleNames.Except(existingRoles);
+            var missingRoles = roleNames.Except(existingRoles, StringComparer.CurrentCultureIgnoreCase);
             var missingGroups = missingRoles.Select(x => new MemberGroup {Name = x}).ToArray();
 
             if (UnitOfWork.Events.DispatchCancelable(SavingMemberGroup, this, new SaveEventArgs<IMemberGroup>(missingGroups)))
@@ -280,8 +280,8 @@ namespace Umbraco.Core.Persistence.Repositories
                 //exist in the roleNames list, then determine which ones are not currently assigned.
                 var mId = memberId;
                 var found = currentlyAssigned.Where(x => x.MemberId == mId).ToArray();
-                var assignedRoles = found.Where(x => roleNames.Contains(x.RoleName)).Select(x => x.RoleName);
-                var nonAssignedRoles = roleNames.Except(assignedRoles);
+                var assignedRoles = found.Where(x => roleNames.Contains(x.RoleName,StringComparer.CurrentCultureIgnoreCase)).Select(x => x.RoleName);
+                var nonAssignedRoles = roleNames.Except(assignedRoles, StringComparer.CurrentCultureIgnoreCase);
                 foreach (var toAssign in nonAssignedRoles)
                 {
                     var groupId = rolesForNames.First(x => x.Text == toAssign).NodeId;


### PR DESCRIPTION
...during assignment, If you use _memberService.AssignRole then you can inadvertently create a duplicate Member Group/Role, same text, different case.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11163

### Description
The issue can occur if you assign a member to a group and don't match the 'case' of the existing Member Group Name.

eg

SPECIAL - Admin

and you use 

_memberService.AssignRole(123,"Special - Admin")

creates a duplicate 'Special - Admin' member group, instead of assigning the member to the existing one.

The MemberGroupRepositiory has an AssignRolesInternal method that uses Except() and Contains() when comparing whether the role passed in to add for the member 'exists' already, and whether they are are already 'assigned to it'. This PR adds StringComparer.CurrentCultureIgnoreCase into those comparisons, so that new duplicate Member Group/Roles aren't created with differing case...

<!-- Thanks for contributing to Umbraco CMS! -->
