### PR TITLE
Make the file extension visible when picking a file using the media picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -33,6 +33,19 @@
     background-color: @gray-10;
 }
 
+.umb-media-grid__item-file-icon > span {
+    color: @white;
+    background: @gray-4;
+    padding: 1px 3px;
+    font-size: 10px;
+    line-height: 130%;
+    display: block;
+    margin-top: -30px;
+    margin-left: -10px;
+    /*Need to reset the opacity?*/
+    opacity: 0.99;
+}
+
 .umb-media-grid__item.-selected {
     box-shadow: 0 2px 8px 0 rgba(0,0,0,.35);
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -42,8 +42,7 @@
     display: block;
     margin-top: -30px;
     margin-left: -10px;
-    /*Need to reset the opacity?*/
-    opacity: 0.99;
+    position: relative;
 }
 
 .umb-media-grid__item.-selected {

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -363,12 +363,29 @@ ul.color-picker li {
     text-align: center;
 }
 
-.umb-sortable-thumbnails .umb-icon-holder .icon{
+.umb-sortable-thumbnails .umb-icon-holder .icon {
     font-size: 40px;
     line-height: 50px;
     color: @gray-3;
     display: block;
 }
+
+.umb-sortable-thumbnails .umb-icon-holder .file-icon > span {
+    color: @white;
+    background: @gray-4;
+    padding: 1px 3px;
+    font-size: 10px;
+    line-height: 130%;
+    display: block;
+    margin-top: -30px;
+    width: 2em;
+}
+
+.umb-sortable-thumbnails .umb-icon-holder .file-icon + small {
+    display: block;
+    margin-top: 1em;
+}
+
 
 .umb-sortable-thumbnails .umb-sortable-thumbnails__wrapper {
     width: 124px;

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -21,8 +21,10 @@
             <img class="umb-media-grid__item-image-placeholder" ng-if="!item.thumbnail && item.extension != 'svg'" src="assets/img/transparent.png" alt="{{item.name}}" draggable="false" />
 
             <!-- Icon for files -->
-            <i class="umb-media-grid__item-icon {{item.icon}}" ng-if="!item.thumbnail && item.extension != 'svg'"></i>
-
+            <span class="umb-media-grid__item-file-icon" ng-if="!item.thumbnail && item.extension != 'svg'">
+                <i class="umb-media-grid__item-icon {{item.icon}}"></i>
+                <span>.{{item.extension}}</span>
+            </span>
         </div>
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -17,7 +17,10 @@
 
                 <!-- FILE -->
                 <span class="umb-icon-holder" ng-hide="image.thumbnail || image.metaData.umbracoExtension.Value === 'svg' || image.extension === 'svg'">
-                    <i class="icon {{image.icon}} large"></i>
+                    <span class="file-icon">
+                        <i class="icon {{image.icon}} large"></i>
+                        <span>.{{image.extension}}</span>
+                    </span>
                     <small>{{image.name}}</small>
                 </span>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: http://issues.umbraco.org/issue/U4-11561
- [x] I have added steps to test this contribution in the description below

### Description
<!-- A description of the changes proposed in the pull-request -->
Updated MediaPicker Views to have the same<span class="file-icon and <span containing the file extension (from the file upload component)
* /src/views/components/umb-media-grid.html
* /src/views/propertyeditors/mediapicker/mediapicker.html

 added some styles, hopefully in the right places in the LESS here, to overlay the text of the extension name over the file icon...
* /src/less/components/umb-media-grid.less
* /src/less/property-editors.less

### Testing

Add a media picker to a document type, upload a PDF, DOCX document etc, on the document, pick the file, in the Media picking process the extension of the document should be overlayed on top of the file icon... and when 'picked' on the document type, the name of the extension should be still visible on the picked file item

<!-- Make sure to link to the related issue number so we can easily find it in the issue tracker -->

<!-- Thanks for contributing to Umbraco CMS! -->
