### PR TITLE
U4-11275 routPath in custom tree always needs a id

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/routes.js
+++ b/src/Umbraco.Web.UI.Client/src/routes.js
@@ -141,13 +141,32 @@ app.config(function ($routeProvider) {
             resolve: canRoute(true)
         })
         .when('/:section/:tree/:method', {
-            templateUrl: function (rp) {
+            //This allows us to dynamically change the template for this route since you cannot inject services into the templateUrl method.
+            template: "<div ng-include='templateUrl'></div>",
+            //This controller will execute for this route, then we replace the template dynamnically based on the current tree.
+            controller: function ($scope, $route, $routeParams, treeService) {
 
-                //if there is no method registered for this then show the dashboard
-                if (!rp.method)
-                    return "views/common/dashboard.html";
-                
-                return ('views/' + rp.tree + '/' + rp.method + '.html');
+                if (!$routeParams.tree || !$routeParams.method) {
+                    $scope.templateUrl = "views/common/dashboard.html";
+                }
+
+                // Here we need to figure out if this route is for a package tree and if so then we need
+                // to change it's convention view path to:
+                // /App_Plugins/{mypackage}/backoffice/{treetype}/{method}.html
+
+                // otherwise if it is a core tree we use the core paths:
+                // views/{treetype}/{method}.html
+
+                var packageTreeFolder = treeService.getTreePackageFolder($routeParams.tree);
+
+                if (packageTreeFolder) {
+                    $scope.templateUrl = (Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath +
+                        "/" + packageTreeFolder +
+                        "/backoffice/" + $routeParams.tree + "/" + $routeParams.method + ".html");
+                }
+                else {
+                    $scope.templateUrl = ('views/' + $routeParams.tree + '/' + $routeParams.method + '.html');
+                }
             },
             resolve: canRoute(true)
         })


### PR DESCRIPTION
Fixes http://issues.umbraco.org/issue/U4-11275

This is a simple fix for U4-11275 so that packages also can set routePath to something like a overview page. Like the new user section when you don't want to display children. Is a copy of /:section/:tree/:method/:id