### PR TITLE
U4-11579 Take startNodeId into account before picking the current nod…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/treepicker/treepicker.controller.js
@@ -162,7 +162,9 @@ angular.module("umbraco").controller("Umbraco.Overlays.TreePickerController",
 
             tree = args.tree;
 
-            if (node && node.path) {
+            var nodeHasPath = typeof node !== "undefined" && typeof node.path !== "undefined";
+            var startNodeNotDefined = typeof dialogOptions.startNodeId === "undefined" || dialogOptions.startNodeId === "" || dialogOptions.startNodeId === "-1";
+            if (startNodeNotDefined && nodeHasPath) {
                 $scope.dialogTreeEventHandler.syncTree({ path: node.path, activate: false });
             }
 


### PR DESCRIPTION
…e to sync to

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11579

### Description
<!-- A description of the changes proposed in the pull-request -->
The [original issue](http://issues.umbraco.org/issue/U4-3921) also altered the start node of the MNTP and other pickers. When we do take the startnodeId into account it starts working again. 


<!-- Thanks for contributing to Umbraco CMS! -->
