### PR TITLE
Media Picker should not show deleted items #2886

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -250,7 +250,8 @@ angular.module("umbraco")
                 // make sure that last opened node is on the same path as start node
                 var nodePath = node.path.split(",");
 
-                if (nodePath.indexOf($scope.startNodeId.toString()) !== -1) {
+                // also make sure the node is not trashed
+                if (nodePath.indexOf($scope.startNodeId.toString()) !== -1 && node.trashed === false) {
                     $scope.gotoFolder({ id: $scope.lastOpenedNode, name: "Media", icon: "icon-folder" });
                     return true;
                 } else {


### PR DESCRIPTION
### Prerequisites

- [X] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/2886
- [X] I have added steps to test this contribution in the description below

### Description
The media picker remembers the last folder used. However, if the folder is deleted and the media picker opened again, it still opens to the last folder - even though that folder is now deleted. You can still select items from the folder. 

https://github.com/umbraco/Umbraco-CMS/issues/2886