### PR TITLE
U4-7958 Cancelling in MemberService.Saving event does not show error message

### DIFF
--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -1,15 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Net.Http;
 using System.Xml.Linq;
 using Umbraco.Core.Models;
-using Umbraco.Core.Models.Membership;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.Querying;
 
 namespace Umbraco.Core.Services
-{
+{    /// <summary>
+     /// A temporary interface until we are in v8, this is used to return a different result for the same method and this interface gets implemented
+     /// explicitly. These methods will replace the normal ones in IContentService in v8 and this will be removed.
+     /// </summary>
+    public interface IMemberServiceOperations
+    {
+        //TODO: Remove this class in v8
+
+        /// <summary>
+        /// Permanently deletes an <see cref="IMember"/> object
+        /// </summary>
+        /// <param name="member">The <see cref="IMember"/> to delete</param>
+        /// <param name="userId">Id of the User deleting the member</param>
+        Attempt<OperationStatus> DeleteAttempt(IMember member, int userId = 0);
+
+        /// <summary>
+        /// Saves a single <see cref="IMember"/> object
+        /// </summary>
+        /// <param name="member">The <see cref="IMember"/> to save</param>
+        /// <param name="userId">Id of the User saving the member</param>
+        /// <param name="raiseEvents">Optional boolean indicating whether or not to raise events.</param>
+        Attempt<OperationStatus> Save(IMember member, int userId = 0, bool raiseEvents = true);
+
+        /// <summary>
+        /// Saves a collection of <see cref="IMember"/> objects
+        /// </summary>
+        /// <param name="members">Collection of <see cref="IMember"/> to save</param>
+        /// <param name="userId">Id of the User saving the member</param>
+        /// <param name="raiseEvents">Optional boolean indicating whether or not to raise events.</param>
+        Attempt<OperationStatus> Save(IEnumerable<IMember> members, int userId = 0, bool raiseEvents = true);
+    }
     /// <summary>
     /// Defines the MemberService, which is an easy access to operations involving (umbraco) members.
     /// </summary>

--- a/src/Umbraco.Core/Services/ServiceContext.cs
+++ b/src/Umbraco.Core/Services/ServiceContext.cs
@@ -26,9 +26,9 @@ namespace Umbraco.Core.Services
         {
             return (IMediaServiceOperations)mediaService;
         }
-        public static IMemberServiceOperations WithResult(this IMemberService mediaService)
+        public static IMemberServiceOperations WithResult(this IMemberService memberService)
         {
-            return (IMemberServiceOperations)mediaService;
+            return (IMemberServiceOperations)memberService;
         }
     }
 

--- a/src/Umbraco.Core/Services/ServiceContext.cs
+++ b/src/Umbraco.Core/Services/ServiceContext.cs
@@ -26,6 +26,10 @@ namespace Umbraco.Core.Services
         {
             return (IMediaServiceOperations)mediaService;
         }
+        public static IMemberServiceOperations WithResult(this IMemberService mediaService)
+        {
+            return (IMemberServiceOperations)mediaService;
+        }
     }
 
     /// <summary>

--- a/src/Umbraco.Web/Security/Providers/UmbracoMembershipProvider.cs
+++ b/src/Umbraco.Web/Security/Providers/UmbracoMembershipProvider.cs
@@ -194,10 +194,12 @@ namespace Umbraco.Web.Security.Providers
         /// </returns>
         public override bool DeleteUser(string username, bool deleteAllRelatedData)
         {
-            var member = MemberService.GetByUsername(username);
+            var memberService = UmbracoContext.Current.Application.Services.MemberService;
+
+            var member = memberService.GetByUsername(username);
             if (member == null) return false;
 
-            MemberService.Delete(member);
+            memberService.WithResult().DeleteAttempt(member, UmbracoContext.Current.Security.GetUserId());
             return true;
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->
http://issues.umbraco.org/issue/U4-7958

Cancelling the Saving event did already work but unlike content and media, it isn't wrapped in a `ServiceOperations` class. 

This has been done now, but unfortunately the custom message set in the cancellation does not show up, instead you get the default `Cancelled: Operation was cancelled by a 3rd party add-in` message. 

The problem seems to be that there's no items coming into the `var evtMsgs = EventMessagesFactory.Get();` call, but I don't understand how that would get populated in the first place.

This is my test code:

```
using Umbraco.Core;
using Umbraco.Core.Events;
using Umbraco.Core.Models;
using Umbraco.Core.Publishing;
using Umbraco.Core.Services;

namespace Tester
{
    public class Test : ApplicationEventHandler
    {
        protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
        {
            MemberService.Saving += MemberService_Saving;
        }

        private void MemberService_Saving(IMemberService sender, SaveEventArgs<IMember> e)
        {
            foreach (var entity in e.SavedEntities)
            {
                e.CancelOperation(new EventMessage("Warning", "Can't save this member", EventMessageType.Warning));
            }
        }
    }
}

```


<!-- Thanks for contributing to Umbraco CMS! -->
