### PR TITLE
U4 11334 Content type edit, click on icon always shows black empty icon

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -212,6 +212,8 @@ Use this directive to construct a header inside the main editor window.
                 scope.dialogModel = {
                     view: "iconpicker",
                     show: true,
+                    icon: scope.icon.split(' ')[0],
+                    color: scope.icon.split(' ')[1],
                     submit: function (model) {
 
                         /* ensure an icon is selected, because on focus on close button

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
@@ -27,7 +27,8 @@
 }
 
 .umb-iconpicker-item a:hover,
-.umb-iconpicker-item a:focus{
+.umb-iconpicker-item a:focus,
+.umb-iconpicker-item.-selected {
     background: @gray-10;
     outline: none;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
@@ -15,6 +15,14 @@ function IconPickerOverlay($scope, iconHelper, localizationService) {
         $scope.model.title = localizationService.localize("defaultdialogs_selectIcon");
     }
 
+    if ($scope.model.color) {
+        $scope.color = $scope.model.color;
+    }
+
+    if ($scope.model.icon) {
+        $scope.searchTerm = $scope.model.icon;
+    }
+
    iconHelper.getIcons().then(function(icons) {
       $scope.icons = icons;
       $scope.loading = false;

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
@@ -9,19 +9,19 @@
 function IconPickerOverlay($scope, iconHelper, localizationService) {
 
    $scope.loading = true;
-   $scope.model.hideSubmitButton = true;
+   $scope.model.hideSubmitButton = false;
 
     if (!$scope.model.title) {
         $scope.model.title = localizationService.localize("defaultdialogs_selectIcon");
-    }
+    };
 
     if ($scope.model.color) {
         $scope.color = $scope.model.color;
-    }
+    };
 
     if ($scope.model.icon) {
-        $scope.searchTerm = $scope.model.icon;
-    }
+        $scope.icon = $scope.model.icon;
+    };
 
    iconHelper.getIcons().then(function(icons) {
       $scope.icons = icons;
@@ -34,6 +34,9 @@ function IconPickerOverlay($scope, iconHelper, localizationService) {
        $scope.submitForm($scope.model);
    };
 
+    $scope.changeColor = function (color) {
+        $scope.model.color = color;
+    };
 }
 
 angular.module("umbraco").controller("Umbraco.Overlays.IconPickerOverlay", IconPickerOverlay);

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
@@ -15,7 +15,7 @@
     </div>
 
     <div class="umb-control-group">
-        <select ng-model="color" class="input-block-level">
+        <select ng-model="color" ng-change="changeColor(color)" class="input-block-level">
             <option value=""><localize key="colors_black">Black</localize></option>
             <option value="color-blue-grey"><localize key="colors_bluegrey">Blue Grey</localize></option>
             <option value="color-grey"><localize key="colors_grey">Grey</localize></option>
@@ -42,7 +42,7 @@
 
     <div class="umb-control-group" ng-show="!loading && filtered.length > 0 ">
         <ul class="umb-iconpicker" ng-class="color" ng-show="icons">
-            <li class="umb-iconpicker-item" ng-repeat="icon in filtered = (icons | filter: searchTerm) track by $id(icon)">
+            <li class="umb-iconpicker-item" ng-class="{'-selected': icon == model.icon}" ng-repeat="icon in filtered = (icons | filter: searchTerm) track by $id(icon)">
                 <a href="#" title="{{icon}}" ng-click="selectIcon(icon, color)" prevent-default>
                     <i class="{{icon}} large"></i>
                 </a>


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
This issue is there for a very long time. Everytime I want to edit any content type and change the icon, when I click on it, Umbraco always gives me empty black icon, instead of selected icon and color I want to change.

![iconpicker2](https://user-images.githubusercontent.com/5310629/41677448-97d39cc6-74c8-11e8-91a9-9a03a6e14d81.gif)

Issue: http://issues.umbraco.org/issue/U4-11334