### PR TITLE
Fix missing expand/collapse tree icon when refreshing page

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
@@ -264,6 +264,11 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
                         args.node.expanded = true;
                         args.node.hasChildren = true;
                     }
+
+                    if (angular.isFunction(args.node.updateNodeData)) {
+                        args.node.updateNodeData(args.node);
+                    }
+
                     return data;
 
                 }, function(reason) {

--- a/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
@@ -263,10 +263,10 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
                     if (args.node.children && args.node.children.length > 0) {
                         args.node.expanded = true;
                         args.node.hasChildren = true;
-                    }
 
-                    if (angular.isFunction(args.node.updateNodeData)) {
-                        args.node.updateNodeData(args.node);
+                        if (angular.isFunction(args.node.updateNodeData)) {
+                            args.node.updateNodeData();
+                        }
                     }
 
                     return data;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-10499

### Description
<!-- A description of the changes proposed in the pull-request -->

This fixes expand/collapse tree icons not being shown in the navigation tree when the page is refreshed

Before:
<img width="250" alt="before" src="https://user-images.githubusercontent.com/379886/41201313-d4ae19de-6cb5-11e8-9748-7f892f031f4c.png">

After:
<img width="237" alt="after" src="https://user-images.githubusercontent.com/379886/41201315-d6fd7400-6cb5-11e8-9eb5-2666e6ae5598.png">



<!-- Thanks for contributing to Umbraco CMS! -->
