### PR TITLE
U4-11295 Added filtering to Nested Content add doctype overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -106,7 +106,8 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
 
         $scope.overlayMenu = {
             show: false,
-            style: {}
+            style: {},
+            showFilter: false
         };
 
         // helper to force the current form into the dirty state
@@ -343,6 +344,8 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
                 if ($scope.singleMode || ($scope.nodes.length == 1 && $scope.maxItems == 1)) {
                     $scope.currentNode = $scope.nodes[0];
                 }
+
+                $scope.overlayMenu.showFilter = $scope.scaffolds.length > 15;
 
                 inited = true;
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -47,8 +47,20 @@
                 <h5>
                     <localize key="grid_insertControl" />
                 </h5>
+
+                <div class="form-search" ng-hide="overlayMenu.showFilter === false" style="margin-bottom: 15px;">
+                    <i class="icon-search"></i>
+                    <input type="text"
+                           ng-model="searchTerm"
+                           class="umb-search-field search-query input-block-level -full-width-input"
+                           localize="placeholder"
+                           placeholder="@placeholders_filter"
+                           umb-auto-focus
+                           no-dirty-check />
+                </div>
+
                 <ul class="elements">
-                    <li ng-repeat="scaffold in overlayMenu.scaffolds">
+                    <li ng-repeat="scaffold in overlayMenu.scaffolds | filter:searchTerm">
                         <a ng-click="addNode(scaffold.alias)" href>
                             <i class="icon {{scaffold.icon}}"></i>
                             {{scaffold.name}}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
[U4-11295](http://issues.umbraco.org/issue/U4-11295)

Adds a filter to the Nested Content "Choose type of content overlay". Similar to #2360, however I'm using Nested Content's own overlay rather than Umbraco's item picker overlay.
