### PR TITLE
#3211 - Add colorpicker prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
@@ -42,8 +42,8 @@
     &.with-labels {
 
         .umb-color-box {
-            width: 120px;
-            height: 100%;
+            width: 130px;
+            height: auto;
             display: flex;
             flex-flow: row wrap;
 
@@ -53,15 +53,21 @@
                 flex: 0 0 100%;
                 max-width: 100%;
                 min-height: 80px;
-                padding-top: 10px;
+                padding: 0;
+
+                .check_circle {
+                    margin: 15px auto;
+                }
 
                 .umb-color-box__label {
                     background: #fff;
                     font-size: 14px;
                     display: flex;
                     flex-flow: column wrap;
-                    flex: 0 0 100%;
+                    flex: 1 0 100%;
+                    justify-content: flex-end;
                     padding: 1px 5px;
+                    min-height: 45px;
                     max-width: 100%;
                     margin-top: auto;
                     margin-bottom: -3px;

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -6,7 +6,7 @@
                 <i class="icon icon-check small"></i>
             </div>
             <div class="umb-color-box__label" ng-if="useLabel">
-                <div class="umb-color-box__name truncate">{{ color.label }}</div>
+                <div class="umb-color-box__name truncate">{{ color.label || color.value }}</div>
                 <div class="umb-color-box__description">#{{ color.value }}</div>
             </div>
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.controller.js
@@ -1,0 +1,41 @@
+angular.module("umbraco").controller("Umbraco.PrevalueEditors.ColorPickerController",
+    function ($scope) {
+
+        function toFullHex(hex) {
+            if (hex.length === 4 && hex.charAt(0) === "#") {
+                hex = "#" + hex.charAt(1) + hex.charAt(1) + hex.charAt(2) + hex.charAt(2) + hex.charAt(3) + hex.charAt(3);
+            }
+            return hex.toLowerCase();
+        }
+
+        $scope.isConfigured = $scope.model.prevalues && _.keys($scope.model.prevalues).length > 0;
+
+        $scope.model.items = [];
+
+        // Make an array from the dictionary
+        var items = [];
+
+        if (angular.isArray($scope.model.prevalues)) {
+
+            for (var i in $scope.model.prevalues) {
+                var oldValue = $scope.model.prevalues[i];
+                if (oldValue.hasOwnProperty("value")) {
+                    items.push({
+                        value: toFullHex(oldValue.value),
+                        label: oldValue.label,
+                        id: i
+                    });
+                } else {
+                    items.push({
+                        value: toFullHex(oldValue),
+                        label: oldValue,
+                        id: i
+                    });
+                }
+            }
+
+            // Now make the editor model the array
+            $scope.model.items = items;
+        }
+
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.controller.js
@@ -28,14 +28,16 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.ColorPickerControl
                     continue;
 
                 if (oldValue.hasOwnProperty("value")) {
+                    var hexCode = toFullHex(oldValue.value);
                     items.push({
-                        value: toFullHex(oldValue.value),
+                        value: hexCode.substr(1, hexCode.length),
                         label: oldValue.label,
                         id: i
                     });
                 } else {
+                    var hexCode = toFullHex(oldValue);
                     items.push({
-                        value: toFullHex(oldValue),
+                        value: hexCode.substr(1, hexCode.length),
                         label: oldValue,
                         id: i
                     });

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.controller.js
@@ -23,6 +23,10 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.ColorPickerControl
 
             for (var i in $scope.model.prevalues) {
                 var oldValue = $scope.model.prevalues[i];
+
+                if (!isValidHex(oldValue.value || oldValue))
+                    continue;
+
                 if (oldValue.hasOwnProperty("value")) {
                     items.push({
                         value: toFullHex(oldValue.value),
@@ -48,4 +52,11 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.ColorPickerControl
             }
             return hex.toLowerCase();
         }
+
+        function isValidHex(str) {
+            console.log("str", str);
+            console.log("test", /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(str));
+            return /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(str);
+        }
+
     });

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.controller.js
@@ -1,12 +1,16 @@
 angular.module("umbraco").controller("Umbraco.PrevalueEditors.ColorPickerController",
     function ($scope) {
 
-        function toFullHex(hex) {
-            if (hex.length === 4 && hex.charAt(0) === "#") {
-                hex = "#" + hex.charAt(1) + hex.charAt(1) + hex.charAt(2) + hex.charAt(2) + hex.charAt(3) + hex.charAt(3);
-            }
-            return hex.toLowerCase();
-        }
+        //setup the default config
+        var config = {
+            useLabel: false
+        };
+
+        //map the user config
+        angular.extend(config, $scope.model.config);
+
+        //map back to the model
+        $scope.model.config = config;
 
         $scope.isConfigured = $scope.model.prevalues && _.keys($scope.model.prevalues).length > 0;
 
@@ -38,4 +42,10 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.ColorPickerControl
             $scope.model.items = items;
         }
 
+        function toFullHex(hex) {
+            if (hex.length === 4 && hex.charAt(0) === "#") {
+                hex = "#" + hex.charAt(1) + hex.charAt(1) + hex.charAt(2) + hex.charAt(2) + hex.charAt(3) + hex.charAt(3);
+            }
+            return hex.toLowerCase();
+        }
     });

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.html
@@ -6,7 +6,8 @@
 
     <umb-color-swatches colors="model.items"
                         selected-color="model.value"
-                        size="s">
+                        size="s"
+                        use-label="model.config.useLabel">
     </umb-color-swatches>
 
     {{model.items | json}}

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.html
@@ -1,0 +1,17 @@
+<div ng-controller="Umbraco.PrevalueEditors.ColorPickerController">
+
+    <div ng-if="!isConfigured">
+        <localize key="colorpicker_noColors">You haven't defined any colors</localize>
+    </div>
+
+    <umb-color-swatches colors="model.items"
+                        selected-color="model.value"
+                        size="s">
+    </umb-color-swatches>
+
+    {{model.items | json}}
+    <br /><br />
+    {{model.value}}
+
+    <input type="hidden" name="modelValue" ng-model="model.value" />
+</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3211
- [x] I have added steps to test this contribution in the description below

### Description
This add a colorpicker prevalue editor, which is useful for grid settings/styles and also in prevalues for other property editors.

![image](https://user-images.githubusercontent.com/2919859/46652283-ec09b600-cba2-11e8-92ef-dc6f76194d2d.png)

An example json of the grid editor config in settings:

```
[
  {
    "label": "Background color of row",
    "description": "Choose background color",
    "key": "background-color",
    "view": "colorpicker",
    "applyTo": "row",
    "prevalues": [
      "#D30535",
      {
        "value": "#32CD32"
      },
      "#81E6E0",
      "#109D95",
      "red",
      {
        "label": "White",
        "value": "#fff"
      },
      "#53B3AE",
      {
        "value": "#f00",
        "label": "Red"
      }
    ]
  }
]
```

We could use tinycolor to ensure color values (rgba(a), hex, hsl, hex) are converted to hex codes. Tinycolor has previous been used, but not sure if it has been removed from the project:
https://github.com/umbraco/Umbraco-CMS/blob/7355ba4b235a2ec9ad3cd61262a56673e5cf9ac3/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js#L30

As a minimum I think we should support both 3 digit and 6 digit hex codes.