### PR TITLE
U4-11067 lazy load tab content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tabs/umbtab.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tabs/umbtab.directive.js
@@ -9,6 +9,19 @@ angular.module("umbraco.directives")
 		restrict: 'E',
 		replace: true,
         transclude: 'true',
-		templateUrl: 'views/components/tabs/umb-tab.html'		
+        templateUrl: 'views/components/tabs/umb-tab.html',
+        link: function (scope, el, attr) {
+            scope.tab["active"] = false;
+            scope.tab["loaded"] = false;
+            if (typeof (scope.tab) != "undefined") {
+                scope.$watch(function () {
+                    return $(el).hasClass("active")
+                },
+                function () {
+                    scope.tab.visible = $(el).hasClass("active");
+                    scope.tab.loaded = scope.tab.visible || scope.tab.loaded;
+                });
+            }
+        }
     };
 });

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tab.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tab.html
@@ -1,5 +1,5 @@
 <div class='umb-tab-pane tab-pane'>
-    <div class='umb-tab-pane-inner'>
+    <div class='umb-tab-pane-inner' ng-if="tab.visible || tab.loaded">
         <div ng-transclude></div>
     </div>
 </div>


### PR DESCRIPTION
### Lazy load tabbed content across the Umbraco system
I have written a solution to lazy load tabbed content so that the angular content only runs if it is active or has been loaded already. 

This means the dashboard content will only load if the tab is clicked on.  Therefore loading on demand, instead of the aggressive loading that is currently in place.

This solution is written within the new tabbing directive, so that it provides seamless integration and will provide instant benefits for anyone using the tabs.  Developers do not need to perform any extra modifications to gain this benefit.

I have tested this in all areas and tested with all property types in place.  Everything is working perfectly.

####Issue link:
http://issues.umbraco.org/issue/U4-11067
