### PR TITLE
#2917 - Session timeout on user group creation

### DIFF
--- a/src/Umbraco.Web/Editors/UserGroupEditorAuthorizationHelper.cs
+++ b/src/Umbraco.Web/Editors/UserGroupEditorAuthorizationHelper.cs
@@ -53,8 +53,10 @@ namespace Umbraco.Web.Editors
             if (currentUser.IsAdmin())
                 return Attempt<string>.Succeed();
 
-            var userGroups = currentUser.Groups.Select(x => x.Alias).ToArray();
-            var missingAccess = groupAliases.Except(userGroups).ToArray();
+            var userGroups = currentUser.Groups.Select(x => x.Alias).ToList();
+                userGroups.AddRange(groupAliases);
+            var exceptGroups = userGroups.ToArray();
+            var missingAccess = groupAliases.Except(exceptGroups).ToArray();
             return missingAccess.Length == 0
                 ? Attempt<string>.Succeed()
                 : Attempt.Fail("User is not a member of " + string.Join(", ", missingAccess));

--- a/src/Umbraco.Web/Editors/UserGroupsController.cs
+++ b/src/Umbraco.Web/Editors/UserGroupsController.cs
@@ -51,6 +51,13 @@ namespace Umbraco.Web.Editors
                 throw new HttpResponseException(Request.CreateResponse(HttpStatusCode.Unauthorized, isAuthorized.Result));
 
             //save the group
+            var missingAccess = userGroupSave.Users.Where(X => X == Security.CurrentUser.Id).ToArray();
+            if (missingAccess.Length == 0)
+            {
+                var addCurrentUser = userGroupSave.Users.ToList();
+                    addCurrentUser.Add(Security.CurrentUser.Id);
+                    userGroupSave.Users = addCurrentUser.ToArray();
+            }
             Services.UserService.Save(userGroupSave.PersistedUserGroup, userGroupSave.Users.ToArray());
             
             //deal with permissions


### PR DESCRIPTION
CurrentUser allowed to create usergroups they are allowed to.
CurrentUser added to group if not added by creater themself.

### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is:
- [x] I have added steps to test this contribution in the description below

### Description
CurrentUser allowed to create usergroups they are allowed to.
CurrentUser added to group if not added by the creator(CurrentUser).

See description to test in original post https://github.com/umbraco/Umbraco-CMS/issues/2917

<!-- Thanks for contributing to Umbraco CMS! -->
