### PR TITLE
Centre-align the title under color picker options

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -137,6 +137,7 @@ ul.color-picker li {
     padding: 2px;
     margin: 3px;
     border: 2px solid transparent;
+    text-align: center;
     width: 60px;
 
     &.active {


### PR DESCRIPTION
Not much or an existing "issue" as such, but I have centre-aligned the title under the color picker options for a nicer layout.

Screenshots of CSS change below.

**Before:**
![before](https://user-images.githubusercontent.com/800136/45423284-c6b08780-b68a-11e8-8f22-19d8e872e15e.png)

**After:**
![after](https://user-images.githubusercontent.com/800136/45423297-cfa15900-b68a-11e8-9929-31b20c797f53.png)

I believe I made the change in the correct place, but please let me know if not!