### PR TITLE
Remedy for U4-11073: Always show the upload dropzone in media pickers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js
@@ -23,10 +23,6 @@ angular.module("umbraco")
                     $scope.acceptedMediatypes = types;
                 });
 
-            $scope.upload = function(v) {
-                angular.element(".umb-file-dropzone-directive .file-select").click();
-            };
-
             $scope.dragLeave = function(el, event) {
                 $scope.activeDrag = false;
             };

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.html
@@ -79,14 +79,6 @@
                            placeholder="@placeholders_filter"
                            no-dirty-check />
                 </div>
-
-                <div class="upload-button">
-                    <button class="btn fileinput-button" ng-click="upload()" ng-class="{disabled: disabled}">
-                        <i class="icon-page-up"></i>
-                        <localize key="general_upload">Upload</localize>
-                    </button>
-                </div>
-
             </div>
 
             <div class="row">
@@ -121,7 +113,6 @@
 
             <umb-file-dropzone ng-if="acceptedMediatypes.length > 0"
                                accepted-mediatypes="acceptedMediatypes"
-                               hide-dropzone="{{!activeDrag && images.length > 0}}"
                                parent-id="{{currentFolder.id}}"
                                files-uploaded="onUploadComplete"
                                files-queued="onFilesQueue">

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -100,10 +100,6 @@ angular.module("umbraco")
                 }
             }
 
-            $scope.upload = function(v) {
-                angular.element(".umb-file-dropzone-directive .file-select").click();
-            };
-
             $scope.dragLeave = function(el, event) {
                 $scope.activeDrag = false;
             };

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
@@ -23,15 +23,6 @@
                        no-dirty-check />
             </div>
 
-            <div class="upload-button">
-                <umb-button type="button"
-                            label-key="general_upload"
-                            action="upload()"
-                            disabled="lockedFolder"
-                            ng-if="acceptedMediatypes.length > 0">
-                </umb-button>
-            </div>
-
         </div>
 
         <div class="row umb-control-group" ng-show="!searchOptions.filter">
@@ -70,7 +61,6 @@
                            files-queued="onFilesQueue"
                            accept="{{acceptedFileTypes}}"
                            max-file-size="{{maxFileSize}}"
-                           hide-dropzone="{{!activeDrag && images.length > 0 || searchOptions.filter }}"
                            compact="{{ images.length > 0 }}">
         </umb-file-dropzone>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
@@ -61,6 +61,7 @@
                            files-queued="onFilesQueue"
                            accept="{{acceptedFileTypes}}"
                            max-file-size="{{maxFileSize}}"
+                           hide-dropzone="{{searchOptions.filter}}"
                            compact="{{ images.length > 0 }}">
         </umb-file-dropzone>
 


### PR DESCRIPTION
### Original issue
See [U4-11073](http://issues.umbraco.org/issue/U4-11073).

### Description
Currently when using a media picker, the upload dropzone is explicitly hidden when a folder is not empty. To upload a file directly from the media picker dialog, you have to use the ill-placed upload button next to the search field. 

![as-is](https://user-images.githubusercontent.com/7405322/42441377-4ba7c7ec-8368-11e8-96ad-94fbd980869c.png)

This isn't the most consistent editorial experience. And per U4-11073 it also leaves the users with a bit of an editorial challenge: The only way to upload an image straight from the clipboard is by having a visible (and active) upload dropzone.

With this PR I'm proposing we keep the upload dropzone visible in the media picker dialog at all times except when searching. The dropzone is shrunk to its small size in non-empty folders. At the same time the upload button is removed entirely, since the dropzone doubles as an upload button.

![to-be](https://user-images.githubusercontent.com/7405322/42441612-dfa69d4c-8368-11e8-91c7-d3f295c62c21.png)
