### PR TITLE
U4-11167 Fixes rare syncTree error

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -289,11 +289,17 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
             }
 
             if (mainTreeEventHandler) {                
-                //returns a promise, but wrap it in a time out,
-                // on some occasions the syncTree method is not defined yet in the umb - tree directive(U4 - 11167)
-                $timeout(function () {                   
+               
+                if (mainTreeEventHandler.syncTree) {
+                    //returns a promise,
                     return mainTreeEventHandler.syncTree(args);
-                }, 50, false);                
+                } else {
+                    //returns a promise, but wrap it in a time out,
+                    // on some occasions the syncTree method is not defined yet in the umb - tree directive(U4 - 11167)
+                    $timeout(function () {
+                        return mainTreeEventHandler.syncTree(args);
+                    }, 50, false);       
+                }
             }
 
             //couldn't sync

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -293,12 +293,6 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
                 if (mainTreeEventHandler.syncTree) {
                     //returns a promise,
                     return mainTreeEventHandler.syncTree(args);
-                } else {
-                    //returns a promise, but wrap it in a time out,
-                    // on some occasions the syncTree method is not defined yet in the umb - tree directive(U4 - 11167)
-                    $timeout(function () {
-                        return mainTreeEventHandler.syncTree(args);
-                    }, 50, false);       
                 }
             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -288,9 +288,12 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
                 throw "args.tree cannot be null";
             }
 
-            if (mainTreeEventHandler) {
-                //returns a promise
-                return mainTreeEventHandler.syncTree(args);
+            if (mainTreeEventHandler) {                
+                //returns a promise, but wrap it in a time out,
+                // on some occasions the syncTree method is not defined yet in the umb - tree directive(U4 - 11167)
+                $timeout(function () {                   
+                    return mainTreeEventHandler.syncTree(args);
+                }, 50, false);                
             }
 
             //couldn't sync


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11167

### Description
<!-- A description of the changes proposed in the pull-request -->

It sometimes occurs when you do a hard refresh of your browser that the syncTree method is called in the navigation service, before the umb-tree directive has finished with setting up external events in this method : https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js#L84

I wrapped in a timeout so we and could not reproduce it anymore

<!-- Thanks for contributing to Umbraco CMS! -->
