### PR TITLE
U4-11329 - GetExternalAuthenticationOptions gets called when AuthType is Null in Umbraco.Web/editors/BackOfficeController.cs

### DIFF
--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -372,7 +372,7 @@ namespace Umbraco.Web.Editors
         {
             if (loginInfo == null) throw new ArgumentNullException("loginInfo");
             if (response == null) throw new ArgumentNullException("response");
-
+            ExternalSignInAutoLinkOptions autoLinkOptions = null;
 
             //Here we can check if the provider associated with the request has been configured to allow
             // new users (auto-linked external accounts). This would never be used with public providers such as 
@@ -383,8 +383,10 @@ namespace Umbraco.Web.Editors
             {
                 Logger.Warn<BackOfficeController>("Could not find external authentication provider registered: " + loginInfo.Login.LoginProvider);
             }
-
-            var autoLinkOptions = authType.GetExternalAuthenticationOptions();
+            else
+            {
+                autoLinkOptions = authType.GetExternalAuthenticationOptions();
+            }
 
             // Sign in the user with this external login provider if the user already has a login
             var user = await UserManager.FindAsync(loginInfo.Login);


### PR DESCRIPTION
Retrieving ExternalSignInAutoLinkOptions only if authType is not null.  
[issue tracker U4-11329](http://issues.umbraco.org/issue/U4-11329)