### PR TITLE
Non-administrator users logged out when creating user groups (issue #3018)

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/MemberGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/MemberGroupRepository.cs
@@ -284,7 +284,7 @@ namespace Umbraco.Core.Persistence.Repositories
                 var nonAssignedRoles = roleNames.Except(assignedRoles, StringComparer.CurrentCultureIgnoreCase);
                 foreach (var toAssign in nonAssignedRoles)
                 {
-                    var groupId = rolesForNames.First(x => x.Text == toAssign).NodeId;
+                    var groupId = rolesForNames.First(x => x.Text.InvariantEquals(toAssign)).NodeId;
                     Database.Insert(new Member2MemberGroupDto { Member = mId, MemberGroup = groupId });
                 }
             }

--- a/src/Umbraco.Tests/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberServiceTests.cs
@@ -289,6 +289,29 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Associate_Members_To_Roles_With_Member_Id_Casing()
+        {
+            ServiceContext.MemberService.AddRole("MyTestRole1");
+
+            IMemberType memberType = MockedContentTypes.CreateSimpleMemberType();
+            ServiceContext.MemberTypeService.Save(memberType);
+            var member1 = MockedMember.CreateSimpleMember(memberType, "test1", "test1@test.com", "pass", "test1");
+            ServiceContext.MemberService.Save(member1);
+            var member2 = MockedMember.CreateSimpleMember(memberType, "test2", "test2@test.com", "pass", "test2");
+            ServiceContext.MemberService.Save(member2);
+
+            // temp make sure they exist
+            Assert.IsNotNull(ServiceContext.MemberService.GetById(member1.Id));
+            Assert.IsNotNull(ServiceContext.MemberService.GetById(member2.Id));
+
+            ServiceContext.MemberService.AssignRoles(new[] { member1.Id, member2.Id }, new[] { "mytestrole1" });
+
+            var membersInRole = ServiceContext.MemberService.GetMembersInRole("MyTestRole1");
+
+            Assert.AreEqual(2, membersInRole.Count());
+        }
+
+        [Test]
         public void Associate_Members_To_Roles_With_Member_Username()
         {
             ServiceContext.MemberService.AddRole("MyTestRole1");

--- a/src/Umbraco.Web/Editors/UserGroupEditorAuthorizationHelper.cs
+++ b/src/Umbraco.Web/Editors/UserGroupEditorAuthorizationHelper.cs
@@ -53,6 +53,18 @@ namespace Umbraco.Web.Editors
             if (currentUser.IsAdmin())
                 return Attempt<string>.Succeed();
 
+            // var derp = ((userGroupSave.Id == null || (int)userGroupSave.Id <= 0) && Services.SectionService.GetAllowedSections(Security.CurrentUser.Id).Select(x => x.Alias).Contains(Constants.Applications.Users)) ? Attempt<string>.Succeed() : Attempt<string>.Failed();
+
+            var existingGroups = _userService.GetUserGroupsByAlias(groupAliases);
+
+            if(!existingGroups.Any())
+            {
+                // We're dealing with new groups,
+                // so authorization should be given to any user with access to Users section
+                if (currentUser.AllowedSections.Contains(Constants.Applications.Users))
+                    return Attempt<string>.Succeed();
+            }
+
             var userGroups = currentUser.Groups.Select(x => x.Alias).ToArray();
             var missingAccess = groupAliases.Except(userGroups).ToArray();
             return missingAccess.Length == 0

--- a/src/Umbraco.Web/Editors/UserGroupEditorAuthorizationHelper.cs
+++ b/src/Umbraco.Web/Editors/UserGroupEditorAuthorizationHelper.cs
@@ -53,8 +53,6 @@ namespace Umbraco.Web.Editors
             if (currentUser.IsAdmin())
                 return Attempt<string>.Succeed();
 
-            // var derp = ((userGroupSave.Id == null || (int)userGroupSave.Id <= 0) && Services.SectionService.GetAllowedSections(Security.CurrentUser.Id).Select(x => x.Alias).Contains(Constants.Applications.Users)) ? Attempt<string>.Succeed() : Attempt<string>.Failed();
-
             var existingGroups = _userService.GetUserGroupsByAlias(groupAliases);
 
             if(!existingGroups.Any())


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3018
- [x] I have added steps to test this contribution in the description below

### Description
<!-- A description of the changes proposed in the pull-request -->
<!-- Make sure to link to the related issue number so we can easily find it in the issue tracker -->
As the linked issue correctly states, any non-admin user will get a 401 Unauthorized response when trying to create a user group, even when they have access to the Users section and thus a "Create Group" button.

This happens because the current authorization logic requires any non-admin user to have access to whatever user group they're trying to save. Which is pretty hard when the group hasn't been created yet...

Exact steps to reproduce are in the issue as well.

These initial commits make it possible for non-admins to create groups, as I believe they should be able to (and I need it to work for a not-so-far-in-the-future project).

I am, however, fairly certain that my "implementation" is less than ideal... But I can't really see how else to make it work without flipping large parts of the authorization logic on its head, so _I'd love some help here_ :-)

<!-- Thanks for contributing to Umbraco CMS! -->
