### PR TITLE
U4-11546 [v7] Clean up to remove compiler warnings

### DIFF
--- a/src/Umbraco.Core/Configuration/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/GlobalSettings.cs
@@ -32,7 +32,6 @@ namespace Umbraco.Core.Configuration
 
         #region Private static fields
 
-        private static Version _version;
         private static readonly object Locker = new object();
         //make this volatile so that we can ensure thread safety with a double check lock
         private static volatile string _reservedUrlsCache;

--- a/src/Umbraco.Core/Persistence/PetaPoco.cs
+++ b/src/Umbraco.Core/Persistence/PetaPoco.cs
@@ -337,7 +337,7 @@ namespace Umbraco.Core.Persistence
 			        _transaction = _sharedConnection.BeginTransaction(isolationLevel);
 			    }
 
-			    catch (Exception e)
+			    catch (Exception)
 			    {
 			        throw;
 			    }

--- a/src/Umbraco.Core/PluginManager.cs
+++ b/src/Umbraco.Core/PluginManager.cs
@@ -343,7 +343,7 @@ namespace Umbraco.Core
             {
                 return ReadCache();
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 try
                 {
@@ -519,7 +519,7 @@ namespace Umbraco.Core
                 {
                     return new FileStream(path, fileMode, fileAccess, fileShare);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     if (--attempts == 0)
                         throw;

--- a/src/Umbraco.Core/Security/MachineKeyGenerator.cs
+++ b/src/Umbraco.Core/Security/MachineKeyGenerator.cs
@@ -26,8 +26,6 @@ namespace Umbraco.Core.Security
     validation=""HMACSHA256"" decryption=""AES""
     />";
 
-            var Xxx = 3;
-
             return string.Format(c, GenerateAESDecryptionKey(), GenerateHMACSHA256ValidationKey());
         }
 

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -207,7 +207,7 @@ namespace Umbraco.Core.Services
                 {
                     return repository.GetByUsername(username, includeSecurityData: true);
                 }
-                catch (DbException ex)
+                catch (DbException)
                 {
                     //we need to handle this one specific case which is when we are upgrading to 7.7 since the user group
                     //tables don't exist yet. This is the 'easiest' way to deal with this without having to create special
@@ -786,7 +786,7 @@ namespace Umbraco.Core.Services
                     var result = repository.Get(id);
                     return result;
                 }
-                catch (DbException ex)
+                catch (DbException)
                 {
                     //we need to handle this one specific case which is when we are upgrading to 7.7 since the user group
                     //tables don't exist yet. This is the 'easiest' way to deal with this without having to create special

--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -164,7 +164,7 @@ namespace Umbraco.Core
                 var obj = JsonConvert.DeserializeObject(input);
                 return obj;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 return input;
             }
@@ -622,7 +622,7 @@ namespace Umbraco.Core
                 byte[] decodedBytes = UrlTokenDecode(input);
                 return decodedBytes != null ? Encoding.UTF8.GetString(decodedBytes) : null;
             }
-            catch (FormatException ex)
+            catch (FormatException)
             {
                 return null;
             }

--- a/src/Umbraco.Core/Strings/DefaultShortStringHelper.cs
+++ b/src/Umbraco.Core/Strings/DefaultShortStringHelper.cs
@@ -26,7 +26,6 @@ namespace Umbraco.Core.Strings
         [Obsolete("Use the other ctor that specifies all dependencies")]
         public DefaultShortStringHelper()
         {
-            _umbracoSettings = _umbracoSettings;
             InitializeLegacyUrlReplaceCharacters();
         }
 

--- a/src/Umbraco.Tests/CodeFirst/ContentTypeMapper.cs
+++ b/src/Umbraco.Tests/CodeFirst/ContentTypeMapper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Umbraco.Core;
 using Umbraco.Core.Models;
 
 namespace Umbraco.Tests.CodeFirst
@@ -32,7 +31,7 @@ namespace Umbraco.Tests.CodeFirst
                     value = DateTime.Parse(property.Value.ToString());
                 else if (propertyInfo.PropertyType == typeof(Boolean))
                 {
-                    if (String.IsNullOrEmpty(property.Value.ToString()) || property.Value == "0")
+                    if (String.IsNullOrEmpty(property.Value.ToString()) || (string)property.Value == "0")
                     {
                         value = false;
                     }

--- a/src/Umbraco.Tests/CoreXml/NavigableNavigatorTests.cs
+++ b/src/Umbraco.Tests/CoreXml/NavigableNavigatorTests.cs
@@ -419,7 +419,6 @@ namespace Umbraco.Tests.CoreXml
         {
             var source = new TestSource5();
             var nav = new NavigableNavigator(source);
-            TestContent content;
 
             Assert.AreEqual(NavigableNavigator.StatePosition.Root, nav.InternalState.Position);
             Assert.IsTrue(nav.MoveToFirstChild());

--- a/src/Umbraco.Tests/DelegateExtensionsTests.cs
+++ b/src/Umbraco.Tests/DelegateExtensionsTests.cs
@@ -26,7 +26,6 @@ namespace Umbraco.Tests
         [Test]
         public void Quits_On_Success_Count()
         {
-            var maxTries = 5;
             var totalTries = 0;
             DelegateExtensions.RetryUntilSuccessOrMaxAttempts((currentTry) =>
             {

--- a/src/Umbraco.Tests/Models/Collections/Item.cs
+++ b/src/Umbraco.Tests/Models/Collections/Item.cs
@@ -12,7 +12,6 @@ namespace Umbraco.Tests.Models.Collections
     public abstract class Item : IEntity, ICanBeDirty
     {
         private bool _hasIdentity;
-        private int? _hash;
         private int _id;
         private Guid _key;
 

--- a/src/Umbraco.Tests/Models/Collections/Item.cs
+++ b/src/Umbraco.Tests/Models/Collections/Item.cs
@@ -173,15 +173,7 @@ namespace Umbraco.Tests.Models.Collections
 
         public static bool operator ==(Item left, Item right)
         {
-            /*if (ReferenceEquals(null, left))
-                return false;
-
-            if(ReferenceEquals(null, right))
-                return false;*/
-
             return ReferenceEquals(left, right);
-
-            return left.Equals(right);
         }
 
         public static bool operator !=(Item left, Item right)

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -935,7 +935,6 @@ namespace Umbraco.Tests.PublishedContent
         {
             // the converter args
             PublishedPropertyType argPropertyType = null;
-            object argSource = null;
             bool argPreview = false;
 
             var pt1 = new PublishedPropertyType("legend", 0, Constants.PropertyEditors.TextboxAlias);

--- a/src/Umbraco.Tests/Scheduling/BackgroundTaskRunnerTests.cs
+++ b/src/Umbraco.Tests/Scheduling/BackgroundTaskRunnerTests.cs
@@ -943,8 +943,6 @@ namespace Umbraco.Tests.Scheduling
                 throw new NotImplementedException();
             }
 
-            private int i;
-
             public async Task RunAsync(CancellationToken token)
             {
                 Console.WriteLine("boom");

--- a/src/Umbraco.Web.UI/umbraco/developer/Packages/DirectoryBrowser.aspx.cs
+++ b/src/Umbraco.Web.UI/umbraco/developer/Packages/DirectoryBrowser.aspx.cs
@@ -95,7 +95,7 @@ namespace Umbraco.Web.UI.Umbraco.Developer.Packages
                     {
                         _sb.Append("<tr><td class=\"tdDir\"><a href=\"" + _lsScriptName + "?path=" + _lsWebPath + oDir.Name + "&target=" + Target + "\">" + oDir.Name + "</a>  <small><a href=\"javascript:postPath('/" + _lsWebPath + oDir.Name + "')\"> (Include entire folder)</small></td></tr>");
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
                         _sb.Append("<tr><td class=\"tdDir\">" + oDir.Name + " (Access Denied)</td></tr>");
                     }

--- a/src/Umbraco.Web/HealthCheck/HealthCheckAction.cs
+++ b/src/Umbraco.Web/HealthCheck/HealthCheckAction.cs
@@ -8,8 +8,6 @@ namespace Umbraco.Web.HealthCheck
     [DataContract(Name = "healtCheckAction", Namespace = "")]
     public class HealthCheckAction
     {
-        private readonly ILocalizedTextService _textService;
-
         /// <summary>
         /// Empty ctor used for serialization
         /// </summary>

--- a/src/Umbraco.Web/Install/FilePermissionHelper.cs
+++ b/src/Umbraco.Web/Install/FilePermissionHelper.cs
@@ -163,7 +163,7 @@ namespace Umbraco.Web.Install
                 if (accessRules == null)
                     return false;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 //This is not 100% accurate btw because it could turn out that the current user doesn't
                 //have access to read the current permissions but does have write access.

--- a/src/Umbraco.Web/Install/InstallSteps/NewInstallStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/NewInstallStep.cs
@@ -64,7 +64,7 @@ namespace Umbraco.Web.Install.InstallSteps
                     throw new FormatException("Password must be at least " + CurrentProvider.MinRequiredPasswordLength + " characters long and contain at least " + CurrentProvider.MinRequiredNonAlphanumericCharacters + " symbols");
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 throw new FormatException("Password must be at least " + CurrentProvider.MinRequiredPasswordLength + " characters long and contain at least " + CurrentProvider.MinRequiredNonAlphanumericCharacters + " symbols");
             }

--- a/src/Umbraco.Web/Trees/PackagesTreeController.cs
+++ b/src/Umbraco.Web/Trees/PackagesTreeController.cs
@@ -36,8 +36,6 @@ namespace Umbraco.Web.Trees
 
         protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
         {
-            var baseUrl = Constants.Applications.Developer + "/packages/";
-
             var nodes = new TreeNodeCollection();
 
             var createdPackages = CreatedPackage.GetAllCreatedPackages();

--- a/src/Umbraco.Web/Trees/UserTreeController.cs
+++ b/src/Umbraco.Web/Trees/UserTreeController.cs
@@ -47,8 +47,6 @@ namespace Umbraco.Web.Trees
 
         protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
         {
-            var baseUrl = Constants.Applications.Users + "/users/";
-
             var nodes = new TreeNodeCollection();
             return nodes;
         }

--- a/src/Umbraco.Web/UmbracoModule.cs
+++ b/src/Umbraco.Web/UmbracoModule.cs
@@ -503,7 +503,7 @@ namespace Umbraco.Web
                     httpContext.Response.Headers.Remove("X-AspNet-Version");
                     httpContext.Response.Headers.Remove("X-AspNetMvc-Version");
                 }
-                catch (PlatformNotSupportedException ex)
+                catch (PlatformNotSupportedException)
                 {
                     // can't remove headers this way on IIS6 or cassini.
                 }

--- a/src/Umbraco.Web/umbraco.presentation/content.cs
+++ b/src/Umbraco.Web/umbraco.presentation/content.cs
@@ -428,8 +428,6 @@ namespace umbraco
 
             if (!e.Cancel)
             {
-                XmlNode x;
-
                 //Hack: this is here purely for backwards compat if someone for some reason is using the
                 // ClearDocumentCache(int documentId) method and expecting it to remove the xml
                 if (removeDbXmlEntry)

--- a/src/Umbraco.Web/umbraco.presentation/requestModule.cs
+++ b/src/Umbraco.Web/umbraco.presentation/requestModule.cs
@@ -253,7 +253,6 @@ namespace umbraco.presentation
 									+ ex;
 
 						// Hide error if getting the user throws an error (e.g. corrupt / blank db)
-						User staticUser = null;
 						try
 						{
 							User.GetCurrent();

--- a/src/umbraco.businesslogic/BasePages/UmbracoEnsuredPage.cs
+++ b/src/umbraco.businesslogic/BasePages/UmbracoEnsuredPage.cs
@@ -165,7 +165,7 @@ namespace umbraco.BasePages
                         throw new UserAuthorizationException(String.Format("The current user doesn't have access to the section/app '{0}'", CurrentApp));
                 }
             }
-            catch (UserAuthorizationException ex)
+            catch (UserAuthorizationException)
             {
                 LogHelper.Warn<UmbracoEnsuredPage>(string.Format("{0} tried to access '{1}'", CurrentUser.Id, CurrentApp));
                 throw;

--- a/src/umbraco.cms/businesslogic/Content.cs
+++ b/src/umbraco.cms/businesslogic/Content.cs
@@ -149,7 +149,7 @@ namespace umbraco.cms.businesslogic
                         {
                             _contentType = new ContentType(contentTypeId);
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             return null;
                         }

--- a/src/umbraco.cms/businesslogic/Packager/PackageActions/publishRootDocument.cs
+++ b/src/umbraco.cms/businesslogic/Packager/PackageActions/publishRootDocument.cs
@@ -25,8 +25,6 @@ namespace umbraco.cms.businesslogic.packager.standardPackageActions
 
 			string documentName = xmlData.Attributes["documentName"].Value;
 
-			int parentDocid = 0;
-
 			web.Document[] rootDocs = web.Document.GetRootDocuments();
 
 			foreach (web.Document rootDoc in rootDocs)

--- a/src/umbraco.controls/UmbracoClientDependencyLoader.cs
+++ b/src/umbraco.controls/UmbracoClientDependencyLoader.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Web.UI;
+﻿using System.Web.UI;
 using ClientDependency.Core.Controls;
 using ClientDependency.Core.FileRegistration.Providers;
 using Umbraco.Core.IO;
 
 namespace umbraco.uicontrols
 {
-
     /// <summary>
     /// Used to load in all client dependencies for Umbraco.
     /// Ensures that both UmbracoClient and UmbracoRoot paths are added to the loader.
@@ -28,7 +23,7 @@ namespace umbraco.uicontrols
             
         }
 
-        public static new ClientDependencyLoader TryCreate(Control parent, out bool isNew)
+        public static ClientDependencyLoader TryCreate(Control parent, out bool isNew)
         {
             if (ClientDependencyLoader.Instance == null)
             {


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11546

### Description

I have cleaned some classes to remove compiler warnings. Some are in classes marked as obsolete; however the overall reduction in compiler warnings makes the code base cleaner.

#### Warning
* CS0109 The member does not hide an accessible member. The new keyword is not required.
* CS0162 Unreachable code detected
* CS0168 The variable is declared but never used
* CS0169 The field is never used
* CS0219 The variable is assigned but its value is never used
* CS0252 Possible unintended reference comparison; to get a value comparison, cast the left hand side to type 'string'
* CS1717 Assignment made to same variable; did you mean to assign something else?

Note: There are other instances of CS0162 and CS0169 warnings left in the codebase. I could remove them as some seem to be there for debugging and some seem abandoned refactorings. Working on the premise that commented out code should be deleted (see Uncle Bob, et al) I could remove them but I won't at the minute unless I have permission to do so.



<!-- Thanks for contributing to Umbraco CMS! -->
