### PR TITLE
Removed "debugger" statement from linkpicker overlay controller

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -119,8 +119,6 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 						$scope.model.target.isMedia = true;
 						$scope.model.target.name = media.name;
 						$scope.model.target.url = mediaHelper.resolveFile(media);
-						
-						debugger;
 
 						$scope.mediaPickerOverlay.show = false;
 						$scope.mediaPickerOverlay = null;


### PR DESCRIPTION
Seems like an oversight 😮 