### PR TITLE
Make base AnchestorOrSelf public

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1199,7 +1199,7 @@ namespace Umbraco.Web
             return content.AncestorsOrSelf<T>(maxLevel).FirstOrDefault();
         }
 
-        internal static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, bool orSelf, Func<IPublishedContent, bool> func)
+        public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, bool orSelf, Func<IPublishedContent, bool> func)
         {
             var ancestorsOrSelf = content.EnumerateAncestors(orSelf);
             return func == null ? ancestorsOrSelf : ancestorsOrSelf.Where(func);


### PR DESCRIPTION
By making the base AnchestorOrSelf function public, developers can use it to iterate over the tree on different properties / functions than the ones which are created by the umbraco Team. It makes umbraco easier to extend. Now we have to copy existing code in order to do this.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->
By making this function public, developers can use it to iterate over the tree on different property / function than the ones which are created. It makes umbraco easier to extend. Now we have to copy existing code in order to do this.


<!-- Thanks for contributing to Umbraco CMS! -->
