### PR TITLE
U4-11522 Add ~/.well-known to umbracoReservedUrls

### DIFF
--- a/src/Umbraco.Tests/App.config
+++ b/src/Umbraco.Tests/App.config
@@ -55,7 +55,7 @@
 
     <appSettings>
         <add key="umbracoConfigurationStatus" value="6.0.0" />
-        <add key="umbracoReservedUrls" value="~/config/splashes/booting.aspx,~/install/default.aspx,~/config/splashes/noNodes.aspx,~/VSEnterpriseHelper.axd" />
+        <add key="umbracoReservedUrls" value="~/config/splashes/booting.aspx,~/install/default.aspx,~/config/splashes/noNodes.aspx,~/VSEnterpriseHelper.axd,~/.well-known" />
         <add key="umbracoReservedPaths" value="~/install/" />
         <add key="umbracoPath" value="~/umbraco" />
         <add key="umbracoHideTopLevelNodeFromPath" value="true" />

--- a/src/Umbraco.Web.UI/web.Template.Debug.config
+++ b/src/Umbraco.Web.UI/web.Template.Debug.config
@@ -54,7 +54,7 @@
   <appSettings xdt:Transform="Remove" xdt:Locator="Condition(@configSource != '')" />
   <appSettings xdt:Transform="InsertIfMissing">
     <add key="umbracoConfigurationStatus" value="" />
-    <add key="umbracoReservedUrls" value="~/config/splashes/booting.aspx,~/install/default.aspx,~/config/splashes/noNodes.aspx,~/VSEnterpriseHelper.axd" />
+    <add key="umbracoReservedUrls" value="~/config/splashes/booting.aspx,~/install/default.aspx,~/config/splashes/noNodes.aspx,~/VSEnterpriseHelper.axd,~/.well-known" />
     <add key="umbracoReservedPaths" value="~/umbraco,~/install/" />
     <add key="umbracoPath" value="~/umbraco" />
     <add key="umbracoHideTopLevelNodeFromPath" value="true" />

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -42,7 +42,7 @@
       http://our.umbraco.org/documentation/using-umbraco/config-files/#webconfig
       -->
 		<add key="umbracoConfigurationStatus" value="" />
-		<add key="umbracoReservedUrls" value="~/config/splashes/booting.aspx,~/install/default.aspx,~/config/splashes/noNodes.aspx,~/VSEnterpriseHelper.axd" />
+		<add key="umbracoReservedUrls" value="~/config/splashes/booting.aspx,~/install/default.aspx,~/config/splashes/noNodes.aspx,~/VSEnterpriseHelper.axd,~/.well-known" />
 		<add key="umbracoReservedPaths" value="~/umbraco,~/install/" />
 		<add key="umbracoPath" value="~/umbraco" />
 		<add key="umbracoHideTopLevelNodeFromPath" value="true" />


### PR DESCRIPTION
Add ~/.well-known to umbracoReservedUrls to support letsencrypt certificates OOTB

### Description

By default the umbracoReservedUrls key in web.config contains pages/urls which are not processed by Umbraco
A common requirement (now) is to add letsencrypt certificates to websites to support HTTPS.
If provisioning a certificate via a tool such as certifytheweb, certification fails initially because ~/well-known is routed to Umbraco, and throws 404s. 

