### PR TITLE
Style confirmations and alerts consistently across all sections (#3251)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/move.html
@@ -12,12 +12,16 @@
             </div>
 
             <div ng-show="error">
-                <h5 class="text-error">{{error.errorMsg}}</h5>
-                <p class="text-error">{{error.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
             </div>
 
             <div ng-show="success">
-                <h5 class="text-success"><strong>{{currentNode.name}}</strong> <localize key="editdatatype_wasMoved">was moved underneath</localize>&nbsp;<strong>{{target.name}}</strong></h5>
+                <div class="alert alert-success">
+                    <strong>{{currentNode.name}}</strong> <localize key="editdatatype_wasMoved">was moved underneath</localize>&nbsp;<strong>{{target.name}}</strong>
+                </div>
                 <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/rename.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/rename.html
@@ -7,8 +7,10 @@
               val-form-manager>
 
             <div ng-show="error">
-                <h5 class="text-error">{{error.errorMsg}}</h5>
-                <p class="text-error">{{error.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
             </div>
 
             <umb-control-group label="@renamecontainer_enterNewFolderName" hide-label="false">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
@@ -12,13 +12,16 @@
             </div>
 
             <div ng-show="error">
-                <h5 class="text-error">{{error.errorMsg}}</h5>
-                <p class="text-error">{{error.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
             </div>
 
             <div ng-show="success">
-                <h5 class="text-success">
-                    <strong>{{currentNode.name}}</strong> <localize key="contentTypeEditor_copiedUnderneath">was copied underneath</localize>&nbsp;<strong>{{target.name}}</strong></h5>
+                <div class="alert alert-success">
+                    <strong>{{currentNode.name}}</strong> <localize key="contentTypeEditor_copiedUnderneath">was copied underneath</localize>&nbsp;<strong>{{target.name}}</strong>
+                </div>
                 <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -50,8 +50,10 @@
               val-form-manager>
 
             <div ng-show="error">
-                <h5 class="text-error">{{error.errorMsg}}</h5>
-                <p class="text-error">{{error.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
             </div>
 
             <umb-control-group label="Enter a folder name" hide-label="false">
@@ -74,8 +76,10 @@
               val-form-manager>
 
             <div ng-show="error">
-                <h5 class="text-error">{{error.errorMsg}}</h5>
-                <p class="text-error">{{error.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
             </div>
 
             <umb-control-group label="Name of the Parent Document Type" hide-label="false">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
@@ -12,13 +12,16 @@
             </div>
 
             <div ng-show="error">
-                <h5 class="text-error">{{error.errorMsg}}</h5>
-                <p class="text-error">{{error.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
             </div>
 
             <div ng-show="success">
-                <h5 class="text-success">
-                    <strong>{{currentNode.name}}</strong> <localize key="contentTypeEditor_movedUnderneath">was moved underneath</localize>&nbsp;<strong>{{target.name}}</strong></h5>
+                <div class="alert alert-success">
+                    <strong>{{currentNode.name}}</strong> <localize key="contentTypeEditor_movedUnderneath">was moved underneath</localize>&nbsp;<strong>{{target.name}}</strong>
+                </div>
                 <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/rename.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/rename.html
@@ -6,8 +6,10 @@
               val-form-manager>
 
             <div ng-show="error">
-                <h5 class="text-error">{{error.errorMsg}}</h5>
-                <p class="text-error">{{error.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
             </div>
 
             <umb-control-group label="@renamecontainer_enterNewFolderName" hide-label="false">

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
@@ -12,13 +12,16 @@
             </div>
 
             <div ng-show="error">
-                <h5 class="text-error">{{error.errorMsg}}</h5>
-                <p class="text-error">{{error.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
             </div>
 
             <div ng-show="success">
-                <h5 class="text-success">
-                    <strong>{{currentNode.name}}</strong> <localize key="contentTypeEditor_copiedUnderneath">was copied underneath</localize>&nbsp;<strong>{{target.name}}</strong></h5>
+                <div class="alert alert-success">
+                    <strong>{{currentNode.name}}</strong> <localize key="contentTypeEditor_copiedUnderneath">was copied underneath</localize>&nbsp;<strong>{{target.name}}</strong>
+                </div>
                 <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
@@ -12,12 +12,16 @@
             </div>
 
             <div ng-show="error">
-                <h5 class="text-error">{{error.errorMsg}}</h5>
-                <p class="text-error">{{error.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
             </div>
 
             <div ng-show="success">
-                <h5 class="text-success"><strong>{{currentNode.name}}</strong> <localize key="contentTypeEditor_movedUnderneath">was moved underneath</localize>&nbsp;<strong>{{target.name}}</strong></h5>
+                <div class="alert alert-success">
+                    <strong>{{currentNode.name}}</strong> <localize key="contentTypeEditor_movedUnderneath">was moved underneath</localize>&nbsp;<strong>{{target.name}}</strong>
+                </div>
                 <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/rename.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/rename.html
@@ -6,8 +6,10 @@
               val-form-manager>
 
             <div ng-show="error">
-                <h5 class="text-error">{{error.errorMsg}}</h5>
-                <p class="text-error">{{error.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
             </div>
 
             <umb-control-group label="@renamecontainer_enterNewFolderName" hide-label="false">

--- a/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/create.html
@@ -61,8 +61,10 @@
                     val-form-manager>
 
                 <div ng-show="vm.createFolderError">
-                    <h5 class="text-error">{{vm.createFolderError.errorMsg}}</h5>
-                    <p class="text-error">{{vm.createFolderError.data.message}}</p>
+                    <div class="alert alert-error">
+                        <div><strong>{{vm.createFolderError.errorMsg}}</strong></div>
+                        <div>{{vm.createFolderError.data.message}}</div>
+                    </div>
                 </div>
 
                 <umb-control-group label="Enter a folder name" hide-label="false">

--- a/src/Umbraco.Web.UI.Client/src/views/partialviews/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviews/create.html
@@ -51,8 +51,10 @@
                     val-form-manager>
                 
                 <div ng-show="vm.createFolderError">
-                    <h5 class="text-error">{{vm.createFolderError.errorMsg}}</h5>
-                    <p class="text-error">{{vm.createFolderError.data.message}}</p>
+                    <div class="alert alert-error">
+                        <div><strong>{{vm.createFolderError.errorMsg}}</strong></div>
+                        <div>{{vm.createFolderError.data.message}}</div>
+                    </div>
                 </div>
 
                 <umb-control-group label="Enter a folder name" hide-label="false">

--- a/src/Umbraco.Web.UI.Client/src/views/scripts/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/scripts/create.html
@@ -26,8 +26,10 @@
               val-form-manager>
             
             <div ng-show="vm.createFolderError">
-                <h5 class="text-error">{{vm.createFolderError.errorMsg}}</h5>
-                <p class="text-error">{{vm.createFolderError.data.message}}</p>
+                <div class="alert alert-error">
+                    <div><strong>{{vm.createFolderError.errorMsg}}</strong></div>
+                    <div>{{vm.createFolderError.data.message}}</div>
+                </div>
             </div>
 
             <umb-control-group label="Enter a folder name" hide-label="false">


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3251
- [x] I have added steps to test this contribution in the description below

### Description

As described in #3251 the confirmations and alerts in the settings and developer sections are in need of some styling updates.

The following have been restyled and should be tested:

1. Data type move
2. Data type rename (folder)
3. Document type copy
4. Document type move
5. Document type create (folder)
6. Document type rename (folder)
7. Media types copy
8. Media types move
9. Media types rename (folder)

Partial views create (folder), partial view macros create (folder) and scripts create (folder) have also been restyled for code base consistency, but these are currently not testable, because the creation of the same folder twice doesn't yield an error.