### PR TITLE
Allow nested content to be copied and pasted - based upon Stacked sim…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -21,6 +21,9 @@
                         <a class="umb-nested-content__icon umb-nested-content__icon--delete" title="{{deleteIconTitle}}" ng-class="{ 'umb-nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.deleteNode($index); $event.stopPropagation();" prevent-default>
                             <i class="icon icon-trash"></i>
                         </a>
+                        <a class="umb-nested-content__icon umb-nested-content__icon--copy" title="{{copyIconTitle}}" ng-click="copyToLocalStorage($event, $index); $event.stopPropagation();" ng-if="canCopy()" prevent-default>
+                            <i class="icon icon-documents"></i>
+                        </a>                        
                     </div>
 
                 </div>
@@ -40,6 +43,9 @@
             <a class="umb-nested-content__icon" ng-click="openNodeTypePicker($event)" prevent-default>
                 <i class="icon icon-add"></i>
             </a>
+            <a class="umb-nested-content__icon" ng-click="pasteFromLocalStorage($event, model.value.length)" title="Paste" ng-if="canPaste()" prevent-default>
+                <i class="icon icon-paste-in"></i>
+            </a>           
         </div>
 
         <div class="usky-grid umb-nested-content__node-type-picker" ng-if="overlayMenu.show">


### PR DESCRIPTION
### Prerequisites
- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://issues.umbraco.org/issue/U4-10154
- [x] I have added steps to test this contribution in the description below

### Description
https://issues.umbraco.org/issue/U4-10154

Introduces the ability to copy existing Nested Content and paste into the same or other Nested Content properties that support the copied Nested Content type.

Heavily based upon the work in https://github.com/umco/umbraco-stacked-content/pull/27/files by @markadrake 

## Steps to test

- Create property using the *Our.Umbraco.NestedContent* editor type on a new/existing document type
- Create a new content node of the document type created/updated in step 1
- Add a new piece of content into the Nested Content property
- Once created, a new copy icon should be visible when hovering over the newly created Nested Content
- Click "copy"
- A new paste icon should appear under the Nested Content property, next to the existing add button
- Click "paste"
- There should now be two pieces of Nested Content, which the second being a duplicate of the first
