### PR TITLE
U4-4732 Anchor missing in TinyMCE of Umbraco 7.x

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -7,856 +7,864 @@
  * A service containing all logic for all of the Umbraco TinyMCE plugins
  */
 function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macroService, $routeParams, umbRequestHelper, angularHelper, userService) {
-    return {
-
-        /**
-        * @ngdoc method
-        * @name umbraco.services.tinyMceService#configuration
-        * @methodOf umbraco.services.tinyMceService
-        *
-        * @description
-        * Returns a collection of plugins available to the tinyMCE editor
-        *
-        */
-        configuration: function () {
-               return umbRequestHelper.resourcePromise(
-                  $http.get(
-                      umbRequestHelper.getApiUrl(
-                          "rteApiBaseUrl",
-                          "GetConfiguration"), { cache: true }),
-                  'Failed to retrieve tinymce configuration');
-        },
-
-        /**
-        * @ngdoc method
-        * @name umbraco.services.tinyMceService#defaultPrevalues
-        * @methodOf umbraco.services.tinyMceService
-        *
-        * @description
-        * Returns a default configration to fallback on in case none is provided
-        *
-        */
-        defaultPrevalues: function () {
-               var cfg = {};
-                       cfg.toolbar = ["code", "bold", "italic", "styleselect","alignleft", "aligncenter", "alignright", "bullist","numlist", "outdent", "indent", "link", "image", "umbmediapicker", "umbembeddialog", "umbmacro"];
-                       cfg.stylesheets = [];
-                       cfg.dimensions = { height: 500 };
-                       cfg.maxImageSize = 500;
-                return cfg;
-        },
-
-        /**
-        * @ngdoc method
-        * @name umbraco.services.tinyMceService#createInsertEmbeddedMedia
-        * @methodOf umbraco.services.tinyMceService
-        *
-        * @description
-        * Creates the umbrco insert embedded media tinymce plugin
-        *
-        * @param {Object} editor the TinyMCE editor instance        
-        * @param {Object} $scope the current controller scope
-        */
-        createInsertEmbeddedMedia: function (editor, scope, callback) {
-            editor.addButton('umbembeddialog', {
-                icon: 'custom icon-tv',
-                tooltip: 'Embed',
-                onclick: function () {
-                    if (callback) {
-                        callback();
-                    }
-                }
-            });
-        },
-
-        insertEmbeddedMediaInEditor: function(editor, preview) {
-            editor.insertContent(preview);
-        },
-
-        /**
-        * @ngdoc method
-        * @name umbraco.services.tinyMceService#createMediaPicker
-        * @methodOf umbraco.services.tinyMceService
-        *
-        * @description
-        * Creates the umbrco insert media tinymce plugin
-        *
-        * @param {Object} editor the TinyMCE editor instance        
-        * @param {Object} $scope the current controller scope
-        */
-        createMediaPicker: function (editor, scope, callback) {
-            editor.addButton('umbmediapicker', {
-                icon: 'custom icon-picture',
-                tooltip: 'Media Picker',
-                stateSelector: 'img',
-                onclick: function () {
-
-                    var selectedElm = editor.selection.getNode(),
-                        currentTarget;
-
-
-                    if(selectedElm.nodeName === 'IMG'){
-                        var img = $(selectedElm);
-
-                        var hasUdi = img.attr("data-udi") ? true : false;
-
-                        currentTarget = {
-                            altText: img.attr("alt"),
-                            url: img.attr("src")                            
-                        };
-
-                        if (hasUdi) {
-                            currentTarget["udi"] = img.attr("data-udi");
-                        }
-                        else {
-                            currentTarget["id"] = img.attr("rel");
-                        }
-                    }
-
-                    userService.getCurrentUser().then(function(userData) {
-                        if(callback) {
-                            callback(currentTarget, userData);
-                        }
-                    });
-
-                }
-            });
-        },
-
-        insertMediaInEditor: function(editor, img) {
-            if(img) {
-
-                var hasUdi = img.udi ? true : false;
-                
-               var data = {
-                   alt: img.altText || "",
-                   src: (img.url) ? img.url : "nothing.jpg",                   
-                   id: '__mcenew'
-                };
-
-                if (hasUdi) {
-                    data["data-udi"] = img.udi;
-                }
-                else {
-                    //Considering these fixed because UDI will now be used and thus
-                    // we have no need for rel http://issues.umbraco.org/issue/U4-6228, http://issues.umbraco.org/issue/U4-6595
-                    data["rel"] = img.id;
-                    data["data-id"] = img.id;
-                }
-
-               editor.insertContent(editor.dom.createHTML('img', data));
-
-               $timeout(function () {
-                   var imgElm = editor.dom.get('__mcenew');
-                   var size = editor.dom.getSize(imgElm);
-
-                   if (editor.settings.maxImageSize && editor.settings.maxImageSize !== 0) {
-                        var newSize = imageHelper.scaleToMaxSize(editor.settings.maxImageSize, size.w, size.h);
-
-                        var s = "width: " + newSize.width + "px; height:" + newSize.height + "px;";
-                        editor.dom.setAttrib(imgElm, 'style', s);
-                        editor.dom.setAttrib(imgElm, 'id', null);
-
-                        if (img.url) {
-                            var src = img.url + "?width=" + newSize.width + "&height=" + newSize.height;
-                            editor.dom.setAttrib(imgElm, 'data-mce-src', src);
-                        }
-                   }
-               }, 500);
-            }
-        },
-
-        /**
-        * @ngdoc method
-        * @name umbraco.services.tinyMceService#createUmbracoMacro
-        * @methodOf umbraco.services.tinyMceService
-        *
-        * @description
-        * Creates the insert umbrco macro tinymce plugin
-        *
-        * @param {Object} editor the TinyMCE editor instance      
-        * @param {Object} $scope the current controller scope
-        */
-        createInsertMacro: function (editor, $scope, callback) {
-
-            var createInsertMacroScope = this;
-
-            /** Adds custom rules for the macro plugin and custom serialization */
-            editor.on('preInit', function (args) {
-                //this is requires so that we tell the serializer that a 'div' is actually allowed in the root, otherwise the cleanup will strip it out
-                editor.serializer.addRules('div');
-
-                /** This checks if the div is a macro container, if so, checks if its wrapped in a p tag and then unwraps it (removes p tag) */
-                editor.serializer.addNodeFilter('div', function (nodes, name) {
-                    for (var i = 0; i < nodes.length; i++) {
-                        if (nodes[i].attr("class") === "umb-macro-holder" && nodes[i].parent && nodes[i].parent.name.toUpperCase() === "P") {
-                            nodes[i].parent.unwrap();
-                        }
-                    }
-                });
-            
-            });
-
-            /**
-            * Because the macro gets wrapped in a P tag because of the way 'enter' works, this 
-            * method will return the macro element if not wrapped in a p, or the p if the macro
-            * element is the only one inside of it even if we are deep inside an element inside the macro
-            */
-            function getRealMacroElem(element) {
-                var e = $(element).closest(".umb-macro-holder");
-                if (e.length > 0) {
-                    if (e.get(0).parentNode.nodeName === "P") {
-                        //now check if we're the only element                    
-                        if (element.parentNode.childNodes.length === 1) {
-                            return e.get(0).parentNode;
-                        }
-                    }
-                    return e.get(0);
-                }
-                return null;
-            }
-
-            /** Adds the button instance */
-            editor.addButton('umbmacro', {
-                icon: 'custom icon-settings-alt',
-                tooltip: 'Insert macro',
-                onPostRender: function () {
-
-                    var ctrl = this;
-                    var isOnMacroElement = false;
-
-                    /**
-                     if the selection comes from a different element that is not the macro's
-                     we need to check if the selection includes part of the macro, if so we'll force the selection
-                     to clear to the next element since if people can select part of the macro markup they can then modify it.
-                    */
-                    function handleSelectionChange() {
-
-                        if (!editor.selection.isCollapsed()) {
-                            var endSelection = tinymce.activeEditor.selection.getEnd();
-                            var startSelection = tinymce.activeEditor.selection.getStart();
-                            //don't proceed if it's an entire element selected
-                            if (endSelection !== startSelection) { 
-                                
-                                //if the end selection is a macro then move the cursor
-                                //NOTE: we don't have to handle when the selection comes from a previous parent because
-                                // that is automatically taken care of with the normal onNodeChanged logic since the 
-                                // evt.element will be the macro once it becomes part of the selection.
-                                var $testForMacro = $(endSelection).closest(".umb-macro-holder");
-                                if ($testForMacro.length > 0) {
-                                    
-                                    //it came from before so move after, if there is no after then select ourselves
-                                    var next = $testForMacro.next();
-                                    if (next.length > 0) {
-                                        editor.selection.setCursorLocation($testForMacro.next().get(0));
-                                    }
-                                    else {
-                                        selectMacroElement($testForMacro.get(0));
-                                    }
-
-                                }
-                            }
-                        }
-                    }
-
-                    /** helper method to select the macro element */
-                    function selectMacroElement(macroElement) {
-
-                        // move selection to top element to ensure we can't edit this
-                        editor.selection.select(macroElement);
-
-                        // check if the current selection *is* the element (ie bug)
-                        var currentSelection = editor.selection.getStart();
-                        if (tinymce.isIE) {
-                            if (!editor.dom.hasClass(currentSelection, 'umb-macro-holder')) {
-                                while (!editor.dom.hasClass(currentSelection, 'umb-macro-holder') && currentSelection.parentNode) {
-                                    currentSelection = currentSelection.parentNode;
-                                }
-                                editor.selection.select(currentSelection);
-                            }
-                        }
-                    }
-
-                    /**
-                    * Add a node change handler, test if we're editing a macro and select the whole thing, then set our isOnMacroElement flag.
-                    * If we change the selection inside this method, then we end up in an infinite loop, so we have to remove ourselves
-                    * from the event listener before changing selection, however, it seems that putting a break point in this method
-                    * will always cause an 'infinite' loop as the caret keeps changing.
-                    */
-                    function onNodeChanged(evt) {
-
-                        //set our macro button active when on a node of class umb-macro-holder
-                        var $macroElement = $(evt.element).closest(".umb-macro-holder");
-                        
-                        handleSelectionChange();
-
-                        //set the button active
-                        ctrl.active($macroElement.length !== 0);
-
-                        if ($macroElement.length > 0) {
-                            var macroElement = $macroElement.get(0);
-
-                            //remove the event listener before re-selecting
-                            editor.off('NodeChange', onNodeChanged);
-
-                            selectMacroElement(macroElement);
-
-                            //set the flag
-                            isOnMacroElement = true;
-
-                            //re-add the event listener
-                            editor.on('NodeChange', onNodeChanged);
-                        }
-                        else {
-                            isOnMacroElement = false;
-                        }
-
-                    }
-
-                    /** when the contents load we need to find any macros declared and load in their content */
-                    editor.on("LoadContent", function (o) {
-                        
-                        //get all macro divs and load their content
-                        $(editor.dom.select(".umb-macro-holder.mceNonEditable")).each(function() {
-                            createInsertMacroScope.loadMacroContent($(this), null, $scope);
-                        });
-
-                    });
-                    
-                    /** This prevents any other commands from executing when the current element is the macro so the content cannot be edited */
-                    editor.on('BeforeExecCommand', function (o) {                        
-                        if (isOnMacroElement) {
-                            if (o.preventDefault) {
-                                o.preventDefault();
-                            }
-                            if (o.stopImmediatePropagation) {
-                                o.stopImmediatePropagation();
-                            }
-                            return;
-                        }
-                    });
-                    
-                    /** This double checks and ensures you can't paste content into the rendered macro */
-                    editor.on("Paste", function (o) {                        
-                        if (isOnMacroElement) {
-                            if (o.preventDefault) {
-                                o.preventDefault();
-                            }
-                            if (o.stopImmediatePropagation) {
-                                o.stopImmediatePropagation();
-                            }
-                            return;
-                        }
-                    });
-
-                    //set onNodeChanged event listener
-                    editor.on('NodeChange', onNodeChanged);
-
-                    /** 
-                    * Listen for the keydown in the editor, we'll check if we are currently on a macro element, if so
-                    * we'll check if the key down is a supported key which requires an action, otherwise we ignore the request
-                    * so the macro cannot be edited.
-                    */
-                    editor.on('KeyDown', function (e) {
-                        if (isOnMacroElement) {
-                            var macroElement = editor.selection.getNode();
-
-                            //get the 'real' element (either p or the real one)
-                            macroElement = getRealMacroElem(macroElement);
-
-                            //prevent editing
-                            e.preventDefault();
-                            e.stopPropagation();
-
-                            var moveSibling = function (element, isNext) {
-                                var $e = $(element);
-                                var $sibling = isNext ? $e.next() : $e.prev();
-                                if ($sibling.length > 0) {
-                                    editor.selection.select($sibling.get(0));
-                                    editor.selection.collapse(true);
-                                }
-                                else {
-                                    //if we're moving previous and there is no sibling, then lets recurse and just select the next one
-                                    if (!isNext) {
-                                        moveSibling(element, true);
-                                        return;
-                                    }
-
-                                    //if there is no sibling we'll generate a new p at the end and select it
-                                    editor.setContent(editor.getContent() + "<p>&nbsp;</p>");
-                                    editor.selection.select($(editor.dom.getRoot()).children().last().get(0));
-                                    editor.selection.collapse(true);
-
-                                }
-                            };
-
-                            //supported keys to move to the next or prev element (13-enter, 27-esc, 38-up, 40-down, 39-right, 37-left)
-                            //supported keys to remove the macro (8-backspace, 46-delete)
-                            //TODO: Should we make the enter key insert a line break before or leave it as moving to the next element?
-                            if ($.inArray(e.keyCode, [13, 40, 39]) !== -1) {
-                                //move to next element
-                                moveSibling(macroElement, true);
-                            }
-                            else if ($.inArray(e.keyCode, [27, 38, 37]) !== -1) {
-                                //move to prev element
-                                moveSibling(macroElement, false);
-                            }
-                            else if ($.inArray(e.keyCode, [8, 46]) !== -1) {
-                                //delete macro element
-
-                                //move first, then delete
-                                moveSibling(macroElement, false);
-                                editor.dom.remove(macroElement);
-                            }
-                            return ;
-                        }
-                    });
-
-                },
-                
-                /** The insert macro button click event handler */
-                onclick: function () {
-
-                    var dialogData = {
-                        //flag for use in rte so we only show macros flagged for the editor
-                        richTextEditor: true  
-                    };
-
-                    //when we click we could have a macro already selected and in that case we'll want to edit the current parameters
-                    //so we'll need to extract them and submit them to the dialog.
-                    var macroElement = editor.selection.getNode();                    
-                    macroElement = getRealMacroElem(macroElement);
-                    if (macroElement) {
-                        //we have a macro selected so we'll need to parse it's alias and parameters
-                        var contents = $(macroElement).contents();                        
-                        var comment = _.find(contents, function(item) {
-                            return item.nodeType === 8;
-                        });
-                        if (!comment) {
-                            throw "Cannot parse the current macro, the syntax in the editor is invalid";
-                        }
-                        var syntax = comment.textContent.trim();
-                        var parsed = macroService.parseMacroSyntax(syntax);
-                        dialogData = {
-                            macroData: parsed  
-                        };
-                    }
-
-                    if(callback) {
-                        callback(dialogData);
-                    }
-
-                }
-            });
-        },
-
-        insertMacroInEditor: function(editor, macroObject, $scope) {
-
-            //put the macro syntax in comments, we will parse this out on the server side to be used
-            //for persisting.
-            var macroSyntaxComment = "<!-- " + macroObject.syntax + " -->";
-            //create an id class for this element so we can re-select it after inserting
-            var uniqueId = "umb-macro-" + editor.dom.uniqueId();
-            var macroDiv = editor.dom.create('div',
-                {
-                    'class': 'umb-macro-holder ' + macroObject.macroAlias + ' mceNonEditable ' + uniqueId
-                },
-                macroSyntaxComment + '<ins>Macro alias: <strong>' + macroObject.macroAlias + '</strong></ins>');
-
-            editor.selection.setNode(macroDiv);
-
-            var $macroDiv = $(editor.dom.select("div.umb-macro-holder." + uniqueId));
-
-            //async load the macro content
-            this.loadMacroContent($macroDiv, macroObject, $scope);
-
-        },
-
-        /** loads in the macro content async from the server */
-        loadMacroContent: function($macroDiv, macroData, $scope) {
-
-            //if we don't have the macroData, then we'll need to parse it from the macro div
-            if (!macroData) {
-                var contents = $macroDiv.contents();
-                var comment = _.find(contents, function (item) {
-                    return item.nodeType === 8;
-                });
-                if (!comment) {
-                    throw "Cannot parse the current macro, the syntax in the editor is invalid";
-                }
-                var syntax = comment.textContent.trim();
-                var parsed = macroService.parseMacroSyntax(syntax);
-                macroData = parsed;
-            }
-
-            var $ins = $macroDiv.find("ins");
-
-            //show the throbber
-            $macroDiv.addClass("loading");
-
-            var contentId = $routeParams.id;
-
-            //need to wrap in safe apply since this might be occuring outside of angular
-            angularHelper.safeApply($scope, function() {
-                macroResource.getMacroResultAsHtmlForEditor(macroData.macroAlias, contentId, macroData.macroParamsDictionary)
-                .then(function (htmlResult) {
-
-                    $macroDiv.removeClass("loading");
-                    htmlResult = htmlResult.trim();
-                    if (htmlResult !== "") {
-                        $ins.html(htmlResult);
-                    }
-                });
-            });
-
-        },
-
-        createLinkPicker: function(editor, $scope, onClick) {
-
-            function createLinkList(callback) {
-                return function() {
-                    var linkList = editor.settings.link_list;
-
-                    if (typeof(linkList) === "string") {
-                        tinymce.util.XHR.send({
-                            url: linkList,
-                            success: function(text) {
-                                callback(tinymce.util.JSON.parse(text));
-                            }
-                        });
-                    } else {
-                        callback(linkList);
-                    }
-                };
-            }
-
-            function showDialog(linkList) {
-                var data = {}, selection = editor.selection, dom = editor.dom, selectedElm, anchorElm, initialText;
-                var win, linkListCtrl, relListCtrl, targetListCtrl;
-
-                function linkListChangeHandler(e) {
-                    var textCtrl = win.find('#text');
-
-                    if (!textCtrl.value() || (e.lastControl && textCtrl.value() === e.lastControl.text())) {
-                        textCtrl.value(e.control.text());
-                    }
-
-                    win.find('#href').value(e.control.value());
-                }
-
-                function buildLinkList() {
-                    var linkListItems = [{
-                        text: 'None',
-                        value: ''
+	return {
+
+		/**
+		 * @ngdoc method
+		 * @name umbraco.services.tinyMceService#configuration
+		 * @methodOf umbraco.services.tinyMceService
+		 *
+		 * @description
+		 * Returns a collection of plugins available to the tinyMCE editor
+		 *
+		 */
+		configuration: function () {
+			return umbRequestHelper.resourcePromise(
+				$http.get(
+					umbRequestHelper.getApiUrl(
+						"rteApiBaseUrl",
+						"GetConfiguration"), {
+						cache: true
+					}),
+				'Failed to retrieve tinymce configuration');
+		},
+
+		/**
+		 * @ngdoc method
+		 * @name umbraco.services.tinyMceService#defaultPrevalues
+		 * @methodOf umbraco.services.tinyMceService
+		 *
+		 * @description
+		 * Returns a default configration to fallback on in case none is provided
+		 *
+		 */
+		defaultPrevalues: function () {
+			var cfg = {};
+			cfg.toolbar = ["code", "bold", "italic", "styleselect", "alignleft", "aligncenter", "alignright", "bullist", "numlist", "outdent", "indent", "link", "image", "umbmediapicker", "umbembeddialog", "umbmacro"];
+			cfg.stylesheets = [];
+			cfg.dimensions = {
+				height: 500
+			};
+			cfg.maxImageSize = 500;
+			return cfg;
+		},
+
+		/**
+		 * @ngdoc method
+		 * @name umbraco.services.tinyMceService#createInsertEmbeddedMedia
+		 * @methodOf umbraco.services.tinyMceService
+		 *
+		 * @description
+		 * Creates the umbrco insert embedded media tinymce plugin
+		 *
+		 * @param {Object} editor the TinyMCE editor instance        
+		 * @param {Object} $scope the current controller scope
+		 */
+		createInsertEmbeddedMedia: function (editor, scope, callback) {
+			editor.addButton('umbembeddialog', {
+				icon: 'custom icon-tv',
+				tooltip: 'Embed',
+				onclick: function () {
+					if (callback) {
+						callback();
+					}
+				}
+			});
+		},
+
+		insertEmbeddedMediaInEditor: function (editor, preview) {
+			editor.insertContent(preview);
+		},
+
+		/**
+		 * @ngdoc method
+		 * @name umbraco.services.tinyMceService#createMediaPicker
+		 * @methodOf umbraco.services.tinyMceService
+		 *
+		 * @description
+		 * Creates the umbrco insert media tinymce plugin
+		 *
+		 * @param {Object} editor the TinyMCE editor instance        
+		 * @param {Object} $scope the current controller scope
+		 */
+		createMediaPicker: function (editor, scope, callback) {
+			editor.addButton('umbmediapicker', {
+				icon: 'custom icon-picture',
+				tooltip: 'Media Picker',
+				stateSelector: 'img',
+				onclick: function () {
+
+					var selectedElm = editor.selection.getNode(),
+						currentTarget;
+
+
+					if (selectedElm.nodeName === 'IMG') {
+						var img = $(selectedElm);
+
+						var hasUdi = img.attr("data-udi") ? true : false;
+
+						currentTarget = {
+							altText: img.attr("alt"),
+							url: img.attr("src")
+						};
+
+						if (hasUdi) {
+							currentTarget["udi"] = img.attr("data-udi");
+						} else {
+							currentTarget["id"] = img.attr("rel");
+						}
+					}
+
+					userService.getCurrentUser().then(function (userData) {
+						if (callback) {
+							callback(currentTarget, userData);
+						}
+					});
+
+				}
+			});
+		},
+
+		insertMediaInEditor: function (editor, img) {
+			if (img) {
+
+				var hasUdi = img.udi ? true : false;
+
+				var data = {
+					alt: img.altText || "",
+					src: (img.url) ? img.url : "nothing.jpg",
+					id: '__mcenew'
+				};
+
+				if (hasUdi) {
+					data["data-udi"] = img.udi;
+				} else {
+					//Considering these fixed because UDI will now be used and thus
+					// we have no need for rel http://issues.umbraco.org/issue/U4-6228, http://issues.umbraco.org/issue/U4-6595
+					data["rel"] = img.id;
+					data["data-id"] = img.id;
+				}
+
+				editor.insertContent(editor.dom.createHTML('img', data));
+
+				$timeout(function () {
+					var imgElm = editor.dom.get('__mcenew');
+					var size = editor.dom.getSize(imgElm);
+
+					if (editor.settings.maxImageSize && editor.settings.maxImageSize !== 0) {
+						var newSize = imageHelper.scaleToMaxSize(editor.settings.maxImageSize, size.w, size.h);
+
+						var s = "width: " + newSize.width + "px; height:" + newSize.height + "px;";
+						editor.dom.setAttrib(imgElm, 'style', s);
+						editor.dom.setAttrib(imgElm, 'id', null);
+
+						if (img.url) {
+							var src = img.url + "?width=" + newSize.width + "&height=" + newSize.height;
+							editor.dom.setAttrib(imgElm, 'data-mce-src', src);
+						}
+					}
+				}, 500);
+			}
+		},
+
+		/**
+		 * @ngdoc method
+		 * @name umbraco.services.tinyMceService#createUmbracoMacro
+		 * @methodOf umbraco.services.tinyMceService
+		 *
+		 * @description
+		 * Creates the insert umbrco macro tinymce plugin
+		 *
+		 * @param {Object} editor the TinyMCE editor instance      
+		 * @param {Object} $scope the current controller scope
+		 */
+		createInsertMacro: function (editor, $scope, callback) {
+
+			var createInsertMacroScope = this;
+
+			/** Adds custom rules for the macro plugin and custom serialization */
+			editor.on('preInit', function (args) {
+				//this is requires so that we tell the serializer that a 'div' is actually allowed in the root, otherwise the cleanup will strip it out
+				editor.serializer.addRules('div');
+
+				/** This checks if the div is a macro container, if so, checks if its wrapped in a p tag and then unwraps it (removes p tag) */
+				editor.serializer.addNodeFilter('div', function (nodes, name) {
+					for (var i = 0; i < nodes.length; i++) {
+						if (nodes[i].attr("class") === "umb-macro-holder" && nodes[i].parent && nodes[i].parent.name.toUpperCase() === "P") {
+							nodes[i].parent.unwrap();
+						}
+					}
+				});
+
+			});
+
+			/**
+			 * Because the macro gets wrapped in a P tag because of the way 'enter' works, this 
+			 * method will return the macro element if not wrapped in a p, or the p if the macro
+			 * element is the only one inside of it even if we are deep inside an element inside the macro
+			 */
+			function getRealMacroElem(element) {
+				var e = $(element).closest(".umb-macro-holder");
+				if (e.length > 0) {
+					if (e.get(0).parentNode.nodeName === "P") {
+						//now check if we're the only element                    
+						if (element.parentNode.childNodes.length === 1) {
+							return e.get(0).parentNode;
+						}
+					}
+					return e.get(0);
+				}
+				return null;
+			}
+
+			/** Adds the button instance */
+			editor.addButton('umbmacro', {
+				icon: 'custom icon-settings-alt',
+				tooltip: 'Insert macro',
+				onPostRender: function () {
+
+					var ctrl = this;
+					var isOnMacroElement = false;
+
+					/**
+					 if the selection comes from a different element that is not the macro's
+					 we need to check if the selection includes part of the macro, if so we'll force the selection
+					 to clear to the next element since if people can select part of the macro markup they can then modify it.
+					*/
+					function handleSelectionChange() {
+
+						if (!editor.selection.isCollapsed()) {
+							var endSelection = tinymce.activeEditor.selection.getEnd();
+							var startSelection = tinymce.activeEditor.selection.getStart();
+							//don't proceed if it's an entire element selected
+							if (endSelection !== startSelection) {
+
+								//if the end selection is a macro then move the cursor
+								//NOTE: we don't have to handle when the selection comes from a previous parent because
+								// that is automatically taken care of with the normal onNodeChanged logic since the 
+								// evt.element will be the macro once it becomes part of the selection.
+								var $testForMacro = $(endSelection).closest(".umb-macro-holder");
+								if ($testForMacro.length > 0) {
+
+									//it came from before so move after, if there is no after then select ourselves
+									var next = $testForMacro.next();
+									if (next.length > 0) {
+										editor.selection.setCursorLocation($testForMacro.next().get(0));
+									} else {
+										selectMacroElement($testForMacro.get(0));
+									}
+
+								}
+							}
+						}
+					}
+
+					/** helper method to select the macro element */
+					function selectMacroElement(macroElement) {
+
+						// move selection to top element to ensure we can't edit this
+						editor.selection.select(macroElement);
+
+						// check if the current selection *is* the element (ie bug)
+						var currentSelection = editor.selection.getStart();
+						if (tinymce.isIE) {
+							if (!editor.dom.hasClass(currentSelection, 'umb-macro-holder')) {
+								while (!editor.dom.hasClass(currentSelection, 'umb-macro-holder') && currentSelection.parentNode) {
+									currentSelection = currentSelection.parentNode;
+								}
+								editor.selection.select(currentSelection);
+							}
+						}
+					}
+
+					/**
+					 * Add a node change handler, test if we're editing a macro and select the whole thing, then set our isOnMacroElement flag.
+					 * If we change the selection inside this method, then we end up in an infinite loop, so we have to remove ourselves
+					 * from the event listener before changing selection, however, it seems that putting a break point in this method
+					 * will always cause an 'infinite' loop as the caret keeps changing.
+					 */
+					function onNodeChanged(evt) {
+
+						//set our macro button active when on a node of class umb-macro-holder
+						var $macroElement = $(evt.element).closest(".umb-macro-holder");
+
+						handleSelectionChange();
+
+						//set the button active
+						ctrl.active($macroElement.length !== 0);
+
+						if ($macroElement.length > 0) {
+							var macroElement = $macroElement.get(0);
+
+							//remove the event listener before re-selecting
+							editor.off('NodeChange', onNodeChanged);
+
+							selectMacroElement(macroElement);
+
+							//set the flag
+							isOnMacroElement = true;
+
+							//re-add the event listener
+							editor.on('NodeChange', onNodeChanged);
+						} else {
+							isOnMacroElement = false;
+						}
+
+					}
+
+					/** when the contents load we need to find any macros declared and load in their content */
+					editor.on("LoadContent", function (o) {
+
+						//get all macro divs and load their content
+						$(editor.dom.select(".umb-macro-holder.mceNonEditable")).each(function () {
+							createInsertMacroScope.loadMacroContent($(this), null, $scope);
+						});
+
+					});
+
+					/** This prevents any other commands from executing when the current element is the macro so the content cannot be edited */
+					editor.on('BeforeExecCommand', function (o) {
+						if (isOnMacroElement) {
+							if (o.preventDefault) {
+								o.preventDefault();
+							}
+							if (o.stopImmediatePropagation) {
+								o.stopImmediatePropagation();
+							}
+							return;
+						}
+					});
+
+					/** This double checks and ensures you can't paste content into the rendered macro */
+					editor.on("Paste", function (o) {
+						if (isOnMacroElement) {
+							if (o.preventDefault) {
+								o.preventDefault();
+							}
+							if (o.stopImmediatePropagation) {
+								o.stopImmediatePropagation();
+							}
+							return;
+						}
+					});
+
+					//set onNodeChanged event listener
+					editor.on('NodeChange', onNodeChanged);
+
+					/** 
+					 * Listen for the keydown in the editor, we'll check if we are currently on a macro element, if so
+					 * we'll check if the key down is a supported key which requires an action, otherwise we ignore the request
+					 * so the macro cannot be edited.
+					 */
+					editor.on('KeyDown', function (e) {
+						if (isOnMacroElement) {
+							var macroElement = editor.selection.getNode();
+
+							//get the 'real' element (either p or the real one)
+							macroElement = getRealMacroElem(macroElement);
+
+							//prevent editing
+							e.preventDefault();
+							e.stopPropagation();
+
+							var moveSibling = function (element, isNext) {
+								var $e = $(element);
+								var $sibling = isNext ? $e.next() : $e.prev();
+								if ($sibling.length > 0) {
+									editor.selection.select($sibling.get(0));
+									editor.selection.collapse(true);
+								} else {
+									//if we're moving previous and there is no sibling, then lets recurse and just select the next one
+									if (!isNext) {
+										moveSibling(element, true);
+										return;
+									}
+
+									//if there is no sibling we'll generate a new p at the end and select it
+									editor.setContent(editor.getContent() + "<p>&nbsp;</p>");
+									editor.selection.select($(editor.dom.getRoot()).children().last().get(0));
+									editor.selection.collapse(true);
+
+								}
+							};
+
+							//supported keys to move to the next or prev element (13-enter, 27-esc, 38-up, 40-down, 39-right, 37-left)
+							//supported keys to remove the macro (8-backspace, 46-delete)
+							//TODO: Should we make the enter key insert a line break before or leave it as moving to the next element?
+							if ($.inArray(e.keyCode, [13, 40, 39]) !== -1) {
+								//move to next element
+								moveSibling(macroElement, true);
+							} else if ($.inArray(e.keyCode, [27, 38, 37]) !== -1) {
+								//move to prev element
+								moveSibling(macroElement, false);
+							} else if ($.inArray(e.keyCode, [8, 46]) !== -1) {
+								//delete macro element
+
+								//move first, then delete
+								moveSibling(macroElement, false);
+								editor.dom.remove(macroElement);
+							}
+							return;
+						}
+					});
+
+				},
+
+				/** The insert macro button click event handler */
+				onclick: function () {
+
+					var dialogData = {
+						//flag for use in rte so we only show macros flagged for the editor
+						richTextEditor: true
+					};
+
+					//when we click we could have a macro already selected and in that case we'll want to edit the current parameters
+					//so we'll need to extract them and submit them to the dialog.
+					var macroElement = editor.selection.getNode();
+					macroElement = getRealMacroElem(macroElement);
+					if (macroElement) {
+						//we have a macro selected so we'll need to parse it's alias and parameters
+						var contents = $(macroElement).contents();
+						var comment = _.find(contents, function (item) {
+							return item.nodeType === 8;
+						});
+						if (!comment) {
+							throw "Cannot parse the current macro, the syntax in the editor is invalid";
+						}
+						var syntax = comment.textContent.trim();
+						var parsed = macroService.parseMacroSyntax(syntax);
+						dialogData = {
+							macroData: parsed
+						};
+					}
+
+					if (callback) {
+						callback(dialogData);
+					}
+
+				}
+			});
+		},
+
+		insertMacroInEditor: function (editor, macroObject, $scope) {
+
+			//put the macro syntax in comments, we will parse this out on the server side to be used
+			//for persisting.
+			var macroSyntaxComment = "<!-- " + macroObject.syntax + " -->";
+			//create an id class for this element so we can re-select it after inserting
+			var uniqueId = "umb-macro-" + editor.dom.uniqueId();
+			var macroDiv = editor.dom.create('div', {
+					'class': 'umb-macro-holder ' + macroObject.macroAlias + ' mceNonEditable ' + uniqueId
+				},
+				macroSyntaxComment + '<ins>Macro alias: <strong>' + macroObject.macroAlias + '</strong></ins>');
+
+			editor.selection.setNode(macroDiv);
+
+			var $macroDiv = $(editor.dom.select("div.umb-macro-holder." + uniqueId));
+
+			//async load the macro content
+			this.loadMacroContent($macroDiv, macroObject, $scope);
+
+		},
+
+		/** loads in the macro content async from the server */
+		loadMacroContent: function ($macroDiv, macroData, $scope) {
+
+			//if we don't have the macroData, then we'll need to parse it from the macro div
+			if (!macroData) {
+				var contents = $macroDiv.contents();
+				var comment = _.find(contents, function (item) {
+					return item.nodeType === 8;
+				});
+				if (!comment) {
+					throw "Cannot parse the current macro, the syntax in the editor is invalid";
+				}
+				var syntax = comment.textContent.trim();
+				var parsed = macroService.parseMacroSyntax(syntax);
+				macroData = parsed;
+			}
+
+			var $ins = $macroDiv.find("ins");
+
+			//show the throbber
+			$macroDiv.addClass("loading");
+
+			var contentId = $routeParams.id;
+
+			//need to wrap in safe apply since this might be occuring outside of angular
+			angularHelper.safeApply($scope, function () {
+				macroResource.getMacroResultAsHtmlForEditor(macroData.macroAlias, contentId, macroData.macroParamsDictionary)
+					.then(function (htmlResult) {
+
+						$macroDiv.removeClass("loading");
+						htmlResult = htmlResult.trim();
+						if (htmlResult !== "") {
+							$ins.html(htmlResult);
+						}
+					});
+			});
+
+		},
+
+		createLinkPicker: function (editor, $scope, onClick) {
+
+			function createLinkList(callback) {
+				return function () {
+					var linkList = editor.settings.link_list;
+
+					if (typeof (linkList) === "string") {
+						tinymce.util.XHR.send({
+							url: linkList,
+							success: function (text) {
+								callback(tinymce.util.JSON.parse(text));
+							}
+						});
+					} else {
+						callback(linkList);
+					}
+				};
+			}
+
+			function showDialog(linkList) {
+				var data = {},
+					selection = editor.selection,
+					dom = editor.dom,
+					selectedElm, anchorElm, initialText;
+				var win, linkListCtrl, relListCtrl, targetListCtrl;
+
+				function linkListChangeHandler(e) {
+					var textCtrl = win.find('#text');
+
+					if (!textCtrl.value() || (e.lastControl && textCtrl.value() === e.lastControl.text())) {
+						textCtrl.value(e.control.text());
+					}
+
+					win.find('#href').value(e.control.value());
+				}
+
+				function buildLinkList() {
+					var linkListItems = [{
+						text: 'None',
+						value: ''
                     }];
 
-                    tinymce.each(linkList, function(link) {
-                        linkListItems.push({
-                            text: link.text || link.title,
-                            value: link.value || link.url,
-                            menu: link.menu
-                        });
-                    });
+					tinymce.each(linkList, function (link) {
+						linkListItems.push({
+							text: link.text || link.title,
+							value: link.value || link.url,
+							menu: link.menu
+						});
+					});
 
-                    return linkListItems;
-                }
+					return linkListItems;
+				}
 
-                function buildRelList(relValue) {
-                    var relListItems = [{
-                        text: 'None',
-                        value: ''
+				function buildRelList(relValue) {
+					var relListItems = [{
+						text: 'None',
+						value: ''
                     }];
 
-                    tinymce.each(editor.settings.rel_list, function(rel) {
-                        relListItems.push({
-                            text: rel.text || rel.title,
-                            value: rel.value,
-                            selected: relValue === rel.value
-                        });
-                    });
+					tinymce.each(editor.settings.rel_list, function (rel) {
+						relListItems.push({
+							text: rel.text || rel.title,
+							value: rel.value,
+							selected: relValue === rel.value
+						});
+					});
 
-                    return relListItems;
-                }
+					return relListItems;
+				}
 
-                function buildTargetList(targetValue) {
-                    var targetListItems = [{
-                        text: 'None',
-                        value: ''
+				function buildTargetList(targetValue) {
+					var targetListItems = [{
+						text: 'None',
+						value: ''
                     }];
 
-                    if (!editor.settings.target_list) {
-                        targetListItems.push({
-                            text: 'New window',
-                            value: '_blank'
-                        });
-                    }
+					if (!editor.settings.target_list) {
+						targetListItems.push({
+							text: 'New window',
+							value: '_blank'
+						});
+					}
 
-                    tinymce.each(editor.settings.target_list, function(target) {
-                        targetListItems.push({
-                            text: target.text || target.title,
-                            value: target.value,
-                            selected: targetValue === target.value
-                        });
-                    });
+					tinymce.each(editor.settings.target_list, function (target) {
+						targetListItems.push({
+							text: target.text || target.title,
+							value: target.value,
+							selected: targetValue === target.value
+						});
+					});
 
-                    return targetListItems;
-                }
+					return targetListItems;
+				}
 
-                function buildAnchorListControl(url) {
-                    var anchorList = [];
+				function buildAnchorListControl(url) {
+					var anchorList = [];
 
-                    tinymce.each(editor.dom.select('a:not([href])'), function(anchor) {
-                        var id = anchor.name || anchor.id;
+					tinymce.each(editor.dom.select('a:not([href])'), function (anchor) {
+						var id = anchor.name || anchor.id;
 
-                        if (id) {
-                            anchorList.push({
-                                text: id,
-                                value: '#' + id,
-                                selected: url.indexOf('#' + id) !== -1
-                            });
-                        }
-                    });
+						if (id) {
+							anchorList.push({
+								text: id,
+								value: '#' + id,
+								selected: url.indexOf('#' + id) !== -1
+							});
+						}
+					});
 
-                    if (anchorList.length) {
-                        anchorList.unshift({
-                            text: 'None',
-                            value: ''
-                        });
+					if (anchorList.length) {
+						anchorList.unshift({
+							text: 'None',
+							value: ''
+						});
 
-                        return {
-                            name: 'anchor',
-                            type: 'listbox',
-                            label: 'Anchors',
-                            values: anchorList,
-                            onselect: linkListChangeHandler
-                        };
-                    }
-                }
+						return {
+							name: 'anchor',
+							type: 'listbox',
+							label: 'Anchors',
+							values: anchorList,
+							onselect: linkListChangeHandler
+						};
+					}
+				}
 
-                function updateText() {
-                    if (!initialText && data.text.length === 0) {
-                        this.parent().parent().find('#text')[0].value(this.value());
-                    }
-                }
+				function updateText() {
+					if (!initialText && data.text.length === 0) {
+						this.parent().parent().find('#text')[0].value(this.value());
+					}
+				}
 
-                selectedElm = selection.getNode();
-                anchorElm = dom.getParent(selectedElm, 'a[href]');
+				selectedElm = selection.getNode();
+				anchorElm = dom.getParent(selectedElm, 'a[href]');
 
-                data.text = initialText = anchorElm ? (anchorElm.innerText || anchorElm.textContent) : selection.getContent({format: 'text'});
-                data.href = anchorElm ? dom.getAttrib(anchorElm, 'href') : '';
-                data.target = anchorElm ? dom.getAttrib(anchorElm, 'target') : '';
-                data.rel = anchorElm ? dom.getAttrib(anchorElm, 'rel') : '';
+				data.text = initialText = anchorElm ? (anchorElm.innerText || anchorElm.textContent) : selection.getContent({
+					format: 'text'
+				});
+				data.href = anchorElm ? dom.getAttrib(anchorElm, 'href') : '';
+				data.target = anchorElm ? dom.getAttrib(anchorElm, 'target') : '';
+				data.rel = anchorElm ? dom.getAttrib(anchorElm, 'rel') : '';
 
-                if (selectedElm.nodeName === "IMG") {
-                    data.text = initialText = " ";
-                }
+				if (selectedElm.nodeName === "IMG") {
+					data.text = initialText = " ";
+				}
 
-                if (linkList) {
-                    linkListCtrl = {
-                        type: 'listbox',
-                        label: 'Link list',
-                        values: buildLinkList(),
-                        onselect: linkListChangeHandler
-                    };
-                }
+				if (linkList) {
+					linkListCtrl = {
+						type: 'listbox',
+						label: 'Link list',
+						values: buildLinkList(),
+						onselect: linkListChangeHandler
+					};
+				}
 
-                if (editor.settings.target_list !== false) {
-                    targetListCtrl = {
-                        name: 'target',
-                        type: 'listbox',
-                        label: 'Target',
-                        values: buildTargetList(data.target)
-                    };
-                }
+				if (editor.settings.target_list !== false) {
+					targetListCtrl = {
+						name: 'target',
+						type: 'listbox',
+						label: 'Target',
+						values: buildTargetList(data.target)
+					};
+				}
 
-                if (editor.settings.rel_list) {
-                    relListCtrl = {
-                        name: 'rel',
-                        type: 'listbox',
-                        label: 'Rel',
-                        values: buildRelList(data.rel)
-                    };
-                }
+				if (editor.settings.rel_list) {
+					relListCtrl = {
+						name: 'rel',
+						type: 'listbox',
+						label: 'Rel',
+						values: buildRelList(data.rel)
+					};
+				}
 
-                var currentTarget = null;
+				var currentTarget = null;
 
-                //if we already have a link selected, we want to pass that data over to the dialog
-                if(anchorElm){
-                    var anchor = $(anchorElm);
-                    currentTarget = {
-                        name: anchor.attr("title"),
-                        url: anchor.attr("href"),
-                        target: anchor.attr("target")
-                    };			
-				
+				//if we already have a link selected, we want to pass that data over to the dialog
+				if (anchorElm) {
+					var anchor = $(anchorElm);
+					currentTarget = {
+						name: anchor.attr("title"),
+						url: anchor.attr("href"),
+						target: anchor.attr("target")
+					};
+
 					// drop the lead char from the anchor text, if it has a value
 					var anchorVal = anchor[0].dataset.anchor;
 					if (anchorVal) {
 						currentTarget.anchor = anchorVal.substring(1);
 					}
-					
-                    //locallink detection, we do this here, to avoid poluting the dialogservice
-                    //so the dialog service can just expect to get a node-like structure
-                    if (currentTarget.url.indexOf("localLink:") > 0) {						
+
+					//locallink detection, we do this here, to avoid poluting the dialogservice
+					//so the dialog service can just expect to get a node-like structure
+					if (currentTarget.url.indexOf("localLink:") > 0) {
 						// if the current link has an anchor, it needs to be considered when getting the udi/id
 						// if an anchor exists, reduce the substring max by its length plus two to offset the removed prefix and trailing curly brace
 						var linkId = currentTarget.url.substring(currentTarget.url.indexOf(":") + 1, currentTarget.url.lastIndexOf("}"));
 
-                        //we need to check if this is an INT or a UDI
-                        var parsedIntId = parseInt(linkId, 10);
-                        if (isNaN(parsedIntId)) {
-                            //it's a UDI
-                            currentTarget.udi = linkId;
-                        }
-                        else {
-                            currentTarget.id = linkId;
-                        }                        
-                    }
-                }
+						//we need to check if this is an INT or a UDI
+						var parsedIntId = parseInt(linkId, 10);
+						if (isNaN(parsedIntId)) {
+							//it's a UDI
+							currentTarget.udi = linkId;
+						} else {
+							currentTarget.id = linkId;
+						}
+					}
+				}
 
-                if(onClick) {
-                    onClick(currentTarget, anchorElm);
-                }
+				if (onClick) {
+					onClick(currentTarget, anchorElm);
+				}
 
-            }
+			}
 
-            editor.addButton('link', {
-                icon: 'link',
-                tooltip: 'Insert/edit link',
-                shortcut: 'Ctrl+K',
-                onclick: createLinkList(showDialog),
-                stateSelector: 'a[href]'
-            });
+			editor.addButton('link', {
+				icon: 'link',
+				tooltip: 'Insert/edit link',
+				shortcut: 'Ctrl+K',
+				onclick: createLinkList(showDialog),
+				stateSelector: 'a[href]'
+			});
 
-            editor.addButton('unlink', {
-                icon: 'unlink',
-                tooltip: 'Remove link',
-                cmd: 'unlink',
-                stateSelector: 'a[href]'
-            });
+			editor.addButton('unlink', {
+				icon: 'unlink',
+				tooltip: 'Remove link',
+				cmd: 'unlink',
+				stateSelector: 'a[href]'
+			});
 
-            editor.addShortcut('Ctrl+K', '', createLinkList(showDialog));
-            this.showDialog = showDialog;
+			editor.addShortcut('Ctrl+K', '', createLinkList(showDialog));
+			this.showDialog = showDialog;
 
-            editor.addMenuItem('link', {
-                icon: 'link',
-                text: 'Insert link',
-                shortcut: 'Ctrl+K',
-                onclick: createLinkList(showDialog),
-                stateSelector: 'a[href]',
-                context: 'insert',
-                prependToContext: true
-            });
+			editor.addMenuItem('link', {
+				icon: 'link',
+				text: 'Insert link',
+				shortcut: 'Ctrl+K',
+				onclick: createLinkList(showDialog),
+				stateSelector: 'a[href]',
+				context: 'insert',
+				prependToContext: true
+			});
 
-        },
-		
+		},
+
 		/**
-        * @ngdoc method
-        * @name umbraco.services.tinyMceService#getAnchorNames
-        * @methodOf umbraco.services.tinyMceService
-        *
-        * @description
-        * From the given string, generates a string array where each item is the id attribute value from a named anchor
-		* 'some string <a id="anchor"></a>with a named anchor' returns ['anchor']
-        *
-        * @param {string} input the string to parse      
-        */
-		getAnchorNames: function(input) {
-			var anchorPattern = /<a id=\\"(.*?)\\">/gi;	
+		 * @ngdoc method
+		 * @name umbraco.services.tinyMceService#getAnchorNames
+		 * @methodOf umbraco.services.tinyMceService
+		 *
+		 * @description
+		 * From the given string, generates a string array where each item is the id attribute value from a named anchor
+		 * 'some string <a id="anchor"></a>with a named anchor' returns ['anchor']
+		 *
+		 * @param {string} input the string to parse      
+		 */
+		getAnchorNames: function (input) {
+			var anchorPattern = /<a id=\\"(.*?)\\">/gi;
 			var matches = input.match(anchorPattern);
-			var anchors = [];			
-			
+			var anchors = [];
+
 			if (matches) {
-				anchors = matches.map(function(v) {
+				anchors = matches.map(function (v) {
 					return v.substring(v.indexOf('"') + 1, v.lastIndexOf('\\'));
 				});
 			}
-			
+
 			return anchors;
 		},
 
-        insertLinkInEditor: function(editor, target, anchorElm) {
+		insertLinkInEditor: function (editor, target, anchorElm) {
 
-            var href = target.url;
-            // We want to use the Udi. If it is set, we use it, else fallback to id, and finally to null
-            var hasUdi = target.udi ? true : false;
-            var id = hasUdi ? target.udi : (target.id ? target.id : null);
+			var href = target.url;
+			// We want to use the Udi. If it is set, we use it, else fallback to id, and finally to null
+			var hasUdi = target.udi ? true : false;
+			var id = hasUdi ? target.udi : (target.id ? target.id : null);
 
 			// if an anchor exists, check that it is appropriately prefixed
 			if (target.anchor && target.anchor[0] !== '?' && target.anchor[0] !== '#') {
-				target.anchor = (target.anchor.indexOf('=') === -1 ? '#' : '?') + target.anchor;				
+				target.anchor = (target.anchor.indexOf('=') === -1 ? '#' : '?') + target.anchor;
+			}
+ 
+			// the href might be an external url, so check the value for an anchor/qs
+			// href has the anchor re-appended later, hence the reset here to avoid duplicating the anchor
+			if (!target.anchor) {
+				var urlParts = href.split(/(#|\?)/);
+				if (urlParts.length === 3) {
+					href = urlParts[0];
+					target.anchor = urlParts[1] + urlParts[2];
+				}
 			}
 			
-            //Create a json obj used to create the attributes for the tag
-            function createElemAttributes() {
-                var a = {
-                    href: href,
-                    title: target.name,
-                    target: target.target ? target.target : null,
-                    rel: target.rel ? target.rel : null
-                };
-				
-                if (hasUdi) {
-                    a["data-udi"] = target.udi;
-                }
-                else if (target.id) {
-                    a["data-id"] = target.id;
-                }         
-				
+			//Create a json obj used to create the attributes for the tag
+			function createElemAttributes() {
+				var a = {
+					href: href,
+					title: target.name,
+					target: target.target ? target.target : null,
+					rel: target.rel ? target.rel : null
+				};
+
+				if (hasUdi) {
+					a["data-udi"] = target.udi;
+				} else if (target.id) {
+					a["data-id"] = target.id;
+				}
+
 				if (target.anchor) {
 					a["data-anchor"] = target.anchor;
 					a.href = a.href + target.anchor;
 				} else {
 					a["data-anchor"] = null;
 				}
-								
-                return a;
-            }
 
-            function insertLink() {
-                if (anchorElm) {
-                    editor.dom.setAttribs(anchorElm, createElemAttributes());
+				return a;
+			}
 
-                    editor.selection.select(anchorElm);
-                    editor.execCommand('mceEndTyping');
-                }
-                else {
-                    editor.execCommand('mceInsertLink', false, createElemAttributes());
-                }
-            }
+			function insertLink() {
+				if (anchorElm) {
+					editor.dom.setAttribs(anchorElm, createElemAttributes());
 
-            if (!href) {
-                editor.execCommand('unlink');
-                return;
-            }
+					editor.selection.select(anchorElm);
+					editor.execCommand('mceEndTyping');
+				} else {
+					editor.execCommand('mceInsertLink', false, createElemAttributes());
+				}
+			}
 
-            //if we have an id, it must be a locallink:id, aslong as the isMedia flag is not set
-            if(id && (angular.isUndefined(target.isMedia) || !target.isMedia)){
-                
-                href = "/{localLink:" + id + "}";
+			if (!href) {
+				editor.execCommand('unlink');
+				return;
+			}
 
-                insertLink();
-                return;
-            }
+			//if we have an id, it must be a locallink:id, aslong as the isMedia flag is not set
+			if (id && (angular.isUndefined(target.isMedia) || !target.isMedia)) {
 
-            // Is email and not //user@domain.com
-            if (href.indexOf('@') > 0 && href.indexOf('//') === -1 && href.indexOf('mailto:') === -1) {
-                href = 'mailto:' + href;
-                insertLink();
-                return;
-            }
+				href = "/{localLink:" + id + "}";
 
-            // Is www. prefixed
-            if (/^\s*www\./i.test(href)) {
-                href = 'http://' + href;
-                insertLink();
-                return;
-            }
+				insertLink();
+				return;
+			}
 
-            insertLink();
+			// Is email and not //user@domain.com
+			if (href.indexOf('@') > 0 && href.indexOf('//') === -1 && href.indexOf('mailto:') === -1) {
+				href = 'mailto:' + href;
+				insertLink();
+				return;
+			}
 
-        }
+			// Is www. prefixed
+			if (/^\s*www\./i.test(href)) {
+				href = 'http://' + href;
+				insertLink();
+				return;
+			}
 
-    };
+			insertLink();
+
+		}
+
+	};
 }
 
 angular.module('umbraco.services').factory('tinyMceService', tinyMceService);

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -645,7 +645,6 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
                 data.href = anchorElm ? dom.getAttrib(anchorElm, 'href') : '';
                 data.target = anchorElm ? dom.getAttrib(anchorElm, 'target') : '';
                 data.rel = anchorElm ? dom.getAttrib(anchorElm, 'rel') : '';
-				data.anchor = anchorElm ? dom.getAttrib(anchorElm, 'anchor') : '';
 
                 if (selectedElm.nodeName === "IMG") {
                     data.text = initialText = " ";

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -689,7 +689,7 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
                     };			
 				
 					// drop the lead char from the anchor text, if it has a value
-					var anchorVal = anchor.data("anchor");
+					var anchorVal = anchor[0].dataset.anchor;
 					if (anchorVal) {
 						currentTarget.anchor = anchorVal.substring(1);
 					}
@@ -699,8 +699,7 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
                     if (currentTarget.url.indexOf("localLink:") > 0) {						
 						// if the current link has an anchor, it needs to be considered when getting the udi/id
 						// if an anchor exists, reduce the substring max by its length plus two to offset the removed prefix and trailing curly brace
-						var linkId = currentTarget.url.substring(currentTarget.url.indexOf(":") + 1, 
-																 currentTarget.url.length - (currentTarget.anchor ? currentTarget.anchor.length + 2 : 1));
+						var linkId = currentTarget.url.substring(currentTarget.url.indexOf(":") + 1, currentTarget.url.lastIndexOf("}"));
 
                         //we need to check if this is an INT or a UDI
                         var parsedIntId = parseInt(linkId, 10);

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -686,12 +686,12 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
                         name: anchor.attr("title"),
                         url: anchor.attr("href"),
                         target: anchor.attr("target")
-                    };
-
-					// split the URL to check for an anchor or querystring, then add that value to the currentTarget object
-					var urlParts = currentTarget.url.split(/(\?|#)/);
-					if (urlParts.length === 3) {
-						currentTarget.anchor = urlParts[2];
+                    };			
+				
+					// drop the lead char from the anchor text, if it has a value
+					var anchorVal = anchor.data("anchor");
+					if (anchorVal) {
+						currentTarget.anchor = anchorVal.substring(1);
 					}
 					
                     //locallink detection, we do this here, to avoid poluting the dialogservice
@@ -795,6 +795,7 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
                     target: target.target ? target.target : null,
                     rel: target.rel ? target.rel : null
                 };
+				
                 if (hasUdi) {
                     a["data-udi"] = target.udi;
                 }
@@ -805,8 +806,10 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
 				if (target.anchor) {
 					a["data-anchor"] = target.anchor;
 					a.href = a.href + target.anchor;
+				} else {
+					a["data-anchor"] = null;
 				}
-				
+								
                 return a;
             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -751,9 +751,20 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
 
         },
 		
-		getAnchorNames: function(propertyString) {
+		/**
+        * @ngdoc method
+        * @name umbraco.services.tinyMceService#getAnchorNames
+        * @methodOf umbraco.services.tinyMceService
+        *
+        * @description
+        * From the given string, generates a string array where each item is the id attribute value from a named anchor
+		* 'some string <a id="anchor"></a>with a named anchor' returns ['anchor']
+        *
+        * @param {string} input the string to parse      
+        */
+		getAnchorNames: function(input) {
 			var anchorPattern = /<a id=\\"(.*?)\\">/gi;	
-			var matches = propertyString.match(anchorPattern);
+			var matches = input.match(anchorPattern);
 			var anchors = [];			
 			
 			if (matches) {

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -42,6 +42,27 @@
   width: 99%;
 }
 
+// displays property inline with preceeding
+.umb-property {
+	&--pull {
+		float:left;
+		width:60%;
+	}
+
+	&--push {
+		float:right;
+		width:35%;
+	}
+	
+	&--pull, &--push {
+		.umb-editor {
+			min-width:0;
+			width:100%;
+		}
+	}
+}
+
+
 //
 // Content picker
 // --------------------------------------------------

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -3,10 +3,24 @@
 // --------------------------------------------------
 .umb-editor {
   min-width:66.6%;
+	
+	&-pull {
+		float:left;
+		width:66.6%;
+	}
+	
+	&-push {
+		float:right;
+	} 
 }
 
 .umb-editor-tiny {
   width: 60px;
+	
+	&.umb-editor-push {
+		width:30%;
+		min-width:0;
+	}
 }
 
 .umb-editor-small {

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
@@ -1,6 +1,6 @@
 //used for the media picker dialog
 angular.module("umbraco").controller("Umbraco.Dialogs.LinkPickerController",
-	function ($scope, eventsService, dialogService, entityResource, contentResource, mediaHelper, userService, localizationService) {
+	function ($scope, eventsService, dialogService, entityResource, contentResource, mediaHelper, userService, localizationService, tinyMceService) {
 	    var dialogOptions = $scope.dialogOptions;
 
 	    var searchText = "Search...";
@@ -39,6 +39,10 @@ angular.module("umbraco").controller("Umbraco.Dialogs.LinkPickerController",
 	            });
 	        }
 	    }
+		
+		if (dialogOptions.anchors) {
+			$scope.anchorValues = dialogOptions.anchors;
+		}
 
 	    function nodeSelectHandler(ev, args) {
 	        args.event.preventDefault();
@@ -69,9 +73,10 @@ angular.module("umbraco").controller("Umbraco.Dialogs.LinkPickerController",
 	                $scope.target.url = "/";
 	            }
 	            else {
-	                contentResource.getNiceUrl(args.node.id).then(function (url) {
-	                    $scope.target.url = url;
-	                });
+					contentResource.getById(args.node.id).then(function (resp) {				
+						$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));									
+						$scope.model.target.url = resp.urls[0];
+					});
 	            }
 
 	            if (!angular.isUndefined($scope.target.isMedia)) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
@@ -1,156 +1,163 @@
 //used for the media picker dialog
 angular.module("umbraco").controller("Umbraco.Dialogs.LinkPickerController",
 	function ($scope, eventsService, dialogService, entityResource, contentResource, mediaHelper, userService, localizationService, tinyMceService) {
-	    var dialogOptions = $scope.dialogOptions;
+		var dialogOptions = $scope.dialogOptions;
 
-	    var searchText = "Search...";
-	    localizationService.localize("general_search").then(function (value) {
-	        searchText = value + "...";
-	    });
+		var searchText = "Search...";
+		localizationService.localize("general_search").then(function (value) {
+			searchText = value + "...";
+		});
 
-	    $scope.dialogTreeEventHandler = $({});
-	    $scope.target = {};
-	    $scope.searchInfo = {
-	        searchFromId: null,
-	        searchFromName: null,
-	        showSearch: false,
-	        results: [],
-	        selectedSearchResults: []
-	    }
+		$scope.dialogTreeEventHandler = $({});
+		$scope.target = {};
+		$scope.searchInfo = {
+			searchFromId: null,
+			searchFromName: null,
+			showSearch: false,
+			results: [],
+			selectedSearchResults: []
+		}
 
-	    if (dialogOptions.currentTarget) {
-	        $scope.target = dialogOptions.currentTarget;
+		if (dialogOptions.currentTarget) {
+			$scope.target = dialogOptions.currentTarget;
 
-	        //if we have a node ID, we fetch the current node to build the form data
-            if ($scope.target.id || $scope.target.udi) {
+			//if we have a node ID, we fetch the current node to build the form data
+			if ($scope.target.id || $scope.target.udi) {
 
-                var id = $scope.target.udi ? $scope.target.udi : $scope.target.id;
+				var id = $scope.target.udi ? $scope.target.udi : $scope.target.id;
 
-	            if (!$scope.target.path) {
-	                entityResource.getPath(id, "Document").then(function (path) {
-	                    $scope.target.path = path;
-	                    //now sync the tree to this path
-	                    $scope.dialogTreeEventHandler.syncTree({ path: $scope.target.path, tree: "content" });
-	                });
-	            }
+				if (!$scope.target.path) {
+					entityResource.getPath(id, "Document").then(function (path) {
+						$scope.target.path = path;
+						//now sync the tree to this path
+						$scope.dialogTreeEventHandler.syncTree({
+							path: $scope.target.path,
+							tree: "content"
+						});
+					});
+				}
 
 				// if a link exists, get the properties to build the anchor name list
-                contentResource.getById(id).then(function (resp) {
+				contentResource.getById(id).then(function (resp) {
 					$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
-	                $scope.model.target.url = resp.urls[0];
-	            });
-	        }
-	    }
-		
+					$scope.model.target.url = resp.urls[0];
+				});
+			} else if ($scope.target.url.length) {
+				// a url but no id/udi indicates an external link - trim the url to remove the anchor/qs
+				$scope.target.url = $scope.model.url.substring(0, $scope.model.url.search(/(#|\?)/));
+			}
+		}
+
 		if (dialogOptions.anchors) {
 			$scope.anchorValues = dialogOptions.anchors;
 		}
 
-	    function nodeSelectHandler(ev, args) {
-	        args.event.preventDefault();
-	        args.event.stopPropagation();
+		function nodeSelectHandler(ev, args) {
+			args.event.preventDefault();
+			args.event.stopPropagation();
 
-	        if (args.node.metaData.listViewNode) {
-	            //check if list view 'search' node was selected
+			if (args.node.metaData.listViewNode) {
+				//check if list view 'search' node was selected
 
-	            $scope.searchInfo.showSearch = true;
-	            $scope.searchInfo.searchFromId = args.node.metaData.listViewNode.id;
-	            $scope.searchInfo.searchFromName = args.node.metaData.listViewNode.name;
-	        }	      
-	        else {
-	            eventsService.emit("dialogs.linkPicker.select", args);
+				$scope.searchInfo.showSearch = true;
+				$scope.searchInfo.searchFromId = args.node.metaData.listViewNode.id;
+				$scope.searchInfo.searchFromName = args.node.metaData.listViewNode.name;
+			} else {
+				eventsService.emit("dialogs.linkPicker.select", args);
 
-	            if ($scope.currentNode) {
-	                //un-select if there's a current one selected
-	                $scope.currentNode.selected = false;
-	            }
+				if ($scope.currentNode) {
+					//un-select if there's a current one selected
+					$scope.currentNode.selected = false;
+				}
 
-	            $scope.currentNode = args.node;
-	            $scope.currentNode.selected = true;
-                $scope.target.id = args.node.id;
-                $scope.target.udi = args.node.udi;
-	            $scope.target.name = args.node.name;
+				$scope.currentNode = args.node;
+				$scope.currentNode.selected = true;
+				$scope.target.id = args.node.id;
+				$scope.target.udi = args.node.udi;
+				$scope.target.name = args.node.name;
 
-	            if (args.node.id < 0) {
-	                $scope.target.url = "/";
-	            }
-	            else {
-					contentResource.getById(args.node.id).then(function (resp) {				
-						$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));									
+				if (args.node.id < 0) {
+					$scope.target.url = "/";
+				} else {
+					contentResource.getById(args.node.id).then(function (resp) {
+						$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
 						$scope.model.target.url = resp.urls[0];
 					});
-	            }
+				}
 
-	            if (!angular.isUndefined($scope.target.isMedia)) {
-	                delete $scope.target.isMedia;
-	            }
-	        }	        
-	    }
+				if (!angular.isUndefined($scope.target.isMedia)) {
+					delete $scope.target.isMedia;
+				}
+			}
+		}
 
-	    function nodeExpandedHandler(ev, args) {
-	        if (angular.isArray(args.children)) {
+		function nodeExpandedHandler(ev, args) {
+			if (angular.isArray(args.children)) {
 
-	            //iterate children
-	            _.each(args.children, function (child) {
-	                //check if any of the items are list views, if so we need to add a custom 
-	                // child: A node to activate the search
-	                if (child.metaData.isContainer) {
-	                    child.hasChildren = true;
-	                    child.children = [
-	                        {
-	                            level: child.level + 1,
-	                            hasChildren: false,
-	                            name: searchText,
-	                            metaData: {
-	                                listViewNode: child,
-	                            },
-	                            cssClass: "icon umb-tree-icon sprTree icon-search",
-	                            cssClasses: ["not-published"]
+				//iterate children
+				_.each(args.children, function (child) {
+					//check if any of the items are list views, if so we need to add a custom 
+					// child: A node to activate the search
+					if (child.metaData.isContainer) {
+						child.hasChildren = true;
+						child.children = [
+							{
+								level: child.level + 1,
+								hasChildren: false,
+								name: searchText,
+								metaData: {
+									listViewNode: child,
+								},
+								cssClass: "icon umb-tree-icon sprTree icon-search",
+								cssClasses: ["not-published"]
 	                        }
 	                    ];
-	                }	                
-	            });
-	        }
-	    }
+					}
+				});
+			}
+		}
 
-	    $scope.switchToMediaPicker = function () {
-	        userService.getCurrentUser().then(function (userData) {
-	          dialogService.mediaPicker({
-	            startNodeId: userData.startMediaIds.length == 0 ? -1 : userData.startMediaIds[0],
-	            callback: function(media) {
-	              $scope.target.id = media.id;
-	              $scope.target.isMedia = true;
-	              $scope.target.name = media.name;
-	              $scope.target.url = mediaHelper.resolveFile(media);
-	            }
-	          });
-	        });
-	    };
+		$scope.switchToMediaPicker = function () {
+			userService.getCurrentUser().then(function (userData) {
+				dialogService.mediaPicker({
+					startNodeId: userData.startMediaIds.length == 0 ? -1 : userData.startMediaIds[0],
+					callback: function (media) {
+						$scope.target.id = media.id;
+						$scope.target.isMedia = true;
+						$scope.target.name = media.name;
+						$scope.target.url = mediaHelper.resolveFile(media);
+					}
+				});
+			});
+		};
 
-	    $scope.hideSearch = function () {
-	        $scope.searchInfo.showSearch = false;
-	        $scope.searchInfo.searchFromId = null;
-	        $scope.searchInfo.searchFromName = null;
-	        $scope.searchInfo.results = [];
-	    }
+		$scope.hideSearch = function () {
+			$scope.searchInfo.showSearch = false;
+			$scope.searchInfo.searchFromId = null;
+			$scope.searchInfo.searchFromName = null;
+			$scope.searchInfo.results = [];
+		}
 
-	    // method to select a search result 
-	    $scope.selectResult = function (evt, result) {
-	        result.selected = result.selected === true ? false : true;
-	        nodeSelectHandler(evt, {event: evt, node: result});
-	    };
+		// method to select a search result 
+		$scope.selectResult = function (evt, result) {
+			result.selected = result.selected === true ? false : true;
+			nodeSelectHandler(evt, {
+				event: evt,
+				node: result
+			});
+		};
 
-        //callback when there are search results 
-	    $scope.onSearchResults = function (results) {
-	        $scope.searchInfo.results = results;
-            $scope.searchInfo.showSearch = true;
-	    };
+		//callback when there are search results 
+		$scope.onSearchResults = function (results) {
+			$scope.searchInfo.results = results;
+			$scope.searchInfo.showSearch = true;
+		};
 
-	    $scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
-	    $scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
+		$scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
+		$scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
 
-	    $scope.$on('$destroy', function () {
-	        $scope.dialogTreeEventHandler.unbind("treeNodeSelect", nodeSelectHandler);
-	        $scope.dialogTreeEventHandler.unbind("treeNodeExpanded", nodeExpandedHandler);
-	    });
+		$scope.$on('$destroy', function () {
+			$scope.dialogTreeEventHandler.unbind("treeNodeSelect", nodeSelectHandler);
+			$scope.dialogTreeEventHandler.unbind("treeNodeExpanded", nodeExpandedHandler);
+		});
 	});

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
@@ -34,8 +34,10 @@ angular.module("umbraco").controller("Umbraco.Dialogs.LinkPickerController",
 	                });
 	            }
 
-	            contentResource.getNiceUrl(id).then(function (url) {
-	                $scope.target.url = url;
+				// if a link exists, get the properties to build the anchor name list
+                contentResource.getById(id).then(function (resp) {
+					$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
+	                $scope.model.target.url = resp.urls[0];
 	            });
 	        }
 	    }

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.html
@@ -1,27 +1,17 @@
 <div class="umb-panel" ng-controller="Umbraco.Dialogs.LinkPickerController">
 	<div class="umb-panel-body no-header with-footer compact">
 		<umb-pane>
-			<umb-control-group label="@defaultdialogs_urlLinkPicker">
-			  	<input type="text"
-					localize="placeholder" 
-					placeholder="@general_url" 
-					class="umb-editor umb-textstring" 
-					ng-model="target.url"
-					style="float:left; min-width:0; width:60%"
-					ng-disabled="target.id"
-					 />
-				<input type="text"
-				   list="anchors"
-				   localize="placeholder"
-				   placeholder="@general_anchor"
-				   class="umb-editor umb-textstring"	
-				   style="float:right; min-width:0; width:30%"
-				   ng-model="target.anchor" />
+	<umb-control-group label="@defaultdialogs_urlLinkPicker" class="umb-property--pull">
+		<input type="text" localize="placeholder" placeholder="@general_url" class="umb-editor umb-textstring" ng-model="target.url" ng-disabled="target.id" />
+	</umb-control-group>
 
-				<datalist id="anchors">
+	<umb-control-group label="@defaultdialogs_anchorLinkPicker" class="umb-property--push">
+		<input type="text" list="anchors" localize="placeholder" placeholder="@placeholders_anchor" class="umb-editor umb-textstring" ng-model="target.anchor" />
+
+		<datalist id="anchors">
 					<option value="{{a}}" ng-repeat="a in anchorValues"></option>
 				</datalist>
-			</umb-control-group>
+	</umb-control-group>			
 
 			<umb-control-group label="@defaultdialogs_nodeNameLinkPicker">
 				<input type="text"

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.html
@@ -2,13 +2,25 @@
 	<div class="umb-panel-body no-header with-footer compact">
 		<umb-pane>
 			<umb-control-group label="@defaultdialogs_urlLinkPicker">
-			  <input type="text"
+			  	<input type="text"
 					localize="placeholder" 
 					placeholder="@general_url" 
 					class="umb-editor umb-textstring" 
 					ng-model="target.url"
+					style="float:left; min-width:0; width:60%"
 					ng-disabled="target.id"
 					 />
+				<input type="text"
+				   list="anchors"
+				   localize="placeholder"
+				   placeholder="@general_anchor"
+				   class="umb-editor umb-textstring"	
+				   style="float:right; min-width:0; width:30%"
+				   ng-model="target.anchor" />
+
+				<datalist id="anchors">
+					<option value="{{a}}" ng-repeat="a in anchorValues"></option>
+				</datalist>
 			</umb-control-group>
 
 			<umb-control-group label="@defaultdialogs_nodeNameLinkPicker">

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -1,60 +1,66 @@
 //used for the media picker dialog
 angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 	function ($scope, eventsService, dialogService, entityResource, contentResource, mediaHelper, userService, localizationService, tinyMceService) {
-	    var dialogOptions = $scope.model;
+		var dialogOptions = $scope.model;
 
 		var anchorPattern = /<a id=\\"(.*?)\\">/gi;
-	
-	    var searchText = "Search...";
-	    localizationService.localize("general_search").then(function (value) {
-	        searchText = value + "...";
-	    });
 
-		if(!$scope.model.title) {
-		    $scope.model.title = localizationService.localize("defaultdialogs_selectLink");
+		var searchText = "Search...";
+		localizationService.localize("general_search").then(function (value) {
+			searchText = value + "...";
+		});
+
+		if (!$scope.model.title) {
+			$scope.model.title = localizationService.localize("defaultdialogs_selectLink");
 		}
 
-	    $scope.dialogTreeEventHandler = $({});
-	    $scope.model.target = {};
-	    $scope.searchInfo = {
-	        searchFromId: null,
-	        searchFromName: null,
-	        showSearch: false,
-	        results: [],
-	        selectedSearchResults: []
-	    };
+		$scope.dialogTreeEventHandler = $({});
+		$scope.model.target = {};
+		$scope.searchInfo = {
+			searchFromId: null,
+			searchFromName: null,
+			showSearch: false,
+			results: [],
+			selectedSearchResults: []
+		};
 
 		$scope.showTarget = $scope.model.hideTarget !== true;
 
-	    if (dialogOptions.currentTarget) {
-	        $scope.model.target = dialogOptions.currentTarget;
-	        //if we have a node ID, we fetch the current node to build the form data
-	        if ($scope.model.target.id || $scope.model.target.udi) {
+		if (dialogOptions.currentTarget) {
+			$scope.model.target = dialogOptions.currentTarget;
+			//if we have a node ID, we fetch the current node to build the form data
+			if ($scope.model.target.id || $scope.model.target.udi) {
 
-                //will be either a udi or an int
-                var id = $scope.model.target.udi ? $scope.model.target.udi : $scope.model.target.id;
+				//will be either a udi or an int
+				var id = $scope.model.target.udi ? $scope.model.target.udi : $scope.model.target.id;
 
-                if (!$scope.model.target.path) {
-                    
-                    entityResource.getPath(id, "Document").then(function (path) {
-	                    $scope.model.target.path = path;
-	                    //now sync the tree to this path
-	                    $scope.dialogTreeEventHandler.syncTree({ path: $scope.model.target.path, tree: "content" });
-	                });
-	            }
-				
+				if (!$scope.model.target.path) {
+
+					entityResource.getPath(id, "Document").then(function (path) {
+						$scope.model.target.path = path;
+						//now sync the tree to this path
+						$scope.dialogTreeEventHandler.syncTree({
+							path: $scope.model.target.path,
+							tree: "content"
+						});
+					});
+				}
+
 				// if a link exists, get the properties to build the anchor name list
-                contentResource.getById(id).then(function (resp) {
+				contentResource.getById(id).then(function (resp) {
 					$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
-	                $scope.model.target.url = resp.urls[0];
-	            });
-	        }
-	    } else if (dialogOptions.anchors) {
+					$scope.model.target.url = resp.urls[0];
+				});
+			} else if ($scope.model.target.url.length) {
+				// a url but no id/udi indicates an external link - trim the url to remove the anchor/qs
+				$scope.model.target.url = $scope.model.target.url.substring(0, $scope.model.target.url.search(/(#|\?)/));				
+			}
+		} else if (dialogOptions.anchors) {
 			$scope.anchorValues = dialogOptions.anchors;
 		}
-	
+
 		function nodeSelectHandler(ev, args) {
-			if(args && args.event) {
+			if (args && args.event) {
 				args.event.preventDefault();
 				args.event.stopPropagation();
 			}
@@ -74,10 +80,9 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 
 			if (args.node.id < 0) {
 				$scope.model.target.url = "/";
-			}
-			else {			
-				contentResource.getById(args.node.id).then(function (resp) {				
-					$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));									
+			} else {
+				contentResource.getById(args.node.id).then(function (resp) {
+					$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
 					$scope.model.target.url = resp.urls[0];
 				});
 			}
@@ -85,69 +90,76 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 			if (!angular.isUndefined($scope.model.target.isMedia)) {
 				delete $scope.model.target.isMedia;
 			}
-	    }
+		}
 
-	    function nodeExpandedHandler(ev, args) {
+		function nodeExpandedHandler(ev, args) {
 			// open mini list view for list views
 			if (args.node.metaData.isContainer) {
 				openMiniListView(args.node);
 			}
-	    }
+		}
 
-	    $scope.switchToMediaPicker = function () {
-	        userService.getCurrentUser().then(function (userData) {
-	          $scope.mediaPickerOverlay = {
-	            view: "mediapicker",
-                startNodeId: userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0],
-	            startNodeIsVirtual: userData.startMediaIds.length !== 1,
-	            show: true,
-	            submit: function(model) {
-	              var media = model.selectedImages[0];
+		$scope.switchToMediaPicker = function () {
+			userService.getCurrentUser().then(function (userData) {
+				$scope.mediaPickerOverlay = {
+					view: "mediapicker",
+					startNodeId: userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0],
+					startNodeIsVirtual: userData.startMediaIds.length !== 1,
+					show: true,
+					submit: function (model) {
+						var media = model.selectedImages[0];
 
-	              $scope.model.target.id = media.id;
-	              $scope.model.target.udi = media.udi;
-	              $scope.model.target.isMedia = true;
-	              $scope.model.target.name = media.name;
-	              $scope.model.target.url = mediaHelper.resolveFile(media);
+						$scope.model.target.id = media.id;
+						$scope.model.target.udi = media.udi;
+						$scope.model.target.isMedia = true;
+						$scope.model.target.name = media.name;
+						$scope.model.target.url = mediaHelper.resolveFile(media);
+						
+						debugger;
 
-	              $scope.mediaPickerOverlay.show = false;
-	              $scope.mediaPickerOverlay = null;
-	            }
-	          };
-	        });
-	    };
+						$scope.mediaPickerOverlay.show = false;
+						$scope.mediaPickerOverlay = null;
+					}
+				};
+			});
+		};
 
-	    $scope.hideSearch = function () {
-	        $scope.searchInfo.showSearch = false;
-	        $scope.searchInfo.searchFromId = null;
-	        $scope.searchInfo.searchFromName = null;
-	        $scope.searchInfo.results = [];
-	    }
+		$scope.hideSearch = function () {
+			$scope.searchInfo.showSearch = false;
+			$scope.searchInfo.searchFromId = null;
+			$scope.searchInfo.searchFromName = null;
+			$scope.searchInfo.results = [];
+		}
 
-	    // method to select a search result
-	    $scope.selectResult = function (evt, result) {
-	        result.selected = result.selected === true ? false : true;
-	        nodeSelectHandler(evt, {event: evt, node: result});
-	    };
+		// method to select a search result
+		$scope.selectResult = function (evt, result) {
+			result.selected = result.selected === true ? false : true;
+			nodeSelectHandler(evt, {
+				event: evt,
+				node: result
+			});
+		};
 
-        //callback when there are search results
-	    $scope.onSearchResults = function (results) {
-	        $scope.searchInfo.results = results;
-            $scope.searchInfo.showSearch = true;
-	    };
+		//callback when there are search results
+		$scope.onSearchResults = function (results) {
+			$scope.searchInfo.results = results;
+			$scope.searchInfo.showSearch = true;
+		};
 
-	    $scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
-	    $scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
+		$scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
+		$scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
 
-	    $scope.$on('$destroy', function () {
-	        $scope.dialogTreeEventHandler.unbind("treeNodeSelect", nodeSelectHandler);
-	        $scope.dialogTreeEventHandler.unbind("treeNodeExpanded", nodeExpandedHandler);
-	    });
+		$scope.$on('$destroy', function () {
+			$scope.dialogTreeEventHandler.unbind("treeNodeSelect", nodeSelectHandler);
+			$scope.dialogTreeEventHandler.unbind("treeNodeExpanded", nodeExpandedHandler);
+		});
 
 		// Mini list view
 		$scope.selectListViewNode = function (node) {
 			node.selected = node.selected === true ? false : true;
-			nodeSelectHandler({}, { node: node });
+			nodeSelectHandler({}, {
+				node: node
+			});
 		};
 
 		$scope.closeMiniListView = function () {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -42,14 +42,14 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 	                    $scope.dialogTreeEventHandler.syncTree({ path: $scope.model.target.path, tree: "content" });
 	                });
 	            }
-
-                contentResource.getNiceUrl(id).then(function (url) {
-	                $scope.model.target.url = url;
+				
+				// if a link exists, get the properties to build the anchor name list
+                contentResource.getById(id).then(function (resp) {
+					$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
+	                $scope.model.target.url = resp.urls[0];
 	            });
 	        }
-	    }
-	
-		if (dialogOptions.anchors) {
+	    } else if (dialogOptions.anchors) {
 			$scope.anchorValues = dialogOptions.anchors;
 		}
 	

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
@@ -4,8 +4,7 @@
         <input type="text"
             localize="placeholder"
             placeholder="@general_url"
-            class="umb-editor umb-textstring"
- 		    style="float:left; min-width:0; width:65%"
+            class="umb-editor umb-editor-pull umb-textstring"
             ng-model="model.target.url"
             ng-disabled="model.target.id"
             focus-when="{{true}} "/>
@@ -14,8 +13,7 @@
 		   list="anchors"
 		   localize="placeholder"
 		   placeholder="@general_anchor"
-		   class="umb-editor umb-textstring"	
-		   style="float:right; min-width:0; width:30%"
+		   class="umb-editor umb-editor-push umb-editor-tiny umb-textstring"	
 		   ng-model="model.target.anchor" />
 		
 		<datalist id="anchors">

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
@@ -1,100 +1,62 @@
 <div ng-controller="Umbraco.Overlays.LinkPickerController">
 
-    <umb-control-group label="@defaultdialogs_urlLinkPicker">
-        <input type="text"
-            localize="placeholder"
-            placeholder="@general_url"
-            class="umb-editor umb-editor-pull umb-textstring"
-            ng-model="model.target.url"
-            ng-disabled="model.target.id"
-            focus-when="{{true}} "/>
-		
-		<input type="text"
-		   list="anchors"
-		   localize="placeholder"
-		   placeholder="@general_anchor"
-		   class="umb-editor umb-editor-push umb-editor-tiny umb-textstring"	
-		   ng-model="model.target.anchor" />
-		
+	<umb-control-group label="@defaultdialogs_urlLinkPicker" class="umb-property--pull">
+		<input type="text" localize="placeholder" placeholder="@general_url" class="umb-editor umb-textstring" ng-model="model.target.url" ng-disabled="model.target.id" />
+	</umb-control-group> 
+
+	<umb-control-group label="@defaultdialogs_anchorLinkPicker" class="umb-property--push">
+		<input type="text" list="anchors" localize="placeholder" placeholder="@placeholders_anchor" class="umb-editor umb-textstring" ng-model="model.target.anchor" />
+
 		<datalist id="anchors">
 			<option value="{{a}}" ng-repeat="a in anchorValues"></option>
 		</datalist>
-    </umb-control-group>
-	
-    <umb-control-group label="@defaultdialogs_nodeNameLinkPicker">
-        <input type="text"
-            localize="placeholder"
-            placeholder="@placeholders_entername"
-            class="umb-editor umb-textstring"
-            ng-model="model.target.name" />
-    </umb-control-group>
+	</umb-control-group>
 
-    <umb-control-group ng-if="showTarget" label="@content_target">
-        <label class="checkbox no-indent">
+	<umb-control-group label="@defaultdialogs_nodeNameLinkPicker">
+		<input type="text" localize="placeholder" placeholder="@placeholders_entername" class="umb-editor umb-textstring" ng-model="model.target.name" />
+	</umb-control-group>
+
+	<umb-control-group ng-if="showTarget" label="@content_target">
+		<label class="checkbox no-indent">
             <input type="checkbox" ng-model="model.target.target" ng-true-value="_blank" ng-false-value="" /> <localize key="defaultdialogs_openInNewWindow">Opens the linked document in a new window or tab</localize>
         </label>
-    </umb-control-group>
+	</umb-control-group>
 
-    <div class="umb-control-group">
-        <h5>
-            <localize key="defaultdialogs_linkToPage">Link to page</localize>
-        </h5>
+	<div class="umb-control-group">
+		<h5>
+			<localize key="defaultdialogs_linkToPage">Link to page</localize>
+		</h5>
 
-        <div ng-hide="miniListView">
-            <umb-tree-search-box
-                hide-search-callback="hideSearch"
-                search-callback="onSearchResults"
-                search-from-id="{{searchInfo.searchFromId}}"
-                search-from-name="{{searchInfo.searchFromName}}"
-                show-search="{{searchInfo.showSearch}}"
-                section="{{section}}">
-            </umb-tree-search-box>
+		<div ng-hide="miniListView">
+			<umb-tree-search-box hide-search-callback="hideSearch" search-callback="onSearchResults" search-from-id="{{searchInfo.searchFromId}}" search-from-name="{{searchInfo.searchFromName}}" show-search="{{searchInfo.showSearch}}" section="{{section}}">
+			</umb-tree-search-box>
 
-            <br/>
+			<br/>
 
-            <umb-tree-search-results
-                ng-if="searchInfo.showSearch"
-                results="searchInfo.results"
-                select-result-callback="selectResult">
-            </umb-tree-search-results>
+			<umb-tree-search-results ng-if="searchInfo.showSearch" results="searchInfo.results" select-result-callback="selectResult">
+			</umb-tree-search-results>
 
-            <div ng-hide="searchInfo.showSearch">
-                <umb-tree
-                    section="content"
-                    hideheader="true"
-                    hideoptions="true"
-                    eventhandler="dialogTreeEventHandler"
-                    enablelistviewexpand="true"
-                    isdialog="true"
-                    enablecheckboxes="true">
-                </umb-tree>
-            </div>
-        </div>
+			<div ng-hide="searchInfo.showSearch">
+				<umb-tree section="content" hideheader="true" hideoptions="true" eventhandler="dialogTreeEventHandler" enablelistviewexpand="true" isdialog="true" enablecheckboxes="true">
+				</umb-tree>
+			</div>
+		</div>
 
-        <umb-mini-list-view
-            ng-if="miniListView"
-            node="miniListView"
-            entity-type="Document"
-            on-select="selectListViewNode(node)"
-            on-close="closeMiniListView()">
-        </umb-mini-list-view>
+		<umb-mini-list-view ng-if="miniListView" node="miniListView" entity-type="Document" on-select="selectListViewNode(node)" on-close="closeMiniListView()">
+		</umb-mini-list-view>
 
-    </div>
+	</div>
 
-    <div class="umb-control-group">
-        <h5>
-            <localize key="defaultdialogs_linkToMedia">Link to media</localize>
-        </h5>
-        <a href ng-click="switchToMediaPicker()" class="btn">
-            <localize key="defaultdialogs_selectMedia">Select media</localize>
-        </a>
-    </div>
+	<div class="umb-control-group">
+		<h5>
+			<localize key="defaultdialogs_linkToMedia">Link to media</localize>
+		</h5>
+		<a href ng-click="switchToMediaPicker()" class="btn">
+			<localize key="defaultdialogs_selectMedia">Select media</localize>
+		</a>
+	</div>
 
-    <umb-overlay
-        ng-if="mediaPickerOverlay.show"
-        model="mediaPickerOverlay"
-        view="mediaPickerOverlay.view"
-        position="right">
-    </umb-overlay>
+	<umb-overlay ng-if="mediaPickerOverlay.show" model="mediaPickerOverlay" view="mediaPickerOverlay.view" position="right">
+	</umb-overlay>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
@@ -5,11 +5,24 @@
             localize="placeholder"
             placeholder="@general_url"
             class="umb-editor umb-textstring"
+ 		    style="float:left; min-width:0; width:65%"
             ng-model="model.target.url"
             ng-disabled="model.target.id"
             focus-when="{{true}} "/>
+		
+		<input type="text"
+		   list="anchors"
+		   localize="placeholder"
+		   placeholder="@general_anchor"
+		   class="umb-editor umb-textstring"	
+		   style="float:right; min-width:0; width:30%"
+		   ng-model="model.target.anchor" />
+		
+		<datalist id="anchors">
+			<option value="{{a}}" ng-repeat="a in anchorValues"></option>
+		</datalist>
     </umb-control-group>
-
+	
     <umb-control-group label="@defaultdialogs_nodeNameLinkPicker">
         <input type="text"
             localize="placeholder"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/rte.controller.js
@@ -1,7 +1,7 @@
 (function() {
     "use strict";
 
-    function GridRichTextEditorController($scope, tinyMceService, macroService) {
+    function GridRichTextEditorController($scope, tinyMceService, macroService, editorState) {
 
         var vm = this;
 
@@ -11,9 +11,11 @@
         vm.openEmbed = openEmbed;
 
         function openLinkPicker(editor, currentTarget, anchorElement) {
+						
             vm.linkPickerOverlay = {
                 view: "linkpicker",
                 currentTarget: currentTarget,
+				anchors: tinyMceService.getAnchorNames(JSON.stringify(editorState.current.properties)),
                 show: true,
                 submit: function(model) {
                     tinyMceService.insertLinkInEditor(editor, model.target, anchorElement);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -1,6 +1,6 @@
 angular.module("umbraco")
     .controller("Umbraco.PropertyEditors.RTEController",
-    function ($rootScope, $scope, $q, $locale, dialogService, $log, imageHelper, assetsService, $timeout, tinyMceService, angularHelper, stylesheetResource, macroService) {
+    function ($rootScope, $scope, $q, $locale, dialogService, $log, imageHelper, assetsService, $timeout, tinyMceService, angularHelper, stylesheetResource, macroService, editorState) {
 
         $scope.isLoading = true;
 
@@ -273,11 +273,12 @@ angular.module("umbraco")
 
                         syncContent(editor);
                     });
-
+					
                     tinyMceService.createLinkPicker(editor, $scope, function(currentTarget, anchorElement) {
                         $scope.linkPickerOverlay = {
                             view: "linkpicker",
                             currentTarget: currentTarget,
+							anchors: tinyMceService.getAnchorNames(JSON.stringify(editorState.current.properties)),
                             show: true,
                             submit: function(model) {
                                 tinyMceService.insertLinkInEditor(editor, model.target, anchorElement);

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -527,6 +527,7 @@
         <key alias="add">Add</key>
         <key alias="alias">Alias</key>
         <key alias="all">All</key>
+        <key alias="anchor">Anchor</key>
         <key alias="areyousure">Are you sure?</key>
         <key alias="back">Back</key>
         <key alias="border">Border</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -318,6 +318,7 @@
     <area alias="defaultdialogs">
         <key alias="nodeNameLinkPicker">Link title</key>
         <key alias="urlLinkPicker">Link</key>
+        <key alias="anchorLinkPicker">Anchor / querystring</key>
         <key alias="anchorInsert">Name</key>
         <key alias="assignDomain">Manage hostnames</key>
         <key alias="closeThisWindow">Close this window</key>
@@ -436,6 +437,7 @@
         <key alias="email">Enter your email...</key>
         <key alias="enterMessage">Enter a message...</key>
         <key alias="usernameHint">Your username is usually your email</key>
+        <key alias="anchor">#value or ?key=value</key>
     </area>
     <area alias="editcontenttype">
         <key alias="allowAtRoot" version="7.2">Allow at root</key>
@@ -527,7 +529,6 @@
         <key alias="add">Add</key>
         <key alias="alias">Alias</key>
         <key alias="all">All</key>
-        <key alias="anchor">Anchor</key>
         <key alias="areyousure">Are you sure?</key>
         <key alias="back">Back</key>
         <key alias="border">Border</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -318,6 +318,7 @@
     <area alias="defaultdialogs">
         <key alias="nodeNameLinkPicker">Link title</key>
         <key alias="urlLinkPicker">Link</key>
+        <key alias="anchorLinkPicker">Anchor / querystring</key>
         <key alias="anchorInsert">Name</key>
         <key alias="closeThisWindow">Close this window</key>
         <key alias="confirmdelete">Are you sure you want to delete</key>
@@ -435,6 +436,7 @@
         <key alias="email">Enter your email...</key>
         <key alias="enterMessage">Enter a message...</key>
         <key alias="usernameHint">Your username is usually your email</key>
+        <key alias="anchor">#value or ?key=value</key>
     </area>
     <area alias="editcontenttype">
         <key alias="allowAtRoot" version="7.2">Allow at root</key>
@@ -526,7 +528,6 @@
         <key alias="add">Add</key>
         <key alias="alias">Alias</key>
         <key alias="all">All</key>
-        <key alias="anchor">Anchor</key>
         <key alias="areyousure">Are you sure?</key>
         <key alias="back">Back</key>
         <key alias="border">Border</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -526,6 +526,7 @@
         <key alias="add">Add</key>
         <key alias="alias">Alias</key>
         <key alias="all">All</key>
+        <key alias="anchor">Anchor</key>
         <key alias="areyousure">Are you sure?</key>
         <key alias="back">Back</key>
         <key alias="border">Border</key>

--- a/src/Umbraco.Web/WebApi/Filters/EnsureUserPermissionForContentAttribute.cs
+++ b/src/Umbraco.Web/WebApi/Filters/EnsureUserPermissionForContentAttribute.cs
@@ -79,7 +79,23 @@ namespace Umbraco.Web.WebApi.Filters
 
                 if (parts.Length == 1)
                 {
-                    nodeId = (int)actionContext.ActionArguments[parts[0]];
+                    var argument = actionContext.ActionArguments[parts[0]].ToString();
+                    // if the argument is an int, it will parse and can be assigned to nodeId
+                    // if might be a udi, so check that next
+                    // otherwise treat it as a guid - unlikely we ever get here
+                    if (int.TryParse(argument, out int parsedId))
+                    {
+                        nodeId = parsedId;
+                    }
+                    else if (Udi.TryParse(argument, true, out Udi udi))
+                    { 
+                        nodeId = ApplicationContext.Current.Services.EntityService.GetIdForUdi(udi).Result;
+                    }
+                    else
+                    {
+                        Guid.TryParse(argument, out Guid key);
+                        nodeId = ApplicationContext.Current.Services.EntityService.GetIdForKey(key, UmbracoObjectTypes.Document).Result;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Changes here update the UI for the linkpicker overlay and dialog (is this actually in use anymore? updated regardless) to add a new input for an anchor to append to the link URL. The value can be an anchor or a querystring, which is added to the returned URL and rendered in the RTE. Also adds a data-anchor attribute to the markup, similar to how it's done for data-id, just because it might be useful.

The new input uses the datalist element to provide a list of anchors from the linked page - I added tinyMceService.getAnchorNames() to parse a string and return an array of values representing any named anchors. By stringifying the node properties, we can then do a bit of regex searching to find named anchors across any properties. 

The datalist element allows the input to accept a text value, or a selection from the list options - this gives flexibility for editors either adding a known anchor (or setting a querystring) or choosing from a list of options.

From there, the selected/specified anchor value is added to the overlay data model, appended to the url in the same model, and returned back to the controller.

Inserting the link into the editor adds a check that the anchor is correctly prefixed - if it doesn't start with # or ?, it is treated as a querystring if the value contains =, otherwise it's assumed to be an anchor, and prefixed with #. 

For that to all work, we need contentResource.getById() to work for udi parameters, as the picker might be storing these rather than id. To resolve that, I've extended Umbraco.Web.Editors.ContentController to function for GetById as it does for GetNiceUrl - accepting int, udi or guid parameters. Get by guid might not really be required as the client should only be sending id or udi, but for consistency with how GetNiceUrl is implemented, I've included all three.

From there, I had to modify the EnsureUserPermissionForContent attribute to handle the different parameter types - not sure that this is the best way to make it all work, more than happy to take input.

Ended up with excessive commits, apologies for that.