### PR TITLE
#3102 - Make styling for media search dialogue prettier

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -52,6 +52,16 @@
         -webkit-flex: 1;
         -ms-flex: 1;
         flex: 1;
+
+        &__toggle{
+            margin: 10px 0;
+
+            label{
+                margin-right: 10px;
+                position: relative;
+                top: -2px;
+            }
+        }
     }
 
     .upload-button {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -151,7 +151,7 @@ angular.module("umbraco")
 
                 if (folder.id > 0) {
                     entityResource.getAncestors(folder.id, "media")
-                        .then(function(anc) {              
+                        .then(function(anc) {
                             $scope.path = _.filter(anc,
                                 function(f) {
                                     return f.path.indexOf($scope.startNodeId) !== -1;
@@ -305,6 +305,23 @@ angular.module("umbraco")
                 $scope.loading = true;
                 debounceSearchMedia();
             };
+
+            /**
+                * Toggle the $scope.model.allowAsRoot value to either true or false
+             */
+            $scope.toggle = function(){
+
+                // Make sure to activate the changeSearch function everytime the toggle is clicked
+                $scope.changeSearch();
+
+                // Toggle the showChilds option
+                if($scope.showChilds){
+                    $scope.showChilds = false;
+                    return;
+                }
+
+                $scope.showChilds = true;
+            }
 
             $scope.changePagination = function(pageNumber) {
                 $scope.loading = true;

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.html
@@ -20,12 +20,17 @@
                        ng-change="changeSearch()"
                        type="text"
                        no-dirty-check />
-                <br />
-                <label>
-                    <localize key="general_includeFromsubFolders">Include subfolders in search</localize>
-                    <input type="checkbox" ng-model="showChilds"
-                           ng-change="changeSearch()">
-                </label>
+
+                <div class="form-search__toggle">
+                    <label>
+                        <localize key="general_includeFromsubFolders">Include subfolders in search</localize>
+                    </label>
+
+                    <umb-toggle
+                        checked="showChilds"
+                        on-click="toggle()">
+                    </umb-toggle>
+                </div>
             </div>
 
             <div class="upload-button">


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/3102) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3102
- [x] I have added steps to test this contribution in the description below

### Description
I changed the default checkbox input to be using the umbToggle directive and added a little spacing around the block so it does not look so cramped.

This is what it looks like now

![prettier-toggle](https://user-images.githubusercontent.com/1932158/46310592-13b7b780-c5c0-11e8-8c08-82766c28d91e.png)
