### PR TITLE
Don't use ng-show on the preview iframe #2952

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
@@ -81,9 +81,9 @@ a, a:hover{
 
 .wait {
     display: block;
-    height: 280px;
+    height: 100%;
     width: 100%;
-    background: center center url(../img/loader.gif) no-repeat;
+    background:#fff center center url(../img/loader.gif) no-repeat;
 }
 
 /****************************/

--- a/src/Umbraco.Web.UI/Umbraco/Views/Preview/Index.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Preview/Index.cshtml
@@ -20,7 +20,7 @@
         @Html.Partial(Model.PreviewExtendedHeaderView)
     }
 
-    <div id="demo-iframe-wrapper" ng-show="frameLoaded" class="{{previewDevice.css}}">
+    <div id="demo-iframe-wrapper" class="{{previewDevice.css}}">
         <iframe id="resultFrame" ng-src="{{pageUrl}}" frameborder="0" iframe-is-loaded></iframe>
     </div>
     <div class="canvasdesigner" ng-init="showDevicesPreview = true; showDevices = !@(disableDevicePreview); showPalettePicker = true" ng-mouseenter="positionSelectedHide()">


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #2952 
- [x] I have added steps to test this contribution in the description below

### Description
Per @mattbrailsford's description in #2952, change here removes the ng-show directive from the preview iframe, instead setting a solid white background on the loading spinner to obscure the iframe while it loads. 
