### PR TITLE
Fix the disappearing action button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -73,7 +73,7 @@
           // if there are any and then clear them so the collection no longer persists them.
           serverValidationManager.executeAndClearAllSubscriptions();
 
-          syncTreeNode($scope.content, data.path, true);
+          waitForTreeAndSyncTreeNode($scope.content, data.path, true);
 
           resetLastListPageNumber($scope.content);
 
@@ -101,6 +101,18 @@
       $scope.defaultButton = buttons.defaultButton;
       $scope.subButtons = buttons.subButtons;
 
+    }
+
+    // navigationService.setupTreeEvents() and umbTree.setupExternalEvents() are called rather nondeterministically,
+    // and we can't initialize the tree node before both have been called so we need to wait for it
+    function waitForTreeAndSyncTreeNode(content, path, initialLoad) {
+      if (!navigationService.treeIsInitialized()) {
+        $timeout(function() {
+          waitForTreeAndSyncTreeNode(content, path, initialLoad);
+        }, 100);
+        return;
+      }
+      syncTreeNode(content, path, initialLoad);
     }
 
     /** Syncs the content item to it's tree node - this occurs on first load and after saving */

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -289,12 +289,9 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
                 throw "args.tree cannot be null";
             }
 
-            if (mainTreeEventHandler) {                
-               
-                if (mainTreeEventHandler.syncTree) {
-                    //returns a promise,
-                    return mainTreeEventHandler.syncTree(args);
-                }
+            if (this.treeIsInitialized()) {
+                //returns a promise,
+                return mainTreeEventHandler.syncTree(args);
             }
 
             //couldn't sync
@@ -324,6 +321,13 @@ function navigationService($rootScope, $routeParams, $log, $location, $q, $timeo
                 mainTreeEventHandler.clearCache({ section: sectionAlias });
                 mainTreeEventHandler.load(sectionAlias);
             }
+        },
+
+        /**
+         * returns true if the tree is initialized and ready for use, false otherwise
+         */
+        treeIsInitialized: function () {
+            return !!(mainTreeEventHandler && mainTreeEventHandler.syncTree);
         },
 
         /**


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3097
- [x] I have added steps to test this contribution in the description below

### Description

The action button disappears because the tree has not yet been initialized when the edit page is rendered. This is due to the nondeterministic order in which the methods `navigationService.setupTreeEvents()` and `umbTree.setupExternalEvents()` are called. And thus the node being edited can't be found in the tree.

To safely locate the edited node, the edit page must first wait for the tree to be initialized. 

I couldn't find a wait-pattern in the code base that supports this scenario (there is no single promise to wait for), so I've implemented a polling solution using `$timeout` here. It's an optimistic solution that expects the tree to be initialized eventually, but the way I see it there isn't anything suggesting that the tree won't initialize. That being said, if I've missed a wait-pattern somewhere in the code base, please say so and I'll adjust the PR accordingly.

![action button](https://user-images.githubusercontent.com/7405322/46868051-5af74100-ce27-11e8-911d-260e75949e75.gif)
