### PR TITLE
Rollback dialog cleanup

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/modals.less
+++ b/src/Umbraco.Web.UI.Client/src/less/modals.less
@@ -105,6 +105,63 @@
     border-top: 1px solid @purple-l3;
 }
 
+.umb-dialog .propertyItemheader {
+    width: 140px !Important;
+}
+
+.umb-dialog .diffDropdown
+{
+    width:400px;
+}
+
+.umb-dialog .diffPanel {
+    height: 400px;
+}
+
+
+.umb-dialog .diff {
+    margin-top: 10px;
+    height: 100%;
+    overflow: auto;
+    border-top: 1px solid #ccc;
+    border-top: 1px solid #ccc;
+    padding: 5px;
+}
+.umb-dialog .diff table{
+    width:95%;
+    max-width:95%;
+    margin: 0 3px;
+}
+.umb-dialog .diff table th {
+    padding: 5px;
+    width: 25%;
+    border-bottom: 1px solid #ccc;
+}
+
+.umb-dialog .diff table td {
+    border-bottom: 1px solid #ccc;
+    padding: 3px;
+}
+
+.umb-dialog .diff del {
+    background: rgb(255, 230, 230) none repeat scroll 0%;
+    -moz-background-clip: -moz-initial;
+    -moz-background-origin: -moz-initial;
+    -moz-background-inline-policy: -moz-initial;
+}
+
+.umb-dialog .diff ins {
+    background: rgb(230, 255, 230) none repeat scroll 0%;
+    -moz-background-clip: -moz-initial;
+    -moz-background-origin: -moz-initial;
+    -moz-background-inline-policy: -moz-initial;
+}
+
+.umb-dialog .diff .diffnotice {
+    text-align: center;
+    margin-bottom: 10px;
+}
+
 /*we will always make sure to wrap iframe dialogs in proper padding*/
 .umbracoDialog{
 	width: auto !Important;

--- a/src/Umbraco.Web.UI/umbraco/dialogs/rollBack.aspx
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/rollBack.aspx
@@ -13,43 +13,6 @@
         var submitOnEnter = true;
     </script>
 
-    <style type="text/css">
-        .propertyItemheader {
-            width: 140px !Important;
-        }
-
-        .diff {
-            margin-top: 10px;
-            height: 100%;
-            overflow: auto;
-            border-top: 1px solid #efefef;
-            padding: 5px;
-        }
-
-            .diff table td {
-                border-bottom: 1px solid #ccc;
-                padding: 3px;
-            }
-
-            .diff del {
-                background: rgb(255, 230, 230) none repeat scroll 0%;
-                -moz-background-clip: -moz-initial;
-                -moz-background-origin: -moz-initial;
-                -moz-background-inline-policy: -moz-initial;
-            }
-
-            .diff ins {
-                background: rgb(230, 255, 230) none repeat scroll 0%;
-                -moz-background-clip: -moz-initial;
-                -moz-background-origin: -moz-initial;
-                -moz-background-inline-policy: -moz-initial;
-            }
-
-            .diff .diffnotice {
-                text-align: center;
-                margin-bottom: 10px;
-            }
-    </style>
 </asp:Content>
 
 <asp:Content ContentPlaceHolderID="body" runat="server">
@@ -63,7 +26,7 @@
                 <asp:Literal ID="currentVersionTitle" runat="server" />
                 <small>(<asp:Literal ID="currentVersionMeta" runat="server" />)</small></cc1:PropertyPanel>
             <cc1:PropertyPanel ID="pp_rollBackTo" Text="Rollback to" runat="server">
-                <asp:DropDownList OnSelectedIndexChanged="version_load" ID="allVersions" runat="server" Width="400px" AutoPostBack="True" CssClass="guiInputTextTiny" />
+                <asp:DropDownList OnSelectedIndexChanged="version_load" ID="allVersions" runat="server" AutoPostBack="True" CssClass="guiInputTextTiny diffDropdown" />
             </cc1:PropertyPanel>
 
             <cc1:PropertyPanel id="pp_view" Text="View" runat="server">
@@ -76,7 +39,7 @@
             </cc1:PropertyPanel>
         </cc1:Pane>
 
-        <asp:Panel ID="diffPanel" Visible="false" runat="server" Height="300px">
+        <asp:Panel ID="diffPanel" Visible="false" runat="server" CssClass="diffPanel">
             <div class="diff">
                 <div class="diffnotice">
                     <p>
@@ -84,7 +47,7 @@
                     </p>
                 </div>
 
-                <table border="0" style="width: 95%;">
+                <table>
                     <asp:Literal ID="propertiesCompare" runat="server"></asp:Literal>
                 </table>
             </div>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/rollBack.aspx
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/rollBack.aspx
@@ -13,44 +13,7 @@
         var submitOnEnter = true;
     </script>
 
-    <style type="text/css">
-        .propertyItemheader {
-            width: 140px !Important;
-        }
-
-        .diff {
-            margin-top: 10px;
-            height: 100%;
-            overflow: auto;
-            border-top: 1px solid #ccc;
-            border-top: 1px solid #ccc;
-            padding: 5px;
-        }
-
-            .diff table td {
-                border-bottom: 1px solid #ccc;
-                padding: 3px;
-            }
-
-            .diff del {
-                background: rgb(255, 230, 230) none repeat scroll 0%;
-                -moz-background-clip: -moz-initial;
-                -moz-background-origin: -moz-initial;
-                -moz-background-inline-policy: -moz-initial;
-            }
-
-            .diff ins {
-                background: rgb(230, 255, 230) none repeat scroll 0%;
-                -moz-background-clip: -moz-initial;
-                -moz-background-origin: -moz-initial;
-                -moz-background-inline-policy: -moz-initial;
-            }
-
-            .diff .diffnotice {
-                text-align: center;
-                margin-bottom: 10px;
-            }
-    </style>
+    
 </asp:Content>
 
 <asp:Content ContentPlaceHolderID="body" runat="server">

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/rollBack.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dialogs/rollBack.aspx.cs
@@ -34,8 +34,8 @@ namespace umbraco.presentation.dialogs
                 diffPanel.Visible = true;
                 Document rollback = new Document(currentDoc.Id, new Guid(allVersions.SelectedValue));
 
-                propertiesCompare.Text = "<tr><th style='width: 25%;' valign='top'>" + ui.Text("general", "name") + ":</th><td>" + rollback.Text + "</td></tr>";
-                propertiesCompare.Text += "<tr><th style='width: 25%;' valign='top'>" + ui.Text("content", "createDate") + ":</th><td>" + rollback.VersionDate.ToLongDateString() + " " + rollback.VersionDate.ToLongTimeString() + " " + ui.Text("general", "by") + ": " + rollback.Writer.Name + "</td></tr>";
+                propertiesCompare.Text = "<tr><th>" + ui.Text("general", "name") + ":</th><td>" + rollback.Text + "</td></tr>";
+                propertiesCompare.Text += "<tr><th>" + ui.Text("content", "createDate") + ":</th><td>" + rollback.VersionDate.ToLongDateString() + " " + rollback.VersionDate.ToLongTimeString() + " " + ui.Text("general", "by") + ": " + rollback.Writer.Name + "</td></tr>";
 
                 if (rbl_mode.SelectedValue == "diff")
                     lt_notice.Text = ui.Text("rollback", "diffHelp");
@@ -66,14 +66,14 @@ namespace umbraco.presentation.dialogs
 
                                     string cThevalue = library.StripHtml(cP.Value.ToString());
 
-                                    propertiesCompare.Text += "<tr><th style='width: 25%;' valign='top'>" + p.PropertyType.Name + ":</th><td>" + library.ReplaceLineBreaks(cms.businesslogic.utilities.Diff.Diff2Html(cThevalue, thevalue)) + "</td></tr>";
+                                    propertiesCompare.Text += "<tr><th>" + p.PropertyType.Name + ":</th><td>" + library.ReplaceLineBreaks(cms.businesslogic.utilities.Diff.Diff2Html(cThevalue, thevalue)) + "</td></tr>";
 
 
                                 }
                                 else
                                 {
                                     //If no current version of the value... display with no diff.
-                                    propertiesCompare.Text += "<tr><th style='width: 25%;' valign='top'>" + p.PropertyType.Name + ":</th><td>" + thevalue + "</td></tr>";
+                                    propertiesCompare.Text += "<tr><th>" + p.PropertyType.Name + ":</th><td>" + thevalue + "</td></tr>";
                                 }
 
 
@@ -81,7 +81,7 @@ namespace umbraco.presentation.dialogs
                             else
                             {
                                 //If display mode is html
-                                propertiesCompare.Text += "<tr><th style='width: 25%;' valign='top'>" + p.PropertyType.Name + ":</th><td>" + thevalue + "</td></tr>";
+                                propertiesCompare.Text += "<tr><th>" + p.PropertyType.Name + ":</th><td>" + thevalue + "</td></tr>";
                             }
 
                             //previewVersionContent.Controls.Add(new LiteralControl("<div style=\"margin-top: 4px; border: 1px solid #DEDEDE; padding: 4px;\"><p style=\"padding: 0px; margin: 0px;\" class=\"guiDialogNormal\"><b>" + p.PropertyType.Name + "</b><br/>"));


### PR DESCRIPTION
### Prerequisites

- [ ] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3201
- [ ] I have added steps to test this contribution in the description below

### Description
The rollback dialog uses a lot of inline styling. I have removed all of that and moved it to the modals.less stylesheet. There were some styling in the code behind files as well which I have got rid off in a similar fashion.

Furthermore I have extended the bottom border to the table head cell of the diff table as well and improved some padding on the table head cell to make it look nicer and more readable.
**Before**
![image](https://user-images.githubusercontent.com/3941753/46616369-50c90000-cb12-11e8-9dfa-a3f6fef6f53b.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/46616260-0fd0eb80-cb12-11e8-8141-755c1527be47.png)


