### PR TITLE
U4-11589 Document Type Collection should create templates for created types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
@@ -298,10 +298,10 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
 
         },
 
-        createCollection: function (parentId, collectionName, collectionItemName, collectionIcon, collectionItemIcon) {
+        createCollection: function (parentId, collectionName, collectionCreateTemplate, collectionItemName, collectionItemCreateTemplate, collectionIcon, collectionItemIcon) {
 
             return umbRequestHelper.resourcePromise(
-                $http.post(umbRequestHelper.getApiUrl("contentTypeApiBaseUrl", "PostCreateCollection", { parentId: parentId, collectionName: collectionName, collectionItemName: collectionItemName, collectionIcon: collectionIcon, collectionItemIcon: collectionItemIcon})),
+                $http.post(umbRequestHelper.getApiUrl("contentTypeApiBaseUrl", "PostCreateCollection", { parentId: parentId, collectionName: collectionName, collectionCreateTemplate: collectionCreateTemplate, collectionItemName: collectionItemName, collectionItemCreateTemplate: collectionItemCreateTemplate, collectionIcon: collectionIcon, collectionItemIcon: collectionItemIcon})),
                 'Failed to create collection under ' + parentId);
 
         },

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
@@ -27,6 +27,8 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
 
     $scope.showCreateDocTypeCollection = function () {
         $scope.model.creatingDoctypeCollection = true;
+        $scope.model.collectionCreateTemplate = true;
+        $scope.model.collectionItemCreateTemplate = true;
     };
 
     $scope.createContainer = function () {
@@ -83,7 +85,7 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
                     }
                 }
 
-                contentTypeResource.createCollection(node.id, $scope.model.collectionName, $scope.model.collectionItemName, collectionIcon, collectionItemIcon).then(function (collectionData) {
+                contentTypeResource.createCollection(node.id, $scope.model.collectionName, $scope.model.collectionCreateTemplate, $scope.model.collectionItemName, $scope.model.collectionItemCreateTemplate, collectionIcon, collectionItemIcon).then(function (collectionData) {
 
                     navigationService.hideMenu();
                     $location.search('create', null);

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -80,10 +80,14 @@
 
             <umb-control-group label="Name of the Parent Document Type" hide-label="false">
                 <input type="text" name="collectionName" ng-model="model.collectionName" class="umb-textstring textstring input-block-level" umb-auto-focus required />
+                <umb-toggle on-click="model.collectionCreateTemplate = !model.collectionCreateTemplate" checked="model.collectionCreateTemplate"></umb-toggle>
+                <label>Create template for the Parent Document Type</label>
             </umb-control-group>
 
             <umb-control-group label="Name of the Item Document Type" hide-label="false">
                 <input type="text" name="collectionItemName" ng-model="model.collectionItemName" class="umb-textstring textstring input-block-level" required />
+                <umb-toggle on-click="model.collectionItemCreateTemplate = !model.collectionItemCreateTemplate" checked="model.collectionItemCreateTemplate"></umb-toggle>
+                <label>Create template for the Item Document Type</label>
             </umb-control-group>
 
             <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>


### PR DESCRIPTION
### Prerequisites

- [X ] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
The new "Document Type Collection" would be a fantastic time-saver - if matching templates were also created. 

PR: http://issues.umbraco.org/issue/U4-11589