### PR TITLE
U4-11426 - Fixed bug with media picker not populating URL in RTE link editor when search is used.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -330,6 +330,11 @@ angular.module("umbraco")
                                         {
                                             alias: "umbracoHeight",
                                             value: mediaItem.metaData.umbracoHeight.Value
+                                        },
+                                        {
+                                            alias: 'umbracoFile',
+                                            editor: mediaItem.metaData.umbracoFile.PropertyEditorAlias,
+                                            value: mediaItem.metaData.umbracoFile.Value
                                         }
                                     ];
                                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11426

### Description

This resolves the bug U4-11426. The issue was that when searching for media using the media picker when inserting or editing a link it would not populate the URL field (there's a gif showing the error in the bug tracker).