### PR TITLE
temp-2939 - Removed hardcoded number of rows from textarea with the d…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
@@ -1,5 +1,5 @@
 <div ng-controller="Umbraco.PropertyEditors.textAreaController">
-	<textarea ng-model="model.value" id="{{model.alias}}" name="textarea" rows="10" class="umb-editor umb-textarea textstring" val-server="value" ng-keyup="model.change()"></textarea>
+	<textarea ng-model="model.value" id="{{model.alias}}" name="textarea" rows="{{model.config.rows || 10}}" class="umb-editor umb-textarea textstring" val-server="value" ng-keyup="model.change()"></textarea>
 	<span class="help-inline" val-msg-for="textarea" val-toggle-msg="required"><localize key="general_required">Required</localize></span>
 	<span class="help-inline" val-msg-for="textarea" val-toggle-msg="valServer"></span>
     <div class="help" ng-if="model.maxlength">

--- a/src/Umbraco.Web/PropertyEditors/TextAreaPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TextAreaPropertyEditor.cs
@@ -19,10 +19,10 @@ namespace Umbraco.Web.PropertyEditors
         internal class TextAreaPreValueEditor : PreValueEditor
         {
             [PreValueField("maxChars", "Maximum allowed characters", "number", Description = "If empty - no character limit")]
-            public bool MaxChars { get; set; }
+            public int MaxChars { get; set; }
 
             [PreValueField("rows", "Number of rows", "number", Description = "If empty - 10 rows would be set as the default value")]
-            public bool Rows { get; set; }
+            public int Rows { get; set; }
         }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/TextAreaPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TextAreaPropertyEditor.cs
@@ -20,6 +20,9 @@ namespace Umbraco.Web.PropertyEditors
         {
             [PreValueField("maxChars", "Maximum allowed characters", "number", Description = "If empty - no character limit")]
             public bool MaxChars { get; set; }
+
+            [PreValueField("rows", "Number of rows", "number", Description = "If empty - 10 rows would be set as the default value")]
+            public bool Rows { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/2939) for the proposed changes in this PR:
- [x] I have added steps to test this contribution in the description below

### Description
In order to test this, you can now customise the number of rows to be shown for textarea datatype and if you don't specify a value, 10 would be used as default. 

Fixes #2939 