### PR TITLE
U4 6946 - Existing template file is overwritten when creating a new template in the backoffice

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-_Looking for Umbraco version 8? [Click here](https://github.com/umbraco/Umbraco-CMS/blob/temp8/CONTRIBUTING.md) to go to the v8 branch_
+_Looking for Umbraco version 8? [Click here](https://github.com/umbraco/Umbraco-CMS/blob/temp8/docs/CONTRIBUTING.md) to go to the v8 branch_
 # Contributing to Umbraco CMS
 
 👍🎉 First off, thanks for taking the time to contribute! 🎉👍

--- a/src/Umbraco.Core/Services/IFileService.cs
+++ b/src/Umbraco.Core/Services/IFileService.cs
@@ -427,5 +427,12 @@ namespace Umbraco.Core.Services
         /// <param name="filepath">The filesystem path to the partial view.</param>
         /// <returns>The size of the partial view.</returns>
         long GetPartialViewFileSize(string filepath);
+
+        /// <summary>
+        /// Gets the content of a view.
+        /// </summary>
+        /// <param name="filename">The name of the view.</param>
+        /// <returns></returns>
+        string GetViewContent(string filename);
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -27,7 +27,7 @@
         vm.page.keyboardShortcutsOverview.push(templateHelper.getTemplateEditorShortcuts());
 
         
-        vm.save = function () {
+        vm.save = function (suppressNotification) {
             vm.page.saveButtonState = "busy";
 
             vm.template.content = vm.editor.getValue();
@@ -44,11 +44,13 @@
                 rebindCallback: function (orignal, saved) {}
             }).then(function (saved) {
 
+							if (!suppressNotification) {
                 localizationService.localizeMany(["speechBubbles_templateSavedHeader", "speechBubbles_templateSavedText"]).then(function(data){
                     var header = data[0];
                     var message = data[1];
                     notificationsService.success(header, message);
                 });
+							}
 
 
                 vm.page.saveButtonState = "success";
@@ -134,6 +136,21 @@
         	vm.page.loading = false;
             vm.template = template;
 
+						// if this is a new template, bind to the blur event on the name
+						if ($routeParams.create) {
+							$timeout(function() {
+								var nameField = angular.element(document.querySelector('[data-element="editor-name-field"]'));
+								if (nameField) {
+									nameField.bind('blur', function(event) {
+										if (event.target.value) {
+											vm.save(true);
+										}
+									});
+								}
+							});
+						}
+					
+					
             //sync state
             editorState.set(vm.template);
             navigationService.syncTree({ tree: "templates", path: vm.template.path, forceReload: true }).then(function (syncArgs) {

--- a/src/Umbraco.Web/Editors/TemplateController.cs
+++ b/src/Umbraco.Web/Editors/TemplateController.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Web;
 using System.Web.Http;
 using AutoMapper;
+using Umbraco.Core;
 using Umbraco.Core.IO;
 using Umbraco.Core.Models;
 using Umbraco.Core.Services;
@@ -178,6 +181,14 @@ namespace Umbraco.Web.Editors
             else
             {
                 //create
+
+                // file might already be on disk, if so grab the content to avoid overwriting
+                string content = Services.FileService.GetViewContent(display.Alias);
+                if (string.IsNullOrEmpty(content) == false)
+                {
+                    display.Content = content;
+                }
+
                 ITemplate master = null;
                 if (string.IsNullOrEmpty(display.MasterTemplateAlias) == false)
                 {

--- a/src/Umbraco.Web/Editors/TemplateController.cs
+++ b/src/Umbraco.Web/Editors/TemplateController.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using AutoMapper;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Web;
 using System.Web.Http;
-using AutoMapper;
-using Umbraco.Core;
 using Umbraco.Core.IO;
 using Umbraco.Core.Models;
-using Umbraco.Core.Services;
 using Umbraco.Web.Models.ContentEditing;
 using Umbraco.Web.Mvc;
-using Umbraco.Web.WebApi;
 using Umbraco.Web.WebApi.Filters;
 using Constants = Umbraco.Core.Constants;
 


### PR DESCRIPTION
When creating a new template or document type (with a template) in the backoffice, and a view already exists on disk where the view name matches the new template alias, the content of the existing view is overwritten with the default snippet.

My changes add a check when creating a new template or creating a template for a document type, where the content of an existing template is used if one exists. 

This works nicely when creating a document type as the template content is not seen until switching sections, but when creating a new template the default snippet loads before the template name is set, so there's no clean way to check for existing content (other than adding a watch to the name input, and checking on blur or similar, which seems a bit heavy handed), so the check is performed on save, and replaces the snippet with the content from an existing view.

- FileService.GetViewContent checks that the filename argument maps to an existing file in /Views, then returns the file content as a string, if the file exists
- FileService.TryGetViewPath is called by GetViewContent, and builds a path to the view, then checks that a file exists at that path
- FileService.CreateTemplateForContentType is extended to include a call to GetViewContent, and assigns it as the template content if a value exists
- TemplateController.PostSave has a similar call added, to check for existing content when creating a new template

There are a few places in the codebase performing file operations (IOHelper and ViewHelper in Core.IO for starters), so wasn't entirely sure where this change should live - added it to FileService as there were similar methods already in the service, and adding it in ViewHelper would have meant a trip down DI road into a service context marked for removal in V8...