### PR TITLE
U4-11526 - Member Group Picker doesn't remove group after unselecting it during selection.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/membergrouppicker/membergrouppicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/membergrouppicker/membergrouppicker.controller.js
@@ -20,15 +20,24 @@ angular.module("umbraco").controller("Umbraco.Overlays.MemberGroupPickerControll
         }
 
         function selectMemberGroup(id) {
+            console.log(id, 'selectMemberGroupMethod');
            $scope.model.selectedMemberGroup = id;
         }
 
         function selectMemberGroups(id) {
+            console.log(id, 'selectMemberGroups');
+
+            //TODO:
+            // Need to check if the id already exists in the array
+            // If it does then we need to splice the value from the array instead
+            // OBS! Also check when the "selectMemberGroup" method is being used?
            $scope.model.selectedMemberGroups.push(id);
         }
 
         /** Method used for selecting a node */
         function select(text, id) {
+
+            console.log(text, id, "selectMethod");
 
             if ($scope.model.multiPicker) {
                selectMemberGroups(id);

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/membergrouppicker/membergrouppicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/membergrouppicker/membergrouppicker.controller.js
@@ -20,24 +20,23 @@ angular.module("umbraco").controller("Umbraco.Overlays.MemberGroupPickerControll
         }
 
         function selectMemberGroup(id) {
-            console.log(id, 'selectMemberGroupMethod');
            $scope.model.selectedMemberGroup = id;
         }
 
         function selectMemberGroups(id) {
-            console.log(id, 'selectMemberGroups');
 
-            //TODO:
-            // Need to check if the id already exists in the array
-            // If it does then we need to splice the value from the array instead
-            // OBS! Also check when the "selectMemberGroup" method is being used?
-           $scope.model.selectedMemberGroups.push(id);
+            if($scope.model.selectedMemberGroups.indexOf(id) === -1){
+                // If the id does not exists in the array then add it
+                $scope.model.selectedMemberGroups.push(id);
+            }
+            else{
+                // Otherwise we will remove it from the array instead
+                $scope.model.selectedMemberGroups.splice(id, 1);
+            }
         }
 
         /** Method used for selecting a node */
         function select(text, id) {
-
-            console.log(text, id, "selectMethod");
 
             if ($scope.model.multiPicker) {
                selectMemberGroups(id);

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/membergrouppicker/membergrouppicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/membergrouppicker/membergrouppicker.controller.js
@@ -24,14 +24,15 @@ angular.module("umbraco").controller("Umbraco.Overlays.MemberGroupPickerControll
         }
 
         function selectMemberGroups(id) {
+            var index = $scope.model.selectedMemberGroups.indexOf(id);
 
-            if($scope.model.selectedMemberGroups.indexOf(id) === -1){
+            if(index === -1){
                 // If the id does not exists in the array then add it
                 $scope.model.selectedMemberGroups.push(id);
             }
             else{
                 // Otherwise we will remove it from the array instead
-                $scope.model.selectedMemberGroups.splice(id, 1);
+                $scope.model.selectedMemberGroups.splice(index, 1);
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/membergrouppicker/membergrouppicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/membergrouppicker/membergrouppicker.html
@@ -1,8 +1,5 @@
 <div ng-controller="Umbraco.Overlays.MemberGroupPickerController">
 
-    {{model | json}} <br /> <br />
-    {{model.multiPicker}}
-
 	<umb-tree section="member"
 				 treealias="memberGroups"
 				 hideheader="true"

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/membergrouppicker/membergrouppicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/membergrouppicker/membergrouppicker.html
@@ -1,5 +1,8 @@
 <div ng-controller="Umbraco.Overlays.MemberGroupPickerController">
 
+    {{model | json}} <br /> <br />
+    {{model.multiPicker}}
+
 	<umb-tree section="member"
 				 treealias="memberGroups"
 				 hideheader="true"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11526

### Description
This PR is currently WIP - The problem is that the selectMemberGroups function does not check the array to see if the id is already in there. So whenever one selects/deselects it's just adding the id over and over again.

I'll update the issue when it's ready for review by the CPR team :)