### PR TITLE
Minor css change regarding dropdown-toggles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/buttons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/buttons.less
@@ -63,9 +63,6 @@
 .btn-group>.btn+.dropdown-toggle {
     box-shadow: none;
     -webkit-box-shadow:none;
-}
-
-.btn-group .btn.dropdown-toggle {
     border-left-width: 1px;
     border-left-style: solid;
 }


### PR DESCRIPTION
https://github.com/umbraco/Umbraco-CMS/issues/3176

This PR changes the way the borde is added to a dropdown-toggle in a button group.

Before, a dropdown-toggle would always have a left border, even when not necessary. Now, the border is only added, when the dropdown-toggle comes after a button.

To test, go to the media section, where the list view have a dropdown button.

Before it would look like this:
![image](https://user-images.githubusercontent.com/3726467/46555190-d5cdd280-c8e2-11e8-92d9-f1cac71e2de1.png)

After:
![image](https://user-images.githubusercontent.com/3726467/46555212-e3835800-c8e2-11e8-9997-1f3d9efe197e.png)
