### PR TITLE
Hide "Created Date" field when the media hasn't yet been created

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
@@ -29,11 +29,11 @@
             <umb-box-header title-key="general_general"></umb-box-header>
             <umb-box-content class="block-form">
 
-                <umb-control-group data-element="node-info-create-date" label="@content_createDate">
+                <umb-control-group ng-if="node.id !== 0" data-element="node-info-create-date" label="@content_createDate">
                     {{node.createDateFormatted}} by {{ node.owner.name }}
                 </umb-control-group>
 
-                <umb-control-group data-element="node-info-update-date" label="@content_updateDate">
+                <umb-control-group ng-if="node.id !== 0" data-element="node-info-update-date" label="@content_updateDate">
                     {{node.updateDateFormatted}}
                 </umb-control-group>
 
@@ -47,7 +47,7 @@
                     </umb-node-preview>
                 </umb-control-group>
 
-                <umb-control-group data-element="node-info-id" label="Id">
+                <umb-control-group ng-if="node.id !== 0" data-element="node-info-id" label="Id">
                     <div>{{ node.id }}</div>
                     <small>{{ node.key }}</small>
                 </umb-control-group>


### PR DESCRIPTION
Similar to #2901 I did for content, the media section has the same issue with the creation date, id and similar being shown before the media is actually created.

**Old:**
![image](https://user-images.githubusercontent.com/3634580/46310657-42ce2900-c5c0-11e8-995f-74c42edeae43.png)

**New:**
![image](https://user-images.githubusercontent.com/3634580/46310625-2500c400-c5c0-11e8-844e-63e414442c40.png)
