### PR TITLE
Only add "Move" action on document type once

### DIFF
--- a/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
@@ -117,21 +117,11 @@ namespace Umbraco.Web.Trees
                 if (enableInheritedDocumentTypes)
                 {
                     menu.Items.Add<ActionNew>(Services.TextService.Localize(string.Format("actions/{0}", ActionNew.Instance.Alias)));
-
-                    //no move action if this is a child doc type
-                    if (parent == null)
-                    {
-                        menu.Items.Add<ActionMove>(Services.TextService.Localize(string.Format("actions/{0}", ActionMove.Instance.Alias)), true);
-                    }
                 }
-                else
+                //no move action if this is a child doc type
+                if (parent == null)
                 {
-                    menu.Items.Add<ActionMove>(Services.TextService.Localize(string.Format("actions/{0}", ActionMove.Instance.Alias)));
-                    //no move action if this is a child doc type
-                    if (parent == null)
-                    {
-                        menu.Items.Add<ActionMove>(Services.TextService.Localize(string.Format("actions/{0}", ActionMove.Instance.Alias)), true);
-                    }
+                    menu.Items.Add<ActionMove>(Services.TextService.Localize(string.Format("actions/{0}", ActionMove.Instance.Alias)), true);
                 }
                 menu.Items.Add<ActionCopy>(Services.TextService.Localize(string.Format("actions/{0}", ActionCopy.Instance.Alias)));
                 menu.Items.Add<ActionExport>(Services.TextService.Localize(string.Format("actions/{0}", ActionExport.Instance.Alias)), true).ConvertLegacyMenuItem(new UmbracoEntity


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3262
- [X] I have added steps to test this contribution in the description below

### Description
<!-- A description of the changes proposed in the pull-request -->
<!-- Make sure to link to the related issue number so we can easily find it in the issue tracker -->

When disabling inherited document types by adding `<EnableInheritedDocumentTypes>false</EnableInheritedDocumentTypes>` to the `<content>` section in `umbracoSettings.config` you end up with two move actions in the document type context menu

<img width="383" alt="screenshot_20181011_190328" src="https://user-images.githubusercontent.com/379886/46823471-9134b200-cd8e-11e8-9aa4-0156a85f16e1.png">

This change removes the extra one

<img width="384" alt="screenshot_20181011_190428" src="https://user-images.githubusercontent.com/379886/46823493-a01b6480-cd8e-11e8-948b-3f4acd127e88.png">

If you have a child document type, the "Move" action is not shown, which is the same logic as today

<img width="383" alt="screenshot_20181011_190655" src="https://user-images.githubusercontent.com/379886/46823659-0b653680-cd8f-11e8-8024-2a07c92c4a84.png">

And you can still move the parent one

<img width="381" alt="screenshot_20181011_190703" src="https://user-images.githubusercontent.com/379886/46823514-b0334400-cd8e-11e8-82a3-94b0e81aa3a9.png">


<!-- Thanks for contributing to Umbraco CMS! -->
