### PR TITLE
Implementing new colour picker for document types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
@@ -1,0 +1,61 @@
+﻿
+/**
+@ngdoc directive
+@name umbraco.directives.directive:umbColorSwatches
+@restrict E
+@scope
+@description
+Use this directive to generate color swatches to pick from.
+<h3>Markup example</h3>
+<pre>
+    <umb-color-swatches
+        colors="colors"
+        selected-color="color"
+        size="s">
+    </umb-color-swatches>
+</pre>
+@param {array} colors (<code>attribute</code>): The array of colors.
+@param {string} colors (<code>attribute</code>): The array of colors.
+@param {string} selectedColor (<code>attribute</code>): The selected color.
+@param {string} size (<code>attribute</code>): The size (s, m).
+@param {function} onSelect (<code>expression</code>): Callback function when the item is selected.
+**/
+
+(function () {
+    'use strict';
+
+    function ColorSwatchesDirective() {
+
+        function link(scope, el, attr, ctrl) {
+
+            scope.setColor = function (color) {
+                //scope.selectedColor({color: color });
+                scope.selectedColor = color;
+
+                if (scope.onSelect) {
+                    scope.onSelect(color);
+                }
+            };
+        }
+
+        var directive = {
+            restrict: 'E',
+            replace: true,
+            transclude: true,
+            templateUrl: 'views/components/umb-color-swatches.html',
+            scope: {
+                colors: '=?',
+                size: '@',
+                selectedColor: '=',
+                onSelect: '&'
+            },
+            link: link
+        };
+
+        return directive;
+
+    }
+
+    angular.module('umbraco.directives').directive('umbColorSwatches', ColorSwatchesDirective);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -114,6 +114,7 @@
 @import "components/umb-grid.less";
 @import "components/umb-empty-state.less";
 @import "components/umb-property-editor.less";
+@import "components/umb-color-swatches.less";
 @import "components/umb-iconpicker.less";
 @import "components/umb-insert-code-box.less";
 @import "components/umb-packages.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
@@ -1,0 +1,61 @@
+﻿.umb-color-swatches {
+
+    .umb-color-box {
+        border: none;
+        color: white;
+        cursor: pointer;
+        padding: 5px;
+        text-align: center;
+        text-decoration: none;
+        display: inline-block;
+        margin: 5px;
+        border-radius: 3px;
+        width: 30px;
+        height: 30px;
+        transition: box-shadow .3s;
+
+        &:hover, &:focus {
+            box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+        }
+
+        .check_circle {
+            display: none;
+            visibility: hidden;
+            width: 20px;
+            height: 20px;
+            margin: 0 auto;
+
+            .icon {
+                font-size: 1em;
+                display: flex;
+                width: 100%;
+                height: 100%;
+                align-items: center;
+                justify-content: center;
+                border-radius: 50%;
+                background-color: rgba(0,0,0,.15);
+                float: left;
+            }
+        }
+
+        &.active {
+            .check_circle {
+                display: flex;
+                visibility: visible;
+            }
+        }
+
+        &.umb-color-box--s {
+        }
+
+        &.umb-color-box--m {
+            width: 40px;
+            height: 40px;
+
+            .check_circle {
+                width: 25px;
+                height: 25px;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
@@ -40,3 +40,39 @@
 .umb-iconpicker-item i {
     font-size: 30px;
 }
+
+
+// Color swatch
+ .button {
+        border: none;
+        color: white;
+        padding: 5px;
+        text-align: center;
+        text-decoration: none;
+        display: inline-block;
+        margin: 5px;
+        border-radius: 3px;
+    }
+ 
+  
+    .check_circle{
+        width: 20px;
+        height: 20px;
+       
+    }
+ 
+    // Hide Circle when not active
+    i.small{
+    display: none;
+    }
+ 
+    // Circle behind the checkmark
+    i.small.active{
+    font-size: 14px;
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background-color: rgba(0,0,0,.15);
+    float: right;
+    }

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -10,26 +10,30 @@
 // Grays
 // -------------------------
 @black:                 #000;
-@blackLight:			#1d1d1d;
+@blackLight:			#1D1D1D;
 @grayDarker:            #222;
 @grayDark:              #343434;
 @gray:                  #555;
-@grayMed:               #7f7f7f;
-@grayLight:             #d9d9d9;
-@grayLighter:           #f8f8f8;
-@white:                 #fff;
-
+@grayMed:               #7F7F7F;
+@blueGrey:              #607D8B;
+@grayLight:             #D9D9D9;
+@grayLighter:           #F8F8F8;
+@white:                 #FFF;
+@grayIcon:              #9E9E9E;
 
 // Accent colors
 // -------------------------
-@blue:                  #2e8aea;
-@blueDark:              #0064cd;
-@blueLight:             #add8e6;
-@green:                 #46a546;
-@red:                   #9d261d;
-@yellow:                #ffc40d;
+
+
+
+@blue:                  #2E8AEA;
+@blueDark:              #0064CD;
+@blueLight:             #ADD8E6;
+@green:                 #46A546;
+@red:                   #9D261D;
+@yellow:                #FFC40D;
 @orange:                #DF7F48;
-@pink:                  #c3325f;
+@pink:                  #C3325F;
 
 
 // Colors
@@ -86,6 +90,28 @@
 @gray-10:               #F3F3F5;
 
 
+// Additional Icon Colours
+@brownIcon:             #795548;
+@blueIcon:              #2196F3;
+@lightBlueIcon:         #03A9F4;
+@cyanIcon:              #00BCD4;
+@greenIcon:             #4CAF50;
+@lightGreenIcon:        #8BC34A;
+@limeIcon:              #CDDC39;
+@yellowIcon:            #FFEB3b;
+@amberIcon:             #FFC107;
+@orangeIcon:            #FF9800;
+@deepOrangeIcon:        #FF5722;
+@redIcon:               #F44336;
+@pinkIcon:              #E91E63;
+@purpleIcon:            #9C27B0;
+@deepPurpleIcon:        #673AB7;
+@indigoIcon:            #3F51B5;
+
+
+
+
+
 .red{color: @red;}
 .blue{color: @blue;}
 .black{color: @black;}
@@ -96,30 +122,70 @@
 //icon colors for tree icons
 .color-red, .color-red i{color: @red-d1 !important;}
 .color-blue, .color-blue i{color: @turquoise-d1 !important;}
-.color-orange, .color-orange i{color: #d9631e !important;}
+.color-orange, .color-orange i{color: @orange !important;}
 .color-green, .color-green i{color: @green-d1 !important;}
 .color-yellow, .color-yellow i{color: @yellow-d1 !important;}
 
 /* Colors based on http://zavoloklom.github.io/material-design-color-palette/colors.html */
-.color-black, .color-black i { color: #000 !important; }
-.color-blue-grey, .color-blue-grey i { color: #607d8b !important; }
-.color-grey, .color-grey i { color: #9e9e9e !important; }
-.color-brown, .color-brown i { color: #795548 !important; }
-.color-blue, .color-blue i { color: #2196f3 !important; }
-.color-light-blue, .color-light-blue i {color: #03a9f4 !important; }
-.color-cyan, .color-cyan i { color: #00bcd4 !important; }
-.color-green, .color-green i { color: #4caf50 !important; }
-.color-light-green, .color-light-green i {color: #8bc34a !important; }
-.color-lime, .color-lime i { color: #cddc39 !important; }
-.color-yellow, .color-yellow i { color: #ffeb3b !important; }
-.color-amber, .color-amber i { color: #ffc107 !important; }
-.color-orange, .color-orange i { color: #ff9800 !important; }
-.color-deep-orange, .color-deep-orange i { color: #ff5722 !important; }
-.color-red, .color-red i { color: #f44336 !important; }
-.color-pink, .color-pink i { color: #e91e63 !important; }
-.color-purple,.color-purple i { color: #9c27b0 !important; }
-.color-deep-purple, .color-deep-purple i { color: #673ab7 !important; }
-.color-indigo, .color-indigo i { color: #3f51b5 !important; }
+.btn-color-black {background-color: @black;}
+.color-black i { color: @black;}
+
+
+.btn-color-blue-grey {background-color: @blueGrey;}
+.color-blue-grey i { color: @blueGrey; }
+
+
+.btn-color-grey{background-color: @grayIcon;}
+.color-grey i { color: @grayIcon; }
+
+
+.btn-color-brown{background-color: @brownIcon;}
+.color-brown i { color: @brownIcon; }
+
+.btn-color-blue{background-color: @blueIcon;}
+.color-blue i { color: @blueIcon; }
+
+.btn-color-light-blue{background-color: @lightBlueIcon;}
+.color-light-blue i {color: @lightBlueIcon;}
+
+.btn-color-cyan{background-color: @cyanIcon;}
+.color-cyan i { color: @cyanIcon; }
+
+.btn-color-green{background-color: @greenIcon;}
+.color-green i { color: @greenIcon }
+
+.btn-color-light-green{background-color: @lightGreenIcon;}
+.color-light-green i {color: @lightGreenIcon; }
+
+.btn-color-lime{background-color: @limeIcon;}
+.color-lime i { color: @limeIcon; }
+
+.btn-color-yellow{background-color: @yellowIcon;}
+.color-yellow i { color: @yellowIcon; }
+
+.btn-color-amber{background-color: @amberIcon;}
+.color-amber i { color: @amberIcon; }
+
+.btn-color-orange{background-color: @orangeIcon;}
+.color-orange i { color: @orangeIcon; }
+
+.btn-color-deep-orange{background-color: @deepOrangeIcon;}
+.color-deep-orange i { color: @deepOrangeIcon; }
+
+.btn-color-red{background-color: @redIcon;}
+.color-red i { color: @redIcon; }
+
+.btn-color-pink{background-color: @pinkIcon;}
+.color-pink i { color: @pinkIcon; }
+
+.btn-color-purple{background-color: @purpleIcon;}
+.color-purple i { color: @purpleIcon; }
+
+.btn-color-deep-purple{background-color: @deepPurpleIcon;}
+.color-deep-purple i { color: @deepPurpleIcon; }
+
+.btn-color-indigo{background-color: @indigoIcon;}
+.color-indigo i { color: @indigoIcon; }
 
 
 

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -98,7 +98,7 @@
 @greenIcon:             #4CAF50;
 @lightGreenIcon:        #8BC34A;
 @limeIcon:              #CDDC39;
-@yellowIcon:            #FFEB3b;
+@yellowIcon:            #FFEB3B;
 @amberIcon:             #FFC107;
 @orangeIcon:            #FF9800;
 @deepOrangeIcon:        #FF5722;
@@ -124,7 +124,7 @@
 .color-blue, .color-blue i{color: @turquoise-d1 !important;}
 .color-orange, .color-orange i{color: @orange !important;}
 .color-green, .color-green i{color: @green-d1 !important;}
-.color-yellow, .color-yellow i{color: @yellow-d1 !important;}
+.color-yellow, .color-yellow i{color: @yellowIcon !important;}
 
 /* Colors based on http://zavoloklom.github.io/material-design-color-palette/colors.html */
 .btn-color-black {background-color: @black;}

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -122,6 +122,7 @@
 .color-indigo, .color-indigo i { color: #3f51b5 !important; }
 
 
+
 // Scaffolding
 // -------------------------
 @bodyBackground:        @white;

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
@@ -8,49 +8,38 @@
  */
 function IconPickerOverlay($scope, iconHelper, localizationService) {
 
-   $scope.loading = true;
-   $scope.model.hideSubmitButton = false;
+    $scope.loading = true;
+    $scope.model.hideSubmitButton = false;
 
     $scope.colors = [
-        {name:'Black',value:'color-black'},
-        {name:'Blue Grey',value:'color-blue-grey'},
-        {name:'Grey',value:'color-grey'},
-        {name:'Brown',value:'color-brown'},
-        {name:'Blue',value:'color-blue'},
-        {name:'Light Blue',value:'color-light-blue'},
-        {name: 'Indigo',value:'color-indigo'},
-        {name: 'Purple',value:'color-purple' },
-        {name: 'Deep Purple',value:'color-deep-purple' },
-        {name: 'Cyan',value:'color-cyan' },
-        {name: 'Green',value:'color-green' },
-        {name: 'Light Green',value:'color-light-green' },
-        {name: 'Lime',value:'color-lime' },
-        {name: 'Yellow',value:'color-yellow' },
-        {name: 'Amber',value:'color-amber' },
-        {name: 'Orange',value:'color-orange' },
-        {name: 'Deep Orange',value:'color-deep-orange' },
-        {name: 'Red',value:'color-red' },
-        {name: 'Pink',value:'color-pink' }       
-    ]
-  
+        { name: "Black", value: "color-black" },
+        { name: "Blue Grey", value: "color-blue-grey" },
+        { name: "Grey", value: "color-grey" },
+        { name: "Brown", value: "color-brown" },
+        { name: "Blue", value: "color-blue" },
+        { name: "Light Blue", value: "color-light-blue" },
+        { name: "Indigo", value: "color-indigo" },
+        { name: "Purple", value: "color-purple" },
+        { name: "Deep Purple", value: "color-deep-purple" },
+        { name: "Cyan", value: "color-cyan" },
+        { name: "Green", value: "color-green" },
+        { name: "Light Green", value: "color-light-green" },
+        { name: "Lime", value: "color-lime" },
+        { name: "Yellow", value: "color-yellow" },
+        { name: "Amber", value: "color-amber" },
+        { name: "Orange", value: "color-orange" },
+        { name: "Deep Orange", value: "color-deep-orange" },
+        { name: "Red", value: "color-red" },
+        { name: "Pink", value: "color-pink" }
+    ];
 
     if (!$scope.color) {
         // Set default selected color to black
         $scope.color = $scope.colors[0].value;
     };
 
-
-
     if (!$scope.model.title) {
-        
         $scope.model.title = localizationService.localize("defaultdialogs_selectIcon");
-        
-    };
-
-
-
-    $scope.setColor = function (color) {
-        $scope.color = color;
     };
 
     if ($scope.model.color) {
@@ -61,20 +50,29 @@ function IconPickerOverlay($scope, iconHelper, localizationService) {
         $scope.icon = $scope.model.icon;
     };
 
-   iconHelper.getIcons().then(function(icons) {
-      $scope.icons = icons;
-      $scope.loading = false;
-   });
+    iconHelper.getIcons().then(function (icons) {
+        $scope.icons = icons;
+        $scope.loading = false;
+    });
 
-   $scope.selectIcon = function(icon, color) {
-       $scope.model.icon = icon;
-       $scope.model.color = color;
-       $scope.submitForm($scope.model);
-   };
-
-    $scope.changeColor = function (color) {
+    $scope.selectIcon = function (icon, color) {
+        $scope.model.icon = icon;
         $scope.model.color = color;
+        $scope.submitForm($scope.model);
     };
+
+    var unsubscribe = $scope.$on("formSubmitting",
+        function () {
+            if ($scope.color) {
+                $scope.model.color = $scope.color;
+            }
+        });
+
+    //when the scope is destroyed we need to unsubscribe
+    $scope.$on("$destroy",
+        function () {
+            unsubscribe();
+        });
 }
 
 angular.module("umbraco").controller("Umbraco.Overlays.IconPickerOverlay", IconPickerOverlay);

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
@@ -11,8 +11,46 @@ function IconPickerOverlay($scope, iconHelper, localizationService) {
    $scope.loading = true;
    $scope.model.hideSubmitButton = false;
 
+    $scope.colors = [
+        {name:'Black',value:'color-black'},
+        {name:'Blue Grey',value:'color-blue-grey'},
+        {name:'Grey',value:'color-grey'},
+        {name:'Brown',value:'color-brown'},
+        {name:'Blue',value:'color-blue'},
+        {name:'Light Blue',value:'color-light-blue'},
+        {name: 'Indigo',value:'color-indigo'},
+        {name: 'Purple',value:'color-purple' },
+        {name: 'Deep Purple',value:'color-deep-purple' },
+        {name: 'Cyan',value:'color-cyan' },
+        {name: 'Green',value:'color-green' },
+        {name: 'Light Green',value:'color-light-green' },
+        {name: 'Lime',value:'color-lime' },
+        {name: 'Yellow',value:'color-yellow' },
+        {name: 'Amber',value:'color-amber' },
+        {name: 'Orange',value:'color-orange' },
+        {name: 'Deep Orange',value:'color-deep-orange' },
+        {name: 'Red',value:'color-red' },
+        {name: 'Pink',value:'color-pink' }       
+    ]
+  
+
+    if (!$scope.color) {
+        // Set default selected color to black
+        $scope.color = $scope.colors[0].value;
+    };
+
+
+
     if (!$scope.model.title) {
+        
         $scope.model.title = localizationService.localize("defaultdialogs_selectIcon");
+        
+    };
+
+
+
+    $scope.setColor = function (color) {
+        $scope.color = color;
     };
 
     if ($scope.model.color) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
@@ -17,14 +17,8 @@
     </div>
 
     <div class="umb-control-group">
-        <button ng-repeat="c in colors" class="button btn-{{c.value}}" ng-class="{active: c.value === color}" title="{{c.name}}" ng-click="setColor(c.value)">
-            <div class="check_circle" ng-class="{active:c.value === color}">
-                <i class="icon-check small" ng-class="{active:c.value === color}"></i>
-            </div>
-            
-        </button>
-    </div> 
- 
+        <umb-color-swatches colors="colors" selected-color="color" size="s"></umb-color-swatches>
+    </div>
 
     <umb-load-indicator ng-if="loading"></umb-load-indicator>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
@@ -1,3 +1,5 @@
+
+
 <div ng-controller="Umbraco.Overlays.IconPickerOverlay">
 
     <div class="umb-control-group">
@@ -15,28 +17,14 @@
     </div>
 
     <div class="umb-control-group">
-        <select ng-model="color" ng-change="changeColor(color)" class="input-block-level">
-            <option value=""><localize key="colors_black">Black</localize></option>
-            <option value="color-blue-grey"><localize key="colors_bluegrey">Blue Grey</localize></option>
-            <option value="color-grey"><localize key="colors_grey">Grey</localize></option>
-            <option value="color-brown"><localize key="colors_brown">Brown</localize></option>
-            <option value="color-blue"><localize key="colors_blue">Blue</localize></option>
-            <option value="color-light-blue"><localize key="colors_lightblue">Light Blue</localize></option>
-            <option value="color-cyan"><localize key="colors_cyan">Cyan</localize></option>
-            <option value="color-green"><localize key="colors_green">Green</localize></option>
-            <option value="color-light-green"><localize key="colors_lightgreen">Light Green</localize></option>
-            <option value="color-yellow"><localize key="colors_yellow">Yellow</localize></option>
-            <option value="color-lime"><localize key="colors_lime">Lime</localize></option>
-            <option value="color-amber"><localize key="colors_amber">Amber</localize></option>
-            <option value="color-orange"><localize key="colors_orange">Orange</localize></option>
-            <option value="color-deep-orange"><localize key="colors_deeporange">Deep Orange</localize></option>
-            <option value="color-red"><localize key="colors_red">Red</localize></option>
-            <option value="color-pink"><localize key="colors_pink">Pink</localize></option>
-            <option value="color-purple"><localize key="colors_purple">Purple</localize></option>
-            <option value="color-deep-purple"><localize key="colors_deeppurple">Deep Purple</localize></option>
-            <option value="color-indigo"><localize key="colors_indigo">Indigo</localize></option>
-        </select>
-    </div>
+        <button ng-repeat="c in colors" class="button btn-{{c.value}}" ng-class="{active: c.value === color}" title="{{c.name}}" ng-click="setColor(c.value)">
+            <div class="check_circle" ng-class="{active:c.value === color}">
+                <i class="icon-check small" ng-class="{active:c.value === color}"></i>
+            </div>
+            
+        </button>
+    </div> 
+ 
 
     <umb-load-indicator ng-if="loading"></umb-load-indicator>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -1,0 +1,9 @@
+﻿<div class="umb-color-swatches">
+
+    <button class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{color.name}}" ng-class="{active:color.value === selectedColor}" ng-click="setColor(color.value)">
+        <div class="check_circle">
+            <i class="icon icon-check small"></i>
+        </div>
+    </button>
+
+</div>


### PR DESCRIPTION
Changing the dropdown menu for a colour swatch picker

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description

Remove the dropdown menu of colours from the Document Type icon selector and replace it with a colour swatch option. 

http://issues.umbraco.org/issue/U4-11168


<!-- Thanks for contributing to Umbraco CMS! -->
