### PR TITLE
Insert Value on Template Editor now uses Model.Value [v8hackaton]

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/insertfield/insertfield.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/insertfield/insertfield.controller.js
@@ -118,20 +118,26 @@
 
         function generateOutputSample() {
 
-            var pageField = (vm.field !== undefined ? '@Umbraco.Field("' + vm.field + '"' : "")
-                + (vm.altField !== undefined ? ', altFieldAlias:"' + vm.altField + '"' : "")
-                + (vm.altText !== undefined ? ', altText:"' + vm.altText + '"' : "")
-                + (vm.insertBefore !== undefined ? ', insertBefore:"' + vm.insertBefore + '"' : "")
-                + (vm.insertAfter !== undefined ? ', insertAfter:"' + vm.insertAfter + '"' : "")
-                + (vm.recursive !== false ? ', recursive: ' + vm.recursive : "")
-                + (vm.date !== false ? ', formatAsDate: ' + vm.date : "")
-                + (vm.dateTime !== false ? ', formatAsDateWithTimeSeparator:"' + vm.dateTimeSeparator + '"' : "")
-                + (vm.casingUpper !== false ? ', casing: ' + "RenderFieldCaseType.Upper" : "")
-                + (vm.casingLower !== false ? ', casing: ' + "RenderFieldCaseType.Lower" : "")
-                + (vm.encodeHtml !== false ? ', encoding: ' + "RenderFieldEncodingType.Html" : "")
-                + (vm.encodeUrl !== false ? ', encoding: ' + "RenderFieldEncodingType.Url" : "")
-                + (vm.convertLinebreaks !== false ? ', convertLineBreaks: ' + "true" : "")
+            var pageField = (vm.field !== undefined ? '@Model.Value("' + vm.field + '"' : "")
+                + (vm.recursive !== false ? ', recurse: ' + vm.recursive : "")
+                + (vm.altText !== undefined ? ', defaultValue:"' + vm.altText + '"' : "")
                 + (vm.field ? ')' : "");
+
+            // TODO: determine the items here to keep as helpers and add them back into the insertfield.html view, then make them work above
+            //var pageField = (vm.field !== undefined ? '@Umbraco.Field("' + vm.field + '"' : "")
+            //    + (vm.altField !== undefined ? ', altFieldAlias:"' + vm.altField + '"' : "")
+            //    + (vm.altText !== undefined ? ', altText:"' + vm.altText + '"' : "")
+            //    + (vm.insertBefore !== undefined ? ', insertBefore:"' + vm.insertBefore + '"' : "")
+            //    + (vm.insertAfter !== undefined ? ', insertAfter:"' + vm.insertAfter + '"' : "")
+            //    + (vm.recursive !== false ? ', recursive: ' + vm.recursive : "")
+            //    + (vm.date !== false ? ', formatAsDate: ' + vm.date : "")
+            //    + (vm.dateTime !== false ? ', formatAsDateWithTimeSeparator:"' + vm.dateTimeSeparator + '"' : "")
+            //    + (vm.casingUpper !== false ? ', casing: ' + "RenderFieldCaseType.Upper" : "")
+            //    + (vm.casingLower !== false ? ', casing: ' + "RenderFieldCaseType.Lower" : "")
+            //    + (vm.encodeHtml !== false ? ', encoding: ' + "RenderFieldEncodingType.Html" : "")
+            //    + (vm.encodeUrl !== false ? ', encoding: ' + "RenderFieldEncodingType.Url" : "")
+            //    + (vm.convertLinebreaks !== false ? ', convertLineBreaks: ' + "true" : "")
+            //    + (vm.field ? ')' : "");
 
             $scope.model.umbracoField = pageField;
             

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/insertfield/insertfield.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/insertfield/insertfield.html
@@ -23,7 +23,7 @@
         <div class="hideAdvanced" style="position:absolute;height:100%;width:100%;background-color:white;opacity:.7;" ng-hide="vm.field"></div>
 
         <!-- Fallback field -->
-        <div>
+        <!--<div>
             <i class="icon icon-add blue" ng-hide="vm.showAltField"></i>
             <a href="" ng-click="vm.showAltField=true" ng-hide="vm.showAltField"><localize key="templateEditor_addFallbackField">Add fallback field</localize></a>
 
@@ -43,7 +43,7 @@
                 </div>
             </div>
         </div>
-        </div>
+        </div>-->
 
         <!-- Default value -->
         <div>
@@ -77,10 +77,10 @@
             </div>
         </div>
 
-        <h5><localize key="templateEditor_formatAndEncoding">Format and encoding</localize></h5>
+        <!--<h5><localize key="templateEditor_formatAndEncoding">Format and encoding</localize></h5>-->
 
         <!-- Format as date -->
-        <div class="control-group umb-control-group">
+        <!--<div class="control-group umb-control-group">
             <div class="umb-el-wrap">
                 <div class="controls">
                     <div>
@@ -94,10 +94,10 @@
                     <input type="text" ng-model="vm.dateTimeSeparator" ng-hide="!vm.dateTime" localize="placeholder" placeholder="@templateEditor_separator">
                 </div>
             </div>
-        </div>
+        </div>-->
 
         <!-- Format casing -->
-        <div class="control-group umb-control-group">
+        <!--<div class="control-group umb-control-group">
             <div class="umb-el-wrap">
                 <div class="controls">
                     <div>
@@ -109,10 +109,10 @@
                     <a href ng-click="vm.setCasingOption('lowercase')" class="btn"style="text-transform: lowercase;"><i class="icon icon-check" ng-if="vm.casingLower"></i> <localize key="templateEditor_lowercase">Lowercase</localize></a>
                 </div>
             </div>
-        </div>
+        </div>-->
 
         <!-- Format encoding -->
-        <div class="control-group umb-control-group">
+        <!--<div class="control-group umb-control-group">
             <div class="umb-el-wrap">
                 <div class="controls">
                     <div>
@@ -125,12 +125,12 @@
                     <a href ng-click="vm.setEncodingOption('url')" class="btn"><i class="icon icon-check" ng-if="vm.encodeUrl"></i> URL</a>
                 </div>
             </div>
-        </div>
+        </div>-->
 
-        <h5><localize key="templateEditor_modifyOutput">Modify output</localize></h5>
+        <!--<h5><localize key="templateEditor_modifyOutput">Modify output</localize></h5>-->
         
         <!-- Insert Before -->
-        <div class="control-group umb-control-group -no-border ng-scope">
+        <!--<div class="control-group umb-control-group -no-border ng-scope">
             <div class="umb-el-wrap">
                 <label class="control-label" for="insertBefore">
                     <localize key="templateEditor_preContent">Insert before field</localize>
@@ -140,10 +140,10 @@
                     <input type="text" id="insertBefore" name="insertBefore" class="-full-width-input" ng-model="vm.insertBefore">
                 </div>
             </div>
-        </div>
+        </div>-->
 
         <!-- Insert after -->
-        <div class="control-group umb-control-group">
+        <!--<div class="control-group umb-control-group">
             <div class="umb-el-wrap">
                 <label class="control-label" for="insertAfter">
                     <localize key="templateEditor_postContent">Insert after field</localize>
@@ -153,10 +153,10 @@
                     <input type="text" id="insertAfter" name="insertAfter" class="-full-width-input" ng-model="vm.insertAfter">
                 </div>
             </div>
-        </div>
+        </div>-->
 
         <!-- Line breaks -->
-        <div class="control-group umb-control-group">
+        <!--<div class="control-group umb-control-group">
             <div class="umb-el-wrap">
                 <div class="controls">
                     <div>
@@ -171,7 +171,7 @@
                     </label>
                 </div>
             </div>
-        </div>
+        </div>-->
 
         <!-- Output -->
         <div class="control-group umb-control-group -no-border">


### PR DESCRIPTION
Insert Value on Template Editor now uses Model.Value instead of the legacy uses the Umbraco.Field() method which no longer exists.

This issue is on the v8 Hackathon Trello board here: https://trello.com/c/PgEICixW