### PR TITLE
u4 11313 - ContainsAny() method in StringExtensions doesn't honour the StringComparison parameter

### DIFF
--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -121,8 +121,8 @@ namespace Umbraco.Core
                     //if the resolution was success, return it, otherwise just return the path, we've detected
                     // it's a path but maybe it's relative and resolution has failed, etc... in which case we're just
                     // returning what was given to us.
-                    return resolvedUrlResult.Success 
-                        ? resolvedUrlResult 
+                    return resolvedUrlResult.Success
+                        ? resolvedUrlResult
                         : Attempt.Succeed(input);
                 }
             }
@@ -144,7 +144,7 @@ namespace Umbraco.Core
         }
 
         internal static readonly Regex Whitespace = new Regex(@"\s+", RegexOptions.Compiled);
-        internal static readonly string[] JsonEmpties = new [] { "[]", "{}" };
+        internal static readonly string[] JsonEmpties = new[] { "[]", "{}" };
         internal static bool DetectIsEmptyJson(this string input)
         {
             return JsonEmpties.Contains(Whitespace.Replace(input, string.Empty));
@@ -1436,14 +1436,25 @@ namespace Umbraco.Core
             return ReplaceMany(text, regexSpecialCharacters);
         }
 
+        /// <summary>
+        /// Checks whether a string "haystack" contains within it any of the strings in the "needles" collection and returns true if it does or false if it doesn't
+        /// </summary>
+        /// <param name="haystack">The string to check</param>
+        /// <param name="needles">The collection of strings to check are contained within the first string</param>
+        /// <param name="comparison">The type of comparision to perform - defaults to <see cref="StringComparison.CurrentCulture"/></param>
+        /// <returns>True if any of the needles are contained with haystack; otherwise returns false</returns>
+        /// Added fix to ensure the comparison is used - see http://issues.umbraco.org/issue/U4-11313
         public static bool ContainsAny(this string haystack, IEnumerable<string> needles, StringComparison comparison = StringComparison.CurrentCulture)
         {
-            if (haystack == null) throw new ArgumentNullException("haystack");
-            if (string.IsNullOrEmpty(haystack) == false || needles.Any())
+            if (haystack == null)
+                throw new ArgumentNullException("haystack");
+
+            if (string.IsNullOrEmpty(haystack) || needles == null || !needles.Any())
             {
-                return needles.Any(value => haystack.IndexOf(value) >= 0);
+                return false;
             }
-            return false;
+
+            return needles.Any(value => haystack.IndexOf(value, comparison) >= 0);
         }
 
         public static bool CsvContains(this string csv, string value)

--- a/src/Umbraco.Tests/Strings/StringExtensionsTests.cs
+++ b/src/Umbraco.Tests/Strings/StringExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using NUnit.Framework;
@@ -11,20 +12,20 @@ namespace Umbraco.Tests.Strings
     [TestFixture]
     public class StringExtensionsTests
     {
-	    [SetUp]
-	    public void Setup()
-	    {
+        [SetUp]
+        public void Setup()
+        {
             ShortStringHelperResolver.Reset();
             ShortStringHelperResolver.Current = new ShortStringHelperResolver(new MockShortStringHelper());
-	        Resolution.Freeze();
-	    }
+            Resolution.Freeze();
+        }
 
         [TearDown]
         public void TearDown()
         {
             ShortStringHelperResolver.Reset();
         }
-        
+
         [TestCase("hello", "world", false)]
         [TestCase("hello", "hello", true)]
         [TestCase("hellohellohellohellohellohellohello", "hellohellohellohellohellohellohelloo", false)]
@@ -53,43 +54,43 @@ namespace Umbraco.Tests.Strings
         [TestCase("hello.txt", "hello")]
         [TestCase("this.is.a.Txt", "this.is.a")]
         [TestCase("this.is.not.a. Txt", "this.is.not.a. Txt")]
-        [TestCase("not a file","not a file")]
+        [TestCase("not a file", "not a file")]
         public void Strip_File_Extension(string input, string result)
         {
             var stripped = input.StripFileExtension();
             Assert.AreEqual(stripped, result);
         }
 
-	    [TestCase("This is a string to encrypt")]
-		[TestCase("This is a string to encrypt\nThis is a second line")]
-		[TestCase("    White space is preserved    ")]
-		[TestCase("\nWhite space is preserved\n")]
-		public void Encrypt_And_Decrypt(string input)
-		{
-			var encrypted = input.EncryptWithMachineKey();
-			var decrypted = encrypted.DecryptWithMachineKey();
-			Assert.AreNotEqual(input, encrypted);
-			Assert.AreEqual(input, decrypted);
-		}
+        [TestCase("This is a string to encrypt")]
+        [TestCase("This is a string to encrypt\nThis is a second line")]
+        [TestCase("    White space is preserved    ")]
+        [TestCase("\nWhite space is preserved\n")]
+        public void Encrypt_And_Decrypt(string input)
+        {
+            var encrypted = input.EncryptWithMachineKey();
+            var decrypted = encrypted.DecryptWithMachineKey();
+            Assert.AreNotEqual(input, encrypted);
+            Assert.AreEqual(input, decrypted);
+        }
 
-		[Test()]
-		public void Encrypt_And_Decrypt_Long_Value()
-		{
-			// Generate a really long string
-			char[] chars = { 'a', 'b', 'c', '1', '2', '3', '\n' };
+        [Test()]
+        public void Encrypt_And_Decrypt_Long_Value()
+        {
+            // Generate a really long string
+            char[] chars = { 'a', 'b', 'c', '1', '2', '3', '\n' };
 
-			string valueToTest = string.Empty;
+            string valueToTest = string.Empty;
 
-			// Create a string 7035 chars long
-			for (int i = 0; i < 1005; i++)
-				for (int j = 0; j < chars.Length; j++)
-					valueToTest += chars[j].ToString();
+            // Create a string 7035 chars long
+            for (int i = 0; i < 1005; i++)
+                for (int j = 0; j < chars.Length; j++)
+                    valueToTest += chars[j].ToString();
 
-			var encrypted = valueToTest.EncryptWithMachineKey();
-			var decrypted = encrypted.DecryptWithMachineKey();
-			Assert.AreNotEqual(valueToTest, encrypted);
-			Assert.AreEqual(valueToTest, decrypted);
-		}
+            var encrypted = valueToTest.EncryptWithMachineKey();
+            var decrypted = encrypted.DecryptWithMachineKey();
+            Assert.AreNotEqual(valueToTest, encrypted);
+            Assert.AreEqual(valueToTest, decrypted);
+        }
 
         [TestCase("Hello this is my string", " string", "Hello this is my")]
         [TestCase("Hello this is my string strung", " string", "Hello this is my string strung")]
@@ -144,6 +145,19 @@ namespace Umbraco.Tests.Strings
         public void ToFirstLower(string input, string expected)
         {
             var output = input.ToFirstLower();
+            Assert.AreEqual(expected, output);
+        }
+
+        [TestCase("pineapple", new string[] { "banana", "apple", "blueberry", "strawberry" }, StringComparison.CurrentCulture, true)]
+        [TestCase("PINEAPPLE", new string[] { "banana", "apple", "blueberry", "strawberry" }, StringComparison.CurrentCulture, false)]
+        [TestCase("pineapple", new string[] { "banana", "Apple", "blueberry", "strawberry" }, StringComparison.CurrentCulture, false)]
+        [TestCase("pineapple", new string[] { "banana", "Apple", "blueberry", "strawberry" }, StringComparison.OrdinalIgnoreCase, true)]
+        [TestCase("pineapple", new string[] { "banana", "blueberry", "strawberry" }, StringComparison.OrdinalIgnoreCase, false)]
+        [TestCase("Strawberry unicorn pie", new string[] { "Berry" }, StringComparison.OrdinalIgnoreCase, true)]
+        [TestCase("empty pie", new string[0], StringComparison.OrdinalIgnoreCase, false)]
+        public void ContainsAny(string haystack, IEnumerable<string> needles, StringComparison comparison, bool expected)
+        {
+            bool output = haystack.ContainsAny(needles, comparison);
             Assert.AreEqual(expected, output);
         }
 
@@ -239,7 +253,7 @@ namespace Umbraco.Tests.Strings
         [Test]
         public void ReplaceManyByOneChar()
         {
-            var output = "JUST-ANYTHING".ReplaceMany(new char[] {}, '*');
+            var output = "JUST-ANYTHING".ReplaceMany(new char[] { }, '*');
             Assert.AreEqual("REPLACE-MANY-B::JUST-ANYTHING", output);
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x ] I have written a descriptive pull-request title
- [ x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11313 

### Description
This is a fix for the `ContainsAny()` method in StringExtensions didn't use the comparison method that was passed into it, meaning it always performs the default comparison method of `StringComparison.CurrentCulture`. This fix allows people to use the extension method for case-insensitive comparisons or use other comparison methods.

I have also written nUnit Tests for this in the `StringExtensionTests.cs` file that all pass.


