### PR TITLE
Fix color-picker prevalue width

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -160,6 +160,7 @@ ul.color-picker li a  {
 .control-group.color-picker-preval {
     .thumbnail {
         width: 36px;
+        min-width: auto;
         border: none;
         cursor: move;
         border-radius: 3px;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
@nul800sebastiaan: This is a quick fix of the width on the color pickers prevalue display of the added colors. Instead of being 36 pixels wide it was 150 pixels, which is the default setting for the .thumbnail class. In this commit we set min-width: auto; to overwrite this when using the .color-picker-preval selector.

We had the same issue when using the datatype, which was fixed in this PR https://github.com/umbraco/Umbraco-CMS/pull/2801#event-1757174003