### PR TITLE
Fixed issue with creating doctypes & templated with an Ampersand : http://issues.umbraco.org/issue/U4-11550

### DIFF
--- a/src/Umbraco.Core/Services/FileService.cs
+++ b/src/Umbraco.Core/Services/FileService.cs
@@ -13,7 +13,7 @@ using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Querying;
 using Umbraco.Core.Persistence.Repositories;
 using Umbraco.Core.Persistence.UnitOfWork;
- 
+
 namespace Umbraco.Core.Services
 {
     /// <summary>
@@ -332,8 +332,10 @@ namespace Umbraco.Core.Services
         public ITemplate CreateTemplateWithIdentity(string name, string content, ITemplate masterTemplate = null, int userId = 0)
         {
             // file might already be on disk, if so grab the content to avoid overwriting
-            var template = new Template(name, name);
-            template.Content = GetViewContent(template.Alias) ?? content;
+            var template = new Template(name, name)
+            {
+                Content = GetViewContent(name) ?? content
+            };
 
             if (masterTemplate != null)
             {

--- a/src/Umbraco.Core/Services/FileService.cs
+++ b/src/Umbraco.Core/Services/FileService.cs
@@ -13,7 +13,7 @@ using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Querying;
 using Umbraco.Core.Persistence.Repositories;
 using Umbraco.Core.Persistence.UnitOfWork;
-
+ 
 namespace Umbraco.Core.Services
 {
     /// <summary>

--- a/src/Umbraco.Core/Services/FileService.cs
+++ b/src/Umbraco.Core/Services/FileService.cs
@@ -332,10 +332,8 @@ namespace Umbraco.Core.Services
         public ITemplate CreateTemplateWithIdentity(string name, string content, ITemplate masterTemplate = null, int userId = 0)
         {
             // file might already be on disk, if so grab the content to avoid overwriting
-            var template = new Template(name, name)
-            {
-                Content = GetViewContent(name) ?? content
-            };
+            var template = new Template(name, name);
+            template.Content = GetViewContent(template.Alias) ?? content;
 
             if (masterTemplate != null)
             {

--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -46,7 +46,7 @@ function entityResource($q, $http, umbRequestHelper) {
                $http.get(
                    umbRequestHelper.getApiUrl(
                        "entityApiBaseUrl",
-                       "GetSafeAlias", { value: value, camelCase: camelCase })),
+                        "GetSafeAlias", { value: encodeURIComponent(value), camelCase: camelCase })),
                'Failed to retrieve content type scaffold');
         },
 


### PR DESCRIPTION
### Prerequisites
Details are in the issue I raised below, in summary you could not create a document type with an Ampersand as the Alias that was automatically created cut off all the letters after the Ampersand.

http://issues.umbraco.org/issue/U4-11550

### Description

I have fixed the issue with the alias not being correctly created, as well as this, while testing this I discovered a related issue, if you tried to save a Doctype with this kind of name it would fail to create, but a template would still be created. 

I have now fixed both issues and you can now successfully create a document type called "Terms & Conditions" and it's alias will now be termsConditions and it's template will be TermsConditions.cshtml