### PR TITLE
Style Public access dialog

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1217,7 +1217,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     </area>
     <area alias="publicAccess">
         <key alias="paAdvanced">Role based protection</key>
-        <key alias="paAdvancedHelp"><![CDATA[If you wish to control access to the page using role-based authentication,<br /> using Umbraco's member groups.]]></key>
+        <key alias="paAdvancedHelp">If you wish to control access to the page using role-based authentication, using Umbraco's member groups.</key>
         <key alias="paAdvancedNoGroups">You need to create a membergroup before you can use role-based authentication</key>
         <key alias="paErrorPage">Error Page</key>
         <key alias="paErrorPageHelp">Used when people are logged on, but do not have access</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1215,7 +1215,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     </area>
     <area alias="publicAccess">
         <key alias="paAdvanced">Role based protection</key>
-        <key alias="paAdvancedHelp"><![CDATA[If you wish to control access to the page using role-based authentication,<br /> using Umbraco's member groups.]]></key>
+        <key alias="paAdvancedHelp">If you wish to control access to the page using role-based authentication, using Umbraco's member groups.</key>
         <key alias="paAdvancedNoGroups">You need to create a membergroup before you can use role-based authentication</key>
         <key alias="paErrorPage">Error Page</key>
         <key alias="paErrorPageHelp">Used when people are logged on, but do not have access</key>

--- a/src/Umbraco.Web.UI/umbraco/dialogs/protectPage.aspx
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/protectPage.aspx
@@ -75,15 +75,19 @@
 
 
 <asp:Content ContentPlaceHolderID="body" runat="server">
-    <style> .umb-dialog { overflow: auto; } .umb-dialog-footer { position: relative; }</style>
 
     <input id="tempFile" type="hidden" name="tempFile" runat="server" />
 
-    <cc1:Feedback ID="feedback" runat="server" />
+    <asp:Panel ID="p_feedback" runat="server" Visible="False">
+        <div class="alert alert-success">
+            <asp:Literal runat="server" ID="feedback_text"></asp:Literal>
+        </div>
+        <button class="btn btn-primary" onclick="UmbClientMgr.closeModalWindow()"><%= umbraco.ui.Text("general", "ok")%></button>
+    </asp:Panel>
 
     <asp:Panel ID="p_mode" runat="server" CssClass="pa-umb-overlay">
 
-        <div class="umg-dialog-body">
+        <div class="umb-dialog-body">
 
             <cc1:Pane ID="pane_chooseMode" runat="server" Text="Choose how to restict access to this page">
 
@@ -116,74 +120,72 @@
 
         <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
             <a href="#" class="btn btn-link" onclick="UmbClientMgr.closeModalWindow()"><%=umbraco.ui.Text("cancel")%></a>
-            <asp:Button ID="bt_selectMode" runat="server" Text="select" CssClass="btn btn-primary" OnClick="selectMode" />
+            <asp:Button ID="bt_selectMode" runat="server" CssClass="btn btn-primary" OnClick="selectMode" />
         </div>
     </asp:Panel>
 
+    <asp:Panel ID="p_setup" runat="server" Visible="false" CssClass="pa-umb-overlay">
+        <div class="umb-dialog-body">
+            <cc1:Pane ID="pane_simple" runat="server" Visible="false" Text="Set the login and password for this page" CssClass="pa-umb-overlay">
 
-    <cc1:Pane ID="pane_simple" runat="server" Visible="false" Text="Set the login and password for this page" CssClass="pa-umb-overlay">
-
-        <div class="pa-form">
-            <cc1:PropertyPanel Text="Login" ID="pp_login" runat="server">
-                <asp:TextBox ID="simpleLogin" runat="server" Width="250px"></asp:TextBox>
-                <asp:Label runat="server" ID="SimpleLoginLabel" Visible="False"></asp:Label>
-            </cc1:PropertyPanel>
-        </div>
-
-        <div class="pa-form">
-            <cc1:PropertyPanel Text="Password" ID="pp_pass" runat="server">
-                <asp:TextBox ID="simplePassword" runat="server" Width="250px"></asp:TextBox>
-            </cc1:PropertyPanel>
-        </div>
-
-        <asp:CustomValidator CssClass="alert alert-danger" runat="server" ID="SimpleLoginNameValidator" Display="Dynamic" EnableViewState="False">
-           <p class="alert">Member name already exists, click <asp:LinkButton runat="server" OnClick="ChangeOnClick" CssClass="btn btn-mini btn-warning">Change</asp:LinkButton> to use a different name or Update to continue</p>
-        </asp:CustomValidator>
-    </cc1:Pane>
-
-    <cc1:Pane ID="pane_advanced" runat="server" Visible="false" Text="Role based protection">
-        <cc1:PropertyPanel ID="PropertyPanel3" runat="server">
-            <p><%= umbraco.ui.Text("publicAccess", "paSelectRoles", UmbracoUser)%></p>
-        </cc1:PropertyPanel>
-        <cc1:PropertyPanel ID="PropertyPanel2" runat="server">
-            <asp:PlaceHolder ID="groupsSelector" runat="server"></asp:PlaceHolder>
-        </cc1:PropertyPanel>
-    </cc1:Pane>
-
-    <asp:Panel ID="p_buttons" runat="server" Visible="false" CssClass="pa-umb-overlay">
-        <cc1:Pane runat="server" ID="pane_pages" Text="Select the pages that contain login form and error messages">
-
-            <cc1:PropertyPanel runat="server" ID="pp_loginPage" CssClass="pa-select-pages">
-                <small class="umb-detail">
-                    <%=umbraco.ui.Text("paLoginPageHelp")%>
-                </small>
-                <div class="pa-choose-page">
-                    <asp:PlaceHolder ID="ph_loginpage" runat="server" />
+                <div class="pa-form">
+                    <cc1:PropertyPanel Text="Login" ID="pp_login" runat="server">
+                        <asp:TextBox ID="simpleLogin" runat="server" Width="250px"></asp:TextBox>
+                        <asp:Label runat="server" ID="SimpleLoginLabel" Visible="False"></asp:Label>
+                    </cc1:PropertyPanel>
                 </div>
 
-                <asp:CustomValidator ErrorMessage="Please pick a login page" runat="server" ID="cv_loginPage" ForeColor="Red" />
-            </cc1:PropertyPanel>
-
-
-            <cc1:PropertyPanel runat="server" ID="pp_errorPage" CssClass="pa-select-pages">
-                <small class="umb-detail">
-                    <%=umbraco.ui.Text("paErrorPageHelp")%>
-                </small>
-                <div class="pa-choose-page">
-                    <asp:PlaceHolder ID="ph_errorpage" runat="server" />
+                <div class="pa-form">
+                    <cc1:PropertyPanel Text="Password" ID="pp_pass" runat="server">
+                        <asp:TextBox ID="simplePassword" runat="server" Width="250px"></asp:TextBox>
+                    </cc1:PropertyPanel>
                 </div>
-                <asp:CustomValidator ErrorMessage="Please pick an error page" runat="server" ID="cv_errorPage"  ForeColor="Red" />
-            </cc1:PropertyPanel>
 
-        </cc1:Pane>
+                <asp:CustomValidator CssClass="alert alert-danger" runat="server" ID="SimpleLoginNameValidator" Display="Dynamic" EnableViewState="False">
+                    <p class="alert">Member name already exists, click <asp:LinkButton runat="server" OnClick="ChangeOnClick" CssClass="btn btn-mini btn-warning">Change</asp:LinkButton> to use a different name or Update to continue</p>
+                </asp:CustomValidator>
+            </cc1:Pane>
+
+            <cc1:Pane ID="pane_advanced" runat="server" Visible="false" Text="Role based protection">
+                <cc1:PropertyPanel ID="PropertyPanel3" runat="server">
+                    <p><%= umbraco.ui.Text("publicAccess", "paSelectRoles", UmbracoUser)%></p>
+                </cc1:PropertyPanel>
+                <cc1:PropertyPanel ID="PropertyPanel2" runat="server">
+                    <asp:PlaceHolder ID="groupsSelector" runat="server"></asp:PlaceHolder>
+                </cc1:PropertyPanel>
+            </cc1:Pane>
+
+            <cc1:Pane runat="server" ID="pane_pages" Text="Select the pages that contain login form and error messages">
+
+                <cc1:PropertyPanel runat="server" ID="pp_loginPage" CssClass="pa-select-pages">
+                    <small class="umb-detail">
+                        <%=umbraco.ui.Text("paLoginPageHelp")%>
+                    </small>
+                    <div class="pa-choose-page">
+                        <asp:PlaceHolder ID="ph_loginpage" runat="server" />
+                    </div>
+
+                    <asp:CustomValidator ErrorMessage="Please pick a login page" runat="server" ID="cv_loginPage" ForeColor="Red" />
+                </cc1:PropertyPanel>
 
 
+                <cc1:PropertyPanel runat="server" ID="pp_errorPage" CssClass="pa-select-pages">
+                    <small class="umb-detail">
+                        <%=umbraco.ui.Text("paErrorPageHelp")%>
+                    </small>
+                    <div class="pa-choose-page">
+                        <asp:PlaceHolder ID="ph_errorpage" runat="server" />
+                    </div>
+                    <asp:CustomValidator ErrorMessage="Please pick an error page" runat="server" ID="cv_errorPage"  ForeColor="Red" />
+                </cc1:PropertyPanel>
+
+            </cc1:Pane>
+        </div>
         <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
             <a href="#" class="btn btn-link" onclick="UmbClientMgr.closeModalWindow()"><%=umbraco.ui.Text("cancel")%></a>
             <asp:Button ID="bt_protect" CssClass="btn btn-primary" runat="server" OnCommand="protect_Click"></asp:Button>
             <asp:Button ID="bt_buttonRemoveProtection" CssClass="btn btn-danger" runat="server" Visible="False" OnClick="buttonRemoveProtection_Click" />
         </div>
-
     </asp:Panel>
 
     <input id="errorId" type="hidden" runat="server" /><input id="loginId" type="hidden" runat="server" />

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/controls/dualSelectBox.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/controls/dualSelectBox.cs
@@ -41,6 +41,15 @@ namespace umbraco.controls
 			}
 		}
 
+	    public new int Height
+	    {
+	        set
+	        {
+	            _possibleValues.Height = new Unit(value);
+	            _selectedValues.Height = new Unit(value);
+	        }
+	    }
+
         protected override void CreateChildControls()
         {
             _possibleValues.ID = "posVals";

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/protectPage.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/protectPage.aspx.cs
@@ -41,7 +41,7 @@ namespace umbraco.presentation.umbraco.dialogs
         protected void selectMode(object sender, EventArgs e)
         {
             p_mode.Visible = false;
-            p_buttons.Visible = true;
+            p_setup.Visible = true;
 
             if (rb_simple.Checked)
             {
@@ -124,8 +124,8 @@ namespace umbraco.presentation.umbraco.dialogs
                         bt_protect.CommandName = "advanced";
                     }
 
-                    p_buttons.Visible = true;
                     p_mode.Visible = false;
+                    p_setup.Visible = true;
                 }
             }
 
@@ -160,6 +160,7 @@ namespace umbraco.presentation.umbraco.dialogs
             groupsSelector.Controls.Add(_memberGroups);
 
 
+            bt_selectMode.Text = ui.Text("buttons", "select");
             bt_protect.Text = ui.Text("update");
             bt_buttonRemoveProtection.Text = ui.Text("paRemoveProtection");
 
@@ -266,37 +267,33 @@ namespace umbraco.presentation.umbraco.dialogs
                 }
             }
 
-            feedback.Text = ui.Text("publicAccess", "paIsProtected", new cms.businesslogic.CMSNode(pageId).Text) + "</p><p><a href='#' onclick='" + ClientTools.Scripts.CloseModalWindow() + "'>" + ui.Text("closeThisWindow") + "</a>";
+            feedback_text.Text = ui.Text("publicAccess", "paIsProtected", new cms.businesslogic.CMSNode(pageId).Text);
 
-            p_buttons.Visible = false;
-            pane_advanced.Visible = false;
-            pane_simple.Visible = false;
+            p_setup.Visible = false;
+            p_feedback.Visible = true;
             var content = ApplicationContext.Current.Services.ContentService.GetById(pageId);
             //reloads the current node in the tree
             ClientTools.SyncTree(content.Path, true);
             //reloads the current node's children in the tree
             ClientTools.ReloadActionNode(false, true);
-            feedback.type = global::umbraco.uicontrols.Feedback.feedbacktype.success;
         }
 
 
         protected void buttonRemoveProtection_Click(object sender, System.EventArgs e)
         {
             int pageId = int.Parse(helper.Request("nodeId"));
-            p_buttons.Visible = false;
-            pane_advanced.Visible = false;
-            pane_simple.Visible = false;
+            p_setup.Visible = false;
 
             Access.RemoveProtection(pageId);
 
-            feedback.Text = ui.Text("publicAccess", "paIsRemoved", new cms.businesslogic.CMSNode(pageId).Text) + "</p><p><a href='#' onclick='" + ClientTools.Scripts.CloseModalWindow() + "'>" + ui.Text("closeThisWindow") + "</a>";
+            feedback_text.Text = ui.Text("publicAccess", "paIsRemoved", new cms.businesslogic.CMSNode(pageId).Text);
+            p_feedback.Visible = true;
 
             var content = ApplicationContext.Current.Services.ContentService.GetById(pageId);
             //reloads the current node in the tree
             ClientTools.SyncTree(content.Path, true);
             //reloads the current node's children in the tree
             ClientTools.ReloadActionNode(false, true);
-            feedback.type = global::umbraco.uicontrols.Feedback.feedbacktype.success;
         }
 
         protected CustomValidator SimpleLoginNameValidator;
@@ -312,13 +309,13 @@ namespace umbraco.presentation.umbraco.dialogs
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden tempFile;
 
         /// <summary>
-        /// feedback control.
+        /// p_feedback control.
         /// </summary>
         /// <remarks>
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::umbraco.uicontrols.Feedback feedback;
+        protected global::System.Web.UI.WebControls.Panel p_feedback;
 
         /// <summary>
         /// p_mode control.
@@ -328,6 +325,15 @@ namespace umbraco.presentation.umbraco.dialogs
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Panel p_mode;
+
+        /// <summary>
+        /// p_setup control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel p_setup;
 
         /// <summary>
         /// pane_chooseMode control.
@@ -465,15 +471,6 @@ namespace umbraco.presentation.umbraco.dialogs
         protected global::System.Web.UI.WebControls.PlaceHolder groupsSelector;
 
         /// <summary>
-        /// p_buttons control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.Panel p_buttons;
-
-        /// <summary>
         /// pane_pages control.
         /// </summary>
         /// <remarks>
@@ -580,6 +577,15 @@ namespace umbraco.presentation.umbraco.dialogs
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.PlaceHolder js;
+
+        /// <summary>
+        /// feedback_text control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Literal feedback_text;
 
 
     }

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/protectPage.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/protectPage.aspx.cs
@@ -132,6 +132,7 @@ namespace umbraco.presentation.umbraco.dialogs
             // Load up membergrouops
             _memberGroups.ID = "Membergroups";
             _memberGroups.Width = 175;
+            _memberGroups.Height = 165;
             var selectedGroups = "";
 
             // get roles from the membership provider

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/protectPage.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/protectPage.aspx.cs
@@ -162,7 +162,7 @@ namespace umbraco.presentation.umbraco.dialogs
 
 
             bt_selectMode.Text = ui.Text("buttons", "select");
-            bt_protect.Text = ui.Text("update");
+            bt_protect.Text = ui.Text("save");
             bt_buttonRemoveProtection.Text = ui.Text("paRemoveProtection");
 
             // Put user code to initialize the page here


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR fixes: https://github.com/umbraco/Umbraco-CMS/issues/3193
- [x] I have added steps to test this contribution in the description below

### Description

This fixes some of the more prominent UI issues in the Public access dialog:

![protect after](https://user-images.githubusercontent.com/7405322/46586941-9c819800-ca85-11e8-890b-18e2b47b14fe.gif)

To test, verify that:

1. The button bar aligns at the bottom of the dialog
2. The group boxes are of equal height
3. The confirmation looks ok
4. It's still possible to both add and remove protection 