### PR TITLE
Add id and guid on datatype pages

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.edit.controller.js
@@ -50,8 +50,9 @@ function DataTypeEditController($scope, $routeParams, $location, appState, navig
     $scope.preValues = [];
 
     if ($routeParams.create) {
-
+        
         $scope.page.loading = true;
+        $scope.showIdentifier = false;
 
         //we are creating so get an empty data type item
         dataTypeResource.getScaffold($routeParams.id)
@@ -76,6 +77,8 @@ function DataTypeEditController($scope, $routeParams, $location, appState, navig
     function loadDataType() {
 
         $scope.page.loading = true;
+
+        $scope.showIdentifier = true;
 
         //we are editing so get the content item from the server
         dataTypeResource.getById($routeParams.id)

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/edit.html
@@ -21,28 +21,31 @@
 
          <umb-editor-container class="form-horizontal">
 
-            <umb-property property="properties.selectedEditor">
-                <div>
-                    <select name="selectedEditor"
-                           ng-model="content.selectedEditor"
-                           required
-                           ng-options="e.alias as e.name for e in content.availableEditors"></select>
-                    <span class="help-inline" val-msg-for="selectedEditor" val-toggle-msg="required"><localize key="general_required">Required</localize></span>
-                </div>
+             <umb-control-group label="Id" ng-if="showIdentifier">
+                 <div>{{content.id}}</div>
+                 <small>{{content.key}}</small>
+             </umb-control-group>
 
-            </umb-property>
+             <umb-property property="properties.selectedEditor">
+                 <div>
+                     <select name="selectedEditor"
+                             ng-model="content.selectedEditor"
+                             required
+                             ng-options="e.alias as e.name for e in content.availableEditors"></select>
+                     <span class="help-inline" val-msg-for="selectedEditor" val-toggle-msg="required"><localize key="general_required">Required</localize></span>
+                 </div>
 
-            <umb-property property="properties.selectedEditorId">
-                <div>{{content.selectedEditor}}</div>
-            </umb-property>
+             </umb-property>
 
+             <umb-property property="properties.selectedEditorId">
+                 <div>{{content.selectedEditor}}</div>
+             </umb-property>
 
-            <umb-property
-                property="preValue"
-                ng-repeat="preValue in preValues">
+             <umb-property property="preValue"
+                           ng-repeat="preValue in preValues">
 
-                <umb-editor model="preValue" is-pre-value="true"></umb-editor>
-            </umb-property>
+                 <umb-editor model="preValue" is-pre-value="true"></umb-editor>
+             </umb-property>
 
          </umb-editor-container>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11301

### Description
This add the datatype id and guid on datatype pages and is a bit more consistent with content and media nodes. When working with Umbraco Cloud once in a while there might be issues when restoring or deploying content, e.g. with LeBlender if a datatype has been deleted, but still referenced in grid content or when configuration of a datatype has changed. Furthermore I think this is useful for the Umbraco Cloud support team 🦄 

![image](https://user-images.githubusercontent.com/2919859/41066494-494b21c8-69e2-11e8-9f9a-b2d0904447bb.png)
