### PR TITLE
The name field is not automatically in focus when creating a new data type folder

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/create.html
@@ -29,7 +29,7 @@
               val-form-manager>
 
             <umb-control-group label="Enter a folder name" hide-label="false">
-                <input type="text" name="folderName" ng-model="model.folderName" class="umb-textstring textstring input-block-level" required />
+                <input type="text" name="folderName" ng-model="model.folderName" class="umb-textstring textstring input-block-level" required autofocus />
             </umb-control-group>
 
             <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>


### PR DESCRIPTION
Not really must to add - the field is now automatically in focus when the dialog opens 😄 

![image](https://user-images.githubusercontent.com/3634580/44995633-3eecbe00-afa4-11e8-89d0-d816b86b7516.png)
