### PR TITLE
Fix for U4 11482 - Adding space before the character counter.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -544,6 +544,9 @@ input[type="checkbox"][readonly] {
   padding-left: 5px;
 }
 
+div.help {
+    margin-top: 5px;
+}
 
 
 // INPUT GROUPS


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11482

### Description

I have added a 5 pixel space above the character counter, as seen on the screen shots in the issue above.