### PR TITLE
Hide "Created Date" field when the content hasn't yet been created

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -171,7 +171,7 @@
                     </umb-badge>
                 </umb-control-group>
 
-                <umb-control-group data-element="node-info-create-date" label="@template_createdDate">
+                <umb-control-group ng-if="node.id !== 0" data-element="node-info-create-date" label="@template_createdDate">
                     {{node.createDateFormatted}} <localize key="general_by">by</localize> {{ node.owner.name }}
                 </umb-control-group>
 


### PR DESCRIPTION
I think it is a bit weird that a creation date is shown even before a content item has been created. Especially when the date is in year 1 👴 

![image](https://user-images.githubusercontent.com/3634580/44994552-6ee59280-af9f-11e8-9589-019a051c5f66.png)

With this PR, the property is hidden when the numeric ID is zero. It will now look like this instead:

![image](https://user-images.githubusercontent.com/3634580/44994571-81f86280-af9f-11e8-909a-011b7d2d611c.png)

Once the content item has been published, the "Created Date" property will be shown as intended.
