### PR TITLE
U4-11572 - better highlight for selected icon in icon picker dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
@@ -27,10 +27,14 @@
 }
 
 .umb-iconpicker-item a:hover,
-.umb-iconpicker-item a:focus,
-.umb-iconpicker-item.-selected {
+.umb-iconpicker-item a:focus {
     background: @gray-10;
     outline: none;
+}
+
+.umb-iconpicker-item.-selected {
+    background: @gray-10;
+    outline: solid 1px @gray-7;
 }
 
 .umb-iconpicker-item a:active {


### PR DESCRIPTION
I created an issue here: http://issues.umbraco.org/issue/U4-11572

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
<!-- A description of the changes proposed in the pull-request -->
I propose adding a border to any (pre-)selected icon in the icon picker dialog. The way it is now, I find it very difficult to spot when scrolling up and down the list.


<!-- Thanks for contributing to Umbraco CMS! -->
