### PR TITLE
Change description text

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TagsPropertyEditor.cs
@@ -133,7 +133,7 @@ namespace Umbraco.Web.PropertyEditors
 
                 Fields.Add(new PreValueField(new ManifestPropertyValidator {Type = "Required"})
                 {
-                    Description = "Select whether to store the tags in cache as CSV (default) or as JSON. The only benefits of storage as JSON is that you are able to have commas in a tag value but this will require parsing the json in your views or using a property value converter",
+                    Description = "Select whether to store the tags in cache as CSV (default) or as JSON. The only benefits of storage as JSON is that you are able to have commas in a tag value",
                     Key = "storageType",
                     Name = "Storage Type",
                     View = "views/propertyeditors/tags/tags.prevalues.html"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11475

### Description
I changed the description text since it's no longer necessary to make a custom value converter when selecting the JSON option. It's handled out of the box now.

**The original text**
"Select whether to store the tags in cache as CSV (default) or as JSON. The only benefits of storage as JSON is that you are able to have commas in a tag value but this will require parsing the json in your views or using a property value converter"

**New text**
"Select whether to store the tags in cache as CSV (default) or as JSON. The only benefits of storage as JSON is that you are able to have commas in a tag value"
