### PR TITLE
U4-11495 - Add border to custom regex in property settings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -530,6 +530,13 @@ input.umb-group-builder__group-title-input {
         overflow: hidden;
     }
 
+    .editor-validation-pattern{
+        border: 1px solid @gray-7;
+        margin: 10px 0 0;
+        padding: 6px;
+        max-height: 32px;
+    }
+
     .umb-dropdown {
         width: 100%;
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
I have added a border for the validation field when adding a datatype in the document type editor making it clearer that it's a field that can be edited

Issue is here: U4-11495 Add border to custom regex in property settings