### PR TITLE
U4-11214 - Display member type name in heading

### DIFF
--- a/src/Umbraco.Web/Editors/MemberController.cs
+++ b/src/Umbraco.Web/Editors/MemberController.cs
@@ -140,13 +140,16 @@ namespace Umbraco.Web.Editors
         /// <returns></returns>
         public MemberListDisplay GetListNodeDisplay(string listName)
         {
+            var foundType = Services.MemberTypeService.Get(listName);
+            var name = foundType != null ? foundType.Name : listName;
+
             var display = new MemberListDisplay
             {
                 ContentTypeAlias = listName,
-                ContentTypeName = listName,
+                ContentTypeName = name,
                 Id = listName,
                 IsContainer = true,
-                Name = listName == Constants.Conventions.MemberTypes.AllMembersListId ? "All Members" : listName,
+                Name = listName == Constants.Conventions.MemberTypes.AllMembersListId ? "All Members" : name,
                 Path = "-1," + listName,
                 ParentId = -1
             };


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11214

### Description
This PR map the name of the member type to the `MemberListDisplay` model instead of just using the alias.

**Before**
![image](https://user-images.githubusercontent.com/2919859/38781103-c72090e0-40e0-11e8-9419-5062220e7e7b.png)


**After**
![image](https://user-images.githubusercontent.com/2919859/38781080-7f28c4ba-40e0-11e8-930c-cbb83c89afe0.png)
