### PR TITLE
U4-11587 Media link does not update when the file is swapped

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
@@ -11,8 +11,8 @@
                 scope.allowOpenMediaType = true;
                 // get document type details
                 scope.mediaType = scope.node.contentType;
-                // get node url
-                scope.nodeUrl = scope.node.mediaLink;
+                // set the media link initially
+                setMediaLink();
                 // make sure dates are formatted to the user's locale
                 formatDatesToLocal();
             }
@@ -25,16 +25,25 @@
                 });
             }
 
+            function setMediaLink(){
+                scope.nodeUrl = scope.node.mediaLink;
+            }
+
             scope.openMediaType = function (mediaType) {
                 // remove first "#" from url if it is prefixed else the path won't work
                 var url = "/settings/mediaTypes/edit/" + mediaType.id;
                 $location.path(url);
             };
-            
+
             // watch for content updates - reload content when node is saved, published etc.
             scope.$watch('node.updateDate', function(newValue, oldValue){
                 if(!newValue) { return; }
                 if(newValue === oldValue) { return; }
+
+                // Update the media link
+                setMediaLink();
+
+                // Update the create and update dates
                 formatDatesToLocal();
             });
 
@@ -46,7 +55,6 @@
             });
 
             onInit();
-
         }
 
         var directive = {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org/issue/U4-11587

### Description
Turns out that the issue was a bit more "minor" than it looked like at a first glance. But this fix makes the url update after a succeful save event happens just like the update date etc. on the "info" tab of the media item. To get an idea about what it does watch the video where it previously worked like this on the issue (The 7.7 one) - I hope it makes sense :-)
