### PR TITLE
Added an `active` css class for Umbraco Tree items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -18,7 +18,7 @@
    </example>
  */
 angular.module("umbraco.directives")
-.directive('umbTreeItem', function ($compile, $http, $templateCache, $interpolate, $log, $location, $rootScope, $window, treeService, $timeout, localizationService) {
+.directive('umbTreeItem', function ($compile, $http, $templateCache, $interpolate, $log, $location, $rootScope, $window, treeService, $timeout, localizationService, appState) {
     return {
         restrict: 'E',
         replace: true,
@@ -132,7 +132,15 @@ angular.module("umbraco.directives")
                 }
                 if (node.selected) {
                     css.push("umb-tree-node-checked");
-                }
+				}
+				
+				//is this the current action node (this is not the same as the current selected node!)
+				var actionNode = appState.getMenuState("currentNode");
+				if(actionNode) {
+					if(actionNode.id === node.id) {
+						css.push("active");
+					}
+				}
                 
                 return css.join(" ");
             };

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -429,7 +429,6 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
          * Hides the menu by hiding the containing dom element
          */
         hideMenu: function() {
-			alert("hideMenu");
             //SD: Would we ever want to access the last action'd node instead of clearing it here?
             appState.setMenuState("currentNode", null);
             appState.setMenuState("menuActions", []);

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -73,6 +73,7 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
             appState.setSectionState("showSearchResults", false);
             appState.setGlobalState("stickyNavigation", false);
             appState.setGlobalState("showTray", false);
+			appState.setMenuState("currentNode", null);
 
             if (appState.getGlobalState("isTablet") === true) {
                 appState.setGlobalState("showNavigation", false);
@@ -347,7 +348,8 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
 
             if (appState.getGlobalState("isTablet") === true && !appState.getGlobalState("stickyNavigation")) {
                 //reset it to whatever is in the url
-                appState.setSectionState("currentSection", $routeParams.section);
+				appState.setSectionState("currentSection", $routeParams.section);
+
                 setMode("default-hidesectiontree");
             }
 
@@ -427,6 +429,7 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
          * Hides the menu by hiding the containing dom element
          */
         hideMenu: function() {
+			alert("hideMenu");
             //SD: Would we ever want to access the last action'd node instead of clearing it here?
             appState.setMenuState("currentNode", null);
             appState.setMenuState("menuActions", []);

--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -185,7 +185,8 @@
 	line-height: 16px;
 }
 
-.umb-tree div:hover {
+.umb-tree div:hover,
+.umb-tree div.active {
 	background: @gray-10;
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3055
- [x] I have added steps to test this contribution in the description below

### Description

- The `currentNode` is already being tracked when the navigation bar is revealed.
- Modified the `umbTreeItem` directive, and it's `getNodeCssClass` method so the `currentNode` would receive the `.active` class.
- Added a new selector to an existing CSS rule-set, so a tree item with class `active` will look exactly as it does if it were hovered.