### PR TITLE
U4-11412 only show buttons in umb-confirm when callback is defined

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirm.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirm.directive.js
@@ -1,12 +1,51 @@
 ﻿/**
- * @ngdoc directive
- * @name umbraco.directives.directive:umbConfirm
- * @function
- * @description
- * A confirmation dialog
- *
- * @restrict E
- */
+@ngdoc directive
+@name umbraco.directives.directive:umbConfirm
+@restrict E
+@scope
+
+@description
+A confirmation dialog
+
+
+<h3>Markup example</h3>
+<pre>
+	<div ng-controller="My.Controller as vm">
+
+       <umb-confirm caption="Title" on-confirm="vm.onConfirm()" on-cancel="vm.onCancel()"></umb-confirm>
+
+	</div>
+</pre>
+
+<h3>Controller example</h3>
+<pre>
+	(function () {
+		"use strict";
+
+		function Controller() {
+
+            var vm = this;
+
+            vm.onConfirm = function() {
+                alert('Confirm clicked');
+            };
+
+            vm.onCancel = function() {
+                alert('Cancel clicked');
+            }
+
+
+        }
+
+		angular.module("umbraco").controller("My.Controller", Controller);
+
+	})();
+</pre>
+
+@param {string} caption (<code>attribute</code>): The caption shown above the buttons
+@param {callback} on-confirm (<code>attribute</code>): The call back when the "OK" button is clicked. If not set the button will not be shown
+@param {callback} on-cancel (<code>atribute</code>): The call back when the "Cancel" button is clicked. If not set the button will not be shown
+**/
 function confirmDirective() {
     return {
         restrict: "E",    // restrict to an element

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirm.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirm.directive.js
@@ -18,7 +18,16 @@ function confirmDirective() {
             caption: '@'
         },
         link: function (scope, element, attr, ctrl) {
+            scope.showCancel = false;
+            scope.showConfirm = false;
 
+            if (scope.onConfirm) {
+                scope.showConfirm = true;
+            }
+
+            if (scope.onCancel) {
+                scope.showCancel = true;
+            }
         }
     };
 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm.html
@@ -3,8 +3,8 @@
     
     <div class="umb-pane btn-toolbar umb-btn-toolbar">
     	<div class="control-group umb-control-group">	
-    		<a ng-if="onCancel" href class="btn btn-link" ng-click="onCancel()"><localize key="general_cancel">Cancel</localize></a>
-    		<a href class="btn btn-primary" ng-click="onConfirm()"><localize key="general_ok">Ok</localize></a>
+    		<a ng-if="showCancel" href class="btn btn-link" ng-click="onCancel()"><localize key="general_cancel">Cancel</localize></a>
+    		<a ng-if="showConfirm" href class="btn btn-primary" ng-click="onConfirm()"><localize key="general_ok">Ok</localize></a>
     	</div>	
 	</div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm.html
@@ -3,7 +3,7 @@
     
     <div class="umb-pane btn-toolbar umb-btn-toolbar">
     	<div class="control-group umb-control-group">	
-    		<a href class="btn btn-link" ng-click="onCancel()"><localize key="general_cancel">Cancel</localize></a>
+    		<a ng-if="onCancel" href class="btn btn-link" ng-click="onCancel()"><localize key="general_cancel">Cancel</localize></a>
     		<a href class="btn btn-primary" ng-click="onConfirm()"><localize key="general_ok">Ok</localize></a>
     	</div>	
 	</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11412

### Description
<!-- A description of the changes proposed in the pull-request -->
This PR fixes that buttons are shown in the umbConfirm directive when no callback is definend.

I also documented the directive for backoffice api docs


<!-- Thanks for contributing to Umbraco CMS! -->
