### PR TITLE
Fixes content getting deleted when saving an RTE before it's fully loaded

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -377,7 +377,9 @@ angular.module("umbraco")
                 var unsubscribe = $scope.$on("formSubmitting", function () {
                     //TODO: Here we should parse out the macro rendered content so we can save on a lot of bytes in data xfer
                     // we do parse it out on the server side but would be nice to do that on the client side before as well.
-                    $scope.model.value = tinyMceEditor ? tinyMceEditor.getContent() : null;
+                    if (tinyMceEditor !== undefined && tinyMceEditor != null) {
+                        $scope.model.value = tinyMceEditor.getContent();
+                    }
                 });
 
                 //when the element is disposed we need to unsubscribe!


### PR DESCRIPTION
It's possible to save content while the rich text editors (RTE) are still loading. This wouldn't be a problem but the RTEController currently checks if the editor object exists and then sets the model value to null if it doesn't! This fix simply leaves the model value alone if the editor is still null or undefined.

The easiest way to reproduce the current issue is as follows:

1. Create a document type with a required RTE field.
1. Create a content item from that document type.
1. Add some content to the RTE field and save the content item.
1. Reload the page and try to save the content item while the RTE is still loading (don't actually edit anything).
1. Keep reloading and saving until the content in the RTE field gets removed and you get the warning saying that the "Value cannot be empty".

It can be quite hard to trigger the problem each time but hitting save while the "loading..." text is there but there's no editor or textarea should do it.

This issue was logged on the old issue tracker as [U4-11302](https://issues.umbraco.org/issue/U4-11302) but doesn't seem to have been copied over to GitHub.
