### PR TITLE
Media library thumbnail does not reload if a new image with the same name is uploaded

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
@@ -73,7 +73,7 @@ function fileUploadController($scope, $element, $compile, imageHelper, fileManag
 
             var extension = file.file.substring(file.file.lastIndexOf(".") + 1, file.file.length);
 
-            file.thumbnail = thumbnailUrl;
+            file.thumbnail = thumbnailUrl + '&rnd=' + Math.random();
             file.extension = extension.toLowerCase();
         });
 


### PR DESCRIPTION
Simple fix to reload thumbnail image if same name

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
Added a simple rnd to the url for GetBigThumbnail. 

Issue: http://issues.umbraco.org/issue/U4-7463 