### PR TITLE
If TinyMCE has not loaded yet, return the initialized value.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -377,7 +377,7 @@ angular.module("umbraco")
                 var unsubscribe = $scope.$on("formSubmitting", function () {
                     //TODO: Here we should parse out the macro rendered content so we can save on a lot of bytes in data xfer
                     // we do parse it out on the server side but would be nice to do that on the client side before as well.
-                    if (tinyMceEditor !== undefined && tinyMceEditor != null) {
+                    if (tinyMceEditor !== undefined && tinyMceEditor != null && !$scope.isLoading) {
                         $scope.model.value = tinyMceEditor.getContent();
                     }
                 });


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3058
- [x] I have added steps to test this contribution in the description below

### Description
There exists a race-condition between TinyMCE and editors in the back office. If a content author saves content at this inopportune time they'll risk losing previously stored content.

At first, I wanted to re-work this behavior as TinyMCE's "Change" event works quite well. Using `._debounce` to respond and keep the model in sync would have been nice.

In the end, I thought it best to add one additional check on `formSubmitting` to make sure `$scope.isLoading` had been set to false. I simulated a 3g connection and clicked the save button before the UI had a chance to load many times. If this value is still true, we know for sure that TinyMCE did not finish loading, thus the content author did not make any changes, and we can safely return the original value of `$scope.model.value`.

Please let me know if anyone can reproduce this bug anymore.