### PR TITLE
Whe moving an item, make sure the current user is registered in Audit instead of the default user

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -895,7 +895,7 @@ namespace Umbraco.Web.Editors
         {
             var toMove = ValidateMoveOrCopy(move);
 
-            Services.ContentService.Move(toMove, move.ParentId);
+            Services.ContentService.Move(toMove, move.ParentId, Security.GetUserId());
 
             var response = Request.CreateResponse(HttpStatusCode.OK);
             response.Content = new StringContent(toMove.Path, Encoding.UTF8, "application/json");


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/2990
- [x] I have added steps to test this contribution in the description below

### Description

This adds the current user as origin to move actions in the audit log. See #2990 for steps to reproduce/test.

![move audit fix](https://user-images.githubusercontent.com/7405322/46465701-9790c000-c7c9-11e8-8a97-3970c6ccbffa.png)
