### PR TITLE
Updating #2742 - U4 6946 - Existing template file is overwritten when creating a new template in the backoffice 

### DIFF
--- a/src/Umbraco.Core/Services/FileService.cs
+++ b/src/Umbraco.Core/Services/FileService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Umbraco.Core.Events;
 using Umbraco.Core.IO;
@@ -1108,9 +1109,15 @@ namespace Umbraco.Core.Services
                 return string.Empty;
             }
 
-            using (var view = new StreamReader(System.IO.File.OpenRead(viewAttempt.Result)))
+            using (var uow = UowProvider.GetUnitOfWork())
             {
-                return view.ReadToEnd().Trim();
+                var repository = RepositoryFactory.CreateTemplateRepository(uow);
+                var stream = repository.GetFileContentStream(viewAttempt.Result);
+
+                using (var reader = new StreamReader(stream, Encoding.UTF8, true))
+                {
+                    return reader.ReadToEnd().Trim();
+                }
             }
         }
 

--- a/src/Umbraco.Core/Services/IFileService.cs
+++ b/src/Umbraco.Core/Services/IFileService.cs
@@ -427,12 +427,5 @@ namespace Umbraco.Core.Services
         /// <param name="filepath">The filesystem path to the partial view.</param>
         /// <returns>The size of the partial view.</returns>
         long GetPartialViewFileSize(string filepath);
-
-        /// <summary>
-        /// Gets the content of a view.
-        /// </summary>
-        /// <param name="filename">The name of the view.</param>
-        /// <returns></returns>
-        string GetViewContent(string filename);
     }
 }

--- a/src/Umbraco.Web/Editors/TemplateController.cs
+++ b/src/Umbraco.Web/Editors/TemplateController.cs
@@ -176,14 +176,6 @@ namespace Umbraco.Web.Editors
             else
             {
                 //create
-
-                // file might already be on disk, if so grab the content to avoid overwriting
-                string content = Services.FileService.GetViewContent(display.Alias);
-                if (string.IsNullOrEmpty(content) == false)
-                {
-                    display.Content = content;
-                }
-
                 ITemplate master = null;
                 if (string.IsNullOrEmpty(display.MasterTemplateAlias) == false)
                 {
@@ -193,7 +185,6 @@ namespace Umbraco.Web.Editors
                 }
 
                 var template = Services.FileService.CreateTemplateWithIdentity(display.Name, display.Content, master);
-                //template = Services.FileService.GetTemplate(template.Id);
                 Mapper.Map(template, display);
             }
 


### PR DESCRIPTION
After feedback from @Shazwazza on #2742 have revised where the logic lives - moved into service method rather than modifying the file service interface. Means no new public method on the interface, one less interface method and no changes to templatecontroller, all good things.

@nul800sebastiaan looping you in on the new pr
