### PR TITLE
Fix for old password not showing/hiding correctly on admin users page #3069

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -93,7 +93,9 @@
                   //in the ASP.NET Identity world, this config option will allow an admin user to change another user's password
                   //if the user has access to the user section. So if this editor is being access, the user of course has access to this section.
                   //the authorization check is also done on the server side when submitted.
-                  vm.changePasswordModel.config.allowManuallyChangingPassword = !vm.user.isCurrentUser;
+                    
+                  
+                  // vm.changePasswordModel.config.allowManuallyChangingPassword = !vm.user.isCurrentUser;
                   
                   vm.loading = false;
                 });

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -94,9 +94,13 @@
                   //if the user has access to the user section. So if this editor is being access, the user of course has access to this section.
                   //the authorization check is also done on the server side when submitted.
                     
-                  
-                  // vm.changePasswordModel.config.allowManuallyChangingPassword = !vm.user.isCurrentUser;
-                  
+                  // only update the setting if not the current logged in user, otherwise leave the value as it is
+                  // currently set in the web.config
+                  if (!vm.user.isCurrentUser)
+                  {
+                      vm.changePasswordModel.config.allowManuallyChangingPassword = true;
+                  }
+                    
                   vm.loading = false;
                 });
             });


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3069
- [x] I have added steps to test this contribution in the description below

### Description
The back office user section has an override to the setting _allowManuallyChangingPassword_ which hides the old password textbox if the current user you're editing is your own. Updated to hide if editing another user and to also hide for your own user if the setting is **true** in the web.config.

### Steps
- Update the web.config setting _allowManuallyChangingPassword_ to be **true**
- Login to the back office
- Go to the users section
- Select a user
- Change password, the old password textbox should be hidden
