### PR TITLE
Fixing issue #2910 -  List view shows dimmed link for saved item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-table.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-table.less
@@ -165,7 +165,7 @@ input.umb-table__input {
 
 }
 
-.-content .-unpublished {
+.-content :not(.with-unpublished-version).-unpublished {
     .umb-table__name > * {
         opacity: .4;
     }

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
@@ -32,7 +32,8 @@
                  ng-class="{
                     '-selected':item.selected,
                     '-published':item.published,
-                    '-unpublished':!item.published
+                    '-unpublished':!item.published,
+                    'with-unpublished-version':!item.published && item.hasPublishedVersion
                 }"
                  ng-click="selectItem(item, $index, $event)">
 


### PR DESCRIPTION
### Description
Issue #2910 was up for grabs so I decide to take a look at it.

If you now have a list the following happens for the child items:

1) If Un-published the item has an Opacity of 0.4
2) If Published there is no Opacity
3) If Published, with a newly saved version ( that has not been published ) there is now no Opacity, but the small green icon that indicates there are saved changes will still be visible.