### PR TITLE
U4-11208 Error : "An item with the same key has already been added." into "Umbraco.Core.Services.IdkMap.Populate" method

### DIFF
--- a/src/Umbraco.Core/Services/IdkMap.cs
+++ b/src/Umbraco.Core/Services/IdkMap.cs
@@ -76,8 +76,9 @@ namespace Umbraco.Core.Services
                 _locker.EnterWriteLock();
                 foreach (var pair in pairs)
                 {
-                    _id2Key.Add(pair.id, new TypedId<Guid>(pair.key, umbracoObjectType));
-                    _key2Id.Add(pair.key, new TypedId<int>(pair.id, umbracoObjectType));
+
+                    _id2Key[pair.id] = new TypedId<Guid>(pair.key, umbracoObjectType);
+                    _key2Id[pair.key] = new TypedId<int>(pair.id, umbracoObjectType);
                 }
             }
             finally


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
See - http://issues.umbraco.org/issue/U4-11208

It is very likely that we're encountering either duplicates or a partially populated cache. It seems much safer to just update the dictionary (and this is a dict so this change does an add-or-update). 



<!-- Thanks for contributing to Umbraco CMS! -->
