### PR TITLE
U4-11166 Hide disabled users from the users list view

### DIFF
--- a/src/Umbraco.Core/Models/Membership/UserState.cs
+++ b/src/Umbraco.Core/Models/Membership/UserState.cs
@@ -9,6 +9,7 @@
         Active = 0,
         Disabled = 1,
         LockedOut = 2,
-        Invited = 3
+        Invited = 3,
+        Inactive = 4
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
@@ -186,6 +186,8 @@ UNION
 SELECT '4CountOfLockedOut' AS colName, COUNT(id) AS num FROM umbracoUser WHERE userNoConsole = 1
 UNION
 SELECT '5CountOfInvited' AS colName, COUNT(id) AS num FROM umbracoUser WHERE lastLoginDate IS NULL AND userDisabled = 1 AND invitedDate IS NOT NULL
+UNION
+SELECT '6CountOfDisabled' AS colName, COUNT(id) AS num FROM umbracoUser WHERE userDisabled = 0 AND userNoConsole = 0 AND lastLoginDate IS NULL 
 ORDER BY colName";
 
             var result = Database.Fetch<dynamic>(sql);
@@ -196,7 +198,8 @@ ORDER BY colName";
                 {UserState.Active, (int)result[1].num},
                 {UserState.Disabled, (int)result[2].num},
                 {UserState.LockedOut, (int)result[3].num},
-                {UserState.Invited, (int)result[4].num}
+                {UserState.Invited, (int)result[4].num},
+                {UserState.Inactive, (int) result[5].num}
             };
         }
 
@@ -763,6 +766,12 @@ ORDER BY colName";
                     if (userState.Contains(UserState.Active))
                     {
                         sb.Append("(userDisabled = 0 AND userNoConsole = 0 AND lastLoginDate IS NOT NULL)");
+                        appended = true;
+                    }
+                    if (userState.Contains(UserState.Inactive))
+                    {
+                        if (appended) sb.Append(" OR ");
+                        sb.Append("(userDisabled = 0 AND userNoConsole = 0 AND lastLoginDate IS NULL)");
                         appended = true;
                     }
                     if (userState.Contains(UserState.Disabled))

--- a/src/Umbraco.Web.UI.Client/src/common/services/usershelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/usershelper.service.js
@@ -8,7 +8,8 @@
             { "value": 0, "name": "Active", "key": "Active", "color": "success" },
             { "value": 1, "name": "Disabled", "key": "Disabled", "color": "danger" },
             { "value": 2, "name": "Locked out", "key": "LockedOut", "color": "danger" },
-            { "value": 3, "name": "Invited", "key": "Invited", "color": "warning" }
+            { "value": 3, "name": "Invited", "key": "Invited", "color": "warning" },
+            { "value": 4, "name": "Inactive", "key": "Inactive", "color": "warning" }
         ];
 
         angular.forEach(userStates, function (userState) {

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -254,10 +254,7 @@ namespace Umbraco.Web.Editors
             var paged = new PagedUserResult(total, pageNumber, pageSize)
             {
                 Items = Mapper.Map<IEnumerable<UserBasic>>(result),
-                UserStates = hideDisabledUsers
-                                 ? Services.UserService.GetUserStates().Where(state => state.Key != UserState.Disabled)
-                                           .ToDictionary(state => state.Key, state => state.Value)
-                                 : Services.UserService.GetUserStates()
+                UserStates = Services.UserService.GetUserStates()
             };
 
             return paged;

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -241,6 +241,11 @@ namespace Umbraco.Web.Editors
                 filterQuery.Where(x => x.Name.Contains(filter) || x.Username.Contains(filter));
             }
 
+            if (UmbracoConfig.For.UmbracoSettings().Security.HideDisabledUsersInBackoffice)
+            {
+                filterQuery.Where(user => !user.IsApproved);
+            }
+
             long pageIndex = pageNumber - 1;
             long total;
             var result = Services.UserService.GetAll(pageIndex, pageSize, out total, orderBy, orderDirection, userStates, userGroups, excludeUserGroups, filterQuery);

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -244,7 +244,10 @@ namespace Umbraco.Web.Editors
 
             if (hideDisabledUsers)
             {
-                filterQuery.Where(user => !user.IsApproved);
+                if (userStates == null || userStates.Any() == false)
+                {
+                    userStates = new[] { UserState.Active, UserState.Invited, UserState.LockedOut };
+                }
             }
 
             long pageIndex = pageNumber - 1;

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -246,7 +246,7 @@ namespace Umbraco.Web.Editors
             {
                 if (userStates == null || userStates.Any() == false)
                 {
-                    userStates = new[] { UserState.Active, UserState.Invited, UserState.LockedOut };
+                    userStates = new[] { UserState.Active, UserState.Invited, UserState.LockedOut, UserState.Inactive };
                 }
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
Fixes [U4-11166](http://issues.umbraco.org/issue/U4-11166). When the `hideDisabledUsersInBackoffice` setting in umbracoSettings.config is set to true disabled users are now hidden from the users list view.
