### PR TITLE
U4-9367 Refined context menu for content in the recycle bin

### DIFF
--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -242,6 +242,11 @@ namespace Umbraco.Web.Trees
             return menu;
         }
 
+        /// <summary>
+        /// Returns a collection of all menu items that can be on a deleted (in recycle bin) content node
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
         protected MenuItemCollection GetNodeMenuItemsForDeletedContent(IUmbracoEntity item)
         {
             var menu = new MenuItemCollection();

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -253,10 +253,6 @@ namespace Umbraco.Web.Trees
             menu.Items.Add<ActionRestore>(ui.Text("actions", ActionRestore.Instance.Alias));
             menu.Items.Add<ActionDelete>(ui.Text("actions", ActionDelete.Instance.Alias));
 
-            menu.Items.Add<ActionSort>(ui.Text("actions", ActionSort.Instance.Alias), true).ConvertLegacyMenuItem(item, "content", "content");
-            menu.Items.Add<ActionRollback>(ui.Text("actions", ActionRollback.Instance.Alias)).ConvertLegacyMenuItem(item, "content", "content");
-            menu.Items.Add<ActionAudit>(ui.Text("actions", ActionAudit.Instance.Alias)).ConvertLegacyMenuItem(item, "content", "content");
-
             menu.Items.Add<RefreshNode, ActionRefresh>(ui.Text("actions", ActionRefresh.Instance.Alias), true);
 
             return menu;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
This is a potential solution to [U4-9367](http://issues.umbraco.org/issue/U4-9367). An old issue, but it makes sense to clean up the context menu for items in the recycle bin. It doesn't look like the original issue is still active (the restore menu appearing for items "moved" from the recycling bin), but having multiple methods is confusing and the restore option is there for a reason.

The new context menu for items in the recycling bin looks as below. I added a new method to build up the menu, rather than pulling items out of the default one.

<img width="456" alt="deletedcontentcontextmenu" src="https://user-images.githubusercontent.com/514825/41256199-cc63df82-6dc0-11e8-8dbd-cfaf8ccfb9d2.PNG">

Happy to make further changes as required. The items left in the menu make sense to me and work in that context, but focus on the user either restoring or permanently deleting the content. 




