### PR TITLE
U4-9309 When node is copied, copy is logged as writer

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1872,7 +1872,7 @@ namespace Umbraco.Core.Services
                     }
                     copyEventArgs.CanCancel = false;
                     uow.Events.Dispatch(Copied, this, copyEventArgs);
-                    Audit(uow, AuditType.Copy, "Copy Content performed by user", content.WriterId, content.Id);
+                    Audit(uow, AuditType.Copy, "Copy Content performed by user", userId, content.Id);
                     uow.Commit();
                 }
 


### PR DESCRIPTION


### Description
When a node is copied in the Umbraco backoffice, the copy is logged as being the source item writer user, not the person who initiated the copy. The creation of the destination node is logged as the current user correctly as fixed under U4-8516 (in v7.11)

http://issues.umbraco.org/issue/U4-9309