### PR TITLE
Update datepickerController to add onValueChanged function

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -38,6 +38,22 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
     };
     $(document).bind("click", $scope.hidePicker);
 
+    //here we declare a special method which will be called whenever the value has changed from the server
+    //this is instead of doing a watch on the model.value = faster
+    $scope.model.onValueChanged = function (newVal, oldVal) {
+        if (newVal != oldVal) {
+            //check for c# System.DateTime.MinValue being passed as the clear indicator
+            var minDate = moment('0001-01-01');
+            var newDate = moment(newVal);
+
+            if (newDate.isAfter(minDate)) {
+                applyDate({ date: moment(newVal) });
+            } else {
+                $scope.clearDate();
+            }
+        }
+    };
+    
     //handles the date changing via the api
     function applyDate(e) {
         angularHelper.safeApply($scope, function() {


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3254

### Description
adding onValueChanged method to capture serverside Model Changes, clearing flag using c# System.DateTime.MinValue.
https://github.com/umbraco/Umbraco-CMS/issues/3254

Steps to reproduce
Add a DateTimePicker Property to Member or Content DataType, add a saving/saved event handler and add code to set the property - overwriting the submitted datetime value
Try and save Member or Content Node with a value in the datetimepicker property.

Expected result
DateTimePicker is updated with the value set in the saving/saved event
