### PR TITLE
Should be "JavaScript" instead of "javascript"

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -287,7 +287,7 @@
         <key alias="documentTypeWithoutTemplate">Document Type without a template</key>
         <key alias="newFolder">New folder</key>
         <key alias="newDataType">New data type</key>
-        <key alias="newJavascriptFile">New javascript file</key>
+        <key alias="newJavascriptFile">New JavaScript file</key>
         <key alias="newEmptyPartialView">New empty partial view</key>
         <key alias="newPartialViewMacro">New partial view macro</key>
         <key alias="newPartialViewFromSnippet">New partial view from snippet</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -288,7 +288,7 @@
         <key alias="documentTypeWithoutTemplate">Document Type without a template</key>
         <key alias="newFolder">New folder</key>
         <key alias="newDataType">New data type</key>
-        <key alias="newJavascriptFile">New javascript file</key>
+        <key alias="newJavascriptFile">New JavaScript file</key>
         <key alias="newEmptyPartialView">New empty partial view</key>
         <key alias="newPartialViewMacro">New partial view macro</key>
         <key alias="newPartialViewFromSnippet">New partial view from snippet</key>


### PR DESCRIPTION
Might as well fix this for the English language files an I overlooked that when doing #2406

Used here:

![image](https://user-images.githubusercontent.com/3634580/46312380-31d3e680-c5c5-11e8-9cb2-f9ccca4bf833.png)