### PR TITLE
Replaced the old checkbox with the umb-toggle directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
@@ -1,9 +1,9 @@
 (function() {
   'use strict';
 
-  function ListViewSettingsDirective(contentTypeResource, dataTypeResource, dataTypeHelper, listViewPrevalueHelper) {
+  function ListViewSettingsDirective(dataTypeResource, dataTypeHelper, listViewPrevalueHelper) {
 
-    function link(scope, el, attr, ctrl) {
+    function link(scope) {
 
       scope.dataType = {};
       scope.editDataTypeSettings = false;
@@ -22,7 +22,6 @@
 
               listViewPrevalueHelper.setPrevalues(dataType.preValues);
               scope.customListViewCreated = checkForCustomListView();
-
             });
 
         } else {
@@ -111,8 +110,16 @@
 
       };
 
+     scope.toggle = function(){
+        if(scope.enableListView){
+          scope.enableListView = false;
+            return;
+        }
+        scope.enableListView = true;
+    };
+
       /* ----------- SCOPE WATCHERS ----------- */
-      var unbindEnableListViewWatcher = scope.$watch('enableListView', function(newValue, oldValue){
+      var unbindEnableListViewWatcher = scope.$watch('enableListView', function(newValue){
 
         if(newValue !== undefined) {
           activate();

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
@@ -1,9 +1,11 @@
 <div class="umb-list-view-settings">
 
   <div class="umb-list-view-settings__trigger">
-    <label class="checkbox no-indent">
-        <input type="checkbox" ng-model="enableListView" hotkey="alt+shift+l" />
-        <localize key="general_yes"></localize> - <localize key="contentTypeEditor_enableListViewHeading"></localize>
+        <umb-toggle
+            checked="enableListView"
+            on-click="toggle()"
+            hotkey="alt+shift+l">
+        </umb-toggle>
   </div>
 
   <!-- list view enabled -->


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description

It behaves the same as before but looks nicer :-), the keyboard shortcut also still works (alt+shift+l) - Also removed some unused references from the code in the directive.

I have uploaded a video showing the new behavior here https://www.youtube.com/watch?v=f58XjqpIJNY&feature=youtu.be

The issue can be found here http://issues.umbraco.org/issue/U4-11423

I'm wondring if I could actually update this PR to remove the Scope watcher if I move the "activate()" function inside the toggle function instead? But I'm a bit unsure if the directive is being used elsewhere, which could be influenced by this? Thoughts @madsrasmussen :-)