### PR TITLE
Nested Content PropertyValueConverter is missing DefaultPropertyValueConverter attribute

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
@@ -8,7 +8,9 @@ using Umbraco.Core.PropertyEditors;
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
     [DefaultPropertyValueConverter]
-    public class NestedContentManyValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    [PropertyValueType(typeof(IEnumerable<IPublishedContent>))]
+    [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]
+    public class NestedContentManyValueConverter : PropertyValueConverterBase
     {
         public override bool IsConverter(PublishedPropertyType propertyType)
         {
@@ -27,16 +29,6 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             }
 
             return null;
-        }
-
-        public virtual Type GetPropertyValueType(PublishedPropertyType propertyType)
-        {
-            return typeof(IEnumerable<IPublishedContent>);
-        }
-
-        public virtual PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType, PropertyCacheValue cacheValue)
-        {
-            return PropertyCacheLevel.Content;
         }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
@@ -4,10 +4,11 @@ using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.PropertyEditors.ValueConverters;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
-    [DefaultPropertyValueConverter]
+    [DefaultPropertyValueConverter(typeof(JsonValueConverter))]
     [PropertyValueType(typeof(IEnumerable<IPublishedContent>))]
     [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]
     public class NestedContentManyValueConverter : PropertyValueConverterBase

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
@@ -7,6 +7,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
+    [DefaultPropertyValueConverter]
     public class NestedContentManyValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
     {
         public override bool IsConverter(PublishedPropertyType propertyType)

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
@@ -7,7 +7,9 @@ using Umbraco.Core.PropertyEditors;
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
     [DefaultPropertyValueConverter]
-    public class NestedContentSingleValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    [PropertyValueType(typeof(IPublishedContent))]
+    [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]
+    public class NestedContentSingleValueConverter : PropertyValueConverterBase
     {
         public override bool IsConverter(PublishedPropertyType propertyType)
         {
@@ -26,16 +28,6 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             }
 
             return null;
-        }
-
-        public virtual Type GetPropertyValueType(PublishedPropertyType propertyType)
-        {
-            return typeof(IPublishedContent);
-        }
-
-        public virtual PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType, PropertyCacheValue cacheValue)
-        {
-            return PropertyCacheLevel.Content;
         }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
@@ -6,6 +6,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
+    [DefaultPropertyValueConverter]
     public class NestedContentSingleValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
     {
         public override bool IsConverter(PublishedPropertyType propertyType)

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
@@ -3,10 +3,11 @@ using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.PropertyEditors.ValueConverters;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
-    [DefaultPropertyValueConverter]
+    [DefaultPropertyValueConverter(typeof(JsonValueConverter))]
     [PropertyValueType(typeof(IPublishedContent))]
     [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]
     public class NestedContentSingleValueConverter : PropertyValueConverterBase


### PR DESCRIPTION
Creating a custom `PropertyValueConverter` for the built-in `Umbraco.NestedContent` editor is not possible, because the built-in PVCs is not marked with a `DefaultPropertyValueConverter` attribute.

This functionality (and the attribute) were added in issue [U4-3591](http://issues.umbraco.org/issue/U4-3591), but because NC was added later and originated from a community package, marking it as a default PVC was probably overlooked.

I've also converted the `IPropertyValueConverterMeta` interface to attributes, since the values are static. Implementing the interface would be the way to go if the PVCs (`NestedContentSingleValueConverter` and `NestedContentManyValueConverter`) were merged into a single class, but changing that would be a breaking change.

Connected to #2925 