### PR TITLE
U4-11474: Bugfix - Umbraco.TrueFalse default value is not being stored in database

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
@@ -16,6 +16,10 @@ function booleanEditorController($scope, $rootScope, assetsService) {
 
     setupViewModel();
 
+    if( $scope.model && !$scope.model.value ) {
+        $scope.model.value = ($scope.renderModel.value === true) ? '1' : '0';
+    }
+
     //here we declare a special method which will be called whenever the value has changed from the server
     //this is instead of doing a watch on the model.value = faster
     $scope.model.onValueChanged = function (newVal, oldVal) {


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->

Adding a check in boolean.controller.js to ensure that $scope.model.value is set to match $scope.model.config.default

Original issue http://issues.umbraco.org/issue/U4-11408
