### PR TITLE
Button styling on inactive user profile & clean up user view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -146,6 +146,7 @@
 @import "components/umb-mini-editor.less";
 
 @import "components/users/umb-user-cards.less";
+@import "components/users/umb-user-details.less";
 @import "components/users/umb-user-group-picker-list.less";
 @import "components/users/umb-user-group-preview.less";
 @import "components/users/umb-user-preview.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-details.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-details.less
@@ -1,0 +1,117 @@
+.umb-user-details-avtar {
+    margin-bottom: 20px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid #d8d7d9;
+}
+
+div.umb-user-details-actions > div {
+    margin-bottom: 20px;
+}
+
+.umb-user-details-actions .umb-button {
+    margin-bottom: 20px;
+}
+
+.umb-user-details-view-title {
+    font-size: 20px;
+    font-weight: bold;
+    color: @black;
+    margin-bottom: 30px;
+}
+
+.umb-user-details-view-wrapper {
+    padding: 20px 60px;
+}
+
+@media (max-width: 768px) {
+
+    .umb-user-details-view-wrapper {
+        padding: 0;
+    }
+}
+
+.umb-user-details-section {
+    margin-bottom: 40px;
+}
+.umb-user-details-details {
+    display: flex;
+}
+
+a.umb-user-details-details__back-link {
+    font-weight: bold;
+    color: @black;
+}
+
+.umb-user-details-details__back-link:hover {
+    color: @gray-4;
+    text-decoration: none;
+}
+
+
+@sidebarwidth: 350px; // Width of sidebar. Ugly hack because of old version of Less
+
+.umb-user-details-details__main-content {
+    flex: 1 1 auto;
+    margin-right: 30px;
+    width: calc(~'100%' - ~'@{sidebarwidth}' - ~'30px'); // Make sure that the main content area doesn't gets affected by inline styling
+}
+
+.umb-user-details-details__sidebar {
+    flex: 0 0 @sidebarwidth;
+}
+
+@media (max-width: 768px) {
+
+    .umb-user-details-details {
+        flex-direction: column;
+    }
+
+    .umb-user-details-details__main-content {
+        flex: 1 1 auto;
+        width: 100%;
+        margin-bottom: 30px;
+        margin-right: 0;
+    }
+
+    .umb-user-details-details__sidebar {
+        flex: 1 1 auto;
+        width: 100%;
+    }
+}
+
+.umb-user-details-details__section {
+    background: @gray-10;
+    padding: 20px;
+    margin-bottom: 20px;
+    border-radius: 3px;
+    border: 1px solid @gray-8;
+}
+
+.umb-user-details-details__section-title {
+    font-size: 17px;
+    font-weight: bold;
+    color: @black;
+    margin-top: 0;
+    margin-bottom: 15px;
+}
+
+.umb-user-details-details__section-description {
+    font-size: 12px;
+    line-height: 1.6em;
+    margin-bottom: 15px;
+}
+
+.umb-user-details-details__information-item {
+    margin-bottom: 10px;
+    font-size: 13px;
+}
+
+.umb-user-details-details__information-item-label {
+    color: @black;
+    font-weight: bold;
+}
+
+.umb-user-details-details__information-item-content {
+    word-break: break-word;
+}
+

--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-details.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-details.less
@@ -56,6 +56,11 @@ a.umb-user-details-details__back-link {
     width: calc(~'100%' - ~'@{sidebarwidth}' - ~'30px'); // Make sure that the main content area doesn't gets affected by inline styling
 }
 
+.umb-user-details-details__main-content .umb-node-preview-add {
+    max-width: 100%;
+}
+
+
 .umb-user-details-details__sidebar {
     flex: 0 0 @sidebarwidth;
 }
@@ -72,7 +77,7 @@ a.umb-user-details-details__back-link {
         margin-bottom: 30px;
         margin-right: 0;
     }
-
+   
     .umb-user-details-details__sidebar {
         flex: 1 1 auto;
         width: 100%;

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.html
@@ -15,7 +15,7 @@
             
             <umb-editor-container>
                 
-                <div ng-if="!vm.loading" class="umb-packages-view-wrapper" style="padding: 0;">
+                <div ng-if="!vm.loading" class="umb-user-details-view-wrapper" style="padding: 0;">
 
                     <umb-editor-sub-views
                         ng-if="!vm.loading"

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -1,6 +1,6 @@
-﻿<div class="umb-package-details">
+﻿<div class="umb-user-details-details">
 
-    <div class="umb-package-details__main-content">
+    <div class="umb-user-details-details__main-content">
 
         <umb-box>
 
@@ -95,8 +95,7 @@
 
                     <a href=""
                        ng-if="!model.user.isCurrentUser"
-                       style="max-width: 100%;"
-                       class="umb-node-preview-add"
+                     class="umb-node-preview-add"
                        ng-click="model.openContentPicker()"
                        prevent-default>
                         <localize key="general_add">Add</localize>
@@ -121,8 +120,7 @@
 
                     <a href=""
                        ng-if="!model.user.isCurrentUser"
-                       style="max-width: 100%;"
-                       class="umb-node-preview-add"
+                     class="umb-node-preview-add"
                        ng-click="model.openMediaPicker()"
                        prevent-default>
                         <localize key="general_add">Add</localize>
@@ -165,12 +163,12 @@
         </umb-box>
     </div>
 
-    <div class="umb-package-details__sidebar">
+    <div class="umb-user-details-details__sidebar">
 
-        <div class="umb-package-details__section">
+        <div class="umb-user-details-details__section">
 
             <!-- Avatar -->
-            <div style="margin-bottom: 20px; padding-bottom: 20px; border-bottom: 1px solid #d8d7d9;">
+            <div>
                 <ng-form name="avatarForm" class="flex flex-column justify-center items-center">
 
                     <umb-avatar style="margin-bottom: 15px;"
@@ -214,9 +212,9 @@
             </div>
 
             <!-- Actions -->
-            <div style="margin-bottom: 20px;">
+            <div class="umb-user-details-actions">
 
-                <div style="margin-bottom: 10px;">
+                <div>
                     <umb-button ng-if="model.user.userDisplayState.key === 'Disabled' && !model.user.isCurrentUser"
                                 type="button"
                                 button-style="[success,block]"
@@ -228,7 +226,7 @@
                     </umb-button>
                 </div>
 
-                <div style="margin-bottom: 10px;">
+                <div>
                     <umb-button ng-if="model.user.userDisplayState.key === 'LockedOut' && !model.user.isCurrentUser"
                                 type="button"
                                 button-style="[success,block]"
@@ -239,8 +237,7 @@
                                 size="s">
                     </umb-button>
                 </div>
-
-                <div style="margin-bottom: 10px;">
+                <div>
                     <umb-button ng-if="model.user.userDisplayState.key !== 'Disabled' && model.user.userDisplayState.key !== 'Invited' && !model.user.isCurrentUser"
                                 type="button"
                                 button-style="[info,block]"
@@ -251,25 +248,27 @@
                                 size="s">
                     </umb-button>
                 </div>
-
-                <umb-button type="button" ng-if="model.user.userDisplayState.key !== 'Invited'"
-                            button-style="[info,block]"
-                            action="model.toggleChangePassword()"
-                            label="Change password"
-                            label-key="general_changePassword"
-                            state="changePasswordButtonState"
-                            ng-if="model.changePasswordModel.isChanging === false"
-                            size="s">
-                </umb-button>
-
-                <umb-button type="button" ng-if="!model.user.lastLoginDate"
-                            button-style="[danger,block]"
-                            action="model.deleteNonLoggedInUser()"
-                            label="Delete"
-                            label-key="user_deleteUser"
-                            state="deleteNotLoggedInUserButtonState"
-                            size="s">
-                </umb-button>
+                <div>
+                    <umb-button type="button" ng-if="model.user.userDisplayState.key !== 'Invited'"
+                                button-style="[info,block]"
+                                action="model.toggleChangePassword()"
+                                label="Change password"
+                                label-key="general_changePassword"
+                                state="changePasswordButtonState"
+                                ng-if="model.changePasswordModel.isChanging === false"
+                                size="s">
+                    </umb-button>
+                </div>
+                <div>
+                    <umb-button type="button" ng-if="!model.user.lastLoginDate"
+                                button-style="[danger,block]"
+                                action="model.deleteNonLoggedInUser()"
+                                label="Delete"
+                                label-key="user_deleteUser"
+                                state="deleteNotLoggedInUserButtonState"
+                                size="s">
+                    </umb-button>
+                </div>
 
                 <ng-form ng-if="model.changePasswordModel.isChanging" name="passwordForm" class="block-form" val-form-manager>
 
@@ -293,26 +292,26 @@
             </div>
 
             <!-- User stats -->
-            <div class="umb-package-details__information-item">
-                <div class="umb-package-details__information-item-label">
+            <div class="umb-user-details-details__information-item">
+                <div class="umb-user-details-details__information-item-label">
                     <localize key="general_status">Status</localize>:
                 </div>
-                <div class="umb-package-details__information-item-content">
+                <div class="umb-user-details-details__information-item-content">
                     <umb-badge style="margin-top: 4px;" size="s" color="{{model.user.userDisplayState.color}}">
                         {{model.user.userDisplayState.name}}
                     </umb-badge>
                 </div>
             </div>
 
-            <div style="margin-bottom: 10px;" ng-if="model.user.userDisplayState.key === 'Invited' && !model.user.isCurrentUser">
+            <div ng-if="model.user.userDisplayState.key === 'Invited' && !model.user.isCurrentUser">
                 <textarea name="resendInviteMessage"
-                    type="text"
-                    class="input-block-level"
-                    localize="placeholder"
-                    placeholder="@placeholders_enterMessage"
-                    ng-model="model.resendInviteMessage"
-                    rows="4">
-                </textarea>                    
+                          type="text"
+                          class="input-block-level"
+                          localize="placeholder"
+                          placeholder="@placeholders_enterMessage"
+                          ng-model="model.resendInviteMessage"
+                          rows="4">
+                </textarea>
                 <umb-button type="button"
                             button-style="[info,block]"
                             action="model.resendInvite()"
@@ -323,30 +322,30 @@
                 </umb-button>
             </div>
 
-            <div class="umb-package-details__information-item">
-                <div class="umb-package-details__information-item-label">
+            <div class="umb-user-details-details__information-item">
+                <div class="umb-user-details-details__information-item-label">
                     <localize key="user_lastLogin">Last login</localize>:
                 </div>
-                <div class="umb-package-details__information-item-content">
+                <div class="umb-user-details-details__information-item-content">
                     <span ng-if="model.user.lastLoginDate">{{ model.user.formattedLastLogin }}</span>
                     <span ng-if="!model.user.lastLoginDate">{{ model.user.name | umbWordLimit:1 }} <localize key="user_noLogin">has not logged in yet</localize></span>
                 </div>
             </div>
 
-            <div class="umb-package-details__information-item">
-                <div class="umb-package-details__information-item-label">
+            <div class="umb-user-details-details__information-item">
+                <div class="umb-user-details-details__information-item-label">
                     <localize key="user_failedPasswordAttempts">Failed login attempts</localize>:
                 </div>
-                <div class="umb-package-details__information-item-content">
+                <div class="umb-user-details-details__information-item-content">
                     {{ model.user.failedPasswordAttempts }}
                 </div>
             </div>
 
-            <div class="umb-package-details__information-item">
-                <div class="umb-package-details__information-item-label">
+            <div class="umb-user-details-details__information-item">
+                <div class="umb-user-details-details__information-item-label">
                     <localize key="user_lastLockoutDate">Last lockout date</localize>:
                 </div>
-                <div class="umb-package-details__information-item-content">
+                <div class="umb-user-details-details__information-item-content">
                     <span ng-if="model.user.lastLockoutDate === '0001-01-01T00:00:00'">
                         {{ model.user.name | umbWordLimit:1 }} <localize key="user_noLockouts">hasn't been locked out</localize>
                     </span>
@@ -354,11 +353,11 @@
                 </div>
             </div>
 
-            <div class="umb-package-details__information-item">
-                <div class="umb-package-details__information-item-label">
+            <div class="umb-user-details-details__information-item">
+                <div class="umb-user-details-details__information-item-label">
                     <localize key="user_lastPasswordChangeDate">Password is last changed</localize>:
                 </div>
-                <div class="umb-package-details__information-item-content">
+                <div class="umb-user-details-details__information-item-content">
                     <span ng-if="model.user.lastPasswordChangeDate === '0001-01-01T00:00:00'">
                         <localize key="user_noPasswordChange">The password hasn't been changed</localize>
                     </span>
@@ -366,20 +365,20 @@
                 </div>
             </div>
 
-            <div class="umb-package-details__information-item">
-                <div class="umb-package-details__information-item-label">
+            <div class="umb-user-details-details__information-item">
+                <div class="umb-user-details-details__information-item-label">
                     <localize key="user_createDate">User is created</localize>:
                 </div>
-                <div class="umb-package-details__information-item-content">
+                <div class="umb-user-details-details__information-item-content">
                     {{ model.user.formattedCreateDate }}
                 </div>
             </div>
 
-            <div class="umb-package-details__information-item">
-                <div class="umb-package-details__information-item-label">
+            <div class="umb-user-details-details__information-item">
+                <div class="umb-user-details-details__information-item-label">
                     <localize key="user_updateDate">User is last updated</localize>:
                 </div>
-                <div class="umb-package-details__information-item-content">
+                <div class="umb-user-details-details__information-item-content">
                     {{ model.user.formattedUpdateDate }}
                 </div>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -95,7 +95,8 @@
 
                     <a href=""
                        ng-if="!model.user.isCurrentUser"
-                     class="umb-node-preview-add"
+                       class="umb-node-preview-add"
+                       id="content-start-add"
                        ng-click="model.openContentPicker()"
                        prevent-default>
                         <localize key="general_add">Add</localize>
@@ -122,6 +123,7 @@
                        ng-if="!model.user.isCurrentUser"
                      class="umb-node-preview-add"
                        ng-click="model.openMediaPicker()"
+                       id="media-start-add"
                        prevent-default>
                         <localize key="general_add">Add</localize>
                     </a>
@@ -168,7 +170,7 @@
         <div class="umb-user-details-details__section">
 
             <!-- Avatar -->
-            <div>
+            <div class="umb-user-details-avtar">
                 <ng-form name="avatarForm" class="flex flex-column justify-center items-center">
 
                     <umb-avatar style="margin-bottom: 15px;"


### PR DESCRIPTION
### Prerequisites

- [ ] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3169
- [ ] I have added steps to test this contribution in the description below

### Description
If you create a new user in umbraco and visit the user profile immediately or if you visit any inactive user's profile the delete button looks quite congested and does not have any margin above it.
![beforeinactive](https://user-images.githubusercontent.com/3941753/46526036-0e3ec380-c885-11e8-8703-28768b704039.PNG)

The user screen was using the "umb-package*" classes, so I have also created a new stylesheet and rules specific to this screen and got rid of all the inline styling. I have not touched the inline styling on the various umb-directives though. Let me know if anything needs revisiting.

![after](https://user-images.githubusercontent.com/3941753/46526181-6f669700-c885-11e8-931b-e9c10dab43c8.PNG)


<!-- Thanks for contributing to Umbraco CMS! -->
