### PR TITLE
MOAR Logging for V8

### DIFF
--- a/src/Umbraco.Core/Logging/DisposableTimer.cs
+++ b/src/Umbraco.Core/Logging/DisposableTimer.cs
@@ -84,15 +84,15 @@ namespace Umbraco.Core.Logging
             {
                 if (_failed)
                 {
-                    _logger.Error(_loggerType, _failException, "[Timing {TimingId}] {FailMessage} ({TimingDuration}ms)", _timingId, _failMessage, Stopwatch.ElapsedMilliseconds);
+                    _logger.Error(_loggerType, _failException, "[Timing {TimingId}] {FailMessage} ({Duration}ms)", _timingId, _failMessage, Stopwatch.ElapsedMilliseconds);
                 }
                 else switch (_level)
                 {
                     case LogLevel.Debug:
-                        _logger.Debug(_loggerType, "[Timing {TimingId}] {EndMessage} ({TimingDuration}ms)", _timingId, _endMessage, Stopwatch.ElapsedMilliseconds);
+                        _logger.Debug(_loggerType, "[Timing {TimingId}] {EndMessage} ({Duration}ms)", _timingId, _endMessage, Stopwatch.ElapsedMilliseconds);
                         break;
                     case LogLevel.Information:
-                        _logger.Info(_loggerType, "[Timing {TimingId}] {EndMessage} ({TimingDuration}ms)", _timingId, _endMessage, Stopwatch.ElapsedMilliseconds);
+                        _logger.Info(_loggerType, "[Timing {TimingId}] {EndMessage} ({Duration}ms)", _timingId, _endMessage, Stopwatch.ElapsedMilliseconds);
                         break;
                     // filtered in the ctor
                     //default:

--- a/src/Umbraco.Core/Logging/Serilog/Enrichers/HttpRequestIdEnricher.cs
+++ b/src/Umbraco.Core/Logging/Serilog/Enrichers/HttpRequestIdEnricher.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Web;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Umbraco.Core.Logging.Serilog.Enrichers
+{
+    /// <summary>
+    /// Enrich log events with a HttpRequestId GUID.
+    /// Original source - https://github.com/serilog-web/classic/blob/master/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestIdEnricher.cs
+    /// Nupkg: 'Serilog.Web.Classic' contains handlers & extra bits we do not want
+    /// </summary>
+    internal class HttpRequestIdEnricher : ILogEventEnricher
+    {
+        /// <summary>
+        /// The property name added to enriched log events.
+        /// </summary>
+        public const string HttpRequestIdPropertyName = "HttpRequestId";
+
+        static readonly string RequestIdItemName = typeof(HttpRequestIdEnricher).Name + "+RequestId";
+
+        /// <summary>
+        /// Enrich the log event with an id assigned to the currently-executing HTTP request, if any.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich.</param>
+        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (logEvent == null) throw new ArgumentNullException("logEvent");
+
+            Guid requestId;
+            if (!TryGetCurrentHttpRequestId(out requestId))
+                return;
+
+            var requestIdProperty = new LogEventProperty(HttpRequestIdPropertyName, new ScalarValue(requestId));
+            logEvent.AddPropertyIfAbsent(requestIdProperty);
+        }
+
+        /// <summary>
+        /// Retrieve the id assigned to the currently-executing HTTP request, if any.
+        /// </summary>
+        /// <param name="requestId">The request id.</param>
+        /// <returns><c>true</c> if there is a request in progress; <c>false</c> otherwise.</returns>
+        public static bool TryGetCurrentHttpRequestId(out Guid requestId)
+        {
+            if (HttpContext.Current == null)
+            {
+                requestId = default(Guid);
+                return false;
+            }
+
+            var requestIdItem = HttpContext.Current.Items[RequestIdItemName];
+            if (requestIdItem == null)
+                HttpContext.Current.Items[RequestIdItemName] = requestId = Guid.NewGuid();
+            else
+                requestId = (Guid)requestIdItem;
+
+            return true;
+        }
+    }
+}

--- a/src/Umbraco.Core/Logging/Serilog/Enrichers/HttpRequestNumberEnricher.cs
+++ b/src/Umbraco.Core/Logging/Serilog/Enrichers/HttpRequestNumberEnricher.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading;
+using System.Web;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Umbraco.Core.Logging.Serilog.Enrichers
+{
+    /// <summary>
+    /// Enrich log events with a HttpRequestNumber unique within the current
+    /// logging session.
+    /// Original source - https://github.com/serilog-web/classic/blob/master/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestNumberEnricher.cs
+    /// Nupkg: 'Serilog.Web.Classic' contains handlers & extra bits we do not want
+    /// </summary>
+    internal class HttpRequestNumberEnricher : ILogEventEnricher
+    {
+        /// <summary>
+        /// The property name added to enriched log events.
+        /// </summary>
+        public const string HttpRequestNumberPropertyName = "HttpRequestNumber";
+
+        static int _lastRequestNumber;
+        static readonly string RequestNumberItemName = typeof(HttpRequestNumberEnricher).Name + "+RequestNumber";
+
+        /// <summary>
+        /// Enrich the log event with the number assigned to the currently-executing HTTP request, if any.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich.</param>
+        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (logEvent == null) throw new ArgumentNullException("logEvent");
+
+            if (HttpContext.Current == null)
+                return;
+
+            int requestNumber;
+            var requestNumberItem = HttpContext.Current.Items[RequestNumberItemName];
+            if (requestNumberItem == null)
+                HttpContext.Current.Items[RequestNumberItemName] = requestNumber = Interlocked.Increment(ref _lastRequestNumber);
+            else
+                requestNumber = (int)requestNumberItem;
+
+            var requestNumberProperty = new LogEventProperty(HttpRequestNumberPropertyName, new ScalarValue(requestNumber));
+            logEvent.AddPropertyIfAbsent(requestNumberProperty);
+        }
+    }
+}

--- a/src/Umbraco.Core/Logging/Serilog/Enrichers/HttpSessionIdEnricher.cs
+++ b/src/Umbraco.Core/Logging/Serilog/Enrichers/HttpSessionIdEnricher.cs
@@ -1,0 +1,39 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+using System;
+using System.Web;
+
+namespace Umbraco.Core.Logging.Serilog.Enrichers
+{
+    /// <summary>
+    /// Enrich log events with the HttpSessionId property.
+    /// Original source - https://github.com/serilog-web/classic/blob/master/src/SerilogWeb.Classic/Classic/Enrichers/HttpSessionIdEnricher.cs
+    /// Nupkg: 'Serilog.Web.Classic' contains handlers & extra bits we do not want
+    /// </summary>
+    internal class HttpSessionIdEnricher : ILogEventEnricher
+    {
+        /// <summary>
+        /// The property name added to enriched log events.
+        /// </summary>
+        public const string HttpSessionIdPropertyName = "HttpSessionId";
+
+        /// <summary>
+        /// Enrich the log event with the current ASP.NET session id, if sessions are enabled.</summary>
+        /// <param name="logEvent">The log event to enrich.</param>
+        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (logEvent == null) throw new ArgumentNullException("logEvent");
+
+            if (HttpContext.Current == null)
+                return;
+
+            if (HttpContext.Current.Session == null)
+                return;
+
+            var sessionId = HttpContext.Current.Session.SessionID;
+            var sessionIdProperty = new LogEventProperty(HttpSessionIdPropertyName, new ScalarValue(sessionId));
+            logEvent.AddPropertyIfAbsent(sessionIdProperty);
+        }
+    }
+}

--- a/src/Umbraco.Core/Logging/Serilog/Enrichers/Log4NetLevelMapperEnricher.cs
+++ b/src/Umbraco.Core/Logging/Serilog/Enrichers/Log4NetLevelMapperEnricher.cs
@@ -1,7 +1,7 @@
 ﻿using Serilog.Core;
 using Serilog.Events;
 
-namespace Umbraco.Core.Logging.Serilog
+namespace Umbraco.Core.Logging.Serilog.Enrichers
 {
     /// <summary>
     /// This is used to create a new property in Logs called 'Log4NetLevel'

--- a/src/Umbraco.Core/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Core/Logging/Serilog/LoggerConfigExtensions.cs
@@ -3,6 +3,7 @@ using System.Web;
 using Serilog;
 using Serilog.Events;
 using Serilog.Formatting.Compact;
+using Umbraco.Core.Logging.Serilog.Enrichers;
 
 namespace Umbraco.Core.Logging.Serilog
 {
@@ -21,7 +22,7 @@ namespace Umbraco.Core.Logging.Serilog
             //Set this environment variable - so that it can be used in external config file
             //add key="serilog:write-to:RollingFile.pathFormat" value="%BASEDIR%\logs\log.txt" />
             Environment.SetEnvironmentVariable("BASEDIR", AppDomain.CurrentDomain.BaseDirectory, EnvironmentVariableTarget.Process);
-            
+
             logConfig.MinimumLevel.Verbose() //Set to highest level of logging (as any sinks may want to restrict it to Errors only)
                 .Enrich.WithProcessId()
                 .Enrich.WithProcessName()
@@ -29,8 +30,11 @@ namespace Umbraco.Core.Logging.Serilog
                 .Enrich.WithProperty("AppDomainId", AppDomain.CurrentDomain.Id)
                 .Enrich.WithProperty("AppDomainAppId", HttpRuntime.AppDomainAppId.ReplaceNonAlphanumericChars(string.Empty))
                 .Enrich.WithProperty("MachineName", Environment.MachineName)
-                .Enrich.With<Log4NetLevelMapperEnricher>();
-
+                .Enrich.With<Log4NetLevelMapperEnricher>()
+                .Enrich.With<HttpSessionIdEnricher>()
+                .Enrich.With<HttpRequestNumberEnricher>()
+                .Enrich.With<HttpRequestIdEnricher>();
+            
             return logConfig;
         }
 

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -363,7 +363,7 @@ namespace Umbraco.Core.Runtime
             _state.CurrentMigrationState = state;
             _state.FinalMigrationState = umbracoPlan.FinalState;
 
-            logger.Debug<CoreRuntime>("Final upgrade state is '{FinalMigrationState}', database contains {DatabaseState}", _state.FinalMigrationState, state ?? "<null>");
+            logger.Debug<CoreRuntime>("Final upgrade state is {FinalMigrationState}, database contains {DatabaseState}", _state.FinalMigrationState, state ?? "<null>");
 
             return state == _state.FinalMigrationState;
         }

--- a/src/Umbraco.Core/RuntimeState.cs
+++ b/src/Umbraco.Core/RuntimeState.cs
@@ -117,7 +117,7 @@ namespace Umbraco.Core
             var change = url != null && !_applicationUrls.Contains(url);
             if (change)
             {
-                _logger.Info(typeof(ApplicationUrlHelper), "New url '{Url}' detected, re-discovering application url.", url);
+                _logger.Info(typeof(ApplicationUrlHelper), "New url {Url} detected, re-discovering application url.", url);
                 _applicationUrls.Add(url);
             }
 

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2178,7 +2178,7 @@ namespace Umbraco.Core.Services.Implement
             // raise Publishing event
             if (scope.Events.DispatchCancelable(Publishing, this, new PublishEventArgs<IContent>(content, evtMsgs)))
             {
-                Logger.Info<ContentService>("Document '{ContentName}' (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "publishing was cancelled");
+                Logger.Info<ContentService>("Document {ContentName} (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "publishing was cancelled");
                 return new PublishResult(PublishResultType.FailedCancelledByEvent, evtMsgs, content);
             }
 
@@ -2186,7 +2186,7 @@ namespace Umbraco.Core.Services.Implement
             // either because it is 'publishing' or because it already has a published version
             if (((Content) content).PublishedState != PublishedState.Publishing && content.PublishedVersionId == 0)
             {
-                Logger.Info<ContentService>("Document '{ContentName}' (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "document does not have published values");
+                Logger.Info<ContentService>("Document {ContentName} (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "document does not have published values");
                 return new PublishResult(PublishResultType.FailedNoPublishedValues, evtMsgs, content);
             }
 
@@ -2194,15 +2194,15 @@ namespace Umbraco.Core.Services.Implement
             switch (content.Status)
             {
                 case ContentStatus.Expired:
-                    Logger.Info<ContentService>("Document '{ContentName}' (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "document has expired");
+                    Logger.Info<ContentService>("Document {ContentName} (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "document has expired");
                     return new PublishResult(PublishResultType.FailedHasExpired, evtMsgs, content);
 
                 case ContentStatus.AwaitingRelease:
-                    Logger.Info<ContentService>("Document '{ContentName}' (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "document is awaiting release");
+                    Logger.Info<ContentService>("Document {ContentName} (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "document is awaiting release");
                     return new PublishResult(PublishResultType.FailedAwaitingRelease, evtMsgs, content);
 
                 case ContentStatus.Trashed:
-                    Logger.Info<ContentService>("Document '{ContentName}' (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "document is trashed");
+                    Logger.Info<ContentService>("Document {ContentName} (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "document is trashed");
                     return new PublishResult(PublishResultType.FailedIsTrashed, evtMsgs, content);
             }
 
@@ -2214,7 +2214,7 @@ namespace Umbraco.Core.Services.Implement
             var pathIsOk = content.ParentId == Constants.System.Root || IsPathPublished(GetParent(content));
             if (pathIsOk == false)
             {
-                Logger.Info<ContentService>("Document '{ContentName}' (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "parent is not published");
+                Logger.Info<ContentService>("Document {ContentName} (id={ContentId}) cannot be published: {Reason}", content.Name, content.Id, "parent is not published");
                 return new PublishResult(PublishResultType.FailedPathNotPublished, evtMsgs, content);
             }
 
@@ -2238,7 +2238,7 @@ namespace Umbraco.Core.Services.Implement
             // change state to publishing
             ((Content) content).PublishedState = PublishedState.Publishing;
 
-            Logger.Info<ContentService>("Document '{ContentName}' (id={ContentId}) has been published.", content.Name, content.Id);
+            Logger.Info<ContentService>("Document {ContentName} (id={ContentId}) has been published.", content.Name, content.Id);
             return result;
         }
 
@@ -2248,7 +2248,7 @@ namespace Umbraco.Core.Services.Implement
             // raise UnPublishing event
             if (scope.Events.DispatchCancelable(UnPublishing, this, new PublishEventArgs<IContent>(content, evtMsgs)))
             {
-                Logger.Info<ContentService>("Document '{ContentName}' (id={ContentId}) cannot be unpublished: unpublishing was cancelled.", content.Name, content.Id);
+                Logger.Info<ContentService>("Document {ContentName} (id={ContentId}) cannot be unpublished: unpublishing was cancelled.", content.Name, content.Id);
                 return new UnpublishResult(UnpublishResultType.FailedCancelledByEvent, evtMsgs, content);
             }
 
@@ -2271,13 +2271,13 @@ namespace Umbraco.Core.Services.Implement
             if (content.ReleaseDate.HasValue && content.ReleaseDate.Value <= DateTime.Now)
             {
                 content.ReleaseDate = null;
-                Logger.Info<ContentService>("Document '{ContentName}' (id={ContentId}) had its release date removed, because it was unpublished.", content.Name, content.Id);
+                Logger.Info<ContentService>("Document {ContentName} (id={ContentId}) had its release date removed, because it was unpublished.", content.Name, content.Id);
             }
 
             // change state to unpublishing
             ((Content) content).PublishedState = PublishedState.Unpublishing;
 
-            Logger.Info<ContentService>("Document '{ContentName}' (id={ContentId}) has been unpublished.", content.Name, content.Id);
+            Logger.Info<ContentService>("Document {ContentName} (id={ContentId}) has been unpublished.", content.Name, content.Id);
             return attempt;
         }
 

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -329,7 +329,7 @@
     <Compile Include="Logging\LogLevel.cs" />
     <Compile Include="Logging\MessageTemplates.cs" />
     <Compile Include="Logging\Serilog\LoggerConfigExtensions.cs" />
-    <Compile Include="Logging\Serilog\Log4NetLevelMapperEnricher.cs" />
+    <Compile Include="Logging\Serilog\Enrichers\Log4NetLevelMapperEnricher.cs" />
     <Compile Include="Migrations\MigrationBase_Extra.cs" />
     <Compile Include="Migrations\Upgrade\V_7_10_0\RenamePreviewFolder.cs" />
     <Compile Include="Migrations\Upgrade\V_7_12_0\AddRelationTypeForMediaFolderOnDelete.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -328,6 +328,9 @@
     <Compile Include="KeyValuePairExtensions.cs" />
     <Compile Include="Logging\LogLevel.cs" />
     <Compile Include="Logging\MessageTemplates.cs" />
+    <Compile Include="Logging\Serilog\Enrichers\HttpRequestIdEnricher.cs" />
+    <Compile Include="Logging\Serilog\Enrichers\HttpRequestNumberEnricher.cs" />
+    <Compile Include="Logging\Serilog\Enrichers\HttpSessionIdEnricher.cs" />
     <Compile Include="Logging\Serilog\LoggerConfigExtensions.cs" />
     <Compile Include="Logging\Serilog\Enrichers\Log4NetLevelMapperEnricher.cs" />
     <Compile Include="Migrations\MigrationBase_Extra.cs" />

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -303,7 +303,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             var kits = _dataSource.GetAllContentSources(scope);
             _contentStore.SetAll(kits);
             sw.Stop();
-            _logger.Debug<PublishedSnapshotService>("Loaded content from database ({ElapsedMilliseconds}ms)", sw.ElapsedMilliseconds);
+            _logger.Debug<PublishedSnapshotService>("Loaded content from database ({Duration}ms)", sw.ElapsedMilliseconds);
         }
 
         private void LoadContentFromLocalDbLocked(IScope scope)
@@ -317,7 +317,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             var kits = _localContentDb.Select(x => x.Value).OrderBy(x => x.Node.Level);
             _contentStore.SetAll(kits);
             sw.Stop();
-            _logger.Debug<PublishedSnapshotService>("Loaded content from local db ({ElapsedMilliseconds}ms)", sw.ElapsedMilliseconds);
+            _logger.Debug<PublishedSnapshotService>("Loaded content from local db ({Duration}ms)", sw.ElapsedMilliseconds);
         }
 
         // keep these around - might be useful
@@ -370,7 +370,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             var kits = _dataSource.GetAllMediaSources(scope);
             _mediaStore.SetAll(kits);
             sw.Stop();
-            _logger.Debug<PublishedSnapshotService>("Loaded media from database ({ElapsedMilliseconds}ms)", sw.ElapsedMilliseconds);
+            _logger.Debug<PublishedSnapshotService>("Loaded media from database ({Duration}ms)", sw.ElapsedMilliseconds);
         }
 
         private void LoadMediaFromLocalDbLocked(IScope scope)
@@ -384,7 +384,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             var kits = _localMediaDb.Select(x => x.Value);
             _mediaStore.SetAll(kits);
             sw.Stop();
-            _logger.Debug<PublishedSnapshotService>("Loaded media from local db ({ElapsedMilliseconds}ms)", sw.ElapsedMilliseconds);
+            _logger.Debug<PublishedSnapshotService>("Loaded media from local db ({Duration}ms)", sw.ElapsedMilliseconds);
         }
 
         // keep these around - might be useful

--- a/src/Umbraco.Web/Routing/ContentFinderByRedirectUrl.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByRedirectUrl.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Web.Routing
 
             if (redirectUrl == null)
             {
-                _logger.Debug<ContentFinderByRedirectUrl>("No match for route: '{Route}'", route);
+                _logger.Debug<ContentFinderByRedirectUrl>("No match for route: {Route}", route);
                 return false;
             }
 
@@ -56,11 +56,11 @@ namespace Umbraco.Web.Routing
             var url = content == null ? "#" : content.Url;
             if (url.StartsWith("#"))
             {
-                _logger.Debug<ContentFinderByRedirectUrl>("Route '{Route}' matches content {ContentId} which has no url.", route, redirectUrl.ContentId);
+                _logger.Debug<ContentFinderByRedirectUrl>("Route {Route} matches content {ContentId} which has no url.", route, redirectUrl.ContentId);
                 return false;
             }
 
-            _logger.Debug<ContentFinderByRedirectUrl>("Route '{Route}' matches content {ContentId} with url '{Url}', redirecting.", route, content.Id, url);
+            _logger.Debug<ContentFinderByRedirectUrl>("Route {Route} matches content {ContentId} with url '{Url}', redirecting.", route, content.Id, url);
             frequest.SetRedirectPermanent(url);
             return true;
         }

--- a/src/Umbraco.Web/Routing/ContentFinderByUrl.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByUrl.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Web.Routing
         {
             if (docreq == null) throw new System.ArgumentNullException(nameof(docreq));
 
-            Logger.Debug<ContentFinderByUrl>("Test route '{Route}'", route);
+            Logger.Debug<ContentFinderByUrl>("Test route {Route}", route);
 
             var node = docreq.UmbracoContext.ContentCache.GetByRoute(route, culture: docreq.Culture?.Name);
             if (node != null)

--- a/src/Umbraco.Web/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Web/Routing/PublishedRouter.cs
@@ -276,7 +276,7 @@ namespace Umbraco.Web.Routing
 
             // note - we are not handling schemes nor ports here.
 
-            _logger.Debug<PublishedRouter>("{TracePrefix}Uri='{RequestUri}'", tracePrefix, request.Uri);
+            _logger.Debug<PublishedRouter>("{TracePrefix}Uri={RequestUri}", tracePrefix, request.Uri);
 
             var domainsCache = request.UmbracoContext.PublishedSnapshot.Domains;
             var domains = domainsCache.GetAll(includeWildcards: false).ToList();
@@ -313,7 +313,7 @@ namespace Umbraco.Web.Routing
             if (domainAndUri != null)
             {
                 // matching an existing domain
-                _logger.Debug<PublishedRouter>("{TracePrefix}Matches domain='{Domain}', rootId={RootContentId}, culture='{Culture}'", tracePrefix, domainAndUri.Name, domainAndUri.ContentId, domainAndUri.Culture);
+                _logger.Debug<PublishedRouter>("{TracePrefix}Matches domain={Domain}, rootId={RootContentId}, culture={Culture}", tracePrefix, domainAndUri.Name, domainAndUri.ContentId, domainAndUri.Culture);
 
                 request.Domain = domainAndUri;
                 request.Culture = domainAndUri.Culture;
@@ -333,7 +333,7 @@ namespace Umbraco.Web.Routing
                 request.Culture = defaultCulture == null ? CultureInfo.CurrentUICulture : new CultureInfo(defaultCulture);
             }
 
-            _logger.Debug<PublishedRouter>("{TracePrefix}Culture='{CultureName}'", tracePrefix, request.Culture.Name);
+            _logger.Debug<PublishedRouter>("{TracePrefix}Culture={CultureName}", tracePrefix, request.Culture.Name);
 
             return request.Domain != null;
         }
@@ -349,7 +349,7 @@ namespace Umbraco.Web.Routing
                 return;
 
             var nodePath = request.PublishedContent.Path;
-            _logger.Debug<PublishedRouter>("{TracePrefix}Path='{NodePath}'", tracePrefix, nodePath);
+            _logger.Debug<PublishedRouter>("{TracePrefix}Path={NodePath}", tracePrefix, nodePath);
             var rootNodeId = request.HasDomain ? request.Domain.ContentId : (int?)null;
             var domain = DomainHelper.FindWildcardDomainInPath(request.UmbracoContext.PublishedSnapshot.Domains.GetAll(true), nodePath, rootNodeId);
 
@@ -357,7 +357,7 @@ namespace Umbraco.Web.Routing
             if (domain != null)
             {
                 request.Culture = domain.Culture;
-                _logger.Debug<PublishedRouter>("{TracePrefix}Got domain on node {DomainContentId}, set culture to '{CultureName}'", tracePrefix, domain.ContentId, request.Culture.Name);
+                _logger.Debug<PublishedRouter>("{TracePrefix}Got domain on node {DomainContentId}, set culture to {CultureName}", tracePrefix, domain.ContentId, request.Culture.Name);
             }
             else
             {
@@ -434,7 +434,7 @@ namespace Umbraco.Web.Routing
         /// <returns>A value indicating whether a document and template were found.</returns>
         private void FindPublishedContentAndTemplate(PublishedRequest request)
         {
-            _logger.Debug<PublishedRouter>("FindPublishedContentAndTemplate: Path='{UriAbsolutePath}'", request.Uri.AbsolutePath);
+            _logger.Debug<PublishedRouter>("FindPublishedContentAndTemplate: Path={UriAbsolutePath}", request.Uri.AbsolutePath);
 
             // run the document finders
             FindPublishedContent(request);
@@ -540,7 +540,7 @@ namespace Umbraco.Web.Routing
 
             if (i == maxLoop || j == maxLoop)
             {
-                _logger.Debug<PublishedRouter>("HandlePublishedContent: Looks like we're running into an infinite loop, abort");
+                _logger.Debug<PublishedRouter>("HandlePublishedContent: Looks like we are running into an infinite loop, abort");
                 request.PublishedContent = null;
             }
 
@@ -712,7 +712,7 @@ namespace Umbraco.Web.Routing
 
                 if (request.HasTemplate)
                     _logger.Debug<PublishedRouter>("FindTemplate: Has a template already, but also an alternative template.");
-                _logger.Debug<PublishedRouter>("FindTemplate: Look for alternative template alias='{AltTemplate}'", altTemplate);
+                _logger.Debug<PublishedRouter>("FindTemplate: Look for alternative template alias={AltTemplate}", altTemplate);
 
                 // IsAllowedTemplate deals both with DisableAlternativeTemplates and ValidateAlternativeTemplates settings
                 if (request.PublishedContent.IsAllowedTemplate(altTemplate))
@@ -723,16 +723,16 @@ namespace Umbraco.Web.Routing
                     if (template != null)
                     {
                         request.TemplateModel = template;
-                        _logger.Debug<PublishedRouter>("FindTemplate: Got alternative template id={TemplateId} alias='{TemplateAlias}'", template.Id, template.Alias);
+                        _logger.Debug<PublishedRouter>("FindTemplate: Got alternative template id={TemplateId} alias={TemplateAlias}", template.Id, template.Alias);
                     }
                     else
                     {
-                        _logger.Debug<PublishedRouter>("FindTemplate: The alternative template with alias='{AltTemplate}' does not exist, ignoring.", altTemplate);
+                        _logger.Debug<PublishedRouter>("FindTemplate: The alternative template with alias={AltTemplate} does not exist, ignoring.", altTemplate);
                     }
                 }
                 else
                 {
-                    _logger.Warn<PublishedRouter>("FindTemplate: Alternative template '{TemplateAlias}' is not allowed on node {NodeId}, ignoring.", altTemplate, request.PublishedContent.Id);
+                    _logger.Warn<PublishedRouter>("FindTemplate: Alternative template {TemplateAlias} is not allowed on node {NodeId}, ignoring.", altTemplate, request.PublishedContent.Id);
 
                     // no allowed, back to default
                     var templateId = request.PublishedContent.TemplateId;
@@ -755,7 +755,7 @@ namespace Umbraco.Web.Routing
             }
             else
             {
-                _logger.Debug<PublishedRouter>("FindTemplate: Running with template id={TemplateId} alias='{TemplateAlias}'", request.TemplateModel.Id, request.TemplateModel.Alias);
+                _logger.Debug<PublishedRouter>("FindTemplate: Running with template id={TemplateId} alias={TemplateAlias}", request.TemplateModel.Id, request.TemplateModel.Alias);
             }
         }
 
@@ -772,7 +772,7 @@ namespace Umbraco.Web.Routing
             var template = _services.FileService.GetTemplate(templateId);
             if (template == null)
                 throw new InvalidOperationException("The template with Id " + templateId + " does not exist, the page cannot render.");
-            _logger.Debug<PublishedRouter>("GetTemplateModel: Got template id={TemplateId} alias=\"{TemplateAlias}\"", template.Id, template.Alias);
+            _logger.Debug<PublishedRouter>("GetTemplateModel: Got template id={TemplateId} alias={TemplateAlias}", template.Id, template.Alias);
             return template;
         }
 

--- a/src/Umbraco.Web/Templates/TemplateUtilities.cs
+++ b/src/Umbraco.Web/Templates/TemplateUtilities.cs
@@ -100,7 +100,7 @@ namespace Umbraco.Web.Templates
             {
                 // find all relative urls (ie. urls that contain ~)
                 var tags = ResolveUrlPattern.Matches(text);
-                Current.Logger.Debug(typeof(IOHelper), "After regex: {ElapsedMilliseconds} matched: {TagsCount}", timer.Stopwatch.ElapsedMilliseconds, tags.Count);
+                Current.Logger.Debug(typeof(IOHelper), "After regex: {Duration} matched: {TagsCount}", timer.Stopwatch.ElapsedMilliseconds, tags.Count);
                 foreach (Match tag in tags)
                 {
                     var url = "";

--- a/src/Umbraco.Web/UmbracoModule.cs
+++ b/src/Umbraco.Web/UmbracoModule.cs
@@ -604,7 +604,7 @@ namespace Umbraco.Web
                 if (UmbracoContext.Current != null)
                 {
                     Logger.Verbose<UmbracoModule>(
-                        "Request: {RequestUrl} ({RequestTotalMilliseconds}ms)",
+                        "Request: {RequestUrl} took {Duration}ms",
                         httpContext.Request.Url,
                         DateTime.Now.Subtract(UmbracoContext.Current.ObjectCreated).TotalMilliseconds);
                 }

--- a/src/Umbraco.Web/UmbracoModule.cs
+++ b/src/Umbraco.Web/UmbracoModule.cs
@@ -561,7 +561,6 @@ namespace Umbraco.Web
                 //Create a new Request ID/GUID
                 requestId = Guid.NewGuid();
 
-                Logger.Verbose<UmbracoModule>("Begin request [{RequestId}]: {RequestUrl}", requestId, httpContext.Request.Url);
                 BeginRequest(new HttpContextWrapper(httpContext));
             };
 
@@ -605,8 +604,7 @@ namespace Umbraco.Web
                 if (UmbracoContext.Current != null)
                 {
                     Logger.Verbose<UmbracoModule>(
-                        "End Request [{RequestId}]: {RequestUrl} ({RequestTotalMilliseconds}ms)",
-                        requestId,
+                        "Request: {RequestUrl} ({RequestTotalMilliseconds}ms)",
                         httpContext.Request.Url,
                         DateTime.Now.Subtract(UmbracoContext.Current.ObjectCreated).TotalMilliseconds);
                 }

--- a/src/Umbraco.Web/UmbracoModule.cs
+++ b/src/Umbraco.Web/UmbracoModule.cs
@@ -21,6 +21,7 @@ using Umbraco.Core.Security;
 using Umbraco.Core.Services;
 using Umbraco.Web.Composing;
 using Umbraco.Web.PublishedCache;
+using Umbraco.Core.Logging.Serilog.Enrichers;
 
 namespace Umbraco.Web
 {
@@ -558,8 +559,12 @@ namespace Umbraco.Web
             {
                 var httpContext = ((HttpApplication) sender).Context;
 
-                //Create a new Request ID/GUID
-                requestId = Guid.NewGuid();
+                var httpRequestId = Guid.Empty;
+                HttpRequestIdEnricher.TryGetCurrentHttpRequestId(out httpRequestId);
+
+                Logger.Verbose<UmbracoModule>("Begin request [{HttpRequestId}]: {RequestUrl}",
+                    httpRequestId,
+                    httpContext.Request.Url);
 
                 BeginRequest(new HttpContextWrapper(httpContext));
             };
@@ -603,8 +608,12 @@ namespace Umbraco.Web
 
                 if (UmbracoContext.Current != null)
                 {
+                    var httpRequestId = Guid.Empty;
+                    HttpRequestIdEnricher.TryGetCurrentHttpRequestId(out httpRequestId);
+
                     Logger.Verbose<UmbracoModule>(
-                        "Request: {RequestUrl} took {Duration}ms",
+                        "End request [{HttpRequestId}]: {RequestUrl} took {Duration}ms",
+                        httpRequestId,
                         httpContext.Request.Url,
                         DateTime.Now.Subtract(UmbracoContext.Current.ObjectCreated).TotalMilliseconds);
                 }


### PR DESCRIPTION
To carry on my other recent related PR's here is some MOAR logging updates & improvements

Adds in some useful Serilog Enrichers from the `Serilog.Web.Classic` project, but rather than adding that Nupkg directly, I have copied over what I think is useful. As there seems some extra bloat we would not such as a HTTPModule and it potentially capturing/logging sensitve info from FORM DATA.

* HttpRequestId (Guid)
* HttpRequestNumber (Increasing int counter)
* HttpSessionId

This PR also contains an update to keep Serilog properties more consistent, rather than having too many uniquly named properties. So all the timing related log messages now use `Duration` which will make it alot easier to query for any timing based log where the value is greater than X

Also the very verbose messages for Begin and End request, has now been changed to only log the end of the request and it's timing, as not sure the beginning message was too useful.
