### PR TITLE
Avoid data loss when dragging an unsaved Nested Content item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -231,6 +231,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             cursor: "move",
             handle: ".umb-nested-content__icon--move",
             start: function (ev, ui) {
+                updateModel();
                 // Yea, yea, we shouldn't modify the dom, sue me
                 $("#umb-nested-content--" + $scope.model.id + " .umb-rte textarea").each(function () {
                     tinymce.execCommand('mceRemoveEditor', false, $(this).attr('id'));


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3014
- [x] I have added steps to test this contribution in the description below

### Description

This PR ensures that data aren't lost when dragging newly created items in a Nested Content property editor. For more details and steps to reproduce/test, see the linkes issue.

This is what it looks like:

![nc save before drag](https://user-images.githubusercontent.com/7405322/46269892-69e71500-c544-11e8-92a2-b002991354a4.gif)

