### PR TITLE
Refactor the extension method IsNullOrWhiteSpace() to use the native version

### DIFF
--- a/src/Umbraco.Core/Configuration/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/GlobalSettings.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Core.Configuration
         private static Version _version;
         private static readonly object Locker = new object();
         //make this volatile so that we can ensure thread safety with a double check lock
-    	private static volatile string _reservedUrlsCache;
+        private static volatile string _reservedUrlsCache;
         private static string _reservedPathsCache;
         private static HashSet<string> _reservedList = new HashSet<string>();
         private static string _reservedPaths;
@@ -190,7 +190,7 @@ namespace Umbraco.Core.Configuration
         /// This will return the MVC area that we will route all custom routes through like surface controllers, etc...
         /// We will use the 'Path' (default ~/umbraco) to create it but since it cannot contain '/' and people may specify a path of ~/asdf/asdf/admin
         /// we will convert the '/' to '-' and use that as the path. its a bit lame but will work.
-		/// 
+        /// 
         /// We also make sure that the virtual directory (SystemDirectories.Root) is stripped off first, otherwise we'd end up with something
         /// like "MyVirtualDirectory-Umbraco" instead of just "Umbraco".
         /// </remarks>
@@ -205,7 +205,7 @@ namespace Umbraco.Core.Configuration
                 var path = Path;
                 if (path.StartsWith(SystemDirectories.Root)) // beware of TrimStart, see U4-2518
                     path = path.Substring(SystemDirectories.Root.Length);
-			    return path.TrimStart('~').TrimStart('/').Replace('/', '-').Trim().ToLower();
+                return path.TrimStart('~').TrimStart('/').Replace('/', '-').Trim().ToLower();
             }
         }
 
@@ -312,7 +312,7 @@ namespace Umbraco.Core.Configuration
                 SetMembershipProvidersLegacyEncoding(UmbracoConfig.For.UmbracoSettings().Providers.DefaultBackOfficeUserProvider, value);
             }
         }
-		
+        
         /// <summary>
         /// Saves a setting into the configuration file.
         /// </summary>
@@ -503,7 +503,7 @@ namespace Umbraco.Core.Configuration
         }
 
         /// <summary>
-        /// Returns a string value to determine if umbraco should skip version-checking.
+        /// Returns the number of days that should take place between version checks.
         /// </summary>
         /// <value>The version check period in days (0 = never).</value>
         public static int VersionCheckPeriod

--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -477,9 +477,6 @@ namespace Umbraco.Core
         /// empty, or consists only of white-space characters, otherwise
         /// returns <see langword="false"/>.</returns>
         public static bool IsNullOrWhiteSpace(this string value) => string.IsNullOrWhiteSpace(value);
-        //{
-        //    return (value == null) || (value.Trim().Length == 0);
-        //}
 
         public static string IfNullOrWhiteSpace(this string str, string defaultValue)
         {

--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -8,14 +8,12 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Web;
-using System.Xml;
-using Newtonsoft.Json;
-using Umbraco.Core.Configuration;
 using System.Web.Security;
-using Umbraco.Core.Strings;
+using Newtonsoft.Json;
 using Umbraco.Core.CodeAnnotations;
+using Umbraco.Core.Configuration;
 using Umbraco.Core.IO;
+using Umbraco.Core.Strings;
 
 namespace Umbraco.Core
 {
@@ -472,13 +470,16 @@ namespace Umbraco.Core
             return ch.ToString(CultureInfo.InvariantCulture) == ch.ToString(CultureInfo.InvariantCulture).ToUpperInvariant();
         }
 
-        /// <summary>Is null or white space.</summary>
-        /// <param name="str">The str.</param>
-        /// <returns>The is null or white space.</returns>
-        public static bool IsNullOrWhiteSpace(this string str)
-        {
-            return (str == null) || (str.Trim().Length == 0);
-        }
+        /// <summary>Indicates whether a specified string is null, empty, or
+        /// consists only of white-space characters.</summary>
+        /// <param name="value">The value to check.</param>
+        /// <returns>Returns <see langword="true"/> if the value is null,
+        /// empty, or consists only of white-space characters, otherwise
+        /// returns <see langword="false"/>.</returns>
+        public static bool IsNullOrWhiteSpace(this string value) => string.IsNullOrWhiteSpace(value);
+        //{
+        //    return (value == null) || (value.Trim().Length == 0);
+        //}
 
         public static string IfNullOrWhiteSpace(this string str, string defaultValue)
         {

--- a/src/Umbraco.Tests/Strings/StringExtensionsTests.cs
+++ b/src/Umbraco.Tests/Strings/StringExtensionsTests.cs
@@ -161,6 +161,29 @@ namespace Umbraco.Tests.Strings
             Assert.AreEqual(expected, output);
         }
 
+        [TestCase("", true)]
+        [TestCase(" ", true)]
+        [TestCase("\r\n\r\n", true)]
+        [TestCase("\r\n", true)]
+        [TestCase(@"
+        Hello
+        ", false)]
+        [TestCase(null, true)]
+        [TestCase("a", false)]
+        [TestCase("abc", false)]
+        [TestCase("abc   ", false)]
+        [TestCase("   abc", false)]
+        [TestCase("   abc   ", false)]
+        public void IsNullOrWhiteSpace(string value, bool expected)
+        {
+            // Act
+            bool result = value.IsNullOrWhiteSpace();
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+
         // FORMAT STRINGS
 
         // note: here we just ensure that the proper helper gets called properly


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-8199

### Description
The IsNullOrWhiteSpace() extension method's implementation can be replaced by a call to the native, static version with no loss in execution speed (there's actually a small gain on average). The main two reasons for the replacement, however, are a simple reduction in Core logic and no new string construction just to count the length. The call to Trim() could return a new string which is then thrown away. The native version steps along the string and is therefore pure, as this version now is.

(I also fixed the comment on the property VersionCheckPeriod.)