### PR TITLE
U4-11259: Duplicates in tag editor throws error and breaks property editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.controller.js
@@ -5,15 +5,12 @@ angular.module("umbraco")
         var $typeahead;
 
         $scope.isLoading = true;
-        $scope.tagToAdd = "";
-
-        assetsService.loadJs("lib/typeahead.js/typeahead.bundle.min.js", $scope).then(function () {
-
-            $scope.isLoading = false;
-
-            //load current value
-
-            if ($scope.model.value) {
+        $scope.tagToAdd = "";	
+		
+		function setModelValue(val) {
+			
+			$scope.model.value = val || $scope.model.value;			
+			if ($scope.model.value) {
                 if (!$scope.model.config.storageType || $scope.model.config.storageType !== "Json") {
                     //it is csv
                     if (!$scope.model.value) {
@@ -21,7 +18,14 @@ angular.module("umbraco")
                     }
                     else {
                        if($scope.model.value.length > 0) {
-                          $scope.model.value = $scope.model.value.split(",");
+						  // split the csv string, and remove any duplicate values
+						  var tempArray = $scope.model.value.split(',').map(function(v) {
+							 return v.trim(); 
+						  });
+						   
+                          $scope.model.value = tempArray.filter(function(v, i, self) {
+							  return self.indexOf(v) === i;
+						  });
                        }
                     }
                 }
@@ -29,6 +33,14 @@ angular.module("umbraco")
             else {
                 $scope.model.value = [];
             }
+		}
+
+        assetsService.loadJs("lib/typeahead.js/typeahead.bundle.min.js", $scope).then(function () {
+
+            $scope.isLoading = false;
+
+            //load current value
+			setModelValue();            
 
             // Method required by the valPropertyValidator directive (returns true if the property editor has at least one tag selected)
             $scope.validateMandatory = function () {
@@ -85,17 +97,7 @@ angular.module("umbraco")
             //vice versa
             $scope.model.onValueChanged = function (newVal, oldVal) {
                 //update the display val again if it has changed from the server
-                $scope.model.value = newVal;
-
-                if (!$scope.model.config.storageType || $scope.model.config.storageType !== "Json") {
-                    //it is csv
-                    if (!$scope.model.value) {
-                        $scope.model.value = [];
-                    }
-                    else {
-                        $scope.model.value = $scope.model.value.split(",");
-                    }
-                }
+				setModelValue(newVal);
             };
 
             //configure the tags data source
@@ -190,4 +192,4 @@ angular.module("umbraco")
         });
 
     }
-);
+);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.html
@@ -8,7 +8,7 @@
 
         <input type="hidden" name="tagCount" ng-model="model.value.length" val-property-validator="validateMandatory" />
 
-        <span ng-repeat="tag in model.value" ng-click="$parent.removeTag(tag)" class="label label-primary tag">
+        <span ng-repeat="tag in model.value track by $index" ng-click="$parent.removeTag(tag)" class="label label-primary tag">
             <span ng-bind-html="tag"></span>
             <i class="icon icon-delete"></i>
         </span>


### PR DESCRIPTION
Per 11259:

To reproduce this bug do the following steps:
1. Input into tags field value "test, test" and press enter.
2. Save the content page.
3. Open the content page again and try to input any tags - after that you will get the error message.

When the editor attempts to re-render the tags, it splits on the comma, resulting in duplicate values, which gives AngularJs a migraine and it falls over.

Easiest fix for this is adding `track by` to the ng-repeat directive, which I've done.

Also added filtering in the controller to ensure cases like the example don't result in duplicate tags being persisted. This ensures a tag like "this,is,a,a,tag,tag,string" is stored as ['this','is','a','tag','string'].

To remove a bit of duplication, I shifted the is-it-csv check and subsequent parsing into a separate function.

If a particular use case requires commas in tags, the editor should be set to store as JSON