### PR TITLE
U4 11449 - adds indicator at property level to show if field varies by culture

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -1,6 +1,6 @@
 <div class="umb-property">
     <ng-form name="propertyForm">
-        <div class="control-group umb-control-group" ng-class="{hidelabel:property.hideLabel}">
+        <div class="control-group umb-control-group" ng-class="{hidelabel: property.hideLabel}">
 
             <val-property-msg property="property"></val-property-msg>
 
@@ -12,10 +12,12 @@
                         <strong class="umb-control-required">*</strong>
                     </span>
                     <small ng-bind-html="property.description | preserveNewLineInHtml"></small>
+                    <i class="icon icon-globe" ng-show="property.canVaryByCulture" />
                 </label>
 
                 <div class="controls" ng-transclude>
                 </div>
+                <i class="icon icon-globe" ng-show="property.canVaryByCulture && property.hideLabel" />
             </div>
         </div>
     </ng-form>

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -6,18 +6,21 @@
 
             <div class="umb-el-wrap">
 
-                <label class="control-label" ng-hide="property.hideLabel" for="{{property.alias}}" ng-attr-title="{{propertyAlias}}">
-                    {{property.label}}
+                <label class="control-label" ng-hide="property.hideLabel" for="{{property.alias}}">
+                    <span ng-attr-title="{{propertyAlias}}">
+                        {{property.label}}
+                    </span>
                     <span ng-if="property.validation.mandatory">
                         <strong class="umb-control-required">*</strong>
                     </span>
                     <small ng-bind-html="property.description | preserveNewLineInHtml"></small>
-                    <i class="icon icon-globe" ng-show="property.canVaryByCulture" />
+                    <i class="icon icon-globe" localize="title" title="@content_propertyCanVaryByCulture" ng-show="property.canVaryByCulture"/>
                 </label>
 
                 <div class="controls" ng-transclude>
                 </div>
-                <i class="icon icon-globe" ng-show="property.canVaryByCulture && property.hideLabel" />
+
+                <i class="icon icon-globe" localize="title" title="@content_propertyCanVaryByCulture" ng-show="property.canVaryByCulture && property.hideLabel"/>
             </div>
         </div>
     </ng-form>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -194,6 +194,10 @@
         <key alias="scheduledPublishDocumentation"><![CDATA[<a href="https://our.umbraco.org/documentation/Getting-Started/Data/Scheduled-Publishing/#timezones" target="_blank">What does this mean?</a>]]></key>
         <key alias="isSensitiveValue">This value is hidden. If you need access to view this value please contact your website administrator.</key>
         <key alias="isSensitiveValue_short">This value is hidden.</key>
+        <key alias="propertyCanVaryByCulture">Property can vary by culture</key>
+        <key alias="languagesToPublish">What languages would you like to publish?</key>
+        <key alias="publishedLanguages">Published Languages.</key>
+        <key alias="readyToPublish">Ready to Publish?</key>
     </area>
     <area alias="media">
         <key alias="clickToUpload">Click to upload</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -232,6 +232,7 @@
         <key alias="contentRoot">Content root</key>
         <key alias="isSensitiveValue">This value is hidden. If you need access to view this value please contact your website administrator.</key>
         <key alias="isSensitiveValue_short">This value is hidden.</key>
+        <key alias="propertyCanVaryByCulture">Property can vary by culture</key>
         <key alias="languagesToPublish">What languages would you like to publish?</key>
         <key alias="publishedLanguages">Published Languages.</key>
         <key alias="readyToPublish">Ready to Publish?</key>

--- a/src/Umbraco.Web/Models/ContentEditing/ContentPropertyDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentPropertyDisplay.cs
@@ -38,5 +38,8 @@ namespace Umbraco.Web.Models.ContentEditing
 
         [DataMember(Name = "readonly")]
         public bool Readonly { get; set; }
+
+        [DataMember(Name = "canVaryByCulture")]
+        public bool CanVaryByCulture { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/Mapping/ContentPropertyDisplayConverter.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentPropertyDisplayConverter.cs
@@ -43,6 +43,7 @@ namespace Umbraco.Web.Models.Mapping
             display.Description = originalProp.PropertyType.Description;
             display.Label = originalProp.PropertyType.Name;
             display.HideLabel = valEditor.HideLabel;
+            display.CanVaryByCulture = originalProp.PropertyType.Variations.HasFlag(Core.Models.ContentVariation.CultureNeutral);
 
             //add the validation information
             display.Validation.Mandatory = originalProp.PropertyType.Mandatory;


### PR DESCRIPTION
This PR adds a little icon indicating which fields within a document can vary by culture, to make this information available to the editor.

![image](https://user-images.githubusercontent.com/1993459/41507326-edf91daa-7230-11e8-9132-afeebb0f31fe.png)

