### PR TITLE
#2898 use getMediaPropertyValue to find the url of the media

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
@@ -132,7 +132,7 @@ angular.module("umbraco").controller("Umbraco.Dialogs.LinkPickerController",
 						$scope.target.id = media.id;
 						$scope.target.isMedia = true;
 						$scope.target.name = media.name;
-						$scope.target.url = mediaHelper.resolveFile(media);
+						$scope.target.url = mediaHelper.getMediaPropertyValue({ mediaModel: media });
 					}
 				});
 			});

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -118,7 +118,7 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 						$scope.model.target.udi = media.udi;
 						$scope.model.target.isMedia = true;
 						$scope.model.target.name = media.name;
-						$scope.model.target.url = mediaHelper.resolveFile(media);
+						$scope.model.target.url = mediaHelper.getMediaPropertyValue({ mediaModel: media });
 						
 						debugger;
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -88,7 +88,7 @@ angular.module("umbraco")
                                 $scope.target = node;
                                 if (ensureWithinStartNode(node)) {
                                     selectImage(node);
-                                    $scope.target.url = mediaHelper.resolveFile(node);
+                                    $scope.target.url = mediaHelper.getMediaPropertyValue({ mediaModel: media });
                                     $scope.target.altText = altText;
                                     $scope.openDetailsDialog();
                                 }
@@ -192,7 +192,7 @@ angular.module("umbraco")
                         if (image.image) {
                             $scope.target.url = image.image;
                         } else {
-                            $scope.target.url = mediaHelper.resolveFile(image);
+                            $scope.target.url = mediaHelper.getMediaPropertyValue({ mediaModel: media });
                         }
 
                         $scope.openDetailsDialog();


### PR DESCRIPTION
, as this specifically searches for the umbracoFile property

Fixes #2898


### Description
This PR changes the way the linkpicker and the mediapicker resolves the url of a media item. Before, they tried to loop through all properties, stopping at the first Upload or Image Cropper property to use for the URL.

On media items with several upload/cropper properties (like a PDF file with a JPEG preview, a webm video with an mp4 fallback etc.) it could get impossible to link to a media, if one of the properties where empty.

Instead, it now uses the getMediaPropertyValue method, which specifically looks for the umbracoFile property, which also is the one used in the Url Property of the IPublishedContent object of the media.