### PR TITLE
U4-11537 - Add title attributes to the umbConfirmAction directive's "buttons"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
@@ -6,11 +6,11 @@
      '-left': direction === 'left'}"
      on-outside-click="clickCancel()">
 
-        <a class="umb_confirm-action__overlay-action -confirm" href="" ng-click="clickConfirm()">
+        <a class="umb_confirm-action__overlay-action -confirm" href="" ng-click="clickConfirm()" localize="title" title="@buttons_confirmActionConfirm">
             <i class="icon-check"></i>
         </a>
 
-        <a class="umb_confirm-action__overlay-action -cancel" href="" ng-click="clickCancel()">
+        <a class="umb_confirm-action__overlay-action -cancel" href="" ng-click="clickCancel()" localize="title" title="@buttons_confirmActionCancel">
             <i class="icon-delete"></i>
         </a>
 </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -133,6 +133,8 @@
     <key alias="undo">Fortryd</key>
     <key alias="redo">Genskab</key>
     <key alias="deleteTag">Slet tag</key>
+    <key alias="confirmActionCancel">Fortryd</key>
+    <key alias="confirmActionConfirm">Bekræft</key>
   </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">For</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -139,6 +139,8 @@
         <key alias="undo">Undo</key>
         <key alias="redo">Redo</key>
         <key alias="deleteTag">Delete tag</key>
+        <key alias="confirmActionCancel">Cancel</key>
+        <key alias="confirmActionConfirm">Confirm</key>
     </area>
     <area alias="auditTrails">
         <key alias="atViewingFor">Viewing for</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -139,6 +139,8 @@
         <key alias="undo">Undo</key>
         <key alias="redo">Redo</key>
         <key alias="deleteTag">Delete tag</key>
+        <key alias="confirmActionCancel">Cancel</key>
+        <key alias="confirmActionConfirm">Confirm</key>
     </area>
     <area alias="auditTrails">
         <key alias="atViewingFor">Viewing for</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11537

### Description
When hovering over the "Two" buttons in the directive it would be nice to get a little hint about what each of the buttons do.