### PR TITLE
Link to template from "document types" or "content" screen

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -55,6 +55,11 @@
                 $location.url(url);
             };
 
+            scope.openTemplate = function () {
+                var url = "/settings/templates/edit/" + scope.node.templateId;
+                $location.url(url);
+            }
+
             scope.updateTemplate = function (templateAlias) {
 
                 // update template value

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgridselector.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgridselector.directive.js
@@ -1,7 +1,7 @@
-(function() {
+(function () {
     'use strict';
 
-    function GridSelector() {
+    function GridSelector($location) {
 
         function link(scope, el, attr, ctrl) {
 
@@ -11,18 +11,18 @@
             scope.itemLabel = "";
 
             // set default item name
-            if(!scope.itemName){
+            if (!scope.itemName) {
                 scope.itemLabel = "item";
             } else {
                 scope.itemLabel = scope.itemName;
             }
 
-            scope.removeItem = function(selectedItem) {
+            scope.removeItem = function (selectedItem) {
                 var selectedItemIndex = scope.selectedItems.indexOf(selectedItem);
                 scope.selectedItems.splice(selectedItemIndex, 1);
             };
 
-            scope.removeDefaultItem = function() {
+            scope.removeDefaultItem = function () {
 
                 // it will be the last item so we can clear the array
                 scope.selectedItems = [];
@@ -32,7 +32,7 @@
 
             };
 
-            scope.openItemPicker = function($event){
+            scope.openItemPicker = function ($event) {
                 scope.dialogModel = {
                     view: "itempicker",
                     title: "Choose " + scope.itemLabel,
@@ -40,11 +40,11 @@
                     selectedItems: scope.selectedItems,
                     event: $event,
                     show: true,
-                    submit: function(model) {
+                    submit: function (model) {
                         scope.selectedItems.push(model.selectedItem);
 
                         // if no default item - set item as default
-                        if(scope.defaultItem === null) {
+                        if (scope.defaultItem === null) {
                             scope.setAsDefaultItem(model.selectedItem);
                         }
 
@@ -54,7 +54,12 @@
                 };
             };
 
-            scope.setAsDefaultItem = function(selectedItem) {
+            scope.openTemplate = function (selectedItem) {
+                var url = "/settings/templates/edit/" + selectedItem.id;
+                $location.url(url);
+            }
+
+            scope.setAsDefaultItem = function (selectedItem) {
 
                 // clear default item
                 scope.defaultItem = {};
@@ -65,69 +70,69 @@
 
             function updatePlaceholders() {
 
-              // update default item
-              if(scope.defaultItem !== null && scope.defaultItem.placeholder) {
+                // update default item
+                if (scope.defaultItem !== null && scope.defaultItem.placeholder) {
 
-                scope.defaultItem.name = scope.name;
+                    scope.defaultItem.name = scope.name;
 
-                if(scope.alias !== null && scope.alias !== undefined) {
-                  scope.defaultItem.alias = scope.alias;
-                }
-
-              }
-
-              // update selected items
-              angular.forEach(scope.selectedItems, function(selectedItem) {
-                if(selectedItem.placeholder) {
-
-                  selectedItem.name = scope.name;
-
-                  if(scope.alias !== null && scope.alias !== undefined) {
-                    selectedItem.alias = scope.alias;
-                  }
+                    if (scope.alias !== null && scope.alias !== undefined) {
+                        scope.defaultItem.alias = scope.alias;
+                    }
 
                 }
-              });
 
-              // update availableItems
-              angular.forEach(scope.availableItems, function(availableItem) {
-                if(availableItem.placeholder) {
+                // update selected items
+                angular.forEach(scope.selectedItems, function (selectedItem) {
+                    if (selectedItem.placeholder) {
 
-                  availableItem.name = scope.name;
+                        selectedItem.name = scope.name;
 
-                  if(scope.alias !== null && scope.alias !== undefined) {
-                    availableItem.alias = scope.alias;
-                  }
+                        if (scope.alias !== null && scope.alias !== undefined) {
+                            selectedItem.alias = scope.alias;
+                        }
 
-                }
-              });
+                    }
+                });
+
+                // update availableItems
+                angular.forEach(scope.availableItems, function (availableItem) {
+                    if (availableItem.placeholder) {
+
+                        availableItem.name = scope.name;
+
+                        if (scope.alias !== null && scope.alias !== undefined) {
+                            availableItem.alias = scope.alias;
+                        }
+
+                    }
+                });
 
             }
 
             function activate() {
 
-              // add watchers for updating placeholde name and alias
-              if(scope.updatePlaceholder) {
-                eventBindings.push(scope.$watch('name', function(newValue, oldValue){
-                  updatePlaceholders();
-                }));
+                // add watchers for updating placeholde name and alias
+                if (scope.updatePlaceholder) {
+                    eventBindings.push(scope.$watch('name', function (newValue, oldValue) {
+                        updatePlaceholders();
+                    }));
 
-                eventBindings.push(scope.$watch('alias', function(newValue, oldValue){
-                  updatePlaceholders();
-                }));
-              }
+                    eventBindings.push(scope.$watch('alias', function (newValue, oldValue) {
+                        updatePlaceholders();
+                    }));
+                }
 
             }
 
             activate();
 
             // clean up
-            scope.$on('$destroy', function(){
+            scope.$on('$destroy', function () {
 
-              // clear watchers
-              for(var e in eventBindings) {
-                eventBindings[e]();
-               }
+                // clear watchers
+                for (var e in eventBindings) {
+                    eventBindings[e]();
+                }
 
             });
 
@@ -138,13 +143,13 @@
             replace: true,
             templateUrl: 'views/components/umb-grid-selector.html',
             scope: {
-              name: "=",
-              alias: "=",
-              selectedItems: '=',
-              availableItems: "=",
-              defaultItem: "=",
-              itemName: "@",
-              updatePlaceholder: "="
+                name: "=",
+                alias: "=",
+                selectedItems: '=',
+                availableItems: "=",
+                defaultItem: "=",
+                itemName: "@",
+                updatePlaceholder: "="
             },
             link: link
         };

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -193,7 +193,9 @@
                                 ng-change="updateTemplate(node.template)">
                             <option value=""><localize key="general_choose">Choose</localize>...</option>
                         </select>
-                        <a href="" class="umb-node-preview__action" style="margin-left:15px;" ng-click="openTemplate()" ng-if="node.template !== null">Open</a>
+                        <a href="" class="umb-node-preview__action" style="margin-left:15px;" ng-click="openTemplate()" ng-if="node.template !== null">
+                            <localize key="general_open">Open</localize>
+                        </a>
                     </div>
                 </umb-control-group>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -194,6 +194,8 @@
                     </select>
                 </umb-control-group>
 
+                <a href="" ng-click="openTemplate()" ng-if="node.template !== null">Open</a>
+
                 <umb-control-group data-element="node-info-id" label="Id">
                     <div>{{ node.id }}</div>
                     <small>{{ node.key }}</small>

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -186,15 +186,16 @@
                 </umb-control-group>
 
                 <umb-control-group ng-if="disableTemplates == false" data-element="node-info-template" label="@template_template">
-                    <select class="input-block-level"
-                            ng-model="node.template"
-                            ng-options="key as value for (key, value) in availableTemplates"
-                            ng-change="updateTemplate(node.template)">
-                        <option value=""><localize key="general_choose">Choose</localize>...</option>
-                    </select>
+                    <div class="flex items-center">
+                        <select class="input-block-level"
+                                ng-model="node.template"
+                                ng-options="key as value for (key, value) in availableTemplates"
+                                ng-change="updateTemplate(node.template)">
+                            <option value=""><localize key="general_choose">Choose</localize>...</option>
+                        </select>
+                        <a href="" class="umb-node-preview__action" style="margin-left:15px;" ng-click="openTemplate()" ng-if="node.template !== null">Open</a>
+                    </div>
                 </umb-control-group>
-
-                <a href="" ng-click="openTemplate()" ng-if="node.template !== null">Open</a>
 
                 <umb-control-group data-element="node-info-id" label="Id">
                     <div>{{ node.id }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-grid-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-grid-selector.html
@@ -6,6 +6,7 @@
             <div class="umb-grid-selector__item-content">
                 <i class="umb-grid-selector__item-icon {{ defaultItem.icon }}"></i>
                 <div class="umb-grid-selector__item-label">{{ defaultItem.name }}</div>
+                <div><a href="" class="umb-grid-selector__item-default-label -blue" ng-click="openTemplate(defaultItem)"><localize key="general_open">Open</localize></a></div>
                 <span class="umb-grid-selector__item-default-label">(<localize key="general_default">Default</localize> {{itemLabel}})</span>
             </div>
             <i class="umb-grid-selector__item-remove icon-trash" ng-if="selectedItems.length === 1" ng-click="removeDefaultItem()"></i>
@@ -15,7 +16,8 @@
             <div class="umb-grid-selector__item-content">
                 <i class="umb-grid-selector__item-icon {{ selectedItem.icon }}"></i>
                 <div class="umb-grid-selector__item-label">{{ selectedItem.name }}</div>
-                <a href="" class="umb-grid-selector__item-default-label -blue" ng-click="setAsDefaultItem(selectedItem)"><localize key="grid_setAsDefault">Set as default</localize></a>
+                <div><a href="" class="umb-grid-selector__item-default-label -blue" ng-click="openTemplate(selectedItem)"><localize key="general_open">Open</localize></a></div>
+                <div><a href="" class="umb-grid-selector__item-default-label -blue" ng-click="setAsDefaultItem(selectedItem)"><localize key="grid_setAsDefault">Set as default</localize></a></div>
             </div>
             <i class="umb-grid-selector__item-remove icon-trash" ng-click="removeItem(selectedItem)"></i>
         </div>
@@ -33,11 +35,10 @@
         <small><localize key="general_all">Akk</localize> {{itemLabel}}s <localize key="grid_areAdded">are added</localize></small>
     </div>
 
-    <umb-overlay
-        ng-if="dialogModel.show"
-        model="dialogModel"
-        position="target"
-        view="dialogModel.view">
+    <umb-overlay ng-if="dialogModel.show"
+                 model="dialogModel"
+                 position="target"
+                 view="dialogModel.view">
     </umb-overlay>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
@@ -7,17 +7,15 @@
 
     <div class="sub-view-column-right">
 
-        <umb-grid-selector
-                ng-if="vm.availableTemplates"
-                selected-items="model.allowedTemplates"
-                available-items="vm.availableTemplates"
-                default-item="model.defaultTemplate"
-                item-name="template"
-                name="model.name"
-                alias="model.alias"
-                update-placeholder="vm.updateTemplatePlaceholder">
+        <umb-grid-selector ng-if="vm.availableTemplates"
+                           selected-items="model.allowedTemplates"
+                           available-items="vm.availableTemplates"
+                           default-item="model.defaultTemplate"
+                           item-name="template"
+                           name="model.name"
+                           alias="model.alias"
+                           update-placeholder="vm.updateTemplatePlaceholder">
         </umb-grid-selector>
-
     </div>
 
 </div>

--- a/src/Umbraco.Web/Models/ContentEditing/ContentItemDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentItemDisplay.cs
@@ -28,6 +28,15 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "template")]
         public string TemplateAlias { get; set; }
 
+
+
+
+        [DataMember(Name = "templateId")]
+        public int TemplateId { get; set; }
+
+
+
+
         [DataMember(Name = "allowedTemplates")]
         public IDictionary<string, string> AllowedTemplates { get; set; }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description

Added the possibility to open the template(s) associated to a document type from the "document type" screen: 

![untitled2](https://user-images.githubusercontent.com/10199821/42820683-03bf315c-89d7-11e8-930b-862e828ab31a.png)

And the "content" screen.

![untitled](https://user-images.githubusercontent.com/10199821/42820685-03f002e6-89d7-11e8-8fa3-aa775d9fda04.png)

The link of the "content" screen disappears if no template has been selected.
For the ID of the template to be available on the "content" screen, I added a "templateId" field in the "ContentItemDisplay" class.

Note that I made way less changes that the ones displayed. All of these modifications are the result of "Visual Studio" auto formatting the file.

