### PR TITLE
U4-11395 - Add Gulp ImageMin to compress images in build process

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulpfile.js
+++ b/src/Umbraco.Web.UI.Client/gulpfile.js
@@ -7,6 +7,7 @@ var sort = require('gulp-sort');
 var connect = require('gulp-connect');
 var open = require('gulp-open');
 var runSequence = require('run-sequence');
+const imagemin = require('gulp-imagemin');
 
 var _ = require('lodash');
 var MergeStream = require('merge-stream');
@@ -206,6 +207,17 @@ gulp.task('dependencies', function () {
     //css, fonts and image files
     stream.add( 
             gulp.src(sources.globs.assets)
+				.pipe(imagemin([
+                    imagemin.gifsicle({interlaced: true}),
+                    imagemin.jpegtran({progressive: true}),
+                    imagemin.optipng({optimizationLevel: 5}),
+                    imagemin.svgo({
+                        plugins: [
+                            {removeViewBox: true},
+                            {cleanupIDs: false}
+                        ]
+                    })
+                ]))
                 .pipe(gulp.dest(root + targets.assets))
         );
 

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -27,6 +27,7 @@
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",
     "gulp-connect": "5.0.0",
+    "gulp-imagemin": "^4.1.0",
     "gulp-less": "^3.5.0",
     "gulp-ngdocs": "^0.3.0",
     "gulp-open": "^2.1.0",


### PR DESCRIPTION
See http://issues.umbraco.org/issue/U4-11395

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->

Simple Gulp task to compress any images it finds as part of the build process. Managed to compress the images by 21% and save 220Kb+ the original images are left untouched.

<!-- Thanks for contributing to Umbraco CMS! -->
