### PR TITLE
Fix comment regarding the length of the salt bytes array

### DIFF
--- a/src/Umbraco.Core/Security/MembershipProviderBase.cs
+++ b/src/Umbraco.Core/Security/MembershipProviderBase.cs
@@ -720,7 +720,7 @@ namespace Umbraco.Core.Security
                     }
                     else
                     {
-                        //if the salt bytes is too long for the required key length for the algorithm, extend it
+                        //if the salt bytes is too short for the required key length for the algorithm, extend it
                         var numArray2 = new byte[keyedHashAlgorithm.Key.Length];
                         var dstOffset = 0;
                         while (dstOffset < numArray2.Length)


### PR DESCRIPTION
### Prerequisites

- No issue required. It's a small fix to an incorrect comment.

### Description

I fixed what looks like a copy and paste mistake in the comment. If the salt bytes array is too short it should be extended. Not if it is too long. The long case is handled in the code above.
