### PR TITLE
U4-11215 - Fix icons in member create dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
@@ -122,6 +122,18 @@ function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
                'Failed to delete content type contaier');
         },
 
+        /**
+         * @ngdoc method
+         * @name umbraco.resources.mediaTypeResource#save
+         * @methodOf umbraco.resources.mediaTypeResource
+         *
+         * @description
+         * Saves or update a media type
+         *
+         * @param {Object} content data type object to create/update
+         * @returns {Promise} resourcePromise object.
+         *
+         */
         save: function (contentType) {
 
             var saveModel = umbDataFormatter.formatContentTypePostData(contentType);

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -86,8 +86,8 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
 
         /**
          * @ngdoc method
-         * @name umbraco.resources.contentTypeResource#save
-         * @methodOf umbraco.resources.contentTypeResource
+         * @name umbraco.resources.memberTypeResource#save
+         * @methodOf umbraco.resources.memberTypeResource
          *
          * @description
          * Saves or update a member type

--- a/src/Umbraco.Web.UI.Client/src/views/media/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/create.html
@@ -16,24 +16,23 @@
 					        <i class="large {{docType.icon}}"></i>
 					        <span class="menu-label">
 	        		        	{{docType.name}}
-	        		            <small>
-	        		                {{docType.description}}
-	        		            </small>
+	        		            <small>{{docType.description}}</small>
 	        		        </span>
 					    </a>
 					</li>
-<!--
-					<li class="add">
-					    <a href="#settings/documenttype/create/{{currentNode.id}}?doctype={{docType.alias}}&create=true" ng-click="nav.hideNavigation()">
-					        <i class="icon-large icon-plus"></i>
-					        <span class="menu-label">
-					            Create a new media type
-					            <small>
-					                Design and configure a new media type
-					            </small>
-					        </span>
-					    </a>
-					</li>	-->
+                    <!--
+					    <li class="add">
+					        <a href="#settings/documenttype/create/{{currentNode.id}}?doctype={{docType.alias}}&create=true" ng-click="nav.hideNavigation()">
+					            <i class="icon-large icon-plus"></i>
+					            <span class="menu-label">
+					                Create a new media type
+					                <small>
+					                    Design and configure a new media type
+					                </small>
+					            </span>
+					        </a>
+					    </li>
+                    -->
 				</ul>
 			</li>
 		</ul>

--- a/src/Umbraco.Web.UI.Client/src/views/member/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/create.html
@@ -6,10 +6,9 @@
 
             <li ng-repeat="docType in allowedTypes">
                 <a href="#member/member/edit/{{currentNode.id}}?doctype={{docType.alias}}&create=true" ng-click="nav.hideNavigation()">
-
-                    <i class="large icon-users"></i>
-
-                    <span class="menu-label">{{docType.name}}
+                    <i class="large {{docType.icon}}"></i>
+                    <span class="menu-label">
+                        {{docType.name}}
                         <small>{{docType.description}}</small>
                     </span>
                 </a>
@@ -24,4 +23,3 @@
         <localize key="buttons_somethingElse">Do something else</localize>
     </button>
 </div>
-

--- a/src/Umbraco.Web/Editors/MediaTypeController.cs
+++ b/src/Umbraco.Web/Editors/MediaTypeController.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Web.Editors
         }
 
         /// <summary>
-        /// Deletes a document type wth a given ID
+        /// Deletes a media type with a given ID
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
@@ -138,17 +138,16 @@ namespace Umbraco.Web.Editors
 
 
         /// <summary>
-        /// Returns all member types
+        /// Returns all media types
         /// </summary>
         public IEnumerable<ContentTypeBasic> GetAll()
         {
-
             return Services.ContentTypeService.GetAllMediaTypes()
                                .Select(Mapper.Map<IMediaType, ContentTypeBasic>);
         }
 
         /// <summary>
-        /// Deletes a document type container wth a given ID
+        /// Deletes a media type container wth a given ID
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11215

### Description
The member create dialog didn't respect the icon of the entity as content and media does and therefore not consistent with content/media. By default the member type has `icon-user`, but it should be allowed the change these.

**Before**
![image](https://user-images.githubusercontent.com/2919859/38782602-56dbe4e0-40f6-11e8-9b6b-9a6be3b761b4.png)

**After**
![image](https://user-images.githubusercontent.com/2919859/38782613-861a1060-40f6-11e8-905a-d847b8745a65.png)