### PR TITLE
fixes #3126 - If no property data is found for a specific version - a…

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
@@ -1220,7 +1220,14 @@ ORDER BY cmsContentVersion.id DESC
                 if (def.DocumentDto.TemplateId.HasValue)
                     templates.TryGetValue(def.DocumentDto.TemplateId.Value, out template); // else null
                 cc.Template = template;
-                cc.Properties = propertyData[cc.Version];
+                if (propertyData.ContainsKey(cc.Version))
+                {
+                    cc.Properties = propertyData[cc.Version];
+                }
+                else
+                {
+                    throw new InvalidOperationException($"No property data found for version: '{cc.Version}'.");
+                }
 
                 //on initial construction we don't want to have dirty properties tracked
                 // http://issues.umbraco.org/issue/U4-1946


### PR DESCRIPTION
… null exception is thrown.
- Throwing an exception with a description instead of hitting a null exception.

### Description
When having corrupt data in the database, you could potentially have a content version that doesn't have corresponding property data. Currently we assume that this is never the case and this causes a null exception to be thrown when trying to assign a non-existing array item (the set of property data) to a property data collection on the item. 
This null exception is pretty hard to debug since the stacktrace is lacking some information - so instead of just hitting a null exception, we now throw an exception with a message telling what the problem is.

