### PR TITLE
U4-10706 - Fixes TypedMedia not working with UDI strings

### DIFF
--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -1033,10 +1033,14 @@ namespace Umbraco.Web
             return ContentQuery.TypedMedia(id);
 		}
 
+        /// <summary>
+        /// Returns typed Media content based on an Identifier
+        /// </summary>
+        /// <param name="id">The id - this can be the numeric Id such as '1234' or a UDI string such as 'umb://media/a1276990a50e4784b25458fc8d0c487c'</param>
+        /// <returns>PublishedContent if a corresponding media Id exists; otherwise null</returns>
 		public IPublishedContent TypedMedia(string id)
 		{
-            int intId;
-            return ConvertIdObjectToInt(id, out intId) ? ContentQuery.TypedMedia(intId) : null;
+            return TypedMediaForObject(id);
 		}
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [ x] I have written a descriptive pull-request title
- [ x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-10706

### Description
Currently if you use the string overload of `Umbraco.TypedMedia` and pass in a UDI string like `umb://media/a1276990a50e4784b25458fc8d0c487c `then it returns null even if a media item with that ID exists. This is inconsistent with TypedContent which does work with UDI strings.

This PR fixes this and uses the same methodology as `TypeContent` and retains backward compatibility with integer strings.
