### PR TITLE
Use the umbConfirmAction directive when deleting tags

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.controller.js
@@ -5,11 +5,11 @@ angular.module("umbraco")
         var $typeahead;
 
         $scope.isLoading = true;
-        $scope.tagToAdd = "";	
-		
+        $scope.tagToAdd = "";
+
 		function setModelValue(val) {
-			
-			$scope.model.value = val || $scope.model.value;			
+
+			$scope.model.value = val || $scope.model.value;
 			if ($scope.model.value) {
                 if (!$scope.model.config.storageType || $scope.model.config.storageType !== "Json") {
                     //it is csv
@@ -20,9 +20,9 @@ angular.module("umbraco")
                        if($scope.model.value.length > 0) {
 						  // split the csv string, and remove any duplicate values
 						  var tempArray = $scope.model.value.split(',').map(function(v) {
-							 return v.trim(); 
+							 return v.trim();
 						  });
-						   
+
                           $scope.model.value = tempArray.filter(function(v, i, self) {
 							  return self.indexOf(v) === i;
 						  });
@@ -40,7 +40,7 @@ angular.module("umbraco")
             $scope.isLoading = false;
 
             //load current value
-			setModelValue();            
+			setModelValue();
 
             // Method required by the valPropertyValidator directive (returns true if the property editor has at least one tag selected)
             $scope.validateMandatory = function () {
@@ -64,7 +64,7 @@ angular.module("umbraco")
 
             $scope.addTagOnEnter = function (e) {
                 var code = e.keyCode || e.which;
-                if (code == 13) { //Enter keycode   
+                if (code == 13) { //Enter keycode
                     if ($element.find('.tags-' + $scope.model.alias).parent().find(".tt-dropdown-menu .tt-cursor").length === 0) {
                         //this is required, otherwise the html form will attempt to submit.
                         e.preventDefault();
@@ -83,16 +83,37 @@ angular.module("umbraco")
                 $typeahead.typeahead('val', '');
             };
 
-
+            // Set the visible prompt to -1 to ensure it will not be visible
+            $scope.promptIsVisible = "-1";
 
             $scope.removeTag = function (tag) {
                 var i = $scope.model.value.indexOf(tag);
+
                 if (i >= 0) {
+                    // Make sure to hide the prompt so it does not stay open because another item gets a new number in the array index
+                    $scope.promptIsVisible = "-1";
+
+                    // Remove the tag from the index
                     $scope.model.value.splice(i, 1);
+
                     //this is required to re-validate
                     $scope.propertyForm.tagCount.$setViewValue($scope.model.value.length);
                 }
             };
+
+            $scope.showPrompt = function (idx, tag){
+
+                var i = $scope.model.value.indexOf(tag);
+
+                // Make the prompt visible for the clicked tag only
+                if (i === idx) {
+                    $scope.promptIsVisible = i;
+                }
+            }
+
+            $scope.hidePrompt = function(){
+                $scope.promptIsVisible = "-1";
+            }
 
             //vice versa
             $scope.model.onValueChanged = function (newVal, oldVal) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.html
@@ -1,27 +1,35 @@
 <div ng-controller="Umbraco.PropertyEditors.TagsController" class="umb-editor umb-tags">
-   
-     <div ng-if="isLoading">
-        <localize key="loading">Loading</localize>...
-    </div>
 
-    <div ng-if="!isLoading">
+    <div ng-if="isLoading">
+       <localize key="loading">Loading</localize>...
+   </div>
 
-        <input type="hidden" name="tagCount" ng-model="model.value.length" val-property-validator="validateMandatory" />
+   <div ng-if="!isLoading">
 
-        <span ng-repeat="tag in model.value track by $index" ng-click="$parent.removeTag(tag)" class="label label-primary tag">
-            <span ng-bind-html="tag"></span>
-            <i class="icon icon-delete"></i>
-        </span>
+       <input type="hidden" name="tagCount" ng-model="model.value.length" val-property-validator="validateMandatory" />
 
-        <input type="text"
-               id="{{model.alias}}"
-               class="typeahead tags-{{model.alias}}"
-               ng-model="$parent.tagToAdd"
-               ng-keydown="$parent.addTagOnEnter($event)"
-               on-blur="$parent.addTag()"
-               localize="placeholder"
-               placeholder="@placeholders_enterTags" />
+       <span ng-repeat="tag in model.value track by $index" class="label label-primary tag" style="position:relative;">
+           <span ng-bind-html="tag"></span>
 
-    </div>
-    
+               <i class="icon-trash" ng-click="$parent.showPrompt($index, tag)"></i>
+
+               <umb-confirm-action
+                   ng-if="$parent.promptIsVisible === $index"
+                   direction="right"
+                   on-confirm="$parent.removeTag(tag)"
+                   on-cancel="$parent.hidePrompt()">
+               </umb-confirm-action>
+       </span>
+
+       <input type="text"
+              id="{{model.alias}}"
+              class="typeahead tags-{{model.alias}}"
+              ng-model="$parent.tagToAdd"
+              ng-keydown="$parent.addTagOnEnter($event)"
+              on-blur="$parent.addTag()"
+              localize="placeholder"
+              placeholder="@placeholders_enterTags" />
+
+   </div>
+
 </div>


### PR DESCRIPTION
… - Still some styling to sort out

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11535

### Description
Instead of deleting a tag once it's being clicked then let's make use of the umbConfirmAction directive so the tag does not disappear immediately if it was clicked by mistake. This also make the UI make use of the "Are you sure you want to do this?" convention.

OBS: It's still a little work in progress! I'll add a comment when I think it's ready for review :)
