### PR TITLE
U4-11460 - Use an OrdinalIgnoreCase for localdb instance lookups

### DIFF
--- a/src/Umbraco.Core/Persistence/LocalDb.cs
+++ b/src/Umbraco.Core/Persistence/LocalDb.cs
@@ -142,7 +142,7 @@ namespace Umbraco.Core.Persistence
         {
             EnsureAvailable();
             var instances = GetInstances();
-            return instances != null && instances.Contains(instanceName);
+            return instances != null && instances.Contains(instanceName, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

-- http://issues.umbraco.org/issue/U4-11460

### Description
As per the issue, when installing a new version of Umbraco, if the connection string was populated with a non-case sensitive matching LocalDB instance name then the database was correctly populated during install, however the site would fail to run with:

>Umbraco cannot start. LocalDb cannot start instance "mssqllocaldb".

It would attempt to create a new localdb instance name, which is a noop in sqllocaldb as instance names are not case sensitive.

(Yes, I lost several hours due to this)

<!-- Thanks for contributing to Umbraco CMS! -->
