### PR TITLE
Fixes U4-11426 for files as well

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -318,25 +318,32 @@ angular.module("umbraco")
                                 mediaItem.thumbnail = mediaHelper.resolveFileFromEntity(mediaItem, true);
                                 mediaItem.image = mediaHelper.resolveFileFromEntity(mediaItem, false);
                                 // set properties to match a media object
-                                if (mediaItem.metaData &&
-                                    mediaItem.metaData.umbracoWidth &&
-                                    mediaItem.metaData.umbracoHeight) {
-
-                                    mediaItem.properties = [
-                                        {
-                                            alias: "umbracoWidth",
-                                            value: mediaItem.metaData.umbracoWidth.Value
-                                        },
-                                        {
-                                            alias: "umbracoHeight",
-                                            value: mediaItem.metaData.umbracoHeight.Value
-                                        },
-                                        {
-                                            alias: 'umbracoFile',
-                                            editor: mediaItem.metaData.umbracoFile.PropertyEditorAlias,
-                                            value: mediaItem.metaData.umbracoFile.Value
-                                        }
-                                    ];
+                                if (mediaItem.metaData) {
+                                    if (mediaItem.metaData.umbracoWidth && mediaItem.metaData.umbracoHeight) {
+                                        mediaItem.properties = [
+                                            {
+                                                alias: "umbracoWidth",
+                                                value: mediaItem.metaData.umbracoWidth.Value
+                                            },
+                                            {
+                                                alias: "umbracoHeight",
+                                                value: mediaItem.metaData.umbracoHeight.Value
+                                            },
+                                            {
+                                                alias: "umbracoFile",
+                                                editor: mediaItem.metaData.umbracoFile.PropertyEditorAlias,
+                                                value: mediaItem.metaData.umbracoFile.Value
+                                            }
+                                        ];
+                                    } else {
+                                        mediaItem.properties = [
+                                            {
+                                                alias: "umbracoFile",
+                                                editor: mediaItem.metaData.umbracoFile.PropertyEditorAlias,
+                                                value: mediaItem.metaData.umbracoFile.Value
+                                            }
+                                        ];
+                                    }
                                 }
                             });
                         // update images


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11426

### Description

The original fix from #2679 only fixes the bug for images, as it checks whether the `umbracoWidth` and `umbracoHeight` properties are present. With this PR, the bug is now fixed for both images and regular files.
