### PR TITLE
U4-7874 - Add events to content editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -77,6 +77,8 @@
 
           resetLastListPageNumber($scope.content);
 
+          eventsService.emit("content.loaded", { content: $scope.content });
+
           $scope.page.loading = false;
 
         });
@@ -130,6 +132,8 @@
 
       $scope.page.buttonGroupState = "busy";
 
+      eventsService.emit("content.saving", { content: $scope.content, action: args.action });
+
       contentEditingHelper.contentEditorPerformSave({
         statusMessage: args.statusMessage,
         saveMethod: args.saveMethod,
@@ -144,6 +148,9 @@
         $scope.page.buttonGroupState = "success";
 
         deferred.resolve(data);
+
+        eventsService.emit("content.saved", { content: $scope.content, action: args.action });
+
       }, function (err) {
         //error
         if (err) {
@@ -183,7 +190,9 @@
 
           $scope.page.loading = false;
 
-        });
+          eventsService.emit("content.newReady", { content: $scope.content });
+
+          });
     }
     else {
 
@@ -197,6 +206,8 @@
       if (formHelper.submitForm({ scope: $scope, statusMessage: "Unpublishing...", skipValidation: true })) {
 
         $scope.page.buttonGroupState = "busy";
+
+        eventsService.emit("content.unpublishing", { content: $scope.content });
 
         contentResource.unPublish($scope.content.id)
           .then(function (data) {
@@ -214,6 +225,8 @@
             syncTreeNode($scope.content, data.path);
 
             $scope.page.buttonGroupState = "success";
+
+            eventsService.emit("content.unpublished", { content: $scope.content });
 
           }, function(err) {
             formHelper.showNotifications(err.data);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
Added events for "new ready", "loaded", "saving", "saved", "unpublishing" and "unpublished".
