### PR TITLE
U4-11184 - Nested Content PropertyValueEditor - return converted value, not update reference value

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/dashboard.tabs.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/dashboard.tabs.controller.js
@@ -18,7 +18,7 @@ function startUpVideosDashboardController($scope, xmlhelper, $log, $http) {
 angular.module("umbraco").controller("Umbraco.Dashboard.StartupVideosController", startUpVideosDashboardController);
 
 
-function startUpDynamicContentController($timeout, dashboardResource, assetsService, tourService, eventsService) {
+function startUpDynamicContentController($timeout, $scope, dashboardResource, assetsService, tourService, eventsService) {
     var vm = this;
     var evts = [];
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -267,11 +267,6 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
         }
 
         var notSupported = [
-          "Umbraco.CheckBoxList",
-          "Umbraco.DropDownMultiple",
-          "Umbraco.MacroContainer",
-          "Umbraco.RadioButtonList",
-          "Umbraco.MultipleTextstring",
           "Umbraco.Tags",
           "Umbraco.UploadField",
           "Umbraco.ImageCropper"

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -182,11 +182,8 @@ namespace Umbraco.Web.PropertyEditors
                     }
                 }
 
-                // Update the value on the property
-                property.Value = JsonConvert.SerializeObject(value);
-
-                // Pass the call down
-                return base.ConvertDbToString(property, propertyType, dataTypeService);
+                // Return the serialized value
+                return JsonConvert.SerializeObject(value);
             }
 
             #endregion
@@ -260,11 +257,8 @@ namespace Umbraco.Web.PropertyEditors
                     }
                 }
 
-                // Update the value on the property
-                property.Value = JsonConvert.SerializeObject(value);
-
-                // Pass the call down
-                return base.ConvertDbToEditor(property, propertyType, dataTypeService);
+                // Return the strongly-typed object, Umbraco will handle the JSON serializing/parsing, then Angular can handle it directly
+                return value;
             }
 
             #endregion

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Core;
@@ -104,10 +102,9 @@ namespace Umbraco.Web.PropertyEditors
             {
                 base.ConfigureForDisplay(preValues);
 
-                var asDictionary = preValues.PreValuesAsDictionary.ToDictionary(x => x.Key, x => x.Value.Value);
-                if (asDictionary.ContainsKey("hideLabel"))
+                if (preValues.PreValuesAsDictionary.ContainsKey("hideLabel"))
                 {
-                    var boolAttempt = asDictionary["hideLabel"].TryConvertTo<bool>();
+                    var boolAttempt = preValues.PreValuesAsDictionary["hideLabel"].Value.TryConvertTo<bool>();
                     if (boolAttempt.Success)
                     {
                         HideLabel = boolAttempt.Result;
@@ -120,10 +117,14 @@ namespace Umbraco.Web.PropertyEditors
             public override string ConvertDbToString(Property property, PropertyType propertyType, IDataTypeService dataTypeService)
             {
                 // Convert / validate value
-                if (property.Value == null || string.IsNullOrWhiteSpace(property.Value.ToString()))
+                if (property.Value == null)
                     return string.Empty;
 
-                var value = JsonConvert.DeserializeObject<List<object>>(property.Value.ToString());
+                var propertyValue = property.Value.ToString();
+                if (string.IsNullOrWhiteSpace(propertyValue))
+                    return string.Empty;
+
+                var value = JsonConvert.DeserializeObject<List<object>>(propertyValue);
                 if (value == null)
                     return string.Empty;
 
@@ -192,10 +193,14 @@ namespace Umbraco.Web.PropertyEditors
 
             public override object ConvertDbToEditor(Property property, PropertyType propertyType, IDataTypeService dataTypeService)
             {
-                if (property.Value == null || string.IsNullOrWhiteSpace(property.Value.ToString()))
+                if (property.Value == null)
                     return string.Empty;
 
-                var value = JsonConvert.DeserializeObject<List<object>>(property.Value.ToString());
+                var propertyValue = property.Value.ToString();
+                if (string.IsNullOrWhiteSpace(propertyValue))
+                    return string.Empty;
+
+                var value = JsonConvert.DeserializeObject<List<object>>(propertyValue);
                 if (value == null)
                     return string.Empty;
 
@@ -267,10 +272,14 @@ namespace Umbraco.Web.PropertyEditors
 
             public override object ConvertEditorToDb(ContentPropertyData editorValue, object currentValue)
             {
-                if (editorValue.Value == null || string.IsNullOrWhiteSpace(editorValue.Value.ToString()))
+                if (editorValue.Value == null)
                     return null;
 
-                var value = JsonConvert.DeserializeObject<List<object>>(editorValue.Value.ToString());
+                var rawValue = editorValue.Value.ToString();
+                if (string.IsNullOrWhiteSpace(rawValue))
+                    return null;
+
+                var value = JsonConvert.DeserializeObject<List<object>>(rawValue);
                 if (value == null)
                     return null;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11184

### Description

In Nested Content's PropertyValueEditor, I found that we had been updating the property.Value reference, rather than returning the converted value.

I think the reason we did this was so that we could make a call to the base method to prepare the value correctly for the appropriate target - e.g. the database, editor, XML cache.

However investigating Umbraco core, it turns out that we don't need to do this - since Nested Content is dealing with string values, those base methods are ultimately calling .ToString(), (or in the case of the editor one, deserializing the JSON string that has just been serialized).

I've refactored the "ConvertDbTo" methods and tested locally, all working as expected - including the following property-editors...

- Umbraco.CheckBoxList
- Umbraco.DropDownMultiple
- Umbraco.MacroContainer
- Umbraco.RadioButtonList
- Umbraco.MultipleTextstring

I've left more comments in the individual commits if you want to know more. :neckbeard: 

More gory details on the issue tracker: <http://issues.umbraco.org/issue/U4-11184> 😈 
