### PR TITLE
Allow capital letters for email address entry in RegesterModel

### DIFF
--- a/src/Umbraco.Web/Models/RegisterModel.cs
+++ b/src/Umbraco.Web/Models/RegisterModel.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Web.Models
         }
 
         [Required]
-        [RegularExpression(@"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?",
+        [RegularExpression(@"[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?",
             ErrorMessage = "Please enter a valid e-mail address")]
         public string Email { get; set; }
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->
Just changed the regular expression for client side validation to include capital letters. I checked the the actual member login was case insensitive and it is.


<!-- Thanks for contributing to Umbraco CMS! -->
