### PR TITLE
Ensure content templates can be saved twice without errors

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -576,7 +576,7 @@ namespace Umbraco.Web.Editors
         [FileUploadCleanupFilter]
         [ContentPostValidate]
         public ContentItemDisplay PostSaveBlueprint(
-            [ModelBinder(typeof(ContentItemBinder))] ContentItemSave contentItem)
+            [ModelBinder(typeof(BlueprintItemBinder))] ContentItemSave contentItem)
         {
             var contentItemDisplay = PostSaveInternal(contentItem,
                 content =>

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -823,6 +823,7 @@
     </Compile>
     <Compile Include="WebApi\AngularJsonMediaTypeFormatter.cs" />
     <Compile Include="WebApi\AngularJsonOnlyConfigurationAttribute.cs" />
+    <Compile Include="WebApi\Binders\BlueprintItemBinder.cs" />
     <Compile Include="WebApi\Binders\MemberBinder.cs" />
     <Compile Include="WebApi\EnableDetailedErrorsAttribute.cs" />
     <Compile Include="WebApi\Filters\AngularAntiForgeryHelper.cs" />

--- a/src/Umbraco.Web/WebApi/Binders/BlueprintItemBinder.cs
+++ b/src/Umbraco.Web/WebApi/Binders/BlueprintItemBinder.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Web.Models.ContentEditing;
+
+namespace Umbraco.Web.WebApi.Binders
+{
+    internal class BlueprintItemBinder : ContentItemBinder
+    {
+        public BlueprintItemBinder(ApplicationContext applicationContext)
+            : base(applicationContext)
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public BlueprintItemBinder()
+            : this(ApplicationContext.Current)
+        {
+        }
+
+        protected override IContent GetExisting(ContentItemSave model)
+        {
+            return ApplicationContext.Services.ContentService.GetBlueprintById(Convert.ToInt32(model.Id));
+        }        
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/2985
- [x] I have added steps to test this contribution in the description below

### Description

The initial issue report on #2985 outlines the steps to reproduce/test nicely.

The root cause for this issue is the content item binder used on the save action (`PostSaveBlueprint`). Currently the default `ContentItemBinder` is reused for saving content templates. This works as long as the content template is in the cache, but if it isn't... things start to fail. 

Incidentally the content template is flushed from the cache when it's saved, which is why the save action fails the second time around.
