### PR TITLE
#3001 Styles cannot be saved - Not sure if oldName is legacy

### DIFF
--- a/src/Umbraco.Web/WebServices/SaveFileController.cs
+++ b/src/Umbraco.Web/WebServices/SaveFileController.cs
@@ -245,18 +245,28 @@ namespace Umbraco.Web.WebServices
         public JsonResult SaveStylesheet(string filename, string oldName, string contents)
         {
             // sanitize input - stylesheet names have no extension
+            var svce = (FileService) Services.FileService;
+
+            if (filename != oldName)
+            {
+               var stylesheetExists = svce.GetStylesheetByName(filename);
+               if (stylesheetExists != null)
+                {
+                    return Failed(ui.Text("speechBubbles", "cssErrorText"), "A file named '" + filename + ".css' already exists." );
+                }
+            }
+
             filename = filename
                 .Replace('\\', '/')
                 .TrimStart('/')
                 .EnsureEndsWith(".css");
 
-            var svce = (FileService) Services.FileService;
             var stylesheet = svce.GetStylesheetByName(oldName);
             if (stylesheet == null)
                 stylesheet = new Stylesheet(filename);
             else
                 stylesheet.Path = filename;
-            stylesheet.Content = contents;
+                stylesheet.Content = contents;
 
             try
             {

--- a/src/Umbraco.Web/WebServices/SaveFileController.cs
+++ b/src/Umbraco.Web/WebServices/SaveFileController.cs
@@ -251,7 +251,7 @@ namespace Umbraco.Web.WebServices
                 .EnsureEndsWith(".css");
 
             var svce = (FileService) Services.FileService;
-            var stylesheet = svce.GetStylesheetByName(oldName);
+            var stylesheet = svce.GetStylesheetByName(filename);
             if (stylesheet == null)
                 stylesheet = new Stylesheet(filename);
             else

--- a/src/Umbraco.Web/WebServices/SaveFileController.cs
+++ b/src/Umbraco.Web/WebServices/SaveFileController.cs
@@ -251,7 +251,7 @@ namespace Umbraco.Web.WebServices
                 .EnsureEndsWith(".css");
 
             var svce = (FileService) Services.FileService;
-            var stylesheet = svce.GetStylesheetByName(filename);
+            var stylesheet = svce.GetStylesheetByName(oldName);
             if (stylesheet == null)
                 stylesheet = new Stylesheet(filename);
             else

--- a/src/Umbraco.Web/WebServices/SaveFileController.cs
+++ b/src/Umbraco.Web/WebServices/SaveFileController.cs
@@ -39,13 +39,13 @@ namespace Umbraco.Web.WebServices
         [HttpPost]
         public JsonResult SavePartialViewMacro(string filename, string oldName, string contents)
         {
-            var svce = (FileService) Services.FileService;
+            var svce = (FileService)Services.FileService;
 
             return SavePartialView(svce,
                 filename, oldName, contents,
                 "MacroPartials/",
                 (s, n) => s.GetPartialViewMacro(n),
-                (s, v) => s.ValidatePartialViewMacro((PartialView) v),
+                (s, v) => s.ValidatePartialViewMacro((PartialView)v),
                 (s, v) => s.SavePartialViewMacro(v));
         }
 
@@ -59,13 +59,13 @@ namespace Umbraco.Web.WebServices
         [HttpPost]
         public JsonResult SavePartialView(string filename, string oldName, string contents)
         {
-            var svce = (FileService) Services.FileService;
+            var svce = (FileService)Services.FileService;
 
             return SavePartialView(svce,
                 filename, oldName, contents,
                 "Partials/",
                 (s, n) => s.GetPartialView(n),
-                (s, v) => s.ValidatePartialView((PartialView) v),
+                (s, v) => s.ValidatePartialView((PartialView)v),
                 (s, v) => s.SavePartialView(v));
         }
 
@@ -77,9 +77,7 @@ namespace Umbraco.Web.WebServices
             Func<IFileService, IPartialView, Attempt<IPartialView>> save)
         {
             // sanitize input - partial view names have an extension
-            filename = filename
-                .Replace('\\', '/')
-                .TrimStart('/');
+            filename = CleanFilename(filename);
 
             // sharing the editor with partial views & partial view macros,
             // using path prefix to differenciate,
@@ -98,7 +96,7 @@ namespace Umbraco.Web.WebServices
                     oldname = oldname.TrimStart(pathPrefix);
             }
 
-            var currentView = oldname.IsNullOrWhiteSpace() 
+            var currentView = oldname.IsNullOrWhiteSpace()
                 ? get(svce, filename)
                 : get(svce, oldname);
 
@@ -108,7 +106,7 @@ namespace Umbraco.Web.WebServices
                 currentView.Path = filename;
             currentView.Content = contents;
 
-            
+
 
 
             Attempt<IPartialView> attempt;
@@ -166,7 +164,7 @@ namespace Umbraco.Web.WebServices
                 if (Math.Max(t.MasterTemplate, 0) != Math.Max(masterTemplateId, 0))
                 {
                     t.MasterTemplate = Math.Max(masterTemplateId, 0);
-                    pathChanged = true;                  
+                    pathChanged = true;
                 }
             }
             catch (ArgumentException ex)
@@ -206,11 +204,9 @@ namespace Umbraco.Web.WebServices
         public JsonResult SaveScript(string filename, string oldName, string contents)
         {
             // sanitize input - script names have an extension
-            filename = filename
-                .Replace('\\', '/')
-                .TrimStart('/');
+            filename = CleanFilename(filename);
 
-            var svce = (FileService) Services.FileService;
+            var svce = (FileService)Services.FileService;
             var script = svce.GetScriptByName(oldName);
             if (script == null)
                 script = new Script(filename);
@@ -223,7 +219,7 @@ namespace Umbraco.Web.WebServices
                 if (svce.ValidateScript(script) == false)
                     return Failed(ui.Text("speechBubbles", "scriptErrorText"), ui.Text("speechBubbles", "scriptErrorHeader"),
                                     new FileSecurityException("File '" + filename + "' is not a valid script file."));
-                
+
                 svce.SaveScript(script);
             }
             catch (Exception e)
@@ -294,6 +290,7 @@ namespace Umbraco.Web.WebServices
                 .TrimStart('/')
                 .EnsureEndsWith(".css");
         }
+
         /// <summary>
         /// Returns a successful message
         /// </summary>

--- a/src/Umbraco.Web/WebServices/SaveFileController.cs
+++ b/src/Umbraco.Web/WebServices/SaveFileController.cs
@@ -245,28 +245,24 @@ namespace Umbraco.Web.WebServices
         public JsonResult SaveStylesheet(string filename, string oldName, string contents)
         {
             // sanitize input - stylesheet names have no extension
-            var svce = (FileService) Services.FileService;
+            var svce = (FileService)Services.FileService;
+
+            filename = CleanFilename(filename);
+            oldName = CleanFilename(oldName);
 
             if (filename != oldName)
             {
-               var stylesheetExists = svce.GetStylesheetByName(filename);
-               if (stylesheetExists != null)
-                {
-                    return Failed(ui.Text("speechBubbles", "cssErrorText"), "A file named '" + filename + ".css' already exists." );
-                }
+                var stylesheetExists = svce.GetStylesheetByName(filename);
+                if (stylesheetExists != null)
+                    return Failed(ui.Text("speechBubbles", "cssErrorText"), "A file named '" + filename + ".css' already exists.");
             }
-
-            filename = filename
-                .Replace('\\', '/')
-                .TrimStart('/')
-                .EnsureEndsWith(".css");
 
             var stylesheet = svce.GetStylesheetByName(oldName);
             if (stylesheet == null)
                 stylesheet = new Stylesheet(filename);
             else
                 stylesheet.Path = filename;
-                stylesheet.Content = contents;
+            stylesheet.Content = contents;
 
             try
             {
@@ -291,6 +287,13 @@ namespace Umbraco.Web.WebServices
                 });
         }
 
+        private static string CleanFilename(string filename)
+        {
+            return filename
+                .Replace('\\', '/')
+                .TrimStart('/')
+                .EnsureEndsWith(".css");
+        }
         /// <summary>
         /// Returns a successful message
         /// </summary>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/stylesheet/editstylesheet.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/stylesheet/editstylesheet.aspx.cs
@@ -63,7 +63,7 @@ namespace umbraco.cms.presentation.settings.stylesheet
             TreeSyncPath = DeepLink.GetTreePathFromFilePath(filename).TrimEnd(".css");
 
             // name derives from path, without the .css extension, clean for xss
-            NameTxt.Text = filename.TrimEnd(".css");
+            NameTxt.Text = stylesheet.Path.TrimEnd(".css").CleanForXss('\\', '/').Replace("\\", "/");
 
             if (IsPostBack == false)
             {

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/stylesheet/editstylesheet.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/stylesheet/editstylesheet.aspx.cs
@@ -63,7 +63,7 @@ namespace umbraco.cms.presentation.settings.stylesheet
             TreeSyncPath = DeepLink.GetTreePathFromFilePath(filename).TrimEnd(".css");
 
             // name derives from path, without the .css extension, clean for xss
-            NameTxt.Text = stylesheet.Path.TrimEnd(".css").CleanForXss('\\', '/');
+            NameTxt.Text = filename.TrimEnd(".css");
 
             if (IsPostBack == false)
             {


### PR DESCRIPTION
Works now -
But is not sure, is oldName used anymore, It fails when used, in both create new stylefile and save filestyle.
If oldName is legacy, I think we should clean up metode and the calls to it.

### Prerequisites

- [ ] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is:
- [ ] I have added steps to test this contribution in the description below

### Description
<!-- A description of the changes proposed in the pull-request -->
<!-- Make sure to link to the related issue number so we can easily find it in the issue tracker -->


<!-- Thanks for contributing to Umbraco CMS! -->
