### PR TITLE
Fixes U4-8516 Copied node now sets the current user as the creator of the new node.

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -565,7 +565,7 @@ namespace Umbraco.Web.Editors
         {
             var toCopy = ValidateMoveOrCopy(copy);
 
-            var c = Services.ContentService.Copy(toCopy, copy.ParentId, copy.RelateToOriginal, copy.Recursive);
+            var c = Services.ContentService.Copy(toCopy, copy.ParentId, copy.RelateToOriginal, copy.Recursive, Security.CurrentUser.Id);
 
             var response = Request.CreateResponse(HttpStatusCode.OK);
             response.Content = new StringContent(c.Path, Encoding.UTF8, "application/json");


### PR DESCRIPTION
Fixes [U4-8516](http://issues.umbraco.org/issue/U4-8516)

### Description
Passes `Security.CurrentUser.Id` to the `Services.ContentService.Copy` method to ensure the user copying the node is set as the creator of the new node.
