### PR TITLE
#3246 - Consistency of macro page and other legacy pages

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/developer/Macros/editMacro.aspx
+++ b/src/Umbraco.Web.UI/umbraco/developer/Macros/editMacro.aspx
@@ -158,7 +158,7 @@
                     </td>
                     <td>
                         <asp:RequiredFieldValidator ID="RequiredFieldValidator2" runat="server" ControlToValidate="macroPropertyName" Display="Dynamic" ForeColor="#b94a48">Required<br/></asp:RequiredFieldValidator>
-                        <asp:TextBox runat="server" ID="macroPropertyName" CLASS="-full-width-input" Text='<%#Eval("Name")%>' />
+                        <asp:TextBox runat="server" ID="macroPropertyName" CssClass="-full-width-input" Text='<%#Eval("Name")%>' />
                     </td>
                     <td>
 
@@ -170,10 +170,10 @@
                     <td>
                         <asp:RequiredFieldValidator ID="RequiredFieldValidator6" runat="server" ControlToValidate="macroPropertySortOrder" Display="Dynamic" ForeColor="#b94a48">Required<br/></asp:RequiredFieldValidator>
                          <asp:RegularExpressionValidator ID="RegularExpressionValidator1" runat="server" ControlToValidate="macroPropertySortOrder" Display="Dynamic" ForeColor="#b94a48" ValidationExpression="^\d+$">Numbers only<br/></asp:RegularExpressionValidator>
-                        <asp:TextBox runat="server" ID="macroPropertySortOrder" CLASS="-full-width-input" Text='<%#Eval("SortOrder")%>' />
+                        <asp:TextBox runat="server" ID="macroPropertySortOrder" CssClass="-full-width-input" Text='<%#Eval("SortOrder")%>' />
                     </td>
                     <td>
-                        <asp:Button OnClick="deleteMacroProperty" ID="delete" Text="Delete" runat="server" CssClass="btn btn-default delete-button" />
+                        <asp:Button OnClick="deleteMacroProperty" ID="delete" Text="Delete" runat="server" CssClass="btn btn-default btn-danger delete-button" />
                     </td>
                 </tr>
             </ItemTemplate>
@@ -181,11 +181,11 @@
                         <tr>
                             <td>
                                 <asp:RequiredFieldValidator ID="RequiredFieldValidator1" EnableViewState="false" Enabled="false" EnableClientScript="false" runat="server" ControlToValidate="macroPropertyAliasNew" Display="Dynamic" ForeColor="#b94a48">Required<br/></asp:RequiredFieldValidator>
-                                <asp:TextBox runat="server" ID="macroPropertyAliasNew" CLASS="-full-width-input" PlaceHolder='New Alias'  />
+                                <asp:TextBox runat="server" ID="macroPropertyAliasNew" CssClass="-full-width-input" PlaceHolder='New Alias'  />
                             </td>
                             <td>
                                 <asp:RequiredFieldValidator ID="RequiredFieldValidator4" EnableViewState="false" Enabled="false" EnableClientScript="false" runat="server" ControlToValidate="macroPropertyNameNew" Display="Dynamic" ForeColor="#b94a48">Required<br/></asp:RequiredFieldValidator>
-                                <asp:TextBox runat="server" ID="macroPropertyNameNew" CLASS="-full-width-input" PlaceHolder='New Name' />
+                                <asp:TextBox runat="server" ID="macroPropertyNameNew" CssClass="-full-width-input" PlaceHolder='New Name' />
                             </td>
                             <td>
                                 <asp:RequiredFieldValidator ID="RequiredFieldValidator5" EnableViewState="false" Enabled="false" EnableClientScript="false" runat="server" ControlToValidate="macroPropertyTypeNew" Display="Dynamic" ForeColor="#b94a48">Required<br/></asp:RequiredFieldValidator>
@@ -199,7 +199,7 @@
                                 <%-- The macro parameter will automatically get sort order when created. --%>
                             </td>
                             <td>
-                                <asp:Button ID="createNew" Text="Add" runat="server" CssClass="btn btn-default add-button" OnClick="macroPropertyCreate" />
+                                <asp:Button ID="createNew" Text="Add" runat="server" CssClass="btn btn-default btn-info add-button" OnClick="macroPropertyCreate" />
                             </td>
                         </tr>
                 </tbody>

--- a/src/Umbraco.Web.UI/umbraco/developer/Macros/editMacro.aspx
+++ b/src/Umbraco.Web.UI/umbraco/developer/Macros/editMacro.aspx
@@ -113,7 +113,7 @@
     <cc1:Pane ID="Pane1_4" runat="server" Title="Cache settings">
 
         <cc1:PropertyPanel runat="server" Text="Cache period">
-            <asp:TextBox ID="cachePeriod" runat="server" CssClass="guiInputText input-small"></asp:TextBox>&nbsp;Seconds
+            <asp:TextBox ID="cachePeriod" runat="server" CssClass="guiInputText input-small" type="number" min="0"></asp:TextBox>&nbsp;Seconds
         </cc1:PropertyPanel>
 
         <cc1:PropertyPanel runat="server" Text="Cache by page">
@@ -170,7 +170,7 @@
                     <td>
                         <asp:RequiredFieldValidator ID="RequiredFieldValidator6" runat="server" ControlToValidate="macroPropertySortOrder" Display="Dynamic" ForeColor="#b94a48">Required<br/></asp:RequiredFieldValidator>
                          <asp:RegularExpressionValidator ID="RegularExpressionValidator1" runat="server" ControlToValidate="macroPropertySortOrder" Display="Dynamic" ForeColor="#b94a48" ValidationExpression="^\d+$">Numbers only<br/></asp:RegularExpressionValidator>
-                        <asp:TextBox runat="server" ID="macroPropertySortOrder" CssClass="-full-width-input" Text='<%#Eval("SortOrder")%>' />
+                        <asp:TextBox runat="server" ID="macroPropertySortOrder" CssClass="-full-width-input" Text='<%#Eval("SortOrder")%>' type="number" />
                     </td>
                     <td>
                         <asp:Button OnClick="deleteMacroProperty" ID="delete" Text="Delete" runat="server" CssClass="btn btn-default btn-danger delete-button" />

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/EditRelationType.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/EditRelationType.aspx.cs
@@ -192,10 +192,10 @@ namespace umbraco.cms.presentation.developer.RelationTypes
 			relationTypeTabPage.Controls.Add(this.objectTypePane);
 
 			var saveMenuImageButton =  tabControl.Menu.NewButton();
-			saveMenuImageButton.ToolTip = "save relation type";
 			saveMenuImageButton.Click +=saveMenuImageButton_Click;
 			saveMenuImageButton.CausesValidation = true;
             saveMenuImageButton.Text = ui.Text("save");
+            saveMenuImageButton.CssClass = "btn btn-primary";
 			saveMenuImageButton.ValidationGroup = "RelationType";
 
 			var relationsTabPage = this.tabControl.NewTabPage("Relations");

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/EditRelationType.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/EditRelationType.aspx.cs
@@ -4,6 +4,7 @@ using System.Web.UI;
 using System.Web.UI.WebControls;
 using umbraco.BasePages;
 using umbraco.BusinessLogic;
+using umbraco.uicontrols;
 using Umbraco.Core;
 using Umbraco.Core.Models;
 using RelationType = umbraco.cms.businesslogic.relation.RelationType;
@@ -191,14 +192,15 @@ namespace umbraco.cms.presentation.developer.RelationTypes
 			relationTypeTabPage.Controls.Add(this.directionPane);
 			relationTypeTabPage.Controls.Add(this.objectTypePane);
 
-			var saveMenuImageButton =  tabControl.Menu.NewButton();
-			saveMenuImageButton.Click +=saveMenuImageButton_Click;
-			saveMenuImageButton.CausesValidation = true;
-            saveMenuImageButton.Text = ui.Text("save");
-            saveMenuImageButton.CssClass = "btn btn-primary";
-			saveMenuImageButton.ValidationGroup = "RelationType";
+			var save =  tabControl.Menu.NewButton();
+            save.Click +=saveMenuImageButton_Click;
+            save.CausesValidation = true;
+            save.Text = ui.Text("save");
+            save.ButtonType = MenuButtonType.Primary;
+            save.ID = "save";
+            save.ValidationGroup = "RelationType";
 
-			var relationsTabPage = this.tabControl.NewTabPage("Relations");
+            var relationsTabPage = this.tabControl.NewTabPage("Relations");
 			relationsTabPage.Controls.Add(this.relationsCountPane);
 			relationsTabPage.Controls.Add(this.relationsPane);
 

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Xslt/editXslt.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Xslt/editXslt.aspx.cs
@@ -38,9 +38,6 @@ namespace umbraco.cms.presentation.developer
 					.SetActiveTreeType(Constants.Trees.Xslt)
 					.SyncTree(path, false);
 			}
-
-
-
 		}
 
 		protected override void OnInit(EventArgs e)

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Xslt/editXslt.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/Xslt/editXslt.aspx.cs
@@ -48,7 +48,6 @@ namespace umbraco.cms.presentation.developer
 			base.OnInit(e);
 
             SaveButton = UmbracoPanel1.Menu.NewButton();
-            SaveButton.ToolTip = "Save Xslt File";
             SaveButton.Text = ui.Text("save");
             SaveButton.ButtonType = MenuButtonType.Primary;
             SaveButton.ID = "save";

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/editLanguage.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/editLanguage.aspx.cs
@@ -83,7 +83,6 @@ namespace umbraco.settings
 			Panel1.hasMenu = true;
 			var save = Panel1.Menu.NewButton();
 			save.Click += save_click;
-			save.ToolTip = ui.Text("save");
             save.Text = ui.Text("save");
 		    save.ID = "save";
             save.ButtonType = uicontrols.MenuButtonType.Primary;

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/settings/editLanguage.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/settings/editLanguage.aspx.cs
@@ -12,6 +12,7 @@ using System.Web.UI.HtmlControls;
 using umbraco.cms.presentation.Trees;
 using Umbraco.Core;
 using Umbraco.Web.Trees;
+using umbraco.uicontrols;
 
 namespace umbraco.settings
 {
@@ -84,8 +85,8 @@ namespace umbraco.settings
 			var save = Panel1.Menu.NewButton();
 			save.Click += save_click;
             save.Text = ui.Text("save");
-		    save.ID = "save";
-            save.ButtonType = uicontrols.MenuButtonType.Primary;
+            save.ButtonType = MenuButtonType.Primary;
+            save.ID = "save";         
 	
 			Panel1.Text = ui.Text("language", "editLanguage");
 


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3246
- [x] I have added steps to test this contribution in the description below

### Description
I have updated the delete and add button style on macro page. Furthermore I have updated the "Save" button on a few pages to be consistent and without tooltip (since it isn't used on other primary or secondary buttons in backoffice UI). I have also updated the macro sortorder input and cache input fields to be numeric fields.

![image](https://user-images.githubusercontent.com/2919859/46768082-62afcc00-cce7-11e8-82e9-4c7c9f2c4172.png)

![image](https://user-images.githubusercontent.com/2919859/46768161-7f4c0400-cce7-11e8-9f02-eb3b2028deb5.png)

