### PR TITLE
U4-11506 - Fix Gregorian DateTime.MinValue is out of range for some calendars (like PersianCalendar)

### DIFF
--- a/src/Umbraco.Web/WebApi/CustomDateTimeConvertor.cs
+++ b/src/Umbraco.Web/WebApi/CustomDateTimeConvertor.cs
@@ -21,17 +21,7 @@ namespace Umbraco.Web.WebApi
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            try
-            {
-                writer.WriteValue(((DateTime)value).ToString(_dateTimeFormat));
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                // in some calendars like Persian, dates are much smaller than Gregorian,
-                // so DateTime.MinValue will cause ArgumentOutOfRangeException
-                // here we make sure if ArgumentOutOfRangeException happends we ignore the culture
-                writer.WriteValue(((DateTime)value).ToString(_dateTimeFormat, CultureInfo.InvariantCulture));
-            }
+            writer.WriteValue(((DateTime)value).ToString(_dateTimeFormat, CultureInfo.InvariantCulture));
         }
     }
 }

--- a/src/Umbraco.Web/WebApi/CustomDateTimeConvertor.cs
+++ b/src/Umbraco.Web/WebApi/CustomDateTimeConvertor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Umbraco.Core;
@@ -20,7 +21,17 @@ namespace Umbraco.Web.WebApi
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteValue(((DateTime)value).ToString(_dateTimeFormat));
+            try
+            {
+                writer.WriteValue(((DateTime)value).ToString(_dateTimeFormat));
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                // in some calendars like Persian, dates are much smaller than Gregorian,
+                // so DateTime.MinValue will cause ArgumentOutOfRangeException
+                // here we make sure if ArgumentOutOfRangeException happends we ignore the culture
+                writer.WriteValue(((DateTime)value).ToString(_dateTimeFormat, CultureInfo.InvariantCulture));
+            }
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
Link to issue tracker: [http://issues.umbraco.org/issue/U4-11506](http://issues.umbraco.org/issue/U4-11506)

In some calendars like Persian calendar which dates are very smaller than Gregorian dates, DateTime.MinValue will cause ArgumentOutOfRangeException exception. I faced such problem when I changed my user's language to Persian and tried to add a Member.

In \Umbraco.Web\WebApi\CustomDateTimeConvertor.cs file, WriteJson method tries to convert and format the date. I just ignore the culture if ArgumentOutOfRangeException happends.