### PR TITLE
Update lazyload.js reference on install pages.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/index.html
+++ b/src/Umbraco.Web.UI.Client/src/index.html
@@ -21,7 +21,7 @@
 
     <umb-notifications></umb-notifications>
 
-    <script src="lib/rgrove-lazyload/lazyload.js"></script>
+    <script src="lib/lazyload-js/lazyload.min.js"></script>
     <script src="js/loader.dev.js"></script>
 </body>
 </html>

--- a/src/Umbraco.Web.UI/Umbraco/Install/Views/Index.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Install/Views/Index.cshtml
@@ -70,7 +70,7 @@
             "umbracoBaseUrl": "@ViewBag.UmbracoBaseFolder"
         };
     </script>
-    <script src="lib/rgrove-lazyload/lazyload.js"></script>
+    <script src="lib/lazyload-js/lazyload.min.js"></script>
     <script src="js/install.loader.js"></script>
 </body>
 </html>

--- a/src/Umbraco.Web.UI/Umbraco/Views/AuthorizeUpgrade.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/AuthorizeUpgrade.cshtml
@@ -72,7 +72,7 @@
     </script>
 
     @*And finally we can load in our angular app*@
-    <script type="text/javascript" src="lib/rgrove-lazyload/lazyload.js"></script>
+    <script type="text/javascript" src="lib/lazyload-js/lazyload.min-js"></script>
     <script type="text/javascript" src="@Url.GetUrlWithCacheBust("Application", "BackOffice")"></script>
 
 </body>

--- a/src/Umbraco.Web.UI/Umbraco/Views/Preview/Index.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Preview/Index.cshtml
@@ -54,7 +54,7 @@
 
     </div>
 
-    <script src="../lib/rgrove-lazyload/lazyload.js"></script>
+    <script src="../lib/lazyload-js/lazyload.min.js"></script>
     <script src="@Url.GetUrlWithCacheBust("Application", "Preview")"></script>
 
 </body>


### PR DESCRIPTION
The reference to lazyload.js used on the install page was pointing to the wrong path & version of lazyload installed via NPM. This PR updates the paths to the correct file.