### PR TITLE
Make TagSupport and related types public

### DIFF
--- a/src/Umbraco.Core/Models/Property.cs
+++ b/src/Umbraco.Core/Models/Property.cs
@@ -83,7 +83,7 @@ namespace Umbraco.Core.Models
         /// <summary>
         /// Returns the instance of the tag support, by default tags are not enabled
         /// </summary>
-        internal PropertyTags TagSupport
+        public PropertyTags TagSupport
         {
             get { return _tagSupport; }
         }

--- a/src/Umbraco.Core/Models/PropertyTagBehavior.cs
+++ b/src/Umbraco.Core/Models/PropertyTagBehavior.cs
@@ -1,6 +1,6 @@
 ﻿namespace Umbraco.Core.Models
 {
-    internal enum PropertyTagBehavior
+    public enum PropertyTagBehavior
     {
         Replace,
         Remove,

--- a/src/Umbraco.Core/Models/PropertyTags.cs
+++ b/src/Umbraco.Core/Models/PropertyTags.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Core.Models
     /// <summary>
     /// A property extension class that allows us to enable tags for any given property
     /// </summary>
-    internal class PropertyTags
+    public class PropertyTags
     {
         public PropertyTags()
         {


### PR DESCRIPTION
### Prerequisites

- [ x ] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #2988 
- [ x ] I have added steps to test this contribution in the description below

### Description
This PR makes the propterty TagSupport on Porperty public, along with related types.

The purpose is to allow you dynamically change the tag group, as described in the issue.

To test, you should be able to create an event handler like this:

````
public class Events : ApplicationEventHandler
{
	protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
	{
		ContentService.Saving += ContentService_Saving;
	}
	
	private void ContentService_Saving(IContentService sender, Umbraco.Core.Events.SaveEventArgs<Umbraco.Core.Models.IContent> e)
	{
		foreach (var entity in e.SavedEntities)
		{
			var tagsproperty = entity.Properties.FirstOrDefault(x => x.PropertyType.PropertyEditorAlias == "Umbraco.Tags");

			if (tagsproperty != null)
			{
				var tagssupport = tagsproperty.TagSupport;
				if (tagssupport != null)
				{
					var tags = tagssupport.Tags;

					var newvalue = new List<Tuple<string, string>>();

					if (tags != null)
					{
						var culture = getNodeCulture(entity.ParentId);

						foreach (var t in tags)
						{
							//Don't modify if we already have a group with culture appended (events)
							if (t.Item2.Contains("-"))
							{
								continue;
							}
							newvalue.Add(new Tuple<string, string>(t.Item1, t.Item2 + "-" + culture));
						}

						tagssupport.Tags = newvalue;
					}
				}
			}
		}
	}
}
````
