### PR TITLE
Preview update: smartphone sizes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
@@ -790,13 +790,13 @@ h4.panel-title {
 }
 
 .smartphone-portrait {
-    width: 320px;
-    height: 504px;
+    width: 360px;
+    height: 640px;
 }
 
 .smartphone-landscape {
-    width: 480px;
-    height: 256px;
+    width: 640px;
+    height: 360px;
 }
 
 .border {


### PR DESCRIPTION
Currently the most used screen size on a smarthphone is 360x640 landscape (640x360 landscape) according to Globalstats Statcounter (http://gs.statcounter.com/screen-resolution-stats/mobile/worldwide). With this in mind I have adjusted the sizes of the smartphone preview frames for both portrait and landscape. Minor change but something that has been on my mind for a while.