### PR TITLE
U4-11437: Added 'Document Type Alias' title to appear on mouse hover …

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbnodepreview.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbnodepreview.directive.js
@@ -91,12 +91,16 @@
 (function () {
     'use strict';
 
-    function NodePreviewDirective() {
+    function NodePreviewDirective(userService) {
 
         function link(scope, el, attr, ctrl) {
             if (!scope.editLabelKey) {
                 scope.editLabelKey = "general_edit";
             }
+            userService.getCurrentUser().then(function (u) {
+                var isAdmin = u.userGroups.indexOf('admin') !== -1;
+                scope.alias = (Umbraco.Sys.ServerVariables.isDebuggingEnabled === true || isAdmin) ? scope.alias : null;
+            });
         }
 
         var directive = {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbnodepreview.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbnodepreview.directive.js
@@ -106,6 +106,7 @@
             scope: {
                 icon: "=?",
                 name: "=",
+                alias: "=?",
                 description: "=?",
                 permissions: "=?",
                 published: "=?",

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -180,6 +180,7 @@
                     <umb-node-preview style="max-width: 100%; margin-bottom: 0;"
                                       icon="documentType.icon"
                                       name="documentType.name"
+                                      alias="documentType.alias"
                                       allow-open="allowOpen"
                                       on-open="openDocumentType(documentType)">
                     </umb-node-preview>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
@@ -2,7 +2,7 @@
     <i ng-if="icon" class="umb-node-preview__icon {{ icon }}"></i>
     <div class="umb-node-preview__content">
         
-        <div class="umb-node-preview__name">{{ name }}</div>
+        <div class="umb-node-preview__name" ng-attr-title="{{alias}}">{{ name }}</div>
         <div class="umb-node-preview__description" ng-if="description">{{ description }}</div>
 
         <div class="umb-user-group-preview__permission" ng-if="permissions">


### PR DESCRIPTION
…over 'Document Type Name' under content 'Info' tab

This is a minor, 'nice to have' feature that allows a developer to preview the Document Type Alias by hovering over the Document Type Name in the 'Info' tab on a content item without having to click and open the Document Type.

Similar functionality exists when hovering over property titles. This is really useful for a quick glance at what an alias is when developing.

*Changes Made*
Added 'alias' to the umbnodepreview directive. This is currently only used by 'umb-content-node-info.html'.

The label will simply not display if 'alias' is not set by other areas using the umbnodepreview directive.

---

This is my first attempt at a contribution - so I thought I'd keep it simple. All feedback welcome :)