### PR TITLE
Removes overflow rule preventing the actions menu from showing fully

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -368,7 +368,6 @@
   flex-direction: column;
   height: 99px;
   padding: 0 20px;
-  overflow-y: hidden;
 }
 
 .umb-panel-header-content {


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3180
- [x] I have added steps to test this contribution in the description below

### Description

This is to fix an issue reported by @skttl on my last PR for #3060. The overflow hidden rule is extraneous and didn't appear to cause any issue removing it.

Again - I'd like any help checking the header, any where tabs show, etc. Thanks!