### PR TITLE
Allow video feeds to load over HTTPS + fix a few feeds

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/media/mediadashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/media/mediadashboardvideos.html
@@ -1,11 +1,11 @@
 <h3>Hours of Umbraco training videos are only a click away</h3>
 <p>Want to master Umbraco? Spend a couple of minutes learning some best practices by watching one of these videos about using Umbraco. And visit <a href="http://umbraco.tv" target="_blank">umbraco.tv</a> for even more Umbraco videos</p>
 
-<h4>To get you started:</h4>
 <div class="row-fluid" 
-	ng-init="init('http://umbraco.tv/videos/implementor/chapterrss?sort=no')" 
+	ng-init="init('https://umbraco.tv/videos/implementor/chapterrss?sort=no')" 
 	ng-controller="Umbraco.Dashboard.StartupVideosController">
 
+    <h4 ng-if="videos.length">To get you started:</h4>
 	<ul class="thumbnails" >
 		<li class="span2" ng-repeat="video in videos">
 	    	<div class="thumbnail" style="margin-right: 20px">

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/media/mediadashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/media/mediadashboardvideos.html
@@ -5,14 +5,16 @@
 	ng-init="init('https://umbraco.tv/videos/implementor/chapterrss?sort=no')" 
 	ng-controller="Umbraco.Dashboard.StartupVideosController">
 
-    <h4 ng-if="videos.length">To get you started:</h4>
-	<ul class="thumbnails" >
-		<li class="span2" ng-repeat="video in videos">
-	    	<div class="thumbnail" style="margin-right: 20px">
-		    	<a target="_blank" href="{{video.link}}" title="{{video.title}}">
-		    		<img ng-src="{{video.thumbnail}}"  alt="{{video.title}}">
-		    	</a>
-	    	</div>
-	    </li>
-	</ul>
+    <div ng-if="videos.length">
+        <h4>To get you started:</h4>
+        <ul class="thumbnails" >
+            <li class="span2" ng-repeat="video in videos">
+                <div class="thumbnail" style="margin-right: 20px">
+                    <a target="_blank" href="{{video.link}}" title="{{video.title}}">
+                        <img ng-src="{{video.thumbnail}}"  alt="{{video.title}}">
+                    </a>
+                </div>
+            </li>
+        </ul>
+    </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/media/mediadashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/media/mediadashboardvideos.html
@@ -5,7 +5,7 @@
 	ng-init="init('https://umbraco.tv/videos/implementor/chapterrss?sort=no')" 
 	ng-controller="Umbraco.Dashboard.StartupVideosController">
 
-    <div ng-if="videos.length">
+    <div ng-show="videos.length">
         <h4>To get you started:</h4>
         <ul class="thumbnails" >
             <li class="span2" ng-repeat="video in videos">

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
@@ -5,14 +5,16 @@
 	ng-init="init('https://umbraco.com/feeds/videos/members')" 
 	ng-controller="Umbraco.Dashboard.StartupVideosController">
 
-    <h4 ng-if="videos.length">To get you started:</h4>
-	<ul class="thumbnails" >
-		<li class="span2" ng-repeat="video in videos">
-	    	<div class="thumbnail" style="margin-right: 20px">
-		    	<a target="_blank" href="{{video.link}}" title="{{video.title}}">
-		    		<img ng-src="{{video.thumbnail}}"  alt="{{video.title}}">
-		    	</a>
-	    	</div>
-	    </li>
-	</ul>
+    <div ng-if="videos.length">
+        <h4>To get you started:</h4>
+        <ul class="thumbnails" >
+            <li class="span2" ng-repeat="video in videos">
+                <div class="thumbnail" style="margin-right: 20px">
+                    <a target="_blank" href="{{video.link}}" title="{{video.title}}">
+                        <img ng-src="{{video.thumbnail}}"  alt="{{video.title}}">
+                    </a>
+                </div>
+            </li>
+        </ul>
+    </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
@@ -1,11 +1,11 @@
 <h3>Hours of Umbraco training videos are only a click away</h3>
 <p>Want to master Umbraco? Spend a couple of minutes learning some best practices by watching one of these videos about using Umbraco. And visit <a href="https://umbraco.tv" target="_blank">umbraco.tv</a> for even more Umbraco videos</p>
 
-<h4>To get you started:</h4>
 <div class="row-fluid" 
-	ng-init="init('https://www.umbraco.com/feeds/videos/members')" 
+	ng-init="init('https://umbraco.com/feeds/videos/members')" 
 	ng-controller="Umbraco.Dashboard.StartupVideosController">
 
+    <h4 ng-if="videos.length">To get you started:</h4>
 	<ul class="thumbnails" >
 		<li class="span2" ng-repeat="video in videos">
 	    	<div class="thumbnail" style="margin-right: 20px">

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
@@ -5,7 +5,7 @@
 	ng-init="init('https://umbraco.com/feeds/videos/members')" 
 	ng-controller="Umbraco.Dashboard.StartupVideosController">
 
-    <div ng-if="videos.length">
+    <div ng-show="videos.length">
         <h4>To get you started:</h4>
         <ul class="thumbnails" >
             <li class="span2" ng-repeat="video in videos">

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardvideos.html
@@ -1,11 +1,11 @@
 <h3>Hours of Umbraco training videos are only a click away</h3>
 <p>Want to master Umbraco? Spend a couple of minutes learning some best practices by watching one of these videos about using Umbraco. And visit <a href="http://umbraco.tv" target="_blank">umbraco.tv</a> for even more Umbraco videos</p>
 
-<h4>To get you started:</h4>
 <div class="row-fluid" 
-	ng-init="init('http://umbraco.tv/videos/implementor/chapterrss?sort=no')" 
+	ng-init="init('https://umbraco.tv/videos/implementor/chapterrss?sort=no')" 
 	ng-controller="Umbraco.Dashboard.StartupVideosController">
 
+    <h4 ng-if="videos.length">To get you started:</h4>
 	<ul class="thumbnails" >
 		<li class="span2" ng-repeat="video in videos">
 	    	<div class="thumbnail" style="margin-right: 20px">

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardvideos.html
@@ -5,14 +5,16 @@
 	ng-init="init('https://umbraco.tv/videos/implementor/chapterrss?sort=no')" 
 	ng-controller="Umbraco.Dashboard.StartupVideosController">
 
-    <h4 ng-if="videos.length">To get you started:</h4>
-	<ul class="thumbnails" >
-		<li class="span2" ng-repeat="video in videos">
-	    	<div class="thumbnail" style="margin-right: 20px">
-		    	<a target="_blank" href="{{video.link}}" title="{{video.title}}">
-		    		<img ng-src="{{video.thumbnail}}"  alt="{{video.title}}">
-		    	</a>
-	    	</div>
-	    </li>
-	</ul>
+    <div ng-if="videos.length">
+        <h4>To get you started:</h4>
+        <ul class="thumbnails" >
+            <li class="span2" ng-repeat="video in videos">
+                <div class="thumbnail" style="margin-right: 20px">
+                    <a target="_blank" href="{{video.link}}" title="{{video.title}}">
+                        <img ng-src="{{video.thumbnail}}"  alt="{{video.title}}">
+                    </a>
+                </div>
+            </li>
+        </ul>
+    </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardvideos.html
@@ -5,7 +5,7 @@
 	ng-init="init('https://umbraco.tv/videos/implementor/chapterrss?sort=no')" 
 	ng-controller="Umbraco.Dashboard.StartupVideosController">
 
-    <div ng-if="videos.length">
+    <div ng-show="videos.length">
         <h4>To get you started:</h4>
         <ul class="thumbnails" >
             <li class="span2" ng-repeat="video in videos">

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/dashboard/FeedProxy.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/dashboard/FeedProxy.aspx.cs
@@ -30,7 +30,7 @@ namespace dashboardUtilities
                     return;
 
                 var feedProxyXml = XmlHelper.OpenAsXmlDocument(IOHelper.MapPath(SystemFiles.FeedProxyConfig));
-                if (feedProxyXml?.SelectSingleNode($"//allow[@host = '{requestUri.Host}']") != null && requestUri.Port == 80)
+                if (feedProxyXml?.SelectSingleNode($"//allow[@host = '{requestUri.Host}']") != null && (requestUri.Port == 80 || requestUri.Port == 443))
                 {
                     if (_httpClient == null)
                         _httpClient = new HttpClient();


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3228
- [x] I have added steps to test this contribution in the description below

### Description

As is there are no videos on the members "Get Started" dashboard (see #3228), nor on the developer equivalent:

![developer before](https://user-images.githubusercontent.com/7405322/46797858-97a43900-cd50-11e8-9f71-fe373e0c623e.png)

This PR allows the video feeds to load over HTTPS, thus bringing back the developer videos:

![developer after](https://user-images.githubusercontent.com/7405322/46797913-b9052500-cd50-11e8-8d5d-24e80e34121e.png)

As for the member section, this PR paves the way for bringing the videos back by removing the www-subdomain from the members video feed. Unfortunately the feed doesn't currently contain any videos (https://umbraco.com/feeds/videos/members is redirected to https://shop.umbraco.com/feeds/videos/members/ which is empty). But once the members video feed has content, the videos *should* start appearing on the members dashboard again.