### PR TITLE
grouped icon colours to logical groups - blues and purples together.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
@@ -22,19 +22,19 @@
             <option value="color-brown"><localize key="colors_brown">Brown</localize></option>
             <option value="color-blue"><localize key="colors_blue">Blue</localize></option>
             <option value="color-light-blue"><localize key="colors_lightblue">Light Blue</localize></option>
+            <option value="color-indigo"><localize key="colors_indigo">Indigo</localize></option>
+            <option value="color-purple"><localize key="colors_purple">Purple</localize></option>
+            <option value="color-deep-purple"><localize key="colors_deeppurple">Deep Purple</localize></option>
             <option value="color-cyan"><localize key="colors_cyan">Cyan</localize></option>
             <option value="color-green"><localize key="colors_green">Green</localize></option>
             <option value="color-light-green"><localize key="colors_lightgreen">Light Green</localize></option>
-            <option value="color-yellow"><localize key="colors_yellow">Yellow</localize></option>
             <option value="color-lime"><localize key="colors_lime">Lime</localize></option>
+            <option value="color-yellow"><localize key="colors_yellow">Yellow</localize></option>
             <option value="color-amber"><localize key="colors_amber">Amber</localize></option>
             <option value="color-orange"><localize key="colors_orange">Orange</localize></option>
             <option value="color-deep-orange"><localize key="colors_deeporange">Deep Orange</localize></option>
             <option value="color-red"><localize key="colors_red">Red</localize></option>
             <option value="color-pink"><localize key="colors_pink">Pink</localize></option>
-            <option value="color-purple"><localize key="colors_purple">Purple</localize></option>
-            <option value="color-deep-purple"><localize key="colors_deeppurple">Deep Purple</localize></option>
-            <option value="color-indigo"><localize key="colors_indigo">Indigo</localize></option>
         </select>
     </div>
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->
During the open circle time at CG18 it was mentioned that it would be nice to have the icon picker colours grouped logically. This PR is to help that.

<!-- Thanks for contributing to Umbraco CMS! -->
