### PR TITLE
3225 - Suggestion: Style the default browser radio button as a custom one to provide a nicer UI experience

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -101,6 +101,7 @@
 @import "components/umb-confirm-action.less";
 @import "components/umb-keyboard-shortcuts-overview.less";
 @import "components/umb-checkbox-list.less";
+@import "components/umb-radiobuttons-list.less";
 @import "components/umb-locked-field.less";
 @import "components/umb-tabs.less";
 @import "components/umb-load-indicator.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-radiobuttons-list.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-radiobuttons-list.less
@@ -1,0 +1,70 @@
+.umb-radiobuttons{
+    &__label{
+        position: relative;
+        padding: 0;
+
+        &-text{
+            margin: 0 0 0 32px;
+        }
+    }
+
+    &__input{
+        position: absolute;
+        top: 0;
+        left: 0;
+        opacity: 0;
+
+        &:checked ~ .umb-radiobuttons__state{
+            &:before{
+                width: 100%;
+                height: 100%;
+            }
+        }
+
+        &:checked ~ .umb-radiobuttons__state .umb-radiobuttons__icon{
+            opacity: 1;
+        }
+    }
+
+    &__state{
+        display: flex;
+        flex-wrap: wrap;
+        border: 1px solid @gray-8;
+        border-radius: 100%;
+        width: 22px;
+        height: 22px;
+        position: relative;
+
+        &:before{
+            content: "";
+            background: @green;
+            width: 0;
+            height: 0;
+            transition: .3s ease-out;
+            position: absolute;
+            left: 0;
+            right: 0;
+            top: 0;
+            bottom: 0;
+            margin: auto;
+            border-radius: 100%;
+        }
+    }
+
+    &__icon{
+        color: @white;
+        text-align: center;
+        font-size: 15px;
+        opacity: 0;
+        transition: .3s ease-out;
+
+        &:before{
+            position: absolute;
+            top: 2px;
+            right: 0;
+            left: 0;
+            bottom: 0;
+            margin: auto;
+        }
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-radiobuttons-list.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-radiobuttons-list.less
@@ -16,6 +16,14 @@
         left: 0;
         opacity: 0;
 
+        &:focus ~ .umb-radiobuttons__state{
+            box-shadow: 0 1px 3px fade(@black, 12%), 0 1px 2px fade(@black, 24%);
+        }
+
+        &:focus:checked ~ .umb-radiobuttons__state{
+            box-shadow: none;
+        }
+
         &:checked ~ .umb-radiobuttons__state{
             &:before{
                 width: 100%;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-radiobuttons-list.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-radiobuttons-list.less
@@ -5,6 +5,8 @@
 
         &-text{
             margin: 0 0 0 32px;
+            position: relative;
+            top: 1px;
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-radiobuttons-list.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-radiobuttons-list.less
@@ -50,7 +50,7 @@
             background: @green;
             width: 0;
             height: 0;
-            transition: .3s ease-out;
+            transition: .1s ease-out;
             position: absolute;
             left: 0;
             right: 0;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/radiobuttons/radiobuttons.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/radiobuttons/radiobuttons.html
@@ -1,11 +1,16 @@
 ﻿<div class="umb-editor umb-radiobuttons" ng-controller="Umbraco.PropertyEditors.RadioButtonsController">
     <ul class="unstyled">
         <li ng-repeat="item in model.config.items">
-            <label class="radio">
+            <label class="radio umb-radiobuttons__label">
                 <input type="radio" name="radiobuttons-{{model.alias}}"
                        value="{{item.id}}"
-                       ng-model="model.value" />
-                {{item.value}}
+                       ng-model="model.value"
+                       class="umb-radiobuttons__input" />
+
+                <div class="umb-radiobuttons__state">
+                    <i class="umb-radiobuttons__icon icon-check"></i>
+                    <span class="umb-radiobuttons__label-text">{{item.value}}</span>
+                </div>
             </label>
         </li>
     </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/radiobuttons/radiobuttons.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/radiobuttons/radiobuttons.html
@@ -8,7 +8,7 @@
                        class="umb-radiobuttons__input" />
 
                 <div class="umb-radiobuttons__state">
-                    <i class="umb-radiobuttons__icon icon-check"></i>
+                    <i class="umb-radiobuttons__icon icon-check" aria-hidden="true"></i>
                     <span class="umb-radiobuttons__label-text">{{item.value}}</span>
                 </div>
             </label>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3225 
- [x] I have added steps to test this contribution in the description below

### Description
So since I've been playing around with the checkbox/toggle and helped implement it many places in the backoffice instead of a regular default browser checkbox I thought to myself "Why not make a nice custom radio button too?" - So I did :)

Please note that I currently have not checked the styling in other browsers than Chrome + currently have only focused on the radio button list property editor. And I don't know if it's being used in other places so it's still a little WIP.

The radio button is still accessible since the input element is hidden using opacity: 0; so it reacts when navigating the list using the arrow keys as it normally would.

Currently I need to fix the following

- Add focus a focus state when tabbing to the radio button list so the first item's focus is easy to see

- Add aria-hidden="true" on the <i> element used for the checkmark icon

I'm of course open for feedback on what has currently been made. The before and after gifs can be seen below

**Before**
![default-radio-buttons](https://user-images.githubusercontent.com/1932158/46694993-97038980-cc0e-11e8-9844-3ba821abbecf.gif)

**After**
![custom-radio-buttons](https://user-images.githubusercontent.com/1932158/46694999-9ec32e00-cc0e-11e8-88c6-319f02849b76.gif)

**EDIT:** This one is ready for review by the CPR team or if any other wants to chime in with suggestions - I fixed the focus state and the aria-hidden attribute and a minor alignment issue on the label text that @karltynan pointed out :-) - Also did a quick test of the change in IE11, Edge, Chrome, Firefox on Windows where everything looked fine to me. @nul800sebastiaan 