### PR TITLE
Fixes #U4-11406 by setting the thread culture before rendering macro

### DIFF
--- a/src/Umbraco.Web/Editors/MacroController.cs
+++ b/src/Umbraco.Web/Editors/MacroController.cs
@@ -121,9 +121,12 @@ namespace Umbraco.Web.Editors
             // Since a Macro might contain thing thats related to the culture of the "IPublishedContent" (ie Dictionary keys) we want
             // to set the current culture to the culture related to the content item. This is hacky but it works.
             var publishedContent = UmbracoContext.ContentCache.GetById(doc.Id);
-            var culture = publishedContent.GetCulture();
-            Thread.CurrentThread.CurrentCulture = culture;
-            Thread.CurrentThread.CurrentUICulture = culture;
+            var culture = publishedContent?.GetCulture();
+            if (culture != null)
+            {
+                Thread.CurrentThread.CurrentCulture = culture;
+                Thread.CurrentThread.CurrentUICulture = culture;
+            }
 
             var legacyPage = new global::umbraco.page(doc);
             UmbracoContext.HttpContext.Items["pageID"] = doc.Id;

--- a/src/Umbraco.Web/Editors/MacroController.cs
+++ b/src/Umbraco.Web/Editors/MacroController.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Web.Http;
 using System.Web.SessionState;
 using AutoMapper;
@@ -114,6 +116,14 @@ namespace Umbraco.Web.Editors
             //because macro's are filled with insane legacy bits and pieces we need all sorts of wierdness to make them render.
             //the 'easiest' way might be to create an IPublishedContent manually and populate the legacy 'page' object with that
             //and then set the legacy parameters.
+
+            // When rendering the macro in the backoffice the default setting would be to use the Culture of the logged in user.
+            // Since a Macro might contain thing thats related to the culture of the "IPublishedContent" (ie Dictionary keys) we want
+            // to set the current culture to the culture related to the content item. This is hacky but it works.
+            var publishedContent = UmbracoContext.ContentCache.GetById(doc.Id);
+            var culture = publishedContent.GetCulture();
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
 
             var legacyPage = new global::umbraco.page(doc);
             UmbracoContext.HttpContext.Items["pageID"] = doc.Id;


### PR DESCRIPTION
Fixes this issue: http://issues.umbraco.org/issue/U4-11406

### Description
Since I wanted to avoid making to much changed in the old legacy stuff I figured that this is a quite pragmatic solution and I guess that these parts of the core will be either rewritten or wiped for V8.

I know that it might be hacky but it does the job. Any feedback is appreciated =D