### PR TITLE
Style the sort result so it looks like e.g. the copy dialog result

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/dialogs/sort.aspx
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/sort.aspx
@@ -30,12 +30,10 @@
             </div>
 
             <div id="sortingDone" style="display: none;" class="success">
-                <p>
+                <div class="alert alert-success">
                     <asp:Literal runat="server" ID="sortDone"></asp:Literal>
-                </p>
-                <p>
-                    <a href="#" onclick="UmbClientMgr.closeModalWindow()"><%= umbraco.ui.Text("defaultdialogs", "closeThisWindow")%></a>
-                </p>
+                </div>
+                <button class="btn btn-primary" onclick="UmbClientMgr.closeModalWindow()"><%= umbraco.ui.Text("general", "ok")%></button>
             </div>
 
             <div id="sortArea">


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3191
- [x] I have added steps to test this contribution in the description below

### Description

This PR updates the sort dialog confirmation to look a bit more confirmation like:

![sort after](https://user-images.githubusercontent.com/7405322/46586851-9e972700-ca84-11e8-8e22-e9e3244539ed.png)

Steps:

1. Sort some content in the content tree
2. Verify that the confirmation indeed looks ok once the sorting is complete