### PR TITLE
V8 Listview Variant Default Nodename fallback

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentMapperProfile.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapperProfile.cs
@@ -92,7 +92,16 @@ namespace Umbraco.Web.Models.Mapping
     {
         public string Resolve(IContent source, ContentItemBasic<ContentPropertyBasic> destination, string destMember, ResolutionContext context)
         {
-            return source.GetCultureName(context.GetCulture());
+            var culture = context.GetCulture();
+
+            if (source.CultureNames.TryGetValue(culture, out var name) && !string.IsNullOrWhiteSpace(name))
+            {
+                return name;
+            }
+            else
+            {
+                return $"({ source.Name })";
+            }
         }
     }
 }


### PR DESCRIPTION
Updates name of variant model mapping in list views - to use same logic as the content tree if a variant has not been set - we fallback to the base/master language of the node name

Connects umbraco/Umbraco.Private#203