### PR TITLE
U4-11528 Problem with length of culture in database

### DIFF
--- a/src/Umbraco.Core/Models/Rdbms/LanguageDto.cs
+++ b/src/Umbraco.Core/Models/Rdbms/LanguageDto.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Core.Models.Rdbms
         [Column("languageISOCode")]
         [Index(IndexTypes.UniqueNonClustered)]
         [NullSetting(NullSetting = NullSettings.Null)]
-        [Length(10)]
+        [Length(14)]
         public string IsoCode { get; set; }
 
         [Column("languageCultureName")]

--- a/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenTwelveZero/IncreaseLanguageIsoCodeColumnLength.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenTwelveZero/IncreaseLanguageIsoCodeColumnLength.cs
@@ -1,0 +1,26 @@
+﻿using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenTwelveZero
+{
+    [Migration("7.12.0", 2, Constants.System.UmbracoMigrationName)]
+    public class IncreaseLanguageIsoCodeColumnLength : MigrationBase
+    {
+        public IncreaseLanguageIsoCodeColumnLength(ISqlSyntaxProvider sqlSyntax, ILogger logger)
+            : base(sqlSyntax, logger)
+        {
+        }
+
+        public override void Up()
+        {
+            Alter.Table("umbracoLanguage")
+                .AlterColumn("languageISOCode")
+                .AsString(14)
+                .Nullable();
+        }
+
+        public override void Down()
+        {
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -636,6 +636,7 @@
     <Compile Include="Media\Exif\TIFFStrip.cs" />
     <Compile Include="Media\Exif\Utility.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenThreeOne\UpdateUserLanguagesToIsoCode.cs" />
+    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\IncreaseLanguageIsoCodeColumnLength.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\UpdateUmbracoConsent.cs" />
     <Compile Include="Persistence\PocoDataDataReader.cs" />
     <Compile Include="Persistence\Querying\CachedExpression.cs" />


### PR DESCRIPTION
### Issue
http://issues.umbraco.org/issue/U4-11528

### Description
There's a problem with the culture "Valencian (Spain) [ca-ES-valencia]". The length of its languageISOCode is 14 characters (ca-ES-valencia) and the maximum length available in database is 10 (nvarchar(10)). I think this is an error because this culture is allowed in the language selection of the Umbraco backoffice and this culture is supported here: https://msdn.microsoft.com/en-us/library/hh441729.aspx



<!-- Thanks for contributing to Umbraco CMS! -->
