### PR TITLE
U4-10561 - Bug fix for IsAncestor/IsDescendant extension methods

### DIFF
--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -93,13 +93,14 @@ namespace Umbraco.Tests.PublishedContent
 				<creatorName><![CDATA[Custom data with same property name as the member name]]></creatorName>
 				<testRecursive><![CDATA[]]></testRecursive>
 			</Home>
-			<CustomDocument id=""1177"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1234"" template=""" + templateId + @""" sortOrder=""2"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-18T14:23:35"" nodeName=""custom sub 1"" urlName=""custom-sub-1"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1177"" isDoc="""" />
-			<CustomDocument id=""1178"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1234"" template=""" + templateId + @""" sortOrder=""3"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-16T14:23:35"" nodeName=""custom sub 2"" urlName=""custom-sub-2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1178"" isDoc="""">
-                <CustomDocument id=""1179"" parentID=""1178"" level=""4"" writerID=""0"" creatorID=""0"" nodeType=""1234"" template=""" + templateId + @""" sortOrder=""1"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-18T14:23:35"" nodeName=""custom sub sub 1"" urlName=""custom-sub-sub-1"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1178,1179"" isDoc="""" />
-            </CustomDocument>
-            <Home id=""1176"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""" + templateId + @""" sortOrder=""4"" createDate=""2012-07-20T18:08:08"" updateDate=""2012-07-20T19:10:52"" nodeName=""Sub 3"" urlName=""sub-3"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1176"" isDoc="""" key=""CDB83BBC-A83B-4BA6-93B8-AADEF67D3C09"">
+			<CustomDocument id=""117"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1234"" template=""" + templateId + @""" sortOrder=""2"" createDate=""2018-07-18T10:06:37"" updateDate=""2018-07-18T10:06:37"" nodeName=""custom sub 1"" urlName=""custom-sub-1"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,117"" isDoc="""" />
+			<CustomDocument id=""1177"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1234"" template=""" + templateId + @""" sortOrder=""3"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-18T14:23:35"" nodeName=""custom sub 1"" urlName=""custom-sub-1"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1177"" isDoc="""" />
+			<CustomDocument id=""1178"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1234"" template=""" + templateId + @""" sortOrder=""4"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-16T14:23:35"" nodeName=""custom sub 2"" urlName=""custom-sub-2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1178"" isDoc="""">
+				<CustomDocument id=""1179"" parentID=""1178"" level=""4"" writerID=""0"" creatorID=""0"" nodeType=""1234"" template=""" + templateId + @""" sortOrder=""1"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-18T14:23:35"" nodeName=""custom sub sub 1"" urlName=""custom-sub-sub-1"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1178,1179"" isDoc="""" />
+			</CustomDocument>
+			<Home id=""1176"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""" + templateId + @""" sortOrder=""5"" createDate=""2012-07-20T18:08:08"" updateDate=""2012-07-20T19:10:52"" nodeName=""Sub 3"" urlName=""sub-3"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1176"" isDoc="""" key=""CDB83BBC-A83B-4BA6-93B8-AADEF67D3C09"">
 				<content><![CDATA[]]></content>
-                <umbracoNaviHide>1</umbracoNaviHide>
+				<umbracoNaviHide>1</umbracoNaviHide>
 			</Home>
 		</Home>
 		<Home id=""1175"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""" + templateId + @""" sortOrder=""2"" createDate=""2012-07-20T18:08:01"" updateDate=""2012-07-20T18:49:32"" nodeName=""Sub 2"" urlName=""sub-2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1175"" isDoc=""""><content><![CDATA[]]></content>
@@ -183,7 +184,7 @@ namespace Umbraco.Tests.PublishedContent
                 .Where(x => x.IsVisible())
                 .ToContentSet();
 
-            Assert.AreEqual(3, items.Count());
+            Assert.AreEqual(4, items.Count());
 
             foreach (var d in items)
             {
@@ -191,6 +192,10 @@ namespace Umbraco.Tests.PublishedContent
                 {
                     case 1174:
                         Assert.IsTrue(d.IsFirst());
+                        Assert.IsFalse(d.IsLast());
+                        break;
+                    case 117:
+                        Assert.IsFalse(d.IsFirst());
                         Assert.IsFalse(d.IsLast());
                         break;
                     case 1177:
@@ -255,7 +260,7 @@ namespace Umbraco.Tests.PublishedContent
         {
             var doc = GetNode(1173);
 
-            var items = doc.Children.Take(3).ToContentSet();
+            var items = doc.Children.Take(4).ToContentSet();
 
             foreach (var item in items)
             {
@@ -315,7 +320,7 @@ namespace Umbraco.Tests.PublishedContent
         {
             var doc = GetNode(1046);
 
-            var expected = new[] { 1046, 1173, 1174, 1177, 1178, 1179, 1176, 1175, 4444, 1172 };
+            var expected = new[] { 1046, 1173, 1174, 117, 1177, 1178, 1179, 1176, 1175, 4444, 1172 };
             var exindex = 0;
 
             // must respect the XPath descendants-or-self axis!
@@ -370,11 +375,11 @@ namespace Umbraco.Tests.PublishedContent
             var doc = GetNode(1173);
             Assert.AreEqual(0, doc.Index());
             doc = GetNode(1176);
-            Assert.AreEqual(3, doc.Index());
+            Assert.AreEqual(4, doc.Index());
             doc = GetNode(1177);
-            Assert.AreEqual(1, doc.Index());
-            doc = GetNode(1178);
             Assert.AreEqual(2, doc.Index());
+            doc = GetNode(1178);
+            Assert.AreEqual(3, doc.Index());
         }
 
         [Test]
@@ -600,6 +605,7 @@ namespace Umbraco.Tests.PublishedContent
             // -- Home: 1173 (parent 1046)
             // -- Custom Doc: 1178 (parent 1173)
             // --- Custom Doc2: 1179 (parent: 1178)
+            // -- Custom Doc4: 117 (parent 1173)
             // - Custom Doc3: 1172 (no parent)
 
             var home = GetNode(1173);
@@ -607,25 +613,30 @@ namespace Umbraco.Tests.PublishedContent
             var customDoc = GetNode(1178);
             var customDoc2 = GetNode(1179);
             var customDoc3 = GetNode(1172);
+            var customDoc4 = GetNode(117);
 
+            Assert.IsTrue(root.IsAncestor(customDoc4));
             Assert.IsFalse(root.IsAncestor(customDoc3));
             Assert.IsTrue(root.IsAncestor(customDoc2));
             Assert.IsTrue(root.IsAncestor(customDoc));
             Assert.IsTrue(root.IsAncestor(home));
             Assert.IsFalse(root.IsAncestor(root));
 
+            Assert.IsTrue(home.IsAncestor(customDoc4));
             Assert.IsFalse(home.IsAncestor(customDoc3));
             Assert.IsTrue(home.IsAncestor(customDoc2));
             Assert.IsTrue(home.IsAncestor(customDoc));
             Assert.IsFalse(home.IsAncestor(home));
             Assert.IsFalse(home.IsAncestor(root));
 
+            Assert.IsFalse(customDoc.IsAncestor(customDoc4));
             Assert.IsFalse(customDoc.IsAncestor(customDoc3));
             Assert.IsTrue(customDoc.IsAncestor(customDoc2));
             Assert.IsFalse(customDoc.IsAncestor(customDoc));
             Assert.IsFalse(customDoc.IsAncestor(home));
             Assert.IsFalse(customDoc.IsAncestor(root));
 
+            Assert.IsFalse(customDoc2.IsAncestor(customDoc4));
             Assert.IsFalse(customDoc2.IsAncestor(customDoc3));
             Assert.IsFalse(customDoc2.IsAncestor(customDoc2));
             Assert.IsFalse(customDoc2.IsAncestor(customDoc));
@@ -643,6 +654,7 @@ namespace Umbraco.Tests.PublishedContent
             // -- Home: 1173 (parent 1046)
             // -- Custom Doc: 1178 (parent 1173)
             // --- Custom Doc2: 1179 (parent: 1178)
+            // -- Custom Doc4: 117 (parent 1173)
             // - Custom Doc3: 1172 (no parent)
 
             var home = GetNode(1173);
@@ -650,31 +662,37 @@ namespace Umbraco.Tests.PublishedContent
             var customDoc = GetNode(1178);
             var customDoc2 = GetNode(1179);
             var customDoc3 = GetNode(1172);
+            var customDoc4 = GetNode(117);
 
+            Assert.IsTrue(root.IsAncestorOrSelf(customDoc4));
             Assert.IsFalse(root.IsAncestorOrSelf(customDoc3));
             Assert.IsTrue(root.IsAncestorOrSelf(customDoc2));
             Assert.IsTrue(root.IsAncestorOrSelf(customDoc));
             Assert.IsTrue(root.IsAncestorOrSelf(home));
             Assert.IsTrue(root.IsAncestorOrSelf(root));
 
+            Assert.IsTrue(home.IsAncestorOrSelf(customDoc4));
             Assert.IsFalse(home.IsAncestorOrSelf(customDoc3));
             Assert.IsTrue(home.IsAncestorOrSelf(customDoc2));
             Assert.IsTrue(home.IsAncestorOrSelf(customDoc));
             Assert.IsTrue(home.IsAncestorOrSelf(home));
             Assert.IsFalse(home.IsAncestorOrSelf(root));
 
+            Assert.IsFalse(customDoc.IsAncestorOrSelf(customDoc4));
             Assert.IsFalse(customDoc.IsAncestorOrSelf(customDoc3));
             Assert.IsTrue(customDoc.IsAncestorOrSelf(customDoc2));
             Assert.IsTrue(customDoc.IsAncestorOrSelf(customDoc));
             Assert.IsFalse(customDoc.IsAncestorOrSelf(home));
             Assert.IsFalse(customDoc.IsAncestorOrSelf(root));
 
+            Assert.IsFalse(customDoc2.IsAncestorOrSelf(customDoc4));
             Assert.IsFalse(customDoc2.IsAncestorOrSelf(customDoc3));
             Assert.IsTrue(customDoc2.IsAncestorOrSelf(customDoc2));
             Assert.IsFalse(customDoc2.IsAncestorOrSelf(customDoc));
             Assert.IsFalse(customDoc2.IsAncestorOrSelf(home));
             Assert.IsFalse(customDoc2.IsAncestorOrSelf(root));
 
+            Assert.IsTrue(customDoc4.IsAncestorOrSelf(customDoc4));
             Assert.IsTrue(customDoc3.IsAncestorOrSelf(customDoc3));
         }
 
@@ -688,7 +706,7 @@ namespace Umbraco.Tests.PublishedContent
 
             Assert.IsNotNull(result);
 
-            Assert.AreEqual(9, result.Count());
+            Assert.AreEqual(10, result.Count());
             Assert.IsTrue(result.Select(x => ((dynamic)x).Id).ContainsAll(new dynamic[] { 1046, 1173, 1174, 1176, 1175 }));
         }
 
@@ -701,7 +719,7 @@ namespace Umbraco.Tests.PublishedContent
 
             Assert.IsNotNull(result);
 
-            Assert.AreEqual(8, result.Count());
+            Assert.AreEqual(9, result.Count());
             Assert.IsTrue(result.Select(x => ((dynamic)x).Id).ContainsAll(new dynamic[] { 1173, 1174, 1176, 1175, 4444 }));
         }
 
@@ -713,6 +731,7 @@ namespace Umbraco.Tests.PublishedContent
             // -- Home: 1173 (parent 1046)
             // -- Custom Doc: 1178 (parent 1173)
             // --- Custom Doc2: 1179 (parent: 1178)
+            // -- Custom Doc4: 117 (parent 1173)
             // - Custom Doc3: 1172 (no parent)
 
             var home = GetNode(1173);
@@ -720,30 +739,35 @@ namespace Umbraco.Tests.PublishedContent
             var customDoc = GetNode(1178);
             var customDoc2 = GetNode(1179);
             var customDoc3 = GetNode(1172);
+            var customDoc4 = GetNode(117);
 
             Assert.IsFalse(root.IsDescendant(root));
             Assert.IsFalse(root.IsDescendant(home));
             Assert.IsFalse(root.IsDescendant(customDoc));
             Assert.IsFalse(root.IsDescendant(customDoc2));
             Assert.IsFalse(root.IsDescendant(customDoc3));
+            Assert.IsFalse(root.IsDescendant(customDoc4));
 
             Assert.IsTrue(home.IsDescendant(root));
             Assert.IsFalse(home.IsDescendant(home));
             Assert.IsFalse(home.IsDescendant(customDoc));
             Assert.IsFalse(home.IsDescendant(customDoc2));
             Assert.IsFalse(home.IsDescendant(customDoc3));
+            Assert.IsFalse(home.IsDescendant(customDoc4));
 
             Assert.IsTrue(customDoc.IsDescendant(root));
             Assert.IsTrue(customDoc.IsDescendant(home));
             Assert.IsFalse(customDoc.IsDescendant(customDoc));
             Assert.IsFalse(customDoc.IsDescendant(customDoc2));
             Assert.IsFalse(customDoc.IsDescendant(customDoc3));
+            Assert.IsFalse(customDoc.IsDescendant(customDoc4));
 
             Assert.IsTrue(customDoc2.IsDescendant(root));
             Assert.IsTrue(customDoc2.IsDescendant(home));
             Assert.IsTrue(customDoc2.IsDescendant(customDoc));
             Assert.IsFalse(customDoc2.IsDescendant(customDoc2));
             Assert.IsFalse(customDoc2.IsDescendant(customDoc3));
+            Assert.IsFalse(customDoc2.IsDescendant(customDoc4));
 
             Assert.IsFalse(customDoc3.IsDescendant(customDoc3));
         }
@@ -756,6 +780,7 @@ namespace Umbraco.Tests.PublishedContent
             // -- Home: 1173 (parent 1046)
             // -- Custom Doc: 1178 (parent 1173)
             // --- Custom Doc2: 1179 (parent: 1178)
+            // -- Custom Doc4: 117 (parent 1173)
             // - Custom Doc3: 1172 (no parent)
 
             var home = GetNode(1173);
@@ -763,30 +788,35 @@ namespace Umbraco.Tests.PublishedContent
             var customDoc = GetNode(1178);
             var customDoc2 = GetNode(1179);
             var customDoc3 = GetNode(1172);
+            var customDoc4 = GetNode(117);
 
             Assert.IsTrue(root.IsDescendantOrSelf(root));
             Assert.IsFalse(root.IsDescendantOrSelf(home));
             Assert.IsFalse(root.IsDescendantOrSelf(customDoc));
             Assert.IsFalse(root.IsDescendantOrSelf(customDoc2));
             Assert.IsFalse(root.IsDescendantOrSelf(customDoc3));
+            Assert.IsFalse(root.IsDescendantOrSelf(customDoc4));
 
             Assert.IsTrue(home.IsDescendantOrSelf(root));
             Assert.IsTrue(home.IsDescendantOrSelf(home));
             Assert.IsFalse(home.IsDescendantOrSelf(customDoc));
             Assert.IsFalse(home.IsDescendantOrSelf(customDoc2));
             Assert.IsFalse(home.IsDescendantOrSelf(customDoc3));
+            Assert.IsFalse(home.IsDescendantOrSelf(customDoc4));
 
             Assert.IsTrue(customDoc.IsDescendantOrSelf(root));
             Assert.IsTrue(customDoc.IsDescendantOrSelf(home));
             Assert.IsTrue(customDoc.IsDescendantOrSelf(customDoc));
             Assert.IsFalse(customDoc.IsDescendantOrSelf(customDoc2));
             Assert.IsFalse(customDoc.IsDescendantOrSelf(customDoc3));
+            Assert.IsFalse(customDoc.IsDescendantOrSelf(customDoc4));
 
             Assert.IsTrue(customDoc2.IsDescendantOrSelf(root));
             Assert.IsTrue(customDoc2.IsDescendantOrSelf(home));
             Assert.IsTrue(customDoc2.IsDescendantOrSelf(customDoc));
             Assert.IsTrue(customDoc2.IsDescendantOrSelf(customDoc2));
             Assert.IsFalse(customDoc2.IsDescendantOrSelf(customDoc3));
+            Assert.IsFalse(customDoc2.IsDescendantOrSelf(customDoc4));
 
             Assert.IsTrue(customDoc3.IsDescendantOrSelf(customDoc3));
         }

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -860,7 +860,7 @@ namespace Umbraco.Web
 
         public static bool IsDescendant(this IPublishedContent content, IPublishedContent other)
         {
-            return other.Level < content.Level && content.Path.InvariantStartsWith(other.Path);
+            return other.Level < content.Level && content.Path.InvariantStartsWith(other.Path.EnsureEndsWith(','));
         }
 
         public static HtmlString IsDescendant(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
@@ -875,7 +875,7 @@ namespace Umbraco.Web
 
         public static bool IsDescendantOrSelf(this IPublishedContent content, IPublishedContent other)
         {
-            return content.Path.InvariantStartsWith(other.Path);
+            return content.Path.InvariantEquals(other.Path) || content.IsDescendant(other);
         }
 
         public static HtmlString IsDescendantOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
@@ -890,8 +890,7 @@ namespace Umbraco.Web
 
         public static bool IsAncestor(this IPublishedContent content, IPublishedContent other)
         {
-            // avoid using Descendants(), or Ancestors(), they're expensive
-            return content.Level < other.Level && other.Path.InvariantStartsWith(content.Path);
+            return content.Level < other.Level && other.Path.InvariantStartsWith(content.Path.EnsureEndsWith(','));
         }
 
         public static HtmlString IsAncestor(this IPublishedContent content, IPublishedContent other, string valueIfTrue)
@@ -906,8 +905,7 @@ namespace Umbraco.Web
 
         public static bool IsAncestorOrSelf(this IPublishedContent content, IPublishedContent other)
         {
-            // avoid using DescendantsOrSelf() or AncestorsOrSelf(), they're expensive
-            return other.Path.InvariantStartsWith(content.Path);
+            return other.Path.InvariantEquals(content.Path) || content.IsAncestor(other);
         }
 
         public static HtmlString IsAncestorOrSelf(this IPublishedContent content, IPublishedContent other, string valueIfTrue)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-10561

### Description

It turns out that the refactored `IsAncestor`/`IsDescendant` extension methods in PR #2768 had a bug, (see commit here: https://github.com/umbraco/Umbraco-CMS/pull/2253#issuecomment-405751083 for details)

This PR resolves that bug and expands the PublishedContent unit-tests.
_I'd have preferred not to update the other unit-test values, but I couldn't see another way around it._

