### PR TITLE
Fix Nested Content "second time dragging" issue

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -1,5 +1,6 @@
 ﻿.umb-nested-content {
     text-align: center;
+    position: relative;
 }
 
 .umb-nested-content--not-supported {


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3079
- [x] I have added steps to test this contribution in the description below

### Description

This PR ensures that the items in the Nested Content item list aren't thrown out of place when dragging them around.

![nc drag offset after](https://user-images.githubusercontent.com/7405322/46269619-b3cefb80-c542-11e8-8ca4-cf720f27e5c7.gif)

To test it:

1. Drag an item twice in a Nested Content item list without reloading the page in between
2. Verify that the dragged item stays within the list while dragging - both times.