### PR TITLE
Conditional Upload button on Media Picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -154,13 +154,14 @@ angular.module("umbraco")
                                 });
                         });
 
-                    mediaTypeHelper.getAllowedImagetypes(folder.id)
-                        .then(function(types) {
-                            $scope.acceptedMediatypes = types;
-                        });
                 } else {
                     $scope.path = [];
                 }
+
+                mediaTypeHelper.getAllowedImagetypes(folder.id)
+                    .then(function (types) {
+                        $scope.acceptedMediatypes = types;
+                    });
 
                 $scope.lockedFolder = folder.id === -1 && $scope.model.startNodeIsVirtual;
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
@@ -27,7 +27,8 @@
                 <umb-button type="button"
                             label-key="general_upload"
                             action="upload()"
-                            disabled="lockedFolder">
+                            disabled="lockedFolder"
+                            ng-if="acceptedMediatypes.length > 0">
                 </umb-button>
             </div>
 


### PR DESCRIPTION
Made upload button only appear when media can be uploaded to the current folder. Also ensured acceptedMediatypes is always valid even in the root directory

http://issues.umbraco.org/issue/U4-11039#