### PR TITLE
U4-11582 - HasChildren property is fixed for a container node 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -39,7 +39,7 @@ angular.module("umbraco.directives")
             '<div ng-class="getNodeCssClass(node)" ng-swipe-right="options(node, $event)" ng-dblclick="load(node)" >' +
             //NOTE: This ins element is used to display the search icon if the node is a container/listview and the tree is currently in dialog
             //'<ins ng-if="tree.enablelistviewsearch && node.metaData.isContainer" class="umb-tree-node-search icon-search" ng-click="searchNode(node, $event)" alt="searchAltText"></ins>' + 
-            '<ins data-element="tree-item-expand" ng-class="{\'icon-navigation-right\': node.hasChildren && !node.metaData.isContainer && !node.expanded || node.hasChildren && enablelistviewexpand === \'true\' && !node.expanded, \'icon-navigation-down\': node.expanded }" ng-click="load(node)">&nbsp;</ins>' +
+            '<ins data-element="tree-item-expand" ng-class="{\'icon-navigation-right\': (node.hasChildren && !node.metaData.isContainer && !node.expanded) || (node.hasChildren && enablelistviewexpand === \'true\' && !node.expanded), \'icon-navigation-down\': node.expanded}" ng-click="load(node)">&nbsp;</ins>' +
             '<i class="icon umb-tree-icon sprTree" ng-click="select(node, $event)"></i>' +
             '<a class="umb-tree-item__label" href="#/{{node.routePath}}" ng-click="select(node, $event)"></a>' +
             //NOTE: These are the 'option' elipses

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -39,7 +39,7 @@ angular.module("umbraco.directives")
             '<div ng-class="getNodeCssClass(node)" ng-swipe-right="options(node, $event)" ng-dblclick="load(node)" >' +
             //NOTE: This ins element is used to display the search icon if the node is a container/listview and the tree is currently in dialog
             //'<ins ng-if="tree.enablelistviewsearch && node.metaData.isContainer" class="umb-tree-node-search icon-search" ng-click="searchNode(node, $event)" alt="searchAltText"></ins>' + 
-            '<ins data-element="tree-item-expand" ng-class="{\'icon-navigation-right\': !node.expanded || node.metaData.isContainer, \'icon-navigation-down\': node.expanded && !node.metaData.isContainer}" ng-click="load(node)">&nbsp;</ins>' +
+            '<ins data-element="tree-item-expand" ng-class="{\'icon-navigation-right\': !node.expanded && !node.metaData.isContainer, \'icon-navigation-down\': node.expanded && !node.metaData.isContainer}" ng-click="load(node)">&nbsp;</ins>' +
             '<i class="icon umb-tree-icon sprTree" ng-click="select(node, $event)"></i>' +
             '<a class="umb-tree-item__label" href="#/{{node.routePath}}" ng-click="select(node, $event)"></a>' +
             //NOTE: These are the 'option' elipses

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -39,7 +39,7 @@ angular.module("umbraco.directives")
             '<div ng-class="getNodeCssClass(node)" ng-swipe-right="options(node, $event)" ng-dblclick="load(node)" >' +
             //NOTE: This ins element is used to display the search icon if the node is a container/listview and the tree is currently in dialog
             //'<ins ng-if="tree.enablelistviewsearch && node.metaData.isContainer" class="umb-tree-node-search icon-search" ng-click="searchNode(node, $event)" alt="searchAltText"></ins>' + 
-            '<ins data-element="tree-item-expand" ng-class="{\'icon-navigation-right\': !node.expanded && !node.metaData.isContainer, \'icon-navigation-down\': node.expanded && !node.metaData.isContainer}" ng-click="load(node)">&nbsp;</ins>' +
+            '<ins data-element="tree-item-expand" ng-class="{\'icon-navigation-right\':  (!node.expanded && (node.metaData.shouldRender || !node.metaData.isContainer)) || enablelistviewexpand === \'true\', \'icon-navigation-down\': node.expanded && (node.metaData.shouldRender || !node.metaData.isContainer)}" ng-click="load(node)">&nbsp;</ins>' +
             '<i class="icon umb-tree-icon sprTree" ng-click="select(node, $event)"></i>' +
             '<a class="umb-tree-item__label" href="#/{{node.routePath}}" ng-click="select(node, $event)"></a>' +
             //NOTE: These are the 'option' elipses

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -39,7 +39,7 @@ angular.module("umbraco.directives")
             '<div ng-class="getNodeCssClass(node)" ng-swipe-right="options(node, $event)" ng-dblclick="load(node)" >' +
             //NOTE: This ins element is used to display the search icon if the node is a container/listview and the tree is currently in dialog
             //'<ins ng-if="tree.enablelistviewsearch && node.metaData.isContainer" class="umb-tree-node-search icon-search" ng-click="searchNode(node, $event)" alt="searchAltText"></ins>' + 
-            '<ins data-element="tree-item-expand" ng-class="{\'icon-navigation-right\':  (!node.expanded && (node.metaData.shouldRender || !node.metaData.isContainer)) || enablelistviewexpand === \'true\', \'icon-navigation-down\': node.expanded && (node.metaData.shouldRender || !node.metaData.isContainer)}" ng-click="load(node)">&nbsp;</ins>' +
+            '<ins data-element="tree-item-expand" ng-class="{\'icon-navigation-right\': node.hasChildren && !node.metaData.isContainer && !node.expanded || node.hasChildren && enablelistviewexpand === \'true\' && !node.expanded, \'icon-navigation-down\': node.expanded}" ng-click="load(node)">&nbsp;</ins>' +
             '<i class="icon umb-tree-icon sprTree" ng-click="select(node, $event)"></i>' +
             '<a class="umb-tree-item__label" href="#/{{node.routePath}}" ng-click="select(node, $event)"></a>' +
             //NOTE: These are the 'option' elipses
@@ -47,7 +47,7 @@ angular.module("umbraco.directives")
             '<div ng-show="node.loading" class="l"><div></div></div>' +
             '</div>' +
             '</li>',
-        
+
         link: function (scope, element, attrs) {
 
             localizationService.localize("general_search").then(function (value) {
@@ -227,7 +227,7 @@ angular.module("umbraco.directives")
                 //emit treeNodeExpanding event, if a callback object is set on the tree
                 emitEvent("treeNodeExpanding", { tree: scope.tree, node: node });
 
-                if (node.hasChildren && (forceReload || !node.children || (angular.isArray(node.children) && node.children.length === 0))) {
+                if (node.hasChildren && !node.metaData.isContainer && (forceReload || !node.children || (angular.isArray(node.children) && node.children.length === 0))) {
                     //get the children from the tree service
                     treeService.loadNodeChildren({ node: node, section: scope.section })
                         .then(function (data) {
@@ -238,7 +238,10 @@ angular.module("umbraco.directives")
                 }
                 else {
                     emitEvent("treeNodeExpanded", { tree: scope.tree, node: node, children: node.children });
-                    node.expanded = true;
+                    // list views don't expand but opens a mini list view
+                    if (!node.metaData.isContainer) {
+                        node.expanded = true;
+                    }
                     enableDeleteAnimations();
                 }
             };            

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -69,14 +69,7 @@ namespace Umbraco.Web.Trees
             if (CanUserAccessNode(e, allowedUserOptions))
             { 
                 var hasChildren = e.HasChildren();
-                var shouldRenderChildren = ShouldRenderChildrenOfContainer(e);
-
-                //Special check to see if the node has no children.
-                if (shouldRenderChildren == false && !hasChildren)
-                {
-                    hasChildren = false;
-                }
-
+                
                 var node = CreateTreeNode(
                     entity,
                     Constants.ObjectTypes.DocumentGuid,
@@ -85,7 +78,6 @@ namespace Umbraco.Web.Trees
                     hasChildren);
 
                 node.AdditionalData.Add("contentType", entity.ContentTypeAlias);
-                node.AdditionalData.Add("shouldRender", shouldRenderChildren);
 
                 if (e.IsContainer())
                 {

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -68,14 +68,12 @@ namespace Umbraco.Web.Trees
             var allowedUserOptions = GetAllowedUserMenuItemsForNode(e);
             if (CanUserAccessNode(e, allowedUserOptions))
             { 
-                var hasChildren = e.HasChildren();
-                
                 var node = CreateTreeNode(
                     entity,
                     Constants.ObjectTypes.DocumentGuid,
                     parentId,
                     queryStrings,
-                    hasChildren);
+                    entity.HasChildren);
 
                 node.AdditionalData.Add("contentType", entity.ContentTypeAlias);
 

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -67,12 +67,12 @@ namespace Umbraco.Web.Trees
 
             var allowedUserOptions = GetAllowedUserMenuItemsForNode(e);
             if (CanUserAccessNode(e, allowedUserOptions))
-            {
-                //The result returned from the method will indicate if there are children. 
-                var hasChildren = (ShouldRenderChildrenOfContainer(e) >= 0);
+            { 
+                var hasChildren = e.HasChildren();
+                var shouldRenderChildren = ShouldRenderChildrenOfContainer(e);
 
                 //Special check to see if the node has no children.
-                if (ShouldRenderChildrenOfContainer(e) < 0)
+                if (shouldRenderChildren == false && !hasChildren)
                 {
                     hasChildren = false;
                 }
@@ -85,6 +85,7 @@ namespace Umbraco.Web.Trees
                     hasChildren);
 
                 node.AdditionalData.Add("contentType", entity.ContentTypeAlias);
+                node.AdditionalData.Add("shouldRender", shouldRenderChildren);
 
                 if (e.IsContainer())
                 {

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -68,11 +68,15 @@ namespace Umbraco.Web.Trees
             var allowedUserOptions = GetAllowedUserMenuItemsForNode(e);
             if (CanUserAccessNode(e, allowedUserOptions))
             {
-                //Special check to see if it ia a container, if so then we'll hide children.
-                var isContainer = e.IsContainer();   // && (queryStrings.Get("isDialog") != "true");
+                //The result returned from the method will indicate if there are children. 
+                var hasChildren = (ShouldRenderChildrenOfContainer(e) >= 0);
 
-                var hasChildren = ShouldRenderChildrenOfContainer(e);
-                
+                //Special check to see if the node has no children.
+                if (ShouldRenderChildrenOfContainer(e) < 0)
+                {
+                    hasChildren = false;
+                }
+
                 var node = CreateTreeNode(
                     entity,
                     Constants.ObjectTypes.DocumentGuid,
@@ -82,7 +86,7 @@ namespace Umbraco.Web.Trees
 
                 node.AdditionalData.Add("contentType", entity.ContentTypeAlias);
 
-                if (isContainer)
+                if (e.IsContainer())
                 {
                     node.AdditionalData.Add("isContainer", true);
                     node.SetContainerStyle();

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -283,25 +283,12 @@ namespace Umbraco.Web.Trees
         /// This is required in case a user has custom start nodes that are children of a list view since in that case we'll need to render the tree node. In normal cases we don't render
         /// children of a list view.
         /// </remarks>
-        protected int ShouldRenderChildrenOfContainer(IUmbracoEntity e)
+        protected bool ShouldRenderChildrenOfContainer(IUmbracoEntity e)
         {
             var isContainer = e.IsContainer();
-            var renderChildren = 0;
 
-            // If a node has children, the outcome will be 1.
-            if(e.HasChildren() == true)
-                renderChildren = 1;
-
-            if (isContainer == true || renderChildren == 0)
-            {
-                if (renderChildren == 1)
-                    renderChildren = 0;
-                else if (isContainer == false)
-                    renderChildren = -1;
-                else
-                    renderChildren = -2;
-            }
-
+            var renderChildren = e.HasChildren() && (isContainer == false);
+            
             //Here we need to figure out if the node is a container and if so check if the user has a custom start node, then check if that start node is a child
             // of this container node. If that is true, the HasChildren must be true so that the tree node still renders even though this current node is a container/list view.
             if (isContainer && UserStartNodes.Length > 0 && UserStartNodes.Contains(Constants.System.Root) == false)
@@ -311,7 +298,7 @@ namespace Umbraco.Web.Trees
                 // the UI that this node does have children and that it isn't a container
                 if (startNodes.Any(x => x.ParentId == e.Id))
                 {
-                    renderChildren = 1;
+                    renderChildren = true;
                 }
             }
 
@@ -334,7 +321,7 @@ namespace Umbraco.Web.Trees
             //before we get the children we need to see if this is a container node
 
             //test if the parent is a listview / container -> the result should be an even number
-            if (current != null && (ShouldRenderChildrenOfContainer(current) % 2) == 0)
+            if (current != null && ShouldRenderChildrenOfContainer(current) == false)
             {
                 //no children rendered!
                 return new TreeNodeCollection();

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -320,7 +320,7 @@ namespace Umbraco.Web.Trees
 
             //before we get the children we need to see if this is a container node
 
-            //test if the parent is a listview / container -> the result should be an even number
+            //test if the parent is a listview / container
             if (current != null && ShouldRenderChildrenOfContainer(current) == false)
             {
                 //no children rendered!

--- a/src/Umbraco.Web/Trees/MediaTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTreeController.cs
@@ -64,19 +64,16 @@ namespace Umbraco.Web.Trees
         {
             var entity = (UmbracoEntity)e;
 
-            //Special check to see if it ia a container, if so then we'll hide children.
-            var isContainer = e.IsContainer(); // && (queryStrings.Get("isDialog") != "true");
-
             var node = CreateTreeNode(
                 entity,
                 Constants.ObjectTypes.MediaGuid,
                 parentId,
                 queryStrings,
-                entity.HasChildren && (isContainer == false));
+                entity.HasChildren);
 
             node.AdditionalData.Add("contentType", entity.ContentTypeAlias);
 
-            if (isContainer)
+            if (e.IsContainer())
             {
                 node.SetContainerStyle();
                 node.AdditionalData.Add("isContainer", true);


### PR DESCRIPTION
### Prerequisites

Connects to https://github.com/umbraco/Umbraco.Private/issues/173

### Description
ShouldRenderChildrenOfContainer() method will detect if the node passed as a parameter to it has children and whether it is a container. The method will return an integer - positive outcome will mean that the node has children, negative signifies the opposite. An even number will show that the node has been set to be a listview/container. 

GetTreeNodesInternal() in the ContentTreecControllerBase class is being used to verify if a node is a listview => the result returned from ShouldRenderChildrenOfContainer() is compared to see if it is an even number. If that is the case a new tree structure is initialized.

The markup for the tree structure is modified - an arrow pointing to the right will only appear if the node hasn't been expanded and if the node is not a container.