### PR TITLE
Removed double encoding

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
@@ -82,7 +82,7 @@ angular.module("umbraco.directives")
 
                     generateAliasTimeout = $timeout(function () {
                        updateAlias = true;
-                        entityResource.getSafeAlias(encodeURIComponent(value), true).then(function (safeAlias) {
+                        entityResource.getSafeAlias(value, true).then(function (safeAlias) {
                             if (updateAlias) {
                               scope.alias = safeAlias.alias;
                            }


### PR DESCRIPTION

It seems that we were double encoding the value that was sent to the server which transformed the original value from "Example%20With%20Space" to "Example%2520With%2520Space" and broke everything.

