### PR TITLE
#3159 - Add border around the colors from the approved color picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
@@ -3,7 +3,7 @@
     flex-flow: row wrap;
 
     .umb-color-box {
-        border: none;
+        border: 1px solid @gray-8;
         color: white;
         cursor: pointer;
         padding: 1px;
@@ -17,10 +17,6 @@
         display: flex;
         align-items: center;
         justify-content: center;
-
-        .approved-color-picker &{
-            border: 1px solid @gray-8;
-        }
 
         &:hover, &:focus {
             box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
@@ -18,6 +18,10 @@
         align-items: center;
         justify-content: center;
 
+        .approved-color-picker &{
+            border: 1px solid @gray-8;
+        }
+
         &:hover, &:focus {
             box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
         }
@@ -69,7 +73,8 @@
                     margin-right: -1px;
                     text-indent: 0;
                     text-align: left;
-                    border: 1px solid @gray-8;
+                    border-top: 1px solid @gray-8;
+                    border-bottom: 1px solid @gray-8;
                     border-bottom-left-radius: 3px;
                     border-bottom-right-radius: 3px;
                     overflow: hidden;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
@@ -1,4 +1,4 @@
-﻿<div ng-controller="Umbraco.PropertyEditors.ColorPickerController">
+﻿<div ng-controller="Umbraco.PropertyEditors.ColorPickerController" class="approved-color-picker">
 
     <div ng-if="!isConfigured">
         <localize key="colorpicker_noColors">You haven't defined any colors</localize>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
@@ -1,4 +1,5 @@
-﻿<div ng-controller="Umbraco.PropertyEditors.ColorPickerController" class="approved-color-picker">
+﻿<div ng-controller="Umbraco.PropertyEditors.ColorPickerController">
+
 
     <div ng-if="!isConfigured">
         <localize key="colorpicker_noColors">You haven't defined any colors</localize>


### PR DESCRIPTION

### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/3159) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3159
- [x] I have added steps to test this contribution in the description below

### Description
Add a border around colors selected in the "Approved color picker" datatype. Added a "approved-color-picker" class to target this scenario specifically without the change affecting the styling in the document type icon color picker.

Before the picker looked like this
![color-picker-before](https://user-images.githubusercontent.com/1932158/46495136-e57ee580-c814-11e8-97b5-a988f4b9408d.png)

Now it looks like this
![color-picker-after](https://user-images.githubusercontent.com/1932158/46495148-eadc3000-c814-11e8-97df-3e449d7d0e26.png)

**EDIT:** Adding image showing what it looks like without the labels before and after too.

No labels before
![color-picker-before-nolabels](https://user-images.githubusercontent.com/1932158/46496130-81a9ec00-c817-11e8-8df7-03cba887cfa1.png)

No labels after
![color-picker-after-nolabels](https://user-images.githubusercontent.com/1932158/46496139-8a022700-c817-11e8-87f2-a8cdd1dd93ad.png)

