### PR TITLE
Adjusting danish translations

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1357,7 +1357,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="uppercase">Store bogstaver</key>
     <key alias="urlEncode">URL encode</key>
     <key alias="urlEncodeHelp">Hvis indholdet af felterne skal sendes til en url, skal denne slåes til så specialtegn formateres</key>
-    <key alias="usedIfAllEmpty">Denne tekst vil blive brugt hvis ovenstående felter er tomme</key>
+    <key alias="usedIfAllEmpty">Denne tekst bruges hvis ovenstående felter er tomme</key>
     <key alias="usedIfEmpty">Dette felt vil blive brugt hvis ovenstående felt er tomt</key>
     <key alias="withTime">Ja, med klokkeslæt. Dato/tid separator: </key>
   </area>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1223,11 +1223,11 @@ Mange hilsner fra Umbraco robotten
   
   <area alias="grid">
     <key alias="rte">Rich Text Editor</key>
-    <key alias="media">Image</key>
+    <key alias="media">Billede</key>
     <key alias="macro">Macro</key>
     <key alias="embed">Embed</key>
-    <key alias="headline">Headline</key>
-    <key alias="quote">Quote</key>  
+    <key alias="headline">Overskrift</key>
+    <key alias="quote">Citat</key>  
     <key alias="insertControl">Vælg indholdstype</key>
     <key alias="chooseLayout">Vælg layout</key>
     <key alias="addRows">Tilføj række</key>
@@ -1243,9 +1243,9 @@ Mange hilsner fra Umbraco robotten
     <key alias="placeholderImageCaption">Billedtekst...</key>
     <key alias="placeholderWriteHere">Skriv her...</key>
 
-    <key alias="gridLayouts">Gitterlayout</key>
-    <key alias="gridLayoutsDetail">Et layout er det overordnede arbejdsområde til dit gitter - du vil typisk kun behøve ét eller to</key>
-    <key alias="addGridLayout">Tilføj gitterlayout</key>
+    <key alias="gridLayouts">Grid layout</key>
+    <key alias="gridLayoutsDetail">Et layout er det overordnede arbejdsområde til dit grid - du vil typisk kun behøve ét eller to</key>
+    <key alias="addGridLayout">Tilføj grid layout</key>
     <key alias="addGridLayoutDetail">Juster dit layout ved at justere kolonnebredder og tilføj yderligere sektioner</key>
 
     <key alias="rowConfigurations">Rækkekonfigurationer</key>
@@ -1254,7 +1254,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="addRowConfigurationDetail">Juster rækken ved at indstille cellebredder og tilføje yderligere celler</key>
 
     <key alias="columns">Kolonner</key>
-    <key alias="columnsDetails">Det totale antaller kolonner i gitteret</key>
+    <key alias="columnsDetails">Det totale antaller kolonner i dit grid</key>
 
     <key alias="settings">Indstillinger</key>
     <key alias="settingsDetails">Konfigurer, hvilket indstillinger, brugeren kan ændre</key>
@@ -1354,7 +1354,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="preContent">Indsæt før felt</key>
     <key alias="recursive">Rekursivt</key>
     <key alias="standardFields">Standard felter</key>
-    <key alias="uppercase">Uppercase</key>
+    <key alias="uppercase">Store bogstaver</key>
     <key alias="urlEncode">URL encode</key>
     <key alias="urlEncodeHelp">Hvis indholdet af felterne skal sendes til en url, skal denne slåes til så specialtegn formateres</key>
     <key alias="usedIfAllEmpty">Denne tekst vil blive brugt hvis ovenstående felter er tomme</key>
@@ -1541,7 +1541,7 @@ Mange hilsner fra Umbraco robotten
     </key>
   </area>
   <area alias="validation">
-    <key alias="validation">Validation</key>
+    <key alias="validation">Validering</key>
     <key alias="validateAsEmail">Valider som e-mail</key>
     <key alias="validateAsNumber">Valider som tal</key>
     <key alias="validateAsUrl">Valider som Url</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1254,7 +1254,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="addRowConfigurationDetail">Juster rækken ved at indstille cellebredder og tilføje yderligere celler</key>
 
     <key alias="columns">Kolonner</key>
-    <key alias="columnsDetails">Det totale antaller kolonner i dit grid</key>
+    <key alias="columnsDetails">Det totale antal kolonner i dit grid</key>
 
     <key alias="settings">Indstillinger</key>
     <key alias="settingsDetails">Konfigurer, hvilket indstillinger, brugeren kan ændre</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
I just noticed a few untranslated words and I also took the liberty to change the translation of "grid" to "gitter" and translate it back to english. "Gitter layout" is not something we say in danish we simply adopt the english word "Grid" :-)
