### PR TITLE
U4-11145 Email validation is too strict on password reset screen

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.html
@@ -181,7 +181,7 @@
                     <form method="POST" name="requestPasswordResetForm" ng-submit="requestPasswordResetSubmit(email)">
                         <div class="control-group" ng-class="{error: requestPasswordResetForm.email.$invalid}">
                             <label><localize key="general_email">Email</localize></label>
-                            <input type="email" ng-model="email" name="email" class="-full-width-input" localize="placeholder" placeholder="@placeholders_email" />
+                            <input type="email" val-email ng-model="email" name="email" class="-full-width-input" localize="placeholder" placeholder="@placeholders_email" />
                         </div>
 
                         <div class="control-group" ng-show="requestPasswordResetForm.$invalid">


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have linked this PR to an issue on the tracker at http://issues.umbraco.org

### Description
 When going to the login screen
 Clicking Forgotten password
 Enter an email address with a new TLD eg user@company.solutions
 Press Submit button

What did you expect to happen?
Form to be submitted

What actually happened?
Email address validation failed in angular app, with no error message displayed too.



issue: http://issues.umbraco.org/issue/U4-11145