### PR TITLE
U4-11233 intro tour step needs to be shown centered

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour.directive.js
@@ -304,6 +304,12 @@ In the following example you see how to run some custom logic before a step goes
                 scope.elementNotFound = false;                
 
                 $timeout(function () {
+                    // clear element when step as marked as intro, so it always displays in the center
+                    if (scope.model.currentStep && scope.model.currentStep.type === "intro") {
+                        scope.model.currentStep.element = null;
+                        scope.model.currentStep.eventElement = null;
+                        scope.model.currentStep.event = null;
+                    }
 
                     // if an element isn't set - show the popover in the center
                     if(scope.model.currentStep && !scope.model.currentStep.element) {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11233

### Description
<!-- A description of the changes proposed in the pull-request -->

This clear's out element, eventElement and event when a tour is marked as intro step so it get's displayed centered

<!-- Thanks for contributing to Umbraco CMS! -->
