### PR TITLE
Fix loading issue for RTE's in Nested Content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -115,6 +115,13 @@ div.umb-codeeditor .umb-btn-toolbar {
 //
 // RTE
 // --------------------------------------------------
+.umb-rte {
+    position: relative;
+
+    .-loading {
+        position: absolute;
+    }
+}
 .mce-tinymce{border: 1px solid @gray-8 !important; border-radius: 0px !important;}
 .mce-panel{background: @gray-10 !important; border-color: @gray-8 !important;}
 .mce-btn-group, .mce-btn{border: none !important; background: none !important;}

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
@@ -1,5 +1,5 @@
 <div ng-controller="Umbraco.PropertyEditors.RTEController" class="umb-editor umb-rte">
-    <div ng-if="isLoading"><localize key="general_loading">Loading</localize>...</div>
+    <div class="-loading" ng-if="isLoading"><localize key="general_loading">Loading</localize>...</div>
     <textarea ng-style="{ visibility :  isLoading ? 'hidden' : 'visible'}"
               ng-model="model.value" rows="10"
               id="{{textAreaHtmlId}}"></textarea>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3080
- [x] I have added steps to test this contribution in the description below

### Description

This PR ensures RTE's within Nested Content items don't look like they're stuck in a "Loading..." state.

![nc rte after](https://user-images.githubusercontent.com/7405322/46269716-30fa7080-c543-11e8-9662-279b6258eb48.gif)

To test it:

1. Create a Nested Content property that contains an item based on a doctype with an RTE
2. Open and close the item a few times in the Nested Content property editor
3. Verify that the "Loading..." label for RTE disappears every time the item is opened
