### PR TITLE
Health checks have hard coded paths to /config/umbracoSettings.config rather than using the configSource path in /web.config

### DIFF
--- a/src/Umbraco.Web/HealthCheck/Checks/Config/MacroErrorsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/MacroErrorsCheck.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 using Umbraco.Core.Services;
 

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/MacroErrorsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/MacroErrorsCheck.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using Umbraco.Core.Services;
 
@@ -13,12 +14,16 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
 
         public MacroErrorsCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
         {
+            
             _textService = healthCheckContext.ApplicationContext.Services.TextService;
         }
 
         public override string FilePath
         {
-            get { return "~/Config/umbracoSettings.config"; }
+            get {
+                System.Configuration.Configuration config = System.Web.Configuration.WebConfigurationManager.OpenWebConfiguration("~");
+                return config.SectionGroups["umbracoConfiguration"].Sections["settings"].ElementInformation.Source;
+            }
         }
 
         public override string XPath

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/NotificationEmailCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/NotificationEmailCheck.cs
@@ -18,7 +18,10 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
 
         public override string FilePath
         {
-            get { return "~/Config/umbracoSettings.config"; }
+            get {
+                System.Configuration.Configuration config = System.Web.Configuration.WebConfigurationManager.OpenWebConfiguration("~");
+                return config.SectionGroups["umbracoConfiguration"].Sections["settings"].ElementInformation.Source;
+            }
         }
 
         public override string XPath

--- a/src/Umbraco.Web/HealthCheck/Checks/Config/TrySkipIisCustomErrorsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Config/TrySkipIisCustomErrorsCheck.cs
@@ -21,7 +21,10 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
 
         public override string FilePath
         {
-            get { return "~/Config/umbracoSettings.config"; }
+            get {
+                System.Configuration.Configuration config = System.Web.Configuration.WebConfigurationManager.OpenWebConfiguration("~");
+                return config.SectionGroups["umbracoConfiguration"].Sections["settings"].ElementInformation.Source;
+            }
         }
 
         public override string XPath


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
[Issue U4-11310](http://issues.umbraco.org/issue/U4-11310)

If have updated the hard coded strings pointing the health checks to ~/config/umbracoSettings.config and have used System.Configuration.Configuration to pull out the configSource path that is under  "umbracoSettings/settings" in the web.config