### PR TITLE
U4 9379 - add confirmation step to unpublish action

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/application/grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/application/grid.less
@@ -248,13 +248,13 @@ body.umb-drawer-is-visible #mainwrapper{
     #applications-tray {
         left: 60px;
     }
-    #navigation {
+    #navigation, #umb-notifications-wrapper {
         left: 60px;
     }
-    #contentwrapper, #contentcolumn, #umb-notifications-wrapper {
+    #contentwrapper, #contentcolumn {
         left: 30px;
     }
-    #umbracoMainPageBody .umb-modal-left.fade.in {
+    #umbracoMainPageBody .umb-modal-left.fade.in { 
         margin-left: 61px;
     }
 }
@@ -277,12 +277,13 @@ body.umb-drawer-is-visible #mainwrapper{
     #applications-tray {
         left: 40px;
     }
-    #navigation {
+    #navigation, #umb-notifications-wrapper {
         left: 40px;
     }
-    #contentwrapper, #contentcolumn, #umb-notifications-wrapper {
+    #contentwrapper, #contentcolumn {
         left: 20px;
     }
+
     #umbracoMainPageBody .umb-modal-left.fade.in {
         margin-left: 41px;
         width: 85%!important;

--- a/src/Umbraco.Web.UI.Client/src/views/common/notifications/confirmunpublish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/notifications/confirmunpublish.controller.js
@@ -1,0 +1,9 @@
+angular.module("umbraco").controller("Umbraco.Notifications.ConfirmUnpublishController",
+	function ($scope, notificationsService, eventsService) {	
+
+		$scope.confirm = function(not, action){
+			eventsService.emit('content.confirmUnpublish', action);
+			notificationsService.remove(not);
+		};
+	
+	});

--- a/src/Umbraco.Web.UI.Client/src/views/common/notifications/confirmunpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/notifications/confirmunpublish.html
@@ -1,0 +1,6 @@
+<div ng-controller="Umbraco.Notifications.ConfirmUnpublishController">
+	<h4><localize key="general_areyousure">Are you sure?</localize></h4>
+	<p><localize key="prompt_confirmUnpublish">Unpublishing will remove this page and all its descendants from the site</localize></p>
+	<button class="btn btn-warning" ng-click="confirm(notification, true)"><localize key="actions_unpublish">Unpublish</localize></button>
+	<button class="btn btn-default" ng-click="confirm(notification, false)" umb-auto-focus><localize key="general_cancel">Cancel</localize></button>
+</div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -286,6 +286,7 @@
         <key alias="discardChanges">Discard changes</key>
         <key alias="unsavedChanges">You have unsaved changes</key>
         <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+        <key alias="confirmUnpublish">Unpublishing will remove this page and all its descendants from the site.</key>
     </area>
     <area alias="bulk">
         <key alias="done">Done</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -286,6 +286,7 @@
         <key alias="discardChanges">Discard changes</key>
         <key alias="unsavedChanges">You have unsaved changes</key>
         <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+        <key alias="confirmUnpublish">Unpublishing will remove this page and all its descendants from the site.</key>
     </area>
     <area alias="bulk">
         <key alias="done">Done</key>


### PR DESCRIPTION
### Prerequisites

- I have written a descriptive pull-request title
- I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
[Discussion on the tracker](http://issues.umbraco.org/issue/U4-9379) was around changing the keyboard shortcut and/or adding a confirmation dialog for unpublish actions, particularly as the CTRL+U shortcut is the default for show source.

I've left the shortcut in place, as (IMO) while unpublish isn't a common action, keeping it ensures a complete set of publishing actions are available from the keyboard. Further, adding a confirmation step removes the risk of accidentally unpublishing an entire 35k node site with a couple of keystrokes...

My changes add a new notification in the same style as the route change warning, which warns that unpublishing the current page will remove it and all descendants from the site. I was going to add this in the valformmanager directive alongside the routechange code, but ended up keeping it all in the edit controller, mainly because the controller should remain responsible for unpublishing the page. It also allows the event subscription to be created just-in-time, when the unpublish button is clicked, rather than when the view loads.

Also included a bit of CSS to ensure the notifications aren't obscured by the left nav on small screens.

Notification works like this:

- user clicks unpublish
- notifications service displays the warning notification, listener subscribes to content.confirmUnpublish
- user clicks either unpublish or cancel in the notification
- the notification controller raises an event
- listener in edit.controller responds to the event data -> a bool representing the action taken (true = unpublish, false = cancel)
- if true, the unpublish proceeds as normal
- if false, just reset the button state
- finally, unsubscribe the confirmUnpublish listener

Unsubscribing inside the listener callback means a user can repeatedly publish and unpublish a page (if they really wanted to) without having to refresh the backoffice to resubscribe to the confirmUnpublish event - subscription happens inside the $scope.unpublish function, so it's always ready when we need it. Also means it's not created by default.

Otherwise, each unpublish request creates a new listener, and raises multiple events, and displays multiple confirmation notifications.

Should look something like this:
![unpublish-notification](https://user-images.githubusercontent.com/3248070/42006480-65ec0162-7abd-11e8-94d1-5fc31a98fba9.gif)

