### PR TITLE
U4-11107 Link to the page is not active after saving content without publish

### DIFF
--- a/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
@@ -112,7 +112,7 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         {
             get
             {
-                return GetOptionalTextElement("PreviewBadge", @"<a id=""umbracoPreviewBadge"" style=""position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px; background: url('{1}/preview/previewModeBadge.png') no-repeat;"" href=""{0}/endPreview.aspx?redir={2}""><span style=""display:none;"">In Preview Mode - click to end</span></a>");                
+                return GetOptionalTextElement("PreviewBadge", @"<a id=""umbracoPreviewBadge"" style=""z-index:99999; position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px; background: url('{1}/preview/previewModeBadge.png') no-repeat;"" href=""{0}/endPreview.aspx?redir={2}""><span style=""display:none;"">In Preview Mode - click to end</span></a>");                
             }
         }
 

--- a/src/Umbraco.Tests/Configurations/UmbracoSettings/ContentElementTests.cs
+++ b/src/Umbraco.Tests/Configurations/UmbracoSettings/ContentElementTests.cs
@@ -156,7 +156,7 @@ namespace Umbraco.Tests.Configurations.UmbracoSettings
         [Test]
         public void PreviewBadge()
         {
-            Assert.IsTrue(SettingsSection.Content.PreviewBadge == @"<a id=""umbracoPreviewBadge"" style=""position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px; background: url('{1}/preview/previewModeBadge.png') no-repeat;"" href=""{0}/endPreview.aspx?redir={2}""><span style=""display:none;"">In Preview Mode - click to end</span></a>");
+            Assert.IsTrue(SettingsSection.Content.PreviewBadge == @"<a id=""umbracoPreviewBadge"" style=""z-index:99999; position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px; background: url('{1}/preview/previewModeBadge.png') no-repeat;"" href=""{0}/endPreview.aspx?redir={2}""><span style=""display:none;"">In Preview Mode - click to end</span></a>");
         }
         [Test]
         public void UmbracoLibraryCacheDuration()

--- a/src/Umbraco.Tests/Configurations/UmbracoSettings/umbracoSettings.config
+++ b/src/Umbraco.Tests/Configurations/UmbracoSettings/umbracoSettings.config
@@ -83,7 +83,7 @@
 
     <ForceSafeAliases>true</ForceSafeAliases>
 
-    <PreviewBadge><![CDATA[<a id="umbracoPreviewBadge" style="position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px; background: url('{1}/preview/previewModeBadge.png') no-repeat;" href="{0}/endPreview.aspx?redir={2}"><span style="display:none;">In Preview Mode - click to end</span></a>]]></PreviewBadge>
+    <PreviewBadge><![CDATA[<a id="umbracoPreviewBadge" style="z-index:99999; position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px; background: url('{1}/preview/previewModeBadge.png') no-repeat;" href="{0}/endPreview.aspx?redir={2}"><span style="display:none;">In Preview Mode - click to end</span></a>]]></PreviewBadge>
 
     <!-- Cache cycle of Media and Member data fetched from the umbraco.library methods -->
     <!-- In seconds. 0 will disable cache -->

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -7,7 +7,7 @@
             <umb-box-content class="block-form">
                 <ul class="nav nav-stacked" style="margin-bottom: 0;">
                     <li ng-repeat="url in node.urls">
-                        <a ng-if="node.hasPublishedVersion" href="{{url}}" target="_blank">
+                        <a ng-if="node.hasPublishedVersion" href="/umbraco/endPreview.aspx?redir={{url}}" target="_blank">
                             <i class="icon icon-window-popin"></i>
                             <span>{{url}}</span>
                         </a>

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -7,7 +7,7 @@
             <umb-box-content class="block-form">
                 <ul class="nav nav-stacked" style="margin-bottom: 0;">
                     <li ng-repeat="url in node.urls">
-                        <a ng-if="node.hasPublishedVersion" href="/umbraco/endPreview.aspx?redir={{url}}" target="_blank">
+                        <a ng-if="node.hasPublishedVersion" href="{{url}}" target="_blank">
                             <i class="icon icon-window-popin"></i>
                             <span>{{url}}</span>
                         </a>

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -7,11 +7,11 @@
             <umb-box-content class="block-form">
                 <ul class="nav nav-stacked" style="margin-bottom: 0;">
                     <li ng-repeat="url in node.urls">
-                        <a ng-if="node.published" href="{{url}}" target="_blank">
+                        <a ng-if="node.hasPublishedVersion" href="{{url}}" target="_blank">
                             <i class="icon icon-window-popin"></i>
                             <span>{{url}}</span>
                         </a>
-                        <div ng-if="!node.published">
+                        <div ng-if="!node.hasPublishedVersion">
                             <i class="icon icon-window-popin"></i>
                             <span>{{url}}</span>
                         </div>

--- a/src/Umbraco.Web.UI/config/umbracoSettings.Release.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.Release.config
@@ -40,7 +40,7 @@
 
     <!-- The html injected into a (x)html page if Umbraco is running in preview mode -->
     <PreviewBadge>
-      <![CDATA[<a id="umbracoPreviewBadge" style="position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px; background: url('{1}/preview/previewModeBadge.png') no-repeat;z-index: 9999999;" href="#" OnClick="javascript:window.top.location.href = '{0}/endPreview.aspx?redir={2}'"><span style="display:none;">In Preview Mode - click to end</span></a>]]></PreviewBadge>
+      <![CDATA[<a id="umbracoPreviewBadge" style="z-index:99999; position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px; background: url('{1}/preview/previewModeBadge.png') no-repeat;z-index: 9999999;" href="#" OnClick="javascript:window.top.location.href = '{0}/endPreview.aspx?redir={2}'"><span style="display:none;">In Preview Mode - click to end</span></a>]]></PreviewBadge>
 
     <!-- How Umbraco should handle errors during macro execution. Can be one of the following values:
          - inline - show an inline error within the macro but allow the page to continue rendering. Historial Umbraco behaviour.

--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -84,7 +84,7 @@
 
     <!-- The html injected into a (x)html page if Umbraco is running in preview mode -->
     <PreviewBadge>
-      <![CDATA[<a id="umbracoPreviewBadge" style="position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px; background: url('{1}/preview/previewModeBadge.png') no-repeat;" href="#" OnClick="javascript:window.top.location.href = '{0}/endPreview.aspx?redir={2}'"><span style="display:none;">In Preview Mode - click to end</span></a>
+      <![CDATA[<a id="umbracoPreviewBadge" style="z-index:99999; position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px; background: url('{1}/preview/previewModeBadge.png') no-repeat;" href="#" OnClick="javascript:window.top.location.href = '{0}/endPreview.aspx?redir={2}'"><span style="display:none;">In Preview Mode - click to end</span></a>
     ]]></PreviewBadge>
 
     <!-- Cache cycle of Media and Member data fetched from the umbraco.library methods -->


### PR DESCRIPTION
From the bug report:
Preconditions:
1. Umbraco 7.9.2 installed
2. The user is logged in Umbraco backoffice.
3. Content node is created and published.
4. Go to "Info" tab
5. See "Links" property. Link is active (screenshot 1)

Steps to reproduce:
1. Change any property value in this content node
2. Click on 'Save' button (without publish)
3. Go to "Info" tab
4. See "Links" property (screenshot 2)
 
Actual result:
Link is not active, even if previous version of content node still published. Content editor cannot navigate to the proper page.

Expected result:
The link is active. The user is able to open the proper page.

Given that the link is restored when the backoffice is refreshed (ie save the node, link is gone, F5, link is back), I'm pretty confident this was not by design.

The `umb-content-node-info` view was referencing `node.published` when determining whether to render a link to the page - that property is set to false when a node is saved, even if it has an existing published version. 

Change replaces `node.published` with `node.hasPublishedVersion`, which is always true if the node is live, pending changes or not. 

