### PR TITLE
3223 - Minor tweaks and code alignment for the checkbox and color picker styling

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -11,8 +11,7 @@
 }
 
 .umb-toggle:focus .umb-toggle__toggle{
-    outline: 0;
-    box-shadow: 0 0 5px fade(@black, 30%);
+    box-shadow: 0 1px 3px fade(@black, 12%), 0 1px 2px fade(@black, 24%);
 }
 
 .umb-toggle__handler {
@@ -35,6 +34,7 @@
     background: @gray-8;
     border-radius: 90px;
     position: relative;
+    transition: box-shadow .3s;
 }
 
 .umb-toggle--checked .umb-toggle__toggle {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
@@ -4,7 +4,7 @@
 
     .umb-color-box {
         border: 1px solid @gray-8;
-        color: white;
+        color: @white;
         cursor: pointer;
         padding: 1px;
         text-align: center;
@@ -19,7 +19,7 @@
         justify-content: center;
 
         &:hover, &:focus {
-            box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+            box-shadow: 0 1px 3px fade(@black, 12%), 0 1px 2px fade(@black, 24%);
         }
 
         &.active {
@@ -56,7 +56,7 @@
                 padding-top: 10px;
 
                 .umb-color-box__label {
-                    background: #fff;
+                    background: @white;
                     font-size: 14px;
                     display: flex;
                     flex-flow: column wrap;


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3223 
- [x] I have added steps to test this contribution in the description below

### Description
Aligning the box-shadows so the checkbox is using the same box-shadow styling as is being used by the color picker already. I think it makes sense to align them :) - At the same time doing a bit of cleanup in the color-swatches.less file making use of color variables instead of hardcoded color values and also making use of the fade() function in the box-shadow.