### PR TITLE
U4 11393 - Health Check for developer files in the root of the site

### DIFF
--- a/src/Umbraco.Core/HttpContextExtensions.cs
+++ b/src/Umbraco.Core/HttpContextExtensions.cs
@@ -10,10 +10,20 @@ namespace Umbraco.Core
             {
                 return "Unknown, httpContext is null";
             }
-            if (httpContext.Request == null)
+
+            try
             {
+                // Sometimes you can't access this and it throws, this catches that and reports back something useful at least
+                var request = httpContext.Request;
+            }
+            catch (HttpException exc) {
                 return "Unknown, httpContext.Request is null";
             }
+
+            if (httpContext.Request == null) {
+                return "Unknown, httpContext.Request is null";
+            }
+
             if (httpContext.Request.ServerVariables == null)
             {
                 return "Unknown, httpContext.Request.ServerVariables is null";

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2135,6 +2135,13 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
         <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status</key>
+
+        <key alias="developerFilesInRootFound"><![CDATA[The following developer related files where found in the root of your website: <ul><li>%0%</li></ul>]]></key>
+        <key alias="developerFilesInRootNotFound">No undesirable developer files where found in the root of your website.</key>
+        <key alias="developerFilesInRootActionButton">Delete these files</key>
+        <key alias="developerFilesInRootActionDescription">Ideally you should manually move these files outside of your website folder so they are not accessible. However you can also delete these files from your site but please ensure you have a back up copy of these files as their is no recovery option.</key>
+        <key alias="developerFilesRemovedFromRoot">Deleted developer files from the root of your site.</key>
+
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Disable URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2126,6 +2126,13 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
         <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status</key>
+
+        <key alias="developerFilesInRootFound"><![CDATA[The following developer related files where found in the root of your website: <ul><li>%0%</li></ul>]]></key>
+        <key alias="developerFilesInRootNotFound">No undesirable developer files where found in the root of your website.</key>
+        <key alias="developerFilesInRootActionButton">Delete these files</key>
+        <key alias="developerFilesInRootActionDescription"><![CDATA[Ideally you should manually move these files outside of your website folder so they are not accessible. However you can also delete these files from your site but <b>please ensure you have a back up copy of these files as their is no recovery option</b>.]]></key>
+        <key alias="developerFilesRemovedFromRoot">Deleted developer files from the root of your site.</key>
+
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Disable URL tracker</key>

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/DeveloperFilesInRootCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/DeveloperFilesInRootCheck.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Web;
+using System.Web.Hosting;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Web.HealthCheck.Checks.Security
+{
+    [HealthCheck(
+        "a3949eab-3932-4600-989e-24a6c5a127e4",
+        "Developer files in website root",
+        Description = "Checks to see if you have any common developers files in on your website which might leak sensitive data.",
+        Group = "Security")]
+    public class DeveloperFilesInRootCheck : HealthCheck
+    {
+        private readonly ILocalizedTextService _textService;
+
+        public DeveloperFilesInRootCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
+        {
+            _textService = healthCheckContext.ApplicationContext.Services.TextService;
+        }
+
+        /// <summary>
+        /// Get the status for this health check
+        /// </summary>
+        /// <returns></returns>
+        public override IEnumerable<HealthCheckStatus> GetStatus()
+        {
+            //return the statuses
+            return new[] { CheckForFiles() };
+        }
+
+        /// <summary>
+        /// Executes the action and returns it's status
+        /// </summary>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            switch (action.Alias)
+            {
+                case "removeDeveloperFilesFromRoot":
+                    return RemoveFiles();
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private HealthCheckStatus RemoveFiles()
+        {
+            var success = false;
+            var message = string.Empty;
+
+            try
+            {
+                var foundFiles = FindFiles();
+                if (foundFiles.Any()) {
+                    foreach ( var file in foundFiles )
+                    {
+                        File.Delete(HostingEnvironment.MapPath(file));
+                    }
+                }
+                success = true;
+                message = _textService.Localize("healthcheck/developerFilesRemovedFromRoot");
+            }
+            catch (Exception exception)
+            {
+                LogHelper.Error<DeveloperFilesInRootCheck>("Could not delete developer files from root of site", exception);
+            }
+
+            return
+                new HealthCheckStatus(message)
+                {
+                    ResultType = success ? StatusResultType.Success : StatusResultType.Error,
+                    Actions = new List<HealthCheckAction>()
+                };
+        }
+
+        private List<string> FindFiles()
+        {
+            var filesToCheck = new string[]
+            {
+                "~/package.json",
+                "~/package-lock.json",
+                "~/gruntfile.js",
+                "~/manifest.json",
+                "~/packages.config",
+                "~/webpack.config.js",
+                "~/readme.txt",
+                "~/readme.doc",
+                "~/readme.md",
+                "~/read-me.txt",
+                "~/read-me.doc",
+                "~/read-me.md",
+                "~/read_me.txt",
+                "~/read_me.doc",
+                "~/read_me.md"
+            };
+
+            var foundFiles = new List<string>();
+
+            foreach (var file in filesToCheck)
+            {
+                if (File.Exists(HostingEnvironment.MapPath(file)))
+                {
+                    foundFiles.Add(file);
+                }
+            }
+
+            return foundFiles;
+        }
+
+        private HealthCheckStatus CheckForFiles()
+        {
+            var message = string.Empty;
+            var foundFiles = FindFiles();
+
+            if (foundFiles.Any())
+            {
+                message = _textService.Localize("healthcheck/developerFilesInRootFound", new[] { String.Join("</li><li>", foundFiles.ToArray<string>()) });
+            }
+            else
+            {
+                message = _textService.Localize("healthcheck/developerFilesInRootNotFound");
+            }
+
+            var actions = new List<HealthCheckAction>();
+            actions.Add(new HealthCheckAction("removeDeveloperFilesFromRoot", Id)
+            // Override the "Rectify" button name and describe what this action will do
+            {
+                Name = _textService.Localize("healthcheck/developerFilesInRootActionButton"),
+                Description = _textService.Localize("healthcheck/developerFilesInRootActionDescription")
+            });
+
+            return
+                new HealthCheckStatus(message)
+                {
+                    ResultType = !foundFiles.Any() ? StatusResultType.Success : StatusResultType.Warning,
+                    Actions = actions
+                };
+        }
+    }
+}
+
+

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -337,6 +337,7 @@
     <Compile Include="Editors\CodeFileController.cs" />
     <Compile Include="Editors\TourController.cs" />
     <Compile Include="Features\EnabledFeatures.cs" />
+    <Compile Include="HealthCheck\Checks\Security\DeveloperFilesInRootCheck.cs" />
     <Compile Include="HealthCheck\Checks\Security\XssProtectionCheck.cs" />
     <Compile Include="HealthCheck\Checks\Security\HstsCheck.cs" />
     <Compile Include="Models\BackOfficeTourFilter.cs" />


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11393

### Description
<!-- A description of the changes proposed in the pull-request -->

New health check that looks for a hardcoded list of developer related files in the root of the website. These files "could" leak sensitive data to hackers and they shouldn't be released on a public site. Add the option to delete these files with a warning that you should have a back up of the files.

Only put in EN language look ups I'm afraid.

<!-- Thanks for contributing to Umbraco CMS! -->
