### PR TITLE
Hide the "Links" box when there are no links

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -2,7 +2,7 @@
 
     <div class="umb-package-details__main-content">
 
-        <umb-box data-element="node-info-urls">
+        <umb-box ng-if="node.urls" data-element="node-info-urls">
             <umb-box-header title-key="general_links"></umb-box-header>
             <umb-box-content class="block-form">
                 <ul class="nav nav-stacked" style="margin-bottom: 0;">


### PR DESCRIPTION
We're usually having some content types that aren't directly accessible from the website, and therefore it doesn't really make sense to show the **Links** box under the **Info** tab as the URL doesn't work anyways.

With the `SendingContentModel` event, we can make sure that the box doesn't contain any links:

```C#
EditorModelEventManager.SendingContentModel += (sender, e) => {
    e.Model.Urls = null;
};
```

But the box is still being shown. With this PR, the **Links** box will be hidden when `node.urls` is either `null` or empty.

**Before:**
![image](https://user-images.githubusercontent.com/3634580/46311678-46af7a80-c5c3-11e8-9585-ff03a6ec3484.png)

**After:**
![image](https://user-images.githubusercontent.com/3634580/46311778-88402580-c5c3-11e8-9992-594351fcb913.png)

