### PR TITLE
U4-11216 Multiple Content Picker allows only one item when used as macro parameter 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -60,6 +60,13 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
 	    
     $scope.dialogEditor = editorState && editorState.current && editorState.current.isDialogEditor === true;
 
+    // very dirty check if it's a parameter editor
+    var isParamEditor = false;
+
+    if ($scope.model.config.multiPicker && $scope.model.config.multiPicker === "1" && !$scope.model.config.maxNumber) {
+        isParamEditor = true;
+    }
+
     //the default pre-values
     var defaultConfig = {
         multiPicker: false,
@@ -95,7 +102,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     $scope.model.config.showPathOnHover = ($scope.model.config.showPathOnHover === "1" ? true : false);
 
     // if it's a multipicker the maxnumber can't be 1, otherwise it does not work as macro parameter editor
-    if ($scope.model.config.multiPicker && $scope.model.config.maxNumber === 1) {
+    if ($scope.model.config.multiPicker && $scope.model.config.maxNumber === 1 && isParamEditor) {
         $scope.model.config.maxNumber = 0;
     }
  

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -93,6 +93,11 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     $scope.model.config.showOpenButton = ($scope.model.config.showOpenButton === "1" ? true : false);
     $scope.model.config.showEditButton = ($scope.model.config.showEditButton === "1" ? true : false);
     $scope.model.config.showPathOnHover = ($scope.model.config.showPathOnHover === "1" ? true : false);
+
+    // if it's a multipicker the maxnumber can't be 1, otherwise it does not work as macro parameter editor
+    if ($scope.model.config.multiPicker && $scope.model.config.maxNumber === 1) {
+        $scope.model.config.maxNumber = 0;
+    }
  
     var entityType = $scope.model.config.startNode.type === "member"
         ? "Member"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11216

### Description
<!-- A description of the changes proposed in the pull-request -->

This does a very dirty check to see if it's used as a parameter editor. Then it sets the maxNumber to 0 when it's set to 1 and used as parameter editor

<!-- Thanks for contributing to Umbraco CMS! -->
