### PR TITLE
old issue tracker reference

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -46,4 +46,5 @@ Umbraco is contribution focused and community driven. If you want to contribute 
 
 Another way you can contribute to Umbraco is by providing issue reports. For information on how to submit an issue report refer to our [online guide for reporting issues](https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/.github/CONTRIBUTING.md).
 
-To view existing issues, please visit [http://issues.umbraco.org](http://issues.umbraco.org).
+You can comment and report issues on the [github issue tracker](https://github.com/umbraco/Umbraco-CMS/issues).
+Since [September 2018](https://umbraco.com/blog/a-second-take-on-umbraco-issue-tracker-hello-github-issues/) the old issue tracker is in read only mode, but can still be found at [http://issues.umbraco.org](http://issues.umbraco.org).


### PR DESCRIPTION
Since the github issue tracker is used, we should at least mention that.

### Prerequisites

- [ ] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is:
- [ ] I have added steps to test this contribution in the description below

### Description
I have not created an issue, but I guess it not necessary for this kind of change?
