### PR TITLE
Changing the document type alias before first save leads to YSOD

### DIFF
--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -290,6 +290,19 @@ namespace Umbraco.Web.Editors
                             template = tryCreateTemplate.Result.Entity;
                         }
 
+                        // If the alias has been manually updated before the first save,
+                        // make sure to also update the first allowed template, as the
+                        // name will come back as a SafeAlias of the document type name,
+                        // not as the actual document type alias.
+                        // For more info: http://issues.umbraco.org/issue/U4-11059
+                        if (ctSave.DefaultTemplate != template.Alias)
+                        {
+                            var allowedTemplates = ctSave.AllowedTemplates.ToArray();
+                            if (allowedTemplates.Any())
+                                allowedTemplates[0] = template.Alias;
+                            ctSave.AllowedTemplates = allowedTemplates;
+                        }
+
                         //make sure the template alias is set on the default and allowed template so we can map it back
                         ctSave.DefaultTemplate = template.Alias;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11059

### Description
<!-- A description of the changes proposed in the pull-request -->

We'll have to update the allowed templates when we don't use the doctype alias to generate the template alias from - see issue tracker for details.


<!-- Thanks for contributing to Umbraco CMS! -->
