### PR TITLE
Safe(r) handling of invalid images in the image cropper

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
@@ -158,8 +158,16 @@ namespace Umbraco.Web.PropertyEditors
                 {
                     var preValues = editorValue.PreValues.FormatAsDictionary();
                     var sizes = preValues.Any() ? preValues.First().Value.Value : string.Empty;
-                    using (var image = Image.FromStream(filestream))
-                        _mediaFileSystem.GenerateThumbnails(image, filepath, sizes);
+                    try
+                    {
+                        using (var image = Image.FromStream(filestream))
+                            _mediaFileSystem.GenerateThumbnails(image, filepath, sizes);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        // send any argument errors caused by the thumbnail generation to the log instead of failing miserably 
+                        LogHelper.WarnWithException<ImageCropperPropertyValueEditor>("Could not extract image thumbnails.", ex);
+                    }
                 }
 
                 // all related properties (auto-fill) are managed by ImageCropperPropertyEditor


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes https://github.com/umbraco/Umbraco-CMS/issues/3026
- [x] I have added steps to test this contribution in the description below

### Description

As described in #3026, uploading images that are in one way or another invalid causes an error that bubbles all the way into the back office. The issue also reports it potentially breaking the app pool, though I haven't been able to reproduce that.

![image](https://user-images.githubusercontent.com/7405322/46569005-ca17f580-c94e-11e8-9777-7ebfab61a1cd.png)

Steps to test:

1. Create an empty text document and rename its extension to ".jpg"
2. Create a new image node in the media library (assuming that the image has an image cropper property)
3. Upload the faulty JPG to the image node
4. Verify that no errors bubble into the back office and that the image node is saved

Please note: This is only a workaround to keep this scenario from showing exception errors in the back office. The downside being that the image cropper property actually saves successfully despite the image being invalid. Someone should probably create a better validator for the image cropper eventually.
