### PR TITLE
fix for U4-10936 "Failed to read the 'rules' property from 'CSSStyleSheet'" when certain chrome extensions are enabled

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
@@ -166,7 +166,13 @@ function iconHelper($q, $timeout) {
                     var c = ".icon-";
 
                     for (var i = document.styleSheets.length - 1; i >= 0; i--) {
-                        var classes = document.styleSheets[i].rules || document.styleSheets[i].cssRules;
+                        var classes = null;
+                        try {
+                            classes = document.styleSheets[i].rules || document.styleSheets[i].cssRules;
+                        } catch (e) {
+                            console.warn("Can't read the css rules of: " + document.styleSheets[i].href, e);
+                            continue;
+                        }
                         
                         if (classes !== null) {
                             for(var x=0;x<classes.length;x++) {


### PR DESCRIPTION
I have the same issue as the author of [U4-10936](http://issues.umbraco.org/issue/U4-10936) - When ceratin chrome extensions are enabled, the `document.styleSheets[i]` does not have a `rules `property. In my case, the cause was in SeleniumIDE ( https://chrome.google.com/webstore/detail/selenium-ide/mooikfkahbdckldjjndioackbalphokd ) 

In the ticket - it is only a workaround for the problem (disable the extension) but I supply the fix for this. Small and simple ;)


