### PR TITLE
U4-10561 - Performance improvement for IsAncestor/IsDescendant extension methods

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -906,8 +906,8 @@ namespace Umbraco.Web
 
         public static bool IsAncestorOrSelf(this IPublishedContent content, IPublishedContent other)
         {
-            // avoid using DescendantsOrSelf(), that's expensive
-            return other.AncestorsOrSelf().Any(x => x.Id == content.Id);
+            // avoid using DescendantsOrSelf() or AncestorsOrSelf(), they're expensive
+            return other.Path.InvariantStartsWith(content.Path);
         }
 
         public static HtmlString IsAncestorOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue)

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -860,7 +860,7 @@ namespace Umbraco.Web
 
         public static bool IsDescendant(this IPublishedContent content, IPublishedContent other)
         {
-            return content.Level < other.Level && content.Path.InvariantStartsWith(other.Path);
+            return other.Level < content.Level && content.Path.InvariantStartsWith(other.Path);
         }
 
         public static HtmlString IsDescendant(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
@@ -891,7 +891,7 @@ namespace Umbraco.Web
         public static bool IsAncestor(this IPublishedContent content, IPublishedContent other)
         {
             // avoid using Descendants(), or Ancestors(), they're expensive
-            return other.Level < content.Level && other.Path.InvariantStartsWith(content.Path);
+            return content.Level < other.Level && other.Path.InvariantStartsWith(content.Path);
         }
 
         public static HtmlString IsAncestor(this IPublishedContent content, IPublishedContent other, string valueIfTrue)

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -860,7 +860,7 @@ namespace Umbraco.Web
 
         public static bool IsDescendant(this IPublishedContent content, IPublishedContent other)
         {
-            return content.Ancestors().Any(x => x.Id == other.Id);
+            return content.Level < other.Level && content.Path.InvariantStartsWith(other.Path);
         }
 
         public static HtmlString IsDescendant(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
@@ -875,7 +875,7 @@ namespace Umbraco.Web
 
         public static bool IsDescendantOrSelf(this IPublishedContent content, IPublishedContent other)
         {
-            return content.AncestorsOrSelf().Any(x => x.Id == other.Id);
+            return content.Path.InvariantStartsWith(other.Path);
         }
 
         public static HtmlString IsDescendantOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
@@ -890,8 +890,8 @@ namespace Umbraco.Web
 
         public static bool IsAncestor(this IPublishedContent content, IPublishedContent other)
         {
-            // avoid using Descendants(), that's expensive
-            return other.Ancestors().Any(x => x.Id == content.Id);
+            // avoid using Descendants(), or Ancestors(), they're expensive
+            return other.Level < content.Level && other.Path.InvariantStartsWith(content.Path);
         }
 
         public static HtmlString IsAncestor(this IPublishedContent content, IPublishedContent other, string valueIfTrue)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-10561

### Description

Refactored the `IPublishedContent` extension methods: `IsAncestor` and `IsDescendant` for improved performance, by comparing the `Path`, rather than traversing the tree.

Reduces allocations, etc.

---

This pull-request supersedes PR #2253, with additional changes to the other `IsAncestor` and `IsDescendant` extension methods, following the same approach.

This extends on @danbramall's original pull-request, so still gets credit for his commit.