### PR TITLE
#3163 - Don't overwrite the label name even though labels are disabled in the color picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -1,6 +1,6 @@
 ﻿<div class="umb-color-swatches" ng-class="{ 'with-labels': useLabel }">
 
-    <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{useLabel ? color.label : color.value}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': color.value === selectedColor }" ng-click="setColor(color.value)">
+    <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{useLabel ? color.label : '#' + color.value}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': color.value === selectedColor }" ng-click="setColor(color.value)">
         <div class="umb-color-box-inner">
             <div class="check_circle">
                 <i class="icon icon-check small"></i>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -1,6 +1,6 @@
 ﻿<div class="umb-color-swatches" ng-class="{ 'with-labels': useLabel }">
 
-    <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{color.label}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': color.value === selectedColor }" ng-click="setColor(color.value)">
+    <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{useLabel ? color.label : color.value}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': color.value === selectedColor }" ng-click="setColor(color.value)">
         <div class="umb-color-box-inner">
             <div class="check_circle">
                 <i class="icon icon-check small"></i>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -16,7 +16,7 @@
                 <div class="thumbnail span1" hex-bg-color="{{item.value}}" hex-bg-orig="transparent"></div>
                 <div class="color-picker-prediv">
                     <pre>#{{item.value}}</pre>
-                    <span ng-bind="item.value" ng-if="!labelEnabled"></span>
+                    <span ng-bind="item.label" ng-if="!labelEnabled"></span>
                     <input type="text" ng-if="labelEnabled" ng-model="item.label" val-server="item_{{$index}}" required />
                 </div>
             </div>

--- a/src/Umbraco.Web/PropertyEditors/ColorListPreValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ColorListPreValueEditor.cs
@@ -120,9 +120,8 @@ namespace Umbraco.Web.PropertyEditors
                         var label = x["label"].ToString();
 
                         sortOrder++;
-                        var value = useLabel
-                            ? JsonConvert.SerializeObject(new { value = color, label = label, sortOrder = sortOrder })
-                            : color;
+
+                        var value = JsonConvert.SerializeObject(new { value = color, label = label, sortOrder = sortOrder });
 
                         return new PreValue(id, value, sortOrder);
                     })


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/3163) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3163
- [x] I have added steps to test this contribution in the description below

### Description
I've modified the code so the entered label does not get deleted in case we need to enable it again at a later stage.

I can see that it might be confusing that there is a label name when labels are not activated. But on the other hand the field is greyed out and it does not change value when switching.

I'm open to change the binding back to item.value instead of label but I don't see any reason why the value can't be kept so when enabling the labels again the label entered earlier is still present 😃 

Behavior before PR
![enabledisable-labels-before](https://user-images.githubusercontent.com/1932158/46501250-38f92f80-c825-11e8-941f-db7f4f3fd76b.gif)

Behavior after PR
![enabledisable-labels-after-2](https://user-images.githubusercontent.com/1932158/46501585-3a772780-c826-11e8-8425-62bb800edc0e.gif)


