### PR TITLE
U4-10839 - Change to login style to hide keychain icon in Safari

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -125,6 +125,10 @@
         display: none;
     }
 
+    input::-webkit-credentials-auto-fill-button {
+        visibility: hidden;
+    }
+
     a {
         opacity: .5;
         cursor: pointer;


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->

I found this issue from the start of 2018 - http://issues.umbraco.org/issue/U4-10839 , and fixed it by adding an "visibility: hidden;" to the "keychain"/autofill icon in Safari on macOS since it was laying on top of the show password icon :)

<!-- Thanks for contributing to Umbraco CMS! -->
