### PR TITLE
U4-9668 RelationService - Relates entities by ID and a relationType + Alias

### DIFF
--- a/src/Umbraco.Core/Services/IRelationService.cs
+++ b/src/Umbraco.Core/Services/IRelationService.cs
@@ -190,6 +190,15 @@ namespace Umbraco.Core.Services
             bool loadBaseType = false);
 
         /// <summary>
+        /// Relates two objects by their entity Ids.
+        /// </summary>
+        /// <param name="parentId">Id of the parent</param>
+        /// <param name="childId">Id of the child</param>
+        /// <param name="relationType">The type of relation to create</param>
+        /// <returns>The created <see cref="Relation"/></returns>
+        IRelation Relate(int parentId, int childId, IRelationType relationType);
+
+        /// <summary>
         /// Relates two objects that are based on the <see cref="IUmbracoEntity"/> interface.
         /// </summary>
         /// <param name="parent">Parent entity</param>
@@ -197,6 +206,15 @@ namespace Umbraco.Core.Services
         /// <param name="relationType">The type of relation to create</param>
         /// <returns>The created <see cref="Relation"/></returns>
         IRelation Relate(IUmbracoEntity parent, IUmbracoEntity child, IRelationType relationType);
+
+        /// <summary>
+        /// Relates two objects by their entity Ids.
+        /// </summary>
+        /// <param name="parentId">Id of the parent</param>
+        /// <param name="childId">Id of the child</param>
+        /// <param name="relationTypeAlias">Alias of the type of relation to create</param>
+        /// <returns>The created <see cref="Relation"/></returns>
+        IRelation Relate(int parentId, int childId, string relationTypeAlias);
 
         /// <summary>
         /// Relates two objects that are based on the <see cref="IUmbracoEntity"/> interface.

--- a/src/Umbraco.Core/Services/RelationService.cs
+++ b/src/Umbraco.Core/Services/RelationService.cs
@@ -395,6 +395,39 @@ namespace Umbraco.Core.Services
         }
 
         /// <summary>
+        /// Relates two objects by their entity Ids.
+        /// </summary>
+        /// <param name="parentId">Id of the parent</param>
+        /// <param name="childId">Id of the child</param>
+        /// <param name="relationType">The type of relation to create</param>
+        /// <returns>The created <see cref="Relation"/></returns>
+        public IRelation Relate(int parentId, int childId, IRelationType relationType)
+        {
+            // Ensure that the RelationType has an indentity before using it to relate two entities
+            if (relationType.HasIdentity == false)
+                Save(relationType);
+
+            var relation = new Relation(parentId, childId, relationType);
+
+            using (var uow = UowProvider.GetUnitOfWork())
+            {
+                var saveEventArgs = new SaveEventArgs<IRelation>(relation);
+                if (uow.Events.DispatchCancelable(SavingRelation, this, saveEventArgs))
+                {
+                    uow.Commit();
+                    return relation;
+                }
+
+                var repository = RepositoryFactory.CreateRelationRepository(uow);
+                repository.AddOrUpdate(relation);
+                uow.Commit();
+                saveEventArgs.CanCancel = false;
+                uow.Events.Dispatch(SavedRelation, this, saveEventArgs);
+                return relation;
+            }
+        }
+
+        /// <summary>
         /// Relates two objects that are based on the <see cref="IUmbracoEntity"/> interface.
         /// </summary>
         /// <param name="parent">Parent entity</param>
@@ -403,28 +436,23 @@ namespace Umbraco.Core.Services
         /// <returns>The created <see cref="Relation"/></returns>
         public IRelation Relate(IUmbracoEntity parent, IUmbracoEntity child, IRelationType relationType)
         {
-            //Ensure that the RelationType has an indentity before using it to relate two entities
-            if (relationType.HasIdentity == false)
-                Save(relationType);
+            return Relate(parent.Id, child.Id, relationType);
+        }
 
-            var relation = new Relation(parent.Id, child.Id, relationType);
+        /// <summary>
+        /// Relates two objects by their entity Ids.
+        /// </summary>
+        /// <param name="parentId">Id of the parent</param>
+        /// <param name="childId">Id of the child</param>
+        /// <param name="relationTypeAlias">Alias of the type of relation to create</param>
+        /// <returns>The created <see cref="Relation"/></returns>
+        public IRelation Relate(int parentId, int childId, string relationTypeAlias)
+        {
+            var relationType = GetRelationTypeByAlias(relationTypeAlias);
+            if (relationType == null || string.IsNullOrEmpty(relationType.Alias))
+                throw new ArgumentNullException(string.Format("No RelationType with Alias '{0}' exists.", relationTypeAlias));
 
-            using (var uow = UowProvider.GetUnitOfWork())
-            {
-                var repository = RepositoryFactory.CreateRelationRepository(uow);
-                var saveEventArgs = new SaveEventArgs<IRelation>(relation);
-                if (uow.Events.DispatchCancelable(SavingRelation, this, saveEventArgs))
-                {
-                    uow.Commit();
-                    return relation;
-                }
-
-                repository.AddOrUpdate(relation);
-                uow.Commit();
-                saveEventArgs.CanCancel = false;
-                uow.Events.Dispatch(SavedRelation, this, saveEventArgs);
-                return relation;
-            }
+            return Relate(parentId, childId, relationType);
         }
 
         /// <summary>
@@ -440,23 +468,7 @@ namespace Umbraco.Core.Services
             if (relationType == null || string.IsNullOrEmpty(relationType.Alias))
                 throw new ArgumentNullException(string.Format("No RelationType with Alias '{0}' exists.", relationTypeAlias));
 
-            var relation = new Relation(parent.Id, child.Id, relationType);
-
-            using (var uow = UowProvider.GetUnitOfWork())
-            {
-                var saveEventArgs = new SaveEventArgs<IRelation>(relation);
-                if (uow.Events.DispatchCancelable(SavingRelation, this, saveEventArgs))
-                {
-                    uow.Commit();
-                    return relation;
-                }
-                var repository = RepositoryFactory.CreateRelationRepository(uow);
-                repository.AddOrUpdate(relation);
-                uow.Commit();
-                saveEventArgs.CanCancel = false;
-                uow.Events.Dispatch(SavedRelation, this, saveEventArgs);
-                return relation;
-            }
+            return Relate(parent.Id, child.Id, relationType);
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description

Currently you need to supply both parent & child entities to create a new relation.
When the underlying code requires the entity IDs (int).

This patch adds methods to accept the int IDs.
http://issues.umbraco.org/issue/U4-9668

This patch also de-duplicates the logic from `Relate(IUmbracoEntity, IUmbracoEntity, string)`,
as it was the same as the method body of `Relate(IUmbracoEntity, IUmbracoEntity, IRelationType)`.