### PR TITLE
In build.ps1, use .Path if .Source returns nothing

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -62,6 +62,7 @@
     $global:node_path = $env:path
     $nodePath = $this.BuildEnv.NodePath
     $gitExe = (Get-Command git).Source
+    if (-not $gitExe) { $gitExe = (Get-Command git).Path }
     $gitPath = [System.IO.Path]::GetDirectoryName($gitExe)
     $env:path = "$nodePath;$gitPath"
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
When building the Umbraco source, the front-end build task failed, so when the browser loads the installer page there's no CSS/JS etc!  This is because, for me, the powershell line in build.ps1:

$gitExe = (Get-Command git).Source

returns nothing.  Whereas .Path returns the pathway to the git exe.
I've had a few people confirm in their powershell that .Source and .Path return the same thing.

Thus my suggestion of adding an extra line to build.ps1 that, if .Source returned nothing, try using .Path.

If this is acceptable then I could do on the dev-v7 branch as the same problem occurs there for me.