### PR TITLE
Media picker: Minor style update + add help text.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
@@ -28,6 +28,7 @@
                             label-key="general_upload"
                             action="upload()"
                             disabled="lockedFolder"
+                            button-style="info"
                             ng-if="acceptedMediatypes.length > 0">
                 </umb-button>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
@@ -37,6 +37,12 @@
         </div>
     </div>
 
+    <div ng-show="hideDropzone" ngf-drag-over-class="hide" class="text-center">
+        <small>
+            <localize key="media_dragFilesHereToUpload">You can drag files here to upload</localize>
+        </small>
+    </div>
+
     <!-- List of uploading/uploaded files  -->
     <ul class="file-list" ng-show="done.length > 0 || queue.length > 0 || rejected.length > 0 || filesHolder.length > 0">
 

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -259,6 +259,7 @@
     <key alias="dropFilesHere">Slip filerne her...</key>
     <key alias="urls">Link til medie</key>
     <key alias="orClickHereToUpload">eller klik her for at vælge filer</key>
+    <key alias="dragFilesHereToUpload">Du kan trække filer herind for at uploade</key>
     <key alias="onlyAllowedFiles">Tilladte filtyper er kun</key>
     <key alias="disallowedFileType">Kan ikke uploade denne fil, den har ikke en godkendt filtype</key>
     <key alias="maxFileSize">Maks filstørrelse er</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -267,6 +267,7 @@
         <key alias="dropFilesHere">Drop your files here...</key>
         <key alias="urls">Link to media</key>
         <key alias="orClickHereToUpload">or click here to choose files</key>
+        <key alias="dragFilesHereToUpload">You can drag files here to upload</key>
         <key alias="onlyAllowedFiles">Only allowed file types are</key>
         <key alias="disallowedFileType">Cannot upload this file, it does not have an approved file type</key>
         <key alias="maxFileSize">Max file size is</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -268,6 +268,7 @@
         <key alias="dropFilesHere">Drop your files here...</key>
         <key alias="urls">Link to media</key>
         <key alias="orClickHereToUpload">or click here to choose files</key>
+        <key alias="dragFilesHereToUpload">You can drag files here to upload</key>
         <key alias="onlyAllowedFiles">Only allowed file types are</key>
         <key alias="disallowedFileType">Cannot upload this file, it does not have an approved file type</key>
         <key alias="maxFileSize">Max file size is</key>


### PR DESCRIPTION
History: See #2765 

This PR is a two-fold update for the media picker:

1. The upload button is styled with the "info" style.
2. A help text is displayed when the dropzone for uploads is hidden.

Here's what it looks like:

![mediapickerupload](https://user-images.githubusercontent.com/7405322/44459762-14e1e600-a60b-11e8-95f4-2fc250f6fbcd.gif)

**Please note** that the PR contains a new localized text. I've added English and Danish translations.