### PR TITLE
Add option to rename colorpicker labels

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -137,11 +137,14 @@ div.umb-codeeditor .umb-btn-toolbar {
 /* pre-value editor */
 .control-group.color-picker-preval {
     .thumbnail {
-        width: 36px;
+        width: 34px;
+        height: 34px;
         min-width: auto;
         border: none;
         cursor: move;
         border-radius: 3px;
+        margin-top: auto;
+        margin-bottom: auto;
     }
 
     .handle {
@@ -159,14 +162,13 @@ div.umb-codeeditor .umb-btn-toolbar {
         pre {
             display: inline-flex;
             font-family: monospace;
-            margin-right: 10px;
-            margin-left: 10px;
+            margin-left: 15px;
+            margin-right: 15px;
             white-space: nowrap;
             overflow: hidden;
             margin-bottom: 0;
             vertical-align: middle;
-            padding-top: 7px;
-            padding-bottom: 7px;
+            padding: 6px 10px;
             background: #f7f7f7;
             flex: 0 0 auto;
         }
@@ -195,11 +197,11 @@ div.umb-codeeditor .umb-btn-toolbar {
 
     label {
         border: 1px solid #fff;
-        padding: 7px 10px;
+        padding: 6px 10px;
         font-family: monospace;
         border: 1px solid #dfdfe1;
         background: #f7f7f7;
-        margin: 0 15px 0 0;
+        margin: 0 15px 0 3px;
         border-radius: 3px;
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -153,7 +153,8 @@ div.umb-codeeditor .umb-btn-toolbar {
     div.color-picker-prediv {
         display: inline-flex;
         align-items: center;
-        max-width: 85%;
+        max-width: 100%;
+        flex: 1;
 
         pre {
             display: inline-flex;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -13,8 +13,8 @@
         <div class="control-group umb-prevalues-multivalues__listitem color-picker-preval" ng-repeat="item in model.value track by $id(item)">
             <i class="icon icon-navigation handle"></i>
             <div class="umb-prevalues-multivalues__left">
-                <div class="thumbnail span1" hex-bg-color="{{item.value}}" bg-orig="transparent"></div>
                 <div class="color-picker-prediv"><pre>#{{item.value}}</pre><span>{{item.label}}</span></div>
+                <div class="thumbnail span1" hex-bg-color="{{item.value}}" hex-bg-orig="transparent"></div>
             </div>
             <div class="umb-prevalues-multivalues__right">
                 <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></a>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -3,7 +3,7 @@
         <div class="umb-prevalues-multivalues__left">
             <input name="newColor" type="hidden" />
             <label for="newColor" val-highlight="{{hasError}}">#{{newColor}}</label>
-            <input name="newLabel" type="text" ng-model="newLabel" class="umb-editor color-label" placeholder="Label" ng-show="labelEnabled" />
+            <input name="newLabel" type="text" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-editor color-label" placeholder="Label" ng-show="labelEnabled" />
         </div>
         <div class="umb-prevalues-multivalues__right">
             <button class="btn btn-info add" ng-click="add($event)"><localize key="general_add">Add</localize></button>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -10,7 +10,7 @@
         </div>
     </div>
     <div ui-sortable="sortableOptions" ng-model="model.value">
-        <div class="control-group umb-prevalues-multivalues__listitem color-picker-preval" ng-repeat="item in model.value">
+        <div class="control-group umb-prevalues-multivalues__listitem color-picker-preval" ng-repeat="item in model.value track by $id(item)">
             <i class="icon icon-navigation handle"></i>
             <div class="umb-prevalues-multivalues__left">
                 <div class="thumbnail span1" hex-bg-color="{{item.value}}" bg-orig="transparent"></div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -13,8 +13,12 @@
         <div class="control-group umb-prevalues-multivalues__listitem color-picker-preval" ng-repeat="item in model.value track by $id(item)">
             <i class="icon icon-navigation handle"></i>
             <div class="umb-prevalues-multivalues__left">
-                <div class="color-picker-prediv"><pre>#{{item.value}}</pre><span>{{item.label}}</span></div>
                 <div class="thumbnail span1" hex-bg-color="{{item.value}}" hex-bg-orig="transparent"></div>
+                <div class="color-picker-prediv">
+                    <pre>#{{item.value}}</pre>
+                    <span ng-bind="item.value" ng-if="!labelEnabled"></span>
+                    <input type="text" ng-if="labelEnabled" ng-model="item.label" val-server="item_{{$index}}" required />
+                </div>
             </div>
             <div class="umb-prevalues-multivalues__right">
                 <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></a>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -7,6 +7,7 @@
         $scope.newColor = defaultColor;
         $scope.newLabel = defaultLabel;
         $scope.hasError = false;
+        $scope.focusOnNew = false;
 
         $scope.labels = {};
 
@@ -118,6 +119,7 @@
                     });
                     $scope.newLabel = "";
                     $scope.hasError = false;
+                    $scope.focusOnNew = true;
                     return;
                 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -104,7 +104,6 @@
         };
 
         $scope.add = function (evt) {
-
             evt.preventDefault();
 
             if ($scope.newColor) {
@@ -117,6 +116,7 @@
                         value: $scope.newColor,
                         label: newLabel
                     });
+                    $scope.newLabel = "";
                     $scope.hasError = false;
                     return;
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -5,7 +5,7 @@
         var defaultLabel = null;
 
         $scope.newColor = defaultColor;
-        $scope.newLavel = defaultLabel;
+        $scope.newLabel = defaultLabel;
         $scope.hasError = false;
 
         $scope.labels = {};


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3120
- [x] I have added steps to test this contribution in the description below

### Description
This add to ability to rename color picker prevalue labels, so you don't have to remove the color and add the color again with a different label.

It also switch between the span/label and text input based on the "use labels" toggle state. When the toggle is disabled, it show the span element with `item.value` since it will use this as "label" with labels not are enabled (or when site has been upgraded from older Umbraco versions).

Also check this out inside the document type editor, when selecting/configurating the datatype from there.

**Before**

![2018-10-03_00-27-11](https://user-images.githubusercontent.com/2919859/46380972-adf12b80-c6a4-11e8-96c7-b9d359e0e535.png)

![image](https://user-images.githubusercontent.com/2919859/46381034-e2fd7e00-c6a4-11e8-9c6e-4c6d23739894.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/46381112-25bf5600-c6a5-11e8-8787-57f2935050b1.png)

![image](https://user-images.githubusercontent.com/2919859/46381064-00cae300-c6a5-11e8-8685-d6b5b2b53a5c.png)

![image](https://user-images.githubusercontent.com/2919859/46381142-49829c00-c6a5-11e8-9a58-c91f0f89820a.png)

![image](https://user-images.githubusercontent.com/2919859/46381171-65863d80-c6a5-11e8-98bb-67befe37c4dd.png)
