### PR TITLE
Don't let the same doctype be selectable twice in the Nested Content configuration

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -37,6 +37,18 @@
             });
         });
 
+        $scope.selectableDocTypesFor = function (config) {
+            // return all doctypes that are:
+            // 1. either already selected for this config, or
+            // 2. not selected in any other config
+            return _.filter($scope.model.docTypes, function (docType) {
+                return docType.alias === config.ncAlias || !_.find($scope.model.value, function(c) {
+                    return docType.alias === c.ncAlias;
+                });
+            });
+
+        }
+
         if (!$scope.model.value) {
             $scope.model.value = [];
             $scope.add();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -22,7 +22,7 @@
                     </td>
                     <td>
                         <select id="{{model.alias}}_doctype_select"
-                            ng-options="dt.alias as dt.name for dt in model.docTypes | orderBy: 'name'"
+                            ng-options="dt.alias as dt.name for dt in selectableDocTypesFor(config) | orderBy: 'name'"
                             ng-model="config.ncAlias" required></select>
                     </td>
                     <td>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3081
- [x] I have added steps to test this contribution in the description below

### Description
This PR ensures that the already used doctypes are no longer selectable when configuring a Nested Content property.

![nc config after 1](https://user-images.githubusercontent.com/7405322/46269812-bf6ef200-c543-11e8-9180-ce262b2389c1.png)

![nc config after 2](https://user-images.githubusercontent.com/7405322/46269815-c1d14c00-c543-11e8-9604-c99451a3bb18.png)

To test it:

1. Create a Nested Content data type
2. Start adding doctypes to the configuration
3. As you add doctypes, verify that the already added ones can't be added again
4. Verify that the selected doctype can still be selected for an existing item in the configuration

