### PR TITLE
U4-11431: add grouping for nested content picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -206,3 +206,7 @@
     position: relative;
     transform: translate(-50%, -25%);
 }
+
+.nested-content__doctypepicker th.nested-content_group {
+    width: 130px;
+}

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -3,12 +3,15 @@
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th/>
+                    <th />
                     <th>
                         <localize key="content_documentType">Document Type</localize>
                     </th>
                     <th>
                         <localize key="editcontenttype_tab">Tab</localize>
+                    </th>
+                    <th class="nested-content_group">
+                        <localize key="editcontenttype_group">Group</localize>
                     </th>
                     <th>
                         <localize key="template_template">Template</localize>
@@ -18,17 +21,19 @@
             </thead>
             <tbody ui-sortable="sortableOptions" ng-model="model.value">
                 <tr ng-repeat="config in model.value">
-                    <td class="icon icon-navigation">
-                    </td>
+                    <td class="icon icon-navigation"></td>
                     <td>
                         <select id="{{model.alias}}_doctype_select"
-                            ng-options="dt.alias as dt.name for dt in model.docTypes | orderBy: 'name'"
-                            ng-model="config.ncAlias" required></select>
+                                ng-options="dt.alias as dt.name for dt in model.docTypes | orderBy: 'name'"
+                                ng-model="config.ncAlias" required></select>
                     </td>
                     <td>
                         <select id="{{model.alias}}_tab_select"
-                            ng-options="t for t in docTypeTabs[config.ncAlias]"
-                            ng-model="config.ncTabAlias" required></select>
+                                ng-options="t for t in docTypeTabs[config.ncAlias]"
+                                ng-model="config.ncTabAlias" required></select>
+                    </td>
+                    <td>
+                        <input type="text" ng-model="config.nameGroup" />
                     </td>
                     <td>
                         <input type="text" ng-model="config.nameTemplate" />
@@ -51,12 +56,16 @@
     <br/>
     <div class="nested-content__help-text" ng-show="showHelpText">
         <p>
-            <b><localize key="editcontenttype_tab">Tab</localize>:</b><br/>
+            <b><localize key="editcontenttype_tab">Tab</localize>:</b><br />
             Select the tab who's properties should be displayed. If left blank, the first tab on the doc type will be used.
         </p>
         <p>
-            <b><localize key="template_template">Template</localize>:</b><br/>
-            Enter an angular expression to evaluate against each item for its name. Use <code ng-non-bindable>{{$index}}</code> to display the item index  
+            <b><localize key="editcontenttype_Group">Group</localize>:</b><br />
+            Enter the group name to appear when inserting an item. If left blank, item will be displayed on the main screen.
+        </p>
+        <p>
+            <b><localize key="template_template">Template</localize>:</b><br />
+            Enter an angular expression to evaluate against each item for its name. Use <code ng-non-bindable>{{$index}}</code> to display the item index
         </p>
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -49,7 +49,11 @@
                 </h5>
                 <ul class="elements">
                     <li ng-repeat="scaffold in overlayMenu.scaffolds">
-                        <a ng-click="addNode(scaffold.alias)" href>
+                        <a ng-if="!isGroup(scaffold)" ng-click="addNode(scaffold.alias)" href>
+                            <i class="icon {{scaffold.icon}}"></i>
+                            {{scaffold.name}}
+                        </a>
+                        <a ng-if="isGroup(scaffold)" ng-click="openNodeTypePicker($event,scaffold.group)" href>
                             <i class="icon {{scaffold.icon}}"></i>
                             {{scaffold.name}}
                         </a>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -453,6 +453,7 @@
         <key alias="currentListViewDesc" version="7.2">The active list view data type</key>
         <key alias="createListView" version="7.2">Create custom list view</key>
         <key alias="removeListView" version="7.2">Remove custom list view</key>
+        <key alias="group">Group</key>
     </area>
     <area alias="renamecontainer">
         <key alias="renamed">Renamed</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -452,6 +452,7 @@
         <key alias="currentListViewDesc" version="7.2">The active list view data type</key>
         <key alias="createListView" version="7.2">Create custom list view</key>
         <key alias="removeListView" version="7.2">Remove custom list view</key>
+        <key alias="group">Group</key>
     </area>
     <area alias="renamecontainer">
         <key alias="renamed">Renamed</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
This is in response to feature request [U4-11431](http://issues.umbraco.org/issue/U4-11431). Have added a grouping for nested content picker. If left blank, content items will display on the main window. Open to suggestions. 

![chrome_2018-06-12_16-22-13](https://user-images.githubusercontent.com/1667477/41274240-149708ac-6e60-11e8-93ff-32ac1aa8de0e.png)
![chrome_2018-06-12_16-22-32](https://user-images.githubusercontent.com/1667477/41274242-17256000-6e60-11e8-8b2c-1394886eff80.png)
![chrome_2018-06-12_16-35-36](https://user-images.githubusercontent.com/1667477/41274246-18f04ddc-6e60-11e8-864e-8da8f4a9db7a.png)

