### PR TITLE
Hide preview button 'initially' on nodes with no template

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentModelMapper.cs
@@ -61,6 +61,13 @@ namespace Umbraco.Web.Models.Mapping
                     {
                         TabsAndPropertiesResolver<IContent>.AddListView(display, "content", applicationContext.Services.DataTypeService, applicationContext.Services.TextService);
                     }
+                    //if there aren't any allowed templates for this content item, default 'AllowPreview' to be false
+                    //this can still be overriden by a developer (SendingContentModel event) if they have route hijacked
+                    //and do have a valid preview to show.
+                    if (display.AllowedTemplates == null || !display.AllowedTemplates.Any())
+                    {
+                        display.AllowPreview = false;
+                    }
                 });
 
             //FROM IContent TO ContentItemBasic<ContentPropertyBasic, IContent>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have linked this PR to an issue on the tracker at http://issues.umbraco.org
See http://issues.umbraco.org/issue/U4-10740


### Description
When a document type is created without a template, and an editor creates a new content item based on it, a Preview button is displayed, but a Preview will nearly always present an error to the User, as there is no template...

Umbraco 6 would grey out the preview button and explain there was no template available.

However it isn't as simple as just hiding the preview button if there aren't any templates for the content item, as it's possible to 'route hijack' a document type without a template, and return a particular view from code, and in these circumstances, you still want the editor to be able to preview.

Therefore this pull request only 'sets' the initial starting value of the 'AllowPreview' flag to false, if there are no templates for the content item, allowing a developer to override this in the SendingContentModel event, and set the AllowPreview flag to be true again, in the circumstance they have provided a route hijacked view for the content item, and require the preview.

Is this a breaking change? eg Preview will suddenly disappear for people who have this kind of hijacked setup, and they'll have to implement setting the flag in the event - and is it worth making (without any evidence to suggest which is the most common scenario!) so that editors encountering nodes without templates won't see the preview button?





<!-- Thanks for contributing to Umbraco CMS! -->
