### PR TITLE
U4-9030 Moving a RTE between grid cells causes rendering issues for other RTEs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -218,7 +218,7 @@ angular.module("umbraco")
                 // Fade in control when sorting stops
                 ui.item.context.style.opacity = "1";
 
-                ui.item.parents(".umb-cell-content").find(".mceNoEditor").each(function () {
+                ui.item.offsetParent().find(".mceNoEditor").each(function () {
                     if ($.inArray($(this).attr("id"), notIncludedRte) < 0) {
                         // add all dragged's neighbouring RTEs in the new cell
                         notIncludedRte.splice(0, 0, $(this).attr("id"));


### PR DESCRIPTION
When moving a rich text editor around in a grid layout, on stop it wouldn't be able to retrieve the parents of the grid cell, causing rendering issues with other rich text editors in the same cell -
![brokengrid](https://user-images.githubusercontent.com/5725774/44576483-9447f480-a786-11e8-948b-842ae1538e79.gif)

Replacing the call to parents(".umb-cell-content") with offsetParent() allows it to find it's parent, and therefore other RTEs in the same cell -
![workinggrid](https://user-images.githubusercontent.com/5725774/44576533-b477b380-a786-11e8-978f-ac00741d9c15.gif)

