### PR TITLE
Improve image cropper UX

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -573,8 +573,12 @@ div.umb-codeeditor .umb-btn-toolbar {
 
     .imagecropper .umb-cropper__container .button-drawer {
         display: flex;
-        justify-content: center;
+        justify-content: flex-end;
         padding: 10px;
+
+        button {
+            margin-left: 4px;
+        }
     }
 
     .umb-close-cropper {

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -312,7 +312,7 @@ div.umb-codeeditor .umb-btn-toolbar {
 
 .umb-mediapicker .umb-sortable-thumbnails li {
     flex-direction: column;
-    margin: 0 5px 5px 0;
+    margin: 0 0 5px 5px;
     padding: 5px;
 }
 
@@ -569,6 +569,12 @@ div.umb-codeeditor .umb-btn-toolbar {
         @media (min-width: 769px) {
             width: 600px;
         }
+    }
+
+    .imagecropper .umb-cropper__container .button-drawer {
+        display: flex;
+        justify-content: center;
+        padding: 10px;
     }
 
     .umb-close-cropper {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
@@ -36,12 +36,32 @@ angular.module('umbraco')
 
         //crop a specific crop
         $scope.crop = function (crop) {
-            $scope.currentCrop = crop;
+            // clone the crop so we can discard the changes
+            $scope.currentCrop = angular.copy(crop);
             $scope.currentPoint = undefined;
         };
 
         //done cropping
         $scope.done = function () {
+            if (!$scope.currentCrop) {
+                return;
+            }
+            // find the original crop by crop alias and update its coordinates
+            var editedCrop = _.find($scope.model.value.crops, function(crop) {
+                return crop.alias === $scope.currentCrop.alias;
+            });
+            editedCrop.coordinates = $scope.currentCrop.coordinates;
+            $scope.close();
+        };
+
+        //reset the current crop
+        $scope.reset = function() {
+            $scope.currentCrop.coordinates = undefined;
+            $scope.done();
+        }
+
+        //close crop overlay
+        $scope.close = function (crop) {
             $scope.currentCrop = undefined;
             $scope.currentPoint = undefined;
         };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
@@ -18,7 +18,7 @@
             <div ng-if="currentCrop" style="float:left; max-width: 100%;" class="clearfix">
                 <div class="umb-cropper__container">
 
-                    <i ng-click="done()" class="icon icon-delete btn-round umb-close-cropper"></i>
+                    <i ng-click="close()" class="icon icon-delete btn-round umb-close-cropper"></i>
 
                     <div>
                         <umb-image-crop height="{{currentCrop.height}}"
@@ -30,10 +30,10 @@
                         </umb-image-crop>
                     </div>
 
-                    <a href style="margin:auto; text-align: center; font-size: 11px;" class="btn btn-link red"
-                       ng-click="currentCrop.coordinates = undefined; done()">
-                        <localize key="imagecropper_reset">Reset</localize>
-                    </a>
+                    <div class="button-drawer">
+                        <button class="btn btn-link" ng-click="reset()"><localize key="imagecropper_reset">Reset this crop</localize></button>
+                        <button class="btn btn-success" ng-click="done()"><localize key="imagecropper_saveCrop">Save crop</localize></button>
+                    </div>
                 </div>
             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
@@ -18,8 +18,6 @@
             <div ng-if="currentCrop" style="float:left; max-width: 100%;" class="clearfix">
                 <div class="umb-cropper__container">
 
-                    <i ng-click="close()" class="icon icon-delete btn-round umb-close-cropper"></i>
-
                     <div>
                         <umb-image-crop height="{{currentCrop.height}}"
                                         width="{{currentCrop.width}}"
@@ -32,7 +30,8 @@
 
                     <div class="button-drawer">
                         <button class="btn btn-link" ng-click="reset()"><localize key="imagecropper_reset">Reset this crop</localize></button>
-                        <button class="btn btn-success" ng-click="done()"><localize key="imagecropper_saveCrop">Save crop</localize></button>
+                        <button class="btn" ng-click="close()"><localize key="imagecropper_undoEditCrop">Undo edits</localize></button>
+                        <button class="btn btn-success" ng-click="done()"><localize key="imagecropper_updateEditCrop">Done</localize></button>
                     </div>
                 </div>
             </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -989,6 +989,8 @@ Mange hilsner fra Umbraco robotten
   </area>
   <area alias="imagecropper">
     <key alias="reset">Nulstil</key>
+    <key alias="updateEditCrop">Acceptér</key>
+    <key alias="undoEditCrop">Fortryd</key>
   </area>
 
 

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1294,7 +1294,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="externalLinkPlaceholder">Enter the link</key>
     </area>
     <area alias="imagecropper">
-        <key alias="reset">Reset</key>
+        <key alias="reset">Reset crop</key>
         <key alias="defineCrop">Define crop</key>
         <key alias="defineCropDescription">Give the crop an alias and its default width and height</key>
         <key alias="saveCrop">Save crop</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1299,6 +1299,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="defineCropDescription">Give the crop an alias and its default width and height</key>
         <key alias="saveCrop">Save crop</key>
         <key alias="addCrop">Add new crop</key>
+        <key alias="updateEditCrop">Done</key>
+        <key alias="undoEditCrop">Undo edits</key>
     </area>
     <area alias="rollback">
         <key alias="currentVersion">Current version</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1297,6 +1297,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="defineCropDescription">Give the crop an alias and its default width and height</key>
         <key alias="saveCrop">Save crop</key>
         <key alias="addCrop">Add new crop</key>
+        <key alias="updateEditCrop">Done</key>
+        <key alias="undoEditCrop">Undo edits</key>
     </area>
     <area alias="rollback">
         <key alias="currentVersion">Current version</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1292,7 +1292,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="externalLinkPlaceholder">Enter the link</key>
     </area>
     <area alias="imagecropper">
-        <key alias="reset">Reset</key>
+        <key alias="reset">Reset crop</key>
         <key alias="defineCrop">Define crop</key>
         <key alias="defineCropDescription">Give the crop an alias and its default width and height</key>
         <key alias="saveCrop">Save crop</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3148
- [x] I have added steps to test this contribution in the description below

### Description

This PR fixes a few UX issues for the Image Cropper, as outlined in #3148:

1. Adds explicit buttons for saving and resetting the crop
2. Makes the close button behaves like a close button should
3. Ensures that crops are only applied when saved (not immediately after opening a crop)
4. A bit of wording and spacing :)

![image cropper after](https://user-images.githubusercontent.com/7405322/46464456-b3df2d80-c7c6-11e8-8065-cdc138ae5dda.png)

The testing should be pretty straight forward. Though - when testing it, make sure you test this scenario also:
1. Upload a new file
2. Open a crop for editing
3. Edit the crop
4. Close the crop editor by the close button (effectively discarding the changes)
5. Ensure that the crop is still "attached" to the main image