### PR TITLE
Fix color swatches title when using css classes for colors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -1,6 +1,6 @@
 ﻿<div class="umb-color-swatches" ng-class="{ 'with-labels': useLabel }">
 
-    <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{useLabel ? color.label : '#' + color.value}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': color.value === selectedColor }" ng-click="setColor(color.value)">
+    <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{useLabel || useColorClass ? (color.label || color.value) : ('#' + color.value)}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': color.value === selectedColor }" ng-click="setColor(color.value)">
         <div class="umb-color-box-inner">
             <div class="check_circle">
                 <i class="icon icon-check small"></i>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is:
- [x] I have added steps to test this contribution in the description below

### Description
This is a small fix, so tooltip title are shown correct when using css classes for colors, e.g. in document type icon picker. Before it was showing a tooltip title `#color-blue`.

![image](https://user-images.githubusercontent.com/2919859/46770332-27190000-ccef-11e8-945a-829d829a5afd.png)