### PR TITLE
U4-11428 CodeAnnotations classes have inconsistent constructor parameter order

### DIFF
--- a/src/Umbraco.Core/CodeAnnotations/UmbracoExperimentalFeatureAttribute.cs
+++ b/src/Umbraco.Core/CodeAnnotations/UmbracoExperimentalFeatureAttribute.cs
@@ -24,7 +24,6 @@ namespace Umbraco.Core.CodeAnnotations
         /// intended.</param>
         public UmbracoExperimentalFeatureAttribute(string description)
         {
-            /* empty */
         }
 
         /// <summary>
@@ -37,7 +36,6 @@ namespace Umbraco.Core.CodeAnnotations
         /// details, discussion, and planning.</param>
         public UmbracoExperimentalFeatureAttribute(string description, string trackerUrl)
         {
-            /* empty */
         }
     }
 }

--- a/src/Umbraco.Core/CodeAnnotations/UmbracoExperimentalFeatureAttribute.cs
+++ b/src/Umbraco.Core/CodeAnnotations/UmbracoExperimentalFeatureAttribute.cs
@@ -3,33 +3,41 @@
 namespace Umbraco.Core.CodeAnnotations
 {
     /// <summary>
-    /// Marks the program elements that Umbraco is experimenting with and could become public.
+    /// Marks the program elements that Umbraco is experimenting with and could
+    /// become public.
     /// </summary>
     /// <remarks>
-    /// <para>Indicates that Umbraco  is experimenting with code that potentially could become
-    /// public, but we're not sure, and the code is not stable and can be refactored at any time.</para>
-    /// <para>The issue tracker should contain more details, discussion, and planning.</para>
+    /// <para>Indicates that Umbraco is experimenting with code that potentially
+    /// could become public, but we're not sure, and the code is not stable and
+    /// can be refactored at any time.</para>
+    /// <para>The issue tracker should contain more details, discussion, and
+    /// planning.</para>
     /// </remarks>
     [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = false)]
     internal sealed class UmbracoExperimentalFeatureAttribute : Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoExperimentalFeatureAttribute"/> class with a description.
+        /// Initializes a new instance of the <see cref="UmbracoExperimentalFeatureAttribute"/>
+        /// class with a description.
         /// </summary>
-        /// <param name="description">The text string that describes what is intended.</param>
+        /// <param name="description">The text string that describes what is
+        /// intended.</param>
         public UmbracoExperimentalFeatureAttribute(string description)
         {
-
+            /* empty */
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoExperimentalFeatureAttribute"/> class with a tracker url and a description.
+        /// Initializes a new instance of the <see cref="UmbracoExperimentalFeatureAttribute"/>
+        /// class with a tracker url and a description.
         /// </summary>
-        /// <param name="trackerUrl">The url of a tracker issue containing more details, discussion, and planning.</param>
-        /// <param name="description">The text string that describes what is intended.</param>
-        public UmbracoExperimentalFeatureAttribute(string trackerUrl, string description)
+        /// <param name="description">The text string that describes what is
+        /// intended.</param>
+        /// <param name="trackerUrl">The url of a tracker issue containing more
+        /// details, discussion, and planning.</param>
+        public UmbracoExperimentalFeatureAttribute(string description, string trackerUrl)
         {
-
+            /* empty */
         }
     }
 }

--- a/src/Umbraco.Core/CodeAnnotations/UmbracoProposedPublicAttribute.cs
+++ b/src/Umbraco.Core/CodeAnnotations/UmbracoProposedPublicAttribute.cs
@@ -25,7 +25,6 @@ namespace Umbraco.Core.CodeAnnotations
         /// intended.</param>
         public UmbracoProposedPublicAttribute(string description)
         {
-            /* empty */
         }
 
         /// <summary>
@@ -38,7 +37,6 @@ namespace Umbraco.Core.CodeAnnotations
         /// details, discussion, and planning.</param>
         public UmbracoProposedPublicAttribute(string description, string trackerUrl)
         {
-            /* empty */
         }
     }
 }

--- a/src/Umbraco.Core/CodeAnnotations/UmbracoProposedPublicAttribute.cs
+++ b/src/Umbraco.Core/CodeAnnotations/UmbracoProposedPublicAttribute.cs
@@ -6,31 +6,39 @@ namespace Umbraco.Core.CodeAnnotations
     /// Marks the program elements that Umbraco is considering making public.
     /// </summary>
     /// <remarks>
-    /// <para>Indicates that Umbraco considers making the (currently internal) program element public
-    /// at some point in the future, but the decision is not fully made yet and is still pending reviews.</para>
-    /// <para>Note that it is not a commitment to make the program element public. It may not ever become public.</para>
-    /// <para>The issue tracker should contain more details, discussion, and planning.</para>
+    /// <para>Indicates that Umbraco considers making the (currently internal)
+    /// program element public at some point in the future, but the decision is
+    /// not fully made yet and is still pending reviews.</para>
+    /// <para>Note that it is not a commitment to make the program element public.
+    /// It may not ever become public.</para>
+    /// <para>The issue tracker should contain more details, discussion, and
+    /// planning.</para>
     /// </remarks>
-    [AttributeUsage(AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = false)]
     internal sealed class UmbracoProposedPublicAttribute : Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoProposedPublicAttribute"/> class with a description.
+        /// Initializes a new instance of the <see cref="UmbracoProposedPublicAttribute"/>
+        /// class with a description.
         /// </summary>
-        /// <param name="description">The text string that describes what is intended.</param>
+        /// <param name="description">The text string that describes what is
+        /// intended.</param>
         public UmbracoProposedPublicAttribute(string description)
         {
-
+            /* empty */
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoProposedPublicAttribute"/> class with a tracker url and a description.
+        /// Initializes a new instance of the <see cref="UmbracoProposedPublicAttribute"/>
+        /// class with a tracker url and a description.
         /// </summary>
-        /// <param name="trackerUrl">The url of a tracker issue containing more details, discussion, and planning.</param>
-        /// <param name="description">The text string that describes what is intended.</param>
-        public UmbracoProposedPublicAttribute(string trackerUrl, string description)
+        /// <param name="description">The text string that describes what is
+        /// intended.</param>
+        /// <param name="trackerUrl">The url of a tracker issue containing more
+        /// details, discussion, and planning.</param>
+        public UmbracoProposedPublicAttribute(string description, string trackerUrl)
         {
-
+            /* empty */
         }
     }
 }

--- a/src/Umbraco.Core/CodeAnnotations/UmbracoWillObsoleteAttribute.cs
+++ b/src/Umbraco.Core/CodeAnnotations/UmbracoWillObsoleteAttribute.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Umbraco.Core.CodeAnnotations
 {
@@ -9,29 +6,35 @@ namespace Umbraco.Core.CodeAnnotations
     /// Marks the program elements that Umbraco will obsolete.
     /// </summary>
     /// <remarks>
-    /// Indicates that Umbraco will obsolete the program element at some point in the future, but we do not want to
-    /// explicitely mark it [Obsolete] yet to avoid warning messages showing when developers compile Umbraco.
+    /// Indicates that Umbraco will obsolete the program element at some point
+    /// in the future, but we do not want to explicitly mark it [Obsolete] yet
+    /// to avoid warning messages showing when developers compile Umbraco.
     /// </remarks>
     [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = false)]
     internal sealed class UmbracoWillObsoleteAttribute : Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoWillObsoleteAttribute"/> class with a description.
+        /// Initializes a new instance of the <see cref="UmbracoWillObsoleteAttribute"/>
+        /// class with a description.
         /// </summary>
-        /// <param name="description">The text string that describes what is intended.</param>
+        /// <param name="description">The text string that describes what is
+        /// intended.</param>
         public UmbracoWillObsoleteAttribute(string description)
         {
-
+            /* empty */
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoWillObsoleteAttribute"/> class with a tracker url and a description.
+        /// Initializes a new instance of the <see cref="UmbracoWillObsoleteAttribute"/>
+        /// class with a tracker url and a description.
         /// </summary>
-        /// <param name="trackerUrl">The url of a tracker issue containing more details, discussion, and planning.</param>
-        /// <param name="description">The text string that describes what is intended.</param>
-        public UmbracoWillObsoleteAttribute(string trackerUrl, string description)
+        /// <param name="description">The text string that describes what is
+        /// intended.</param>
+        /// <param name="trackerUrl">The url of a tracker issue containing more
+        /// details, discussion, and planning.</param>
+        public UmbracoWillObsoleteAttribute(string description, string trackerUrl)
         {
-
+            /* empty */
         }
     }
 }

--- a/src/Umbraco.Core/CodeAnnotations/UmbracoWillObsoleteAttribute.cs
+++ b/src/Umbraco.Core/CodeAnnotations/UmbracoWillObsoleteAttribute.cs
@@ -21,7 +21,6 @@ namespace Umbraco.Core.CodeAnnotations
         /// intended.</param>
         public UmbracoWillObsoleteAttribute(string description)
         {
-            /* empty */
         }
 
         /// <summary>
@@ -34,7 +33,6 @@ namespace Umbraco.Core.CodeAnnotations
         /// details, discussion, and planning.</param>
         public UmbracoWillObsoleteAttribute(string description, string trackerUrl)
         {
-            /* empty */
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11428

### Description
Attribute classes defined in the ``Umbraco.Core.CodeAnnotations`` namespace have inconsistent constructor parameter order. By this I mean that sometimes a parameter from the single parameter constructor will appear either as the first or second parameter in a multiple parameter constructor.

See the issue on the tracker for more details.



