### PR TITLE
Features/u4 11424 use umb toggle directive permissions.tab

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
@@ -1,9 +1,9 @@
 (function() {
   'use strict';
 
-  function ListViewSettingsDirective(contentTypeResource, dataTypeResource, dataTypeHelper, listViewPrevalueHelper) {
+  function ListViewSettingsDirective(dataTypeResource, dataTypeHelper, listViewPrevalueHelper) {
 
-    function link(scope, el, attr, ctrl) {
+    function link(scope) {
 
       scope.dataType = {};
       scope.editDataTypeSettings = false;
@@ -22,7 +22,6 @@
 
               listViewPrevalueHelper.setPrevalues(dataType.preValues);
               scope.customListViewCreated = checkForCustomListView();
-
             });
 
         } else {
@@ -111,8 +110,16 @@
 
       };
 
+     scope.toggle = function(){
+        if(scope.enableListView){
+          scope.enableListView = false;
+            return;
+        }
+        scope.enableListView = true;
+    };
+
       /* ----------- SCOPE WATCHERS ----------- */
-      var unbindEnableListViewWatcher = scope.$watch('enableListView', function(newValue, oldValue){
+      var unbindEnableListViewWatcher = scope.$watch('enableListView', function(newValue){
 
         if(newValue !== undefined) {
           activate();

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
@@ -1,9 +1,11 @@
 <div class="umb-list-view-settings">
 
   <div class="umb-list-view-settings__trigger">
-    <label class="checkbox no-indent">
-        <input type="checkbox" ng-model="enableListView" hotkey="alt+shift+l" />
-        <localize key="general_yes"></localize> - <localize key="contentTypeEditor_enableListViewHeading"></localize>
+        <umb-toggle
+            checked="enableListView"
+            on-click="toggle()"
+            hotkey="alt+shift+l">
+        </umb-toggle>
   </div>
 
   <!-- list view enabled -->

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
@@ -23,6 +23,7 @@
 
         vm.addChild = addChild;
         vm.removeChild = removeChild;
+        vm.toggle = toggle;
 
         /* ---------- INIT ---------- */
 
@@ -73,6 +74,18 @@
            // remove from content type model
            var selectedChildIndex = $scope.model.allowedContentTypes.indexOf(selectedChild.id);
            $scope.model.allowedContentTypes.splice(selectedChildIndex, 1);
+        }
+
+        /**
+         * Toggle the $scope.model.allowAsRoot value to either true or false
+         */
+        function toggle(){
+            if($scope.model.allowAsRoot){
+                $scope.model.allowAsRoot = false;
+                return;
+            }
+
+            $scope.model.allowAsRoot = true;
         }
 
     }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
@@ -7,10 +7,12 @@
             <small><localize key="contentTypeEditor_allowAsRootDescription" /></small>
         </div>
         <div class="sub-view-column-right">
-            <label class="checkbox no-indent" >
-                <input type="checkbox" ng-model="model.allowAsRoot" hotkey="alt+shift+r" />
-                <localize key="contentTypeEditor_allowAsRootCheckbox" />
-            </label>
+            <umb-toggle
+                checked="model.allowAsRoot"
+                on-click="vm.toggle()"
+                hotkey="alt+shift+r"
+                >
+            </umb-toggle>
         </div>
 
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.controller.js
@@ -13,6 +13,7 @@
 
         vm.addChild = addChild;
         vm.removeChild = removeChild;
+        vm.toggle = toggle;
 
         /* ---------- INIT ---------- */
 
@@ -63,6 +64,18 @@
            // remove from content type model
            var selectedChildIndex = $scope.model.allowedContentTypes.indexOf(selectedChild.id);
            $scope.model.allowedContentTypes.splice(selectedChildIndex, 1);
+        }
+
+        /**
+         * Toggle the $scope.model.allowAsRoot value to either true or false
+         */
+        function toggle(){
+            if($scope.model.allowAsRoot){
+                $scope.model.allowAsRoot = false;
+                return;
+            }
+
+            $scope.model.allowAsRoot = true;
         }
 
     }

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.html
@@ -7,10 +7,12 @@
             <small><localize key="contentTypeEditor_allowAsRootDescription" /></small>
         </div>
         <div class="sub-view-column-right">
-            <label class="checkbox no-indent" >
-                <input type="checkbox" ng-model="model.allowAsRoot" hotkey="alt+shift+r" />
-                <localize key="contentTypeEditor_allowAsRootCheckbox" />
-            </label>
+            <umb-toggle
+                checked="model.allowAsRoot"
+                on-click="vm.toggle()"
+                hotkey="alt+shift+r"
+                >
+            </umb-toggle>
         </div>
 
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
Replacing the "checkbox" in the document and media type editors "permissions" tab to make use of the umb-toggle directive, which is already in the codebase.

Video showing the toggle on the "Media Type" permissions tab here: https://www.youtube.com/watch?reload=9&v=fHshO8jiRlY&feature=youtu.be

Video showing the toggle on the "Document Type" permissions tab here: https://www.youtube.com/watch?v=Iy8Mqp9Pf_o&feature=youtu.be

Pretty much identical but my hope is that it makes it easier to just see what has changed and what the test scenario is? :-)


Link to issue tracker: http://issues.umbraco.org/issue/U4-11424