### PR TITLE
U4-11164 fixed blank screen for about 30 seconds after logging in with other culture than en-US

### DIFF
--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -11,5 +11,5 @@ using System.Resources;
 
 [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyFileVersion("7.10.0")]
-[assembly: AssemblyInformationalVersion("7.10.0")]
+[assembly: AssemblyFileVersion("7.11.0")]
+[assembly: AssemblyInformationalVersion("7.11.0")]

--- a/src/Umbraco.Core/Configuration/UmbracoVersion.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoVersion.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Core.Configuration
 {
     public class UmbracoVersion
     {
-        private static readonly Version Version = new Version("7.10.0");
+        private static readonly Version Version = new Version("7.11.0");
 
         /// <summary>
         /// Gets the current version of Umbraco.

--- a/src/Umbraco.Web.UI.Client/src/common/services/user.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/user.service.js
@@ -278,7 +278,7 @@ angular.module('umbraco.services')
 
             /** Loads the Moment.js Locale for the current user. */
             loadMomentLocaleForCurrentUser: function () {
-                var deferred = $q.defer();
+                
 
 
                 function loadLocales(currentUser, supportedLocales) {
@@ -295,11 +295,9 @@ angular.module('umbraco.services')
                             }
                         }
                         assetsService.load(localeUrls).then(function () {
-                            deferred.resolve(localeUrls);
+                            
                         });
-                    } else {
-                        deferred.resolve(['']);
-                    }
+                    } 
                 }
 
                 var promises = {
@@ -307,11 +305,11 @@ angular.module('umbraco.services')
                     supportedLocales: javascriptLibraryService.getSupportedLocalesForMoment()
                 }
 
-                $q.all(promises).then(function (values) {
-                    loadLocales(values.currentUser, values.supportedLocales);
+                return $q.all(promises).then(function (values) {
+                    return loadLocales(values.currentUser, values.supportedLocales);
                 });
                 
-                return deferred.promise;
+                
 
             },
 

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -1035,9 +1035,9 @@ xcopy "$(ProjectDir)"..\packages\SqlServerCE.4.0.0.1\x86\*.* "$(TargetDir)x86\" 
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>7100</DevelopmentServerPort>
+          <DevelopmentServerPort>7110</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:7100</IISUrl>
+          <IISUrl>http://localhost:7110</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/src/Umbraco.Web.UI/Umbraco/Views/Preview/Index.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Preview/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@inherits System.Web.Mvc.WebViewPage<Umbraco.Web.Models.ContentEditing.BackOfficePreview>
+﻿@using System.Web.Mvc.Html
+@inherits System.Web.Mvc.WebViewPage<Umbraco.Web.Models.ContentEditing.BackOfficePreview>
 @{
     var disableDevicePreview = Model.DisableDevicePreview.ToString().ToLowerInvariant();
 }


### PR DESCRIPTION

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11164

### Description
<!-- A description of the changes proposed in the pull-request -->
Because of $q.all we don't need to wait until promise is resolved, because all promises are resolved when this is hit. This fixes the issue at my side. 
Locale file of moment.js is retreived by asset service. So I think we don't need to wait for that. What is the change the user hit's a datepicker before this is loaded in ?


<!-- Thanks for contributing to Umbraco CMS! -->
