### PR TITLE
V8 Hackathon: Removed obsolete constructors from actions

### DIFF
--- a/src/Umbraco.Web/_Legacy/Actions/ActionAssignDomain.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionAssignDomain.cs
@@ -11,14 +11,6 @@ namespace Umbraco.Web._Legacy.Actions
     [ActionMetadata(Constants.Conventions.PermissionCategories.AdministrationCategory)]
     public class ActionAssignDomain : IAction
     {
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionAssignDomain() { }
-
         public static ActionAssignDomain Instance { get; } = new ActionAssignDomain();
 
         #region IAction Members

--- a/src/Umbraco.Web/_Legacy/Actions/ActionAudit.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionAudit.cs
@@ -11,14 +11,6 @@ namespace Umbraco.Web._Legacy.Actions
     [ActionMetadata(Constants.Conventions.PermissionCategories.AdministrationCategory)]
     public class ActionAudit : IAction
     {
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionAudit() { }
-
         public static ActionAudit Instance { get; } = new ActionAudit();
 
         #region IAction Members

--- a/src/Umbraco.Web/_Legacy/Actions/ActionChangeDocType.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionChangeDocType.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionChangeDocType m_instance = new ActionChangeDocType();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionChangeDocType() { }
-
         public static ActionChangeDocType Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionCopy.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionCopy.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionCopy m_instance = new ActionCopy();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionCopy() { }
-
         public static ActionCopy Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionDelete.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionDelete.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionDelete m_instance = new ActionDelete();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionDelete() { }
-
         public static ActionDelete Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionEmptyTranscan.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionEmptyTranscan.cs
@@ -11,14 +11,6 @@ namespace Umbraco.Web._Legacy.Actions
         //create singleton
         private static readonly ActionEmptyTranscan InnerInstance = new ActionEmptyTranscan();
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionEmptyTranscan() { }
-
         public static ActionEmptyTranscan Instance
         {
             get { return InnerInstance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionExport.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionExport.cs
@@ -13,14 +13,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionExport m_instance = new ActionExport();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionExport() { }
-
         public static ActionExport Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionImport.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionImport.cs
@@ -13,14 +13,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionImport m_instance = new ActionImport();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionImport() { }
-
         public static ActionImport Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionMove.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionMove.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionMove m_instance = new ActionMove();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionMove() { }
-
         public static ActionMove Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionNew.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionNew.cs
@@ -11,14 +11,6 @@ namespace Umbraco.Web._Legacy.Actions
     [ActionMetadata(Constants.Conventions.PermissionCategories.ContentCategory)]
     public class ActionNew : IAction
     {
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionNew() { }
-
         public static ActionNew Instance { get; } = new ActionNew();
 
         #region IAction Members

--- a/src/Umbraco.Web/_Legacy/Actions/ActionNotify.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionNotify.cs
@@ -13,14 +13,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionNotify m_instance = new ActionNotify();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionNotify() { }
-
         public static ActionNotify Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionPackage.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionPackage.cs
@@ -13,14 +13,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionPackage m_instance = new ActionPackage();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionPackage() { }
-
         public static ActionPackage Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionPackageCreate.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionPackageCreate.cs
@@ -13,14 +13,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionPackageCreate m_instance = new ActionPackageCreate();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionPackageCreate() { }
-
         public static ActionPackageCreate Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionProtect.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionProtect.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionProtect m_instance = new ActionProtect();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionProtect() { }
-
         public static ActionProtect Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionPublish.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionPublish.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionPublish m_instance = new ActionPublish();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionPublish() { }
-
         public static ActionPublish Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionRePublish.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionRePublish.cs
@@ -13,14 +13,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionRePublish m_instance = new ActionRePublish();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionRePublish() { }
-
         public static ActionRePublish Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionRefresh.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionRefresh.cs
@@ -14,14 +14,6 @@ namespace Umbraco.Web._Legacy.Actions
         //create singleton
         private static readonly ActionRefresh InnerInstance = new ActionRefresh();
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionRefresh() { }
-
         public static ActionRefresh Instance
         {
             get { return InnerInstance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionRights.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionRights.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionRights m_instance = new ActionRights();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionRights() { }
-
         public static ActionRights Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionRollback.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionRollback.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionRollback m_instance = new ActionRollback();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionRollback() { }
-
         public static ActionRollback Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionSendToTranslate.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionSendToTranslate.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionSendToTranslate m_instance = new ActionSendToTranslate();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionSendToTranslate() { }
-
         public static ActionSendToTranslate Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionSort.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionSort.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionSort m_instance = new ActionSort();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionSort() { }
-
         public static ActionSort Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionToPublish.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionToPublish.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionToPublish m_instance = new ActionToPublish();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionToPublish() { }
-
         public static ActionToPublish Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionTranslate.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionTranslate.cs
@@ -15,14 +15,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionTranslate m_instance = new ActionTranslate();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionTranslate() { }
-
         public static ActionTranslate Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionUnPublish.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionUnPublish.cs
@@ -15,14 +15,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionUnPublish m_instance = new ActionUnPublish();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance).
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionUnPublish() { }
-
         public static ActionUnPublish Instance
         {
             get { return m_instance; }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionUpdate.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionUpdate.cs
@@ -16,14 +16,6 @@ namespace Umbraco.Web._Legacy.Actions
         private static readonly ActionUpdate m_instance = new ActionUpdate();
 #pragma warning restore 612,618
 
-        /// <summary>
-        /// A public constructor exists ONLY for backwards compatibility in regards to 3rd party add-ons.
-        /// All Umbraco assemblies should use the singleton instantiation (this.Instance)
-        /// When this applicatio is refactored, this constuctor should be made private.
-        /// </summary>
-        [Obsolete("Use the singleton instantiation instead of a constructor")]
-        public ActionUpdate() { }
-
         public static ActionUpdate Instance
         {
             get { return m_instance; }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
A few more removed methods that are marked as obsolete. Think the next step is to remove the `Action` class that is also marked as obsolete, but there are a few dependencies that need to be worked out first.
