### PR TITLE
U4-11041 Bundle ImageProcessor.Web.PostProcessor with Umbraco

### DIFF
--- a/build/NuSpecs/UmbracoCms.Core.nuspec
+++ b/build/NuSpecs/UmbracoCms.Core.nuspec
@@ -35,6 +35,7 @@
       <dependency id="Examine" version="[0.1.89, 1.0.0)" />
       <dependency id="ImageProcessor" version="[2.5.6, 3.0.0)" />
       <dependency id="ImageProcessor.Web" version="[4.8.7, 5.0.0)" />
+      <dependency id="ImageProcessor.Web.PostProcessor" version="[1.2.3, 2.0.0)" />
       <dependency id="semver" version="[1.1.2, 3.0.0)" />
 	    <!-- Markdown can not be updated due to: https://github.com/hey-red/markdownsharp/issues/71#issuecomment-233585487 -->
       <dependency id="Markdown" version="[1.14.7, 2.0.0)" />

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -138,6 +138,9 @@
     <Reference Include="ImageProcessor.Web, Version=4.8.7.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ImageProcessor.Web.4.8.7\lib\net45\ImageProcessor.Web.dll</HintPath>
     </Reference>
+    <Reference Include="ImageProcessor.Web.Plugins.PostProcessor, Version=1.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.Web.PostProcessor.1.2.3\lib\net45\ImageProcessor.Web.Plugins.PostProcessor.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>

--- a/src/Umbraco.Web.UI/config/imageprocessor/processing.config
+++ b/src/Umbraco.Web.UI/config/imageprocessor/processing.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<processing preserveExifMetaData="true" fixGamma="false" interceptAllRequests="false" allowCacheBuster="true">
+<processing preserveExifMetaData="false" fixGamma="false" interceptAllRequests="false" allowCacheBuster="true">
   <presets>
   </presets>
   <plugins>

--- a/src/Umbraco.Web.UI/packages.config
+++ b/src/Umbraco.Web.UI/packages.config
@@ -8,6 +8,7 @@
   <package id="ImageProcessor" version="2.5.6" targetFramework="net45" />
   <package id="ImageProcessor.Web" version="4.8.7" targetFramework="net45" />
   <package id="ImageProcessor.Web.Config" version="2.3.1" targetFramework="net45" />
+  <package id="ImageProcessor.Web.PostProcessor" version="1.2.3" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net45" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11041

### Description

It might have been taught, mentioned or just plain given, but somehow I never knew about the post processor before I asked James.
Any big reason it's not just bundled with Umbraco? At least with nuget?
We've been forcing JPG with quality and juggled to leave out the transparent PNGs, while we could've just relied on this to compress the PNGs as well. :)

For reference:
https://www.nuget.org/packages/ImageProcessor.Web.PostProcessor/
