### PR TITLE
U4 10778 - FirstChild<T> extension returns IPublishedContent rather than model of type T

### DIFF
--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -478,7 +478,7 @@ namespace Umbraco.Tests.PublishedContent
         }
 
         [Test]
-        public void FirstChildT()
+        public void FirstChildOfT()
         {
             var doc = GetNode(1046); // has child nodes
             var model = doc.FirstChild<Home>();
@@ -488,7 +488,7 @@ namespace Umbraco.Tests.PublishedContent
             Assert.IsInstanceOf<Home>(model);
             Assert.IsInstanceOf<IPublishedContent>(model);
 
-            model = doc.FirstChild<Home>(x => true); // predicate
+            model = doc.FirstChildOf<Home>(x => true); // predicate
 
             Assert.IsNotNull(model);
             Assert.IsTrue(model.Id == 1173);
@@ -496,8 +496,8 @@ namespace Umbraco.Tests.PublishedContent
             Assert.IsInstanceOf<IPublishedContent>(model);
 
             doc = GetNode(1175); // does not have child nodes
-            Assert.IsNull(doc.FirstChild<Home>());
-            Assert.IsNull(doc.FirstChild<Home>(x => true));
+            Assert.IsNull(doc.FirstChildOf<Home>());
+            Assert.IsNull(doc.FirstChildOf<Home>(x => true));
         }
 
         [Test]

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -7,19 +7,27 @@ using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Tests.PublishedContent.StronglyTypedModels;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Web;
 using Umbraco.Web.Models;
 
 namespace Umbraco.Tests.PublishedContent
 {
-	/// <summary>
-	/// Tests the methods on IPublishedContent using the DefaultPublishedContentStore
-	/// </summary>
-	[TestFixture]
+    /// <summary>
+    /// Tests the methods on IPublishedContent using the DefaultPublishedContentStore
+    /// </summary>
+    [TestFixture]
     public class PublishedContentTests : PublishedContentTestBase
-	{
+    {
         private PluginManager _pluginManager;
+
+        private class StrongModel : PublishedContentModel
+        {
+            private StrongModel(IPublishedContent content) : base(content)
+            {
+            }
+        }
 
         public override void Initialize()
         {
@@ -50,7 +58,7 @@ namespace Umbraco.Tests.PublishedContent
                     new PublishedPropertyType("content", 0, Constants.PropertyEditors.TinyMCEAlias),
                     new PublishedPropertyType("testRecursive", 0, "?"),
                 };
-            var compositionAliases = new[] {"MyCompositionAlias"};
+            var compositionAliases = new[] { "MyCompositionAlias" };
             var type = new AutoPublishedContentType(0, "anything", compositionAliases, propertyTypes);
             PublishedContentType.GetPublishedContentTypeCallback = (alias) => type;
         }
@@ -62,17 +70,17 @@ namespace Umbraco.Tests.PublishedContent
             ApplicationContext.Current = null;
         }
 
-	    protected override void FreezeResolution()
-	    {
+        protected override void FreezeResolution()
+        {
             var types = PluginManager.Current.ResolveTypes<PublishedContentModel>();
             PublishedContentModelFactoryResolver.Current = new PublishedContentModelFactoryResolver(
                 new PublishedContentModelFactory(types));
-	        base.FreezeResolution();
-	    }
+            base.FreezeResolution();
+        }
 
-	    protected override string GetXmlContent(int templateId)
-		{
-			return @"<?xml version=""1.0"" encoding=""utf-8""?>
+        protected override string GetXmlContent(int templateId)
+        {
+            return @"<?xml version=""1.0"" encoding=""utf-8""?>
 <!DOCTYPE root[
 <!ELEMENT Home ANY>
 <!ATTLIST Home id ID #REQUIRED>
@@ -110,15 +118,15 @@ namespace Umbraco.Tests.PublishedContent
 	</Home>
 	<CustomDocument id=""1172"" parentID=""-1"" level=""1"" writerID=""0"" creatorID=""0"" nodeType=""1234"" template=""" + templateId + @""" sortOrder=""2"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-18T14:23:35"" nodeName=""Test"" urlName=""test-page"" writerName=""admin"" creatorName=""admin"" path=""-1,1172"" isDoc="""" />
 </root>";
-		}
+        }
 
-		internal IPublishedContent GetNode(int id)
-		{
-			var ctx = GetUmbracoContext("/test", 1234);
-			var doc = ctx.ContentCache.GetById(id);
-			Assert.IsNotNull(doc);
-			return doc;
-		}
+        internal IPublishedContent GetNode(int id)
+        {
+            var ctx = GetUmbracoContext("/test", 1234);
+            var doc = ctx.ContentCache.GetById(id);
+            Assert.IsNotNull(doc);
+            return doc;
+        }
 
         [Test]
         [Ignore("IPublishedContent currently (6.1 as of april 25, 2013) has bugs")]
@@ -213,7 +221,7 @@ namespace Umbraco.Tests.PublishedContent
         {
             public Home(IPublishedContent content)
                 : base(content)
-            {}
+            { }
         }
 
         [Test]
@@ -310,164 +318,187 @@ namespace Umbraco.Tests.PublishedContent
             }
         }
 
-	    [Test]
-	    public void Descendants_Ordered_Properly()
-	    {
+        [Test]
+        public void Descendants_Ordered_Properly()
+        {
             var doc = GetNode(1046);
 
-	        var expected = new[] {1046, 1173, 1174, 1177, 1178, 1176, 1175, 4444, 1172};
-	        var exindex = 0;
+            var expected = new[] { 1046, 1173, 1174, 1177, 1178, 1176, 1175, 4444, 1172 };
+            var exindex = 0;
 
             // must respect the XPath descendants-or-self axis!
             foreach (var d in doc.DescendantsOrSelf())
                 Assert.AreEqual(expected[exindex++], d.Id);
-	    }
+        }
 
-	    [Test]
-		public void Test_Get_Recursive_Val()
-		{
-			var doc = GetNode(1174);
-			var rVal = doc.GetRecursiveValue("testRecursive");
-			var nullVal = doc.GetRecursiveValue("DoNotFindThis");
-			Assert.AreEqual("This is the recursive val", rVal);
-			Assert.AreEqual("", nullVal);
-		}
+        [Test]
+        public void Test_Get_Recursive_Val()
+        {
+            var doc = GetNode(1174);
+            var rVal = doc.GetRecursiveValue("testRecursive");
+            var nullVal = doc.GetRecursiveValue("DoNotFindThis");
+            Assert.AreEqual("This is the recursive val", rVal);
+            Assert.AreEqual("", nullVal);
+        }
 
-		[Test]
-		public void Get_Property_Value_Uses_Converter()
-		{
-			var doc = GetNode(1173);
+        [Test]
+        public void Get_Property_Value_Uses_Converter()
+        {
+            var doc = GetNode(1173);
 
-			var propVal = doc.GetPropertyValue("content");
+            var propVal = doc.GetPropertyValue("content");
             Assert.IsInstanceOf(typeof(IHtmlString), propVal);
-			Assert.AreEqual("<div>This is some content</div>", propVal.ToString());
+            Assert.AreEqual("<div>This is some content</div>", propVal.ToString());
 
-			var propVal2 = doc.GetPropertyValue<IHtmlString>("content");
+            var propVal2 = doc.GetPropertyValue<IHtmlString>("content");
             Assert.IsInstanceOf(typeof(IHtmlString), propVal2);
             Assert.AreEqual("<div>This is some content</div>", propVal2.ToString());
 
             var propVal3 = doc.GetPropertyValue("Content");
             Assert.IsInstanceOf(typeof(IHtmlString), propVal3);
             Assert.AreEqual("<div>This is some content</div>", propVal3.ToString());
-		}
+        }
 
-		[Test]
-		public void Complex_Linq()
-		{
-			var doc = GetNode(1173);
+        [Test]
+        public void Complex_Linq()
+        {
+            var doc = GetNode(1173);
 
-			var result = doc.Ancestors().OrderBy(x => x.Level)
-				.Single()
-				.Descendants()
-				.FirstOrDefault(x => x.GetPropertyValue<string>("selectedNodes", "").Split(',').Contains("1173"));
+            var result = doc.Ancestors().OrderBy(x => x.Level)
+                .Single()
+                .Descendants()
+                .FirstOrDefault(x => x.GetPropertyValue<string>("selectedNodes", "").Split(',').Contains("1173"));
 
-			Assert.IsNotNull(result);
-		}
+            Assert.IsNotNull(result);
+        }
 
-		[Test]
-		public void Index()
-		{
-			var doc = GetNode(1173);
-			Assert.AreEqual(0, doc.Index());
-			doc = GetNode(1176);
-			Assert.AreEqual(3, doc.Index());
-			doc = GetNode(1177);
-			Assert.AreEqual(1, doc.Index());
-			doc = GetNode(1178);
-			Assert.AreEqual(2, doc.Index());
-		}
+        [Test]
+        public void Index()
+        {
+            var doc = GetNode(1173);
+            Assert.AreEqual(0, doc.Index());
+            doc = GetNode(1176);
+            Assert.AreEqual(3, doc.Index());
+            doc = GetNode(1177);
+            Assert.AreEqual(1, doc.Index());
+            doc = GetNode(1178);
+            Assert.AreEqual(2, doc.Index());
+        }
 
-		[Test]
-		public void Is_First()
-		{
-			var doc = GetNode(1046); //test root nodes
-			Assert.IsTrue(doc.IsFirst());
-			doc = GetNode(1172);
-			Assert.IsFalse(doc.IsFirst());
-			doc = GetNode(1173); //test normal nodes
-			Assert.IsTrue(doc.IsFirst());
-			doc = GetNode(1175);
-			Assert.IsFalse(doc.IsFirst());
-		}
+        [Test]
+        public void Is_First()
+        {
+            var doc = GetNode(1046); //test root nodes
+            Assert.IsTrue(doc.IsFirst());
+            doc = GetNode(1172);
+            Assert.IsFalse(doc.IsFirst());
+            doc = GetNode(1173); //test normal nodes
+            Assert.IsTrue(doc.IsFirst());
+            doc = GetNode(1175);
+            Assert.IsFalse(doc.IsFirst());
+        }
 
-		[Test]
-		public void Is_Not_First()
-		{
-			var doc = GetNode(1046); //test root nodes
-			Assert.IsFalse(doc.IsNotFirst());
-			doc = GetNode(1172);
-			Assert.IsTrue(doc.IsNotFirst());
-			doc = GetNode(1173); //test normal nodes
-			Assert.IsFalse(doc.IsNotFirst());
-			doc = GetNode(1175);
-			Assert.IsTrue(doc.IsNotFirst());
-		}
+        [Test]
+        public void Is_Not_First()
+        {
+            var doc = GetNode(1046); //test root nodes
+            Assert.IsFalse(doc.IsNotFirst());
+            doc = GetNode(1172);
+            Assert.IsTrue(doc.IsNotFirst());
+            doc = GetNode(1173); //test normal nodes
+            Assert.IsFalse(doc.IsNotFirst());
+            doc = GetNode(1175);
+            Assert.IsTrue(doc.IsNotFirst());
+        }
 
-		[Test]
-		public void Is_Position()
-		{
-			var doc = GetNode(1046); //test root nodes
-			Assert.IsTrue(doc.IsPosition(0));
-			doc = GetNode(1172);
-			Assert.IsTrue(doc.IsPosition(1));
-			doc = GetNode(1173); //test normal nodes
-			Assert.IsTrue(doc.IsPosition(0));
-			doc = GetNode(1175);
-			Assert.IsTrue(doc.IsPosition(1));
-		}
+        [Test]
+        public void Is_Position()
+        {
+            var doc = GetNode(1046); //test root nodes
+            Assert.IsTrue(doc.IsPosition(0));
+            doc = GetNode(1172);
+            Assert.IsTrue(doc.IsPosition(1));
+            doc = GetNode(1173); //test normal nodes
+            Assert.IsTrue(doc.IsPosition(0));
+            doc = GetNode(1175);
+            Assert.IsTrue(doc.IsPosition(1));
+        }
 
-		[Test]
-		public void Children_GroupBy_DocumentTypeAlias()
-		{
-			var doc = GetNode(1046);
+        [Test]
+        public void Children_GroupBy_DocumentTypeAlias()
+        {
+            var doc = GetNode(1046);
 
-			var found1 = doc.Children.GroupBy("DocumentTypeAlias");
+            var found1 = doc.Children.GroupBy("DocumentTypeAlias");
 
-			Assert.AreEqual(2, found1.Count());
-			Assert.AreEqual(2, found1.Single(x => x.Key.ToString() == "Home").Count());
-			Assert.AreEqual(1, found1.Single(x => x.Key.ToString() == "CustomDocument").Count());
-		}
+            Assert.AreEqual(2, found1.Count());
+            Assert.AreEqual(2, found1.Single(x => x.Key.ToString() == "Home").Count());
+            Assert.AreEqual(1, found1.Single(x => x.Key.ToString() == "CustomDocument").Count());
+        }
 
-		[Test]
-		public void Children_Where_DocumentTypeAlias()
-		{
-			var doc = GetNode(1046);
+        [Test]
+        public void Children_Where_DocumentTypeAlias()
+        {
+            var doc = GetNode(1046);
 
-			var found1 = doc.Children.Where("DocumentTypeAlias == \"CustomDocument\"");
-			var found2 = doc.Children.Where("DocumentTypeAlias == \"Home\"");
+            var found1 = doc.Children.Where("DocumentTypeAlias == \"CustomDocument\"");
+            var found2 = doc.Children.Where("DocumentTypeAlias == \"Home\"");
 
-			Assert.AreEqual(1, found1.Count());
-			Assert.AreEqual(2, found2.Count());
-		}
+            Assert.AreEqual(1, found1.Count());
+            Assert.AreEqual(2, found2.Count());
+        }
 
-		[Test]
-		public void Children_Order_By_Update_Date()
-		{
-			var doc = GetNode(1173);
+        [Test]
+        public void Children_Order_By_Update_Date()
+        {
+            var doc = GetNode(1173);
 
-			var ordered = doc.Children.OrderBy("UpdateDate");
+            var ordered = doc.Children.OrderBy("UpdateDate");
 
-			var correctOrder = new[] { 1178, 1177, 1174, 1176 };
-			for (var i = 0; i < correctOrder.Length; i++)
-			{
-				Assert.AreEqual(correctOrder[i], ordered.ElementAt(i).Id);
-			}
+            var correctOrder = new[] { 1178, 1177, 1174, 1176 };
+            for (var i = 0; i < correctOrder.Length; i++)
+            {
+                Assert.AreEqual(correctOrder[i], ordered.ElementAt(i).Id);
+            }
 
-		}
+        }
 
-		[Test]
-		public void FirstChild()
-		{
-			var doc = GetNode(1173); // has child nodes
-			Assert.IsNotNull(doc.FirstChild());
-			Assert.IsNotNull(doc.FirstChild(x => true));
-			Assert.IsNotNull(doc.FirstChild<IPublishedContent>());
+        [Test]
+        public void FirstChild()
+        {
+            var doc = GetNode(1173); // has child nodes
+            Assert.IsNotNull(doc.FirstChild());
+            Assert.IsNotNull(doc.FirstChild(x => true));
+            Assert.IsNotNull(doc.FirstChild<IPublishedContent>());
 
-			doc = GetNode(1175); // does not have child nodes
-			Assert.IsNull(doc.FirstChild());
-			Assert.IsNull(doc.FirstChild(x => true));
-			Assert.IsNull(doc.FirstChild<IPublishedContent>());
-		}
+            doc = GetNode(1175); // does not have child nodes
+            Assert.IsNull(doc.FirstChild());
+            Assert.IsNull(doc.FirstChild(x => true));
+            Assert.IsNull(doc.FirstChild<IPublishedContent>());
+        }
+
+        [Test]
+        public void FirstChildT()
+        {
+            var doc = GetNode(1046); // has child nodes
+            var model = doc.FirstChild<Home>();
+
+            Assert.IsNotNull(model);
+            Assert.IsTrue(model.Id == 1173);
+            Assert.IsInstanceOf<Home>(model);
+            Assert.IsInstanceOf<IPublishedContent>(model);
+
+            model = doc.FirstChild<Home>(x => true); // predicate
+
+            Assert.IsNotNull(model);
+            Assert.IsTrue(model.Id == 1173);
+            Assert.IsInstanceOf<Home>(model);
+            Assert.IsInstanceOf<IPublishedContent>(model);
+
+            doc = GetNode(1175); // does not have child nodes
+            Assert.IsNull(doc.FirstChild<Home>());
+            Assert.IsNull(doc.FirstChild<Home>(x => true));
+        }
 
         [Test]
         public void IsComposedOf()
@@ -479,190 +510,190 @@ namespace Umbraco.Tests.PublishedContent
             Assert.IsTrue(isComposedOf);
         }
 
-		[Test]
-		public void HasProperty()
-		{
-			var doc = GetNode(1173);
+        [Test]
+        public void HasProperty()
+        {
+            var doc = GetNode(1173);
 
-			var hasProp = doc.HasProperty(Constants.Conventions.Content.UrlAlias);
+            var hasProp = doc.HasProperty(Constants.Conventions.Content.UrlAlias);
 
             Assert.IsTrue(hasProp);
-		}
+        }
 
-		[Test]
-		public void HasValue()
-		{
-			var doc = GetNode(1173);
+        [Test]
+        public void HasValue()
+        {
+            var doc = GetNode(1173);
 
-			var hasValue = doc.HasValue(Constants.Conventions.Content.UrlAlias);
-			var noValue = doc.HasValue("blahblahblah");
+            var hasValue = doc.HasValue(Constants.Conventions.Content.UrlAlias);
+            var noValue = doc.HasValue("blahblahblah");
 
-			Assert.IsTrue(hasValue);
-			Assert.IsFalse(noValue);
-		}
+            Assert.IsTrue(hasValue);
+            Assert.IsFalse(noValue);
+        }
 
-		[Test]
-		public void Ancestors_Where_Visible()
-		{
-			var doc = GetNode(1174);
+        [Test]
+        public void Ancestors_Where_Visible()
+        {
+            var doc = GetNode(1174);
 
-			var whereVisible = doc.Ancestors().Where("Visible");
-			Assert.AreEqual(1, whereVisible.Count());
+            var whereVisible = doc.Ancestors().Where("Visible");
+            Assert.AreEqual(1, whereVisible.Count());
 
-		}
+        }
 
-		[Test]
-		public void Visible()
-		{
-			var hidden = GetNode(1046);
-			var visible = GetNode(1173);
+        [Test]
+        public void Visible()
+        {
+            var hidden = GetNode(1046);
+            var visible = GetNode(1173);
 
-			Assert.IsFalse(hidden.IsVisible());
-			Assert.IsTrue(visible.IsVisible());
-		}
+            Assert.IsFalse(hidden.IsVisible());
+            Assert.IsTrue(visible.IsVisible());
+        }
 
-		[Test]
-		public void Ancestor_Or_Self()
-		{
-			var doc = GetNode(1173);
+        [Test]
+        public void Ancestor_Or_Self()
+        {
+            var doc = GetNode(1173);
 
-			var result = doc.AncestorOrSelf();
+            var result = doc.AncestorOrSelf();
 
-			Assert.IsNotNull(result);
+            Assert.IsNotNull(result);
 
             // ancestor-or-self has to be self!
             Assert.AreEqual(1173, result.Id);
-		}
+        }
 
-	    [Test]
-	    public void U4_4559()
-	    {
-	        var doc = GetNode(1174);
-	        var result = doc.AncestorOrSelf(1);
+        [Test]
+        public void U4_4559()
+        {
+            var doc = GetNode(1174);
+            var result = doc.AncestorOrSelf(1);
             Assert.IsNotNull(result);
             Assert.AreEqual(1046, result.Id);
-	    }
+        }
 
-		[Test]
-		public void Ancestors_Or_Self()
-		{
-			var doc = GetNode(1174);
+        [Test]
+        public void Ancestors_Or_Self()
+        {
+            var doc = GetNode(1174);
 
-			var result = doc.AncestorsOrSelf();
+            var result = doc.AncestorsOrSelf();
 
-			Assert.IsNotNull(result);
+            Assert.IsNotNull(result);
 
-			Assert.AreEqual(3, result.Count());
-			Assert.IsTrue(result.Select(x => ((dynamic)x).Id).ContainsAll(new dynamic[] { 1174, 1173, 1046 }));
-		}
+            Assert.AreEqual(3, result.Count());
+            Assert.IsTrue(result.Select(x => ((dynamic)x).Id).ContainsAll(new dynamic[] { 1174, 1173, 1046 }));
+        }
 
-		[Test]
-		public void Ancestors()
-		{
-			var doc = GetNode(1174);
+        [Test]
+        public void Ancestors()
+        {
+            var doc = GetNode(1174);
 
-			var result = doc.Ancestors();
+            var result = doc.Ancestors();
 
-			Assert.IsNotNull(result);
+            Assert.IsNotNull(result);
 
-			Assert.AreEqual(2, result.Count());
-			Assert.IsTrue(result.Select(x => ((dynamic)x).Id).ContainsAll(new dynamic[] { 1173, 1046 }));
-		}
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.Select(x => ((dynamic)x).Id).ContainsAll(new dynamic[] { 1173, 1046 }));
+        }
 
-		[Test]
-		public void Descendants_Or_Self()
-		{
-			var doc = GetNode(1046);
+        [Test]
+        public void Descendants_Or_Self()
+        {
+            var doc = GetNode(1046);
 
-			var result = doc.DescendantsOrSelf();
+            var result = doc.DescendantsOrSelf();
 
-			Assert.IsNotNull(result);
+            Assert.IsNotNull(result);
 
-			Assert.AreEqual(8, result.Count());
-			Assert.IsTrue(result.Select(x => ((dynamic)x).Id).ContainsAll(new dynamic[] { 1046, 1173, 1174, 1176, 1175 }));
-		}
+            Assert.AreEqual(8, result.Count());
+            Assert.IsTrue(result.Select(x => ((dynamic)x).Id).ContainsAll(new dynamic[] { 1046, 1173, 1174, 1176, 1175 }));
+        }
 
-		[Test]
-		public void Descendants()
-		{
-			var doc = GetNode(1046);
+        [Test]
+        public void Descendants()
+        {
+            var doc = GetNode(1046);
 
-			var result = doc.Descendants();
+            var result = doc.Descendants();
 
-			Assert.IsNotNull(result);
+            Assert.IsNotNull(result);
 
-			Assert.AreEqual(7, result.Count());
-			Assert.IsTrue(result.Select(x => ((dynamic)x).Id).ContainsAll(new dynamic[] { 1173, 1174, 1176, 1175, 4444 }));
-		}
+            Assert.AreEqual(7, result.Count());
+            Assert.IsTrue(result.Select(x => ((dynamic)x).Id).ContainsAll(new dynamic[] { 1173, 1174, 1176, 1175, 4444 }));
+        }
 
-		[Test]
-		public void Up()
-		{
-			var doc = GetNode(1173);
+        [Test]
+        public void Up()
+        {
+            var doc = GetNode(1173);
 
-			var result = doc.Up();
+            var result = doc.Up();
 
-			Assert.IsNotNull(result);
+            Assert.IsNotNull(result);
 
-			Assert.AreEqual((int)1046, (int)result.Id);
-		}
+            Assert.AreEqual((int)1046, (int)result.Id);
+        }
 
-		[Test]
-		public void Down()
-		{
-			var doc = GetNode(1173);
+        [Test]
+        public void Down()
+        {
+            var doc = GetNode(1173);
 
-			var result = doc.Down();
+            var result = doc.Down();
 
-			Assert.IsNotNull(result);
+            Assert.IsNotNull(result);
 
-			Assert.AreEqual((int)1174, (int)result.Id);
-		}
+            Assert.AreEqual((int)1174, (int)result.Id);
+        }
 
-		[Test]
-		public void Next()
-		{
-			var doc = GetNode(1173);
+        [Test]
+        public void Next()
+        {
+            var doc = GetNode(1173);
 
-			var result = doc.Next();
+            var result = doc.Next();
 
-			Assert.IsNotNull(result);
+            Assert.IsNotNull(result);
 
-			Assert.AreEqual((int)1175, (int)result.Id);
-		}
+            Assert.AreEqual((int)1175, (int)result.Id);
+        }
 
-		[Test]
-		public void Next_Without_Sibling()
-		{
+        [Test]
+        public void Next_Without_Sibling()
+        {
             var doc = GetNode(1176);
 
-			Assert.IsNull(doc.Next());
-		}
+            Assert.IsNull(doc.Next());
+        }
 
-		[Test]
-		public void Previous_Without_Sibling()
-		{
-			var doc = GetNode(1173);
+        [Test]
+        public void Previous_Without_Sibling()
+        {
+            var doc = GetNode(1173);
 
-			Assert.IsNull(doc.Previous());
-		}
+            Assert.IsNull(doc.Previous());
+        }
 
-		[Test]
-		public void Previous()
-		{
-			var doc = GetNode(1176);
+        [Test]
+        public void Previous()
+        {
+            var doc = GetNode(1176);
 
-			var result = doc.Previous();
+            var result = doc.Previous();
 
-			Assert.IsNotNull(result);
+            Assert.IsNotNull(result);
 
-			Assert.AreEqual((int)1178, (int)result.Id);
-		}
+            Assert.AreEqual((int)1178, (int)result.Id);
+        }
 
-	    [Test]
-	    public void GetKey()
-	    {
-	        var key = Guid.Parse("CDB83BBC-A83B-4BA6-93B8-AADEF67D3C09");
+        [Test]
+        public void GetKey()
+        {
+            var key = Guid.Parse("CDB83BBC-A83B-4BA6-93B8-AADEF67D3C09");
 
             // doc is Home (a model) and GetKey unwraps and works
             var doc = GetNode(1176);
@@ -671,8 +702,8 @@ namespace Umbraco.Tests.PublishedContent
 
             // wrapped is PublishedContentWrapped and WithKey unwraps
             var wrapped = new TestWrapped(doc);
-	        Assert.AreEqual(key, wrapped.GetKey());
-	    }
+            Assert.AreEqual(key, wrapped.GetKey());
+        }
 
         class TestWrapped : PublishedContentWrapped
         {
@@ -690,8 +721,8 @@ namespace Umbraco.Tests.PublishedContent
             Assert.AreEqual(5548, prop.Value);
         }
 
-	    public void CreateDetachedContentSample()
-	    {
+        public void CreateDetachedContentSample()
+        {
             bool previewing = false;
             var t = PublishedContentType.Get(PublishedItemType.Content, "detachedSomething");
             var values = new Dictionary<string, object>();
@@ -705,33 +736,33 @@ namespace Umbraco.Tests.PublishedContent
             var c = new DetachedContent(properties);
         }
 
-	    public void CreatedDetachedContentInConverterSample()
-	    {
+        public void CreatedDetachedContentInConverterSample()
+        {
             // the converter args
-	        PublishedPropertyType argPropertyType = null;
-	        object argSource = null;
-	        bool argPreview = false;
+            PublishedPropertyType argPropertyType = null;
+            object argSource = null;
+            bool argPreview = false;
 
-	        var pt1 = new PublishedPropertyType("legend", 0, Constants.PropertyEditors.TextboxAlias);
-	        var pt2 = new PublishedPropertyType("image", 0, Constants.PropertyEditors.MediaPickerAlias);
-	        string val1 = "";
-	        int val2 = 0;
+            var pt1 = new PublishedPropertyType("legend", 0, Constants.PropertyEditors.TextboxAlias);
+            var pt2 = new PublishedPropertyType("image", 0, Constants.PropertyEditors.MediaPickerAlias);
+            string val1 = "";
+            int val2 = 0;
 
             var c = new ImageWithLegendModel(
                 PublishedProperty.GetDetached(pt1.Nested(argPropertyType), val1, argPreview),
                 PublishedProperty.GetDetached(pt2.Nested(argPropertyType), val2, argPreview));
         }
 
-	    class ImageWithLegendModel
-	    {
-	        private IPublishedProperty _legendProperty;
-	        private IPublishedProperty _imageProperty;
+        class ImageWithLegendModel
+        {
+            private IPublishedProperty _legendProperty;
+            private IPublishedProperty _imageProperty;
 
-	        public ImageWithLegendModel(IPublishedProperty legendProperty, IPublishedProperty imageProperty)
-	        {
-	            _legendProperty = legendProperty;
-	            _imageProperty = imageProperty;
-	        }
+            public ImageWithLegendModel(IPublishedProperty legendProperty, IPublishedProperty imageProperty)
+            {
+                _legendProperty = legendProperty;
+                _imageProperty = imageProperty;
+            }
 
             public string Legend { get { return _legendProperty.GetValue<string>(); } }
             public IPublishedContent Image { get { return _imageProperty.GetValue<IPublishedContent>(); } }

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -478,7 +478,7 @@ namespace Umbraco.Tests.PublishedContent
         }
 
         [Test]
-        public void FirstChildOfT()
+        public void FirstChildAsT()
         {
             var doc = GetNode(1046); // has child nodes
             var model = doc.FirstChild<Home>();
@@ -488,7 +488,7 @@ namespace Umbraco.Tests.PublishedContent
             Assert.IsInstanceOf<Home>(model);
             Assert.IsInstanceOf<IPublishedContent>(model);
 
-            model = doc.FirstChildOf<Home>(x => true); // predicate
+            model = doc.FirstChildAs<Home>(x => true); // predicate
 
             Assert.IsNotNull(model);
             Assert.IsTrue(model.Id == 1173);
@@ -496,8 +496,8 @@ namespace Umbraco.Tests.PublishedContent
             Assert.IsInstanceOf<IPublishedContent>(model);
 
             doc = GetNode(1175); // does not have child nodes
-            Assert.IsNull(doc.FirstChildOf<Home>());
-            Assert.IsNull(doc.FirstChildOf<Home>(x => true));
+            Assert.IsNull(doc.FirstChildAs<Home>());
+            Assert.IsNull(doc.FirstChildAs<Home>(x => true));
         }
 
         [Test]

--- a/src/Umbraco.Tests/PublishedContent/StronglyTypedModels/Home.cs
+++ b/src/Umbraco.Tests/PublishedContent/StronglyTypedModels/Home.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Web;
+using Umbraco.Core.Models;
+
+namespace Umbraco.Tests.PublishedContent.StronglyTypedModels
+{
+    /// <summary>
+    /// Used for testing strongly-typed published content extensions that work against the <see cref="PublishedContentTests"/>
+    /// </summary>
+    public class Home : TypedModelBase
+    {
+        public Home(IPublishedContent publishedContent) : base(publishedContent)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Models\Mapping\UserModelMapperTests.cs" />
     <Compile Include="Packaging\PackageExtractionTests.cs" />
     <Compile Include="Persistence\Repositories\SimilarNodeNameTests.cs" />
+    <Compile Include="PublishedContent\StronglyTypedModels\Home.cs" />
     <Compile Include="Services\AuditServiceTests.cs" />
     <Compile Include="Services\ConsentServiceTests.cs" />
     <Compile Include="TestHelpers\ControllerTesting\AuthenticateEverythingExtensions.cs" />

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -56,43 +56,43 @@ namespace Umbraco.Web
 		/// <param name="content">The content.</param>
 		/// <returns>The url for the content.</returns>
 		[Obsolete("NiceUrl() is obsolete, use the Url() method instead")]
-		public static string NiceUrl(this IPublishedContent content)
-		{
-			return content.Url();
-		}
+        public static string NiceUrl(this IPublishedContent content)
+        {
+            return content.Url();
+        }
 
-		/// <summary>
-		/// Gets the url for the content.
-		/// </summary>
-		/// <param name="content">The content.</param>
-		/// <returns>The url for the content.</returns>
-		/// <remarks>Better use the <c>Url</c> property but that method is here to complement <c>UrlAbsolute()</c>.</remarks>
-		public static string Url(this IPublishedContent content)
-		{
-		    return content.Url;
-		}
-
-		/// <summary>
-		/// Gets the absolute url for the content.
-		/// </summary>
+        /// <summary>
+        /// Gets the url for the content.
+        /// </summary>
         /// <param name="content">The content.</param>
-		/// <returns>The absolute url for the content.</returns>
-		[Obsolete("NiceUrlWithDomain() is obsolete, use the UrlAbsolute() method instead.")]
-		public static string NiceUrlWithDomain(this IPublishedContent content)
-		{
-            return content.UrlAbsolute();
-		}
+        /// <returns>The url for the content.</returns>
+        /// <remarks>Better use the <c>Url</c> property but that method is here to complement <c>UrlAbsolute()</c>.</remarks>
+        public static string Url(this IPublishedContent content)
+        {
+            return content.Url;
+        }
 
-		/// <summary>
-		/// Gets the absolute url for the content.
-		/// </summary>
-		/// <param name="content">The content.</param>
-		/// <returns>The absolute url for the content.</returns>
+        /// <summary>
+        /// Gets the absolute url for the content.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <returns>The absolute url for the content.</returns>
+        [Obsolete("NiceUrlWithDomain() is obsolete, use the UrlAbsolute() method instead.")]
+        public static string NiceUrlWithDomain(this IPublishedContent content)
+        {
+            return content.UrlAbsolute();
+        }
+
+        /// <summary>
+        /// Gets the absolute url for the content.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <returns>The absolute url for the content.</returns>
         //[Obsolete("UrlWithDomain() is obsolete, use the UrlAbsolute() method instead.")]
         public static string UrlWithDomain(this IPublishedContent content)
-		{
-		    return content.UrlAbsolute();
-		}
+        {
+            return content.UrlAbsolute();
+        }
 
         /// <summary>
         /// Gets the absolute url for the content.
@@ -129,8 +129,8 @@ namespace Umbraco.Web
 		public static string GetTemplateAlias(this IPublishedContent content)
         {
             var template = ApplicationContext.Current.Services.FileService.GetTemplate(content.TemplateId);
-			return template == null ? string.Empty : template.Alias;
-		}
+            return template == null ? string.Empty : template.Alias;
+        }
 
         #endregion
 
@@ -248,7 +248,7 @@ namespace Umbraco.Web
         {
             var property = content.GetProperty(alias);
             return property == null ? null : property.Value;
-		}
+        }
 
         /// <summary>
         /// Gets the value of a content's property identified by its alias, if it exists, otherwise a default value.
@@ -347,9 +347,9 @@ namespace Umbraco.Web
         /// <para>The alias is case-insensitive.</para>
         /// </remarks>
         public static T GetPropertyValue<T>(this IPublishedContent content, string alias)
-		{
-			return content.GetPropertyValue(alias, false, false, default(T));
-		}
+        {
+            return content.GetPropertyValue(alias, false, false, default(T));
+        }
 
         /// <summary>
         /// Gets the value of a content's property identified by its alias, converted to a specified type, if it exists, otherwise a default value.
@@ -417,9 +417,9 @@ namespace Umbraco.Web
             if (property == null) return defaultValue;
 
             return property.GetValue(withDefaultValue, defaultValue);
-		}
+        }
 
-		#endregion
+        #endregion
 
         // copied over from Core.PublishedContentExtensions - should be obsoleted
         [Obsolete("GetRecursiveValue() is obsolete, use GetPropertyValue().")]
@@ -429,56 +429,56 @@ namespace Umbraco.Web
             return value == null ? string.Empty : value.ToString();
         }
 
-		#region Search
+        #region Search
 
         public static IEnumerable<IPublishedContent> Search(this IPublishedContent content, string term, bool useWildCards = true, string searchProvider = null)
-		{
-			var searcher = Examine.ExamineManager.Instance.DefaultSearchProvider;
-			if (string.IsNullOrEmpty(searchProvider) == false)
-				searcher = Examine.ExamineManager.Instance.SearchProviderCollection[searchProvider];
+        {
+            var searcher = Examine.ExamineManager.Instance.DefaultSearchProvider;
+            if (string.IsNullOrEmpty(searchProvider) == false)
+                searcher = Examine.ExamineManager.Instance.SearchProviderCollection[searchProvider];
 
-			var t = term.Escape().Value;
-			if (useWildCards)
-				t = term.MultipleCharacterWildcard().Value;
+            var t = term.Escape().Value;
+            if (useWildCards)
+                t = term.MultipleCharacterWildcard().Value;
 
-			var luceneQuery = "+__Path:(" + content.Path.Replace("-", "\\-") + "*) +" + t;
-			var crit = searcher.CreateSearchCriteria().RawQuery(luceneQuery);
+            var luceneQuery = "+__Path:(" + content.Path.Replace("-", "\\-") + "*) +" + t;
+            var crit = searcher.CreateSearchCriteria().RawQuery(luceneQuery);
 
-			return content.Search(crit, searcher);
-		}
+            return content.Search(crit, searcher);
+        }
 
         public static IEnumerable<IPublishedContent> SearchDescendants(this IPublishedContent content, string term, bool useWildCards = true, string searchProvider = null)
-		{
-			return content.Search(term, useWildCards, searchProvider);
-		}
+        {
+            return content.Search(term, useWildCards, searchProvider);
+        }
 
         public static IEnumerable<IPublishedContent> SearchChildren(this IPublishedContent content, string term, bool useWildCards = true, string searchProvider = null)
-		{
-			var searcher = Examine.ExamineManager.Instance.DefaultSearchProvider;
-			if (string.IsNullOrEmpty(searchProvider) == false)
-				searcher = Examine.ExamineManager.Instance.SearchProviderCollection[searchProvider];
+        {
+            var searcher = Examine.ExamineManager.Instance.DefaultSearchProvider;
+            if (string.IsNullOrEmpty(searchProvider) == false)
+                searcher = Examine.ExamineManager.Instance.SearchProviderCollection[searchProvider];
 
-			var t = term.Escape().Value;
-			if (useWildCards)
-				t = term.MultipleCharacterWildcard().Value;
+            var t = term.Escape().Value;
+            if (useWildCards)
+                t = term.MultipleCharacterWildcard().Value;
 
-			var luceneQuery = "+parentID:" + content.Id + " +" + t;
-			var crit = searcher.CreateSearchCriteria().RawQuery(luceneQuery);
+            var luceneQuery = "+parentID:" + content.Id + " +" + t;
+            var crit = searcher.CreateSearchCriteria().RawQuery(luceneQuery);
 
-			return content.Search(crit, searcher);
-		}
+            return content.Search(crit, searcher);
+        }
 
         public static IEnumerable<IPublishedContent> Search(this IPublishedContent content, Examine.SearchCriteria.ISearchCriteria criteria, Examine.Providers.BaseSearchProvider searchProvider = null)
-		{
-			var s = Examine.ExamineManager.Instance.DefaultSearchProvider;
-			if (searchProvider != null)
-				s = searchProvider;
+        {
+            var s = Examine.ExamineManager.Instance.DefaultSearchProvider;
+            if (searchProvider != null)
+                s = searchProvider;
 
-			var results = s.Search(criteria);
-			return results.ConvertSearchResultToPublishedContent(UmbracoContext.Current.ContentCache);
-		}
+            var results = s.Search(criteria);
+            return results.ConvertSearchResultToPublishedContent(UmbracoContext.Current.ContentCache);
+        }
 
-		#endregion
+        #endregion
 
         #region ToContentSet
 
@@ -507,43 +507,43 @@ namespace Umbraco.Web
         #endregion
 
         #region Dynamic Linq Extensions
-        
+
         [Obsolete("This method uses dynamics which will be removed in future versions, use strongly typed syntax instead")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IQueryable<IPublishedContent> OrderBy(this IEnumerable<IPublishedContent> source, string predicate)
-		{
-			var dList = new DynamicPublishedContentList(source);
-			return dList.OrderBy<DynamicPublishedContent>(predicate);
-		}
+        {
+            var dList = new DynamicPublishedContentList(source);
+            return dList.OrderBy<DynamicPublishedContent>(predicate);
+        }
 
         [Obsolete("This method uses dynamics which will be removed in future versions, use strongly typed syntax instead")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IQueryable<IPublishedContent> Where(this IEnumerable<IPublishedContent> list, string predicate)
-		{
+        {
             // wrap in DynamicPublishedContentList so that the ContentSet is correct
             // though that code is somewhat ugly.
 
-		    var dlist = new DynamicPublishedContentList(new DynamicPublishedContentList(list)
-		                                                    .Where<DynamicPublishedContent>(predicate));
+            var dlist = new DynamicPublishedContentList(new DynamicPublishedContentList(list)
+                                                            .Where<DynamicPublishedContent>(predicate));
 
-		    return dlist.AsQueryable<IPublishedContent>();
-		}
+            return dlist.AsQueryable<IPublishedContent>();
+        }
 
         [Obsolete("This method uses dynamics which will be removed in future versions, use strongly typed syntax instead")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IEnumerable<IGrouping<object, IPublishedContent>> GroupBy(this IEnumerable<IPublishedContent> list, string predicate)
-		{
-			var dList = new DynamicPublishedContentList(list);
-			return dList.GroupBy(predicate);
-		}
+        {
+            var dList = new DynamicPublishedContentList(list);
+            return dList.GroupBy(predicate);
+        }
 
         [Obsolete("This method uses dynamics which will be removed in future versions, use strongly typed syntax instead")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IQueryable Select(this IEnumerable<IPublishedContent> list, string predicate, params object[] values)
-		{
-			var dList = new DynamicPublishedContentList(list);
-			return dList.Select(predicate);
-		}
+        {
+            var dList = new DynamicPublishedContentList(list);
+            return dList.Select(predicate);
+        }
 
         [Obsolete("This method uses dynamics which will be removed in future versions, use strongly typed syntax instead")]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -578,26 +578,26 @@ namespace Umbraco.Web
         [Obsolete("The use of dynamics has been deprecated, use strongly typed syntax instead, dynamics will be removed in future versions")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static dynamic AsDynamic(this IPublishedContent content)
-		{
-			if (content == null) throw new ArgumentNullException("content");
-			return new DynamicPublishedContent(content);
-		}
+        {
+            if (content == null) throw new ArgumentNullException("content");
+            return new DynamicPublishedContent(content);
+        }
 
         [Obsolete("The use of dynamics has been deprecated, use strongly typed syntax instead, dynamics will be removed in future versions")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static DynamicPublishedContent AsDynamicOrNull(this IPublishedContent content)
-		{
-		    return content == null ? null : new DynamicPublishedContent(content);
-		}
+        {
+            return content == null ? null : new DynamicPublishedContent(content);
+        }
 
         #endregion
 
-		#region ContentSet
+        #region ContentSet
 
-		public static int Position(this IPublishedContent content)
-		{
-			return content.GetIndex();
-		}
+        public static int Position(this IPublishedContent content)
+        {
+            return content.GetIndex();
+        }
 
         public static int Index(this IPublishedContent content)
         {
@@ -612,9 +612,9 @@ namespace Umbraco.Web
             return index;
         }
 
-		#endregion
+        #endregion
 
-		#region IsSomething: misc.
+        #region IsSomething: misc.
 
         /// <summary>
         /// Gets a value indicating whether the content is visible.
@@ -640,31 +640,31 @@ namespace Umbraco.Web
         /// <param name="docTypeAlias">The alias of the content type to test against.</param>
         /// <returns>True if the content is of the specified content type; otherwise false.</returns>
 	    public static bool IsDocumentType(this IPublishedContent content, string docTypeAlias)
-	    {
-	        return content.DocumentTypeAlias.InvariantEquals(docTypeAlias);
-	    }
+        {
+            return content.DocumentTypeAlias.InvariantEquals(docTypeAlias);
+        }
 
-	    /// <summary>
-	    /// Determines whether the specified content is a specified content type or it's derived types.
-	    /// </summary>
-	    /// <param name="content">The content to determine content type of.</param>
-	    /// <param name="docTypeAlias">The alias of the content type to test against.</param>
-	    /// <param name="recursive">When true, recurses up the content type tree to check inheritance; when false just calls IsDocumentType(this IPublishedContent content, string docTypeAlias).</param>
-	    /// <returns>True if the content is of the specified content type or a derived content type; otherwise false.</returns>
-	    public static bool IsDocumentType(this IPublishedContent content, string docTypeAlias, bool recursive)
-	    {
-	        return content.DocumentTypeAlias.InvariantEquals(docTypeAlias) || (recursive && content.IsComposedOf(docTypeAlias));
-	    }
+        /// <summary>
+        /// Determines whether the specified content is a specified content type or it's derived types.
+        /// </summary>
+        /// <param name="content">The content to determine content type of.</param>
+        /// <param name="docTypeAlias">The alias of the content type to test against.</param>
+        /// <param name="recursive">When true, recurses up the content type tree to check inheritance; when false just calls IsDocumentType(this IPublishedContent content, string docTypeAlias).</param>
+        /// <returns>True if the content is of the specified content type or a derived content type; otherwise false.</returns>
+        public static bool IsDocumentType(this IPublishedContent content, string docTypeAlias, bool recursive)
+        {
+            return content.DocumentTypeAlias.InvariantEquals(docTypeAlias) || (recursive && content.IsComposedOf(docTypeAlias));
+        }
 
-		public static bool IsNull(this IPublishedContent content, string alias, bool recurse)
-		{
-		    return content.HasValue(alias, recurse) == false;
-		}
+        public static bool IsNull(this IPublishedContent content, string alias, bool recurse)
+        {
+            return content.HasValue(alias, recurse) == false;
+        }
 
-		public static bool IsNull(this IPublishedContent content, string alias)
-		{
-		    return content.HasValue(alias) == false;
-		}
+        public static bool IsNull(this IPublishedContent content, string alias)
+        {
+            return content.HasValue(alias) == false;
+        }
 
         #endregion
 
@@ -825,24 +825,24 @@ namespace Umbraco.Web
         #region IsSomething: equality
 
         public static bool IsEqual(this IPublishedContent content, IPublishedContent other)
-		{
-			return content.Id == other.Id;
-		}
+        {
+            return content.Id == other.Id;
+        }
 
         public static HtmlString IsEqual(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
         {
             return content.IsEqual(other, valueIfTrue, string.Empty);
         }
 
-		public static HtmlString IsEqual(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
-		{
-			return new HtmlString(content.IsEqual(other) ? valueIfTrue : valueIfFalse);
-		}
+        public static HtmlString IsEqual(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
+        {
+            return new HtmlString(content.IsEqual(other) ? valueIfTrue : valueIfFalse);
+        }
 
-		public static bool IsNotEqual(this IPublishedContent content, IPublishedContent other)
-		{
-		    return content.IsEqual(other) == false;
-		}
+        public static bool IsNotEqual(this IPublishedContent content, IPublishedContent other)
+        {
+            return content.IsEqual(other) == false;
+        }
 
         public static HtmlString IsNotEqual(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
         {
@@ -850,9 +850,9 @@ namespace Umbraco.Web
         }
 
         public static HtmlString IsNotEqual(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
-		{
-			return new HtmlString(content.IsNotEqual(other) ? valueIfTrue : valueIfFalse);
-		}
+        {
+            return new HtmlString(content.IsNotEqual(other) ? valueIfTrue : valueIfFalse);
+        }
 
         #endregion
 
@@ -861,62 +861,62 @@ namespace Umbraco.Web
         public static bool IsDescendant(this IPublishedContent content, IPublishedContent other)
         {
             return content.Ancestors().Any(x => x.Id == other.Id);
-		}
+        }
 
-		public static HtmlString IsDescendant(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
-		{
-		    return content.IsDescendant(other, valueIfTrue, string.Empty);
-		}
+        public static HtmlString IsDescendant(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
+        {
+            return content.IsDescendant(other, valueIfTrue, string.Empty);
+        }
 
-		public static HtmlString IsDescendant(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
-		{
+        public static HtmlString IsDescendant(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
+        {
             return new HtmlString(content.IsDescendant(other) ? valueIfTrue : valueIfFalse);
-		}
+        }
 
-		public static bool IsDescendantOrSelf(this IPublishedContent content, IPublishedContent other)
-		{
+        public static bool IsDescendantOrSelf(this IPublishedContent content, IPublishedContent other)
+        {
             return content.AncestorsOrSelf().Any(x => x.Id == other.Id);
         }
 
-		public static HtmlString IsDescendantOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
-		{
+        public static HtmlString IsDescendantOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
+        {
             return content.IsDescendantOrSelf(other, valueIfTrue, string.Empty);
         }
 
-		public static HtmlString IsDescendantOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
-		{
+        public static HtmlString IsDescendantOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
+        {
             return new HtmlString(content.IsDescendantOrSelf(other) ? valueIfTrue : valueIfFalse);
         }
 
-		public static bool IsAncestor(this IPublishedContent content, IPublishedContent other)
-		{
+        public static bool IsAncestor(this IPublishedContent content, IPublishedContent other)
+        {
             // avoid using Descendants(), that's expensive
-		    return other.Ancestors().Any(x => x.Id == content.Id);
-		}
+            return other.Ancestors().Any(x => x.Id == content.Id);
+        }
 
-		public static HtmlString IsAncestor(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
-		{
+        public static HtmlString IsAncestor(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
+        {
             return content.IsAncestor(other, valueIfTrue, string.Empty);
         }
 
-		public static HtmlString IsAncestor(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
-		{
+        public static HtmlString IsAncestor(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
+        {
             return new HtmlString(content.IsAncestor(other) ? valueIfTrue : valueIfFalse);
         }
 
-		public static bool IsAncestorOrSelf(this IPublishedContent content, IPublishedContent other)
-		{
+        public static bool IsAncestorOrSelf(this IPublishedContent content, IPublishedContent other)
+        {
             // avoid using DescendantsOrSelf(), that's expensive
             return other.AncestorsOrSelf().Any(x => x.Id == content.Id);
         }
 
-		public static HtmlString IsAncestorOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
-		{
+        public static HtmlString IsAncestorOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
+        {
             return content.IsAncestorOrSelf(other, valueIfTrue, string.Empty);
         }
 
-		public static HtmlString IsAncestorOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
-		{
+        public static HtmlString IsAncestorOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue, string valueIfFalse)
+        {
             return new HtmlString(content.IsAncestorOrSelf(other) ? valueIfTrue : valueIfFalse);
         }
 
@@ -1221,7 +1221,7 @@ namespace Umbraco.Web
 
         #endregion
 
-		#region Axes: descendants, descendants-or-self
+        #region Axes: descendants, descendants-or-self
 
         /// <summary>
         /// Returns all DescendantsOrSelf of all content referenced
@@ -1282,9 +1282,9 @@ namespace Umbraco.Web
         }
 
         public static IEnumerable<IPublishedContent> Descendants(this IPublishedContent content, string contentTypeAlias)
-		{
-			return content.DescendantsOrSelf(false, p => p.DocumentTypeAlias == contentTypeAlias);
-		}
+        {
+            return content.DescendantsOrSelf(false, p => p.DocumentTypeAlias == contentTypeAlias);
+        }
 
         public static IEnumerable<T> Descendants<T>(this IPublishedContent content)
             where T : class, IPublishedContent
@@ -1304,14 +1304,14 @@ namespace Umbraco.Web
         }
 
         public static IEnumerable<IPublishedContent> DescendantsOrSelf(this IPublishedContent content, int level)
-		{
-			return content.DescendantsOrSelf(true, p => p.Level >= level);
-		}
+        {
+            return content.DescendantsOrSelf(true, p => p.Level >= level);
+        }
 
         public static IEnumerable<IPublishedContent> DescendantsOrSelf(this IPublishedContent content, string contentTypeAlias)
-		{
-			return content.DescendantsOrSelf(true, p => p.DocumentTypeAlias == contentTypeAlias);
-		}
+        {
+            return content.DescendantsOrSelf(true, p => p.DocumentTypeAlias == contentTypeAlias);
+        }
 
         public static IEnumerable<T> DescendantsOrSelf<T>(this IPublishedContent content)
             where T : class, IPublishedContent
@@ -1405,82 +1405,84 @@ namespace Umbraco.Web
 
         #endregion
 
-		#region Axes: following-sibling, preceding-sibling, following, preceding + pseudo-axes up, down, next, previous
+        #region Axes: following-sibling, preceding-sibling, following, preceding + pseudo-axes up, down, next, previous
 
         // up pseudo-axe ~ ancestors
         // bogus, kept for backward compatibility but we should get rid of it
         // better use ancestors
 
-		public static IPublishedContent Up(this IPublishedContent content)
-		{
-		    return content.Parent;
-		}
+        public static IPublishedContent Up(this IPublishedContent content)
+        {
+            return content.Parent;
+        }
 
-		public static IPublishedContent Up(this IPublishedContent content, int number)
-		{
+        public static IPublishedContent Up(this IPublishedContent content, int number)
+        {
             if (number < 0)
                 throw new ArgumentOutOfRangeException("number", "Must be greater than, or equal to, zero.");
-		    return number == 0 ? content : content.EnumerateAncestors(false).Skip(number).FirstOrDefault();
-		}
+            return number == 0 ? content : content.EnumerateAncestors(false).Skip(number).FirstOrDefault();
+        }
 
-		public static IPublishedContent Up(this IPublishedContent content, string contentTypeAlias)
-		{
-		    return string.IsNullOrEmpty(contentTypeAlias)
+        public static IPublishedContent Up(this IPublishedContent content, string contentTypeAlias)
+        {
+            return string.IsNullOrEmpty(contentTypeAlias)
                 ? content.Parent
                 : content.Ancestor(contentTypeAlias);
-		}
+        }
 
         // down pseudo-axe ~ children (not descendants)
         // bogus, kept for backward compatibility but we should get rid of it
         // better use descendants
 
-		public static IPublishedContent Down(this IPublishedContent content)
-		{
-		    return content.Children.FirstOrDefault();
-		}
+        public static IPublishedContent Down(this IPublishedContent content)
+        {
+            return content.Children.FirstOrDefault();
+        }
 
-		public static IPublishedContent Down(this IPublishedContent content, int number)
-		{
+        public static IPublishedContent Down(this IPublishedContent content, int number)
+        {
             if (number < 0)
                 throw new ArgumentOutOfRangeException("number", "Must be greater than, or equal to, zero.");
-		    if (number == 0) return content;
+            if (number == 0) return content;
 
             content = content.Children.FirstOrDefault();
             while (content != null && --number > 0)
                 content = content.Children.FirstOrDefault();
 
-		    return content;
-		}
+            return content;
+        }
 
-		public static IPublishedContent Down(this IPublishedContent content, string contentTypeAlias)
-		{
-		    if (string.IsNullOrEmpty(contentTypeAlias))
-		        return content.Children.FirstOrDefault();
+        public static IPublishedContent Down(this IPublishedContent content, string contentTypeAlias)
+        {
+            if (string.IsNullOrEmpty(contentTypeAlias))
+                return content.Children.FirstOrDefault();
 
             // note: this is what legacy did, but with a broken Descendant
             // so fixing Descendant will change how it works...
-			return content.Descendant(contentTypeAlias);
-		}
+            return content.Descendant(contentTypeAlias);
+        }
 
         // next pseudo-axe ~ following within the content set
         // bogus, kept for backward compatibility but we should get rid of it
 
-		public static IPublishedContent Next(this IPublishedContent content)
-		{
+        public static IPublishedContent Next(this IPublishedContent content)
+        {
             return content.ContentSet.ElementAtOrDefault(content.GetIndex() + 1);
         }
 
-		public static IPublishedContent Next(this IPublishedContent current, Func<IPublishedContent, bool> func) {
-			IPublishedContent next = current.Next();
-			while (next != null) {
-				if (func(next)) return next;
-				next = next.Next();
-			}
-			return null;
-		}
+        public static IPublishedContent Next(this IPublishedContent current, Func<IPublishedContent, bool> func)
+        {
+            IPublishedContent next = current.Next();
+            while (next != null)
+            {
+                if (func(next)) return next;
+                next = next.Next();
+            }
+            return null;
+        }
 
         public static IPublishedContent Next(this IPublishedContent content, int number)
-		{
+        {
             if (number < 0)
                 throw new ArgumentOutOfRangeException("number", "Must be greater than, or equal to, zero.");
             return number == 0 ? content : content.ContentSet.ElementAtOrDefault(content.GetIndex() + number);
@@ -1533,30 +1535,32 @@ namespace Umbraco.Web
         // bogus, kept for backward compatibility but we should get rid of it
 
         public static IPublishedContent Previous(this IPublishedContent content)
-		{
+        {
             return content.ContentSet.ElementAtOrDefault(content.GetIndex() - 1);
         }
 
-		public static IPublishedContent Previous(this IPublishedContent current, Func<IPublishedContent, bool> func) {
-			IPublishedContent prev = current.Previous();
-			while (prev != null) {
-				if (func(prev)) return prev;
-				prev = prev.Previous();
-			}
-			return null;
-		}
+        public static IPublishedContent Previous(this IPublishedContent current, Func<IPublishedContent, bool> func)
+        {
+            IPublishedContent prev = current.Previous();
+            while (prev != null)
+            {
+                if (func(prev)) return prev;
+                prev = prev.Previous();
+            }
+            return null;
+        }
 
-		public static IPublishedContent Previous(this IPublishedContent content, int number)
-		{
+        public static IPublishedContent Previous(this IPublishedContent content, int number)
+        {
             if (number < 0)
                 throw new ArgumentOutOfRangeException("number", "Must be greater than, or equal to, zero.");
             return number == 0 ? content : content.ContentSet.ElementAtOrDefault(content.GetIndex() - number);
         }
 
-		public static IPublishedContent Previous(this IPublishedContent content, string contentTypeAlias)
-		{
-		    return content.Previous(contentTypeAlias, false);
-		}
+        public static IPublishedContent Previous(this IPublishedContent content, string contentTypeAlias)
+        {
+            return content.Previous(contentTypeAlias, false);
+        }
 
         public static IPublishedContent Previous(this IPublishedContent content, string contentTypeAlias, bool wrap)
         {
@@ -1578,13 +1582,13 @@ namespace Umbraco.Web
         //
 
         [Obsolete("Obsolete, use FollowingSibling or PrecedingSibling instead.")]
-		public static IPublishedContent Sibling(this IPublishedContent content, int number)
+        public static IPublishedContent Sibling(this IPublishedContent content, int number)
         {
             if (number < 0)
                 throw new ArgumentOutOfRangeException("number", "Must be greater than, or equal to, zero.");
             number += 1; // legacy is zero-based
             return content.FollowingSibling(number);
-		}
+        }
 
         // contentTypeAlias is case-insensitive
         [Obsolete("Obsolete, use FollowingSibling or PrecedingSibling instead.")]
@@ -1801,14 +1805,40 @@ namespace Umbraco.Web
         }
 
         /// <summary>
-        /// Gets the first child of the content, of a given content type.
+        /// Gets the first child of the content using the passed predicate
         /// </summary>
         /// <param name="content">The content.</param>
-        /// <param name="predicate">The matching predicate func.</param>
+        /// <param name="predicate">The predicate query.</param>
         /// <returns>The first child of content that matches the predicate.</returns>
         public static IPublishedContent FirstChild(this IPublishedContent content, Func<IPublishedContent, bool> predicate)
         {
             return content.Children(predicate).FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets the first child of the content, of a given content type, and returns it as <see cref="IPublishedContent"/>.
+        /// For strongly typed version use <seealso cref="FirstChildOf{T}(IPublishedContent)"/>.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="alias">The content type alias.</param>
+        /// <returns>The first child of content, of the given content type.</returns>
+        public static IPublishedContent FirstChild<T>(this IPublishedContent content)
+            where T : class, IPublishedContent
+        {
+            return content.Children<T>().FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets the first child of the content using the passed predicate and returns it as <see cref="IPublishedContent"/>.
+        /// For strongly typed version use <see cref="FirstChildOf{T}(IPublishedContent, Func{T, bool})"/>.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="predicate">The predicate query.</param>
+        /// <returns>The first child of content that matches the predicate.</returns>
+        public static IPublishedContent FirstChild<T>(this IPublishedContent content, Func<IPublishedContent, bool> predicate)
+            where T : class, IPublishedContent
+        {
+            return content.Children<T>().FirstOrDefault(predicate);
         }
 
         /// <summary>
@@ -1817,7 +1847,7 @@ namespace Umbraco.Web
         /// <param name="content">The content.</param>
         /// <param name="alias">The content type alias.</param>
         /// <returns>The first child of content, of the given content type as type T.</returns>
-        public static T FirstChild<T>(this IPublishedContent content)
+        public static T FirstChildOf<T>(this IPublishedContent content)
             where T : class, IPublishedContent
         {
             return content.Children<T>().FirstOrDefault();
@@ -1829,10 +1859,10 @@ namespace Umbraco.Web
         /// <param name="content">The content.</param>
         /// <param name="predicate">The matching predicate func.</param>
         /// <returns>The first child of content that matches the predicate as type T.</returns>
-        public static T FirstChild<T>(this IPublishedContent content, Func<T, bool> predicate)
+        public static T FirstChildOf<T>(this IPublishedContent content, Func<T, bool> predicate)
             where T : class, IPublishedContent
         {
-            return content.Children<T>().FirstOrDefault(predicate).OfType<T>();
+            return content.Children<T>().FirstOrDefault(predicate);
         }
 
         /// <summary>
@@ -1842,72 +1872,72 @@ namespace Umbraco.Web
         /// <param name="contentTypeAliasFilter">An optional content type alias.</param>
         /// <returns>The children of the content.</returns>
         public static DataTable ChildrenAsTable(this IPublishedContent content, string contentTypeAliasFilter = "")
-		{
+        {
             return GenerateDataTable(content, contentTypeAliasFilter);
-		}
+        }
 
-		/// <summary>
+        /// <summary>
         /// Gets the children of the content in a DataTable.
         /// </summary>
         /// <param name="content">The content.</param>
         /// <param name="contentTypeAliasFilter">An optional content type alias.</param>
         /// <returns>The children of the content.</returns>
         private static DataTable GenerateDataTable(IPublishedContent content, string contentTypeAliasFilter = "")
-		{
-			var firstNode = contentTypeAliasFilter.IsNullOrWhiteSpace()
-								? content.Children.Any()
-									? content.Children.ElementAt(0)
-									: null
-								: content.Children.FirstOrDefault(x => x.DocumentTypeAlias == contentTypeAliasFilter);
-			if (firstNode == null)
-				return new DataTable(); //no children found
+        {
+            var firstNode = contentTypeAliasFilter.IsNullOrWhiteSpace()
+                                ? content.Children.Any()
+                                    ? content.Children.ElementAt(0)
+                                    : null
+                                : content.Children.FirstOrDefault(x => x.DocumentTypeAlias == contentTypeAliasFilter);
+            if (firstNode == null)
+                return new DataTable(); //no children found
 
-			//use new utility class to create table so that we don't have to maintain code in many places, just one
-			var dt = Core.DataTableExtensions.GenerateDataTable(
-				//pass in the alias of the first child node since this is the node type we're rendering headers for
-				firstNode.DocumentTypeAlias,
-				//pass in the callback to extract the Dictionary<string, string> of all defined aliases to their names
-				alias => GetPropertyAliasesAndNames(alias),
-				//pass in a callback to populate the datatable, yup its a bit ugly but it's already legacy and we just want to maintain code in one place.
-				() =>
-				{
-					//create all row data
-					var tableData = Core.DataTableExtensions.CreateTableData();
-					//loop through each child and create row data for it
-					foreach (var n in content.Children.OrderBy(x => x.SortOrder))
-					{
-						if (contentTypeAliasFilter.IsNullOrWhiteSpace() == false)
-						{
-							if (n.DocumentTypeAlias != contentTypeAliasFilter)
-								continue; //skip this one, it doesn't match the filter
-						}
+            //use new utility class to create table so that we don't have to maintain code in many places, just one
+            var dt = Core.DataTableExtensions.GenerateDataTable(
+                //pass in the alias of the first child node since this is the node type we're rendering headers for
+                firstNode.DocumentTypeAlias,
+                //pass in the callback to extract the Dictionary<string, string> of all defined aliases to their names
+                alias => GetPropertyAliasesAndNames(alias),
+                //pass in a callback to populate the datatable, yup its a bit ugly but it's already legacy and we just want to maintain code in one place.
+                () =>
+                {
+                    //create all row data
+                    var tableData = Core.DataTableExtensions.CreateTableData();
+                    //loop through each child and create row data for it
+                    foreach (var n in content.Children.OrderBy(x => x.SortOrder))
+                    {
+                        if (contentTypeAliasFilter.IsNullOrWhiteSpace() == false)
+                        {
+                            if (n.DocumentTypeAlias != contentTypeAliasFilter)
+                                continue; //skip this one, it doesn't match the filter
+                        }
 
-						var standardVals = new Dictionary<string, object>
-						    {
-									{ "Id", n.Id },
-									{ "NodeName", n.Name },
-									{ "NodeTypeAlias", n.DocumentTypeAlias },
-									{ "CreateDate", n.CreateDate },
-									{ "UpdateDate", n.UpdateDate },
-									{ "CreatorName", n.CreatorName },
-									{ "WriterName", n.WriterName },
-									{ "Url", n.Url }
-								};
+                        var standardVals = new Dictionary<string, object>
+                            {
+                                    { "Id", n.Id },
+                                    { "NodeName", n.Name },
+                                    { "NodeTypeAlias", n.DocumentTypeAlias },
+                                    { "CreateDate", n.CreateDate },
+                                    { "UpdateDate", n.UpdateDate },
+                                    { "CreatorName", n.CreatorName },
+                                    { "WriterName", n.WriterName },
+                                    { "Url", n.Url }
+                                };
 
-						var userVals = new Dictionary<string, object>();
+                        var userVals = new Dictionary<string, object>();
                         foreach (var p in from IPublishedProperty p in n.Properties where p.DataValue != null select p)
                         {
                             // probably want the "object value" of the property here...
-							userVals[p.PropertyTypeAlias] = p.Value;
-						}
-						//add the row data
-						Core.DataTableExtensions.AddRowData(tableData, standardVals, userVals);
-					}
-					return tableData;
-				}
-				);
-			return dt;
-		}
+                            userVals[p.PropertyTypeAlias] = p.Value;
+                        }
+                        //add the row data
+                        Core.DataTableExtensions.AddRowData(tableData, standardVals, userVals);
+                    }
+                    return tableData;
+                }
+                );
+            return dt;
+        }
 
         #endregion
 
@@ -1954,36 +1984,36 @@ namespace Umbraco.Web
 
         private static Func<string, Dictionary<string, string>> _getPropertyAliasesAndNames;
 
-		/// <summary>
-		/// This is used only for unit tests to set the delegate to look up aliases/names dictionary of a content type
-		/// </summary>
-		internal static Func<string, Dictionary<string, string>> GetPropertyAliasesAndNames
-		{
-			get
-			{
-				return _getPropertyAliasesAndNames ?? (_getPropertyAliasesAndNames = alias =>
-					{
-						var userFields = ContentType.GetAliasesAndNames(alias);
-						//ensure the standard fields are there
-						var allFields = new Dictionary<string, string>()
-							{
-								{"Id", "Id"},
-								{"NodeName", "NodeName"},
-								{"NodeTypeAlias", "NodeTypeAlias"},
-								{"CreateDate", "CreateDate"},
-								{"UpdateDate", "UpdateDate"},
-								{"CreatorName", "CreatorName"},
-								{"WriterName", "WriterName"},
-								{"Url", "Url"}
-							};
-						foreach (var f in userFields.Where(f => allFields.ContainsKey(f.Key) == false))
-						{
-							allFields.Add(f.Key, f.Value);
-						}
-						return allFields;
-					});
-			}
-			set { _getPropertyAliasesAndNames = value; }
+        /// <summary>
+        /// This is used only for unit tests to set the delegate to look up aliases/names dictionary of a content type
+        /// </summary>
+        internal static Func<string, Dictionary<string, string>> GetPropertyAliasesAndNames
+        {
+            get
+            {
+                return _getPropertyAliasesAndNames ?? (_getPropertyAliasesAndNames = alias =>
+                {
+                    var userFields = ContentType.GetAliasesAndNames(alias);
+                    //ensure the standard fields are there
+                    var allFields = new Dictionary<string, string>()
+                            {
+                                {"Id", "Id"},
+                                {"NodeName", "NodeName"},
+                                {"NodeTypeAlias", "NodeTypeAlias"},
+                                {"CreateDate", "CreateDate"},
+                                {"UpdateDate", "UpdateDate"},
+                                {"CreatorName", "CreatorName"},
+                                {"WriterName", "WriterName"},
+                                {"Url", "Url"}
+                            };
+                    foreach (var f in userFields.Where(f => allFields.ContainsKey(f.Key) == false))
+                    {
+                        allFields.Add(f.Key, f.Value);
+                    }
+                    return allFields;
+                });
+            }
+            set { _getPropertyAliasesAndNames = value; }
         }
 
         #endregion

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1797,24 +1797,42 @@ namespace Umbraco.Web
         /// <returns>The first child of content, of the given content type.</returns>
         public static IPublishedContent FirstChild(this IPublishedContent content, string alias)
         {
-            return content.Children( alias ).FirstOrDefault();
+            return content.Children(alias).FirstOrDefault();
         }
 
+        /// <summary>
+        /// Gets the first child of the content, of a given content type.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="predicate">The matching predicate func.</param>
+        /// <returns>The first child of content that matches the predicate.</returns>
         public static IPublishedContent FirstChild(this IPublishedContent content, Func<IPublishedContent, bool> predicate)
         {
             return content.Children(predicate).FirstOrDefault();
         }
 
-        public static IPublishedContent FirstChild<T>(this IPublishedContent content)
+        /// <summary>
+        /// Gets the first child of the content, of a given content type and returns it as a strongly-typed model
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="alias">The content type alias.</param>
+        /// <returns>The first child of content, of the given content type as type T.</returns>
+        public static T FirstChild<T>(this IPublishedContent content)
             where T : class, IPublishedContent
         {
             return content.Children<T>().FirstOrDefault();
         }
 
-        public static IPublishedContent FirstChild<T>(this IPublishedContent content, Func<IPublishedContent, bool> predicate)
+        /// <summary>
+        /// Gets the first child of the content, of a given content type and returns it as a strongly-typed model
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="predicate">The matching predicate func.</param>
+        /// <returns>The first child of content that matches the predicate as type T.</returns>
+        public static T FirstChild<T>(this IPublishedContent content, Func<T, bool> predicate)
             where T : class, IPublishedContent
         {
-            return content.Children<T>().FirstOrDefault(predicate);
+            return content.Children<T>().FirstOrDefault(predicate).OfType<T>();
         }
 
         /// <summary>

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1817,7 +1817,7 @@ namespace Umbraco.Web
 
         /// <summary>
         /// Gets the first child of the content, of a given content type, and returns it as <see cref="IPublishedContent"/>.
-        /// For strongly typed version use <seealso cref="FirstChildOf{T}(IPublishedContent)"/>.
+        /// For strongly typed version use <seealso cref="FirstChildAs{T}(IPublishedContent)"/>.
         /// </summary>
         /// <param name="content">The content.</param>
         /// <param name="alias">The content type alias.</param>
@@ -1830,7 +1830,7 @@ namespace Umbraco.Web
 
         /// <summary>
         /// Gets the first child of the content using the passed predicate and returns it as <see cref="IPublishedContent"/>.
-        /// For strongly typed version use <see cref="FirstChildOf{T}(IPublishedContent, Func{T, bool})"/>.
+        /// For strongly typed version use <see cref="FirstChildAs{T}(IPublishedContent, Func{T, bool})"/>.
         /// </summary>
         /// <param name="content">The content.</param>
         /// <param name="predicate">The predicate query.</param>
@@ -1847,7 +1847,7 @@ namespace Umbraco.Web
         /// <param name="content">The content.</param>
         /// <param name="alias">The content type alias.</param>
         /// <returns>The first child of content, of the given content type as type T.</returns>
-        public static T FirstChildOf<T>(this IPublishedContent content)
+        public static T FirstChildAs<T>(this IPublishedContent content)
             where T : class, IPublishedContent
         {
             return content.Children<T>().FirstOrDefault();
@@ -1859,7 +1859,7 @@ namespace Umbraco.Web
         /// <param name="content">The content.</param>
         /// <param name="predicate">The matching predicate func.</param>
         /// <returns>The first child of content that matches the predicate as type T.</returns>
-        public static T FirstChildOf<T>(this IPublishedContent content, Func<T, bool> predicate)
+        public static T FirstChildAs<T>(this IPublishedContent content, Func<T, bool> predicate)
             where T : class, IPublishedContent
         {
             return content.Children<T>().FirstOrDefault(predicate);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-10778

### Description
Currently the `FirstChild<T>` method returns `IPublishedContent `rather than a mode of type `T`. This is inconsistent with the other strongly-typed extensions that do return type T. eg. `Descendant<T>` returns `<T>` and not `IPublishedContent`. This pull request enables consumers to now use `FirstChildOf<T>` to return strongly-typed models like the other similar axis extensions.

There should be no backward compatibility issues since this is a new method.

I have implemented Unit tests in `PublishedContentTests` that pass.