### PR TITLE
U4-11253 New Chrome 66 trimStart function is overriding the Umbraco C…

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/umbraco/Extensions.js
+++ b/src/Umbraco.Web.UI.Client/lib/umbraco/Extensions.js
@@ -84,27 +84,21 @@
         };
     }
     
-    if (!String.prototype.trimStart) {
-        
-        /** trims the start of the string*/
-        String.prototype.trimStart = function (str) {
-            if (this.startsWith(str)) {
-                return this.substring(str.length);
-            }
-            return this;
-        };
-    }
-    
-    if (!String.prototype.trimEnd) {
+    /** trims the start of the string*/
+    String.prototype.trimStart = function (str) {
+        if (this.startsWith(str)) {
+            return this.substring(str.length);
+        }
+        return this;
+    };
 
-        /** trims the end of the string*/
-        String.prototype.trimEnd = function (str) {
-            if (this.endsWith(str)) {
-                return this.substring(0, this.length - str.length);
-            }
-            return this;
-        };
-    }
+    /** trims the end of the string*/
+    String.prototype.trimEnd = function (str) {
+        if (this.endsWith(str)) {
+            return this.substring(0, this.length - str.length);
+        }
+        return this;
+    };
 
     if (!String.prototype.utf8Encode) {
 


### PR DESCRIPTION
…ore trimStart polyfill

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->
Re: http://issues.umbraco.org/issue/U4-11253

By ALWAYS overriding the `trimStart` and `trimEnd` method we are not affected by the change to Chrome 66 which implements these methods without the ability to remove a specific character.

<!-- Thanks for contributing to Umbraco CMS! -->
