### PR TITLE
U4 7316 Media Cropper Take 2

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -196,6 +196,11 @@ namespace Umbraco.Core
             public const string MacroContainerAlias = "Umbraco.MacroContainer";
 
             /// <summary>
+            /// Alias for the Media Cropper datatype.
+            /// </summary>
+            public const string MediaCropperAlias = "Umbraco.MediaCropper";
+
+            /// <summary>
             /// Guid for the Media Picker datatype.
             /// </summary>
             [Obsolete("GUIDs are no longer used to reference Property Editors, use the Alias constant instead. This will be removed in future versions")]

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -561,6 +561,12 @@ ul.color-picker li {
             float: left;
             max-width: 100%;
         }
+
+        .umb-overlay & {
+            flex-direction: column;
+            float: left;
+            max-width: 100%;
+        }
     }
 
     .imagecropper .umb-cropper__container {
@@ -580,6 +586,8 @@ ul.color-picker li {
         right: 3px;
         cursor: pointer;
         z-index: 1;
+        border:0;
+        padding:0;
     }
 
     .umb-close-cropper:hover {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
@@ -16,10 +16,10 @@
 
         <div class="imagecropper clearfix">
 
-            <div ng-if="currentCrop" style="float:left; max-width: 100%;" class="clearfix">
+            <div ng-if="currentCrop" class="umb-cropper-imageholder clearfix">
                 <div class="umb-cropper__container">
 
-                    <i ng-click="done()" class="icon icon-delete btn-round umb-close-cropper"></i>
+                    <button ng-click="done()" class="icon icon-delete btn-round umb-close-cropper"></button>
 
                     <div>
                         <umb-image-crop height="{{currentCrop.height}}"
@@ -44,7 +44,7 @@
                     center="model.value.focalPoint"
                     on-image-loaded="imageLoaded">
                 </umb-image-gravity>
-                <a href class="btn btn-link btn-crop-delete" ng-click="clear()"><i class="icon-delete red"></i> <localize key="content_uploadClear">Remove file</localize></a>
+                <a href class="btn btn-link btn-crop-delete" ng-click="clear()" ng-if="model.value.udi == null"><i class="icon-delete red"></i> <localize key="content_uploadClear">Remove file</localize></a>
             </div>
 
             <ul class="umb-sortable-thumbnails cropList clearfix">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.controller.js
@@ -1,0 +1,277 @@
+//this controller simply tells the dialogs service to open a mediaPicker window
+//with a specified callback, this callback will receive an object with a selection on it
+angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaCropperController",
+    function ($scope, entityResource, mediaHelper, $timeout, userService, $location, localizationService) {
+
+        var config = angular.copy($scope.model.config);
+
+        //check the pre-values for multi-picker
+        var multiPicker = $scope.model.config.multiPicker && $scope.model.config.multiPicker !== '0' ? true : false;
+
+        if (!$scope.model.config.startNodeId) {
+            userService.getCurrentUser().then(function(userData) {
+                $scope.model.config.startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
+                $scope.model.config.startNodeIsVirtual = userData.startMediaIds.length !== 1;
+            });
+        }
+
+        function setupViewModel() {
+            $scope.images = [];
+            $scope.ids = [];
+
+            $scope.isMultiPicker = multiPicker;
+
+            if ($scope.model.value) {
+                var ids = $scope.model.value.map(function (data) { return data.udi; });
+
+                //NOTE: We need to use the entityResource NOT the mediaResource here because
+                // the mediaResource has server side auth configured for which the user must have
+                // access to the media section, if they don't they'll get auth errors. The entityResource
+                // acts differently in that it allows access if the user has access to any of the apps that
+                // might require it's use. Therefore we need to use the metaData property to get at the thumbnail
+                // value.
+
+                entityResource.getByIds(ids, "Media").then(function (medias) {
+
+                    // The service only returns item results for ids that exist (deleted items are silently ignored).
+                    // This results in the picked items value to be set to contain only ids of picked items that could actually be found.
+                    // Since a referenced item could potentially be restored later on, instead of changing the selected values here based
+                    // on whether the items exist during a save event - we should keep "placeholder" items for picked items that currently
+                    // could not be fetched. This will preserve references and ensure that the state of an item does not differ depending
+                    // on whether it is simply resaved or not.
+                    // This is done by remapping the int/guid ids into a new array of items, where we create "Deleted item" placeholders
+                    // when there is no match for a selected id. This will ensure that the values being set on save, are the same as before.
+
+                    medias = _.map(ids,
+                        function (id) {
+                            var found = _.find(medias,
+                                function (m) {
+                                    // We could use coercion (two ='s) here .. but not sure if this works equally well in all browsers and
+                                    // it's prone to someone "fixing" it at some point without knowing the effects. Rather use toString()
+                                    // compares and be completely sure it works.
+                                    return m.udi.toString() === id.toString() || m.id.toString() === id.toString();
+                                });
+                            if (found) {
+                                return found;
+                            } else {
+                                return {
+                                    name: localizationService.dictionary.mediaPicker_deletedItem,
+                                    id: $scope.model.config.idType !== "udi" ? id : null,
+                                    udi: $scope.model.config.idType === "udi" ? id : null,
+                                    icon: "icon-picture",
+                                    thumbnail: null,
+                                    trashed: true
+                                };
+                            }
+                        });
+
+                    _.each(medias,
+                        function (media, i) {
+                            // if there is no thumbnail, try getting one if the media is not a placeholder item
+                            if (!media.thumbnail && media.id && media.metaData) {
+                                media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
+                                media.file = mediaHelper.resolveFileFromEntity(media, false);
+                            }
+
+                            $scope.images.push(media);
+                            $scope.ids.push(media.udi);
+                        });
+
+                    $scope.sync();
+
+                    angular.forEach($scope.model.value, function (cropDataSet, i) {
+                        $scope.resetCropFromUdi(cropDataSet.udi, cropDataSet);
+                    });
+                });
+            }
+            else {
+                $scope.model.value = [];
+            }
+        }
+
+        setupViewModel();
+
+        $scope.remove = function(index) {
+            $scope.images.splice(index, 1);
+            $scope.ids.splice(index, 1);
+            $scope.sync();
+        };
+
+        $scope.goToItem = function(item) {
+            $location.path('media/media/edit/' + item.id);
+        };
+
+       $scope.add = function() {
+
+           $scope.mediaPickerOverlay = {
+               view: "mediapicker",
+               title: "Select media",
+               startNodeId: $scope.model.config.startNodeId,
+               startNodeIsVirtual: $scope.model.config.startNodeIsVirtual,
+               multiPicker: multiPicker,
+               onlyImages: true,
+               disableFolderSelect: true,
+               show: true,
+               submit: function(model) {
+
+                   _.each(model.selectedImages, function(media, i) {
+                       // if there is no thumbnail, try getting one if the media is not a placeholder item
+                       if (!media.thumbnail && media.id && media.metaData) {
+                           media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
+                       }
+
+                       $scope.images.push(media);
+
+                       $scope.ids.push(media.udi);
+                   });
+
+                   $scope.sync();
+
+                   _.each(model.selectedImages, function (media, i) {
+                       $scope.resetCropFromMedia(media);
+                   });
+
+                   $scope.mediaPickerOverlay.show = false;
+                   $scope.mediaPickerOverlay = null;
+               }
+           };
+        };
+
+        $scope.cropItem = function (item) {
+
+            var cropDataSet = $scope.model.value.filter(function (data) { return data.udi == item.udi });
+            if (angular.isString(item.file)) {
+                cropDataSet[0].src = item.file;
+            }
+            else {
+                cropDataSet[0].src = item.file.src;
+            }
+
+            $scope.mediaPickerOverlay = {
+                view: "views/propertyeditors/imagecropper/imagecropper.html",
+                title: "Crop settings",
+                config: config,
+                value: cropDataSet[0],
+                show: true,
+                submit: function (model) {
+
+                    _.each($scope.model.value, function (crop, i) {
+                        if (crop.udi == item.udi) {
+                            $scope.model.value[i] = crop;
+                        }
+                    });
+
+                    $scope.sync();
+
+                    $scope.mediaPickerOverlay.show = false;
+                    $scope.mediaPickerOverlay = null;
+                }
+            };
+        }
+
+       $scope.sortableOptions = {
+           disabled: !$scope.isMultiPicker,
+           items: "li:not(.add-wrapper)",
+           cancel: ".unsortable",
+           update: function(e, ui) {
+               var r = [];
+               // TODO: Instead of doing this with a half second delay would be better to use a watch like we do in the
+               // content picker. Then we don't have to worry about setting ids, render models, models, we just set one and let the
+               // watch do all the rest.
+                $timeout(function(){
+                    angular.forEach($scope.images, function(value, key) {
+                        r.push(value.udi);
+                    });
+                    $scope.ids = r;
+                    $scope.sync();
+                }, 500, false);
+            }
+        };
+
+        $scope.resetCropFromUdi = function (udi, cropDataSet) {
+            entityResource.getById(udi, "Media").then(function (media) {
+                $scope.resetCropFromMedia(media, cropDataSet);
+            });
+        };
+
+        $scope.resetCropFromMedia = function (media, cropDataSet) {
+            if (cropDataSet === undefined) {
+                if (media.file === undefined) {
+                    var newCropDataSet = mediaHelper.resolveFileFromEntity(media, false);
+                    if (!angular.isString(newCropDataSet)) {
+                        cropDataSet = newCropDataSet;
+                    }
+                }
+                else if (!angular.isString(media.file)) {
+                    cropDataSet = media.file;
+                }
+            }
+
+            if (cropDataSet !== undefined) {
+
+
+                var savedUdis = $scope.model.value.map(function (value) { return value.udi; });
+                var cropDataSetIndex = savedUdis.indexOf(media.udi);
+
+                if (cropDataSetIndex > -1) {
+
+                    //sync any config changes with the editor and drop outdated crops
+                    _.each(cropDataSet.crops, function (saved) {
+                        var configured = _.find(config.crops, function (item) { return item.alias === saved.alias });
+
+                        if (configured && configured.height === saved.height && configured.width === saved.width) {
+                            configured.coordinates = saved.coordinates;
+                        }
+                    });
+                    cropDataSet.crops = config.crops;
+
+                    //restore focalpoint if missing
+                    if (!cropDataSet.focalPoint) {
+                        cropDataSet.focalPoint = config.focalPoint;
+                    }
+
+                    $scope.model.value[cropDataSetIndex] = cropDataSet;
+                    $scope.model.value[cropDataSetIndex].udi = media.udi;
+                }
+
+            }
+        }
+
+        $scope.sync = function () {
+            var newValue = [];
+            angular.forEach($scope.ids, function (id, i) {
+
+
+                foundCropDataSet = $scope.model.value.filter(function (value) { return value.udi == id; });
+                if (foundCropDataSet.length > 0) {
+                    newValue.push(foundCropDataSet[0]);
+                }
+                else {
+                    var cropDataSet = {
+                        udi: id,
+                        crops: config.crops,
+                        focalPoint: config.focalPoint
+                    }
+                    newValue.push(cropDataSet);
+                }
+
+            });
+            $scope.model.value = newValue;
+        };
+
+        $scope.showAdd = function () {
+            if (!multiPicker) {
+                if ($scope.model.value && $scope.model.value !== "") {
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        //here we declare a special method which will be called whenever the value has changed from the server
+        //this is instead of doing a watch on the model.value = faster
+        $scope.model.onValueChanged = function (newVal, oldVal) {
+            //update the display val again if it has changed from the server
+            setupViewModel();
+        };
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.controller.js
@@ -263,7 +263,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaCropperContro
 
         $scope.showAdd = function () {
             if (!multiPicker) {
-                if ($scope.model.value && $scope.model.value !== "") {
+                if ($scope.model.value && $scope.model.value.length > 0) {
                     return false;
                 }
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.controller.js
@@ -3,7 +3,7 @@
 angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaCropperController",
     function ($scope, entityResource, mediaHelper, $timeout, userService, $location, localizationService) {
 
-        var config = angular.copy($scope.model.config);
+        var defaultConfig = angular.copy($scope.model.config);
 
         //check the pre-values for multi-picker
         var multiPicker = $scope.model.config.multiPicker && $scope.model.config.multiPicker !== '0' ? true : false;
@@ -150,7 +150,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaCropperContro
             $scope.mediaPickerOverlay = {
                 view: "views/propertyeditors/imagecropper/imagecropper.html",
                 title: "Crop settings",
-                config: config,
+                config: $scope.model.config,
                 value: cropDataSet[0],
                 show: true,
                 submit: function (model) {
@@ -165,6 +165,8 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaCropperContro
 
                     $scope.mediaPickerOverlay.show = false;
                     $scope.mediaPickerOverlay = null;
+
+                    $scope.model.config = defaultConfig;
                 }
             };
         }
@@ -217,17 +219,17 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaCropperContro
 
                     //sync any config changes with the editor and drop outdated crops
                     _.each(cropDataSet.crops, function (saved) {
-                        var configured = _.find(config.crops, function (item) { return item.alias === saved.alias });
+                        var configured = _.find($scope.model.config.crops, function (item) { return item.alias === saved.alias });
 
                         if (configured && configured.height === saved.height && configured.width === saved.width) {
                             configured.coordinates = saved.coordinates;
                         }
                     });
-                    cropDataSet.crops = config.crops;
+                    cropDataSet.crops = $scope.model.config.crops;
 
                     //restore focalpoint if missing
                     if (!cropDataSet.focalPoint) {
-                        cropDataSet.focalPoint = config.focalPoint;
+                        cropDataSet.focalPoint = $scope.model.config.focalPoint;
                     }
 
                     $scope.model.value[cropDataSetIndex] = cropDataSet;
@@ -249,8 +251,8 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaCropperContro
                 else {
                     var cropDataSet = {
                         udi: id,
-                        crops: config.crops,
-                        focalPoint: config.focalPoint
+                        crops: $scope.model.config.crops,
+                        focalPoint: $scope.model.config.focalPoint
                     }
                     newValue.push(cropDataSet);
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediacropper/mediacropper.html
@@ -1,0 +1,46 @@
+<div class="umb-editor umb-mediapicker" ng-controller="Umbraco.PropertyEditors.MediaCropperController">
+
+    <p ng-if="(images|filter:{trashed:true}).length == 1"><localize key="mediaPicker_pickedTrashedItem"></localize></p>
+    <p ng-if="(images|filter:{trashed:true}).length > 1"><localize key="mediaPicker_pickedTrashedItems"></localize></p>
+    
+    <div data-element="sortable-thumbnails" class="flex flex-wrap error">
+        <ul ui-sortable="sortableOptions" ng-model="images" class="umb-sortable-thumbnails">
+            <li data-element="sortable-thumbnail-{{$index}}" class="umb-sortable-thumbnails__wrapper" ng-repeat="image in images track by $index">
+
+                <span class="label trashed" ng-if="image.trashed"><localize key="mediaPicker_trashed"></localize></span>
+                <!-- IMAGE -->
+                <img ng-class="{'trashed': image.trashed}" ng-src="{{image.thumbnail}}" alt="" ng-show="image.thumbnail" title="{{image.trashed ? 'Trashed: ' + image.name : image.name}}" />
+
+                <!-- SVG -->
+                <img ng-class="{'trashed': image.trashed}" ng-if="image.metaData.umbracoExtension.Value === 'svg'" ng-src="{{image.metaData.umbracoFile.Value}}" alt="" title="{{image.trashed ? 'Trashed: ' + image.name : image.name}}" />
+                <img ng-class="{'trashed': image.trashed}" ng-if="image.extension === 'svg'" ng-src="{{image.file}}" alt="" />
+
+                <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
+                    <a class="umb-sortable-thumbnails__action" data-element="action-crop" href="" ng-click="cropItem(image)">
+                        <i class="icon icon-crop"></i>
+                    </a>
+                    <a class="umb-sortable-thumbnails__action" data-element="action-edit" href="" ng-click="goToItem(image)">
+                        <i class="icon icon-edit"></i>
+                    </a>
+                    <a class="umb-sortable-thumbnails__action -red" data-element="action-remove" href="" ng-click="remove($index)">
+                        <i class="icon icon-delete"></i>
+                    </a>
+                </div>
+            </li>
+            <li style="border: none;" class="add-wrapper unsortable" ng-if="showAdd()">
+                <a data-element="sortable-thumbnails-add" href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': (images.length === 0 || isMultiPicker)}" prevent-default>
+                    <i class="icon icon-add large"></i>
+                </a>
+            </li>
+        </ul>
+    </div>
+
+    <umb-overlay
+        data-element="overlay-media-picker"
+        ng-if="mediaPickerOverlay.show"
+        model="mediaPickerOverlay"
+        position="right"
+        view="mediaPickerOverlay.view">
+    </umb-overlay>
+
+</div>

--- a/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
@@ -432,5 +432,73 @@ namespace Umbraco.Web
 
             return string.Empty;
         }
+
+        /// <summary>
+        /// Gets the ImageProcessor Url from the ImageCropDataSet.
+        /// </summary>
+        /// <param name="cropDataSet"></param>
+        /// <param name="width">
+        /// The width of the output image.
+        /// </param>
+        /// <param name="height">
+        /// The height of the output image.
+        /// </param>
+        /// <param name="cropAlias">
+        /// The crop alias.
+        /// </param>
+        /// <param name="quality">
+        /// Quality percentage of the output image.
+        /// </param>
+        /// <param name="imageCropMode">
+        /// The image crop mode.
+        /// </param>
+        /// <param name="imageCropAnchor">
+        /// The image crop anchor.
+        /// </param>
+        /// <param name="preferFocalPoint">
+        /// Use focal point to generate an output image using the focal point instead of the predefined crop if there is one
+        /// </param>
+        /// <param name="useCropDimensions">
+        /// Use crop dimensions to have the output image sized according to the predefined crop sizes, this will override the width and height parameters
+        /// </param>
+        /// <param name="cacheBusterValue">
+        /// Add a serialised date of the last edit of the item to ensure client cache refresh when updated
+        /// </param>
+        /// <param name="furtherOptions">
+        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// <example>
+        /// <![CDATA[
+        /// furtherOptions: "&bgcolor=fff"
+        /// ]]>
+        /// </example>
+        /// </param>
+        /// <param name="ratioMode">
+        /// Use a dimension as a ratio
+        /// </param>
+        /// <param name="upScale">
+        /// If the image should be upscaled to requested dimensions
+        /// </param>        
+        /// <returns>
+        /// The <see cref="string"/>.
+        /// </returns>
+        public static string GetCropUrl(
+            this MediaCropDataSet cropDataSet,
+            int? width = null,
+            int? height = null,
+            string cropAlias = null,
+            int? quality = null,
+            ImageCropMode? imageCropMode = null,
+            ImageCropAnchor? imageCropAnchor = null,
+            bool preferFocalPoint = false,
+            bool useCropDimensions = false,
+            string cacheBusterValue = null,
+            string furtherOptions = null,
+            ImageCropRatioMode? ratioMode = null,
+            bool upScale = true)
+        {
+            var imageUrl = cropDataSet.Src;
+            return imageUrl.GetCropUrl(cropDataSet, width, height, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode, upScale);
+        }
     }
+
 }

--- a/src/Umbraco.Web/Models/ImageCropDataSet.cs
+++ b/src/Umbraco.Web/Models/ImageCropDataSet.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Web.Models
         [DataMember(Name = "crops")]
         public IEnumerable<ImageCropData> Crops { get; set; }
 
-        public string GetCropUrl(string alias, bool useCropDimensions = true, bool useFocalPoint = false, string cacheBusterValue = null)
+        public virtual string GetCropUrl(string alias, bool useCropDimensions = true, bool useFocalPoint = false, string cacheBusterValue = null)
         {
 
             var crop = Crops.GetCrop(alias);

--- a/src/Umbraco.Web/Models/MediaCropDataSet.cs
+++ b/src/Umbraco.Web/Models/MediaCropDataSet.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Web.Models
     [JsonConverter(typeof(NoTypeConverterJsonConverter<MediaCropDataSet>))]
     [TypeConverter(typeof(MediaCropDataSetConverter))]
     [DataContract(Name="mediaCropDataSet")]
-    public class MediaCropDataSet : ImageCropDataSet, IHtmlString, IEquatable<MediaCropDataSet>
+    public class MediaCropDataSet : ImageCropDataSet, IEquatable<MediaCropDataSet>
     {
         [DataMember(Name = "udi")]
         public Udi Udi { get; set; }

--- a/src/Umbraco.Web/Models/MediaCropDataSet.cs
+++ b/src/Umbraco.Web/Models/MediaCropDataSet.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Web.Models
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return string.Equals(Udi, other.Udi) && Equals(FocalPoint, other.FocalPoint) 
+            return Udi.Equals(other.Udi) && Equals(FocalPoint, other.FocalPoint) 
                 && Crops.SequenceEqual(other.Crops);
         }
 

--- a/src/Umbraco.Web/Models/MediaCropDataSet.cs
+++ b/src/Umbraco.Web/Models/MediaCropDataSet.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Dynamic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Web;
+using Newtonsoft.Json;
+using Umbraco.Core;
+using Umbraco.Core.Dynamics;
+using Umbraco.Core.Models;
+using Umbraco.Core.Serialization;
+using Umbraco.Web.PropertyEditors.ValueConverters;
+
+namespace Umbraco.Web.Models
+{
+    [JsonConverter(typeof(NoTypeConverterJsonConverter<MediaCropDataSet>))]
+    [TypeConverter(typeof(MediaCropDataSetConverter))]
+    [DataContract(Name="mediaCropDataSet")]
+    public class MediaCropDataSet : ImageCropDataSet, IHtmlString, IEquatable<MediaCropDataSet>
+    {
+        [DataMember(Name = "udi")]
+        public Udi Udi { get; set; }
+
+        public IPublishedContent MediaItem { get; set; }
+
+        public override string GetCropUrl(string alias, bool useCropDimensions = true, bool useFocalPoint = false, string cacheBusterValue = null)
+        {
+            return Src + base.GetCropUrl(alias, useCropDimensions, useFocalPoint, cacheBusterValue);
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other"/> parameter; otherwise, false.
+        /// </returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(MediaCropDataSet other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Udi, other.Udi) && Equals(FocalPoint, other.FocalPoint) 
+                && Crops.SequenceEqual(other.Crops);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((MediaCropDataSet) obj);
+        }
+
+        /// <summary>
+        /// Serves as the default hash function. 
+        /// </summary>
+        /// <returns>
+        /// A hash code for the current object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (Udi != null ? Udi.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ (FocalPoint != null ? FocalPoint.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ (Crops != null ? Crops.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        public static bool operator == (MediaCropDataSet left, MediaCropDataSet right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator != (MediaCropDataSet left, MediaCropDataSet right)
+        {
+            return !Equals(left, right);
+        }
+    }
+}

--- a/src/Umbraco.Web/PropertyEditors/MediaCropperPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaCropperPropertyEditor.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using Umbraco.Core;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Web.PropertyEditors
+{
+    /// <summary>
+    /// Media picker property editors that stores crop data
+    /// </summary>
+    [PropertyEditor(Constants.PropertyEditors.MediaCropperAlias, "Media Cropper", PropertyEditorValueTypes.Text, "mediacropper", IsParameterEditor = true, Group = "media", Icon = "icon-crop")]
+    public class MediaCropperPropertyEditor : PropertyEditor
+    {
+        public MediaCropperPropertyEditor()
+        {
+            InternalPreValues = new Dictionary<string, object>
+            {
+                {"idType", "udi"},
+                {"focalPoint", "{left: 0.5, top: 0.5}"},
+                {"src", ""}
+            };
+        }
+
+        internal IDictionary<string, object> InternalPreValues;
+        
+        public override IDictionary<string, object> DefaultPreValues
+        {
+            get { return InternalPreValues; }
+            set { InternalPreValues = value; }
+        }
+
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new MediaCropperPreValueEditor();
+        }
+
+        internal class MediaCropperPreValueEditor : PreValueEditor
+        {
+            [PreValueField("crops", "Crop sizes", "views/propertyeditors/imagecropper/imagecropper.prevalues.html")]
+            public string Crops { get; set; }
+
+            public MediaCropperPreValueEditor()
+            {
+                //create the fields
+                Fields.Add(new PreValueField()
+                {
+                    Key = "multiPicker",
+                    View = "boolean",
+                    Name = "Pick multiple items"
+                });
+                Fields.Add(new PreValueField()
+                {
+                    Key = "startNodeId",
+                    View = "mediapicker",
+                    Name = "Start node",
+                    Config = new Dictionary<string, object>
+                    {
+                        {"idType", "udi"}
+                    }
+                });
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaCropDataSetConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaCropDataSetConverter.cs
@@ -1,0 +1,46 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core;
+using Umbraco.Web.Models;
+
+namespace Umbraco.Web.PropertyEditors.ValueConverters
+{
+    /// <summary>
+    /// Used to do some type conversions from MediaCropDataSet to string and JObject
+    /// </summary>
+    public class MediaCropDataSetConverter : TypeConverter
+    {
+        private static readonly Type[] ConvertableTypes = new[]
+        {
+            typeof(JObject)
+        };
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return ConvertableTypes.Any(x => TypeHelper.IsTypeAssignableFrom(x, destinationType))
+                   || base.CanConvertFrom(context, destinationType);
+        }
+
+        public override object ConvertTo(
+            ITypeDescriptorContext context,
+            CultureInfo culture,
+            object value,
+            Type destinationType)
+        {
+            var cropDataSet = value as MediaCropDataSet;
+            if (cropDataSet == null)
+                return null;
+
+            //JObject
+            if (TypeHelper.IsTypeAssignableFrom<JObject>(destinationType))
+            {
+                return JObject.FromObject(cropDataSet);
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaCropperPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaCropperPropertyConverter.cs
@@ -1,0 +1,270 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MediaPickerPropertyConverter.cs" company="Umbraco">
+//   Umbraco
+// </copyright>
+// <summary>
+//  The media picker 2 value converter
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
+using Umbraco.Web.Extensions;
+using Umbraco.Web.Models;
+
+namespace Umbraco.Web.PropertyEditors.ValueConverters
+{
+    /// <summary>
+    /// The media picker property value converter.
+    /// </summary>
+    [DefaultPropertyValueConverter]
+    public class MediaCropperPropertyConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
+    {
+        private readonly IDataTypeService _dataTypeService;
+
+        //TODO: Remove this ctor in v8 since the other one will use IoC
+        public MediaCropperPropertyConverter()
+            : this(ApplicationContext.Current.Services.DataTypeService)
+        {
+        }
+
+        public MediaCropperPropertyConverter(IDataTypeService dataTypeService)
+        {
+            if (dataTypeService == null) throw new ArgumentNullException("dataTypeService");
+            _dataTypeService = dataTypeService;
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType)
+        {
+            return IsMultipleDataType(propertyType.DataTypeId, propertyType.PropertyEditorAlias) ? typeof(IEnumerable<ImageCropDataSet>) : typeof(ImageCropDataSet);
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType, PropertyCacheValue cacheValue)
+        {
+            PropertyCacheLevel returnLevel;
+            switch (cacheValue)
+            {
+                case PropertyCacheValue.Object:
+                    returnLevel = PropertyCacheLevel.ContentCache;
+                    break;
+                case PropertyCacheValue.Source:
+                    returnLevel = PropertyCacheLevel.Content;
+                    break;
+                case PropertyCacheValue.XPath:
+                    returnLevel = PropertyCacheLevel.Content;
+                    break;
+                default:
+                    returnLevel = PropertyCacheLevel.None;
+                    break;
+            }
+
+            return returnLevel;
+        }
+
+        /// <summary>
+        /// The is multiple data type.
+        /// </summary>
+        /// <param name="dataTypeId">
+        /// The data type id.
+        /// </param>
+        /// <param name="propertyEditorAlias"></param>
+        /// <returns>
+        /// The <see cref="bool"/>.
+        /// </returns>
+        private bool IsMultipleDataType(int dataTypeId, string propertyEditorAlias)
+        {
+            // GetPreValuesCollectionByDataTypeId is cached at repository level;
+            // still, the collection is deep-cloned so this is kinda expensive,
+            // better to cache here + trigger refresh in DataTypeCacheRefresher
+
+            return Storages.GetOrAdd(dataTypeId, id =>
+            {
+                var preVals = _dataTypeService.GetPreValuesCollectionByDataTypeId(id).PreValuesAsDictionary;
+
+                if (preVals.ContainsKey("multiPicker"))
+                {
+                    var preValue = preVals
+                        .FirstOrDefault(x => string.Equals(x.Key, "multiPicker", StringComparison.InvariantCultureIgnoreCase))
+                        .Value;
+
+                    return preValue != null && preValue.Value.TryConvertTo<bool>().Result;
+                }
+
+                //in some odd cases, the pre-values in the db won't exist but their default pre-values contain this key so check there 
+                var propertyEditor = PropertyEditorResolver.Current.GetByAlias(propertyEditorAlias);
+                if (propertyEditor != null)
+                {
+                    var preValue = propertyEditor.DefaultPreValues
+                        .FirstOrDefault(x => string.Equals(x.Key, "multiPicker", StringComparison.InvariantCultureIgnoreCase))
+                        .Value;
+
+                    return preValue != null && preValue.TryConvertTo<bool>().Result;
+                }
+
+                return false;
+            });
+        }
+
+        /// <summary>
+        /// Checks if this converter can convert the property editor and registers if it can.
+        /// </summary>
+        /// <param name="propertyType">
+        /// The published property type.
+        /// </param>
+        /// <returns>
+        /// The <see cref="bool"/>.
+        /// </returns>
+        public override bool IsConverter(PublishedPropertyType propertyType)
+        {
+            if (propertyType.PropertyEditorAlias.Equals(Constants.PropertyEditors.MediaCropperAlias))
+                return true;
+
+            return false;
+        }
+
+
+        internal static void MergePreValues(JArray currentValues, IDataTypeService dataTypeService, int dataTypeId)
+        {
+            //need to lookup the pre-values for this data type
+            //TODO: Change all singleton access to use ctor injection in v8!!!
+            var dt = dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeId);
+
+            if (dt != null && dt.IsDictionaryBased && dt.PreValuesAsDictionary.ContainsKey("crops"))
+            {
+                var cropsString = dt.PreValuesAsDictionary["crops"].Value;
+                JArray preValueCrops;
+                try
+                {
+                    preValueCrops = JsonConvert.DeserializeObject<JArray>(cropsString);
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.Error<ImageCropperValueConverter>("Could not parse the string " + cropsString + " to a json object", ex);
+                    return;
+                }
+
+                //now we need to merge the crop values - the alias + width + height comes from pre-configured pre-values,
+                // however, each crop can store it's own coordinates
+
+                JArray existingCropsArray;
+
+                foreach (var currentValue in currentValues)
+                {
+                    if (currentValue["crops"] != null)
+                    {
+                        existingCropsArray = (JArray)currentValue["crops"];
+                    }
+                    else
+                    {
+                        currentValue["crops"] = existingCropsArray = new JArray();
+                    }
+
+                    foreach (var preValueCrop in preValueCrops.Where(x => x.HasValues))
+                    {
+                        var found = existingCropsArray.FirstOrDefault(x =>
+                        {
+                            if (x.HasValues && x["alias"] != null)
+                            {
+                                return x["alias"].Value<string>() == preValueCrop["alias"].Value<string>();
+                            }
+                            return false;
+                        });
+                        if (found != null)
+                        {
+                            found["width"] = preValueCrop["width"];
+                            found["height"] = preValueCrop["height"];
+                        }
+                        else
+                        {
+                            existingCropsArray.Add(preValueCrop);
+                        }
+                    }
+                }
+            }
+        }
+
+        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source == null) return null;
+            var sourceString = source.ToString();
+
+            if (sourceString.DetectIsJson())
+            {
+                JArray obj;
+                try
+                {
+                    obj = JsonConvert.DeserializeObject<JArray>(sourceString, new JsonSerializerSettings
+                    {
+                        Culture = CultureInfo.InvariantCulture,
+                        FloatParseHandling = FloatParseHandling.Decimal
+                    });
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.Error<MediaCropperPropertyConverter>("Could not parse the string " + sourceString + " to a json object", ex);
+                    return sourceString;
+                }
+
+                MergePreValues(obj, _dataTypeService, propertyType.DataTypeId);
+
+                return obj;
+            }
+
+            //it's not json, just return the string
+            return sourceString;
+        }
+
+        /// <summary>
+        /// Convert the source nodeId into a IPublishedContent (or DynamicPublishedContent)
+        /// </summary>
+        /// <param name="propertyType">
+        /// The published property type.
+        /// </param>
+        /// <param name="source">
+        /// The value of the property
+        /// </param>
+        /// <param name="preview">
+        /// The preview.
+        /// </param>
+        /// <returns>
+        /// The <see cref="object"/>.
+        /// </returns>
+        public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            var cropDataSets = ((JArray)source).ToObject<IEnumerable<ImageCropDataSet>>();
+
+            if (IsMultipleDataType(propertyType.DataTypeId, propertyType.PropertyEditorAlias))
+            {
+                return cropDataSets;
+            }
+            else
+            {
+                return cropDataSets.FirstOrDefault();
+            }
+        }
+
+        private static readonly ConcurrentDictionary<int, bool> Storages = new ConcurrentDictionary<int, bool>();
+
+        internal static void ClearCaches()
+        {
+            Storages.Clear();
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -350,6 +350,8 @@
     <Compile Include="Models\Mapping\MemberTreeNodeUrlResolver.cs" />
     <Compile Include="Models\Trees\ExportMember.cs" />
     <Compile Include="PropertyEditors\DropdownFlexiblePropertyEditor.cs" />
+    <Compile Include="PropertyEditors\MediaCropperPropertyEditor.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\MediaCropperPropertyConverter.cs" />
     <Compile Include="TourFilterResolver.cs" />
     <Compile Include="Editors\UserEditorAuthorizationHelper.cs" />
     <Compile Include="Editors\UserGroupAuthorizationAttribute.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -345,13 +345,15 @@
     <Compile Include="Models\ContentEditing\BackOfficePreview.cs" />
     <Compile Include="Models\ContentEditing\DocumentTypeCollectionDisplay.cs" />
     <Compile Include="Models\ContentEditing\NotifySetting.cs" />
+    <Compile Include="Models\MediaCropDataSet.cs" />
     <Compile Include="Models\Mapping\AutoMapperExtensions.cs" />
     <Compile Include="Models\Mapping\ContentTreeNodeUrlResolver.cs" />
     <Compile Include="Models\Mapping\MemberTreeNodeUrlResolver.cs" />
     <Compile Include="Models\Trees\ExportMember.cs" />
     <Compile Include="PropertyEditors\DropdownFlexiblePropertyEditor.cs" />
     <Compile Include="PropertyEditors\MediaCropperPropertyEditor.cs" />
-    <Compile Include="PropertyEditors\ValueConverters\MediaCropperPropertyConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\MediaCropperValueConverter.cs" />
+    <Compile Include="PropertyEditors\ValueConverters\MediaCropDataSetConverter.cs" />
     <Compile Include="TourFilterResolver.cs" />
     <Compile Include="Editors\UserEditorAuthorizationHelper.cs" />
     <Compile Include="Editors\UserGroupAuthorizationAttribute.cs" />


### PR DESCRIPTION
I created a new branch for #2903 (http://issues.umbraco.org/issue/U4-7316) with the suggested changes from @ronaldbarendse.

Moved the media cropper data set to it's own models, making the implementation a lot simpler.

Also added a `MediaItem` property on the `MediaCropDataSet` for easy access to the underlying mediaitem. It is wired up in the Property Value Converter.

> Should we allow enabling/disabling inheriting the focus point from the media's image cropper (e.g. when you just want to specify a single node specific crop, but always use the focus point of the media item)?

Now it uses the crops defined on the media, when adding to the picker. I have thought of making a "Reset" function in the media cropper, for resetting to the values from the media item. But that wouldn't update on changes on the media item anyway. So I think, we should get this out, and see if there is a need for having a reset functionality.

> How to deal with conflicting crops (same crop alias on node and media, but different size)?
> Do we need to add a setting to enable/disable crops from the media item (like the grid editors: allow all or specify which ones)? This makes sense if you'd like node specific crops for all media crops (including newly added ones).

In this implementation it only inherits the media items crop if the alias AND width AND height is the same. We could add a setting to enable/disable crops, but I think we should start out simple.

> Resetting a crop should 'inherit' the crop (with the same alias) from the media item, but not store this data on the node property itself (it should combine the node specific crops with the media crops when retrieving the data, so they're always current - again like the grid does with it's editor settings).

I agree, and that is why it doesn't allow resetting ATM, as that would add (maybe unnecessary) complexity to the code. We would probably need some kind of property for storing the reset state, and the value converter (or something else, should pick and match crops from the media if reset).

> Should we just name this 'Media Cropper'? It only allows picking and cropping images from the media library, so maybe 'Media Image Cropper' is more concise. And who knows, maybe someday we could have a 'Media Video Cropper', 'Media Audio Cropper', 'Media PDF Cropper' built-in 😅

I don't think a video/audio/pdf cropper is anywhere near, so I would go for Media Cropper. But it's just a name, if HQ thinks Media Image Cropper is better, then that is fine with me :)