### PR TITLE
Lecoati CSS reference removed (issue #3147)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/approvedcolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/approvedcolorpicker.controller.js
@@ -19,7 +19,6 @@ angular.module("umbraco")
                             $scope.classes.splice(0, 0, "noclass");
                         })
 
-                    assetsService.loadCss("/App_Plugins/Lecoati.uSky.Grid/lib/uSky.Grid.ApprovedColorPicker.css", $scope);
                     assetsService.loadCss(cssPath, $scope);
 			    });
 });


### PR DESCRIPTION
ApprovedColorPickerController had a reference for no apparent reason.

### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3147
- [x] I have added steps to test this contribution in the description below

### Description
<!-- A description of the changes proposed in the pull-request -->
<!-- Make sure to link to the related issue number so we can easily find it in the issue tracker -->
Simple removal of a stylesheet that was loaded for no reason.

To test after removal:

- Edit "Approved Color" datatype and add some colors.
- Add an "Approved Color" property to a doctype
- See that everything looks right and saves correctly.

<!-- Thanks for contributing to Umbraco CMS! -->
