### PR TITLE
Update v8_getting_started.md after v8 hackathon

### DIFF
--- a/docs/V8_GETTING_STARTED.md
+++ b/docs/V8_GETTING_STARTED.md
@@ -5,15 +5,15 @@
 * [Visual Studio 2017 Community (Free)](https://www.visualstudio.com/vs/community/), or Professional, Enterprise, etc... _(**Minimum of Version 15.7** or higher, this is important, you WILL get issues with lesser versions)_
 * .NET Framework 4.7.2 installed, get it here: https://www.microsoft.com/net/download/thank-you/net472?survey=false
 * .NET Framework 4.7.2 developer pack, get it here: https://www.microsoft.com/net/download/thank-you/net472-developer-pack _(be sure this is the ENU file which will be named `NDP472-DevPack-ENU.exe`)_
-* Clone the Umbraco repository and ensure you have the `temp8` branch checked out
+* Clone the Umbraco repository using the `temp8` branch. If your git client doesn't support specifying the branch as you clone then use the command `git clone --single-branch -b temp8 <your fork url>`. _(If you clone the repo using the default v7 branch and then checkout the `temp8` branch you **might** get problems)_
 
 ### Start the solution
 
 * Open the `/src/umbraco.sln` Visual Studio solution
 * Start the solution (easiest way is to use `ctrl + F5`)
-  * When the solution is first built this may take some time since it will restore all nuget, npm and bower packages, build the .net solution and also build the angular solution.
+* When the solution is first built this may take some time since it will restore all nuget, npm and bower packages, build the .net solution and also build the angular solution
 * When the website starts you'll see the Umbraco installer and just follow the prompts
-* Your all set!
+* You're all set!
 
 ### Want to run from a zip instead?
 
@@ -26,7 +26,8 @@ We recommend running the site with the Visual Studio since you'll be able to rem
 * _[The process for making code changes in v8 is the same as v7](https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/docs/CONTRIBUTING.md)_
 * Any .NET changes you make you just need to compile
 * Any Angular/JS changes you make you will need to make sure you are running the Gulp build. Easiest way to do this is from within Visual Studio in the `Task Runner Explorer`. You can find this window by pressing `ctrl + q` and typing in `Task Runner Explorer`. In this window you'll see all Gulp tasks, double click on the `dev` task, this will compile the angular solution and start a file watcher, then any html/js changes you make are automatically built.  
-  * When making js changes, you should have the chrome developer tools open to ensure that cache is disabled
+* When making js changes, you should have the chrome developer tools open to ensure that cache is disabled
+* If you are only making C# changes and are not touching the UI code at all, you can significantly speed up the VS build by adding an empty file specifically called `~/src/preserve.belle`. The UI (Belle) build will then be skipped during a Rebuild.
 
 ### What to work on?
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
- Recommendation that people clone the temp8 branch directly rather than cloning v7 then checking out temp8 branch.  Doing the latter left some legacy files that caused people problems
- Pointing out how to significantly speed up the build if only doing C# changes by creating a preserve.belle file