### PR TITLE
U4-9088 - Macro Container Property Type returned incorrect object-type

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MacroContainerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MacroContainerValueConverter.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
     /// Ensures macro syntax is parsed for the macro container which will work when getting the field
     /// values in any way (i.e. dynamically, using Field(), or IPublishedContent)
     /// </summary>
-    [PropertyValueType(typeof (IHtmlString))]
+    [PropertyValueType(typeof(IHtmlString))]
     [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Request)]
     [DefaultPropertyValueConverter]
     public class MacroContainerValueConverter : PropertyValueConverterBase
@@ -64,7 +64,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             // ensure string is parsed for macros and macros are executed correctly
             sourceString = RenderMacros(sourceString, preview);
 
-            return sourceString;
+            return new HtmlString(sourceString);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-9088

### Description

The `PropertyValueType` attribute marks this converter as returning an `IHtmlString`, but `ConvertDataToSource` returns a `string` type.

This patch corrects the return type to be a `HtmlString`.

More info and discussion over on the issue tracker: <http://issues.umbraco.org/issue/U4-9088>
