### PR TITLE
U4-11368 - Sort language by name in languages settings page 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/languages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/edit.controller.js
@@ -41,7 +41,14 @@
 
                 if($routeParams.create) {
                     vm.page.name = vm.labels.addLanguage;
-                    languageResource.getCultures().then(function(cultures) {
+                    languageResource.getCultures().then(function (culturesDictionary) {
+                        var cultures = [];
+                        angular.forEach(culturesDictionary, function (value, key) {
+                            cultures.push({
+                                name: key,
+                                displayName: value
+                            });
+                        });
                         vm.availableCultures = cultures;
                     });
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/languages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/edit.html
@@ -25,7 +25,7 @@
                             <select name="newLang"
                                     class="input-block-level"
                                     ng-model="vm.language.culture"
-                                    ng-options="key as value for (key, value) in vm.availableCultures"
+                                    ng-options="culture.name as culture.displayName for culture in vm.availableCultures"
                                     val-server-field="IsoCode"
                                     required></select>
                             <span class="help-inline" val-msg-for="newLang" val-toggle-msg="required">Required</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->

The issue was that the web API was returning a dictionary that was interpreted as data object by AngularJS, with each key becoming a property of an enormous object, so when binding this object to the select element, it was sorted by property name, thus the key of the array, which was the culture identifier, an being an object it was impossible to sort it again by value.
Only option was to convert it to an array. And since the original list of culture is already sorted correctly, no need to sort it again.

Other options for fixing the issue would be to change the response returned by the WebAPI from `IDictionary` to a `IList<LanguageDTO>` where `LanguageDTO` is just name and display name, and then there would be no need to convert the result in AngularJS (but still the binding to the options would need to be changed)

Fixes: http://issues.umbraco.org/issue/U4-11368
<!-- Thanks for contributing to Umbraco CMS! -->
