### PR TITLE
Add ExpireDate to IPublishedContent

### DIFF
--- a/src/Umbraco.Core/Models/IPublishedContent.cs
+++ b/src/Umbraco.Core/Models/IPublishedContent.cs
@@ -55,7 +55,8 @@ namespace Umbraco.Core.Models
 		int CreatorId { get; }
 		string Path { get; }
 		DateTime CreateDate { get; }
-		DateTime UpdateDate { get; }
+        DateTime UpdateDate { get; }
+        DateTime? ExpireDate { get; }
 		Guid Version { get; }
 		int Level { get; }
 		string Url { get; }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
@@ -135,6 +135,11 @@ namespace Umbraco.Core.Models.PublishedContent
             get { return Content.UpdateDate; }
         }
 
+        public virtual DateTime? ExpireDate
+        {
+            get { return Content.ExpireDate; }
+        }
+
         public virtual Guid Version
         {
             get { return Content.Version; }

--- a/src/Umbraco.Core/Services/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/EntityXmlSerializer.cs
@@ -43,6 +43,7 @@ namespace Umbraco.Core.Services
             xml.Add(new XAttribute("template", content.Template == null ? "0" : content.Template.Id.ToString(CultureInfo.InvariantCulture)));
             xml.Add(new XAttribute("nodeTypeAlias", content.ContentType.Alias));
             xml.Add(new XAttribute("isPublished", content.Published));
+            xml.Add(new XAttribute("expireDate", content.ExpireDate?.ToString("s") ?? string.Empty));
 
             if (deep)
             {

--- a/src/Umbraco.Tests.Benchmarks/XmlPublishedContentInitBenchmarks.cs
+++ b/src/Umbraco.Tests.Benchmarks/XmlPublishedContentInitBenchmarks.cs
@@ -91,6 +91,7 @@ namespace Umbraco.Tests.Benchmarks
         string name, urlName, writerName, creatorName, docTypeAlias, path;
         bool isDraft;
         DateTime createDate, updateDate;
+        DateTime? expireDate;
         PublishedContentType publishedContentType;
         Dictionary<string, IPublishedProperty> properties;
 
@@ -140,7 +141,7 @@ namespace Umbraco.Tests.Benchmarks
             XmlPublishedContent.InitializeNode(_xml10.DocumentElement, false, false,
                 out id, out key, out template, out sortOrder, out name, out writerName, out urlName,
                 out creatorName, out creatorId, out writerId, out docTypeAlias, out nodeType, out path,
-                out version, out createDate, out updateDate, out level, out isDraft, out publishedContentType,
+                out version, out createDate, out updateDate, out expireDate, out level, out isDraft, out publishedContentType,
                 out properties, GetPublishedContentType);
         }
 
@@ -150,7 +151,7 @@ namespace Umbraco.Tests.Benchmarks
             XmlPublishedContent.InitializeNode(_xml100.DocumentElement, false, false,
                 out id, out key, out template, out sortOrder, out name, out writerName, out urlName,
                 out creatorName, out creatorId, out writerId, out docTypeAlias, out nodeType, out path,
-                out version, out createDate, out updateDate, out level, out isDraft, out publishedContentType,
+                out version, out createDate, out updateDate, out expireDate, out level, out isDraft, out publishedContentType,
                 out properties, GetPublishedContentType);
         }
 
@@ -160,7 +161,7 @@ namespace Umbraco.Tests.Benchmarks
             XmlPublishedContent.InitializeNode(_xml1000.DocumentElement, false, false,
                 out id, out key, out template, out sortOrder, out name, out writerName, out urlName,
                 out creatorName, out creatorId, out writerId, out docTypeAlias, out nodeType, out path,
-                out version, out createDate, out updateDate, out level, out isDraft, out publishedContentType,
+                out version, out createDate, out updateDate, out expireDate, out level, out isDraft, out publishedContentType,
                 out properties, GetPublishedContentType);
         }
 
@@ -170,7 +171,7 @@ namespace Umbraco.Tests.Benchmarks
             XmlPublishedContent.InitializeNode(_xml10000.DocumentElement, false, false,
                 out id, out key, out template, out sortOrder, out name, out writerName, out urlName,
                 out creatorName, out creatorId, out writerId, out docTypeAlias, out nodeType, out path,
-                out version, out createDate, out updateDate, out level, out isDraft, out publishedContentType,
+                out version, out createDate, out updateDate, out expireDate, out level, out isDraft, out publishedContentType,
                 out properties, GetPublishedContentType);
         }
 

--- a/src/Umbraco.Tests/Cache/PublishedCache/PublishedContentCacheTests.cs
+++ b/src/Umbraco.Tests/Cache/PublishedCache/PublishedContentCacheTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Xml;
 using Moq;
@@ -28,17 +29,17 @@ namespace Umbraco.Tests.Cache.PublishedCache
 
 ]>
 <root id=""-1"">
-	<node id=""1046"" parentID=""-1"" level=""1"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-06-12T14:13:17"" updateDate=""2012-07-20T18:50:43"" nodeName=""Home"" urlName=""home"" writerName=""admin"" creatorName=""admin"" path=""-1,1046"" nodeTypeAlias=""Home""  ><content><![CDATA[]]></content>
-		<node id=""1173"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""1"" createDate=""2012-07-20T18:06:45"" updateDate=""2012-07-20T19:07:31"" nodeName=""Sub1"" urlName=""sub1"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173"" nodeTypeAlias=""Home""><content><![CDATA[]]></content>
-			<node id=""1174"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""1"" createDate=""2012-07-20T18:07:54"" updateDate=""2012-07-20T19:10:27"" nodeName=""Sub2"" urlName=""sub2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1174"" nodeTypeAlias=""Home"" ><content><![CDATA[]]></content>
+	<node id=""1046"" parentID=""-1"" level=""1"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-06-12T14:13:17"" updateDate=""2012-07-20T18:50:43"" expireDate="""" nodeName=""Home"" urlName=""home"" writerName=""admin"" creatorName=""admin"" path=""-1,1046"" nodeTypeAlias=""Home""  ><content><![CDATA[]]></content>
+		<node id=""1173"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""1"" createDate=""2012-07-20T18:06:45"" updateDate=""2012-07-20T19:07:31"" expireDate="""" nodeName=""Sub1"" urlName=""sub1"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173"" nodeTypeAlias=""Home""><content><![CDATA[]]></content>
+			<node id=""1174"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""1"" createDate=""2012-07-20T18:07:54"" updateDate=""2012-07-20T19:10:27"" expireDate="""" nodeName=""Sub2"" urlName=""sub2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1174"" nodeTypeAlias=""Home"" ><content><![CDATA[]]></content>
 			</node>
-			<node id=""1176"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-07-20T18:08:08"" updateDate=""2012-07-20T19:10:52"" nodeName=""Sub 3"" urlName=""sub-3"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1176"" nodeTypeAlias=""Home"" ><content><![CDATA[]]></content>
+			<node id=""1176"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-07-20T18:08:08"" updateDate=""2012-07-20T19:10:52"" expireDate="""" nodeName=""Sub 3"" urlName=""sub-3"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1176"" nodeTypeAlias=""Home"" ><content><![CDATA[]]></content>
 			</node>
 		</node>
-		<node id=""1175"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-07-20T18:08:01"" updateDate=""2012-07-20T18:49:32"" nodeName=""Sub 2"" urlName=""sub-2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1175"" nodeTypeAlias=""Home"" ><content><![CDATA[]]></content>
+		<node id=""1175"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-07-20T18:08:01"" updateDate=""2012-07-20T18:49:32"" expireDate="""" nodeName=""Sub 2"" urlName=""sub-2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1175"" nodeTypeAlias=""Home"" ><content><![CDATA[]]></content>
 		</node>
 	</node>
-	<node id=""1172"" parentID=""-1"" level=""1"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""3"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-18T14:23:35"" nodeName=""Test"" urlName=""test"" writerName=""admin"" creatorName=""admin"" path=""-1,1172"" nodeTypeAlias=""Home"" />
+	<node id=""1172"" parentID=""-1"" level=""1"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""3"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-18T14:23:35"" expireDate=""2030-01-01T00:00:00"" nodeName=""Test"" urlName=""test"" writerName=""admin"" creatorName=""admin"" path=""-1,1172"" nodeTypeAlias=""Home"" />
 </root>";
 		}
 
@@ -50,19 +51,19 @@ namespace Umbraco.Tests.Cache.PublishedCache
 
 ]>
 <root id=""-1"">
-	<Home id=""1046"" parentID=""-1"" level=""1"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-06-12T14:13:17"" updateDate=""2012-07-20T18:50:43"" nodeName=""Home"" urlName=""home"" writerName=""admin"" creatorName=""admin"" path=""-1,1046"" isDoc=""""><content><![CDATA[]]></content>
-		<Home id=""1173"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""1"" createDate=""2012-07-20T18:06:45"" updateDate=""2012-07-20T19:07:31"" nodeName=""Sub1"" urlName=""sub1"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173"" isDoc=""""><content><![CDATA[]]></content>
-			<Home id=""1174"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""1"" createDate=""2012-07-20T18:07:54"" updateDate=""2012-07-20T19:10:27"" nodeName=""Sub2"" urlName=""sub2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1174"" isDoc=""""><content><![CDATA[]]></content>
+	<Home id=""1046"" parentID=""-1"" level=""1"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-06-12T14:13:17"" updateDate=""2012-07-20T18:50:43"" expireDate="""" nodeName=""Home"" urlName=""home"" writerName=""admin"" creatorName=""admin"" path=""-1,1046"" isDoc=""""><content><![CDATA[]]></content>
+		<Home id=""1173"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""1"" createDate=""2012-07-20T18:06:45"" updateDate=""2012-07-20T19:07:31"" expireDate="""" nodeName=""Sub1"" urlName=""sub1"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173"" isDoc=""""><content><![CDATA[]]></content>
+			<Home id=""1174"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""1"" createDate=""2012-07-20T18:07:54"" updateDate=""2012-07-20T19:10:27"" expireDate="""" nodeName=""Sub2"" urlName=""sub2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1174"" isDoc=""""><content><![CDATA[]]></content>
 			</Home>
-			<Home id=""1176"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-07-20T18:08:08"" updateDate=""2012-07-20T19:10:52"" nodeName=""Sub 3"" urlName=""sub-3"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1176"" isDoc=""""><content><![CDATA[]]></content>
+			<Home id=""1176"" parentID=""1173"" level=""3"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-07-20T18:08:08"" updateDate=""2012-07-20T19:10:52"" expireDate="""" nodeName=""Sub 3"" urlName=""sub-3"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1173,1176"" isDoc=""""><content><![CDATA[]]></content>
 			</Home>
 		</Home>
-		<Home id=""1175"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-07-20T18:08:01"" updateDate=""2012-07-20T18:49:32"" nodeName=""Sub 2"" urlName=""sub-2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1175"" isDoc=""""><content><![CDATA[]]></content>
+		<Home id=""1175"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-07-20T18:08:01"" updateDate=""2012-07-20T18:49:32"" expireDate="""" nodeName=""Sub 2"" urlName=""sub-2"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1175"" isDoc=""""><content><![CDATA[]]></content>
 		</Home>
-		<Home id=""1177"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-07-20T18:08:01"" updateDate=""2012-07-20T18:49:32"" nodeName=""Sub'Apostrophe"" urlName=""sub'apostrophe"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1177"" isDoc=""""><content><![CDATA[]]></content>
+		<Home id=""1177"" parentID=""1046"" level=""2"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""2"" createDate=""2012-07-20T18:08:01"" updateDate=""2012-07-20T18:49:32"" expireDate="""" nodeName=""Sub'Apostrophe"" urlName=""sub'apostrophe"" writerName=""admin"" creatorName=""admin"" path=""-1,1046,1177"" isDoc=""""><content><![CDATA[]]></content>
 		</Home>
 	</Home>
-	<Home id=""1172"" parentID=""-1"" level=""1"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""3"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-18T14:23:35"" nodeName=""Test"" urlName=""test"" writerName=""admin"" creatorName=""admin"" path=""-1,1172"" isDoc="""" />
+	<Home id=""1172"" parentID=""-1"" level=""1"" writerID=""0"" creatorID=""0"" nodeType=""1044"" template=""1045"" sortOrder=""3"" createDate=""2012-07-16T15:26:59"" updateDate=""2012-07-18T14:23:35"" expireDate=""2030-01-01T00:00:00"" nodeName=""Test"" urlName=""test"" writerName=""admin"" creatorName=""admin"" path=""-1,1172"" isDoc="""" />
 </root>";
 		}
 
@@ -184,5 +185,28 @@ namespace Umbraco.Tests.Cache.PublishedCache
 			Assert.IsNotNull(result);
 			Assert.AreEqual(nodeId, result.Id);
 		}
+
+	    [TestCase(1046, null)]
+	    [TestCase(1172, "2030-01-01T00:00:00")]
+	    [TestCase(1173, null)]
+	    public void Content_With_Expiry_Loads_Expire_Date_LegacySchema(int nodeId, string expireDateAsString)
+	    {
+	        SetupForLegacy();
+	        Content_With_Expiry_Loads_Expire_Date(nodeId, expireDateAsString);
+	    }
+
+        [TestCase(1046, null)]
+	    [TestCase(1172, "2030-01-01T00:00:00")]
+	    [TestCase(1173, null)]
+	    public void Content_With_Expiry_Loads_Expire_Date(int nodeId, string expireDateAsString)
+	    {
+	        var result = _cache.GetById(nodeId);
+	        Assert.IsNotNull(result);
+	        Assert.AreEqual(nodeId, result.Id);
+	        DateTime? expireDate = expireDateAsString == null
+	            ? (DateTime?)null
+	            : DateTime.Parse(expireDateAsString);
+	        Assert.AreEqual(expireDate, result.ExpireDate);
+	    }
 	}
 }

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentDataTableTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentDataTableTests.cs
@@ -206,6 +206,7 @@ namespace Umbraco.Tests.PublishedContent
 	        public string Path { get; set; }
 	        public DateTime CreateDate { get; set; }
 	        public DateTime UpdateDate { get; set; }
+	        public DateTime? ExpireDate { get; set; }
 	        public Guid Version { get; set; }
 	        public int Level { get; set; }
             public bool IsDraft { get; set; }

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTestElements.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTestElements.cs
@@ -204,6 +204,7 @@ namespace Umbraco.Tests.PublishedContent
         public string Path { get; set; }
         public DateTime CreateDate { get; set; }
         public DateTime UpdateDate { get; set; }
+        public DateTime? ExpireDate { get; set; }
         public Guid Version { get; set; }
         public int Level { get; set; }
         public string Url { get; set; }

--- a/src/Umbraco.Web/Models/DetachedPublishedContent.cs
+++ b/src/Umbraco.Web/Models/DetachedPublishedContent.cs
@@ -153,6 +153,11 @@ namespace Umbraco.Web.Models
             get { return _containerNode != null ? _containerNode.UpdateDate : DateTime.MinValue; }
         }
 
+        public override DateTime? ExpireDate
+        {
+            get { return _containerNode?.ExpireDate; }
+        }
+
         public override Guid Version
         {
             get { return _containerNode != null ? _containerNode.Version : Guid.Empty; }

--- a/src/Umbraco.Web/Models/DynamicPublishedContent.cs
+++ b/src/Umbraco.Web/Models/DynamicPublishedContent.cs
@@ -423,6 +423,11 @@ namespace Umbraco.Web.Models
             get { return PublishedContent.UpdateDate; }
         }
 
+	    DateTime? IPublishedContent.ExpireDate
+	    {
+	        get { return PublishedContent.ExpireDate; }
+	    }
+
         Guid IPublishedContent.Version
         {
             get { return PublishedContent.Version; }

--- a/src/Umbraco.Web/Models/PublishedContentBase.cs
+++ b/src/Umbraco.Web/Models/PublishedContentBase.cs
@@ -108,7 +108,8 @@ namespace Umbraco.Web.Models
 		public abstract int CreatorId { get; }
 		public abstract string Path { get; }
 		public abstract DateTime CreateDate { get; }
-		public abstract DateTime UpdateDate { get; }
+        public abstract DateTime UpdateDate { get; }
+		public abstract DateTime? ExpireDate { get; }
 		public abstract Guid Version { get; }
 		public abstract int Level { get; }
 

--- a/src/Umbraco.Web/PublishedCache/MemberPublishedContent.cs
+++ b/src/Umbraco.Web/PublishedCache/MemberPublishedContent.cs
@@ -220,6 +220,11 @@ namespace Umbraco.Web.PublishedCache
             get { return _member.UpdateDate; }
         }
 
+        public override DateTime? ExpireDate
+        {
+            get { return null; }
+        }
+
         public override Guid Version
         {
             get { return _member.Version; }

--- a/src/Umbraco.Web/PublishedCache/XmlPublishedCache/PublishedMediaCache.cs
+++ b/src/Umbraco.Web/PublishedCache/XmlPublishedCache/PublishedMediaCache.cs
@@ -854,6 +854,11 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
                 get { return _updateDate; }
             }
 
+            public override DateTime? ExpireDate
+            {
+                get { return null; }
+            }
+
             public override Guid Version
             {
                 get { return _version; }

--- a/src/Umbraco.Web/PublishedCache/XmlPublishedCache/XmlPublishedContent.cs
+++ b/src/Umbraco.Web/PublishedCache/XmlPublishedCache/XmlPublishedContent.cs
@@ -59,12 +59,13 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
 		private string _path;
 		private DateTime _createDate;
 		private DateTime _updateDate;
+	    private DateTime? _expireDate;
 		private Guid _version;
 		private int _sortOrder;
 		private int _level;
 	    private bool _isDraft;
 
-		public override IEnumerable<IPublishedContent> Children
+	    public override IEnumerable<IPublishedContent> Children
 		{
 			get
 			{
@@ -246,7 +247,16 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
 			}
 		}
 
-		public override Guid Version
+	    public override DateTime? ExpireDate
+	    {
+	        get
+	        {
+	            if (_nodeInitialized == false) InitializeNode();
+	            return _expireDate;
+	        }
+	    }
+
+        public override Guid Version
 		{
 			get
 			{
@@ -319,7 +329,7 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
             InitializeNode(_xmlNode, UmbracoConfig.For.UmbracoSettings().Content.UseLegacyXmlSchema, _isPreviewing,
                 out _id, out _key, out _template, out _sortOrder, out _name, out _writerName,
                 out _urlName, out _creatorName, out _creatorId, out _writerId, out _docTypeAlias, out _docTypeId, out _path,
-                out _version, out _createDate, out _updateDate, out _level, out _isDraft, out _contentType, out _properties,
+                out _version, out _createDate, out _updateDate, out _expireDate, out _level, out _isDraft, out _contentType, out _properties,
                 PublishedContentType.Get);
 
             // warn: this is not thread-safe...
@@ -329,7 +339,7 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
         internal static void InitializeNode(XmlNode xmlNode, bool legacy, bool isPreviewing,
             out int id, out Guid key, out int template, out int sortOrder, out string name, out string writerName, out string urlName,
             out string creatorName, out int creatorId, out int writerId, out string docTypeAlias, out int docTypeId, out string path,
-            out Guid version, out DateTime createDate, out DateTime updateDate, out int level, out bool isDraft,
+            out Guid version, out DateTime createDate, out DateTime updateDate, out DateTime? expireDate, out int level, out bool isDraft,
             out PublishedContentType contentType, out Dictionary<string, IPublishedProperty> properties,
             Func<PublishedItemType, string, PublishedContentType> getPublishedContentType)
         {
@@ -340,6 +350,7 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
             key = version = default(Guid);
             name = writerName = urlName = creatorName = docTypeAlias = path = null;
             createDate = updateDate = default(DateTime);
+            expireDate = null;
             isDraft = false;
             contentType = null;
             properties = null;
@@ -401,7 +412,10 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
 		            createDate = DateTime.Parse(xmlNode.Attributes.GetNamedItem("createDate").Value);
 		        if (xmlNode.Attributes.GetNamedItem("updateDate") != null)
 		            updateDate = DateTime.Parse(xmlNode.Attributes.GetNamedItem("updateDate").Value);
-		        if (xmlNode.Attributes.GetNamedItem("level") != null)
+		        if (xmlNode.Attributes.GetNamedItem("expireDate") != null
+		            && string.IsNullOrEmpty(xmlNode.Attributes.GetNamedItem("expireDate").Value) == false)
+		            expireDate = DateTime.Parse(xmlNode.Attributes.GetNamedItem("expireDate").Value);
+                if (xmlNode.Attributes.GetNamedItem("level") != null)
 		            level = int.Parse(xmlNode.Attributes.GetNamedItem("level").Value);
 
                 isDraft = (xmlNode.Attributes.GetNamedItem("isDraft") != null);

--- a/src/Umbraco.Web/umbraco.presentation/page.cs
+++ b/src/Umbraco.Web/umbraco.presentation/page.cs
@@ -612,6 +612,11 @@ namespace umbraco
                 get { return _inner.UpdateDate; }
             }
 
+            public DateTime? ExpireDate
+            {
+                get { return _inner.ExpireDate; }
+            }
+
             public Guid Version
             {
                 get { return _inner.Version; }


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/2930
- [x] I have added steps to test this contribution in the description below

### Description

As outlined in #2930, this PR adds `ExpireDate` to IPublishedContent. It allows us to utilize the unpublish date of content when rendering - like this:

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoTemplatePage
@{
    Layout = null;
}
<h1>My super awesome page</h1>

@if(Model.Content.ExpireDate.HasValue) {
    <i>This document expires @Model.Content.ExpireDate</i>
}
```

This can be tested by:

1. Set an unpublish date on some content
2. Publish the content (Choose "Save and publish", *not* "Save and schedule")
3. Render `Model.Content.ExpireDate` as outlined in the sample template above

**PLEASE NOTE:** Adding stuff to IPublishedContent is a breaking change for a lot of package devs.
