### PR TITLE
Hackathon use logger info with func

### DIFF
--- a/src/Umbraco.Core/Components/BootLoader.cs
+++ b/src/Umbraco.Core/Components/BootLoader.cs
@@ -111,7 +111,7 @@ namespace Umbraco.Core.Components
             catch (Exception e)
             {
                 // in case of an error, force-dump everything to log
-                _logger.Info<BootLoader>(GetComponentsReport(requirements));
+                _logger.Info<BootLoader>(() => GetComponentsReport(requirements));
                 _logger.Error<BootLoader>("Failed to sort components.", e);
                 throw;
             }

--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -494,7 +494,7 @@ namespace Umbraco.Core.Composing
                     if (--attempts == 0)
                         throw;
 
-                    _logger.Logger.Debug<TypeLoader>($"Attempted to get filestream for file {path} failed, {attempts} attempts left, pausing for {pauseMilliseconds} milliseconds");
+                    _logger.Logger.Debug<TypeLoader>(() => $"Attempted to get filestream for file {path} failed, {attempts} attempts left, pausing for {pauseMilliseconds} milliseconds");
                     Thread.Sleep(pauseMilliseconds);
                 }
             }

--- a/src/Umbraco.Core/Configuration/ClientDependencyConfiguration.cs
+++ b/src/Umbraco.Core/Configuration/ClientDependencyConfiguration.cs
@@ -79,7 +79,7 @@ namespace Umbraco.Core.Configuration
                     versionAttribute.SetValue(newVersion);
                     clientDependencyConfigXml.Save(_fileName, SaveOptions.DisableFormatting);
 
-                    _logger.Info<ClientDependencyConfiguration>(string.Format("Updated version number from {0} to {1}", oldVersion, newVersion));
+                    _logger.Info<ClientDependencyConfiguration>(() => $"Updated version number from {oldVersion} to {newVersion}");
                     return true;
                 }
             }
@@ -113,7 +113,7 @@ namespace Umbraco.Core.Configuration
                     versionAttribute.SetValue(newVersion);
                     clientDependencyConfigXml.Save(_fileName, SaveOptions.DisableFormatting);
 
-                    _logger.Info<ClientDependencyConfiguration>(string.Format("Updated version number from {0} to {1}", oldVersion, newVersion));
+                    _logger.Info<ClientDependencyConfiguration>(() => $"Updated version number from {oldVersion} to {newVersion}");
                     return true;
                 }
             }

--- a/src/Umbraco.Core/IO/PhysicalFileSystem.cs
+++ b/src/Umbraco.Core/IO/PhysicalFileSystem.cs
@@ -226,7 +226,7 @@ namespace Umbraco.Core.IO
             }
             catch (FileNotFoundException ex)
             {
-                Current.Logger.Info<PhysicalFileSystem>(string.Format("DeleteFile failed with FileNotFoundException: {0}", ex.InnerException));
+                Current.Logger.Info<PhysicalFileSystem>(() => $"DeleteFile failed with FileNotFoundException: {ex.InnerException}");
             }
         }
 

--- a/src/Umbraco.Core/IO/ShadowFileSystems.cs
+++ b/src/Umbraco.Core/IO/ShadowFileSystems.cs
@@ -54,7 +54,7 @@ namespace Umbraco.Core.IO
             }
 
             _logger = logger;
-            _logger.Debug<ShadowFileSystems>("Shadow " + id + ".");
+            _logger.Debug<ShadowFileSystems>(() => "Shadow " + id + ".");
             _id = id;
 
             _wrappers = wrappers;
@@ -112,7 +112,7 @@ namespace Umbraco.Core.IO
         {
             lock (Locker)
             {
-                _logger.Debug<ShadowFileSystems>("UnShadow " + _id + " (" + (_completed ? "complete" : "abort") + ").");
+                _logger.Debug<ShadowFileSystems>(() => "UnShadow " + _id + " (" + (_completed ? "complete" : "abort") + ").");
 
                 var exceptions = new List<Exception>();
                 foreach (var wrapper in _wrappers)

--- a/src/Umbraco.Core/Logging/LogProfiler.cs
+++ b/src/Umbraco.Core/Logging/LogProfiler.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Core.Logging
         public IDisposable Step(string name)
         {
             _logger.Debug<LogProfiler>(() => $"Begin: {name}.");
-            return new LightDisposableTimer(duration => _logger.Info<LogProfiler>($"End {name}. ({duration}ms)"));
+            return new LightDisposableTimer(duration => _logger.Info<LogProfiler>(() => $"End {name}. ({duration}ms)"));
         }
 
         /// <inheritdoc/>

--- a/src/Umbraco.Core/Logging/LogProfiler.cs
+++ b/src/Umbraco.Core/Logging/LogProfiler.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Core.Logging
         /// <inheritdoc/>
         public IDisposable Step(string name)
         {
-            _logger.Debug<LogProfiler>($"Begin: {name}.");
+            _logger.Debug<LogProfiler>(() => $"Begin: {name}.");
             return new LightDisposableTimer(duration => _logger.Info<LogProfiler>($"End {name}. ({duration}ms)"));
         }
 

--- a/src/Umbraco.Core/MainDom.cs
+++ b/src/Umbraco.Core/MainDom.cs
@@ -117,7 +117,7 @@ namespace Umbraco.Core
 
             lock (_locko)
             {
-                _logger.Debug<MainDom>("Signaled" + (_signaled ? " (again)" : "") + " (" + source + ").");
+                _logger.Debug<MainDom>(() => "Signaled" + (_signaled ? " (again)" : "") + " (" + source + ").");
                 if (_signaled) return;
                 if (_isMainDom == false) return; // probably not needed
                 _signaled = true;

--- a/src/Umbraco.Core/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseBuilder.cs
@@ -309,7 +309,7 @@ namespace Umbraco.Core.Migrations.Install
             {
                 var source = connectionStrings.Attribute("configSource").Value;
                 var configFile = IOHelper.MapPath($"{SystemDirectories.Root}/{source}");
-                logger.Info<DatabaseBuilder>($"Storing ConnectionString in {configFile}");
+                logger.Info<DatabaseBuilder>(() => $"Storing ConnectionString in {configFile}");
                 if (File.Exists(configFile))
                 {
                     xml = XDocument.Load(fileName, LoadOptions.PreserveWhitespace);
@@ -335,7 +335,7 @@ namespace Umbraco.Core.Migrations.Install
             }
 
             xml.Save(fileName, SaveOptions.DisableFormatting);
-            logger.Info<DatabaseBuilder>("Configured a new ConnectionString using the '" + providerName + "' provider.");
+            logger.Info<DatabaseBuilder>(() => $"Configured a new ConnectionString using the '{providerName}' provider.");
         }
 
         internal bool IsConnectionStringConfigured(ConnectionStringSettings databaseSettings)
@@ -500,7 +500,7 @@ namespace Umbraco.Core.Migrations.Install
                     message = message + "<p>Installation completed!</p>";
 
                     //now that everything is done, we need to determine the version of SQL server that is executing
-                    _logger.Info<DatabaseBuilder>("Database configuration status: " + message);
+                    _logger.Info<DatabaseBuilder>(() => $"Database configuration status: {message}");
                     return new Result { Message = message, Success = true, Percentage = "100" };
                 }
 
@@ -589,7 +589,7 @@ namespace Umbraco.Core.Migrations.Install
 
                 //now that everything is done, we need to determine the version of SQL server that is executing
 
-                _logger.Info<DatabaseBuilder>("Database configuration status: " + message);
+                _logger.Info<DatabaseBuilder>(() => $"Database configuration status: {message}");
 
                 return new Result { Message = message, Success = true, Percentage = "100" };
             }
@@ -662,7 +662,7 @@ namespace Umbraco.Core.Migrations.Install
 
             if (_databaseSchemaValidationResult != null)
             {
-                _logger.Info<DatabaseBuilder>("The database schema validation produced the following summary: \n" + _databaseSchemaValidationResult.GetSummary());
+                _logger.Info<DatabaseBuilder>(() => $"The database schema validation produced the following summary: {Environment.NewLine}{_databaseSchemaValidationResult.GetSummary()}");
             }
 
             return new Result

--- a/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Core.Migrations.Install
         /// <param name="tableName">Name of the table to create base data for</param>
         public void InitializeBaseData(string tableName)
         {
-            _logger.Info<DatabaseDataCreator>($"Creating data in table {tableName}");
+            _logger.Info<DatabaseDataCreator>(() => $"Creating data in table {tableName}");
 
             if (tableName.Equals(Constants.DatabaseSchema.Tables.Node))
                 CreateNodeData();
@@ -76,7 +76,7 @@ namespace Umbraco.Core.Migrations.Install
             if (tableName.Equals(Constants.DatabaseSchema.Tables.KeyValue))
                 CreateKeyValueData();
 
-            _logger.Info<DatabaseDataCreator>($"Done creating table {tableName} data.");
+            _logger.Info<DatabaseDataCreator>(() => $"Done creating table {tableName} data.");
         }
 
         private void CreateNodeData()

--- a/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
@@ -98,7 +98,7 @@ namespace Umbraco.Core.Migrations.Install
                 var tableNameAttribute = table.FirstAttribute<TableNameAttribute>();
                 var tableName = tableNameAttribute == null ? table.Name : tableNameAttribute.Value;
 
-                _logger.Info<DatabaseSchemaCreator>("Uninstall" + tableName);
+                _logger.Info<DatabaseSchemaCreator>(() => $"Uninstall {tableName}");
 
                 try
                 {
@@ -388,13 +388,13 @@ namespace Umbraco.Core.Migrations.Install
                 {
                     //Execute the Create Table sql
                     var created = _database.Execute(new Sql(createSql));
-                    _logger.Info<DatabaseSchemaCreator>($"Create Table '{tableName}' ({created}):\n {createSql}");
+                    _logger.Info<DatabaseSchemaCreator>(() => $"Create Table '{tableName}' ({created}):\n {createSql}");
 
                     //If any statements exists for the primary key execute them here
                     if (string.IsNullOrEmpty(createPrimaryKeySql) == false)
                     {
                         var createdPk = _database.Execute(new Sql(createPrimaryKeySql));
-                        _logger.Info<DatabaseSchemaCreator>($"Create Primary Key ({createdPk}):\n {createPrimaryKeySql}");
+                        _logger.Info<DatabaseSchemaCreator>(() => $"Create Primary Key ({createdPk}):\n {createPrimaryKeySql}");
                     }
 
                     //Turn on identity insert if db provider is not mysql
@@ -420,21 +420,21 @@ namespace Umbraco.Core.Migrations.Install
                     foreach (var sql in indexSql)
                     {
                         var createdIndex = _database.Execute(new Sql(sql));
-                        _logger.Info<DatabaseSchemaCreator>($"Create Index ({createdIndex}):\n {sql}");
+                        _logger.Info<DatabaseSchemaCreator>(() => $"Create Index ({createdIndex}):\n {sql}");
                     }
 
                     //Loop through foreignkey statements and execute sql
                     foreach (var sql in foreignSql)
                     {
                         var createdFk = _database.Execute(new Sql(sql));
-                        _logger.Info<DatabaseSchemaCreator>($"Create Foreign Key ({createdFk}):\n {sql}");
+                        _logger.Info<DatabaseSchemaCreator>(() => $"Create Foreign Key ({createdFk}):\n {sql}");
                     }
 
                     transaction.Complete();
                 }
             }
 
-            _logger.Info<DatabaseSchemaCreator>($"Created table '{tableName}'");
+            _logger.Info<DatabaseSchemaCreator>(() => $"Created table '{tableName}'");
         }
 
         public void DropTable(string tableName)

--- a/src/Umbraco.Core/Migrations/MigrationPlan.cs
+++ b/src/Umbraco.Core/Migrations/MigrationPlan.cs
@@ -211,11 +211,14 @@ namespace Umbraco.Core.Migrations
             if (_migrationBuilder == null || _logger == null)
                 throw new InvalidOperationException("Cannot execute a non-executing plan.");
 
-            _logger.Info<MigrationPlan>($"Starting \"{Name}\"...");
+            _logger.Info<MigrationPlan>(() => $"Starting \"{Name}\"...");
             var origState = fromState ?? string.Empty;
-            var info = "At " + (string.IsNullOrWhiteSpace(origState) ? "origin" : ("\"" + origState + "\"")) + ".";
-            info = info.Replace("{", "{{").Replace("}", "}}"); // stupid log4net
-            _logger.Info<MigrationPlan>(info);
+
+            _logger.Info<MigrationPlan>(() =>
+            {
+                var info = "At " + (string.IsNullOrWhiteSpace(origState) ? "origin" : ("\"" + origState + "\"")) + ".";
+                return info.Replace("{", "{{").Replace("}", "}}"); // stupid log4net
+            });
 
             if (!_transitions.TryGetValue(origState, out var transition))
                 throw new Exception($"Unknown state \"{origState}\".");
@@ -230,7 +233,7 @@ namespace Umbraco.Core.Migrations
                 var nextState = transition.TargetState;
                 origState = nextState;
 
-                _logger.Info<MigrationPlan>($"At \"{origState}\".");
+                _logger.Info<MigrationPlan>(() => $"At \"{origState}\".");
 
                 if (!_transitions.TryGetValue(origState, out transition))
                     throw new Exception($"Unknown state \"{origState}\".");

--- a/src/Umbraco.Core/Persistence/UmbracoDatabase.cs
+++ b/src/Umbraco.Core/Persistence/UmbracoDatabase.cs
@@ -193,9 +193,9 @@ namespace Umbraco.Core.Persistence
         protected override void OnException(Exception x)
         {
             _logger.Error<UmbracoDatabase>("Exception (" + InstanceId + ").", x);
-            _logger.Debug<UmbracoDatabase>("At:\r\n" + Environment.StackTrace);
+            _logger.Debug<UmbracoDatabase>(() => "At:\r\n" + Environment.StackTrace);
             if (EnableSqlTrace == false)
-                _logger.Debug<UmbracoDatabase>("Sql:\r\n" + CommandToString(LastSQL, LastArgs));
+                _logger.Debug<UmbracoDatabase>(() => "Sql:\r\n" + CommandToString(LastSQL, LastArgs));
             base.OnException(x);
         }
 
@@ -208,7 +208,7 @@ namespace Umbraco.Core.Persistence
                 cmd.CommandTimeout = cmd.Connection.ConnectionTimeout;
 
             if (EnableSqlTrace)
-                _logger.Debug<UmbracoDatabase>(CommandToString(cmd).Replace("{", "{{").Replace("}", "}}")); // fixme these escapes should be builtin
+                _logger.Debug<UmbracoDatabase>(() => CommandToString(cmd).Replace("{", "{{").Replace("}", "}}")); // fixme these escapes should be builtin
 
 #if DEBUG_DATABASES
             // detects whether the command is already in use (eg still has an open reader...)

--- a/src/Umbraco.Core/Publishing/ScheduledPublisher.cs
+++ b/src/Umbraco.Core/Publishing/ScheduledPublisher.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Core.Publishing
             var counter = 0;
             var contentForRelease = _contentService.GetContentForRelease().ToArray();
             if (contentForRelease.Length > 0)
-                _logger.Debug<ScheduledPublisher>($"There's {contentForRelease.Length} item(s) of content to be published");
+                _logger.Debug<ScheduledPublisher>(() => $"There's {contentForRelease.Length} item(s) of content to be published");
             foreach (var d in contentForRelease)
             {
                 try
@@ -43,7 +43,7 @@ namespace Umbraco.Core.Publishing
                     d.ReleaseDate = null;
                     d.TryPublishValues(); // fixme variants?
                     var result = _contentService.SaveAndPublish(d, _userService.GetProfileById(d.WriterId).Id);
-                    _logger.Debug<ContentService>($"Result of publish attempt: {result.Result}");
+                    _logger.Debug<ContentService>(() => $"Result of publish attempt: {result.Result}");
                     if (result.Success == false)
                     {
                         _logger.Error<ScheduledPublisher>($"Error publishing node {d.Id}");
@@ -62,7 +62,7 @@ namespace Umbraco.Core.Publishing
 
             var contentForExpiration = _contentService.GetContentForExpiration().ToArray();
             if (contentForExpiration.Length > 0)
-                _logger.Debug<ScheduledPublisher>($"There's {contentForExpiration.Length} item(s) of content to be unpublished");
+                _logger.Debug<ScheduledPublisher>(() => $"There's {contentForExpiration.Length} item(s) of content to be unpublished");
             foreach (var d in contentForExpiration)
             {
                 try

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -83,7 +83,7 @@ namespace Umbraco.Core.Runtime
 
                 try
                 {
-                    Logger.Debug<CoreRuntime>($"Runtime: {GetType().FullName}");
+                    Logger.Debug<CoreRuntime>(() => $"Runtime: {GetType().FullName}");
 
                     AquireMainDom(container);
                     DetermineRuntimeLevel(container);
@@ -141,11 +141,11 @@ namespace Umbraco.Core.Runtime
                     var dbfactory = container.GetInstance<IUmbracoDatabaseFactory>();
                     SetRuntimeStateLevel(dbfactory, Logger);
 
-                    Logger.Debug<CoreRuntime>($"Runtime level: {_state.Level}");
+                    Logger.Debug<CoreRuntime>(() => $"Runtime level: {_state.Level}");
 
                     if (_state.Level == RuntimeLevel.Upgrade)
                     {
-                        Logger.Debug<CoreRuntime>($"Configure database factory for upgrades.");
+                        Logger.Debug<CoreRuntime>(() => $"Configure database factory for upgrades.");
                         dbfactory.ConfigureForUpgrade();
                     }
                 }
@@ -262,7 +262,7 @@ namespace Umbraco.Core.Runtime
             {
                 // there *is* a local version, but it does not match the code version
                 // need to upgrade
-                logger.Debug<CoreRuntime>($"Local version \"{localVersion}\" != code version \"{codeVersion}\", need to upgrade Umbraco.");
+                logger.Debug<CoreRuntime>(() => $"Local version \"{localVersion}\" != code version \"{codeVersion}\", need to upgrade Umbraco.");
                 _state.Level = RuntimeLevel.Upgrade;
             }
             else if (databaseFactory.Configured == false)
@@ -284,7 +284,7 @@ namespace Umbraco.Core.Runtime
             {
                 connect = databaseFactory.CanConnect;
                 if (connect) break;
-                logger.Debug<CoreRuntime>(i == 0
+                logger.Debug<CoreRuntime>(() => i == 0
                     ? "Could not immediately connect to database, trying again."
                     : "Could not connect to database.");
                 Thread.Sleep(1000);
@@ -293,7 +293,7 @@ namespace Umbraco.Core.Runtime
             if (connect == false)
             {
                 // cannot connect to configured database, this is bad, fail
-                logger.Debug<CoreRuntime>("Could not connect to database.");
+                logger.Debug<CoreRuntime>(() => "Could not connect to database.");
                 _state.Level = RuntimeLevel.BootFailed;
 
                 // in fact, this is bad enough that we want to throw
@@ -357,7 +357,7 @@ namespace Umbraco.Core.Runtime
             _state.CurrentMigrationState = state;
             _state.FinalMigrationState = umbracoPlan.FinalState;
 
-            logger.Debug<CoreRuntime>($"Final upgrade state is \"{_state.FinalMigrationState}\", database contains \"{state ?? "<null>"}\".");
+            logger.Debug<CoreRuntime>(() => $"Final upgrade state is \"{_state.FinalMigrationState}\", database contains \"{state ?? "<null>"}\".");
 
             return state == _state.FinalMigrationState;
         }

--- a/src/Umbraco.Core/Scoping/Scope.cs
+++ b/src/Umbraco.Core/Scoping/Scope.cs
@@ -318,7 +318,7 @@ namespace Umbraco.Core.Scoping
             if (completed.HasValue == false || completed.Value == false)
             {
                 if (LogUncompletedScopes)
-                    _logger.Debug<Scope>("Uncompleted Child Scope at\r\n" + Environment.StackTrace);
+                    _logger.Debug<Scope>(() => "Uncompleted Child Scope at\r\n" + Environment.StackTrace);
                 _completed = false;
             }
         }

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2094,7 +2094,7 @@ namespace Umbraco.Core.Services.Implement
             // raise Publishing event
             if (scope.Events.DispatchCancelable(Publishing, this, new PublishEventArgs<IContent>(content, evtMsgs)))
             {
-                Logger.Info<ContentService>($"Document  \"'{content.Name}\" (id={content.Id}) cannot be published: publishing was cancelled.");
+                Logger.Info<ContentService>(() => $"Document  \"'{content.Name}\" (id={content.Id}) cannot be published: publishing was cancelled.");
                 return new PublishResult(PublishResultType.FailedCancelledByEvent, evtMsgs, content);
             }
 
@@ -2102,7 +2102,7 @@ namespace Umbraco.Core.Services.Implement
             // either because it is 'publishing' or because it already has a published version
             if (((Content) content).PublishedState != PublishedState.Publishing && content.PublishedVersionId == 0)
             {
-                Logger.Info<ContentService>($"Document \"{content.Name}\" (id={content.Id}) cannot be published: document does not have published values.");
+                Logger.Info<ContentService>(() => $"Document \"{content.Name}\" (id={content.Id}) cannot be published: document does not have published values.");
                 return new PublishResult(PublishResultType.FailedNoPublishedValues, evtMsgs, content);
             }
 
@@ -2110,15 +2110,15 @@ namespace Umbraco.Core.Services.Implement
             switch (content.Status)
             {
                 case ContentStatus.Expired:
-                    Logger.Info<ContentService>($"Document \"{content.Name}\" (id={content.Id}) cannot be published: document has expired.");
+                    Logger.Info<ContentService>(() => $"Document \"{content.Name}\" (id={content.Id}) cannot be published: document has expired.");
                     return new PublishResult(PublishResultType.FailedHasExpired, evtMsgs, content);
 
                 case ContentStatus.AwaitingRelease:
-                    Logger.Info<ContentService>($"Document \"{content.Name}\" (id={content.Id}) cannot be published: document is awaiting release.");
+                    Logger.Info<ContentService>(() => $"Document \"{content.Name}\" (id={content.Id}) cannot be published: document is awaiting release.");
                     return new PublishResult(PublishResultType.FailedAwaitingRelease, evtMsgs, content);
 
                 case ContentStatus.Trashed:
-                    Logger.Info<ContentService>($"Document \"{content.Name}\" (id={content.Id}) cannot be published: document is trashed.");
+                    Logger.Info<ContentService>(() => $"Document \"{content.Name}\" (id={content.Id}) cannot be published: document is trashed.");
                     return new PublishResult(PublishResultType.FailedIsTrashed, evtMsgs, content);
             }
 
@@ -2130,7 +2130,7 @@ namespace Umbraco.Core.Services.Implement
             var pathIsOk = content.ParentId == Constants.System.Root || IsPathPublished(GetParent(content));
             if (pathIsOk == false)
             {
-                Logger.Info<ContentService>($"Document \"{content.Name}\" (id={content.Id}) cannot be published: parent is not published.");
+                Logger.Info<ContentService>(() => $"Document \"{content.Name}\" (id={content.Id}) cannot be published: parent is not published.");
                 return new PublishResult(PublishResultType.FailedPathNotPublished, evtMsgs, content);
             }
 
@@ -2154,7 +2154,7 @@ namespace Umbraco.Core.Services.Implement
             // change state to publishing
             ((Content) content).PublishedState = PublishedState.Publishing;
 
-            Logger.Info<ContentService>($"Content \"{content.Name}\" (id={content.Id}) has been published.");
+            Logger.Info<ContentService>(() => $"Content \"{content.Name}\" (id={content.Id}) has been published.");
             return result;
         }
 
@@ -2164,7 +2164,7 @@ namespace Umbraco.Core.Services.Implement
             // raise UnPublishing event
             if (scope.Events.DispatchCancelable(UnPublishing, this, new PublishEventArgs<IContent>(content, evtMsgs)))
             {
-                Logger.Info<ContentService>($"Document \"{content.Name}\" (id={content.Id}) cannot be unpublished: unpublishing was cancelled.");
+                Logger.Info<ContentService>(() => $"Document \"{content.Name}\" (id={content.Id}) cannot be unpublished: unpublishing was cancelled.");
                 return new UnpublishResult(UnpublishResultType.FailedCancelledByEvent, evtMsgs, content);
             }
 
@@ -2187,13 +2187,13 @@ namespace Umbraco.Core.Services.Implement
             if (content.ReleaseDate.HasValue && content.ReleaseDate.Value <= DateTime.Now)
             {
                 content.ReleaseDate = null;
-                Logger.Info<ContentService>($"Document \"{content.Name}\" (id={content.Id}) had its release date removed, because it was unpublished.");
+                Logger.Info<ContentService>(() => $"Document \"{content.Name}\" (id={content.Id}) had its release date removed, because it was unpublished.");
             }
 
             // change state to unpublishing
             ((Content) content).PublishedState = PublishedState.Unpublishing;
 
-            Logger.Info<ContentService>($"Document \"{content.Name}\" (id={content.Id}) has been unpublished.");
+            Logger.Info<ContentService>(() => $"Document \"{content.Name}\" (id={content.Id}) has been unpublished.");
             return attempt;
         }
 

--- a/src/Umbraco.Core/Services/Implement/NotificationService.cs
+++ b/src/Umbraco.Core/Services/Implement/NotificationService.cs
@@ -629,7 +629,7 @@ namespace Umbraco.Core.Services.Implement
                             try
                             {
                                 if (Sendmail != null) Sendmail(s, request.Mail, _logger); else s.Send(request.Mail);
-                                _logger.Debug<NotificationService>(string.Format("Notification \"{0}\" sent to {1} ({2})", request.Action, request.UserName, request.Email));
+                                _logger.Debug<NotificationService>(() => string.Format("Notification \"{0}\" sent to {1} ({2})", request.Action, request.UserName, request.Email));
                             }
                             catch (Exception ex)
                             {

--- a/src/Umbraco.Web/Editors/AuthenticationController.cs
+++ b/src/Umbraco.Web/Editors/AuthenticationController.cs
@@ -406,7 +406,7 @@ namespace Umbraco.Web.Editors
                 var lockedOut = await UserManager.IsLockedOutAsync(model.UserId);
                 if (lockedOut)
                 {
-                    Logger.Info<AuthenticationController>(
+                    Logger.Info<AuthenticationController>(() => 
                         $"User {model.UserId} is currently locked out, unlocking and resetting AccessFailedCount");
 
                     //var user = await UserManager.FindByIdAsync(model.UserId);
@@ -445,7 +445,7 @@ namespace Umbraco.Web.Editors
                 Core.Constants.Security.BackOfficeAuthenticationType,
                 Core.Constants.Security.BackOfficeExternalAuthenticationType);
 
-            Logger.Info<AuthenticationController>($"User {(User.Identity == null ? "UNKNOWN" : User.Identity.Name)} from IP address {owinContext.Request.RemoteIpAddress} has logged out");
+            Logger.Info<AuthenticationController>(() => $"User {(User.Identity == null ? "UNKNOWN" : User.Identity.Name)} from IP address {owinContext.Request.RemoteIpAddress} has logged out");
 
             if (UserManager != null)
             {

--- a/src/Umbraco.Web/Editors/DashboardController.cs
+++ b/src/Umbraco.Web/Editors/DashboardController.cs
@@ -66,7 +66,7 @@ namespace Umbraco.Web.Editors
                 }
                 catch (HttpRequestException ex)
                 {
-                    Logger.Debug<DashboardController>($"Error getting dashboard content from '{url}': {ex.Message}\n{ex.InnerException}");
+                    Logger.Debug<DashboardController>(() => $"Error getting dashboard content from '{url}': {ex.Message}\n{ex.InnerException}");
 
                     //it's still new JObject() - we return it like this to avoid error codes which triggers UI warnings
                     ApplicationCache.RuntimeCache.InsertCacheItem<JObject>(key, () => result, new TimeSpan(0, 5, 0));
@@ -107,7 +107,7 @@ namespace Umbraco.Web.Editors
                 }
                 catch (HttpRequestException ex)
                 {
-                    Logger.Debug<DashboardController>(string.Format("Error getting dashboard CSS from '{0}': {1}\n{2}", url, ex.Message, ex.InnerException));
+                    Logger.Debug<DashboardController>(() => string.Format("Error getting dashboard CSS from '{0}': {1}\n{2}", url, ex.Message, ex.InnerException));
 
                     //it's still string.Empty - we return it like this to avoid error codes which triggers UI warnings
                     ApplicationCache.RuntimeCache.InsertCacheItem<string>(key, () => result, new TimeSpan(0, 5, 0));

--- a/src/Umbraco.Web/HealthCheck/HealthCheckResults.cs
+++ b/src/Umbraco.Web/HealthCheck/HealthCheckResults.cs
@@ -62,7 +62,7 @@ namespace Umbraco.Web.HealthCheck
                 var checkIsSuccess = result.Value.All(x => x.ResultType == StatusResultType.Success);
                 if (checkIsSuccess)
                 {
-                    Logger.Info<HealthCheckResults>($"    Checks for '{checkName}' all completed succesfully.");
+                    Logger.Info<HealthCheckResults>(() => $"    Checks for '{checkName}' all completed succesfully.");
                 }
                 else
                 {
@@ -71,7 +71,7 @@ namespace Umbraco.Web.HealthCheck
 
                 foreach (var checkResult in checkResults)
                 {
-                    Logger.Info<HealthCheckResults>($"        Result: {checkResult.ResultType}, Message: '{checkResult.Message}'");
+                    Logger.Info<HealthCheckResults>(() => $"        Result: {checkResult.ResultType}, Message: '{checkResult.Message}'");
                 }
             }
         }

--- a/src/Umbraco.Web/Macros/UserControlMacroEngine.cs
+++ b/src/Umbraco.Web/Macros/UserControlMacroEngine.cs
@@ -74,7 +74,7 @@ namespace Umbraco.Web.Macros
                     try
                     {
                         controlProperty.SetValue(control, tryConvert.Result, null);
-                        Current.Logger.Debug<UserControlMacroEngine>($"Set property \"{modelProperty.Key}\" value \"{modelProperty.Value}\".");
+                        Current.Logger.Debug<UserControlMacroEngine>(() => $"Set property \"{modelProperty.Key}\" value \"{modelProperty.Value}\".");
                     }
                     catch (Exception e)
                     {

--- a/src/Umbraco.Web/Macros/UserControlMacroEngine.cs
+++ b/src/Umbraco.Web/Macros/UserControlMacroEngine.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Web.Macros
             // note: we are not setting the 'CurrentNode' property on the control anymore,
             // as that was an INode which is gone in v8. Use UmbracoContext to access the
             // current content.
-            Current.Logger.Info<UserControlMacroEngine>($"Loaded control \"{filename}\" with ID \"{control.ID}\".");
+            Current.Logger.Info<UserControlMacroEngine>(() => $"Loaded control \"{filename}\" with ID \"{control.ID}\".");
             UpdateControlProperties(control, model);
 
             return new MacroContent { Control = control };

--- a/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
@@ -443,7 +443,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 throw new ArgumentException("Kit content cannot have children.", nameof(kit));
             // ReSharper restore LocalizableElement
 
-            _logger.Debug<ContentStore>("Set content ID:" + kit.Node.Id);
+            _logger.Debug<ContentStore>(() => "Set content ID:" + kit.Node.Id);
 
             var lockInfo = new WriteLockInfo();
             try
@@ -568,7 +568,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 if (link?.Value == null) return false;
 
                 var content = link.Value;
-                _logger.Debug<ContentStore>("Clear content ID:" + content.Id);
+                _logger.Debug<ContentStore>(() => "Clear content ID:" + content.Id);
 
                 // clear the entire branch
                 ClearBranchLocked(content);
@@ -909,7 +909,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
         {
             // see notes in CreateSnapshot
 #if DEBUG
-            _logger.Debug<ContentStore>("Collect.");
+            _logger.Debug<ContentStore>(() => "Collect.");
 #endif
             while (_genRefRefs.TryPeek(out GenRefRef genRefRef) && (genRefRef.Count == 0 || genRefRef.WGenRef.IsAlive == false))
             {
@@ -1086,7 +1086,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
 #if DEBUG
                 _logger = logger;
-                _logger.Debug<Snapshot>("Creating snapshot.");
+                _logger.Debug<Snapshot>(() => "Creating snapshot.");
 #endif
             }
 
@@ -1101,7 +1101,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
 #if DEBUG
                 _logger = logger;
-                _logger.Debug<Snapshot>("Creating live.");
+                _logger.Debug<Snapshot>(() => "Creating live.");
 #endif
             }
 
@@ -1182,7 +1182,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             {
                 if (_gen < 0) return;
 #if DEBUG
-                _logger.Debug<Snapshot>("Dispose snapshot (" + (_genRef?.GenRefRef.Count.ToString() ?? "live") + ").");
+                _logger.Debug<Snapshot>(() => "Dispose snapshot (" + (_genRef?.GenRefRef.Count.ToString() ?? "live") + ").");
 #endif
                 _gen = -1;
                 if (_genRef != null)

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -298,12 +298,12 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
             _localContentDb?.Clear();
 
-            _logger.Debug<PublishedSnapshotService>("Loading content from database...");
+            _logger.Debug<PublishedSnapshotService>(() => "Loading content from database...");
             var sw = Stopwatch.StartNew();
             var kits = _dataSource.GetAllContentSources(scope);
             _contentStore.SetAll(kits);
             sw.Stop();
-            _logger.Debug<PublishedSnapshotService>("Loaded content from database (" + sw.ElapsedMilliseconds + "ms).");
+            _logger.Debug<PublishedSnapshotService>(() => "Loaded content from database (" + sw.ElapsedMilliseconds + "ms).");
         }
 
         private void LoadContentFromLocalDbLocked(IScope scope)
@@ -312,12 +312,12 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 .Select(x => _publishedContentTypeFactory.CreateContentType(x));
             _contentStore.UpdateContentTypes(null, contentTypes, null);
 
-            _logger.Debug<PublishedSnapshotService>("Loading content from local db...");
+            _logger.Debug<PublishedSnapshotService>(() => "Loading content from local db...");
             var sw = Stopwatch.StartNew();
             var kits = _localContentDb.Select(x => x.Value).OrderBy(x => x.Node.Level);
             _contentStore.SetAll(kits);
             sw.Stop();
-            _logger.Debug<PublishedSnapshotService>("Loaded content from local db (" + sw.ElapsedMilliseconds + "ms).");
+            _logger.Debug<PublishedSnapshotService>(() => "Loaded content from local db (" + sw.ElapsedMilliseconds + "ms).");
         }
 
         // keep these around - might be useful
@@ -365,12 +365,12 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
             _localMediaDb?.Clear();
 
-            _logger.Debug<PublishedSnapshotService>("Loading media from database...");
+            _logger.Debug<PublishedSnapshotService>(() => "Loading media from database...");
             var sw = Stopwatch.StartNew();
             var kits = _dataSource.GetAllMediaSources(scope);
             _mediaStore.SetAll(kits);
             sw.Stop();
-            _logger.Debug<PublishedSnapshotService>("Loaded media from database (" + sw.ElapsedMilliseconds + "ms).");
+            _logger.Debug<PublishedSnapshotService>(() => "Loaded media from database (" + sw.ElapsedMilliseconds + "ms).");
         }
 
         private void LoadMediaFromLocalDbLocked(IScope scope)
@@ -379,12 +379,12 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 .Select(x => _publishedContentTypeFactory.CreateContentType(x));
             _mediaStore.UpdateContentTypes(null, mediaTypes, null);
 
-            _logger.Debug<PublishedSnapshotService>("Loading media from local db...");
+            _logger.Debug<PublishedSnapshotService>(() => "Loading media from local db...");
             var sw = Stopwatch.StartNew();
             var kits = _localMediaDb.Select(x => x.Value);
             _mediaStore.SetAll(kits);
             sw.Stop();
-            _logger.Debug<PublishedSnapshotService>("Loaded media from local db (" + sw.ElapsedMilliseconds + "ms).");
+            _logger.Debug<PublishedSnapshotService>(() => "Loaded media from local db (" + sw.ElapsedMilliseconds + "ms).");
         }
 
         // keep these around - might be useful
@@ -551,7 +551,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
             foreach (var payload in payloads)
             {
-                _logger.Debug<PublishedSnapshotService>($"Notified {payload.ChangeTypes} for content {payload.Id}");
+                _logger.Debug<PublishedSnapshotService>(() => $"Notified {payload.ChangeTypes} for content {payload.Id}");
 
                 if (payload.ChangeTypes.HasType(TreeChangeTypes.RefreshAll))
                 {
@@ -641,7 +641,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
             foreach (var payload in payloads)
             {
-                _logger.Debug<PublishedSnapshotService>($"Notified {payload.ChangeTypes} for media {payload.Id}");
+                _logger.Debug<PublishedSnapshotService>(() => $"Notified {payload.ChangeTypes} for media {payload.Id}");
 
                 if (payload.ChangeTypes.HasType(TreeChangeTypes.RefreshAll))
                 {
@@ -710,7 +710,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 return;
 
             foreach (var payload in payloads)
-                _logger.Debug<PublishedSnapshotService>($"Notified {payload.ChangeTypes} for {payload.ItemType} {payload.Id}");
+                _logger.Debug<PublishedSnapshotService>(() => $"Notified {payload.ChangeTypes} for {payload.ItemType} {payload.Id}");
 
             Notify<IContentType>(_contentStore, payloads, RefreshContentTypesLocked);
             Notify<IMediaType>(_mediaStore, payloads, RefreshMediaTypesLocked);
@@ -760,7 +760,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             var idsA = payloads.Select(x => x.Id).ToArray();
 
             foreach (var payload in payloads)
-                _logger.Debug<PublishedSnapshotService>($"Notified {(payload.Removed ? "Removed" : "Refreshed")} for data type {payload.Id}");
+                _logger.Debug<PublishedSnapshotService>(() => $"Notified {(payload.Removed ? "Removed" : "Refreshed")} for data type {payload.Id}");
 
             using (_contentStore.GetWriter(_scopeProvider))
             using (_mediaStore.GetWriter(_scopeProvider))

--- a/src/Umbraco.Web/PublishedCache/PublishedContentTypeCache.cs
+++ b/src/Umbraco.Web/PublishedCache/PublishedContentTypeCache.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Web.PublishedCache
         /// </summary>
         public void ClearAll()
         {
-            _logger.Debug<PublishedContentTypeCache>("Clear all.");
+            _logger.Debug<PublishedContentTypeCache>(() => "Clear all.");
 
             try
             {

--- a/src/Umbraco.Web/PublishedCache/XmlPublishedCache/XmlStore.cs
+++ b/src/Umbraco.Web/PublishedCache/XmlPublishedCache/XmlStore.cs
@@ -1038,7 +1038,7 @@ ORDER BY umbracoNode.level, umbracoNode.sortOrder";
             {
                 foreach (var payload in payloads)
                 {
-                    Current.Logger.Debug<XmlStore>($"Notified {payload.ChangeTypes} for content {payload.Id}.");
+                    Current.Logger.Debug<XmlStore>(() => $"Notified {payload.ChangeTypes} for content {payload.Id}.");
 
                     if (payload.ChangeTypes.HasType(TreeChangeTypes.RefreshAll))
                     {
@@ -1071,7 +1071,7 @@ ORDER BY umbracoNode.level, umbracoNode.sortOrder";
                     if (content == null || content.Published == false || content.Trashed)
                     {
                         // no published version
-                        Current.Logger.Debug<XmlStore>($"Notified, content {payload.Id} has no published version.");
+                        Current.Logger.Debug<XmlStore>(() => $"Notified, content {payload.Id} has no published version.");
                         if (current != null)
                         {
                             // remove from xml if exists
@@ -1109,7 +1109,7 @@ ORDER BY umbracoNode.level, umbracoNode.sortOrder";
                             if (dtos.MoveNext() == false)
                             {
                                 // gone fishing, remove (possible race condition)
-                                Current.Logger.Debug<XmlStore>($"Notifified, content {payload.Id} gone fishing.");
+                                Current.Logger.Debug<XmlStore>(() => $"Notifified, content {payload.Id} gone fishing.");
                                 if (current != null)
                                 {
                                     // remove from xml if exists
@@ -1222,7 +1222,7 @@ ORDER BY umbracoNode.level, umbracoNode.sortOrder";
                 .ToArray();
 
             foreach (var payload in payloads)
-                Current.Logger.Debug<XmlStore>($"Notified {payload.ChangeTypes} for content type {payload.Id}.");
+                Current.Logger.Debug<XmlStore>(() => $"Notified {payload.ChangeTypes} for content type {payload.Id}.");
 
             if (ids.Length > 0) // must have refreshes, not only removes
                 RefreshContentTypes(ids);
@@ -1241,7 +1241,7 @@ ORDER BY umbracoNode.level, umbracoNode.sortOrder";
                 _contentTypeCache.ClearDataType(payload.Id);
 
             foreach (var payload in payloads)
-                Current.Logger.Debug<XmlStore>($"Notified {(payload.Removed ? "Removed" : "Refreshed")} for data type {payload.Id}.");
+                Current.Logger.Debug<XmlStore>(() => $"Notified {(payload.Removed ? "Removed" : "Refreshed")} for data type {payload.Id}.");
 
             // that's all we need to do as the changes have NO impact whatsoever on the Xml content
 

--- a/src/Umbraco.Web/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Web/Routing/PublishedRouter.cs
@@ -478,7 +478,7 @@ namespace Umbraco.Web.Routing
                 //iterate but return on first one that finds it
                 var found = _contentFinders.Any(finder =>
                 {
-                    _logger.Debug<PublishedRouter>("Finder " + finder.GetType().FullName);
+                    _logger.Debug<PublishedRouter>(() => "Finder " + finder.GetType().FullName);
                     return finder.TryFindContent(request);
                 });
             }
@@ -592,23 +592,23 @@ namespace Umbraco.Web.Routing
             if (valid == false)
             {
                 // bad redirect - log and display the current page (legacy behavior)
-                _logger.Debug<PublishedRouter>($"{tracePrefix}Failed to redirect to id={request.PublishedContent.GetProperty(Constants.Conventions.Content.InternalRedirectId).GetSourceValue()}: value is not an int nor a GuidUdi.");
+                _logger.Debug<PublishedRouter>(() => $"{tracePrefix}Failed to redirect to id={request.PublishedContent.GetProperty(Constants.Conventions.Content.InternalRedirectId).GetSourceValue()}: value is not an int nor a GuidUdi.");
             }
 
             if (internalRedirectNode == null)
             {
-                _logger.Debug<PublishedRouter>($"{tracePrefix}Failed to redirect to id={request.PublishedContent.GetProperty(Constants.Conventions.Content.InternalRedirectId).GetSourceValue()}: no such published document.");
+                _logger.Debug<PublishedRouter>(() => $"{tracePrefix}Failed to redirect to id={request.PublishedContent.GetProperty(Constants.Conventions.Content.InternalRedirectId).GetSourceValue()}: no such published document.");
             }
             else if (internalRedirectId == request.PublishedContent.Id)
             {
                 // redirect to self
-                _logger.Debug<PublishedRouter>($"{tracePrefix}Redirecting to self, ignore");
+                _logger.Debug<PublishedRouter>(() => $"{tracePrefix}Redirecting to self, ignore");
             }
             else
             {
                 request.SetInternalRedirectPublishedContent(internalRedirectNode); // don't use .PublishedContent here
                 redirect = true;
-                _logger.Debug<PublishedRouter>($"{tracePrefix}Redirecting to id={internalRedirectId}");
+                _logger.Debug<PublishedRouter>(() => $"{tracePrefix}Redirecting to id={internalRedirectId}");
             }
 
             return redirect;

--- a/src/Umbraco.Web/Scheduling/BackgroundTaskRunner.cs
+++ b/src/Umbraco.Web/Scheduling/BackgroundTaskRunner.cs
@@ -667,7 +667,7 @@ namespace Umbraco.Web.Scheduling
                 if (_terminating == false)
                 {
                     _terminating = true;
-                    _logger.Info<BackgroundTaskRunner>(_logPrefix + "Terminating" + (immediate ? " (immediate)" : ""));
+                    _logger.Info<BackgroundTaskRunner>(() => $"{_logPrefix}Terminating{(immediate ? immediate.ToString() : "")}");
                     onTerminating = true;
                 }
             }
@@ -681,7 +681,7 @@ namespace Umbraco.Web.Scheduling
                 // processing, call the UnregisterObject method, and then return or it can return immediately and complete
                 // processing asynchronously before calling the UnregisterObject method.
 
-                _logger.Info<BackgroundTaskRunner>(_logPrefix + "Waiting for tasks to complete");
+                _logger.Info<BackgroundTaskRunner>(() => _logPrefix + "Waiting for tasks to complete");
                 Shutdown(false, false); // do not accept any more tasks, flush the queue, do not wait
 
                 // raise the completed event only after the running threading task has completed
@@ -700,7 +700,7 @@ namespace Umbraco.Web.Scheduling
                 // immediate parameter is true, the registered object must call the UnregisterObject method before returning;
                 // otherwise, its registration will be removed by the application manager.
 
-                _logger.Info<BackgroundTaskRunner>(_logPrefix + "Cancelling tasks");
+                _logger.Info<BackgroundTaskRunner>(() => _logPrefix + "Cancelling tasks");
                 Shutdown(true, true); // cancel all tasks, wait for the current one to end
                 Terminate(true);
             }
@@ -723,7 +723,7 @@ namespace Umbraco.Web.Scheduling
                 terminatedSource = _terminatedSource;
             }
 
-            _logger.Info<BackgroundTaskRunner>(_logPrefix + "Tasks " + (immediate ? "cancelled" : "completed") + ", terminated");
+            _logger.Info<BackgroundTaskRunner>(() => _logPrefix + "Tasks " + (immediate ? "cancelled" : "completed") + ", terminated");
 
             OnEvent(Terminated, "Terminated");
 

--- a/src/Umbraco.Web/Scheduling/BackgroundTaskRunner.cs
+++ b/src/Umbraco.Web/Scheduling/BackgroundTaskRunner.cs
@@ -315,7 +315,7 @@ namespace Umbraco.Web.Scheduling
             _shutdownToken = _shutdownTokenSource.Token;
             _runningTask = Task.Run(async () => await Pump().ConfigureAwait(false), _shutdownToken);
 
-            _logger.Debug<BackgroundTaskRunner>(_logPrefix + "Starting");
+            _logger.Debug<BackgroundTaskRunner>(() => _logPrefix + "Starting");
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace Umbraco.Web.Scheduling
                     if (_shutdownToken.IsCancellationRequested == false && _tasks.Count > 0) continue;
 
                     // if we really have nothing to do, stop
-                    _logger.Debug<BackgroundTaskRunner>(_logPrefix + "Stopping");
+                    _logger.Debug<BackgroundTaskRunner>(() => _logPrefix + "Stopping");
 
                     if (_options.PreserveRunningTask == false)
                         _runningTask = null;

--- a/src/Umbraco.Web/Search/ExamineComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineComponent.cs
@@ -91,7 +91,7 @@ namespace Umbraco.Web.Search
 
             var registeredIndexers = examineManager.IndexProviders.Values.OfType<UmbracoExamineIndexer>().Count(x => x.EnableDefaultEventHandler);
 
-            profilingLogger.Logger.Info<ExamineComponent>($"Adding examine event handlers for {registeredIndexers} index providers.");
+            profilingLogger.Logger.Info<ExamineComponent>(() => $"Adding examine event handlers for {registeredIndexers} index providers.");
 
             // don't bind event handlers if we're not suppose to listen
             if (registeredIndexers == 0)
@@ -200,7 +200,7 @@ namespace Umbraco.Web.Search
                     var dir = luceneIndexer.GetLuceneDirectory();
                     if (IndexWriter.IsLocked(dir))
                     {
-                        logger.Info<ExamineComponent>("Forcing index " + luceneIndexer.Name + " to be unlocked since it was left in a locked state");
+                        logger.Info<ExamineComponent>(() => $"Forcing index {luceneIndexer.Name} to be unlocked since it was left in a locked state");
                         IndexWriter.Unlock(dir);
                     }
                 }

--- a/src/Umbraco.Web/Security/Providers/UmbracoMembershipProvider.cs
+++ b/src/Umbraco.Web/Security/Providers/UmbracoMembershipProvider.cs
@@ -525,11 +525,8 @@ namespace Umbraco.Web.Security.Providers
 
             if (member == null)
             {
-                Current.Logger.Info<UmbracoMembershipProviderBase>(
-                    string.Format(
-                        "Login attempt failed for username {0} from IP address {1}, the user does not exist",
-                        username,
-                        GetCurrentRequestIpAddress()));
+                Current.Logger.Info<UmbracoMembershipProviderBase>(() => 
+                        $"Login attempt failed for username {username} from IP address {GetCurrentRequestIpAddress()}, the user does not exist" );
 
                 return new ValidateUserResult
                 {
@@ -539,11 +536,8 @@ namespace Umbraco.Web.Security.Providers
 
             if (member.IsApproved == false)
             {
-                Current.Logger.Info<UmbracoMembershipProviderBase>(
-                    string.Format(
-                        "Login attempt failed for username {0} from IP address {1}, the user is not approved",
-                        username,
-                        GetCurrentRequestIpAddress()));
+                Current.Logger.Info<UmbracoMembershipProviderBase>(() => 
+                        $"Login attempt failed for username {username} from IP address {GetCurrentRequestIpAddress()}, the user is not approved");
 
                 return new ValidateUserResult
                 {
@@ -553,11 +547,8 @@ namespace Umbraco.Web.Security.Providers
             }
             if (member.IsLockedOut)
             {
-                Current.Logger.Info<UmbracoMembershipProviderBase>(
-                    string.Format(
-                        "Login attempt failed for username {0} from IP address {1}, the user is locked",
-                        username,
-                        GetCurrentRequestIpAddress()));
+                Current.Logger.Info<UmbracoMembershipProviderBase>(() => 
+                        $"Login attempt failed for username {username} from IP address {GetCurrentRequestIpAddress()}, the user is locked");
 
                 return new ValidateUserResult
                 {
@@ -581,19 +572,13 @@ namespace Umbraco.Web.Security.Providers
                     member.IsLockedOut = true;
                     member.LastLockoutDate = DateTime.Now;
 
-                    Current.Logger.Info<UmbracoMembershipProviderBase>(
-                        string.Format(
-                            "Login attempt failed for username {0} from IP address {1}, the user is now locked out, max invalid password attempts exceeded",
-                            username,
-                            GetCurrentRequestIpAddress()));
+                    Current.Logger.Info<UmbracoMembershipProviderBase>(() => 
+                            $"Login attempt failed for username {username} from IP address {GetCurrentRequestIpAddress()}, the user is now locked out, max invalid password attempts exceeded");
                 }
                 else
                 {
-                    Current.Logger.Info<UmbracoMembershipProviderBase>(
-                        string.Format(
-                            "Login attempt failed for username {0} from IP address {1}",
-                            username,
-                            GetCurrentRequestIpAddress()));
+                    Current.Logger.Info<UmbracoMembershipProviderBase>(() => 
+                            $"Login attempt failed for username {username} from IP address {GetCurrentRequestIpAddress()}");
                 }
             }
             else
@@ -606,11 +591,8 @@ namespace Umbraco.Web.Security.Providers
 
                 member.LastLoginDate = DateTime.Now;
 
-                Current.Logger.Info<UmbracoMembershipProviderBase>(
-                        string.Format(
-                            "Login attempt succeeded for username {0} from IP address {1}",
-                            username,
-                            GetCurrentRequestIpAddress()));
+                Current.Logger.Info<UmbracoMembershipProviderBase>(() => 
+                            $"Login attempt succeeded for username {username} from IP address {GetCurrentRequestIpAddress()}");
             }
 
             //don't raise events for this! It just sets the member dates, if we do raise events this will

--- a/src/Umbraco.Web/UmbracoModule.cs
+++ b/src/Umbraco.Web/UmbracoModule.cs
@@ -594,7 +594,7 @@ namespace Umbraco.Web
 
                 if (UmbracoContext.Current != null && UmbracoContext.Current.IsFrontEndUmbracoRequest)
                 {
-                    Logger.Debug<UmbracoModule>($"End Request. ({DateTime.Now.Subtract(UmbracoContext.Current.ObjectCreated).TotalMilliseconds}ms)");
+                    Logger.Debug<UmbracoModule>(() => $"End Request. ({DateTime.Now.Subtract(UmbracoContext.Current.ObjectCreated).TotalMilliseconds}ms)");
                 }
 
                 OnEndRequest(new UmbracoRequestEventArgs(UmbracoContext.Current, new HttpContextWrapper(httpContext)));

--- a/src/Umbraco.Web/WebServices/ExamineManagementApiController.cs
+++ b/src/Umbraco.Web/WebServices/ExamineManagementApiController.cs
@@ -166,7 +166,7 @@ namespace Umbraco.Web.WebServices
             var msg = ValidateLuceneIndexer(indexerName, out LuceneIndexer indexer);
             if (msg.IsSuccessStatusCode)
             {
-                _logger.Info<ExamineManagementApiController>($"Rebuilding index '{indexerName}'");
+                _logger.Info<ExamineManagementApiController>(() => $"Rebuilding index '{indexerName}'");
 
                 //remove it in case there's a handler there alraedy
                 indexer.IndexOperationComplete -= Indexer_IndexOperationComplete;
@@ -203,7 +203,7 @@ namespace Umbraco.Web.WebServices
             //ensure it's not listening anymore
             indexer.IndexOperationComplete -= Indexer_IndexOperationComplete;
 
-            _logger.Info<ExamineManagementApiController>($"Rebuilding index '{indexer.Name}' done, {indexer.CommitCount} items committed (can differ from the number of items in the index)");
+            _logger.Info<ExamineManagementApiController>(() => $"Rebuilding index '{indexer.Name}' done, {indexer.CommitCount} items committed (can differ from the number of items in the index)");
 
             var cacheKey = "temp_indexing_op_" + indexer.Name;
             _runtimeCacheProvider.ClearCacheItem(cacheKey);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have linked this PR to an issue on the tracker at http://issues.umbraco.org
NOTE:
I haven't linked this PR to an issue because this work was done during hackathon and we don't have issue for this.

### Description
<!-- A description of the changes proposed in the pull-request -->

This is to complete a task from the V8 Hackathon, with a couple of details here.

Replacing call to logger.Info(string) to logger.Info(Func) in order to evaluate log text only if needed, when log level is Info.

<!-- Thanks for contributing to Umbraco CMS! -->
