### PR TITLE
Register an audit on the parent node when sorting child nodes.

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2060,12 +2060,15 @@ namespace Umbraco.Core.Services
             using (new WriteLock(Locker))
             {
                 var allContent = GetByIds(ids).ToDictionary(x => x.Id, x => x);
-                var items = ids.Select(x => allContent[x]);
+                if (allContent.Any() == false)
+                {
+                    return false;
+                }
+                var items = ids.Select(x => allContent[x]).ToArray();
 
                 using (var uow = UowProvider.GetUnitOfWork())
                 {
-                    var asArray = items.ToArray();
-                    var saveEventArgs = new SaveEventArgs<IContent>(asArray);
+                    var saveEventArgs = new SaveEventArgs<IContent>(items);
                     if (raiseEvents && uow.Events.DispatchCancelable(Saving, this, saveEventArgs, "Saving"))
                     {
                         uow.Commit();
@@ -2075,7 +2078,7 @@ namespace Umbraco.Core.Services
                     var repository = RepositoryFactory.CreateContentRepository(uow);
 
                     var i = 0;
-                    foreach (var content in asArray)
+                    foreach (var content in items)
                     {
                         //If the current sort order equals that of the content
                         //we don't need to update it, so just increment the sort order
@@ -2122,7 +2125,7 @@ namespace Umbraco.Core.Services
                         _publishingStrategy.PublishingFinalized(uow, shouldBePublished, false);
                     }
 
-                    Audit(uow, AuditType.Sort, "Sorting content performed by user", userId, 0);
+                    Audit(uow, AuditType.Sort, "Sort child items performed by user", userId, items.First().ParentId);
                     uow.Commit();
                 }
             }

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -147,6 +147,7 @@
     <key alias="rollback">Brugeren har tilbagerullet indholdet til en tidligere tilstand</key>
     <key alias="sendtopublish">Brugeren har sendt indholdet til udgivelse</key>
     <key alias="sendtotranslate">Brugeren har sendt indholdet til oversættelse</key>
+    <key alias="sort">Brugeren har sorteret de underliggende sider</key>
     <key alias="smallCopy">Kopieret</key>
     <key alias="smallPublish">Udgivet</key>
     <key alias="smallMove">Flyttet</key>
@@ -156,6 +157,7 @@
     <key alias="smallRollBack">Indhold tilbagerullet</key>
     <key alias="smallSendToPublish">Sendt til udgivelse</key>
     <key alias="smallSendToTranslate">Sendt til oversættelse</key>
+    <key alias="smallSort">Sorteret</key>
   </area>
   <area alias="changeDocType">
     <key alias="changeDocTypeInstruction">For at skifte det valgte indholds dokumenttype, skal du først vælge en ny dokumenttype, som er gyldig på denne placering.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -153,6 +153,7 @@
         <key alias="rollback">Content rollback performed by user</key>
         <key alias="sendtopublish">Content Send To Publish performed by user</key>
         <key alias="sendtotranslate">Content Send To Translation performed by user</key>
+        <key alias="sort">Sort child items performed by user</key>
         <key alias="smallCopy">Copy</key>
         <key alias="smallPublish">Publish</key>
         <key alias="smallMove">Move</key>
@@ -162,6 +163,7 @@
         <key alias="smallRollBack">Rollback</key>
         <key alias="smallSendToPublish">Send To Publish</key>
         <key alias="smallSendToTranslate">Send To Translation</key>
+        <key alias="smallSort">Sort</key>
     </area>
     <area alias="changeDocType">
         <key alias="changeDocTypeInstruction">To change the document type for the selected content, first select from the list of valid types for this location.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -153,6 +153,7 @@
         <key alias="rollback">Content rollback performed by user</key>
         <key alias="sendtopublish">Content Send To Publish performed by user</key>
         <key alias="sendtotranslate">Content Send To Translation performed by user</key>
+        <key alias="sort">Sort child items performed by user</key>
         <key alias="smallCopy">Copy</key>
         <key alias="smallPublish">Publish</key>
         <key alias="smallMove">Move</key>
@@ -162,6 +163,7 @@
         <key alias="smallRollBack">Rollback</key>
         <key alias="smallSendToPublish">Send To Publish</key>
         <key alias="smallSendToTranslate">Send To Translation</key>
+        <key alias="smallSort">Sort</key>
     </area>
 
     <area alias="changeDocType">

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -871,7 +871,7 @@ namespace Umbraco.Web.Editors
                 var contentService = Services.ContentService;
 
                 // Save content with new sort order and update content xml in db accordingly
-                if (contentService.Sort(sorted.IdSortOrder) == false)
+                if (contentService.Sort(sorted.IdSortOrder, Security.CurrentUser.Id) == false)
                 {
                     LogHelper.Warn<ContentController>("Content sorting failed, this was probably caused by an event being cancelled");
                     return Request.CreateValidationErrorResponse("Content sorting failed, this was probably caused by an event being cancelled");


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3160
- [x] I have added steps to test this contribution in the description below

### Description

This PR ensures that the sort action is logged to the audit history on the item whose child items have been sorted.

To test:

1. Create an item (A) with some children
2. Change the sort order of the children
3. Verify that the sorting caused an entry in the history log for (A)

![image](https://user-images.githubusercontent.com/7405322/46495195-0a735880-c815-11e8-91a7-22a29adf1e25.png)
