### PR TITLE
#3024: Removed unnecessary queries in MultiNodeTreePickerPropertyConv…

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiNodeTreePickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiNodeTreePickerPropertyConverter.cs
@@ -164,13 +164,23 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                     var multiNodeTreePicker = new List<IPublishedContent>();
 
                     var objectType = UmbracoObjectTypes.Unknown;
+                    IPublishedContent multiNodeTreePickerItem = null;
 
                     foreach (var udi in udis)
                     {
-                        var multiNodeTreePickerItem =
-                            GetPublishedContent(udi, ref objectType, UmbracoObjectTypes.Document, umbHelper.TypedContent)
-                            ?? GetPublishedContent(udi, ref objectType, UmbracoObjectTypes.Media, umbHelper.TypedMedia)
-                            ?? GetPublishedContent(udi, ref objectType, UmbracoObjectTypes.Member, umbHelper.TypedMember);
+                        switch (udi.EntityType)
+                        {
+                            case Constants.UdiEntityType.Document:
+                                multiNodeTreePickerItem = GetPublishedContent(udi, ref objectType, UmbracoObjectTypes.Document, umbHelper.TypedContent);
+                                break;
+                            case Constants.UdiEntityType.Media:
+                                multiNodeTreePickerItem = GetPublishedContent(udi, ref objectType, UmbracoObjectTypes.Media, umbHelper.TypedMedia);
+                                break;
+                            case Constants.UdiEntityType.Member:
+                                multiNodeTreePickerItem = GetPublishedContent(udi, ref objectType, UmbracoObjectTypes.Member, umbHelper.TypedMember);
+                                break;
+                        }
+
                         if (multiNodeTreePickerItem != null)
                         {
                             multiNodeTreePicker.Add(multiNodeTreePickerItem);


### PR DESCRIPTION
### Prerequisites

- [X] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3024
- [X] I have added steps to test this contribution in the description below

### Description
This pull request replaces the `??` calls to `GetPublishedContent` for all entity types with a `switch - case` construct based on the entity type referenced from UDI.