### PR TITLE
Issue with "Select editor" modal on document type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-tabs.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-tabs.less
@@ -10,6 +10,6 @@
 .umb-tab-content {
   padding-top: 20px;
   position: relative;
-  top: 22px;
+  top: 31px;
   border-top: 1px solid @purple-l3;
 }


### PR DESCRIPTION
### Prerequisites

- [ ] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is:https://github.com/umbraco/Umbraco-CMS/issues/3207
- [ ] I have added steps to test this contribution in the description below

### Description
The border at the bottom of the Available/Reuse tabs in Select Editor screen looks out of place. 

**Before**
https://github.com/umbraco/Umbraco-CMS/issues/3207
![image](https://user-images.githubusercontent.com/3941753/46637150-c48afd00-cb52-11e8-9c3e-fa40350b5bf3.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/46637163-d2408280-cb52-11e8-986d-9e814aa4a2c1.png)


