### PR TITLE
#3187 - Small UI fixes for the toggle directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -10,6 +10,11 @@
     }
 }
 
+.umb-toggle:focus .umb-toggle__toggle{
+    outline: 0;
+    box-shadow: 0 0 5px rgba(0,0,0,.5);
+}
+
 .umb-toggle__handler {
     position: absolute;
     top: 0;
@@ -43,7 +48,6 @@
 /* Labels */
 
 .umb-toggle__label {
-    font-size: 12px;
     color: @gray-2;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -12,7 +12,7 @@
 
 .umb-toggle:focus .umb-toggle__toggle{
     outline: 0;
-    box-shadow: 0 0 5px rgba(0,0,0,.5);
+    box-shadow: 0 0 5px fade(@black, 30%);
 }
 
 .umb-toggle__handler {

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
@@ -1,4 +1,4 @@
-<button ng-click="click()" type="button" class="umb-toggle dib" ng-class="{'umb-toggle--checked': checked}">
+<button ng-click="click()" type="button" class="umb-toggle" ng-class="{'umb-toggle--checked': checked}">
 
     <span ng-if="!labelPosition && showLabels === 'true' || labelPosition === 'left' && showLabels === 'true'">
         <span ng-if="!checked" class="umb-toggle__label umb-toggle__label--left">{{ displayLabelOff }}</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3187
- [x] I have added steps to test this contribution in the description below

### Description
This PR addresses fixing some UI/Styling issues with the umbToggle directive. It's still work in progress since fixing the label alignment might influence other areas where this directive is being used like in the document type and template editors.

The issues were discovered during the work on https://github.com/umbraco/Umbraco-CMS/pull/3179

Edit: This PR is now ready for review. I noticed in the log for the umb-toggle.html directive that there was a comment about the dib class being added to fix some labelling issue in the template editor. I have tested my change after removing it and I have not been able to spot any issues with doing so. In the template editor it appears to still be the good ol' native checkbox being used. 

So after merging this PR and #3179 this is what it will look like:

![after-toggle-style-changes](https://user-images.githubusercontent.com/1932158/46579304-d794b480-ca0e-11e8-9e59-62bc62e21f5e.gif)


And this is what it looked like **BEFORE**:

![before-toggle-style-changes](https://user-images.githubusercontent.com/1932158/46579306-de232c00-ca0e-11e8-9e3d-822aa654dc81.gif)
