### PR TITLE
U4-7316 (wip)

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -209,6 +209,11 @@ namespace Umbraco.Core
             /// </summary>
             public const string MediaPicker2Alias = "Umbraco.MediaPicker2";
 
+            /// <summary>
+            /// Alias for the Media Cropper datatype.
+            /// </summary>
+            public const string MediaCropperAlias = "Umbraco.MediaCropper";
+
             [Obsolete("This is an obsoleted picker, use MediaPicker2Alias instead")]
             public const string MultipleMediaPickerAlias = "Umbraco.MultipleMediaPicker";
 

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -567,8 +567,8 @@
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenEightZero\AddInstructionCountColumn.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenEightZero\AddCmsMediaTable.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenEightZero\AddUserLoginTable.cs" />
-    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\RenameTrueFalseField.cs" />	
-    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\SetDefaultTagsStorageType.cs" />      
+    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\RenameTrueFalseField.cs" />
+    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\SetDefaultTagsStorageType.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenNineZero\AddUmbracoAuditTable.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenNineZero\AddUmbracoConsentTable.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenNineZero\AddIsSensitiveMemberTypeColumn.cs" />
@@ -638,7 +638,7 @@
     <Compile Include="Media\Exif\TIFFStrip.cs" />
     <Compile Include="Media\Exif\Utility.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenThreeOne\UpdateUserLanguagesToIsoCode.cs" />
-    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\IncreaseLanguageIsoCodeColumnLength.cs" />      
+    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\IncreaseLanguageIsoCodeColumnLength.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\UpdateUmbracoConsent.cs" />
     <Compile Include="Persistence\PocoDataDataReader.cs" />
     <Compile Include="Persistence\Querying\CachedExpression.cs" />

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.controller.js
@@ -1,0 +1,243 @@
+//this controller simply tells the dialogs service to open a mediaPicker window
+//with a specified callback, this callback will receive an object with a selection on it
+angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaCropperController",
+    function ($rootScope, $scope, dialogService, entityResource, mediaResource, mediaHelper, $timeout, userService, $location, localizationService) {
+
+        var config = angular.copy($scope.model.config);
+
+        //check the pre-values for multi-picker
+        var multiPicker = $scope.model.config.multiPicker && $scope.model.config.multiPicker !== '0' ? true : false;
+        var disableFolderSelect = $scope.model.config.disableFolderSelect && $scope.model.config.disableFolderSelect !== '0' ? true : false;
+
+        if (!$scope.model.config.startNodeId) {
+            userService.getCurrentUser().then(function(userData) {
+                $scope.model.config.startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
+                $scope.model.config.startNodeIsVirtual = userData.startMediaIds.length !== 1;
+            });
+        }
+
+        function setupViewModel() {
+            $scope.images = [];
+            $scope.ids = [];
+
+            $scope.isMultiPicker = multiPicker;
+
+            if ($scope.model.value) {
+                var ids = $scope.model.value.map(function (data) { return data.udi; });
+
+                //NOTE: We need to use the entityResource NOT the mediaResource here because
+                // the mediaResource has server side auth configured for which the user must have
+                // access to the media section, if they don't they'll get auth errors. The entityResource
+                // acts differently in that it allows access if the user has access to any of the apps that
+                // might require it's use. Therefore we need to use the metaData property to get at the thumbnail
+                // value.
+
+                entityResource.getByIds(ids, "Media").then(function (medias) {
+
+                    // The service only returns item results for ids that exist (deleted items are silently ignored).
+                    // This results in the picked items value to be set to contain only ids of picked items that could actually be found.
+                    // Since a referenced item could potentially be restored later on, instead of changing the selected values here based
+                    // on whether the items exist during a save event - we should keep "placeholder" items for picked items that currently
+                    // could not be fetched. This will preserve references and ensure that the state of an item does not differ depending
+                    // on whether it is simply resaved or not.
+                    // This is done by remapping the int/guid ids into a new array of items, where we create "Deleted item" placeholders
+                    // when there is no match for a selected id. This will ensure that the values being set on save, are the same as before.
+
+                    medias = _.map(ids,
+                        function (id) {
+                            var found = _.find(medias,
+                                function (m) {
+                                    // We could use coercion (two ='s) here .. but not sure if this works equally well in all browsers and
+                                    // it's prone to someone "fixing" it at some point without knowing the effects. Rather use toString()
+                                    // compares and be completely sure it works.
+                                    return m.udi.toString() === id.toString() || m.id.toString() === id.toString();
+                                });
+                            if (found) {
+                                return found;
+                            } else {
+                                return {
+                                    name: localizationService.dictionary.mediaPicker_deletedItem,
+                                    id: $scope.model.config.idType !== "udi" ? id : null,
+                                    udi: $scope.model.config.idType === "udi" ? id : null,
+                                    icon: "icon-picture",
+                                    thumbnail: null,
+                                    trashed: true
+                                };
+                            }
+                        });
+
+                    _.each(medias,
+                        function (media, i) {
+                            // if there is no thumbnail, try getting one if the media is not a placeholder item
+                            if (!media.thumbnail && media.id && media.metaData) {
+                                media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
+                            }
+
+                            $scope.images.push(media);
+
+                            if ($scope.model.config.idType === "udi") {
+                                $scope.ids.push(media.udi);
+                            } else {
+                                $scope.ids.push(media.id);
+                            }
+                        });
+
+                    $scope.sync();
+                });
+            }
+            else {
+                $scope.model.value = [];
+            }
+        }
+
+        setupViewModel();
+
+        $scope.remove = function(index) {
+            $scope.images.splice(index, 1);
+            $scope.ids.splice(index, 1);
+            $scope.sync();
+        };
+
+        $scope.goToItem = function(item) {
+            $location.path('media/media/edit/' + item.id);
+        };
+
+       $scope.add = function() {
+
+           $scope.mediaPickerOverlay = {
+               view: "mediapicker",
+               title: "Select media",
+               startNodeId: $scope.model.config.startNodeId,
+               startNodeIsVirtual: $scope.model.config.startNodeIsVirtual,
+               multiPicker: multiPicker,
+               onlyImages: true,
+               disableFolderSelect: true,
+               show: true,
+               submit: function(model) {
+
+                   _.each(model.selectedImages, function(media, i) {
+                       // if there is no thumbnail, try getting one if the media is not a placeholder item
+                       if (!media.thumbnail && media.id && media.metaData) {
+                           media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
+                       }
+
+                       $scope.images.push(media);
+
+                       if ($scope.model.config.idType === "udi") {
+                           $scope.ids.push(media.udi);
+                       }
+                       else {
+                           $scope.ids.push(media.id);
+                       }
+                   });
+
+                   $scope.sync();
+
+                   $scope.mediaPickerOverlay.show = false;
+                   $scope.mediaPickerOverlay = null;
+               }
+           };
+        };
+
+        $scope.cropItem = function (item) {
+
+            var cropDataSet = $scope.model.value.filter(function (data) { return data.udi == item.udi });
+            cropDataSet[0].src = item.file;
+
+            $scope.mediaPickerOverlay = {
+                view: "views/propertyeditors/imagecropper/imagecropper.html",
+                title: "Crop settings",
+                config: config,
+                value: cropDataSet[0],
+                show: true,
+                submit: function (model) {
+
+                    _.each($scope.model.value, function (crop, i) {
+                        if (crop.udi == item.udi) {
+                            $scope.model.value[i] = crop;
+                        }
+                    });
+
+                    $scope.sync();
+
+                    $scope.mediaPickerOverlay.show = false;
+                    $scope.mediaPickerOverlay = null;
+                }
+            };
+        }
+
+       $scope.sortableOptions = {
+           disabled: !$scope.isMultiPicker,
+           items: "li:not(.add-wrapper)",
+           cancel: ".unsortable",
+           update: function(e, ui) {
+               var r = [];
+               // TODO: Instead of doing this with a half second delay would be better to use a watch like we do in the
+               // content picker. Then we don't have to worry about setting ids, render models, models, we just set one and let the
+               // watch do all the rest.
+                $timeout(function(){
+                    angular.forEach($scope.images, function(value, key) {
+                        r.push($scope.model.config.idType === "udi" ? value.udi : value.id);
+                    });
+                    $scope.ids = r;
+                    $scope.sync();
+                }, 500, false);
+            }
+        };
+
+        $scope.sync = function () {
+            var newValue = [];
+            angular.forEach($scope.ids, function (id, i) {
+
+                foundCropDataSet = $scope.model.value.filter(function (value) { return value.udi == id; });
+                if (foundCropDataSet.length > 0) {
+
+                    var cropDataSet = foundCropDataSet[0];
+
+                    //sync any config changes with the editor and drop outdated crops
+                    _.each(cropDataSet.crops, function (saved) {
+                        var configured = _.find(config.crops, function (item) { return item.alias === saved.alias });
+
+                        if (configured && configured.height === saved.height && configured.width === saved.width) {
+                            configured.coordinates = saved.coordinates;
+                        }
+                    });
+                    cropDataSet.crops = config.crops;
+
+                    //restore focalpoint if missing
+                    if (!cropDataSet.focalPoint) {
+                        cropDataSet.focalPoint = config.focalPoint;
+                    }
+
+                    newValue.push(cropDataSet);
+                }
+                else {
+                    var cropDataSet = {
+                        udi: id,
+                        crops: config.crops,
+                        focalPoint: config.focalPoint
+                    }
+
+                    newValue.push(cropDataSet);
+                }
+
+            });
+            $scope.model.value = newValue;
+        };
+
+        $scope.showAdd = function () {
+            if (!multiPicker) {
+                if ($scope.model.value && $scope.model.value !== "") {
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        //here we declare a special method which will be called whenever the value has changed from the server
+        //this is instead of doing a watch on the model.value = faster
+        $scope.model.onValueChanged = function (newVal, oldVal) {
+            //update the display val again if it has changed from the server
+            setupViewModel();
+        };
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.html
@@ -1,0 +1,46 @@
+<div class="umb-editor umb-mediapicker" ng-controller="Umbraco.PropertyEditors.MediaCropperController">
+
+    <p ng-if="(images|filter:{trashed:true}).length == 1"><localize key="mediaPicker_pickedTrashedItem"></localize></p>
+    <p ng-if="(images|filter:{trashed:true}).length > 1"><localize key="mediaPicker_pickedTrashedItems"></localize></p>
+    
+    <div data-element="sortable-thumbnails" class="flex flex-wrap error">
+        <ul ui-sortable="sortableOptions" ng-model="images" class="umb-sortable-thumbnails">
+            <li data-element="sortable-thumbnail-{{$index}}" class="umb-sortable-thumbnails__wrapper" ng-repeat="image in images track by $index">
+
+                <span class="label trashed" ng-if="image.trashed"><localize key="mediaPicker_trashed"></localize></span>
+                <!-- IMAGE -->
+                <img ng-class="{'trashed': image.trashed}" ng-src="{{image.thumbnail}}" alt="" ng-show="image.thumbnail" title="{{image.trashed ? 'Trashed: ' + image.name : image.name}}" />
+
+                <!-- SVG -->
+                <img ng-class="{'trashed': image.trashed}" ng-if="image.metaData.umbracoExtension.Value === 'svg'" ng-src="{{image.metaData.umbracoFile.Value}}" alt="" title="{{image.trashed ? 'Trashed: ' + image.name : image.name}}" />
+                <img ng-class="{'trashed': image.trashed}" ng-if="image.extension === 'svg'" ng-src="{{image.file}}" alt="" />
+
+                <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
+                    <a class="umb-sortable-thumbnails__action" data-element="action-crop" href="" ng-click="cropItem(image)">
+                        <i class="icon icon-crop"></i>
+                    </a>
+                    <a class="umb-sortable-thumbnails__action" data-element="action-edit" href="" ng-click="goToItem(image)">
+                        <i class="icon icon-edit"></i>
+                    </a>
+                    <a class="umb-sortable-thumbnails__action -red" data-element="action-remove" href="" ng-click="remove($index)">
+                        <i class="icon icon-delete"></i>
+                    </a>
+                </div>
+            </li>
+            <li style="border: none;" class="add-wrapper unsortable" ng-if="showAdd()">
+                <a data-element="sortable-thumbnails-add" href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': (images.length === 0 || isMultiPicker)}" prevent-default>
+                    <i class="icon icon-add large"></i>
+                </a>
+            </li>
+        </ul>
+    </div>
+
+    <umb-overlay
+        data-element="overlay-media-picker"
+        ng-if="mediaPickerOverlay.show"
+        model="mediaPickerOverlay"
+        position="right"
+        view="mediaPickerOverlay.view">
+    </umb-overlay>
+
+</div>

--- a/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
@@ -240,6 +240,89 @@ namespace Umbraco.Web
         }
 
         /// <summary>
+        /// Gets the ImageProcessor Url from the IPublishedContent item.
+        /// </summary>
+        /// <param name="cropDataSet">
+        /// The ImageCropDataSet.
+        /// </param>
+        /// <param name="width">
+        /// The width of the output image.
+        /// </param>
+        /// <param name="height">
+        /// The height of the output image.
+        /// </param>
+        /// <param name="propertyAlias">
+        /// Property alias of the property containing the Json data.
+        /// </param>
+        /// <param name="cropAlias">
+        /// The crop alias.
+        /// </param>
+        /// <param name="quality">
+        /// Quality percentage of the output image.
+        /// </param>
+        /// <param name="imageCropMode">
+        /// The image crop mode.
+        /// </param>
+        /// <param name="imageCropAnchor">
+        /// The image crop anchor.
+        /// </param>
+        /// <param name="preferFocalPoint">
+        /// Use focal point, to generate an output image using the focal point instead of the predefined crop
+        /// </param>
+        /// <param name="useCropDimensions">
+        /// Use crop dimensions to have the output image sized according to the predefined crop sizes, this will override the width and height parameters.
+        /// </param>
+        /// <param name="cacheBuster">
+        /// Add a serialised date of the last edit of the item to ensure client cache refresh when updated
+        /// </param>
+        /// <param name="furtherOptions">
+        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// <example>
+        /// <![CDATA[
+        /// furtherOptions: "&bgcolor=fff"
+        /// ]]>
+        /// </example>
+        /// </param>
+        /// <param name="ratioMode">
+        /// Use a dimension as a ratio
+        /// </param>
+        /// <param name="upScale">
+        /// If the image should be upscaled to requested dimensions
+        /// </param>        
+        /// <returns>
+        /// The <see cref="string"/>.
+        /// </returns>
+        public static string GetCropUrl(
+             this ImageCropDataSet cropDataSet,
+             int? width = null,
+             int? height = null,
+             string cropAlias = null,
+             int? quality = null,
+             ImageCropMode? imageCropMode = null,
+             ImageCropAnchor? imageCropAnchor = null,
+             bool preferFocalPoint = false,
+             bool useCropDimensions = false,
+             bool cacheBuster = true,
+             string cacheBusterValue = null,
+             string furtherOptions = null,
+             ImageCropRatioMode? ratioMode = null,
+             bool upScale = true)
+        {
+            var mediaItem = UmbracoContext.Current.MediaCache.GetById(cropDataSet.Udi.AsGuid());
+            if (mediaItem == null) throw new ArgumentNullException("mediaItem");
+
+            var imageUrl = mediaItem.Url;
+
+            if (string.IsNullOrEmpty(imageUrl)) return string.Empty;
+
+            cacheBusterValue = cacheBuster ? mediaItem.UpdateDate.ToFileTimeUtc().ToString(CultureInfo.InvariantCulture) : cacheBusterValue;
+
+            return GetCropUrl(
+                imageUrl, cropDataSet, width, height, cropAlias, quality, imageCropMode,
+                imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode, upScale);
+        }
+
+        /// <summary>
         /// Gets the ImageProcessor Url from the image path.
         /// </summary>
         /// <param name="imageUrl">

--- a/src/Umbraco.Web/Models/ImageCropDataSet.cs
+++ b/src/Umbraco.Web/Models/ImageCropDataSet.cs
@@ -31,6 +31,9 @@ namespace Umbraco.Web.Models
         [DataMember(Name = "crops")]
         public IEnumerable<ImageCropData> Crops { get; set; }
 
+        [DataMember(Name = "udi")]
+        public Udi Udi { get; set; }
+
         public string GetCropUrl(string alias, bool useCropDimensions = true, bool useFocalPoint = false, string cacheBusterValue = null)
         {
 
@@ -76,7 +79,7 @@ namespace Umbraco.Web.Models
 
         public bool HasImage()
         {
-            return ! string.IsNullOrEmpty(Src);
+            return !string.IsNullOrEmpty(Src) || Udi != null;
         }
 
         public string ToHtmlString()
@@ -108,7 +111,7 @@ namespace Umbraco.Web.Models
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return string.Equals(Src, other.Src) && Equals(FocalPoint, other.FocalPoint) 
-                && Crops.SequenceEqual(other.Crops);
+                && Crops.SequenceEqual(other.Crops) && Udi.Equals(other.Udi);
         }
 
         /// <summary>
@@ -137,6 +140,7 @@ namespace Umbraco.Web.Models
             unchecked
             {
                 var hashCode = (Src != null ? Src.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Udi != null ? Udi.GetHashCode() : 0);
                 hashCode = (hashCode*397) ^ (FocalPoint != null ? FocalPoint.GetHashCode() : 0);
                 hashCode = (hashCode*397) ^ (Crops != null ? Crops.GetHashCode() : 0);
                 return hashCode;

--- a/src/Umbraco.Web/PropertyEditors/MediaCropperPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaCropperPropertyEditor.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using Umbraco.Core;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Web.PropertyEditors
+{
+    /// <summary>
+    /// Media picker property editors that stores crop data
+    /// </summary>
+    [PropertyEditor(Constants.PropertyEditors.MediaCropperAlias, "Media Cropper", PropertyEditorValueTypes.Text, "mediacropper", IsParameterEditor = true, Group = "media", Icon = "icon-crop")]
+    public class MediaCropperPropertyEditor : PropertyEditor
+    {
+        public MediaCropperPropertyEditor()
+        {
+            InternalPreValues = new Dictionary<string, object>
+            {
+                {"idType", "udi"},
+                {"focalPoint", "{left: 0.5, top: 0.5}"},
+                {"src", ""}
+            };
+        }
+
+        internal IDictionary<string, object> InternalPreValues;
+        
+        public override IDictionary<string, object> DefaultPreValues
+        {
+            get { return InternalPreValues; }
+            set { InternalPreValues = value; }
+        }
+
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new MediaCropperPreValueEditor();
+        }
+
+        internal class MediaCropperPreValueEditor : PreValueEditor
+        {
+            [PreValueField("crops", "Crop sizes", "views/propertyeditors/imagecropper/imagecropper.prevalues.html")]
+            public string Crops { get; set; }
+
+            public MediaCropperPreValueEditor()
+            {
+                //create the fields
+                Fields.Add(new PreValueField()
+                {
+                    Key = "multiPicker",
+                    View = "boolean",
+                    Name = "Pick multiple items"
+                });
+                Fields.Add(new PreValueField()
+                {
+                    Key = "startNodeId",
+                    View = "mediapicker",
+                    Name = "Start node",
+                    Config = new Dictionary<string, object>
+                    {
+                        {"idType", "udi"}
+                    }
+                });
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaCropperPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaCropperPropertyConverter.cs
@@ -1,0 +1,270 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MediaPickerPropertyConverter.cs" company="Umbraco">
+//   Umbraco
+// </copyright>
+// <summary>
+//  The media picker 2 value converter
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
+using Umbraco.Web.Extensions;
+using Umbraco.Web.Models;
+
+namespace Umbraco.Web.PropertyEditors.ValueConverters
+{
+    /// <summary>
+    /// The media picker property value converter.
+    /// </summary>
+    [DefaultPropertyValueConverter]
+    public class MediaCropperPropertyConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        private readonly IDataTypeService _dataTypeService;
+
+        //TODO: Remove this ctor in v8 since the other one will use IoC
+        public MediaCropperPropertyConverter()
+            : this(ApplicationContext.Current.Services.DataTypeService)
+        {
+        }
+
+        public MediaCropperPropertyConverter(IDataTypeService dataTypeService)
+        {
+            if (dataTypeService == null) throw new ArgumentNullException("dataTypeService");
+            _dataTypeService = dataTypeService;
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return IsMultipleDataType(propertyType.DataTypeId, propertyType.PropertyEditorAlias) ? typeof(IEnumerable<ImageCropDataSet>) : typeof(ImageCropDataSet);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType, PropertyCacheValue cacheValue)
+        {
+            PropertyCacheLevel returnLevel;
+            switch (cacheValue)
+            {
+                case PropertyCacheValue.Object:
+                    returnLevel = PropertyCacheLevel.ContentCache;
+                    break;
+                case PropertyCacheValue.Source:
+                    returnLevel = PropertyCacheLevel.Content;
+                    break;
+                case PropertyCacheValue.XPath:
+                    returnLevel = PropertyCacheLevel.Content;
+                    break;
+                default:
+                    returnLevel = PropertyCacheLevel.None;
+                    break;
+            }
+
+            return returnLevel;
+        }
+
+        /// <summary>
+        /// The is multiple data type.
+        /// </summary>
+        /// <param name="dataTypeId">
+        /// The data type id.
+        /// </param>
+        /// <param name="propertyEditorAlias"></param>
+        /// <returns>
+        /// The <see cref="bool"/>.
+        /// </returns>
+        private bool IsMultipleDataType(int dataTypeId, string propertyEditorAlias)
+        {
+            // GetPreValuesCollectionByDataTypeId is cached at repository level;
+            // still, the collection is deep-cloned so this is kinda expensive,
+            // better to cache here + trigger refresh in DataTypeCacheRefresher
+
+            return Storages.GetOrAdd(dataTypeId, id =>
+            {
+                var preVals = _dataTypeService.GetPreValuesCollectionByDataTypeId(id).PreValuesAsDictionary;
+
+                if (preVals.ContainsKey("multiPicker"))
+                {
+                    var preValue = preVals
+                        .FirstOrDefault(x => string.Equals(x.Key, "multiPicker", StringComparison.InvariantCultureIgnoreCase))
+                        .Value;
+
+                    return preValue != null && preValue.Value.TryConvertTo<bool>().Result;
+                }
+
+                //in some odd cases, the pre-values in the db won't exist but their default pre-values contain this key so check there 
+                var propertyEditor = PropertyEditorResolver.Current.GetByAlias(propertyEditorAlias);
+                if (propertyEditor != null)
+                {
+                    var preValue = propertyEditor.DefaultPreValues
+                        .FirstOrDefault(x => string.Equals(x.Key, "multiPicker", StringComparison.InvariantCultureIgnoreCase))
+                        .Value;
+
+                    return preValue != null && preValue.TryConvertTo<bool>().Result;
+                }
+
+                return false;
+            });
+        }
+
+        /// <summary>
+        /// Checks if this converter can convert the property editor and registers if it can.
+        /// </summary>
+        /// <param name="propertyType">
+        /// The published property type.
+        /// </param>
+        /// <returns>
+        /// The <see cref="bool"/>.
+        /// </returns>
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            if (propertyType.PropertyEditorAlias.Equals(Constants.PropertyEditors.MediaCropperAlias))
+                return true;
+
+            return false;
+        }
+
+
+        internal static void MergePreValues(JArray currentValues, IDataTypeService dataTypeService, int dataTypeId)
+        {
+            //need to lookup the pre-values for this data type
+            //TODO: Change all singleton access to use ctor injection in v8!!!
+            var dt = dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeId);
+
+            if (dt != null && dt.IsDictionaryBased && dt.PreValuesAsDictionary.ContainsKey("crops"))
+            {
+                var cropsString = dt.PreValuesAsDictionary["crops"].Value;
+                JArray preValueCrops;
+                try
+                {
+                    preValueCrops = JsonConvert.DeserializeObject<JArray>(cropsString);
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.Error<ImageCropperValueConverter>("Could not parse the string " + cropsString + " to a json object", ex);
+                    return;
+                }
+
+                //now we need to merge the crop values - the alias + width + height comes from pre-configured pre-values,
+                // however, each crop can store it's own coordinates
+
+                JArray existingCropsArray;
+
+                foreach (var currentValue in currentValues)
+                {
+                    if (currentValue["crops"] != null)
+                    {
+                        existingCropsArray = (JArray)currentValue["crops"];
+                    }
+                    else
+                    {
+                        currentValue["crops"] = existingCropsArray = new JArray();
+                    }
+
+                    foreach (var preValueCrop in preValueCrops.Where(x => x.HasValues))
+                    {
+                        var found = existingCropsArray.FirstOrDefault(x =>
+                        {
+                            if (x.HasValues && x["alias"] != null)
+                            {
+                                return x["alias"].Value<string>() == preValueCrop["alias"].Value<string>();
+                            }
+                            return false;
+                        });
+                        if (found != null)
+                        {
+                            found["width"] = preValueCrop["width"];
+                            found["height"] = preValueCrop["height"];
+                        }
+                        else
+                        {
+                            existingCropsArray.Add(preValueCrop);
+                        }
+                    }
+                }
+            }
+        }
+
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source == null) return null;
+            var sourceString = source.ToString();
+
+            if (sourceString.DetectIsJson())
+            {
+                JArray obj;
+                try
+                {
+                    obj = JsonConvert.DeserializeObject<JArray>(sourceString, new JsonSerializerSettings
+                    {
+                        Culture = CultureInfo.InvariantCulture,
+                        FloatParseHandling = FloatParseHandling.Decimal
+                    });
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.Error<MediaCropperPropertyConverter>("Could not parse the string " + sourceString + " to a json object", ex);
+                    return sourceString;
+                }
+
+                MergePreValues(obj, _dataTypeService, propertyType.DataTypeId);
+
+                return obj;
+            }
+
+            //it's not json, just return the string
+            return sourceString;
+        }
+
+        /// <summary>
+        /// Convert the source nodeId into a IPublishedContent (or DynamicPublishedContent)
+        /// </summary>
+        /// <param name="propertyType">
+        /// The published property type.
+        /// </param>
+        /// <param name="source">
+        /// The value of the property
+        /// </param>
+        /// <param name="preview">
+        /// The preview.
+        /// </param>
+        /// <returns>
+        /// The <see cref="object"/>.
+        /// </returns>
+        public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            var cropDataSets = ((JArray)source).ToObject<IEnumerable<ImageCropDataSet>>();
+
+            if (IsMultipleDataType(propertyType.DataTypeId, propertyType.PropertyEditorAlias))
+            {
+                return cropDataSets;
+            }
+            else
+            {
+                return cropDataSets.FirstOrDefault();
+            }
+        }
+
+        private static readonly ConcurrentDictionary<int, bool> Storages = new ConcurrentDictionary<int, bool>();
+
+        internal static void ClearCaches()
+        {
+            Storages.Clear();
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -350,6 +350,8 @@
     <Compile Include="Models\Mapping\MemberTreeNodeUrlResolver.cs" />
     <Compile Include="Models\Trees\ExportMember.cs" />
     <Compile Include="PropertyEditors\DropdownFlexiblePropertyEditor.cs" />
+    <Compile Include="PropertyEditors\MediaCropperPropertyEditor.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\MediaCropperPropertyConverter.cs" />
     <Compile Include="TourFilterResolver.cs" />
     <Compile Include="Editors\UserEditorAuthorizationHelper.cs" />
     <Compile Include="Editors\UserGroupAuthorizationAttribute.cs" />

--- a/src/Umbraco.Web/UrlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/UrlHelperRenderExtensions.cs
@@ -223,7 +223,188 @@ namespace Umbraco.Web
             var url = imageUrl.GetCropUrl(width, height, imageCropperValue, cropAlias, quality, imageCropMode,
                 imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode,
                 upScale);
-            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);            
+            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+        }
+
+        /// <summary>
+        /// Gets the ImageProcessor Url of a media item by the crop alias (using default media item property alias of "umbracoFile")
+        /// </summary>
+        /// <param name="urlHelper"></param>
+        /// <param name="mediaItem">
+        /// The IPublishedContent item.
+        /// </param>
+        /// <param name="cropAlias">
+        /// The crop alias e.g. thumbnail
+        /// </param>
+        /// <param name="htmlEncode">
+        /// Whether to HTML encode this URL - default is true - w3c standards require html attributes to be html encoded but this can be 
+        /// set to false if using the result of this method for CSS.
+        /// </param>
+        /// <returns></returns>
+        public static IHtmlString GetCropUrl(this UrlHelper urlHelper, ImageCropDataSet cropDataSet, string cropAlias, bool htmlEncode = true)
+        {
+            var url = cropDataSet.GetCropUrl(cropAlias: cropAlias, useCropDimensions: true);
+            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+        }
+
+        /// <summary>
+        /// Gets the ImageProcessor Url from the image path.
+        /// </summary>
+        /// <param name="mediaItem">
+        /// The IPublishedContent item.
+        /// </param>
+        /// <param name="width">
+        /// The width of the output image.
+        /// </param>
+        /// <param name="height">
+        /// The height of the output image.
+        /// </param>
+        /// <param name="propertyAlias">
+        /// Property alias of the property containing the Json data.
+        /// </param>
+        /// <param name="cropAlias">
+        /// The crop alias.
+        /// </param>
+        /// <param name="quality">
+        /// Quality percentage of the output image.
+        /// </param>
+        /// <param name="imageCropMode">
+        /// The image crop mode.
+        /// </param>
+        /// <param name="imageCropAnchor">
+        /// The image crop anchor.
+        /// </param>
+        /// <param name="preferFocalPoint">
+        /// Use focal point to generate an output image using the focal point instead of the predefined crop if there is one
+        /// </param>
+        /// <param name="useCropDimensions">
+        /// Use crop dimensions to have the output image sized according to the predefined crop sizes, this will override the width and height parameters
+        /// </param>
+        /// <param name="cacheBuster">
+        /// Add a serialised date of the last edit of the item to ensure client cache refresh when updated
+        /// </param>
+        /// <param name="furtherOptions">
+        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// <example>
+        /// <![CDATA[
+        /// furtherOptions: "&bgcolor=fff"
+        /// ]]>
+        /// </example>
+        /// </param>
+        /// <param name="ratioMode">
+        /// Use a dimension as a ratio
+        /// </param>
+        /// <param name="upScale">
+        /// If the image should be upscaled to requested dimensions
+        /// </param>
+        /// <param name="urlHelper"></param>
+        /// <param name="htmlEncode">
+        /// Whether to HTML encode this URL - default is true - w3c standards require html attributes to be html encoded but this can be 
+        /// set to false if using the result of this method for CSS.
+        /// </param>        
+        /// <returns>
+        /// The <see cref="string"/>.
+        /// </returns>
+        public static IHtmlString GetCropUrl(this UrlHelper urlHelper,
+            ImageCropDataSet cropDataSet,
+            int? width = null,
+            int? height = null,
+            string cropAlias = null,
+            int? quality = null,
+            ImageCropMode? imageCropMode = null,
+            ImageCropAnchor? imageCropAnchor = null,
+            bool preferFocalPoint = false,
+            bool useCropDimensions = false,
+            bool cacheBuster = true,
+            string furtherOptions = null,
+            ImageCropRatioMode? ratioMode = null,
+            bool upScale = true,
+            bool htmlEncode = true)
+        {
+            var url = cropDataSet.GetCropUrl(width, height, cropAlias, quality, imageCropMode,
+                imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, null, furtherOptions, ratioMode,
+                upScale);
+            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+        }
+
+        /// <summary>
+        /// Gets the ImageProcessor Url from the image path.
+        /// </summary>
+        /// <param name="imageUrl">
+        /// The image url.
+        /// </param>
+        /// <param name="width">
+        /// The width of the output image.
+        /// </param>
+        /// <param name="height">
+        /// The height of the output image.
+        /// </param>
+        /// <param name="imageCropperValue">
+        /// The Json data from the Umbraco Core Image Cropper property editor
+        /// </param>
+        /// <param name="cropAlias">
+        /// The crop alias.
+        /// </param>
+        /// <param name="quality">
+        /// Quality percentage of the output image.
+        /// </param>
+        /// <param name="imageCropMode">
+        /// The image crop mode.
+        /// </param>
+        /// <param name="imageCropAnchor">
+        /// The image crop anchor.
+        /// </param>
+        /// <param name="preferFocalPoint">
+        /// Use focal point to generate an output image using the focal point instead of the predefined crop if there is one
+        /// </param>
+        /// <param name="useCropDimensions">
+        /// Use crop dimensions to have the output image sized according to the predefined crop sizes, this will override the width and height parameters
+        /// </param>
+        /// <param name="cacheBusterValue">
+        /// Add a serialised date of the last edit of the item to ensure client cache refresh when updated
+        /// </param>
+        /// <param name="furtherOptions">
+        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// <example>
+        /// <![CDATA[
+        /// furtherOptions: "&bgcolor=fff"
+        /// ]]>
+        /// </example>
+        /// </param>
+        /// <param name="ratioMode">
+        /// Use a dimension as a ratio
+        /// </param>
+        /// <param name="upScale">
+        /// If the image should be upscaled to requested dimensions
+        /// </param>
+        /// <param name="urlHelper"></param>
+        /// <param name="htmlEncode">
+        /// Whether to HTML encode this URL - default is true - w3c standards require html attributes to be html encoded but this can be 
+        /// set to false if using the result of this method for CSS.
+        /// </param>        
+        /// <returns>
+        /// The <see cref="string"/>.
+        /// </returns>
+        public static IHtmlString GetCropUrl(this UrlHelper urlHelper,
+            ImageCropDataSet cropDataSet,
+            int? width = null,
+            int? height = null,
+            string cropAlias = null,
+            int? quality = null,
+            ImageCropMode? imageCropMode = null,
+            ImageCropAnchor? imageCropAnchor = null,
+            bool preferFocalPoint = false,
+            bool useCropDimensions = false,
+            string cacheBusterValue = null,
+            string furtherOptions = null,
+            ImageCropRatioMode? ratioMode = null,
+            bool upScale = true,
+            bool htmlEncode = true)
+        {
+            var url = cropDataSet.GetCropUrl(width, height, cropAlias, quality, imageCropMode,
+                imageCropAnchor, preferFocalPoint, useCropDimensions, false, cacheBusterValue, furtherOptions, ratioMode,
+                upScale);
+            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
         }
 
         #endregion


### PR DESCRIPTION
http://issues.umbraco.org/issue/U4-7316

### Description
This PR adds a new property editor, allowing the editor to pick media images, and then on a per node basis, add crops to the picked images.

I have added a `Udi` property to the `ImageCropDataSet` model, and added additional methods for `GetCropUrl` using that `ImageCropDataSet`.

A new property editor, creating an array of `ImageCropDataSets` is added.

It works in the backoffice, when selecting media and adding crop info. But I'm currently stuck on getting the valueconverter to work. I get this message, when I start the solution:
`Type 'Umbraco.Core.PropertyEditors.ValueConverters.JsonValueConverter' cannot be an IPropertyValueConverter for property 'testMediaCrop' of content type 'home' because type 'Umbraco.Web.PropertyEditors.ValueConverters.MediaCropperPropertyConverter' has already been detected as a converter for that property, and only one converter can exist for a property.. This usually indicates that the content cache is corrupt; the content cache has been rebuilt in an attempt to self-fix the issue.`

I could use some help sorting that one out, and also some feedback on the direction I'm going.

https://i.imgur.com/0Gf30o6.gifv

I know the cropping dialog is buggy ATM, but I wan't to get the value converter working, before fixing the dialog.