### PR TITLE
Moved the css rules for the rollback modal to a new stylesheet

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -66,6 +66,7 @@
 // Belle styles
 @import "buttons.less";
 @import "forms.less";
+@import "legacydialog.less";
 @import "modals.less";
 @import "panel.less";
 @import "sections.less";

--- a/src/Umbraco.Web.UI.Client/src/less/legacydialog.less
+++ b/src/Umbraco.Web.UI.Client/src/less/legacydialog.less
@@ -1,0 +1,58 @@
+﻿
+.umb-dialog .propertyItemheader {
+    width: 140px !Important;
+}
+
+.umb-dialog .diffDropdown {
+    width: 400px;
+}
+
+.umb-dialog .diffPanel {
+    height: 400px;
+}
+
+
+.umb-dialog .diff {
+    margin-top: 10px;
+    height: 100%;
+    overflow: auto;
+    border-top: 1px solid #ccc;
+    border-top: 1px solid #ccc;
+    padding: 5px;
+}
+
+.umb-dialog .diff table {
+    width: 95%;
+    max-width: 95%;
+    margin: 0 3px;
+}
+
+.umb-dialog .diff table th {
+    padding: 5px;
+    width: 25%;
+    border-bottom: 1px solid #ccc;
+}
+
+.umb-dialog .diff table td {
+    border-bottom: 1px solid #ccc;
+    padding: 3px;
+}
+
+.umb-dialog .diff del {
+    background: rgb(255, 230, 230) none repeat scroll 0%;
+    -moz-background-clip: -moz-initial;
+    -moz-background-origin: -moz-initial;
+    -moz-background-inline-policy: -moz-initial;
+}
+
+.umb-dialog .diff ins {
+    background: rgb(230, 255, 230) none repeat scroll 0%;
+    -moz-background-clip: -moz-initial;
+    -moz-background-origin: -moz-initial;
+    -moz-background-inline-policy: -moz-initial;
+}
+
+.umb-dialog .diff .diffnotice {
+    text-align: center;
+    margin-bottom: 10px;
+}

--- a/src/Umbraco.Web.UI.Client/src/less/modals.less
+++ b/src/Umbraco.Web.UI.Client/src/less/modals.less
@@ -105,63 +105,6 @@
     border-top: 1px solid @purple-l3;
 }
 
-.umb-dialog .propertyItemheader {
-    width: 140px !Important;
-}
-
-.umb-dialog .diffDropdown
-{
-    width:400px;
-}
-
-.umb-dialog .diffPanel {
-    height: 400px;
-}
-
-
-.umb-dialog .diff {
-    margin-top: 10px;
-    height: 100%;
-    overflow: auto;
-    border-top: 1px solid #ccc;
-    border-top: 1px solid #ccc;
-    padding: 5px;
-}
-.umb-dialog .diff table{
-    width:95%;
-    max-width:95%;
-    margin: 0 3px;
-}
-.umb-dialog .diff table th {
-    padding: 5px;
-    width: 25%;
-    border-bottom: 1px solid #ccc;
-}
-
-.umb-dialog .diff table td {
-    border-bottom: 1px solid #ccc;
-    padding: 3px;
-}
-
-.umb-dialog .diff del {
-    background: rgb(255, 230, 230) none repeat scroll 0%;
-    -moz-background-clip: -moz-initial;
-    -moz-background-origin: -moz-initial;
-    -moz-background-inline-policy: -moz-initial;
-}
-
-.umb-dialog .diff ins {
-    background: rgb(230, 255, 230) none repeat scroll 0%;
-    -moz-background-clip: -moz-initial;
-    -moz-background-origin: -moz-initial;
-    -moz-background-inline-policy: -moz-initial;
-}
-
-.umb-dialog .diff .diffnotice {
-    text-align: center;
-    margin-bottom: 10px;
-}
-
 /*we will always make sure to wrap iframe dialogs in proper padding*/
 .umbracoDialog{
 	width: auto !Important;


### PR DESCRIPTION
### Prerequisites

- [ ] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3233
- [ ] I have added steps to test this contribution in the description below

### Description
I have moved the css rules for the rollback modal from [modals.less](https://github.com/umbraco/Umbraco-CMS/blob/13f67a1f4e0dbf70baa02457452f96bee5752735/src/Umbraco.Web.UI.Client/src/less/modals.less) into [legacydialog.less](https://github.com/umbraco/Umbraco-CMS/blob/13f67a1f4e0dbf70baa02457452f96bee5752735/src/Umbraco.Web.UI.Client/src/less/legacydialog.less)
