### PR TITLE
Issue U4-6585 - Add Textbox to Grid Row Config to add Grid Cell Css Classes

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/GridValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/GridValueConverter.cs
@@ -133,7 +133,7 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
             //(if there isn't, eg the number of columns have been changed for this row since the content was published... what is expected behaviour then?)
             if (gridCellConfig != null)
             {
-                gridCellCssClasses = gridCellConfig?["gridclasses"]?.Value<string>();
+                gridCellCssClasses = gridCellConfig?["gridCellCssClasses"]?.Value<string>();
             }
             return gridCellCssClasses;
         }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
@@ -54,7 +54,10 @@
                   </a>
               </div>
           </umb-control-group>
-          
+          <umb-control-group label="@grid_gridCellCssClasses" description="@grid_gridCellCssClassesDescription">
+              <input type="text" ng-model="currentCell.gridCellCssClasses" />
+          </umb-control-group>
+   
           <umb-control-group label="@grid_maxItems" description="@grid_maxItemsDescription">
               <input type="number" ng-model="currentCell.maxItems" class="umb-editor-tiny" placeholder="Max" min="0" />
           </umb-control-group>

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap2-Fluid.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap2-Fluid.cshtml
@@ -43,7 +43,7 @@
         @Umbraco.If(singleColumn, "<div class='container-fluid'>")
         <div class="row-fluid clearfix">
             @foreach ( var area in row.areas ) {
-            <div class="@("span" + area.grid) column">
+            <div class="@("span" + area.grid) @area.gridCellCssClasses column">
                 <div @RenderElementAttributes(area)>
                     @foreach (var control in area.controls) {
                         if (control !=null && control.editor != null && control.editor.view != null ) {

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap2.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap2.cshtml
@@ -39,7 +39,7 @@
         @Umbraco.If(singleColumn, "<div class='container'>")
         <div class="row clearfix">
             @foreach ( var area in row.areas ) {
-            <div class="@("span" + area.grid) column">
+            <div class="@("span" + area.grid) @area.gridCellCssClasses column">
                 <div @RenderElementAttributes(area)>
                     @foreach (var control in area.controls) {
                         if (control !=null && control.editor != null && control.editor.view != null ) {

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3-Fluid.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3-Fluid.cshtml
@@ -40,7 +40,7 @@
     <div @RenderElementAttributes(row)>
         <div class="row clearfix">
             @foreach ( var area in row.areas ) {
-            <div class="col-md-@area.grid column">
+            <div class="col-md-@area.grid @area.gridCellCssClasses column">
                 <div @RenderElementAttributes(area)>
                     @foreach (var control in area.controls) {
                         if (control !=null && control.editor != null && control.editor.view != null ) {

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3.cshtml
@@ -39,7 +39,7 @@
         @Umbraco.If(singleColumn, "<div class='container'>")
         <div class="row clearfix">
             @foreach ( var area in row.areas ) {
-            <div class="col-md-@area.grid column">
+            <div class="col-md-@area.grid @area.gridCellCssClasses column">
                 <div @RenderElementAttributes(area)>
                     @foreach (var control in area.controls) {
                         if (control !=null && control.editor != null && control.editor.view != null ) {

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1581,6 +1581,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="allowAllRowConfigurations">Allow all row configurations</key>
         <key alias="maxItems">Maximum items</key>
         <key alias="maxItemsDescription">Leave blank or set to 0 for unlimited</key>
+        <key alias="gridCellCssClasses">Grid Cell Css Classes</key>
+        <key alias="gridCellCssClassesDescription">Optional additional Css Classes to set for this cell, eg col-sm-6</key>
         <key alias="setAsDefault">Set as default</key>
         <key alias="chooseExtra">Choose extra</key>
         <key alias="chooseDefault">Choose default</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1576,6 +1576,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="allowAllRowConfigurations">Allow all row configurations</key>
         <key alias="maxItems">Maximum items</key>
         <key alias="maxItemsDescription">Leave blank or set to 0 for unlimited</key>
+        <key alias="gridCellCssClasses">Grid Cell Css Classes</key>
+        <key alias="gridCellCssClassesDescription">Optional additional Css Classes to set for this cell, eg col-sm-6</key>
         <key alias="setAsDefault">Set as default</key>
         <key alias="chooseExtra">Choose extra</key>
         <key alias="chooseDefault">Choose default</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org - see Issue: U4-6585 and previous conversation, on an earlier PR: https://github.com/umbraco/Umbraco-CMS/pull/678 that I tried to update with these changes but it's showing many more files changed, than have between the two branches, so just thought it was easier to create a new PR!

### Description
This PR adds an additional textbox when configuring a cell of a grid row, to enable you to add Css Classes that are for the specific Cell - Think Responsive Grid Layouts, you don't just have col-md-4, you have col-sm-6 and col-xs-12 all potentially for the same cell, having a textbox here enables these additional css classes to be configured when implementing the grid, meaning Editors aren't asked to manually add Css Classes via Settings, to achieve the 'design'... and developers aren't having to write custom rendering files 'Just' to add an extra css class name to cell. (Blog post here: http://tooorangey.co.uk/posts/evolution-of-the-grid/)

As it's just a textbox any css classes can be added here for the cell - it doesn't need to be bootstrap etc, 

In your custom grid renderer file you have access to these classes via @area.gridCellCssClasses

            <div class="col-md-@area.grid @area.gridCellCssClasses column">

This PR adds them to the 4 default grid rendering files that ship with Umbraco eg:

Finally the old PR for this functionality stuffed the classes inside the content, which was no good... (if the classes changed, you'd have to republish everything)

So now this new PR updates the GridValueConverter.cs  file following the pattern of how editor configuration is merged back into the grid JSON (hopefully following the advice correctly from Mr @Shazwazza) - to read the configured classes from the PreValues for the grid property, ensuring it is the provided Css Classes from the configuration of the row cell that are applied to the Grid Cell when it is rendered, not what is stored in published content.

This bit uses JObject and SelectToken, which could probably do with an eye over to make sure it's the most efficient way to do this (previously the prevalues for the grid weren't accessed in the value converter, so has that added any additional unwanted overhead...


<!-- Thanks for contributing to Umbraco CMS! -->
