### PR TITLE
Load specific locales for moment.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/user.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/user.service.js
@@ -143,12 +143,36 @@ angular.module('umbraco.services')
         /** Called to update the current user's timeout */
         function setUserTimeoutInternal(newTimeout) {
 
-
             var asNumber = parseFloat(newTimeout);
             if (!isNaN(asNumber) && currentUser && angular.isNumber(asNumber)) {
                 currentUser.remainingAuthSeconds = newTimeout;
                 lastServerTimeoutSet = new Date();
             }
+        }
+
+        function getMomentLocales(locales, supportedLocales) {
+            
+            var localeUrls = [];
+            var locales = locales.split(',');
+            for (var i = 0; i < locales.length; i++) {
+                var locale = locales[i].toString().toLowerCase();
+                console.log("locale", locale);
+
+                if (locale !== 'en-us') {
+
+                    if (supportedLocales.indexOf(locale + '.js') > -1) {
+                        localeUrls.push('lib/moment/' + locale + '.js');
+                    }
+                    if (locale.indexOf('-') > -1) {
+                        var majorLocale = locale.split('-')[0] + '.js';
+                        if (supportedLocales.indexOf(majorLocale) > -1) {
+                            localeUrls.push('lib/moment/' + majorLocale);
+                        }
+                    }
+                }
+            }
+
+            return localeUrls;
         }
 
         /** resets all user data, broadcasts the notAuthenticated event and shows the login dialog */
@@ -178,7 +202,7 @@ angular.module('umbraco.services')
             }
         });
 
-        return {
+        var services = {
 
             /** Internal method to display the login dialog */
             _showLoginDialog: function () {
@@ -279,41 +303,33 @@ angular.module('umbraco.services')
             /** Loads the Moment.js Locale for the current user. */
             loadMomentLocaleForCurrentUser: function () {
 
-                function loadLocales(currentUser, supportedLocales) {
-                    var locale = currentUser.locale.toLowerCase();
-                    if (locale !== 'en-us') {
-                        var localeUrls = [];
-                        if (supportedLocales.indexOf(locale + '.js') > -1) {
-                            localeUrls.push('lib/moment/' + locale + '.js');
-                        }
-                        if (locale.indexOf('-') > -1) {
-                            var majorLocale = locale.split('-')[0] + '.js';
-                            if (supportedLocales.indexOf(majorLocale) > -1) {
-                                localeUrls.push('lib/moment/' + majorLocale);
-                            }
-                        }
-                        return assetsService.load(localeUrls, $rootScope);
-                    }
-                    else {
-                        //return a noop promise
-                        var deferred = $q.defer();
-                        var promise = deferred.promise;
-                        deferred.resolve(true);
-                        return promise;
-                    }
-                }
-
                 var promises = {
                     currentUser: this.getCurrentUser(),
                     supportedLocales: javascriptLibraryService.getSupportedLocalesForMoment()
                 }
 
                 return $q.all(promises).then(function (values) {
-                    return loadLocales(values.currentUser, values.supportedLocales);
+                    return services.loadLocales(values.currentUser.locale, values.supportedLocales);
                 });
-                
-                
 
+            },
+
+            /** Loads specific Moment.js Locales. */
+            loadLocales: function (locales, supportedLocales) {
+                
+                var localeUrls = getMomentLocales(locales, supportedLocales);
+                console.log("localeUrls", localeUrls);
+
+                if (localeUrls.length >= 1) {
+                    return assetsService.load(localeUrls, $rootScope);
+                }
+                else {
+                    //return a noop promise
+                    var deferred = $q.defer();
+                    var promise = deferred.promise;
+                    deferred.resolve(true);
+                    return promise;
+                }
             },
 
             /** Called whenever a server request is made that contains a x-umb-user-seconds response header for which we can update the user's remaining timeout seconds */
@@ -322,4 +338,5 @@ angular.module('umbraco.services')
             }
         };
 
+        return services;
     });

--- a/src/Umbraco.Web.UI.Client/src/common/services/user.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/user.service.js
@@ -156,8 +156,6 @@ angular.module('umbraco.services')
             var locales = locales.split(',');
             for (var i = 0; i < locales.length; i++) {
                 var locale = locales[i].toString().toLowerCase();
-                console.log("locale", locale);
-
                 if (locale !== 'en-us') {
 
                     if (supportedLocales.indexOf(locale + '.js') > -1) {
@@ -318,7 +316,6 @@ angular.module('umbraco.services')
             loadLocales: function (locales, supportedLocales) {
                 
                 var localeUrls = getMomentLocales(locales, supportedLocales);
-                console.log("localeUrls", localeUrls);
 
                 if (localeUrls.length >= 1) {
                     return assetsService.load(localeUrls, $rootScope);


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/2983) for the proposed changes in this PR, the link is:
- [x] I have added steps to test this contribution in the description below

### Description
This move the logic to load moment.js locales to a public function, which can be used to load specific locales needed, e.g. to format a date in a specific language independently of backoffice user language.

```
javascriptLibraryService.getSupportedLocalesForMoment().then(function (supportedLocales) {
        userService.loadLocales("da-DK", supportedLocales).then(function () {
            vm.date = moment().locale("da").format("LL");
        });
    });
```

Download the dashboard attachment [MyDashboards.zip](https://github.com/umbraco/Umbraco-CMS/files/2381302/MyDashboards.zip) and extract the folder to `/App_Plugins` and add the following `section` to `/Config/Dashboard.config`:

```
<section alias="Custom Welcome Dashboard">
    <access>
        <deny>translator</deny>
    </access>
    <areas>
        <area>content</area>
    </areas>
    <tab caption="Welcome">
        <control>
            /App_Plugins/MyDashboards/dashboard.html
        </control>
    </tab>
  </section>
```

Backoffice user language English - en-GB
Formatted date in Danish - da-DK

![image](https://user-images.githubusercontent.com/2919859/45520750-1f7f3d80-b7bb-11e8-891f-aade248e9e58.png)


I would be great if you didn't need to call `getSupportedLocalesForMoment` in your controller and just call `loadLocales` with one parameter (comma delimited string of locales), but not sure how to handle this, when we at the same time in core want to re-use same function:

```
return $q.all(promises).then(function (values) {
                    return services.loadLocales(values.currentUser.locale, values.supportedLocales);
            });
```

The function `loadLocales` could also be moved to another service, e.g. `assetsService` or `javascriptLibraryService`. If moved to `javascriptLibraryService` the function `loadMomentLocaleForCurrentUser` might not need to call `javascriptLibraryService.getSupportedLocalesForMoment()` but just call `loadLocales` function instead, which load requested locales from the supported cultures. By defeault I think moment.js has fallback to English locale.