### PR TITLE
U4-7030 enable use of radiobuttonlist pre editor

### DIFF
--- a/src/Umbraco.Core/Models/PreValueInnerListItem.cs
+++ b/src/Umbraco.Core/Models/PreValueInnerListItem.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Umbraco.Core.Models
+{
+    public class PreValueInnerListItem
+    {
+        [JsonProperty("value")]
+        public object Value { get; set; }
+
+        [JsonProperty("label")]
+        public string Label { get; set; }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/PreValueField.cs
+++ b/src/Umbraco.Core/PropertyEditors/PreValueField.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using Umbraco.Core.Manifest;
+using Umbraco.Core.Models;
 
 namespace Umbraco.Core.PropertyEditors
 {
@@ -86,5 +87,11 @@ namespace Umbraco.Core.PropertyEditors
         /// </summary>        
         [JsonProperty("config")]
         public IDictionary<string, object> Config { get; set; }
+
+        /// <summary>
+        /// This allows for inner prevalues to be defined, for views such as radiobuttonlist, that require a selection.
+        /// </summary>        
+        [JsonProperty("prevalues")]
+        public PreValueInnerListItem[] PreValues { get; set; }
     }
 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -386,6 +386,7 @@
     <Compile Include="Models\Membership\UserProfile.cs" />
     <Compile Include="Models\Membership\UserState.cs" />
     <Compile Include="Models\Membership\UserType.cs" />
+    <Compile Include="Models\PreValueInnerListItem.cs" />
     <Compile Include="Models\PublishedContent\PublishedContentTypeConverter.cs" />
     <Compile Include="Models\Rdbms\AuditEntryDto.cs" />
     <Compile Include="Models\Rdbms\ConsentDto.cs" />

--- a/src/Umbraco.Web.UI.Client/src/common/services/datatypehelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/datatypehelper.service.js
@@ -18,7 +18,8 @@ function dataTypeHelper() {
                     description: preVals[i].description,
                     label: preVals[i].label,
                     view: preVals[i].view,
-                    value: preVals[i].value
+                    value: preVals[i].value,
+                    prevalues: preVals[i].prevalues
                 });
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.edit.controller.js
@@ -29,6 +29,7 @@ function DataTypeEditController($scope, $routeParams, $location, appState, navig
                 view: preVals[i].view,
                 value: preVals[i].value,
                 config: preVals[i].config,
+                prevalues: preVals[i].prevalues
             });
         }
     }

--- a/src/Umbraco.Web/Models/ContentEditing/PreValueFieldDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/PreValueFieldDisplay.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Umbraco.Core.Models;
 
 namespace Umbraco.Web.Models.ContentEditing
 {
@@ -40,5 +41,10 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "config")]
         public IDictionary<string, object> Config { get; set; }
 
+        /// <summary>
+        /// This allows for inner prevalues to be defined, for views such as radiobuttonlist, that require a selection.
+        /// </summary>        
+        [DataMember(Name = "prevalues")]
+        public PreValueInnerListItem[] PreValues { get; set; }
     }
 }


### PR DESCRIPTION
http://issues.umbraco.org/issue/U4-7030

### Description

Enables use of radiobuttonlist view in custom data type prevalues.

![6ef9b0d46a228d0d5a8232b31f0945b4](https://user-images.githubusercontent.com/4321599/42420245-b39b1b46-82ba-11e8-908d-737f09f849ea.png)

The inner prevalues, are configured as below, in the package.manifest:

```
{
    "propertyEditors": [
        {
            "alias": "testPropertyEditor",
            "name": "Test Property Editor",
            "editor": {
                "view": "~/App_Plugins/TestPropertyEditor/testpropertyeditor.html",
                "valueType": "JSON"
            },
            "prevalues": {
                "fields": [
                    {
                        "label": "My Radio Button List",
                        "description": "Demo data type to show a radio button list with prevalues on a custom data type.",
                        "key": "myRadioButtonList",
                        "view": "radiobuttonlist",
                        "prevalues": [
                            { "value": "arnold-schwarzenegger", "label": "Arnold Schwarzenegger" },
                            { "value": "chuck-norris", "label": "Chuck Norris" },
                            { "value": "bruce-lee", "label": "Bruce Lee" }
                        ]
                    }
                ]
            }
        }
    ],
    "javascript": [
        "~/App_Plugins/TestPropertyEditor/testpropertyeditor.controller.js"
    ]
}
```

And the selected value is accessible from the custom data type controller/view as below:

![2a5238b0471ab1277d7848af2f8616d4](https://user-images.githubusercontent.com/4321599/42420314-c07f455c-82bb-11e8-94fc-62481998d38d.png)
