### PR TITLE
U4-11581 In rare cases the umbracoLanguage table has a constraint ins…

### DIFF
--- a/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenTwelveZero/IncreaseLanguageIsoCodeColumnLength.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenTwelveZero/IncreaseLanguageIsoCodeColumnLength.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
+using Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSeven;
 using Umbraco.Core.Persistence.SqlSyntax;
 
 namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenTwelveZero
@@ -15,21 +16,37 @@ namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenTwelveZ
 
         public override void Up()
         {
-            var dbIndexes = SqlSyntax.GetDefinedIndexes(Context.Database)
-                .Select(x => new DbIndexDefinition()
-                {
-                    TableName = x.Item1,
-                    IndexName = x.Item2,
-                    ColumnName = x.Item3,
-                    IsUnique = x.Item4
-                }).ToArray();
-
-            //Ensure the index exists before dropping it
-            if (dbIndexes.Any(x => x.IndexName.InvariantEquals("IX_umbracoLanguage_languageISOCode")))
+            // Some people seem to have a constraint in their DB instead of an index, we'd need to drop that one
+            // See: https://our.umbraco.com/forum/using-umbraco-and-getting-started/93282-upgrade-from-711-to-712-fails
+            var constraints = SqlSyntax.GetConstraintsPerColumn(Context.Database).Distinct().Select(x => new ConstraintDefinition(ConstraintType.Unique)
             {
-                Delete.Index("IX_umbracoLanguage_languageISOCode").OnTable("umbracoLanguage");
+                TableName = x.Item1,
+                SchemaName = x.Item2,
+                ConstraintName = x.Item3
+            }).ToArray();
+
+            if (constraints.Any(x => x.ConstraintName.InvariantEquals("IX_umbracoLanguage_languageISOCode")))
+            {
+                Delete.UniqueConstraint("IX_umbracoLanguage_languageISOCode").FromTable("umbracoLanguage");
             }
-            
+            else
+            {
+                var dbIndexes = SqlSyntax.GetDefinedIndexes(Context.Database)
+                    .Select(x => new DbIndexDefinition()
+                    {
+                        TableName = x.Item1,
+                        IndexName = x.Item2,
+                        ColumnName = x.Item3,
+                        IsUnique = x.Item4
+                    }).ToArray();
+
+                //Ensure the index exists before dropping it
+                if (dbIndexes.Any(x => x.IndexName.InvariantEquals("IX_umbracoLanguage_languageISOCode")))
+                {
+                    Delete.Index("IX_umbracoLanguage_languageISOCode").OnTable("umbracoLanguage");
+                }
+            }
+
             Alter.Table("umbracoLanguage")
                 .AlterColumn("languageISOCode")
                 .AsString(14)
@@ -38,6 +55,8 @@ namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenTwelveZ
             Create.Index("IX_umbracoLanguage_languageISOCode")
                 .OnTable("umbracoLanguage")
                 .OnColumn("languageISOCode")
+                .Ascending()
+                .WithOptions()
                 .Unique();
         }
 


### PR DESCRIPTION
…tead of an index, making the migration fail

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11581

### Description
<!-- A description of the changes proposed in the pull-request -->
See [http://issues.umbraco.org/issue/U4-11581](http://issues.umbraco.org/issue/U4-11581) for details on how to reproduce. 

Make sure to test with the constraint AND with the "normal" index that we expect. Both should work. The code starts with looking for the constraint, which really shouldn't exist, but if it does it gets dropped and we'll no longer need to drop the index. 

If the constraint doesn't exist, all is well and we drop the index like before. 

Also updated adding the index back with a few more options to make it consistent with other migrations, added:

```
                .Ascending()
                .WithOptions()
```

<!-- Thanks for contributing to Umbraco CMS! -->
