### PR TITLE
Added app setting umbracoDisableElectionForSingleServer

### DIFF
--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -50,6 +50,8 @@
 		<add key="umbracoTimeOutInMinutes" value="20" />
 		<add key="umbracoDefaultUILanguage" value="en-US" />
 		<add key="umbracoUseSSL" value="false" />
+	    <add key="umbracoDisableElectionForSingleServer" value="true" />
+
 
 		<add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
 		<add key="webpages:Enabled" value="false" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11210

### Description
Added app setting umbracoDisableElectionForSingleServer with value true to the web.config. This is also default on Umbraco Cloud. 

I think the majority of Umbraco installs don't need flexible loadbalancing at all. 

I also created a PR on the docs that you need to remove this or set it to false in the loadbalancing docs : https://github.com/umbraco/UmbracoDocs/pull/741


<!-- Thanks for contributing to Umbraco CMS! -->
