### PR TITLE
Disable move/copy button until a target node is selected

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/copy.html
@@ -83,7 +83,7 @@
     </div>
 
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
+        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-show="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
         <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy || !target">

--- a/src/Umbraco.Web.UI.Client/src/views/content/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/copy.html
@@ -86,7 +86,7 @@
         <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
-        <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy">
+        <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy || !target">
             <localize key="actions_copy">Copy</localize>
         </button>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/move.html
@@ -76,7 +76,7 @@
         <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
-        <button class="btn btn-primary" ng-click="move()" ng-disabled="busy">
+        <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target">
             <localize key="actions_move">Move</localize>
         </button>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/move.html
@@ -73,7 +73,7 @@
 
 
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
+        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-show="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
         <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target">

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/move.html
@@ -40,7 +40,7 @@
     </div>
 
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
+        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-show="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
         <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target">

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/move.html
@@ -43,7 +43,7 @@
         <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
-        <button class="btn btn-primary" ng-click="move()" ng-disabled="busy">
+        <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target">
             <localize key="actions_move">Move</localize>
         </button>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
@@ -41,7 +41,7 @@
     </div>
 
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
+        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-show="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
         <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy || !target">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
@@ -44,7 +44,7 @@
         <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
-        <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy">
+        <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy || !target">
             <localize key="actions_copy">Copy</localize>
         </button>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
@@ -41,7 +41,7 @@
     </div>
 
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
+        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-show="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
         <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
@@ -44,7 +44,7 @@
         <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
-        <button class="btn btn-primary" ng-click="move()" ng-disabled="busy">
+        <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target">
             <localize key="actions_move">Move</localize>
         </button>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.move.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.move.controller.js
@@ -49,8 +49,10 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
 	    $scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
 
 	    $scope.move = function () {
+	        $scope.busy = true;
 	        mediaResource.move({ parentId: $scope.target.id, id: node.id })
                 .then(function (path) {
+	                $scope.busy = false;
                     $scope.error = false;
                     $scope.success = true;
 

--- a/src/Umbraco.Web.UI.Client/src/views/media/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/move.html
@@ -49,7 +49,7 @@
     </div>
 
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-	    <a class="btn btn-link" ng-click="nav.hideDialog()"><localize key="general_cancel">Cancel</localize></a>
-	    <button class="btn btn-primary" ng-click="move()"><localize key="actions_move">Move</localize></button>
+	    <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy"><localize key="general_cancel">Cancel</localize></a>
+	    <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target"><localize key="actions_move">Move</localize></button>
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/move.html
@@ -49,7 +49,7 @@
     </div>
 
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-	    <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy"><localize key="general_cancel">Cancel</localize></a>
+	    <a class="btn btn-link" ng-click="nav.hideDialog()" ng-show="!busy"><localize key="general_cancel">Cancel</localize></a>
 	    <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target"><localize key="actions_move">Move</localize></button>
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
@@ -41,7 +41,7 @@
     </div>
 
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
+        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-show="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
         <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy || !target">

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
@@ -44,7 +44,7 @@
         <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
-        <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy">
+        <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy || !target">
             <localize key="actions_copy">Copy</localize>
         </button>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
@@ -40,7 +40,7 @@
     </div>
 
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
+        <a class="btn btn-link" ng-click="nav.hideDialog()" ng-show="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
         <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target">

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
@@ -43,7 +43,7 @@
         <a class="btn btn-link" ng-click="nav.hideDialog()" ng-if="!busy">
             <localize key="general_cancel">Cancel</localize>
         </a>
-        <button class="btn btn-primary" ng-click="move()" ng-disabled="busy">
+        <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target">
             <localize key="actions_move">Move</localize>
         </button>
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3241
- [x] I have added steps to test this contribution in the description below

### Description

#3241 describes the issue, although only for copying document types. The same issue is present quite a few other places as well. Here's the list of places I've found (and fixed with this PR):

- Content move/copy
- Media move
- Document types move/copy
- Media types move/copy
- Data types move

To test:

1. Perform each of the actions in the list above
2. Verify that the "move" or "copy" button is disabled in the action dialog until a target node is selected
