### PR TITLE
U4-11514 - Content Picker adds sortable options to restrict within container

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -77,7 +77,10 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
 
     // sortable options
     $scope.sortableOptions = {
+        axis: "y",
+        containment: "parent",
         distance: 10,
+        opacity: 0.7,
         tolerance: "pointer",
         scroll: true,
         zIndex: 6000


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11514

### Description

This pull-request adds options to the Content Picker's `sortableOptions` configuration, to restrict within the container and only drag vertically, (X axis).
