### PR TITLE
Health Checks: the warning icon should be orange instead of yellow

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/healthcheck.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/healthcheck.html
@@ -31,7 +31,7 @@
                         </div>
 
                         <div class="umb-healthcheck-message" ng-if="group.totalWarning > 0">
-                            <i class="icon-alert color-yellow"></i>
+                            <i class="icon-alert color-orange"></i>
                             {{ group.totalWarning }}
                         </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->

Issue here: http://issues.umbraco.org/issue/U4-11358

Both the yellow and orange colors used to be a bit darker, but when more colors were introduced in 7.10.x, the two colors were made a bit lighter. So now the yellow warning icon is hard to see on a white background, but the orange color now looks just right ;)

![image](https://user-images.githubusercontent.com/3634580/40351723-66b68e14-5dad-11e8-9c42-c018308c4d12.png)

![image](https://user-images.githubusercontent.com/3634580/40351801-8f8edc56-5dad-11e8-98f6-e5a29f2c466e.png)




<!-- Thanks for contributing to Umbraco CMS! -->
