### PR TITLE
Updated the Imageprocessor cache location

### DIFF
--- a/src/Umbraco.Web.UI/config/imageprocessor/cache.config
+++ b/src/Umbraco.Web.UI/config/imageprocessor/cache.config
@@ -3,7 +3,7 @@
   <caches>
     <cache name="DiskCache" type="ImageProcessor.Web.Caching.DiskCache, ImageProcessor.Web" maxDays="365" browserMaxDays="7" trimCache="false">
       <settings>
-        <setting key="VirtualCachePath" value="~/app_data/cache" />
+        <setting key="VirtualCachePath" value="~/app_data/ImageProcessorCache" />
       </settings>
     </cache>
   </caches>


### PR DESCRIPTION
ImageProcessor by a default configuration value stores it's cached data in a folder within /App_Data/cache, I believe it is a DX issue where there is a folder within App_Data named cache, which is used exclusively by image processor. It should be descriptive as to what it is the cache for! (Especially seeing as Umbraco has many caches!)

I can't think of anything which this would negatively effect, upgrades would be unaffected i believe? 

Any feedback?

### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is:
- [ ] I have added steps to test this contribution in the description below

### Description
<!-- A description of the changes proposed in the pull-request -->
<!-- Make sure to link to the related issue number so we can easily find it in the issue tracker -->


<!-- Thanks for contributing to Umbraco CMS! -->
