### PR TITLE
U4-11594 HasFocalPoint in ImageCropDataSet does not return correct value 

### DIFF
--- a/src/Umbraco.Web/Models/ImageCropDataSet.cs
+++ b/src/Umbraco.Web/Models/ImageCropDataSet.cs
@@ -66,7 +66,7 @@ namespace Umbraco.Web.Models
 
         public bool HasFocalPoint()
         {
-            return FocalPoint != null && FocalPoint.Left != 0.5m && FocalPoint.Top != 0.5m;
+            return FocalPoint != null && (FocalPoint.Left != 0.5m || FocalPoint.Top != 0.5m);
         }
 
         public bool HasCrop(string alias)


### PR DESCRIPTION
If only one of the Left or Right values changed the HasFocalPoint function would return false but this should now return true if only one is altered
