### PR TITLE
Only remove ? or # if it's part of the url

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
@@ -43,8 +43,12 @@ angular.module("umbraco").controller("Umbraco.Dialogs.LinkPickerController",
 					$scope.model.target.url = resp.urls[0];
 				});
 			} else if ($scope.target.url.length) {
-				// a url but no id/udi indicates an external link - trim the url to remove the anchor/qs
-				$scope.target.url = $scope.model.url.substring(0, $scope.model.url.search(/(#|\?)/));
+                // a url but no id/udi indicates an external link - trim the url to remove the anchor/qs
+                // only do the substring if there's a # or a ?
+                var indexOfAnchor = $scope.model.target.url.search(/(#|\?)/);
+                if (indexOfAnchor > -1) {
+                    $scope.model.target.url = $scope.model.target.url.substring(0, indexOfAnchor);
+                }
 			}
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -53,7 +53,11 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 				});
 			} else if ($scope.model.target.url.length) {
 				// a url but no id/udi indicates an external link - trim the url to remove the anchor/qs
-				$scope.model.target.url = $scope.model.target.url.substring(0, $scope.model.target.url.search(/(#|\?)/));				
+                // only do the substring if there's a # or a ?
+                var indexOfAnchor = $scope.model.target.url.search(/(#|\?)/);
+                if (indexOfAnchor > -1) {
+                    $scope.model.target.url = $scope.model.target.url.substring(0, indexOfAnchor);
+                }
 			}
 		} else if (dialogOptions.anchors) {
 			$scope.anchorValues = dialogOptions.anchors;


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description

I was updating my Multi Url Picker to support the new anchor/querystring field and I noticed that the URL field didn't get set if there were no anchor/querystring because it did a substring(0, -1).

This PR checks if there's an anchor/querystring found in the url before doing the substring.


@MMasey also mentioned it in [the issue](http://issues.umbraco.org/issue/U4-4732) with steps how to reproduce