### PR TITLE
Ensures referential integrity for all FKs to umbracoUser but supports NULL entries

### DIFF
--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -12,6 +12,14 @@ namespace Umbraco.Core
             /// </summary>
             public const int SuperId = -1;
 
+            /// <summary>
+            /// The id for the 'unknown' user
+            /// </summary>
+            /// <remarks>
+            /// This is a user row that exists in the DB only for referential integrity but the user is never returned from any of the services
+            /// </remarks>
+            public const int UnknownId = 0;
+
             public const string AdminGroupAlias = "admin";
             public const string SensitiveDataGroupAlias = "sensitiveData";
             public const string TranslatorGroupAlias = "translator";

--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Core
             /// <summary>
             /// Gets the identifier of the 'super' user.
             /// </summary>
-            public const int SuperId = -1;
+            public const int SuperUserId = -1;
 
             /// <summary>
             /// The id for the 'unknown' user
@@ -18,7 +18,7 @@ namespace Umbraco.Core
             /// <remarks>
             /// This is a user row that exists in the DB only for referential integrity but the user is never returned from any of the services
             /// </remarks>
-            public const int UnknownId = 0;
+            public const int UnknownUserId = 0;
 
             public const string AdminGroupAlias = "admin";
             public const string SensitiveDataGroupAlias = "sensitiveData";

--- a/src/Umbraco.Core/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseBuilder.cs
@@ -101,7 +101,7 @@ namespace Umbraco.Core.Migrations.Install
                 var sql = scope.Database.SqlContext.Sql()
                     .SelectCount()
                     .From<UserDto>()
-                    .Where<UserDto>(x => x.Id == Constants.Security.SuperId && x.Password == "default");
+                    .Where<UserDto>(x => x.Id == Constants.Security.SuperUserId && x.Password == "default");
                 var result = scope.Database.ExecuteScalar<int>(sql);
                 var has = result != 1;
                 if (has == false)

--- a/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
@@ -144,6 +144,7 @@ namespace Umbraco.Core.Migrations.Install
 
         private void CreateUserData()
         {
+            _database.Insert(Constants.DatabaseSchema.Tables.User, "id", false, new UserDto { Id = Constants.Security.UnknownId, Disabled = true, NoConsole = true, UserName = "$UMB_UNKNOWN_USER$", Login = "$UMB_UNKNOWN_USER$", Password = "$UMB_UNKNOWN_USER$", Email = "", UserLanguage = "en-US", CreateDate = DateTime.Now, UpdateDate = DateTime.Now });
             _database.Insert(Constants.DatabaseSchema.Tables.User, "id", false, new UserDto { Id = Constants.Security.SuperId, Disabled = false, NoConsole = false, UserName = "Administrator", Login = "admin", Password = "default", Email = "", UserLanguage = "en-US", CreateDate = DateTime.Now, UpdateDate = DateTime.Now });
         }
 

--- a/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
@@ -144,8 +144,7 @@ namespace Umbraco.Core.Migrations.Install
 
         private void CreateUserData()
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.User, "id", false, new UserDto { Id = Constants.Security.UnknownId, Disabled = true, NoConsole = true, UserName = "$UMB_UNKNOWN_USER$", Login = "$UMB_UNKNOWN_USER$", Password = "$UMB_UNKNOWN_USER$", Email = "", UserLanguage = "en-US", CreateDate = DateTime.Now, UpdateDate = DateTime.Now });
-            _database.Insert(Constants.DatabaseSchema.Tables.User, "id", false, new UserDto { Id = Constants.Security.SuperId, Disabled = false, NoConsole = false, UserName = "Administrator", Login = "admin", Password = "default", Email = "", UserLanguage = "en-US", CreateDate = DateTime.Now, UpdateDate = DateTime.Now });
+            _database.Insert(Constants.DatabaseSchema.Tables.User, "id", false, new UserDto { Id = Constants.Security.SuperUserId, Disabled = false, NoConsole = false, UserName = "Administrator", Login = "admin", Password = "default", Email = "", UserLanguage = "en-US", CreateDate = DateTime.Now, UpdateDate = DateTime.Now });
         }
 
         private void CreateUserGroupData()
@@ -159,8 +158,8 @@ namespace Umbraco.Core.Migrations.Install
 
         private void CreateUser2UserGroupData()
         {
-            _database.Insert(new User2UserGroupDto { UserGroupId = 1, UserId = Constants.Security.SuperId }); // add super to admins
-            _database.Insert(new User2UserGroupDto { UserGroupId = 5, UserId = Constants.Security.SuperId }); // add super to sensitive data
+            _database.Insert(new User2UserGroupDto { UserGroupId = 1, UserId = Constants.Security.SuperUserId }); // add super to admins
+            _database.Insert(new User2UserGroupDto { UserGroupId = 5, UserId = Constants.Security.SuperUserId }); // add super to sensitive data
         }
 
         private void CreateUserGroup2AppData()

--- a/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
@@ -30,6 +30,7 @@ namespace Umbraco.Core.Migrations.Install
         // all tables, in order
         public static readonly List<Type> OrderedTables = new List<Type>
         {
+            typeof (UserDto),
             typeof (NodeDto),
             typeof (ContentTypeDto),
             typeof (TemplateDto),
@@ -58,7 +59,6 @@ namespace Umbraco.Core.Migrations.Install
             typeof (RelationDto),
             typeof (TagDto),
             typeof (TagRelationshipDto),
-            typeof (UserDto),
             typeof (TaskTypeDto),
             typeof (TaskDto),
             typeof (ContentType2ContentTypeDto),

--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -119,6 +119,7 @@ namespace Umbraco.Core.Migrations.Upgrade
             Chain<AddVariationTables1A>("{66B6821A-0DE3-4DF8-A6A4-65ABD211EDDE}");
             Chain<AddVariationTables2>("{49506BAE-CEBB-4431-A1A6-24AD6EBBBC57}");
             Chain<RefactorMacroColumns>("{083A9894-903D-41B7-B6B3-9EAF2D4CCED0}");
+            Chain<UserForeignKeys>("{42097524-0F8C-482C-BD79-AC7407D8A028}");
 
             // must chain to v8 final state (see at end of file)
             Chain("{A7540C58-171D-462A-91C5-7A9AA5CB8BFD}");
@@ -211,11 +212,12 @@ namespace Umbraco.Core.Migrations.Upgrade
             Add<AddVariationTables1A>("{941B2ABA-2D06-4E04-81F5-74224F1DB037}", "{76DF5CD7-A884-41A5-8DC6-7860D95B1DF5}");
 
             Chain<RefactorMacroColumns>("{A7540C58-171D-462A-91C5-7A9AA5CB8BFD}");
+            Chain<UserForeignKeys>("{3E44F712-E2E3-473A-AE49-5D7F8E67CE3F}");
 
             // FINAL STATE - MUST MATCH LAST ONE ABOVE !
             // whenever this changes, update all references in this file!
 
-            Add(string.Empty, "{A7540C58-171D-462A-91C5-7A9AA5CB8BFD}");
+            Add(string.Empty, "{3E44F712-E2E3-473A-AE49-5D7F8E67CE3F}");
         }
     }
 }

--- a/src/Umbraco.Core/Migrations/Upgrade/V_7_9_0/CreateSensitiveDataUserGroup.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_7_9_0/CreateSensitiveDataUserGroup.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_7_9_0
             if (exists) return;
 
             var groupId = Database.Insert(Constants.DatabaseSchema.Tables.UserGroup, "id", new UserGroupDto { StartMediaId = -1, StartContentId = -1, Alias = Constants.Security.SensitiveDataGroupAlias, Name = "Sensitive data", DefaultPermissions = "", CreateDate = DateTime.Now, UpdateDate = DateTime.Now, Icon = "icon-lock" });
-            Database.Insert(new User2UserGroupDto { UserGroupId = Convert.ToInt32(groupId), UserId = Constants.Security.SuperId }); // add super to sensitive data
+            Database.Insert(new User2UserGroupDto { UserGroupId = Convert.ToInt32(groupId), UserId = Constants.Security.SuperUserId }); // add super to sensitive data
         }
     }
 }

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/UserForeignKeys.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/UserForeignKeys.cs
@@ -1,0 +1,38 @@
+﻿using NPoco;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
+{
+    /// <summary>
+    /// Creates/Updates non mandatory FK columns to the user table
+    /// </summary>
+    public class UserForeignKeys : MigrationBase
+    {
+        public UserForeignKeys(IMigrationContext context)
+            : base(context)
+        { }
+
+        public override void Migrate()
+        {
+            //first allow NULL-able
+            Alter.Table(ContentVersionCultureVariationDto.TableName).AlterColumn("availableUserId").AsInt32().Nullable().Do();
+            Alter.Table(ContentVersionDto.TableName).AlterColumn("userId").AsInt32().Nullable().Do();
+            Alter.Table(Constants.DatabaseSchema.Tables.Log).AlterColumn("userId").AsInt32().Nullable().Do();
+            Alter.Table(NodeDto.TableName).AlterColumn("nodeUser").AsInt32().Nullable().Do();
+
+            //then we can update any non existing users to NULL
+            Execute.Sql($"UPDATE {ContentVersionCultureVariationDto.TableName} SET availableUserId = NULL WHERE availableUserId NOT IN (SELECT id FROM {UserDto.TableName})").Do();
+            Execute.Sql($"UPDATE {ContentVersionDto.TableName} SET userId = NULL WHERE userId NOT IN (SELECT id FROM {UserDto.TableName})").Do();
+            Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.Log} SET userId = NULL WHERE userId NOT IN (SELECT id FROM {UserDto.TableName})").Do();
+            Execute.Sql($"UPDATE {NodeDto.TableName} SET nodeUser = NULL WHERE nodeUser NOT IN (SELECT id FROM {UserDto.TableName})").Do();
+
+            //now NULL-able with FKs
+            Alter.Table(ContentVersionCultureVariationDto.TableName).AlterColumn("availableUserId").AsInt32().Nullable().ForeignKey(UserDto.TableName, "id").Do();
+            Alter.Table(ContentVersionDto.TableName).AlterColumn("userId").AsInt32().Nullable().ForeignKey(UserDto.TableName, "id").Do();
+            Alter.Table(Constants.DatabaseSchema.Tables.Log).AlterColumn("userId").AsInt32().Nullable().ForeignKey(UserDto.TableName, "id").Do();
+            Alter.Table(NodeDto.TableName).AlterColumn("nodeUser").AsInt32().Nullable().ForeignKey(UserDto.TableName, "id").Do();
+        }
+
+    }
+}

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Core.Models
         public static bool IsSuper(this IUser user)
         {
             if (user == null) throw new ArgumentNullException(nameof(user));
-            return user.Id == Constants.Security.SuperId;
+            return user.Id == Constants.Security.SuperUserId;
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Packaging/PackageInstallation.cs
+++ b/src/Umbraco.Core/Packaging/PackageInstallation.cs
@@ -309,7 +309,7 @@ namespace Umbraco.Core.Packaging
                 }).ToArray();
         }
 
-        private IEnumerable<IContent> InstallDocuments(XElement documentsElement, int userId = -1)
+        private IEnumerable<IContent> InstallDocuments(XElement documentsElement, int userId = 0)
         {
             if ((string.Equals(Constants.Packaging.DocumentSetNodeName, documentsElement.Name.LocalName) == false)
                 && (string.Equals(Constants.Packaging.DocumentsNodeName, documentsElement.Name.LocalName) == false))
@@ -341,7 +341,7 @@ namespace Umbraco.Core.Packaging
             throw new NotImplementedException("The packaging service do not yes have a method for importing stylesheets");
         }
 
-        private IEnumerable<IContentType> InstallDocumentTypes(XElement documentTypes, int userId = -1)
+        private IEnumerable<IContentType> InstallDocumentTypes(XElement documentTypes, int userId = 0)
         {
             if (string.Equals(Constants.Packaging.DocumentTypesNodeName, documentTypes.Name.LocalName) == false)
             {
@@ -355,7 +355,7 @@ namespace Umbraco.Core.Packaging
             return _packagingService.ImportContentTypes(documentTypes, userId);
         }
 
-        private IEnumerable<ITemplate> InstallTemplats(XElement templateElement, int userId = -1)
+        private IEnumerable<ITemplate> InstallTemplats(XElement templateElement, int userId = 0)
         {
             if (string.Equals(Constants.Packaging.TemplatesNodeName, templateElement.Name.LocalName) == false)
             {
@@ -382,7 +382,7 @@ namespace Umbraco.Core.Packaging
                     sd => new KeyValuePair<string, string>(sd.Key, Path.Combine(fullpathToRoot, sd.Value))).ToArray();
         }
 
-        private IEnumerable<IMacro> InstallMacros(XElement macroElements, int userId = -1)
+        private IEnumerable<IMacro> InstallMacros(XElement macroElements, int userId = 0)
         {
             if (string.Equals(Constants.Packaging.MacrosNodeName, macroElements.Name.LocalName) == false)
             {
@@ -403,7 +403,7 @@ namespace Umbraco.Core.Packaging
             return _packagingService.ImportDictionaryItems(dictionaryItemsElement);
         }
 
-        private IEnumerable<ILanguage> InstallLanguages(XElement languageElement, int userId = -1)
+        private IEnumerable<ILanguage> InstallLanguages(XElement languageElement, int userId = 0)
         {
             if (string.Equals(Constants.Packaging.LanguagesNodeName, languageElement.Name.LocalName) == false)
             {
@@ -412,7 +412,7 @@ namespace Umbraco.Core.Packaging
             return _packagingService.ImportLanguages(languageElement, userId);
         }
 
-        private IEnumerable<IDataType> InstallDataTypes(XElement dataTypeElements, int userId = -1)
+        private IEnumerable<IDataType> InstallDataTypes(XElement dataTypeElements, int userId = 0)
         {
             if (string.Equals(Constants.Packaging.DataTypesNodeName, dataTypeElements.Name.LocalName) == false)
             {

--- a/src/Umbraco.Core/Persistence/Dtos/ContentVersionCultureVariationDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ContentVersionCultureVariationDto.cs
@@ -10,6 +10,7 @@ namespace Umbraco.Core.Persistence.Dtos
     internal class ContentVersionCultureVariationDto
     {
         public const string TableName = Constants.DatabaseSchema.Tables.ContentVersionCultureVariation;
+        private int? _publishedUserId;
 
         [Column("id")]
         [PrimaryKeyColumn]
@@ -38,7 +39,8 @@ namespace Umbraco.Core.Persistence.Dtos
         // fixme want?
         [Column("availableUserId")]
         [ForeignKey(typeof(UserDto))]
-        public int PublishedUserId { get; set; }
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public int? PublishedUserId { get => _publishedUserId == 0 ? null : _publishedUserId; set => _publishedUserId = value; } //return null if zero
 
         [Column("edited")]
         public bool Edited { get; set; }

--- a/src/Umbraco.Core/Persistence/Dtos/ContentVersionCultureVariationDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ContentVersionCultureVariationDto.cs
@@ -37,8 +37,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         // fixme want?
         [Column("availableUserId")]
-        // [ForeignKey(typeof(UserDto))] -- there is no foreign key so we can delete users without deleting associated content
-        //[NullSetting(NullSetting = NullSettings.Null)]
+        [ForeignKey(typeof(UserDto))]
         public int PublishedUserId { get; set; }
 
         [Column("edited")]

--- a/src/Umbraco.Core/Persistence/Dtos/ContentVersionDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ContentVersionDto.cs
@@ -25,6 +25,7 @@ namespace Umbraco.Core.Persistence.Dtos
         public DateTime VersionDate { get; set; }
 
         [Column("userId")]
+        [ForeignKey(typeof(UserDto))]
         public int UserId { get; set; }
 
         [Column("current")]

--- a/src/Umbraco.Core/Persistence/Dtos/ContentVersionDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ContentVersionDto.cs
@@ -11,6 +11,7 @@ namespace Umbraco.Core.Persistence.Dtos
     internal class ContentVersionDto
     {
         public const string TableName = Constants.DatabaseSchema.Tables.ContentVersion;
+        private int? _userId;
 
         [Column("id")]
         [PrimaryKeyColumn]
@@ -26,7 +27,8 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("userId")]
         [ForeignKey(typeof(UserDto))]
-        public int UserId { get; set; }
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public int? UserId { get => _userId == 0 ? null : _userId; set => _userId = value; } //return null if zero
 
         [Column("current")]
         public bool Current { get; set; }

--- a/src/Umbraco.Core/Persistence/Dtos/LogDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/LogDto.cs
@@ -10,12 +10,16 @@ namespace Umbraco.Core.Persistence.Dtos
     [ExplicitColumns]
     internal class LogDto
     {
+        private int? _userId;
+
         [Column("id")]
         [PrimaryKeyColumn]
         public int Id { get; set; }
 
         [Column("userId")]
-        public int UserId { get; set; }
+        [ForeignKey(typeof(UserDto))]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public int? UserId { get => _userId == 0 ? null : _userId; set => _userId = value; } //return null if zero
 
         [Column("NodeId")]
         [Index(IndexTypes.NonClustered, Name = "IX_umbracoLog")]

--- a/src/Umbraco.Core/Persistence/Dtos/NodeDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/NodeDto.cs
@@ -12,6 +12,7 @@ namespace Umbraco.Core.Persistence.Dtos
     {
         public const string TableName = Constants.DatabaseSchema.Tables.Node;
         public const int NodeIdSeed = 1060;
+        private int? _userId;
 
         [Column("id")]
         [PrimaryKeyColumn(IdentitySeed = NodeIdSeed)]
@@ -45,8 +46,9 @@ namespace Umbraco.Core.Persistence.Dtos
         public bool Trashed { get; set; }
 
         [Column("nodeUser")] // fixme dbfix rename userId
+        [ForeignKey(typeof(UserDto))]
         [NullSetting(NullSetting = NullSettings.Null)]
-        public int? UserId { get; set; }
+        public int? UserId { get => _userId == 0 ? null : _userId; set => _userId = value; } //return null if zero
 
         [Column("text")]
         [NullSetting(NullSetting = NullSettings.Null)]

--- a/src/Umbraco.Core/Persistence/Factories/ContentBaseFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/ContentBaseFactory.cs
@@ -38,8 +38,8 @@ namespace Umbraco.Core.Persistence.Factories
                 content.SortOrder = nodeDto.SortOrder;
                 content.Trashed = nodeDto.Trashed;
 
-                content.CreatorId = nodeDto.UserId ?? 0;
-                content.WriterId = contentVersionDto.UserId;
+                content.CreatorId = nodeDto.UserId ?? Constants.Security.UnknownUserId;
+                content.WriterId = contentVersionDto.UserId ?? Constants.Security.UnknownUserId;
                 content.CreateDate = nodeDto.CreateDate;
                 content.UpdateDate = contentVersionDto.VersionDate;
 
@@ -96,8 +96,8 @@ namespace Umbraco.Core.Persistence.Factories
                 content.SortOrder = nodeDto.SortOrder;
                 content.Trashed = nodeDto.Trashed;
 
-                content.CreatorId = nodeDto.UserId ?? 0;
-                content.WriterId = contentVersionDto.UserId;
+                content.CreatorId = nodeDto.UserId ?? Constants.Security.UnknownUserId;
+                content.WriterId = contentVersionDto.UserId ?? Constants.Security.UnknownUserId;
                 content.CreateDate = nodeDto.CreateDate;
                 content.UpdateDate = contentVersionDto.VersionDate;
 
@@ -137,8 +137,8 @@ namespace Umbraco.Core.Persistence.Factories
                 content.SortOrder = nodeDto.SortOrder;
                 content.Trashed = nodeDto.Trashed;
 
-                content.CreatorId = nodeDto.UserId ?? 0;
-                content.WriterId = contentVersionDto.UserId;
+                content.CreatorId = nodeDto.UserId ?? Constants.Security.UnknownUserId;
+                content.WriterId = contentVersionDto.UserId ?? Constants.Security.UnknownUserId;
                 content.CreateDate = nodeDto.CreateDate;
                 content.UpdateDate = contentVersionDto.VersionDate;
 

--- a/src/Umbraco.Core/Persistence/Factories/ContentTypeFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/ContentTypeFactory.cs
@@ -105,7 +105,7 @@ namespace Umbraco.Core.Persistence.Factories
             entity.CreateDate = dto.NodeDto.CreateDate;
             entity.Path = dto.NodeDto.Path;
             entity.Level = dto.NodeDto.Level;
-            entity.CreatorId = dto.NodeDto.UserId.Value;
+            entity.CreatorId = dto.NodeDto.UserId ?? Constants.Security.UnknownUserId;
             entity.AllowedAsRoot = dto.AllowAtRoot;
             entity.IsContainer = dto.IsContainer;
             entity.Trashed = dto.NodeDto.Trashed;

--- a/src/Umbraco.Core/Persistence/Factories/DataTypeFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/DataTypeFactory.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Core.Persistence.Factories
                 dataType.Path = dto.NodeDto.Path;
                 dataType.SortOrder = dto.NodeDto.SortOrder;
                 dataType.Trashed = dto.NodeDto.Trashed;
-                dataType.CreatorId = dto.NodeDto.UserId ?? 0;
+                dataType.CreatorId = dto.NodeDto.UserId ?? Constants.Security.UnknownUserId;
 
                 dataType.SetLazyConfiguration(dto.Configuration);
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/AuditRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/AuditRepository.cs
@@ -53,7 +53,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var dto = Database.First<LogDto>(sql);
             return dto == null
                 ? null
-                : new AuditItem(dto.NodeId, dto.Comment, Enum<AuditType>.Parse(dto.Header), dto.UserId);
+                : new AuditItem(dto.NodeId, dto.Comment, Enum<AuditType>.Parse(dto.Header), dto.UserId ?? Constants.Security.UnknownUserId);
         }
 
         protected override IEnumerable<IAuditItem> PerformGetAll(params int[] ids)
@@ -69,7 +69,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             var dtos = Database.Fetch<LogDto>(sql);
 
-            return dtos.Select(x => new AuditItem(x.NodeId, x.Comment, Enum<AuditType>.Parse(x.Header), x.UserId)).ToArray();
+            return dtos.Select(x => new AuditItem(x.NodeId, x.Comment, Enum<AuditType>.Parse(x.Header), x.UserId ?? Constants.Security.UnknownUserId)).ToArray();
         }
 
         protected override Sql<ISqlContext> GetBaseQuery(bool isCount)
@@ -160,7 +160,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             totalRecords = page.TotalItems;
 
             var items = page.Items.Select(
-                dto => new AuditItem(dto.Id, dto.Comment, Enum<AuditType>.Parse(dto.Header), dto.UserId)).ToArray();
+                dto => new AuditItem(dto.Id, dto.Comment, Enum<AuditType>.Parse(dto.Header), dto.UserId ?? Constants.Security.UnknownUserId)).ToArray();
 
             // map the DateStamp
             for (var i = 0; i < items.Length; i++)

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/EntityContainerRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/EntityContainerRepository.cs
@@ -93,7 +93,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var entity = new EntityContainer(nodeDto.NodeId, nodeDto.UniqueId,
                 nodeDto.ParentId, nodeDto.Path, nodeDto.Level, nodeDto.SortOrder,
                 containedObjectType,
-                nodeDto.Text, nodeDto.UserId ?? 0);
+                nodeDto.Text, nodeDto.UserId ?? Constants.Security.UnknownUserId);
 
             // reset dirty initial properties (U4-1946)
             entity.ResetDirtyProperties(false);

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
@@ -847,7 +847,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         {
             entity.Trashed = dto.Trashed;
             entity.CreateDate = dto.CreateDate;
-            entity.CreatorId = dto.UserId ?? 0;
+            entity.CreatorId = dto.UserId ?? Constants.Security.UnknownUserId;
             entity.Id = dto.NodeId;
             entity.Key = dto.UniqueId;
             entity.Level = dto.Level;

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
@@ -83,9 +83,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override IUser PerformGet(int id)
         {
-            if (id == Constants.Security.UnknownId)
-                return null;
-
             var sql = SqlContext.Sql()
                 .Select<UserDto>()
                 .From<UserDto>()
@@ -285,8 +282,7 @@ ORDER BY colName";
         {
             var sql = SqlContext.Sql()
                 .Select<UserDto>()
-                .From<UserDto>()
-                .Where<UserDto>(x => x.Id != Constants.Security.UnknownId); 
+                .From<UserDto>();
 
             with?.Invoke(sql);
 
@@ -620,9 +616,7 @@ ORDER BY colName";
 
         public int GetCountByQuery(IQuery<IUser> query)
         {
-            var sqlClause = GetBaseQuery("umbracoUser.id")
-                .Where<UserDto>(x => x.Id != Constants.Security.UnknownId);
-
+            var sqlClause = GetBaseQuery("umbracoUser.id");
             var translator = new SqlTranslator<IUser>(sqlClause, query);
             var subquery = translator.Translate();
             //get the COUNT base query
@@ -637,7 +631,7 @@ ORDER BY colName";
             var sql = SqlContext.Sql()
                 .SelectCount()
                 .From<UserDto>()
-                .Where<UserDto>(x => x.Id != Constants.Security.UnknownId && x.UserName == username);
+                .Where<UserDto>(x => x.UserName == username);
 
             return Database.ExecuteScalar<int>(sql) > 0;
         }
@@ -675,8 +669,6 @@ ORDER BY colName";
                 sql.WhereIn<UserDto>(x => x.Id, inSql);
             else
                 sql.WhereNotIn<UserDto>(x => x.Id, inSql);
-
-            sql.Where<UserDto>(x => x.Id != Constants.Security.UnknownId);
 
             return ConvertFromDtos(Database.Fetch<UserDto>(sql));
         }
@@ -808,7 +800,7 @@ ORDER BY colName";
                 sql = new SqlTranslator<IUser>(sql, query).Translate();
 
             // get sorted and filtered sql
-            var sqlNodeIdsWithSort = ApplySort(ApplyFilter(sql, filterSql), orderDirection, orderBy);                
+            var sqlNodeIdsWithSort = ApplySort(ApplyFilter(sql, filterSql), orderDirection, orderBy);
 
             // get a page of results and total count
             var pagedResult = Database.Page<UserDto>(pageIndex + 1, pageSize, sqlNodeIdsWithSort);
@@ -821,11 +813,9 @@ ORDER BY colName";
 
         private Sql<ISqlContext> ApplyFilter(Sql<ISqlContext> sql, Sql<ISqlContext> filterSql)
         {
-            if (filterSql == null)
-                return sql.Where<UserDto>(x => x.Id != Constants.Security.UnknownId);
+            if (filterSql == null) return sql;
 
             sql.Append(SqlContext.Sql(" WHERE " + filterSql.SQL.TrimStart("AND "), filterSql.Arguments));
-            sql.Append($" AND umbracoUser.id <> {Constants.Security.UnknownId}");
 
             return sql;
         }
@@ -847,7 +837,7 @@ ORDER BY colName";
             var idsQuery = SqlContext.Sql()
                 .Select<UserDto>(x => x.Id)
                 .From<UserDto>()
-                .Where<UserDto>(x => x.Id != Constants.Security.UnknownId && x.Id >= id)
+                .Where<UserDto>(x => x.Id >= id)
                 .OrderBy<UserDto>(x => x.Id);
 
             // first page is index 1, not zero

--- a/src/Umbraco.Core/Services/ContentServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/ContentServiceExtensions.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Core.Services
         /// <param name="mediaTypeAlias"></param>
         /// <param name="userId"></param>
         /// <returns></returns>
-        public static IContent CreateContent(this IContentService contentService, string name, Udi parentId, string mediaTypeAlias, int userId = -1)
+        public static IContent CreateContent(this IContentService contentService, string name, Udi parentId, string mediaTypeAlias, int userId = 0)
         {
             var guidUdi = parentId as GuidUdi;
             if (guidUdi == null)

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -32,27 +32,27 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Saves a blueprint.
         /// </summary>
-        void SaveBlueprint(IContent content, int userId = -1);
+        void SaveBlueprint(IContent content, int userId = 0);
 
         /// <summary>
         /// Deletes a blueprint.
         /// </summary>
-        void DeleteBlueprint(IContent content, int userId = -1);
+        void DeleteBlueprint(IContent content, int userId = 0);
 
         /// <summary>
         /// Creates a new content item from a blueprint.
         /// </summary>
-        IContent CreateContentFromBlueprint(IContent blueprint, string name, int userId = -1);
+        IContent CreateContentFromBlueprint(IContent blueprint, string name, int userId = 0);
 
         /// <summary>
         /// Deletes blueprints for a content type.
         /// </summary>
-        void DeleteBlueprintsOfType(int contentTypeId, int userId = -1);
+        void DeleteBlueprintsOfType(int contentTypeId, int userId = 0);
 
         /// <summary>
         /// Deletes blueprints for content types.
         /// </summary>
-        void DeleteBlueprintsOfTypes(IEnumerable<int> contentTypeIds, int userId = -1);
+        void DeleteBlueprintsOfTypes(IEnumerable<int> contentTypeIds, int userId = 0);
 
         #endregion
 
@@ -251,13 +251,13 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Saves a document.
         /// </summary>
-        OperationResult Save(IContent content, int userId = -1, bool raiseEvents = true);
+        OperationResult Save(IContent content, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Saves documents.
         /// </summary>
         // fixme why only 1 result not 1 per content?!
-        OperationResult Save(IEnumerable<IContent> contents, int userId = -1, bool raiseEvents = true);
+        OperationResult Save(IEnumerable<IContent> contents, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Deletes a document.
@@ -266,7 +266,7 @@ namespace Umbraco.Core.Services
         /// <para>This method will also delete associated media files, child content and possibly associated domains.</para>
         /// <para>This method entirely clears the content from the database.</para>
         /// </remarks>
-        OperationResult Delete(IContent content, int userId = -1);
+        OperationResult Delete(IContent content, int userId = 0);
 
         /// <summary>
         /// Deletes all documents of a given document type.
@@ -275,7 +275,7 @@ namespace Umbraco.Core.Services
         /// <para>All non-deleted descendants of the deleted documents are moved to the recycle bin.</para>
         /// <para>This operation is potentially dangerous and expensive.</para>
         /// </remarks>
-        void DeleteOfType(int documentTypeId, int userId = -1);
+        void DeleteOfType(int documentTypeId, int userId = 0);
 
         /// <summary>
         /// Deletes all documents of given document types.
@@ -284,17 +284,17 @@ namespace Umbraco.Core.Services
         /// <para>All non-deleted descendants of the deleted documents are moved to the recycle bin.</para>
         /// <para>This operation is potentially dangerous and expensive.</para>
         /// </remarks>
-        void DeleteOfTypes(IEnumerable<int> contentTypeIds, int userId = -1);
+        void DeleteOfTypes(IEnumerable<int> contentTypeIds, int userId = 0);
 
         /// <summary>
         /// Deletes versions of a document prior to a given date.
         /// </summary>
-        void DeleteVersions(int id, DateTime date, int userId = -1);
+        void DeleteVersions(int id, DateTime date, int userId = 0);
 
         /// <summary>
         /// Deletes a version of a document.
         /// </summary>
-        void DeleteVersion(int id, int versionId, bool deletePriorVersions, int userId = -1);
+        void DeleteVersion(int id, int versionId, bool deletePriorVersions, int userId = 0);
 
         #endregion
 
@@ -303,7 +303,7 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Moves a document under a new parent.
         /// </summary>
-        void Move(IContent content, int parentId, int userId = -1);
+        void Move(IContent content, int parentId, int userId = 0);
 
         /// <summary>
         /// Copies a document.
@@ -311,7 +311,7 @@ namespace Umbraco.Core.Services
         /// <remarks>
         /// <para>Recursively copies all children.</para>
         /// </remarks>
-        IContent Copy(IContent content, int parentId, bool relateToOriginal, int userId = -1);
+        IContent Copy(IContent content, int parentId, bool relateToOriginal, int userId = 0);
 
         /// <summary>
         /// Copies a document.
@@ -319,12 +319,12 @@ namespace Umbraco.Core.Services
         /// <remarks>
         /// <para>Optionaly recursively copies all children.</para>
         /// </remarks>
-        IContent Copy(IContent content, int parentId, bool relateToOriginal, bool recursive, int userId = -1);
+        IContent Copy(IContent content, int parentId, bool relateToOriginal, bool recursive, int userId = 0);
 
         /// <summary>
         /// Moves a document to the recycle bin.
         /// </summary>
-        OperationResult MoveToRecycleBin(IContent content, int userId = -1);
+        OperationResult MoveToRecycleBin(IContent content, int userId = 0);
 
         /// <summary>
         /// Empties the recycle bin.
@@ -334,12 +334,12 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Sorts documents.
         /// </summary>
-        bool Sort(IEnumerable<IContent> items, int userId = -1, bool raiseEvents = true);
+        bool Sort(IEnumerable<IContent> items, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Sorts documents.
         /// </summary>
-        bool Sort(IEnumerable<int> ids, int userId = -1, bool raiseEvents = true);
+        bool Sort(IEnumerable<int> ids, int userId = 0, bool raiseEvents = true);
 
         #endregion
 
@@ -349,22 +349,22 @@ namespace Umbraco.Core.Services
         /// Saves and publishes a document.
         /// </summary>
         /// <remarks>Property values must first be published at document level.</remarks>
-        PublishResult SaveAndPublish(IContent content, int userId = -1, bool raiseEvents = true);
+        PublishResult SaveAndPublish(IContent content, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Saves and publishes a document branch.
         /// </summary>
-        IEnumerable<PublishResult> SaveAndPublishBranch(IContent content, bool force, string culture = null, string segment = null, int userId = -1);
+        IEnumerable<PublishResult> SaveAndPublishBranch(IContent content, bool force, string culture = null, string segment = null, int userId = 0);
 
         /// <summary>
         /// Saves and publishes a document branch.
         /// </summary>
-        IEnumerable<PublishResult> SaveAndPublishBranch(IContent content, bool force, Func<IContent, bool> editing, Func<IContent, bool> publishValues, int userId = -1);
+        IEnumerable<PublishResult> SaveAndPublishBranch(IContent content, bool force, Func<IContent, bool> editing, Func<IContent, bool> publishValues, int userId = 0);
 
         /// <summary>
         /// Unpublishes a document or optionally unpublishes a culture and/or segment for the document.
         /// </summary>
-        UnpublishResult Unpublish(IContent content, string culture = null, string segment = null, int userId = -1);
+        UnpublishResult Unpublish(IContent content, string culture = null, string segment = null, int userId = 0);
 
         /// <summary>
         /// Gets a value indicating whether a document is path-publishable.
@@ -381,7 +381,7 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Saves a document and raises the "sent to publication" events.
         /// </summary>
-        bool SendToPublication(IContent content, int userId = -1);
+        bool SendToPublication(IContent content, int userId = 0);
 
         /// <summary>
         /// Publishes and unpublishes scheduled documents.
@@ -416,27 +416,27 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Creates a document.
         /// </summary>
-        IContent Create(string name, Guid parentId, string documentTypeAlias, int userId = -1);
+        IContent Create(string name, Guid parentId, string documentTypeAlias, int userId = 0);
 
         /// <summary>
         /// Creates a document.
         /// </summary>
-        IContent Create(string name, int parentId, string documentTypeAlias, int userId = -1);
+        IContent Create(string name, int parentId, string documentTypeAlias, int userId = 0);
 
         /// <summary>
         /// Creates a document.
         /// </summary>
-        IContent Create(string name, IContent parent, string documentTypeAlias, int userId = -1);
+        IContent Create(string name, IContent parent, string documentTypeAlias, int userId = 0);
 
         /// <summary>
         /// Creates and saves a document.
         /// </summary>
-        IContent CreateAndSave(string name, int parentId, string contentTypeAlias, int userId = -1);
+        IContent CreateAndSave(string name, int parentId, string contentTypeAlias, int userId = 0);
 
         /// <summary>
         /// Creates and saves a document.
         /// </summary>
-        IContent CreateAndSave(string name, IContent parent, string contentTypeAlias, int userId = -1);
+        IContent CreateAndSave(string name, IContent parent, string contentTypeAlias, int userId = 0);
 
         #endregion
     }

--- a/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
+++ b/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
@@ -25,11 +25,11 @@ namespace Umbraco.Core.Services
         IEnumerable<TItem> GetChildren(int id);
         bool HasChildren(int id);
 
-        void Save(TItem item, int userId = -1);
-        void Save(IEnumerable<TItem> items, int userId = -1);
+        void Save(TItem item, int userId = 0);
+        void Save(IEnumerable<TItem> items, int userId = 0);
 
-        void Delete(TItem item, int userId = -1);
-        void Delete(IEnumerable<TItem> item, int userId = -1);
+        void Delete(TItem item, int userId = 0);
+        void Delete(IEnumerable<TItem> item, int userId = 0);
 
 
         Attempt<string[]> ValidateComposition(TItem compo);
@@ -41,15 +41,15 @@ namespace Umbraco.Core.Services
         /// <returns></returns>
         bool HasContainerInPath(string contentPath);
 
-        Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentContainerId, string name, int userId = -1);
-        Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = -1);
+        Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentContainerId, string name, int userId = 0);
+        Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = 0);
         EntityContainer GetContainer(int containerId);
         EntityContainer GetContainer(Guid containerId);
         IEnumerable<EntityContainer> GetContainers(int[] containerIds);
         IEnumerable<EntityContainer> GetContainers(TItem contentType);
         IEnumerable<EntityContainer> GetContainers(string folderName, int level);
-        Attempt<OperationResult> DeleteContainer(int containerId, int userId = -1);
-        Attempt<OperationResult<OperationResultType, EntityContainer>> RenameContainer(int id, string name, int userId = -1);
+        Attempt<OperationResult> DeleteContainer(int containerId, int userId = 0);
+        Attempt<OperationResult<OperationResultType, EntityContainer>> RenameContainer(int id, string name, int userId = 0);
 
         Attempt<OperationResult<MoveOperationStatusType>> Move(TItem moving, int containerId);
         Attempt<OperationResult<MoveOperationStatusType, TItem>> Copy(TItem copying, int containerId);

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -9,15 +9,15 @@ namespace Umbraco.Core.Services
     /// </summary>
     public interface IDataTypeService : IService
     {
-        Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentId, string name, int userId = -1);
-        Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = -1);
+        Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentId, string name, int userId = 0);
+        Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = 0);
         EntityContainer GetContainer(int containerId);
         EntityContainer GetContainer(Guid containerId);
         IEnumerable<EntityContainer> GetContainers(string folderName, int level);
         IEnumerable<EntityContainer> GetContainers(IDataType dataType);
         IEnumerable<EntityContainer> GetContainers(int[] containerIds);
-        Attempt<OperationResult> DeleteContainer(int containerId, int userId = -1);
-        Attempt<OperationResult<OperationResultType, EntityContainer>> RenameContainer(int id, string name, int userId = -1);
+        Attempt<OperationResult> DeleteContainer(int containerId, int userId = 0);
+        Attempt<OperationResult<OperationResultType, EntityContainer>> RenameContainer(int id, string name, int userId = 0);
 
         /// <summary>
         /// Gets a <see cref="IDataType"/> by its Name
@@ -52,14 +52,14 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="dataType"><see cref="IDataType"/> to save</param>
         /// <param name="userId">Id of the user issueing the save</param>
-        void Save(IDataType dataType, int userId = -1);
+        void Save(IDataType dataType, int userId = 0);
 
         /// <summary>
         /// Saves a collection of <see cref="IDataType"/>
         /// </summary>
         /// <param name="dataTypeDefinitions"><see cref="IDataType"/> to save</param>
         /// <param name="userId">Id of the user issueing the save</param>
-        void Save(IEnumerable<IDataType> dataTypeDefinitions, int userId = -1);
+        void Save(IEnumerable<IDataType> dataTypeDefinitions, int userId = 0);
 
         /// <summary>
         /// Saves a collection of <see cref="IDataType"/>
@@ -78,7 +78,7 @@ namespace Umbraco.Core.Services
         /// </remarks>
         /// <param name="dataType"><see cref="IDataType"/> to delete</param>
         /// <param name="userId">Id of the user issueing the deletion</param>
-        void Delete(IDataType dataType, int userId = -1);
+        void Delete(IDataType dataType, int userId = 0);
 
         /// <summary>
         /// Gets a <see cref="IDataType"/> by its control Id

--- a/src/Umbraco.Core/Services/IFileService.cs
+++ b/src/Umbraco.Core/Services/IFileService.cs
@@ -18,12 +18,12 @@ namespace Umbraco.Core.Services
         IPartialView GetPartialView(string path);
         IPartialView GetPartialViewMacro(string path);
         IEnumerable<IPartialView> GetPartialViewMacros(params string[] names);
-        Attempt<IPartialView> CreatePartialView(IPartialView partialView, string snippetName = null, int userId = -1);
-        Attempt<IPartialView> CreatePartialViewMacro(IPartialView partialView, string snippetName = null, int userId = -1);
-        bool DeletePartialView(string path, int userId = -1);
-        bool DeletePartialViewMacro(string path, int userId = -1);
-        Attempt<IPartialView> SavePartialView(IPartialView partialView, int userId = -1);
-        Attempt<IPartialView> SavePartialViewMacro(IPartialView partialView, int userId = -1);
+        Attempt<IPartialView> CreatePartialView(IPartialView partialView, string snippetName = null, int userId = 0);
+        Attempt<IPartialView> CreatePartialViewMacro(IPartialView partialView, string snippetName = null, int userId = 0);
+        bool DeletePartialView(string path, int userId = 0);
+        bool DeletePartialViewMacro(string path, int userId = 0);
+        Attempt<IPartialView> SavePartialView(IPartialView partialView, int userId = 0);
+        Attempt<IPartialView> SavePartialViewMacro(IPartialView partialView, int userId = 0);
         bool ValidatePartialView(PartialView partialView);
         bool ValidatePartialViewMacro(PartialView partialView);
 
@@ -45,14 +45,14 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="stylesheet"><see cref="Stylesheet"/> to save</param>
         /// <param name="userId">Optional id of the user saving the stylesheet</param>
-        void SaveStylesheet(Stylesheet stylesheet, int userId = -1);
+        void SaveStylesheet(Stylesheet stylesheet, int userId = 0);
 
         /// <summary>
         /// Deletes a stylesheet by its name
         /// </summary>
         /// <param name="path">Name incl. extension of the Stylesheet to delete</param>
         /// <param name="userId">Optional id of the user deleting the stylesheet</param>
-        void DeleteStylesheet(string path, int userId = -1);
+        void DeleteStylesheet(string path, int userId = 0);
 
         /// <summary>
         /// Validates a <see cref="Stylesheet"/>
@@ -79,14 +79,14 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="script"><see cref="Script"/> to save</param>
         /// <param name="userId">Optional id of the user saving the script</param>
-        void SaveScript(Script script, int userId = -1);
+        void SaveScript(Script script, int userId = 0);
 
         /// <summary>
         /// Deletes a script by its name
         /// </summary>
         /// <param name="path">Name incl. extension of the Script to delete</param>
         /// <param name="userId">Optional id of the user deleting the script</param>
-        void DeleteScript(string path, int userId = -1);
+        void DeleteScript(string path, int userId = 0);
 
         /// <summary>
         /// Validates a <see cref="Script"/>
@@ -189,7 +189,7 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="template"><see cref="ITemplate"/> to save</param>
         /// <param name="userId">Optional id of the user saving the template</param>
-        void SaveTemplate(ITemplate template, int userId = -1);
+        void SaveTemplate(ITemplate template, int userId = 0);
 
         /// <summary>
         /// Creates a template for a content type
@@ -200,16 +200,16 @@ namespace Umbraco.Core.Services
         /// <returns>
         /// The template created
         /// </returns>
-        Attempt<OperationResult<OperationResultType, ITemplate>> CreateTemplateForContentType(string contentTypeAlias, string contentTypeName, int userId = -1);
+        Attempt<OperationResult<OperationResultType, ITemplate>> CreateTemplateForContentType(string contentTypeAlias, string contentTypeName, int userId = 0);
 
-        ITemplate CreateTemplateWithIdentity(string name, string content, ITemplate masterTemplate = null, int userId = -1);
+        ITemplate CreateTemplateWithIdentity(string name, string content, ITemplate masterTemplate = null, int userId = 0);
 
         /// <summary>
         /// Deletes a template by its alias
         /// </summary>
         /// <param name="alias">Alias of the <see cref="ITemplate"/> to delete</param>
         /// <param name="userId">Optional id of the user deleting the template</param>
-        void DeleteTemplate(string alias, int userId = -1);
+        void DeleteTemplate(string alias, int userId = 0);
 
         /// <summary>
         /// Validates a <see cref="ITemplate"/>
@@ -223,7 +223,7 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="templates">List of <see cref="Template"/> to save</param>
         /// <param name="userId">Optional id of the user</param>
-        void SaveTemplate(IEnumerable<ITemplate> templates, int userId = -1);
+        void SaveTemplate(IEnumerable<ITemplate> templates, int userId = 0);
 
         /// <summary>
         /// This checks what the default rendering engine is set in config but then also ensures that there isn't already

--- a/src/Umbraco.Core/Services/ILocalizationService.cs
+++ b/src/Umbraco.Core/Services/ILocalizationService.cs
@@ -86,7 +86,7 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="dictionaryItem"><see cref="IDictionaryItem"/> to save</param>
         /// <param name="userId">Optional id of the user saving the dictionary item</param>
-        void Save(IDictionaryItem dictionaryItem, int userId = -1);
+        void Save(IDictionaryItem dictionaryItem, int userId = 0);
 
         /// <summary>
         /// Deletes a <see cref="IDictionaryItem"/> object and its related translations
@@ -94,7 +94,7 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="dictionaryItem"><see cref="IDictionaryItem"/> to delete</param>
         /// <param name="userId">Optional id of the user deleting the dictionary item</param>
-        void Delete(IDictionaryItem dictionaryItem, int userId = -1);
+        void Delete(IDictionaryItem dictionaryItem, int userId = 0);
 
         /// <summary>
         /// Gets a <see cref="ILanguage"/> by its id
@@ -153,14 +153,14 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="language"><see cref="ILanguage"/> to save</param>
         /// <param name="userId">Optional id of the user saving the language</param>
-        void Save(ILanguage language, int userId = -1);
+        void Save(ILanguage language, int userId = 0);
 
         /// <summary>
         /// Deletes a <see cref="ILanguage"/> by removing it and its usages from the db
         /// </summary>
         /// <param name="language"><see cref="ILanguage"/> to delete</param>
         /// <param name="userId">Optional id of the user deleting the language</param>
-        void Delete(ILanguage language, int userId = -1);
+        void Delete(ILanguage language, int userId = 0);
 
         /// <summary>
         /// Gets the full dictionary key map.

--- a/src/Umbraco.Core/Services/IMacroService.cs
+++ b/src/Umbraco.Core/Services/IMacroService.cs
@@ -39,14 +39,14 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="macro"><see cref="IMacro"/> to delete</param>
         /// <param name="userId">Optional id of the user deleting the macro</param>
-        void Delete(IMacro macro, int userId = -1);
+        void Delete(IMacro macro, int userId = 0);
 
         /// <summary>
         /// Saves an <see cref="IMacro"/>
         /// </summary>
         /// <param name="macro"><see cref="IMacro"/> to save</param>
         /// <param name="userId">Optional id of the user saving the macro</param>
-        void Save(IMacro macro, int userId = -1);
+        void Save(IMacro macro, int userId = 0);
 
         ///// <summary>
         ///// Gets a list all available <see cref="IMacroPropertyType"/> plugins

--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="media">The <see cref="IMedia"/> to delete</param>
         /// <param name="userId">Id of the User deleting the Media</param>
-        Attempt<OperationResult> MoveToRecycleBin(IMedia media, int userId = -1);
+        Attempt<OperationResult> MoveToRecycleBin(IMedia media, int userId = 0);
 
         /// <summary>
         /// Permanently deletes an <see cref="IMedia"/> object
@@ -36,7 +36,7 @@ namespace Umbraco.Core.Services
         /// </remarks>
         /// <param name="media">The <see cref="IMedia"/> to delete</param>
         /// <param name="userId">Id of the User deleting the Media</param>
-        Attempt<OperationResult> Delete(IMedia media, int userId = -1);
+        Attempt<OperationResult> Delete(IMedia media, int userId = 0);
 
         /// <summary>
         /// Saves a single <see cref="IMedia"/> object
@@ -44,7 +44,7 @@ namespace Umbraco.Core.Services
         /// <param name="media">The <see cref="IMedia"/> to save</param>
         /// <param name="userId">Id of the User saving the Media</param>
         /// <param name="raiseEvents">Optional boolean indicating whether or not to raise events.</param>
-        Attempt<OperationResult> Save(IMedia media, int userId = -1, bool raiseEvents = true);
+        Attempt<OperationResult> Save(IMedia media, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Saves a collection of <see cref="IMedia"/> objects
@@ -52,7 +52,7 @@ namespace Umbraco.Core.Services
         /// <param name="medias">Collection of <see cref="IMedia"/> to save</param>
         /// <param name="userId">Id of the User saving the Media</param>
         /// <param name="raiseEvents">Optional boolean indicating whether or not to raise events.</param>
-        Attempt<OperationResult> Save(IEnumerable<IMedia> medias, int userId = -1, bool raiseEvents = true);
+        Attempt<OperationResult> Save(IEnumerable<IMedia> medias, int userId = 0, bool raiseEvents = true);
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ namespace Umbraco.Core.Services
         /// <param name="mediaTypeAlias">Alias of the <see cref="IMediaType"/></param>
         /// <param name="userId">Optional id of the user creating the media item</param>
         /// <returns><see cref="IMedia"/></returns>
-        IMedia CreateMedia(string name, Guid parentId, string mediaTypeAlias, int userId = -1);
+        IMedia CreateMedia(string name, Guid parentId, string mediaTypeAlias, int userId = 0);
 
         /// <summary>
         /// Creates an <see cref="IMedia"/> object using the alias of the <see cref="IMediaType"/>
@@ -98,7 +98,7 @@ namespace Umbraco.Core.Services
         /// <param name="mediaTypeAlias">Alias of the <see cref="IMediaType"/></param>
         /// <param name="userId">Optional id of the user creating the media item</param>
         /// <returns><see cref="IMedia"/></returns>
-        IMedia CreateMedia(string name, int parentId, string mediaTypeAlias, int userId = -1);
+        IMedia CreateMedia(string name, int parentId, string mediaTypeAlias, int userId = 0);
 
         /// <summary>
         /// Creates an <see cref="IMedia"/> object using the alias of the <see cref="IMediaType"/>
@@ -114,7 +114,7 @@ namespace Umbraco.Core.Services
         /// <param name="mediaTypeAlias">Alias of the <see cref="IMediaType"/></param>
         /// <param name="userId">Optional id of the user creating the media item</param>
         /// <returns><see cref="IMedia"/></returns>
-        IMedia CreateMedia(string name, IMedia parent, string mediaTypeAlias, int userId = -1);
+        IMedia CreateMedia(string name, IMedia parent, string mediaTypeAlias, int userId = 0);
 
         /// <summary>
         /// Gets an <see cref="IMedia"/> object by Id
@@ -236,14 +236,14 @@ namespace Umbraco.Core.Services
         /// <param name="media">The <see cref="IMedia"/> to move</param>
         /// <param name="parentId">Id of the Media's new Parent</param>
         /// <param name="userId">Id of the User moving the Media</param>
-        void Move(IMedia media, int parentId, int userId = -1);
+        void Move(IMedia media, int parentId, int userId = 0);
 
         /// <summary>
         /// Deletes an <see cref="IMedia"/> object by moving it to the Recycle Bin
         /// </summary>
         /// <param name="media">The <see cref="IMedia"/> to delete</param>
         /// <param name="userId">Id of the User deleting the Media</param>
-        void MoveToRecycleBin(IMedia media, int userId = -1);
+        void MoveToRecycleBin(IMedia media, int userId = 0);
 
         /// <summary>
         /// Empties the Recycle Bin by deleting all <see cref="IMedia"/> that resides in the bin
@@ -256,7 +256,7 @@ namespace Umbraco.Core.Services
         /// <remarks>This needs extra care and attention as its potentially a dangerous and extensive operation</remarks>
         /// <param name="mediaTypeId">Id of the <see cref="IMediaType"/></param>
         /// <param name="userId">Optional Id of the user deleting Media</param>
-        void DeleteMediaOfType(int mediaTypeId, int userId = -1);
+        void DeleteMediaOfType(int mediaTypeId, int userId = 0);
 
         /// <summary>
         /// Deletes all media of the specified types. All Descendants of deleted media that is not of these types is moved to Recycle Bin.
@@ -264,7 +264,7 @@ namespace Umbraco.Core.Services
         /// <remarks>This needs extra care and attention as its potentially a dangerous and extensive operation</remarks>
         /// <param name="mediaTypeIds">Ids of the <see cref="IMediaType"/>s</param>
         /// <param name="userId">Optional Id of the user issueing the delete operation</param>
-        void DeleteMediaOfTypes(IEnumerable<int> mediaTypeIds, int userId = -1);
+        void DeleteMediaOfTypes(IEnumerable<int> mediaTypeIds, int userId = 0);
 
         /// <summary>
         /// Permanently deletes an <see cref="IMedia"/> object
@@ -275,7 +275,7 @@ namespace Umbraco.Core.Services
         /// </remarks>
         /// <param name="media">The <see cref="IMedia"/> to delete</param>
         /// <param name="userId">Id of the User deleting the Media</param>
-        void Delete(IMedia media, int userId = -1);
+        void Delete(IMedia media, int userId = 0);
 
         /// <summary>
         /// Saves a single <see cref="IMedia"/> object
@@ -283,7 +283,7 @@ namespace Umbraco.Core.Services
         /// <param name="media">The <see cref="IMedia"/> to save</param>
         /// <param name="userId">Id of the User saving the Media</param>
         /// <param name="raiseEvents">Optional boolean indicating whether or not to raise events.</param>
-        void Save(IMedia media, int userId = -1, bool raiseEvents = true);
+        void Save(IMedia media, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Saves a collection of <see cref="IMedia"/> objects
@@ -291,7 +291,7 @@ namespace Umbraco.Core.Services
         /// <param name="medias">Collection of <see cref="IMedia"/> to save</param>
         /// <param name="userId">Id of the User saving the Media</param>
         /// <param name="raiseEvents">Optional boolean indicating whether or not to raise events.</param>
-        void Save(IEnumerable<IMedia> medias, int userId = -1, bool raiseEvents = true);
+        void Save(IEnumerable<IMedia> medias, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Gets an <see cref="IMedia"/> object by its 'UniqueId'
@@ -334,7 +334,7 @@ namespace Umbraco.Core.Services
         /// <param name="id">Id of the <see cref="IMedia"/> object to delete versions from</param>
         /// <param name="versionDate">Latest version date</param>
         /// <param name="userId">Optional Id of the User deleting versions of a Content object</param>
-        void DeleteVersions(int id, DateTime versionDate, int userId = -1);
+        void DeleteVersions(int id, DateTime versionDate, int userId = 0);
 
         /// <summary>
         /// Permanently deletes specific version(s) from an <see cref="IMedia"/> object.
@@ -343,7 +343,7 @@ namespace Umbraco.Core.Services
         /// <param name="versionId">Id of the version to delete</param>
         /// <param name="deletePriorVersions">Boolean indicating whether to delete versions prior to the versionId</param>
         /// <param name="userId">Optional Id of the User deleting versions of a Content object</param>
-        void DeleteVersion(int id, int versionId, bool deletePriorVersions, int userId = -1);
+        void DeleteVersion(int id, int versionId, bool deletePriorVersions, int userId = 0);
 
         /// <summary>
         /// Gets an <see cref="IMedia"/> object from the path stored in the 'umbracoFile' property.
@@ -395,7 +395,7 @@ namespace Umbraco.Core.Services
         /// <param name="userId"></param>
         /// <param name="raiseEvents"></param>
         /// <returns>True if sorting succeeded, otherwise False</returns>
-        bool Sort(IEnumerable<IMedia> items, int userId = -1, bool raiseEvents = true);
+        bool Sort(IEnumerable<IMedia> items, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Creates an <see cref="IMedia"/> object using the alias of the <see cref="IMediaType"/>
@@ -410,7 +410,7 @@ namespace Umbraco.Core.Services
         /// <param name="mediaTypeAlias">Alias of the <see cref="IMediaType"/></param>
         /// <param name="userId">Optional id of the user creating the media item</param>
         /// <returns><see cref="IMedia"/></returns>
-        IMedia CreateMediaWithIdentity(string name, IMedia parent, string mediaTypeAlias, int userId = -1);
+        IMedia CreateMediaWithIdentity(string name, IMedia parent, string mediaTypeAlias, int userId = 0);
 
         /// <summary>
         /// Creates an <see cref="IMedia"/> object using the alias of the <see cref="IMediaType"/>
@@ -425,7 +425,7 @@ namespace Umbraco.Core.Services
         /// <param name="mediaTypeAlias">Alias of the <see cref="IMediaType"/></param>
         /// <param name="userId">Optional id of the user creating the media item</param>
         /// <returns><see cref="IMedia"/></returns>
-        IMedia CreateMediaWithIdentity(string name, int parentId, string mediaTypeAlias, int userId = -1);
+        IMedia CreateMediaWithIdentity(string name, int parentId, string mediaTypeAlias, int userId = 0);
 
         /// <summary>
         /// Gets the content of a media as a stream.

--- a/src/Umbraco.Core/Services/IPackagingService.cs
+++ b/src/Umbraco.Core/Services/IPackagingService.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Core.Services
         /// <param name="userId">Optional Id of the user performing the import</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumrable list of generated content</returns>
-        IEnumerable<IContent> ImportContent(XElement element, int parentId = -1, int userId = -1, bool raiseEvents = true);
+        IEnumerable<IContent> ImportContent(XElement element, int parentId = -1, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Imports and saves package xml as <see cref="IContentType"/>
@@ -24,7 +24,7 @@ namespace Umbraco.Core.Services
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin)</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumrable list of generated ContentTypes</returns>
-        IEnumerable<IContentType> ImportContentTypes(XElement element, int userId = -1, bool raiseEvents = true);
+        IEnumerable<IContentType> ImportContentTypes(XElement element, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Imports and saves package xml as <see cref="IContentType"/>
@@ -34,7 +34,7 @@ namespace Umbraco.Core.Services
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin)</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumrable list of generated ContentTypes</returns>
-        IEnumerable<IContentType> ImportContentTypes(XElement element, bool importStructure, int userId = -1, bool raiseEvents = true);
+        IEnumerable<IContentType> ImportContentTypes(XElement element, bool importStructure, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Imports and saves package xml as <see cref="IDataType"/>
@@ -43,7 +43,7 @@ namespace Umbraco.Core.Services
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin).</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumrable list of generated DataTypeDefinitions</returns>
-        IEnumerable<IDataType> ImportDataTypeDefinitions(XElement element, int userId = -1, bool raiseEvents = true);
+        IEnumerable<IDataType> ImportDataTypeDefinitions(XElement element, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Imports and saves the 'DictionaryItems' part of the package xml as a list of <see cref="IDictionaryItem"/>
@@ -60,7 +60,7 @@ namespace Umbraco.Core.Services
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin)</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumerable list of generated languages</returns>
-        IEnumerable<ILanguage> ImportLanguages(XElement languageElementList, int userId = -1, bool raiseEvents = true);
+        IEnumerable<ILanguage> ImportLanguages(XElement languageElementList, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Imports and saves the 'Macros' part of a package xml as a list of <see cref="IMacro"/>
@@ -69,7 +69,7 @@ namespace Umbraco.Core.Services
         /// <param name="userId">Optional id of the User performing the operation</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns></returns>
-        IEnumerable<IMacro> ImportMacros(XElement element, int userId = -1, bool raiseEvents = true);
+        IEnumerable<IMacro> ImportMacros(XElement element, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Imports and saves package xml as <see cref="ITemplate"/>
@@ -78,7 +78,7 @@ namespace Umbraco.Core.Services
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin)</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumrable list of generated Templates</returns>
-        IEnumerable<ITemplate> ImportTemplates(XElement element, int userId = -1, bool raiseEvents = true);
+        IEnumerable<ITemplate> ImportTemplates(XElement element, int userId = 0, bool raiseEvents = true);
 
         /// <summary>
         /// Exports an <see cref="IContentType"/> to xml as an <see cref="XElement"/>

--- a/src/Umbraco.Core/Services/Implement/AuditService.cs
+++ b/src/Umbraco.Core/Services/Implement/AuditService.cs
@@ -159,7 +159,7 @@ namespace Umbraco.Core.Services.Implement
         /// <inheritdoc />
         public IAuditEntry Write(int performingUserId, string perfomingDetails, string performingIp, DateTime eventDateUtc, int affectedUserId, string affectedDetails, string eventType, string eventDetails)
         {
-            if (performingUserId < 0 && performingUserId != Constants.Security.SuperId) throw new ArgumentOutOfRangeException(nameof(performingUserId));
+            if (performingUserId < 0 && performingUserId != Constants.Security.SuperUserId) throw new ArgumentOutOfRangeException(nameof(performingUserId));
             if (string.IsNullOrWhiteSpace(perfomingDetails)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(perfomingDetails));
             if (string.IsNullOrWhiteSpace(eventType)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(eventType));
             if (string.IsNullOrWhiteSpace(eventDetails)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(eventDetails));

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -162,7 +162,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="contentTypeAlias">Alias of the <see cref="IContentType"/></param>
         /// <param name="userId">Optional id of the user creating the content</param>
         /// <returns><see cref="IContent"/></returns>
-        public IContent Create(string name, Guid parentId, string contentTypeAlias, int userId = -1)
+        public IContent Create(string name, Guid parentId, string contentTypeAlias, int userId = 0)
         {
             //fixme - what about culture?
 
@@ -182,7 +182,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="contentTypeAlias">The alias of the content type.</param>
         /// <param name="userId">The optional id of the user creating the content.</param>
         /// <returns>The content object.</returns>
-        public IContent Create(string name, int parentId, string contentTypeAlias, int userId = -1)
+        public IContent Create(string name, int parentId, string contentTypeAlias, int userId = 0)
         {
             //fixme - what about culture?
 
@@ -215,7 +215,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="contentTypeAlias">The alias of the content type.</param>
         /// <param name="userId">The optional id of the user creating the content.</param>
         /// <returns>The content object.</returns>
-        public IContent Create(string name, IContent parent, string contentTypeAlias, int userId = -1)
+        public IContent Create(string name, IContent parent, string contentTypeAlias, int userId = 0)
         {
             //fixme - what about culture?
 
@@ -246,7 +246,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="contentTypeAlias">The alias of the content type.</param>
         /// <param name="userId">The optional id of the user creating the content.</param>
         /// <returns>The content object.</returns>
-        public IContent CreateAndSave(string name, int parentId, string contentTypeAlias, int userId = -1)
+        public IContent CreateAndSave(string name, int parentId, string contentTypeAlias, int userId = 0)
         {
             //fixme - what about culture?
 
@@ -280,7 +280,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="contentTypeAlias">The alias of the content type.</param>
         /// <param name="userId">The optional id of the user creating the content.</param>
         /// <returns>The content object.</returns>
-        public IContent CreateAndSave(string name, IContent parent, string contentTypeAlias, int userId = -1)
+        public IContent CreateAndSave(string name, IContent parent, string contentTypeAlias, int userId = 0)
         {
             //fixme - what about culture?
 
@@ -858,7 +858,7 @@ namespace Umbraco.Core.Services.Implement
         // fixme - kill all those raiseEvents
 
         /// <inheritdoc />
-        public OperationResult Save(IContent content, int userId = -1, bool raiseEvents = true)
+        public OperationResult Save(IContent content, int userId = 0, bool raiseEvents = true)
         {
             var publishedState = content.PublishedState;
             if (publishedState != PublishedState.Published && publishedState != PublishedState.Unpublished)
@@ -900,7 +900,7 @@ namespace Umbraco.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public OperationResult Save(IEnumerable<IContent> contents, int userId = -1, bool raiseEvents = true)
+        public OperationResult Save(IEnumerable<IContent> contents, int userId = 0, bool raiseEvents = true)
         {
             var evtMsgs = EventMessagesFactory.Get();
             var contentsA = contents.ToArray();
@@ -942,7 +942,7 @@ namespace Umbraco.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public PublishResult SaveAndPublish(IContent content, int userId = -1, bool raiseEvents = true)
+        public PublishResult SaveAndPublish(IContent content, int userId = 0, bool raiseEvents = true)
         {
             var evtMsgs = EventMessagesFactory.Get();
             PublishResult result;
@@ -1026,7 +1026,7 @@ namespace Umbraco.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public UnpublishResult Unpublish(IContent content, string culture = null, string segment = null, int userId = -1)
+        public UnpublishResult Unpublish(IContent content, string culture = null, string segment = null, int userId = 0)
         {
             var evtMsgs = EventMessagesFactory.Get();
 
@@ -1189,7 +1189,7 @@ namespace Umbraco.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public IEnumerable<PublishResult> SaveAndPublishBranch(IContent content, bool force, string culture = null, string segment = null, int userId = -1)
+        public IEnumerable<PublishResult> SaveAndPublishBranch(IContent content, bool force, string culture = null, string segment = null, int userId = 0)
         {
             segment = segment?.ToLowerInvariant();
 
@@ -1201,7 +1201,7 @@ namespace Umbraco.Core.Services.Implement
 
         /// <inheritdoc />
         public IEnumerable<PublishResult> SaveAndPublishBranch(IContent document, bool force,
-            Func<IContent, bool> editing, Func<IContent, bool> publishValues, int userId = -1)
+            Func<IContent, bool> editing, Func<IContent, bool> publishValues, int userId = 0)
         {
             var evtMsgs = EventMessagesFactory.Get();
             var results = new List<PublishResult>();
@@ -1372,7 +1372,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="id">Id of the <see cref="IContent"/> object to delete versions from</param>
         /// <param name="versionDate">Latest version date</param>
         /// <param name="userId">Optional Id of the User deleting versions of a Content object</param>
-        public void DeleteVersions(int id, DateTime versionDate, int userId = -1)
+        public void DeleteVersions(int id, DateTime versionDate, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -1402,7 +1402,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="versionId">Id of the version to delete</param>
         /// <param name="deletePriorVersions">Boolean indicating whether to delete versions prior to the versionId</param>
         /// <param name="userId">Optional Id of the User deleting versions of a Content object</param>
-        public void DeleteVersion(int id, int versionId, bool deletePriorVersions, int userId = -1)
+        public void DeleteVersion(int id, int versionId, bool deletePriorVersions, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -1489,7 +1489,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="content">The <see cref="IContent"/> to move</param>
         /// <param name="parentId">Id of the Content's new Parent</param>
         /// <param name="userId">Optional Id of the User moving the Content</param>
-        public void Move(IContent content, int parentId, int userId = -1)
+        public void Move(IContent content, int parentId, int userId = 0)
         {
             // if moving to the recycle bin then use the proper method
             if (parentId == Constants.System.RecycleBinContent)
@@ -1660,7 +1660,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="relateToOriginal">Boolean indicating whether the copy should be related to the original</param>
         /// <param name="userId">Optional Id of the User copying the Content</param>
         /// <returns>The newly created <see cref="IContent"/> object</returns>
-        public IContent Copy(IContent content, int parentId, bool relateToOriginal, int userId = -1)
+        public IContent Copy(IContent content, int parentId, bool relateToOriginal, int userId = 0)
         {
             return Copy(content, parentId, relateToOriginal, true, userId);
         }
@@ -1675,7 +1675,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="recursive">A value indicating whether to recursively copy children.</param>
         /// <param name="userId">Optional Id of the User copying the Content</param>
         /// <returns>The newly created <see cref="IContent"/> object</returns>
-        public IContent Copy(IContent content, int parentId, bool relateToOriginal, bool recursive, int userId = -1)
+        public IContent Copy(IContent content, int parentId, bool relateToOriginal, bool recursive, int userId = 0)
         {
             var copy = content.DeepCloneWithResetIdentities();
             copy.ParentId = parentId;
@@ -1771,7 +1771,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="content">The <see cref="IContent"/> to send to publication</param>
         /// <param name="userId">Optional Id of the User issueing the send to publication</param>
         /// <returns>True if sending publication was succesfull otherwise false</returns>
-        public bool SendToPublication(IContent content, int userId = -1)
+        public bool SendToPublication(IContent content, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -1806,7 +1806,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="userId"></param>
         /// <param name="raiseEvents"></param>
         /// <returns>True if sorting succeeded, otherwise False</returns>
-        public bool Sort(IEnumerable<IContent> items, int userId = -1, bool raiseEvents = true)
+        public bool Sort(IEnumerable<IContent> items, int userId = 0, bool raiseEvents = true)
         {
             var itemsA = items.ToArray();
             if (itemsA.Length == 0) return true;
@@ -1833,7 +1833,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="userId"></param>
         /// <param name="raiseEvents"></param>
         /// <returns>True if sorting succeeded, otherwise False</returns>
-        public bool Sort(IEnumerable<int> ids, int userId = -1, bool raiseEvents = true)
+        public bool Sort(IEnumerable<int> ids, int userId = 0, bool raiseEvents = true)
         {
             var idsA = ids.ToArray();
             if (idsA.Length == 0) return true;
@@ -2211,7 +2211,7 @@ namespace Umbraco.Core.Services.Implement
         /// </remarks>
         /// <param name="contentTypeId">Id of the <see cref="IContentType"/></param>
         /// <param name="userId">Optional Id of the user issueing the delete operation</param>
-        public void DeleteOfTypes(IEnumerable<int> contentTypeIds, int userId = -1)
+        public void DeleteOfTypes(IEnumerable<int> contentTypeIds, int userId = 0)
         {
             //TODO: This currently this is called from the ContentTypeService but that needs to change,
             // if we are deleting a content type, we should just delete the data and do this operation slightly differently.
@@ -2287,7 +2287,7 @@ namespace Umbraco.Core.Services.Implement
         /// <remarks>This needs extra care and attention as its potentially a dangerous and extensive operation</remarks>
         /// <param name="contentTypeId">Id of the <see cref="IContentType"/></param>
         /// <param name="userId">Optional id of the user deleting the media</param>
-        public void DeleteOfType(int contentTypeId, int userId = -1)
+        public void DeleteOfType(int contentTypeId, int userId = 0)
         {
             DeleteOfTypes(new[] { contentTypeId }, userId);
         }
@@ -2345,7 +2345,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public void SaveBlueprint(IContent content, int userId = -1)
+        public void SaveBlueprint(IContent content, int userId = 0)
         {
             //always ensure the blueprint is at the root
             if (content.ParentId != -1)
@@ -2376,7 +2376,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public void DeleteBlueprint(IContent content, int userId = -1)
+        public void DeleteBlueprint(IContent content, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -2387,7 +2387,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public IContent CreateContentFromBlueprint(IContent blueprint, string name, int userId = -1)
+        public IContent CreateContentFromBlueprint(IContent blueprint, string name, int userId = 0)
         {
             if (blueprint == null) throw new ArgumentNullException(nameof(blueprint));
 
@@ -2421,7 +2421,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public void DeleteBlueprintsOfTypes(IEnumerable<int> contentTypeIds, int userId = -1)
+        public void DeleteBlueprintsOfTypes(IEnumerable<int> contentTypeIds, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -2448,7 +2448,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public void DeleteBlueprintsOfType(int contentTypeId, int userId = -1)
+        public void DeleteBlueprintsOfType(int contentTypeId, int userId = 0)
         {
             DeleteBlueprintsOfTypes(new[] { contentTypeId }, userId);
         }

--- a/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -377,7 +377,7 @@ namespace Umbraco.Core.Services.Implement
 
         #region Save
 
-        public void Save(TItem item, int userId = -1)
+        public void Save(TItem item, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -415,7 +415,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public void Save(IEnumerable<TItem> items, int userId = -1)
+        public void Save(IEnumerable<TItem> items, int userId = 0)
         {
             var itemsA = items.ToArray();
 
@@ -461,7 +461,7 @@ namespace Umbraco.Core.Services.Implement
 
         #region Delete
 
-        public void Delete(TItem item, int userId = -1)
+        public void Delete(TItem item, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -515,7 +515,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public void Delete(IEnumerable<TItem> items, int userId = -1)
+        public void Delete(IEnumerable<TItem> items, int userId = 0)
         {
             var itemsA = items.ToArray();
 
@@ -736,7 +736,7 @@ namespace Umbraco.Core.Services.Implement
 
         protected Guid ContainerObjectType => EntityContainer.GetContainerObjectType(ContainedObjectType);
 
-        public Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentId, string name, int userId = -1)
+        public Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentId, string name, int userId = 0)
         {
             var evtMsgs = EventMessagesFactory.Get();
             using (var scope = ScopeProvider.CreateScope())
@@ -776,7 +776,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = -1)
+        public Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = 0)
         {
             var evtMsgs = EventMessagesFactory.Get();
 
@@ -870,7 +870,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public Attempt<OperationResult> DeleteContainer(int containerId, int userId = -1)
+        public Attempt<OperationResult> DeleteContainer(int containerId, int userId = 0)
         {
             var evtMsgs = EventMessagesFactory.Get();
             using (var scope = ScopeProvider.CreateScope())
@@ -907,7 +907,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public Attempt<OperationResult<OperationResultType, EntityContainer>> RenameContainer(int id, string name, int userId = -1)
+        public Attempt<OperationResult<OperationResultType, EntityContainer>> RenameContainer(int id, string name, int userId = 0)
         {
             var evtMsgs = EventMessagesFactory.Get();
             using (var scope = ScopeProvider.CreateScope())

--- a/src/Umbraco.Core/Services/Implement/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/Implement/DataTypeService.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Core.Services.Implement
 
         #region Containers
 
-        public Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentId, string name, int userId = -1)
+        public Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentId, string name, int userId = 0)
         {
             var evtMsgs = EventMessagesFactory.Get();
             using (var scope = ScopeProvider.CreateScope())
@@ -119,7 +119,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = -1)
+        public Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = 0)
         {
             var evtMsgs = EventMessagesFactory.Get();
 
@@ -153,7 +153,7 @@ namespace Umbraco.Core.Services.Implement
             return OperationResult.Attempt.Succeed(evtMsgs);
         }
 
-        public Attempt<OperationResult> DeleteContainer(int containerId, int userId = -1)
+        public Attempt<OperationResult> DeleteContainer(int containerId, int userId = 0)
         {
             var evtMsgs = EventMessagesFactory.Get();
             using (var scope = ScopeProvider.CreateScope())
@@ -186,7 +186,7 @@ namespace Umbraco.Core.Services.Implement
             return OperationResult.Attempt.Succeed(evtMsgs);
         }
 
-        public Attempt<OperationResult<OperationResultType, EntityContainer>> RenameContainer(int id, string name, int userId = -1)
+        public Attempt<OperationResult<OperationResultType, EntityContainer>> RenameContainer(int id, string name, int userId = 0)
         {
             var evtMsgs = EventMessagesFactory.Get();
             using (var scope = ScopeProvider.CreateScope())
@@ -331,7 +331,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="dataType"><see cref="IDataType"/> to save</param>
         /// <param name="userId">Id of the user issueing the save</param>
-        public void Save(IDataType dataType, int userId = -1)
+        public void Save(IDataType dataType, int userId = 0)
         {
             dataType.CreatorId = userId;
 
@@ -363,7 +363,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="dataTypeDefinitions"><see cref="IDataType"/> to save</param>
         /// <param name="userId">Id of the user issueing the save</param>
-        public void Save(IEnumerable<IDataType> dataTypeDefinitions, int userId = -1)
+        public void Save(IEnumerable<IDataType> dataTypeDefinitions, int userId = 0)
         {
             Save(dataTypeDefinitions, userId, true);
         }
@@ -413,7 +413,7 @@ namespace Umbraco.Core.Services.Implement
         /// </remarks>
         /// <param name="dataType"><see cref="IDataType"/> to delete</param>
         /// <param name="userId">Optional Id of the user issueing the deletion</param>
-        public void Delete(IDataType dataType, int userId = -1)
+        public void Delete(IDataType dataType, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {

--- a/src/Umbraco.Core/Services/Implement/EntityService.cs
+++ b/src/Umbraco.Core/Services/Implement/EntityService.cs
@@ -604,7 +604,7 @@ namespace Umbraco.Core.Services.Implement
                     NodeObjectType = Constants.ObjectTypes.IdReservation,
 
                     CreateDate = DateTime.Now,
-                    UserId = -1,
+                    UserId = null,
                     ParentId = -1,
                     Level = 1,
                     Path = "-1",

--- a/src/Umbraco.Core/Services/Implement/FileService.cs
+++ b/src/Umbraco.Core/Services/Implement/FileService.cs
@@ -75,7 +75,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="stylesheet"><see cref="Stylesheet"/> to save</param>
         /// <param name="userId"></param>
-        public void SaveStylesheet(Stylesheet stylesheet, int userId = -1)
+        public void SaveStylesheet(Stylesheet stylesheet, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -101,7 +101,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="path">Name incl. extension of the Stylesheet to delete</param>
         /// <param name="userId"></param>
-        public void DeleteStylesheet(string path, int userId = -1)
+        public void DeleteStylesheet(string path, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -200,7 +200,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="script"><see cref="Script"/> to save</param>
         /// <param name="userId"></param>
-        public void SaveScript(Script script, int userId = -1)
+        public void SaveScript(Script script, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -225,7 +225,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="path">Name incl. extension of the Script to delete</param>
         /// <param name="userId"></param>
-        public void DeleteScript(string path, int userId = -1)
+        public void DeleteScript(string path, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -321,7 +321,7 @@ namespace Umbraco.Core.Services.Implement
         /// <returns>
         /// The template created
         /// </returns>
-        public Attempt<OperationResult<OperationResultType, ITemplate>> CreateTemplateForContentType(string contentTypeAlias, string contentTypeName, int userId = -1)
+        public Attempt<OperationResult<OperationResultType, ITemplate>> CreateTemplateForContentType(string contentTypeAlias, string contentTypeName, int userId = 0)
         {
             var template = new Template(contentTypeName,
                 //NOTE: We are NOT passing in the content type alias here, we want to use it's name since we don't
@@ -362,7 +362,7 @@ namespace Umbraco.Core.Services.Implement
             return OperationResult.Attempt.Succeed<OperationResultType, ITemplate>(OperationResultType.Success, evtMsgs, template);
         }
 
-        public ITemplate CreateTemplateWithIdentity(string name, string content, ITemplate masterTemplate = null, int userId = -1)
+        public ITemplate CreateTemplateWithIdentity(string name, string content, ITemplate masterTemplate = null, int userId = 0)
         {
             var template = new Template(name, name)
             {
@@ -523,7 +523,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="template"><see cref="Template"/> to save</param>
         /// <param name="userId"></param>
-        public void SaveTemplate(ITemplate template, int userId = -1)
+        public void SaveTemplate(ITemplate template, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -547,7 +547,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="templates">List of <see cref="Template"/> to save</param>
         /// <param name="userId">Optional id of the user</param>
-        public void SaveTemplate(IEnumerable<ITemplate> templates, int userId = -1)
+        public void SaveTemplate(IEnumerable<ITemplate> templates, int userId = 0)
         {
             var templatesA = templates.ToArray();
             using (var scope = ScopeProvider.CreateScope())
@@ -594,7 +594,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="alias">Alias of the <see cref="ITemplate"/> to delete</param>
         /// <param name="userId"></param>
-        public void DeleteTemplate(string alias, int userId = -1)
+        public void DeleteTemplate(string alias, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -722,17 +722,17 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public Attempt<IPartialView> CreatePartialView(IPartialView partialView, string snippetName = null, int userId = -1)
+        public Attempt<IPartialView> CreatePartialView(IPartialView partialView, string snippetName = null, int userId = 0)
         {
             return CreatePartialViewMacro(partialView, PartialViewType.PartialView, snippetName, userId);
         }
 
-        public Attempt<IPartialView> CreatePartialViewMacro(IPartialView partialView, string snippetName = null, int userId = -1)
+        public Attempt<IPartialView> CreatePartialViewMacro(IPartialView partialView, string snippetName = null, int userId = 0)
         {
             return CreatePartialViewMacro(partialView, PartialViewType.PartialViewMacro, snippetName, userId);
         }
 
-        private Attempt<IPartialView> CreatePartialViewMacro(IPartialView partialView, PartialViewType partialViewType, string snippetName = null, int userId = -1)
+        private Attempt<IPartialView> CreatePartialViewMacro(IPartialView partialView, PartialViewType partialViewType, string snippetName = null, int userId = 0)
         {
             string partialViewHeader;
             switch (partialViewType)
@@ -792,17 +792,17 @@ namespace Umbraco.Core.Services.Implement
             return Attempt<IPartialView>.Succeed(partialView);
         }
 
-        public bool DeletePartialView(string path, int userId = -1)
+        public bool DeletePartialView(string path, int userId = 0)
         {
             return DeletePartialViewMacro(path, PartialViewType.PartialView, userId);
         }
 
-        public bool DeletePartialViewMacro(string path, int userId = -1)
+        public bool DeletePartialViewMacro(string path, int userId = 0)
         {
             return DeletePartialViewMacro(path, PartialViewType.PartialViewMacro, userId);
         }
 
-        private bool DeletePartialViewMacro(string path, PartialViewType partialViewType, int userId = -1)
+        private bool DeletePartialViewMacro(string path, PartialViewType partialViewType, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -832,17 +832,17 @@ namespace Umbraco.Core.Services.Implement
             return true;
         }
 
-        public Attempt<IPartialView> SavePartialView(IPartialView partialView, int userId = -1)
+        public Attempt<IPartialView> SavePartialView(IPartialView partialView, int userId = 0)
         {
             return SavePartialView(partialView, PartialViewType.PartialView, userId);
         }
 
-        public Attempt<IPartialView> SavePartialViewMacro(IPartialView partialView, int userId = -1)
+        public Attempt<IPartialView> SavePartialViewMacro(IPartialView partialView, int userId = 0)
         {
             return SavePartialView(partialView, PartialViewType.PartialViewMacro, userId);
         }
 
-        private Attempt<IPartialView> SavePartialView(IPartialView partialView, PartialViewType partialViewType, int userId = -1)
+        private Attempt<IPartialView> SavePartialView(IPartialView partialView, PartialViewType partialViewType, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {

--- a/src/Umbraco.Core/Services/Implement/LocalizationService.cs
+++ b/src/Umbraco.Core/Services/Implement/LocalizationService.cs
@@ -227,7 +227,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="dictionaryItem"><see cref="IDictionaryItem"/> to save</param>
         /// <param name="userId">Optional id of the user saving the dictionary item</param>
-        public void Save(IDictionaryItem dictionaryItem, int userId = -1)
+        public void Save(IDictionaryItem dictionaryItem, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -256,7 +256,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="dictionaryItem"><see cref="IDictionaryItem"/> to delete</param>
         /// <param name="userId">Optional id of the user deleting the dictionary item</param>
-        public void Delete(IDictionaryItem dictionaryItem, int userId = -1)
+        public void Delete(IDictionaryItem dictionaryItem, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -356,7 +356,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="language"><see cref="ILanguage"/> to save</param>
         /// <param name="userId">Optional id of the user saving the language</param>
-        public void Save(ILanguage language, int userId = -1)
+        public void Save(ILanguage language, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -382,7 +382,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="language"><see cref="ILanguage"/> to delete</param>
         /// <param name="userId">Optional id of the user deleting the language</param>
-        public void Delete(ILanguage language, int userId = -1)
+        public void Delete(ILanguage language, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {

--- a/src/Umbraco.Core/Services/Implement/MacroService.cs
+++ b/src/Umbraco.Core/Services/Implement/MacroService.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="macro"><see cref="IMacro"/> to delete</param>
         /// <param name="userId">Optional id of the user deleting the macro</param>
-        public void Delete(IMacro macro, int userId = -1)
+        public void Delete(IMacro macro, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -106,7 +106,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="macro"><see cref="IMacro"/> to save</param>
         /// <param name="userId">Optional Id of the user deleting the macro</param>
-        public void Save(IMacro macro, int userId = -1)
+        public void Save(IMacro macro, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {

--- a/src/Umbraco.Core/Services/Implement/MediaService.cs
+++ b/src/Umbraco.Core/Services/Implement/MediaService.cs
@@ -112,7 +112,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="mediaTypeAlias">Alias of the <see cref="IMediaType"/></param>
         /// <param name="userId">Optional id of the user creating the media item</param>
         /// <returns><see cref="IMedia"/></returns>
-        public IMedia CreateMedia(string name, Guid parentId, string mediaTypeAlias, int userId = -1)
+        public IMedia CreateMedia(string name, Guid parentId, string mediaTypeAlias, int userId = 0)
         {
             var parent = GetById(parentId);
             return CreateMedia(name, parent, mediaTypeAlias, userId);
@@ -130,7 +130,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="mediaTypeAlias">The alias of the media type.</param>
         /// <param name="userId">The optional id of the user creating the media.</param>
         /// <returns>The media object.</returns>
-        public IMedia CreateMedia(string name, int parentId, string mediaTypeAlias, int userId = -1)
+        public IMedia CreateMedia(string name, int parentId, string mediaTypeAlias, int userId = 0)
         {
             var mediaType = GetMediaType(mediaTypeAlias);
             if (mediaType == null)
@@ -160,7 +160,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="mediaTypeAlias">The alias of the media type.</param>
         /// <param name="userId">The optional id of the user creating the media.</param>
         /// <returns>The media object.</returns>
-        public IMedia CreateMedia(string name, string mediaTypeAlias, int userId = -1)
+        public IMedia CreateMedia(string name, string mediaTypeAlias, int userId = 0)
         {
             // not locking since not saving anything
 
@@ -190,7 +190,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="mediaTypeAlias">The alias of the media type.</param>
         /// <param name="userId">The optional id of the user creating the media.</param>
         /// <returns>The media object.</returns>
-        public IMedia CreateMedia(string name, IMedia parent, string mediaTypeAlias, int userId = -1)
+        public IMedia CreateMedia(string name, IMedia parent, string mediaTypeAlias, int userId = 0)
         {
             if (parent == null) throw new ArgumentNullException(nameof(parent));
 
@@ -219,7 +219,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="mediaTypeAlias">The alias of the media type.</param>
         /// <param name="userId">The optional id of the user creating the media.</param>
         /// <returns>The media object.</returns>
-        public IMedia CreateMediaWithIdentity(string name, int parentId, string mediaTypeAlias, int userId = -1)
+        public IMedia CreateMediaWithIdentity(string name, int parentId, string mediaTypeAlias, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -251,7 +251,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="mediaTypeAlias">The alias of the media type.</param>
         /// <param name="userId">The optional id of the user creating the media.</param>
         /// <returns>The media object.</returns>
-        public IMedia CreateMediaWithIdentity(string name, IMedia parent, string mediaTypeAlias, int userId = -1)
+        public IMedia CreateMediaWithIdentity(string name, IMedia parent, string mediaTypeAlias, int userId = 0)
         {
             if (parent == null) throw new ArgumentNullException(nameof(parent));
 
@@ -749,7 +749,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="media">The <see cref="IMedia"/> to save</param>
         /// <param name="userId">Id of the User saving the Media</param>
         /// <param name="raiseEvents">Optional boolean indicating whether or not to raise events.</param>
-        public void Save(IMedia media, int userId = -1, bool raiseEvents = true)
+        public void Save(IMedia media, int userId = 0, bool raiseEvents = true)
         {
             ((IMediaServiceOperations) this).Save(media, userId, raiseEvents);
         }
@@ -807,7 +807,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="medias">Collection of <see cref="IMedia"/> to save</param>
         /// <param name="userId">Id of the User saving the Media</param>
         /// <param name="raiseEvents">Optional boolean indicating whether or not to raise events.</param>
-        public void Save(IEnumerable<IMedia> medias, int userId = -1, bool raiseEvents = true)
+        public void Save(IEnumerable<IMedia> medias, int userId = 0, bool raiseEvents = true)
         {
             ((IMediaServiceOperations) this).Save(medias, userId, raiseEvents);
         }
@@ -869,7 +869,7 @@ namespace Umbraco.Core.Services.Implement
         /// </remarks>
         /// <param name="media">The <see cref="IMedia"/> to delete</param>
         /// <param name="userId">Id of the User deleting the Media</param>
-        public void Delete(IMedia media, int userId = -1)
+        public void Delete(IMedia media, int userId = 0)
         {
             ((IMediaServiceOperations) this).Delete(media, userId);
         }
@@ -947,7 +947,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="id">Id of the <see cref="IMedia"/> object to delete versions from</param>
         /// <param name="versionDate">Latest version date</param>
         /// <param name="userId">Optional Id of the User deleting versions of a Media object</param>
-        public void DeleteVersions(int id, DateTime versionDate, int userId = -1)
+        public void DeleteVersions(int id, DateTime versionDate, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -971,7 +971,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        private void DeleteVersions(IScope scope, bool wlock, int id, DateTime versionDate, int userId = -1)
+        private void DeleteVersions(IScope scope, bool wlock, int id, DateTime versionDate, int userId = 0)
         {
             var args = new DeleteRevisionsEventArgs(id, dateToRetain: versionDate);
             if (scope.Events.DispatchCancelable(DeletingVersions, this, args))
@@ -994,7 +994,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="versionId">Id of the version to delete</param>
         /// <param name="deletePriorVersions">Boolean indicating whether to delete versions prior to the versionId</param>
         /// <param name="userId">Optional Id of the User deleting versions of a Media object</param>
-        public void DeleteVersion(int id, int versionId, bool deletePriorVersions, int userId = -1)
+        public void DeleteVersion(int id, int versionId, bool deletePriorVersions, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
@@ -1034,7 +1034,7 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="media">The <see cref="IMedia"/> to delete</param>
         /// <param name="userId">Id of the User deleting the Media</param>
-        public void MoveToRecycleBin(IMedia media, int userId = -1)
+        public void MoveToRecycleBin(IMedia media, int userId = 0)
         {
             ((IMediaServiceOperations) this).MoveToRecycleBin(media, userId);
         }
@@ -1085,7 +1085,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="media">The <see cref="IMedia"/> to move</param>
         /// <param name="parentId">Id of the Media's new Parent</param>
         /// <param name="userId">Id of the User moving the Media</param>
-        public void Move(IMedia media, int parentId, int userId = -1)
+        public void Move(IMedia media, int parentId, int userId = 0)
         {
             // if moving to the recycle bin then use the proper method
             if (parentId == Constants.System.RecycleBinMedia)
@@ -1243,7 +1243,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="userId"></param>
         /// <param name="raiseEvents"></param>
         /// <returns>True if sorting succeeded, otherwise False</returns>
-        public bool Sort(IEnumerable<IMedia> items, int userId = -1, bool raiseEvents = true)
+        public bool Sort(IEnumerable<IMedia> items, int userId = 0, bool raiseEvents = true)
         {
             var itemsA = items.ToArray();
             if (itemsA.Length == 0) return true;
@@ -1432,7 +1432,7 @@ namespace Umbraco.Core.Services.Implement
         /// </remarks>
         /// <param name="mediaTypeId">Id of the <see cref="IMediaType"/></param>
         /// <param name="userId">Optional id of the user deleting the media</param>
-        public void DeleteMediaOfTypes(IEnumerable<int> mediaTypeIds, int userId = -1)
+        public void DeleteMediaOfTypes(IEnumerable<int> mediaTypeIds, int userId = 0)
         {
             //TODO: This currently this is called from the ContentTypeService but that needs to change,
             // if we are deleting a content type, we should just delete the data and do this operation slightly differently.
@@ -1497,7 +1497,7 @@ namespace Umbraco.Core.Services.Implement
         /// <remarks>This needs extra care and attention as its potentially a dangerous and extensive operation</remarks>
         /// <param name="mediaTypeId">Id of the <see cref="IMediaType"/></param>
         /// <param name="userId">Optional id of the user deleting the media</param>
-        public void DeleteMediaOfType(int mediaTypeId, int userId = -1)
+        public void DeleteMediaOfType(int mediaTypeId, int userId = 0)
         {
             DeleteMediaOfTypes(new[] { mediaTypeId }, userId);
         }

--- a/src/Umbraco.Core/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Core/Services/Implement/PackagingService.cs
@@ -127,7 +127,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="userId">Optional Id of the user performing the import</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumrable list of generated content</returns>
-        public IEnumerable<IContent> ImportContent(XElement element, int parentId = -1, int userId = -1, bool raiseEvents = true)
+        public IEnumerable<IContent> ImportContent(XElement element, int parentId = -1, int userId = 0, bool raiseEvents = true)
         {
             if (raiseEvents)
             {
@@ -337,7 +337,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin).</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumrable list of generated ContentTypes</returns>
-        public IEnumerable<IContentType> ImportContentTypes(XElement element, int userId = -1, bool raiseEvents = true)
+        public IEnumerable<IContentType> ImportContentTypes(XElement element, int userId = 0, bool raiseEvents = true)
         {
             return ImportContentTypes(element, true, userId);
         }
@@ -350,7 +350,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin).</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumrable list of generated ContentTypes</returns>
-        public IEnumerable<IContentType> ImportContentTypes(XElement element, bool importStructure, int userId = -1, bool raiseEvents = true)
+        public IEnumerable<IContentType> ImportContentTypes(XElement element, bool importStructure, int userId = 0, bool raiseEvents = true)
         {
             if (raiseEvents)
             {
@@ -856,7 +856,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="userId">Optional id of the user</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumrable list of generated DataTypeDefinitions</returns>
-        public IEnumerable<IDataType> ImportDataTypeDefinitions(XElement element, int userId = -1, bool raiseEvents = true)
+        public IEnumerable<IDataType> ImportDataTypeDefinitions(XElement element, int userId = 0, bool raiseEvents = true)
         {
             if (raiseEvents)
             {
@@ -1190,7 +1190,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="userId">Optional id of the User performing the operation</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumerable list of generated languages</returns>
-        public IEnumerable<ILanguage> ImportLanguages(XElement languageElementList, int userId = -1, bool raiseEvents = true)
+        public IEnumerable<ILanguage> ImportLanguages(XElement languageElementList, int userId = 0, bool raiseEvents = true)
         {
             if (raiseEvents)
             {
@@ -1231,7 +1231,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="userId">Optional id of the User performing the operation</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns></returns>
-        public IEnumerable<IMacro> ImportMacros(XElement element, int userId = -1, bool raiseEvents = true)
+        public IEnumerable<IMacro> ImportMacros(XElement element, int userId = 0, bool raiseEvents = true)
         {
             if (raiseEvents)
             {
@@ -1502,7 +1502,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="userId">Optional user id</param>
         /// <param name="raiseEvents">Optional parameter indicating whether or not to raise events</param>
         /// <returns>An enumrable list of generated Templates</returns>
-        public IEnumerable<ITemplate> ImportTemplates(XElement element, int userId = -1, bool raiseEvents = true)
+        public IEnumerable<ITemplate> ImportTemplates(XElement element, int userId = 0, bool raiseEvents = true)
         {
             if (raiseEvents)
             {
@@ -1579,7 +1579,7 @@ namespace Umbraco.Core.Services.Implement
         }
 
 
-        public IEnumerable<IFile> ImportStylesheets(XElement element, int userId = -1, bool raiseEvents = true)
+        public IEnumerable<IFile> ImportStylesheets(XElement element, int userId = 0, bool raiseEvents = true)
         {
 
             if (raiseEvents)
@@ -1670,7 +1670,7 @@ namespace Umbraco.Core.Services.Implement
             set { _packageInstallation = value; }
         }
 
-        internal InstallationSummary InstallPackage(string packageFilePath, int userId = -1, bool raiseEvents = false)
+        internal InstallationSummary InstallPackage(string packageFilePath, int userId = 0, bool raiseEvents = false)
         {
             var metaData = GetPackageMetaData(packageFilePath);
 

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -329,6 +329,7 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\RefactorMacroColumns.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\SuperZero.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\TagsMigration.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_0_0\UserForeignKeys.cs" />
     <Compile Include="Models\AuditEntry.cs" />
     <Compile Include="Models\Consent.cs" />
     <Compile Include="Models\ConsentExtensions.cs" />

--- a/src/Umbraco.Tests/Models/ContentXmlTest.cs
+++ b/src/Umbraco.Tests/Models/ContentXmlTest.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Tests.Models
             ServiceContext.ContentTypeService.Save(contentType);
 
             var content = MockedContent.CreateTextpageContent(contentType, "Root Home", -1);
-            ServiceContext.ContentService.Save(content, Constants.Security.SuperId);
+            ServiceContext.ContentService.Save(content, Constants.Security.SuperUserId);
 
             var nodeName = content.ContentType.Alias.ToSafeAliasWithForcingCheck();
             var urlName = content.GetUrlSegment(new[]{new DefaultUrlSegmentProvider() });

--- a/src/Umbraco.Tests/Models/Mapping/ContentWebModelMappingTests.cs
+++ b/src/Umbraco.Tests/Models/Mapping/ContentWebModelMappingTests.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Tests.Models.Mapping
             // v8 is changing this, so the test would report a <null> creator
             // temp. fixing by assigning super here
             //
-            content.CreatorId = Constants.Security.SuperId;
+            content.CreatorId = Constants.Security.SuperUserId;
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace Umbraco.Tests.Models.Mapping
             if (ownerId != 0)
             {
                 Assert.IsNotNull(result.Owner);
-                Assert.AreEqual(Constants.Security.SuperId, result.Owner.UserId);
+                Assert.AreEqual(Constants.Security.SuperUserId, result.Owner.UserId);
                 Assert.AreEqual("Administrator", result.Owner.Name);
             }
             else

--- a/src/Umbraco.Tests/Models/MediaXmlTest.cs
+++ b/src/Umbraco.Tests/Models/MediaXmlTest.cs
@@ -33,7 +33,7 @@ namespace Umbraco.Tests.Models
 
             var media = MockedMedia.CreateMediaImage(mediaType, -1);
             media.WriterId = -1; // else it's zero and that's not a user and it breaks the tests
-            ServiceContext.MediaService.Save(media, Constants.Security.SuperId);
+            ServiceContext.MediaService.Save(media, Constants.Security.SuperUserId);
 
             // so we have to force-reset these values because the property editor has cleared them
             media.SetValue(Constants.Conventions.Media.Width, "200");

--- a/src/Umbraco.Tests/Persistence/Repositories/NotificationsRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/NotificationsRepositoryTest.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Tests.Persistence.Repositories
                     Text = "hello",
                     Trashed = false,
                     UniqueId = Guid.NewGuid(),
-                    UserId = Constants.Security.SuperId
+                    UserId = Constants.Security.SuperUserId
                 };
                 var result = scope.Database.Insert(node);
                 var entity = Mock.Of<IEntity>(e => e.Id == node.NodeId);
@@ -66,7 +66,7 @@ namespace Umbraco.Tests.Persistence.Repositories
                 scope.Database.Insert(userDto);
 
                 var userNew = Mock.Of<IUser>(e => e.Id == userDto.Id);
-                var userAdmin = Mock.Of<IUser>(e => e.Id == Constants.Security.SuperId);
+                var userAdmin = Mock.Of<IUser>(e => e.Id == Constants.Security.SuperUserId);
 
                 for (var i = 0; i < 10; i++)
                 {
@@ -155,7 +155,7 @@ namespace Umbraco.Tests.Persistence.Repositories
                 scope.Database.Insert(userDto);
 
                 var userNew = Mock.Of<IUser>(e => e.Id == userDto.Id);
-                var userAdmin = Mock.Of<IUser>(e => e.Id == Constants.Security.SuperId);
+                var userAdmin = Mock.Of<IUser>(e => e.Id == Constants.Security.SuperUserId);
 
                 for (var i = 0; i < 10; i++)
                 {

--- a/src/Umbraco.Tests/Persistence/Repositories/TaskRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/TaskRepositoryTest.cs
@@ -26,11 +26,11 @@ namespace Umbraco.Tests.Persistence.Repositories
                 var created = DateTime.Now;
                 var task = new Task(new TaskType("asdfasdf"))
                 {
-                    AssigneeUserId = Constants.Security.SuperId,
+                    AssigneeUserId = Constants.Security.SuperUserId,
                     Closed = false,
                     Comment = "hello world",
                     EntityId = -1,
-                    OwnerUserId = Constants.Security.SuperId
+                    OwnerUserId = Constants.Security.SuperUserId
                 };
                 repo.Save(task);
                 
@@ -54,23 +54,23 @@ namespace Umbraco.Tests.Persistence.Repositories
                 var created = DateTime.Now;
                 repo.Save(new Task(new TaskType("asdfasdf"))
                 {
-                    AssigneeUserId = Constants.Security.SuperId,
+                    AssigneeUserId = Constants.Security.SuperUserId,
                     Closed = false,
                     Comment = "hello world",
                     EntityId = -1,
-                    OwnerUserId = Constants.Security.SuperId
+                    OwnerUserId = Constants.Security.SuperUserId
                 });
                 
 
                 var found = repo.GetMany().ToArray();
 
                 Assert.AreEqual(1, found.Length);
-                Assert.AreEqual(Constants.Security.SuperId, found.First().AssigneeUserId);
+                Assert.AreEqual(Constants.Security.SuperUserId, found.First().AssigneeUserId);
                 Assert.AreEqual(false, found.First().Closed);
                 Assert.AreEqual("hello world", found.First().Comment);
                 Assert.GreaterOrEqual(found.First().CreateDate.TruncateTo(DateTimeExtensions.DateTruncate.Second), created.TruncateTo(DateTimeExtensions.DateTruncate.Second));
                 Assert.AreEqual(-1, found.First().EntityId);
-                Assert.AreEqual(Constants.Security.SuperId, found.First().OwnerUserId);
+                Assert.AreEqual(Constants.Security.SuperUserId, found.First().OwnerUserId);
                 Assert.AreEqual(true, found.First().HasIdentity);
                 Assert.AreEqual(true, found.First().TaskType.HasIdentity);
             }
@@ -86,11 +86,11 @@ namespace Umbraco.Tests.Persistence.Repositories
 
                 var task = new Task(new TaskType("asdfasdf"))
                 {
-                    AssigneeUserId = Constants.Security.SuperId,
+                    AssigneeUserId = Constants.Security.SuperUserId,
                     Closed = false,
                     Comment = "hello world",
                     EntityId = -1,
-                    OwnerUserId = Constants.Security.SuperId
+                    OwnerUserId = Constants.Security.SuperUserId
                 };
 
                 repo.Save(task);
@@ -123,11 +123,11 @@ namespace Umbraco.Tests.Persistence.Repositories
 
                 var task = new Task(new TaskType("asdfasdf"))
                 {
-                    AssigneeUserId = Constants.Security.SuperId,
+                    AssigneeUserId = Constants.Security.SuperUserId,
                     Closed = false,
                     Comment = "hello world",
                     EntityId = -1,
-                    OwnerUserId = Constants.Security.SuperId
+                    OwnerUserId = Constants.Security.SuperUserId
                 };
 
                 repo.Save(task);
@@ -214,11 +214,11 @@ namespace Umbraco.Tests.Persistence.Repositories
                 {
                     repo.Save(new Task(new TaskType("asdfasdf"))
                     {
-                        AssigneeUserId = Constants.Security.SuperId,
+                        AssigneeUserId = Constants.Security.SuperUserId,
                         Closed = closed,
                         Comment = "hello world " + i,
                         EntityId = entityId,
-                        OwnerUserId = Constants.Security.SuperId
+                        OwnerUserId = Constants.Security.SuperUserId
                     });
                 }
 

--- a/src/Umbraco.Tests/Persistence/Repositories/TaskTypeRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/TaskTypeRepositoryTest.cs
@@ -28,11 +28,11 @@ namespace Umbraco.Tests.Persistence.Repositories
                 var created = DateTime.Now;
                 var task = new Task(taskType)
                 {
-                    AssigneeUserId = Constants.Security.SuperId,
+                    AssigneeUserId = Constants.Security.SuperUserId,
                     Closed = false,
                     Comment = "hello world",
                     EntityId = -1,
-                    OwnerUserId = Constants.Security.SuperId
+                    OwnerUserId = Constants.Security.SuperUserId
                 };
                 repo.Save(task);
                 

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -1875,7 +1875,7 @@ namespace Umbraco.Tests.Services
             editorGroup.StartContentId = content1.Id;
             ServiceContext.UserService.Save(editorGroup);
 
-            var admin = ServiceContext.UserService.GetUserById(Constants.Security.SuperId);
+            var admin = ServiceContext.UserService.GetUserById(Constants.Security.SuperUserId);
             admin.StartContentIds = new[] {content1.Id};
             ServiceContext.UserService.Save(admin);
 
@@ -1892,7 +1892,7 @@ namespace Umbraco.Tests.Services
             }));
             Assert.IsTrue(ServiceContext.PublicAccessService.AddRule(content1, "test2", "test2").Success);
 
-            var user = ServiceContext.UserService.GetUserById(Constants.Security.SuperId);
+            var user = ServiceContext.UserService.GetUserById(Constants.Security.SuperUserId);
             var userGroup = ServiceContext.UserService.GetUserGroupByAlias(user.Groups.First().Alias);
             Assert.IsNotNull(ServiceContext.NotificationService.CreateNotification(user, content1, "X"));
 

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -208,7 +208,7 @@ namespace Umbraco.Web.Editors
             {
                 // only super can see super - but don't use IsSuper, cannot be mapped to SQL - fixme NOW
                 //filterQuery.Where(x => !x.IsSuper());
-                filterQuery.Where(x => x.Id != Constants.Security.SuperId);
+                filterQuery.Where(x => x.Id != Constants.Security.SuperUserId);
             }
 
             if (filter.IsNullOrWhiteSpace() == false)

--- a/src/Umbraco.Web/Install/InstallSteps/NewInstallStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/NewInstallStep.cs
@@ -49,16 +49,16 @@ namespace Umbraco.Web.Install.InstallSteps
 
         public override InstallSetupResult Execute(UserModel user)
         {
-            var admin = _userService.GetUserById(Constants.Security.SuperId);
+            var admin = _userService.GetUserById(Constants.Security.SuperUserId);
             if (admin == null)
             {
                 throw new InvalidOperationException("Could not find the super user!");
             }
 
-            var membershipUser = CurrentProvider.GetUser(Constants.Security.SuperId, true);
+            var membershipUser = CurrentProvider.GetUser(Constants.Security.SuperUserId, true);
             if (membershipUser == null)
             {
-                throw new InvalidOperationException($"No user found in membership provider with id of {Constants.Security.SuperId}.");
+                throw new InvalidOperationException($"No user found in membership provider with id of {Constants.Security.SuperUserId}.");
             }
 
             try

--- a/src/Umbraco.Web/Mvc/AdminTokenAuthorizeAttribute.cs
+++ b/src/Umbraco.Web/Mvc/AdminTokenAuthorizeAttribute.cs
@@ -62,7 +62,7 @@ namespace Umbraco.Web.Mvc
 
         private static string GetAuthHeaderVal(IUserService userService)
         {
-            var admin = userService.GetUserById(Core.Constants.Security.SuperId);
+            var admin = userService.GetUserById(Core.Constants.Security.SuperUserId);
 
             var token = $"{admin.Email}u____u{admin.Username}u____u{admin.RawPasswordValue}";
 
@@ -94,7 +94,7 @@ namespace Umbraco.Web.Mvc
             if (keyVal.Count != 1) return false;
             if (keyVal[0].Groups.Count != 2) return false;
 
-            var admin = UserService.GetUserById(Core.Constants.Security.SuperId);
+            var admin = UserService.GetUserById(Core.Constants.Security.SuperUserId);
             if (admin == null) return false;
 
             try

--- a/src/Umbraco.Web/NotificationServiceExtensions.cs
+++ b/src/Umbraco.Web/NotificationServiceExtensions.cs
@@ -73,10 +73,10 @@ namespace Umbraco.Web
             if (user == null)
             {
                 Current.Logger.Debug(typeof(NotificationServiceExtensions), "There is no current Umbraco user logged in, the notifications will be sent from the administrator");
-                user = userService.GetUserById(Constants.Security.SuperId);
+                user = userService.GetUserById(Constants.Security.SuperUserId);
                 if (user == null)
                 {
-                    Current.Logger.Warn(typeof(NotificationServiceExtensions), $"Noticiations can not be sent, no admin user with id {Constants.Security.SuperId} could be resolved");
+                    Current.Logger.Warn(typeof(NotificationServiceExtensions), $"Noticiations can not be sent, no admin user with id {Constants.Security.SuperUserId} could be resolved");
                     return;
                 }
             }
@@ -98,10 +98,10 @@ namespace Umbraco.Web
             if (user == null)
             {
                 Current.Logger.Debug(typeof(NotificationServiceExtensions), "There is no current Umbraco user logged in, the notifications will be sent from the administrator");
-                user = userService.GetUserById(Constants.Security.SuperId);
+                user = userService.GetUserById(Constants.Security.SuperUserId);
                 if (user == null)
                 {
-                    Current.Logger.Warn(typeof(NotificationServiceExtensions), $"Noticiations can not be sent, no admin user with id {Constants.Security.SuperId} could be resolved");
+                    Current.Logger.Warn(typeof(NotificationServiceExtensions), $"Noticiations can not be sent, no admin user with id {Constants.Security.SuperUserId} could be resolved");
                     return;
                 }
             }

--- a/src/Umbraco.Web/Trees/UserPermissionsTreeController.cs
+++ b/src/Umbraco.Web/Trees/UserPermissionsTreeController.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Web.Trees
             long totalUsers;
             nodes.AddRange(
                 Services.UserService.GetAll(0, int.MaxValue, out totalUsers)
-                    .Where(x => x.Id != Constants.Security.SuperId && x.IsApproved)
+                    .Where(x => x.Id != Constants.Security.SuperUserId && x.IsApproved)
                     .Select(x => CreateTreeNode(x.Id.ToString(),
                         id,
                         queryStrings,

--- a/src/Umbraco.Web/_Legacy/Packager/Installer.cs
+++ b/src/Umbraco.Web/_Legacy/Packager/Installer.cs
@@ -349,7 +349,7 @@ namespace umbraco.cms.businesslogic.packager
                     //bool saveNeeded = false;
 
                     // Get current user, with a fallback
-                    var currentUser = Current.Services.UserService.GetUserById(Constants.Security.SuperId);
+                    var currentUser = Current.Services.UserService.GetUserById(Constants.Security.SuperUserId);
 
                     //TODO: Get rid of this entire class! Until then all packages will be installed by the admin user
 


### PR DESCRIPTION
With the change of the super user id to -1, we still want to ensure referential integrity between tables but currently there aren't FKs to enforce this. This enforces this but allows NULL for a user id in case it's an unknown user.