### PR TITLE
Fixed reference System.ValueTuple mismatch which caused build error when upgrading

### DIFF
--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -115,7 +115,7 @@
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Transactions" />
-    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+    <Reference Include="System.ValueTuple, Version=4.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->

Issue: [U4-11441](http://issues.umbraco.org/issue/U4-11441)

Possible reference error which caused a build error for me when upgrading. The change proposed is that changing the reference key/name to the correct version for the actual NuGet package it is referring to.

<!-- Thanks for contributing to Umbraco CMS! -->
