### PR TITLE
#3214 - umbracoUrlAlias with uppercase characters

### DIFF
--- a/src/Umbraco.Web/Routing/ContentFinderByUrlAlias.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByUrlAlias.cs
@@ -94,18 +94,18 @@ namespace Umbraco.Web.Routing
 					case 0:
 						DescendantDocumentById = "//node [@id={0}]";
 						DescendantDocumentByAlias = "//node[("
-							+ "contains(concat(',',translate(data [@alias='umbracoUrlAlias'], ' ', ''),','),',{0},')"
-							+ " or contains(concat(',',translate(data [@alias='umbracoUrlAlias'], ' ', ''),','),',/{0},')"
-							+ ")]";
+							+ "contains(concat(',',translate(translate(data [@alias='umbracoUrlAlias'], ' ', ''),'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),','),',{0},')"
+                            + " or contains(concat(',',translate(translate(data [@alias='umbracoUrlAlias'], ' ', ''),'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),','),',/{0},')"
+                            + ")]";
 						break;
 
 					// default XML schema as of 4.10
 					case 1:
 						DescendantDocumentById = "//* [@isDoc and @id={0}]";
 						DescendantDocumentByAlias = "//* [@isDoc and ("
-							+ "contains(concat(',',translate(umbracoUrlAlias, ' ', ''),','),',{0},')"
-							+ " or contains(concat(',',translate(umbracoUrlAlias, ' ', ''),','),',/{0},')"
-							+ ")]";
+							+ "contains(concat(',',translate(translate(umbracoUrlAlias, ' ', ''),'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),','),',{0},')"
+                            + " or contains(concat(',',translate(translate(umbracoUrlAlias, ' ', ''),'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),','),',/{0},')"
+                            + ")]";
 						break;
 
 					default:

--- a/src/Umbraco.Web/Routing/ContentFinderByUrlAlias.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByUrlAlias.cs
@@ -54,10 +54,17 @@ namespace Umbraco.Web.Routing
 
             alias = alias.TrimStart('/');
             var xpathBuilder = new StringBuilder();
-            xpathBuilder.Append(XPathStringsDefinition.Root);
+            
 
             if (rootNodeId > 0)
+            {
                 xpathBuilder.AppendFormat(XPathStrings.DescendantDocumentById, rootNodeId);
+            }
+            else
+            {
+                xpathBuilder.Append(XPathStringsDefinition.Root);
+            }
+               
 
             XPathVariable var = null;
             if (alias.Contains('\'') || alias.Contains('"'))
@@ -92,7 +99,7 @@ namespace Umbraco.Web.Routing
 				{
 					// legacy XML schema
 					case 0:
-						DescendantDocumentById = "//node [@id={0}]";
+						DescendantDocumentById = "id({0})";
 						DescendantDocumentByAlias = "//node[("
 							+ "contains(concat(',',translate(translate(data [@alias='umbracoUrlAlias'], ' ', ''),'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),','),',{0},')"
                             + " or contains(concat(',',translate(translate(data [@alias='umbracoUrlAlias'], ' ', ''),'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),','),',/{0},')"
@@ -101,7 +108,7 @@ namespace Umbraco.Web.Routing
 
 					// default XML schema as of 4.10
 					case 1:
-						DescendantDocumentById = "//* [@isDoc and @id={0}]";
+						DescendantDocumentById = "id({0})[@isDoc]";
 						DescendantDocumentByAlias = "//* [@isDoc and ("
 							+ "contains(concat(',',translate(translate(umbracoUrlAlias, ' ', ''),'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),','),',{0},')"
                             + " or contains(concat(',',translate(translate(umbracoUrlAlias, ' ', ''),'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),','),',/{0},')"


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is:  #3214 
- [x] I have added steps to test this contribution in the description below

### Description

Because the request is always lower case in PublishedContentRequest.Uri the xpath didn't find content when the umbracoUrlAlias was entered with capital letters. This PR fixes that and I also optimized the xpath for when a domain is assigned. I used the xpath id function because that is much faster than scanning all id attributes on documents.

For testing this see steps to reproduce in the related issue

Some extra things to keep in mind when testing this 
1. Should be tested with legacy xml (in umbracoSettings.config set UseLegacyXmlSchema to true)
2. Should be tested in a multi site solution with domains assigned


