### PR TITLE
U4-11538 Color picker thumbnail is to wide

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -138,6 +138,11 @@ ul.color-picker li {
   margin: 3px;
   border: 2px solid transparent;
   width: 60px;
+
+  .thumbnail{
+      min-width: auto;
+      width: inherit;
+  }
 }
 ul.color-picker li.active {
   border: 2px dashed @gray-8;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -141,7 +141,8 @@ ul.color-picker li {
 
   .thumbnail{
       min-width: auto;
-      width: inherit;
+      width: 58px;
+      padding: 0;
   }
 }
 ul.color-picker li.active {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11538 

### Description
I think that when introducing the option to sort the color prevalues some classnames where refactored, which means the thumbnails get to wide. This PR fixes this by making sure the .thumbnail inherits the width from the parent li.
