### PR TITLE
Minor update to the grid settings/style section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
@@ -2,7 +2,7 @@
     <div style="max-width: 600px">
         <div class="control-group uSky-templates">
 
-            <h4><localize key="grid_gridLayouts"/></h4>
+            <h4><localize key="grid_gridLayouts" /></h4>
             <p><localize key="grid_gridLayoutsDetail" /></p>
 
             <ul class="unstyled"
@@ -38,7 +38,7 @@
             <button class="btn btn-small"
                     prevent-default
                     ng-click="configureTemplate()">
-                    <i class="icon-add"></i> <localize key="grid_addGridLayout" />
+                <i class="icon-add"></i> <localize key="grid_addGridLayout" />
             </button>
         </div>
     </div>
@@ -57,13 +57,13 @@
                     <li ng-repeat="layout in model.value.layouts" class="clearfix">
 
                         <div ng-click="configureLayout(layout)"
-                            class="preview-rows columns" style="margin-top: 5px; margin-bottom: 25px; float:left">
+                             class="preview-rows columns" style="margin-top: 5px; margin-bottom: 25px; float:left">
 
                             <div class="preview-row">
                                 <div class="preview-col"
-                                    ng-class="{last:$last}"
-                                    ng-repeat="area in layout.areas | filter:zeroWidthFilter"
-                                    ng-style="{width: percentage(area.grid) + '%', 'max-width': '100%'}">
+                                     ng-class="{last:$last}"
+                                     ng-repeat="area in layout.areas | filter:zeroWidthFilter"
+                                     ng-style="{width: percentage(area.grid) + '%', 'max-width': '100%'}">
 
                                     <div class="preview-cell">
                                         <p style="font-size: 6px; line-height: 8px; text-align: center" ng-show="area.maxItems > 0">{{area.maxItems}}</p>
@@ -95,15 +95,13 @@
 
     <div style="max-width: 600px">
 
-        <umb-control-group
-            label="@grid_columns"
-            description="@grid_columnsDetails">
-                <input type="number" min="1" ng-model="model.value.columns" />
+        <umb-control-group label="@grid_columns"
+                           description="@grid_columnsDetails">
+            <input type="number" min="1" ng-model="model.value.columns" />
         </umb-control-group>
 
-        <umb-control-group
-            label="@grid_settings"
-            description="@grid_settingsDetails">
+        <umb-control-group label="@grid_settings"
+                           description="@grid_settingsDetails">
 
             <ul class="unstyled list-icons umb-contentpicker"
                 ui-sortable
@@ -113,16 +111,15 @@
                     <i class="icon icon-navigation handle"></i>
 
                     <a href="#" prevent-default ng-click="removeConfigValue(model.value.config, $index)">
-                        <i class="icon icon-delete red hover-show"></i>
-                        <i class="icon-settings-alt-2 hover-hide"></i>
                         {{configValue.label}}
+                        <i class="icon icon-delete red hover-show"></i>
                     </a>
                 </li>
             </ul>
 
             <ul class="unstyled list-icons">
                 <li>
-                    <i class="icon icon-add turquoise"></i>
+                    <i class="icon icon-settings-alt-2 turquoise"></i>
 
                     <a href="#" ng-click="editConfig()" prevent-default>
                         <localize key="general_edit" />
@@ -133,9 +130,8 @@
 
 
 
-        <umb-control-group
-            label="@grid_styles"
-            description="@grid_stylesDetails">
+        <umb-control-group label="@grid_styles"
+                           description="@grid_stylesDetails">
 
             <ul class="unstyled list-icons umb-contentpicker"
                 ui-sortable
@@ -145,9 +141,8 @@
                     <i class="icon icon-navigation handle"></i>
 
                     <a href="#" prevent-default ng-click="removeConfigValue(model.value.styles, $index)">
-                        <i class="icon icon-delete red hover-show"></i>
-                        <i class="icon-brush hover-hide"></i>
                         {{style.label}}
+                        <i class="icon icon-delete red hover-show"></i>
                     </a>
 
                 </li>
@@ -155,7 +150,7 @@
 
             <ul class="unstyled list-icons">
                 <li>
-                    <i class="icon icon-add turquoise"></i>
+                    <i class="icon icon-brush turquoise"></i>
                     <a href="#" ng-click="editStyles()" prevent-default>
                         <localize key="general_edit" />
                     </a>
@@ -164,32 +159,28 @@
         </umb-control-group>
     </div>
 
-    <umb-overlay
-      ng-if="layoutConfigOverlay.show"
-      model="layoutConfigOverlay"
-      view="layoutConfigOverlay.view"
-      position="right">
+    <umb-overlay ng-if="layoutConfigOverlay.show"
+                 model="layoutConfigOverlay"
+                 view="layoutConfigOverlay.view"
+                 position="right">
     </umb-overlay>
 
-    <umb-overlay
-      ng-if="rowConfigOverlay.show"
-      model="rowConfigOverlay"
-      view="rowConfigOverlay.view"
-      position="right">
+    <umb-overlay ng-if="rowConfigOverlay.show"
+                 model="rowConfigOverlay"
+                 view="rowConfigOverlay.view"
+                 position="right">
     </umb-overlay>
 
-    <umb-overlay
-      ng-if="editConfigCollectionOverlay.show"
-      model="editConfigCollectionOverlay"
-      view="editConfigCollectionOverlay.view"
-      position="right">
+    <umb-overlay ng-if="editConfigCollectionOverlay.show"
+                 model="editConfigCollectionOverlay"
+                 view="editConfigCollectionOverlay.view"
+                 position="right">
     </umb-overlay>
 
-    <umb-overlay
-      ng-if="rowDeleteOverlay.show"
-      model="rowDeleteOverlay"
-      view="rowDeleteOverlay.view"
-      position="right">
+    <umb-overlay ng-if="rowDeleteOverlay.show"
+                 model="rowDeleteOverlay"
+                 view="rowDeleteOverlay.view"
+                 position="right">
     </umb-overlay>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
@@ -111,8 +111,8 @@
                     <i class="icon icon-navigation handle"></i>
 
                     <a href="#" prevent-default ng-click="removeConfigValue(model.value.config, $index)">
+                        <i class="icon icon-delete red"></i>
                         {{configValue.label}}
-                        <i class="icon icon-delete red hover-show"></i>
                     </a>
                 </li>
             </ul>
@@ -129,7 +129,6 @@
         </umb-control-group>
 
 
-
         <umb-control-group label="@grid_styles"
                            description="@grid_stylesDetails">
 
@@ -141,8 +140,8 @@
                     <i class="icon icon-navigation handle"></i>
 
                     <a href="#" prevent-default ng-click="removeConfigValue(model.value.styles, $index)">
+                        <i class="icon icon-delete red"></i>
                         {{style.label}}
-                        <i class="icon icon-delete red hover-show"></i>
                     </a>
 
                 </li>
@@ -150,7 +149,7 @@
 
             <ul class="unstyled list-icons">
                 <li>
-                    <i class="icon icon-brush turquoise"></i>
+                    <i class="icon icon-settings-alt-2 turquoise"></i>
                     <a href="#" ng-click="editStyles()" prevent-default>
                         <localize key="general_edit" />
                     </a>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description

The current UI for the grid settings/styles section is the following:

![untitled](https://user-images.githubusercontent.com/10199821/43315492-686b3b66-9196-11e8-85de-757fc7efc4a8.png)

When the mouse is not hover a setting, a cog appears meaning that we can edit this settings. However, when clicking on it, a delete icon appears. At that time, it's unclear if clicking on the link (not the icon) will edit or delete the the setting and it's very frustrating when the later occurs.

Moreover, the "add" icon next to the "edit" link seems to indicate that it's possible to add a new style while it actually allows to edit the whole configuration.

The same applies for the styles section. I propose the following UI;

![untitled2](https://user-images.githubusercontent.com/10199821/43315497-6e0294de-9196-11e8-8ed4-e29332246d76.png)

This way, it's very clear that clicking on the setting will delete it. Moreover, it's also clear than clicking on the "Edit" link will edit the whole configuration and not add one.