### PR TITLE
Ensure the correct color for items in the Nested Content item picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -208,11 +208,25 @@
     width: 99%;
 }
 
-.usky-grid.umb-nested-content__node-type-picker .cell-tools-menu {
-    position: relative;
-    transform: translate(-50%, -25%);
-}
+.usky-grid.umb-nested-content__node-type-picker {
+    .cell-tools-menu {
+        position: relative;
+        transform: translate(-50%, -25%);
+    }
 
+    .elements li {
+        &:hover {
+            i {
+                color: @white !important;
+            }
+        }
+
+        i {
+            // make sure the item icons shown are in the correct color according to their doc type icon instead of the grid editor item color
+            color: unset;
+        }
+    }
+}
 
 // this resolves the layout issue introduced in nested content in 7.12 with the addition of the input for link anchors
 // the attribute selector ensures the change only applies to the linkpicker overlay


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3078
- [x] I have added steps to test this contribution in the description below

### Description

This PR ensures that the icon colors in the Nested Content item picker are consistent with the icon colors in the Nested Content item list.

![nc icon color after](https://user-images.githubusercontent.com/7405322/46269526-0360f780-c542-11e8-8d9d-d0129147fe12.png)

To test it:

1. Create a doctype with a Nested Content property
2. The Nested Content property must have at least one doctype with a black icon
3. Open the item picker in the Nested Content property and verify that the doctype icon is indeed black
 