### PR TITLE
U4-11477 Improves URL not being populated in the RTE link media picker when searching for content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -322,31 +322,24 @@ angular.module("umbraco")
                                 mediaItem.thumbnail = mediaHelper.resolveFileFromEntity(mediaItem, true);
                                 mediaItem.image = mediaHelper.resolveFileFromEntity(mediaItem, false);
                                 // set properties to match a media object
+                                mediaItem.properties = [];
                                 if (mediaItem.metaData) {
                                     if (mediaItem.metaData.umbracoWidth && mediaItem.metaData.umbracoHeight) {
-                                        mediaItem.properties = [
-                                            {
-                                                alias: "umbracoWidth",
-                                                value: mediaItem.metaData.umbracoWidth.Value
-                                            },
-                                            {
-                                                alias: "umbracoHeight",
-                                                value: mediaItem.metaData.umbracoHeight.Value
-                                            },
-                                            {
-                                                alias: "umbracoFile",
-                                                editor: mediaItem.metaData.umbracoFile.PropertyEditorAlias,
-                                                value: mediaItem.metaData.umbracoFile.Value
-                                            }
-                                        ];
-                                    } else {
-                                        mediaItem.properties = [
-                                            {
-                                                alias: "umbracoFile",
-                                                editor: mediaItem.metaData.umbracoFile.PropertyEditorAlias,
-                                                value: mediaItem.metaData.umbracoFile.Value
-                                            }
-                                        ];
+                                        mediaItem.properties.push({
+                                            alias: "umbracoWidth",
+                                            value: mediaItem.metaData.umbracoWidth.Value
+                                        });
+                                        mediaItem.properties.push({
+                                            alias: "umbracoHeight",
+                                            value: mediaItem.metaData.umbracoHeight.Value
+                                        });
+                                    }
+                                    if (mediaItem.metaData.umbracoFile) {
+                                        mediaItem.properties.push({
+                                            alias: "umbracoFile",
+                                            editor: mediaItem.metaData.umbracoFile.PropertyEditorAlias,
+                                            value: mediaItem.metaData.umbracoFile.Value
+                                        });
                                     }
                                 }
                             });


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11477

### Description
Follow up on https://github.com/umbraco/Umbraco-CMS/pull/2720#issuecomment-400106496