### PR TITLE
#3229 - Enable email address as macro parameter editor

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/EmailAddressPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/EmailAddressPropertyEditor.cs
@@ -3,7 +3,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.EmailAddressAlias, "Email address", "email", Icon="icon-message")]
+    [PropertyEditor(Constants.PropertyEditors.EmailAddressAlias, "Email address", "email", IsParameterEditor = true, Icon ="icon-message")]
     public class EmailAddressPropertyEditor : PropertyEditor
     {
         protected override PropertyValueEditor CreateValueEditor()

--- a/src/Umbraco.Web/PropertyEditors/EmailAddressPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/EmailAddressPropertyEditor.cs
@@ -3,7 +3,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.EmailAddressAlias, "Email address", "email", IsParameterEditor = true, Icon ="icon-message")]
+    [PropertyEditor(Constants.PropertyEditors.EmailAddressAlias, "Email address", "email", IsParameterEditor = true, Icon="icon-message")]
     public class EmailAddressPropertyEditor : PropertyEditor
     {
         protected override PropertyValueEditor CreateValueEditor()


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3229
- [x] I have added steps to test this contribution in the description below

### Description
This enable Email Address property editor as macro parameter, which could be useful, e.g. if a form is wrapped in a macro and you want to specify the "to" email address.

![image](https://user-images.githubusercontent.com/2919859/46703952-3fbee280-cc29-11e8-97f7-2bbdc60783cd.png)

![image](https://user-images.githubusercontent.com/2919859/46703886-f66e9300-cc28-11e8-8eca-795c5ba3ec4c.png)

![image](https://user-images.githubusercontent.com/2919859/46703899-01c1be80-cc29-11e8-839f-a74b704babf7.png)

