### PR TITLE
Expand tree to current node on copy/move and when picking content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/treepicker/treepicker.controller.js
@@ -26,7 +26,7 @@ angular.module("umbraco").controller("Umbraco.Overlays.TreePickerController",
         //Some trees can have no items (dictionary & forms email templates)
         $scope.hasItems = true;
         $scope.emptyStateMessage = dialogOptions.emptyStateMessage;
-
+        var node = dialogOptions.currentNode;
 
         //This is called from ng-init
         //it turns out it is called from the angular html : / Have a look at views/common / overlays / contentpicker / contentpicker.html you'll see ng-init. 
@@ -161,6 +161,11 @@ angular.module("umbraco").controller("Umbraco.Overlays.TreePickerController",
             $scope.hasItems = args.tree.root.children.length > 0;
 
             tree = args.tree;
+
+            if (node && node.path) {
+                $scope.dialogTreeEventHandler.syncTree({ path: node.path, activate: false });
+            }
+
         }
 
         //wires up selection

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.copy.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.copy.controller.js
@@ -27,6 +27,12 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.CopyController",
 
 	    var node = dialogOptions.currentNode;
 
+        function treeLoadedHandler(ev, args) {
+            if (node && node.path) {
+                $scope.dialogTreeEventHandler.syncTree({ path: node.path, activate: false });
+            }
+        }
+
 	    function nodeSelectHandler(ev, args) {
 
 			if(args && args.event) {
@@ -110,10 +116,12 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.CopyController",
                 });
 	    };
 
+	    $scope.dialogTreeEventHandler.bind("treeLoaded", treeLoadedHandler);
 	    $scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
 	    $scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
 
 	    $scope.$on('$destroy', function () {
+	        $scope.dialogTreeEventHandler.unbind("treeLoaded", treeLoadedHandler);
 	        $scope.dialogTreeEventHandler.unbind("treeNodeSelect", nodeSelectHandler);
 	        $scope.dialogTreeEventHandler.unbind("treeNodeExpanded", nodeExpandedHandler);
 	    });
@@ -131,5 +139,5 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.CopyController",
 		function openMiniListView(node) {
 			$scope.miniListView = node;
 		}
-		
+
 	});

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.move.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.move.controller.js
@@ -25,6 +25,12 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.MoveController",
 
 	    var node = dialogOptions.currentNode;
 
+        function treeLoadedHandler(ev, args) {
+            if (node && node.path) {
+                $scope.dialogTreeEventHandler.syncTree({ path: node.path, activate: false });
+            }
+        }
+
 	    function nodeSelectHandler(ev, args) {
 
 			if(args && args.event) {
@@ -111,10 +117,12 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.MoveController",
                 });
 	    };
 
+	    $scope.dialogTreeEventHandler.bind("treeLoaded", treeLoadedHandler);
 	    $scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
 	    $scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
 
 	    $scope.$on('$destroy', function () {
+	        $scope.dialogTreeEventHandler.unbind("treeLoaded", treeLoadedHandler);
 	        $scope.dialogTreeEventHandler.unbind("treeNodeSelect", nodeSelectHandler);
 	        $scope.dialogTreeEventHandler.unbind("treeNodeExpanded", nodeExpandedHandler);
 	    });

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.move.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.move.controller.js
@@ -13,6 +13,12 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
             $scope.treeModel.hideHeader = userData.startMediaIds.length > 0 && userData.startMediaIds.indexOf(-1) == -1;
         });
 
+        function treeLoadedHandler(ev, args) {
+            if (node && node.path) {
+                $scope.dialogTreeEventHandler.syncTree({ path: node.path, activate: false });
+            }
+        }
+
 	    function nodeSelectHandler(ev, args) {
 
 			if(args && args.event) {
@@ -38,6 +44,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
 			}
 	    }
 
+	    $scope.dialogTreeEventHandler.bind("treeLoaded", treeLoadedHandler);
 	    $scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
 	    $scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
 
@@ -71,6 +78,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
 	    };
 
 	    $scope.$on('$destroy', function () {
+	        $scope.dialogTreeEventHandler.unbind("treeLoaded", treeLoadedHandler);
 	        $scope.dialogTreeEventHandler.unbind("treeNodeSelect", nodeSelectHandler);
 			$scope.dialogTreeEventHandler.unbind("treeNodeExpanded", nodeExpandedHandler);
 	    });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -109,6 +109,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         entityType: entityType,
         filterCssClass: "not-allowed not-published",
         startNodeId: null,
+        currentNode: editorState ? editorState.current : null,
         callback: function (data) {
             if (angular.isArray(data)) {
                 _.each(data, function (item, i) {

--- a/src/Umbraco.Web/Trees/TreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/TreeControllerBase.cs
@@ -243,6 +243,7 @@ namespace Umbraco.Web.Trees
         public TreeNode CreateTreeNode(UmbracoEntity entity, Guid entityObjectType, string parentId, FormDataCollection queryStrings, bool hasChildren)
         {
             var treeNode = CreateTreeNode(entity.Id.ToInvariantString(), parentId, queryStrings, entity.Name, entity.ContentTypeIcon);
+            treeNode.Path = entity.Path;
             treeNode.Udi = Udi.Create(UmbracoObjectTypesExtensions.GetUdiType(entityObjectType), entity.Key);
             treeNode.HasChildren = hasChildren;
             return treeNode;
@@ -261,6 +262,7 @@ namespace Umbraco.Web.Trees
         public TreeNode CreateTreeNode(IUmbracoEntity entity, Guid entityObjectType, string parentId, FormDataCollection queryStrings, string icon, bool hasChildren)
         {
             var treeNode = CreateTreeNode(entity.Id.ToInvariantString(), parentId, queryStrings, entity.Name, icon);
+            treeNode.Path = entity.Path;
             treeNode.Udi = Udi.Create(UmbracoObjectTypesExtensions.GetUdiType(entityObjectType), entity.Key);
             treeNode.HasChildren = hasChildren;
             return treeNode;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-3921

### Description
<!-- A description of the changes proposed in the pull-request -->

When moving or copying content/media or opening a content picker the tree is now expanded to the current location of where the node is.

<!-- Thanks for contributing to Umbraco CMS! -->
