### PR TITLE
U4 4732 - fix regressions in 7.12

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -761,6 +761,8 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
 		 * @param {string} input the string to parse      
 		 */
 		getAnchorNames: function (input) {
+      if (!input) return [];
+        
 			var anchorPattern = /<a id=\\"(.*?)\\">/gi;
 			var matches = input.match(anchorPattern);
 			var anchors = [];
@@ -771,7 +773,9 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
 				});
 			}
 
-			return anchors;
+			return anchors.filter(function(val, i, self) {
+          return self.indexOf(val) === i;
+      });
 		},
 
 		insertLinkInEditor: function (editor, target, anchorElm) {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -212,3 +212,14 @@
     position: relative;
     transform: translate(-50%, -25%);
 }
+
+
+// this resolves the layout issue introduced in nested content in 7.12 with the addition of the input for link anchors
+// the attribute selector ensures the change only applies to the linkpicker overlay
+.form-horizontal .umb-nested-content--narrow [ng-controller*="Umbraco.Overlays.LinkPickerController"] .controls-row {
+    margin-left:0!important;
+    
+    .umb-textarea, .umb-textstring {
+        width:100%;
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.html
@@ -7,7 +7,7 @@
 	           placeholder="@general_url"
 	           class="umb-editor umb-textstring"
 	           ng-model="target.url"
-	           ng-disabled="target.id" />
+	           ng-disabled="target.id || target.udi" />
 	</umb-control-group>
 
 	<umb-control-group label="@defaultdialogs_anchorLinkPicker" class="umb-property--push">

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
@@ -6,7 +6,7 @@
                placeholder="@general_url"
                class="umb-editor umb-textstring"
                ng-model="model.target.url"
-               ng-disabled="model.target.id" />
+               ng-disabled="model.target.id || model.target.udi" />
     </umb-control-group>
 
     <umb-control-group label="@defaultdialogs_anchorLinkPicker" class="umb-property--push">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
This fixes a couple of regressions identified in 7.12, introduced in #2702:
 - prevent editing a url on an existing link when editing the link. Needed to check for target.udi and target.id when setting the disabled state on the input
 - fix layout in linkpicker dialog in nested content. It's some not-very-pretty CSS, but without knowing why the overlay has different styles in NC compared to a standalone RTE, I'm not too keen on pulling things apart. 