### PR TITLE
U4-11487 | FileSystemTreeController not working with wildcards

### DIFF
--- a/src/Umbraco.Web/Trees/FileSystemTreeController.cs
+++ b/src/Umbraco.Web/Trees/FileSystemTreeController.cs
@@ -49,12 +49,11 @@ namespace Umbraco.Web.Trees
                     nodes.Add(node);
             }
 
-            //this is a hack to enable file system tree to support multiple file extension look-up
-            //so the pattern both support *.* *.xml and xml,js,vb for lookups
-            var files = FileSystem.GetFiles(path).Where(x =>
+            //This will support wildcards aswell as normal extensions like xml
+            var files = Extensions.SelectMany(x =>
             {
-                var extension = Path.GetExtension(x);
-                return extension != null && Extensions.Contains(extension.Trim('.'), StringComparer.InvariantCultureIgnoreCase);
+                string filter = (x.StartsWith("*")) ? x : "*" + x;
+                return FileSystem.GetFiles(path, filter);
             });
 
             foreach (var file in files)


### PR DESCRIPTION
**Prerequisites**

- [x]   I have written a descriptive pull-request title
- [x]   I have linked this PR to an issue on the tracker at http://issues.umbraco.org

**Description**
Link to bug tracker: http://issues.umbraco.org/issue/U4-11487 

Currently the code in FileSystemTreeController doesn't work with wildcards for the extension. Extensions like "*.*" doesn't seem to work along with "*.xml" even though the comment seems to indicate that it should.

The FileSystem itself can be used as it supports wildcards for the GetFiles function.


I am currently using the FileSystem build GetFiles method with the filter to look for the extensions. This only works with *.xml and *.*. That's why I use a little hack to make sure there is always a * before the extension. We could also remove the little hack and update the other TreeControllers using this controller to use the new format for extensions.
