### PR TITLE
Added the user ID and GUID to the user details view.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/idwithguid/idwithguid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/idwithguid/idwithguid.controller.js
@@ -1,0 +1,25 @@
+/**
+ * @ngdoc controller
+ * @name Umbraco.Editors.IdWithGuidValueController
+ * @function
+ * 
+ * @description
+ * The controller for the idwithguid property editor, which formats the ID as normal
+ * with the GUID in smaller text below, as used across the backoffice.
+*/
+function IdWithGuidValueController($rootScope, $scope, $filter) {
+
+    function formatDisplayValue() {
+        if ($scope.model.value.length > 1) {
+            $scope.displayid = $scope.model.value[0];
+            $scope.displayguid = $scope.model.value[1];   
+        } else {
+            $scope.displayid = $scope.model.value;
+        }
+    }
+
+    //format the display value on init:
+    formatDisplayValue();
+}
+
+angular.module('umbraco').controller("Umbraco.PropertyEditors.IdWithGuidValueController", IdWithGuidValueController);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/idwithguid/idwithguid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/idwithguid/idwithguid.html
@@ -1,0 +1,4 @@
+﻿<div class="umb-editor umb-readonlyvalue umb-idwithguidvalue" ng-controller="Umbraco.PropertyEditors.IdWithGuidValueController">
+    <div>{{ displayid }}</div>
+    <small>{{ displayguid }}</small>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -387,14 +387,17 @@
 
             <div class="umb-user-details-details__information-item">
                 <div class="umb-user-details-details__information-item-label">
-                    <localize key="template_id">Id</localize>: {{ model.user.id }}
+                    <localize key="general_id">Id</localize>:
+                </div>
+                <div class="umb-user-details-details__information-item-content">
+                    {{ model.user.id }}
                 </div>
                 <div class="umb-user-details-details__information-item-content">
                     <small>{{ model.user.key }}</small>
                 </div>
-            </div>
+                </div>
 
-        </div>
+            </div>
 
     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -385,6 +385,15 @@
                 </div>
             </div>
 
+            <div class="umb-user-details-details__information-item">
+                <div class="umb-user-details-details__information-item-label">
+                    <localize key="template_id">Id</localize>: {{ model.user.id }}
+                </div>
+                <div class="umb-user-details-details__information-item-content">
+                    <small>{{ model.user.key }}</small>
+                </div>
+            </div>
+
         </div>
 
     </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -564,6 +564,7 @@
     <key alias="hide">Skjul</key>
     <key alias="history">Historik</key>
     <key alias="icon">Ikon</key>
+    <key alias="id">Id</key>
     <key alias="import">Importer</key>
     <key alias="innerMargin">Indre margen</key>
     <key alias="insert">Indsæt</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -597,6 +597,7 @@
         <key alias="hide">Hide</key>
         <key alias="history">History</key>
         <key alias="icon">Icon</key>
+        <key alias="id">Id</key>
         <key alias="import">Import</key>
         <key alias="info">Info</key>
         <key alias="innerMargin">Inner margin</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -597,6 +597,7 @@
         <key alias="hide">Hide</key>
         <key alias="history">History</key>
         <key alias="icon">Icon</key>
+        <key alias="id">Id</key>
         <key alias="import">Import</key>
         <key alias="info">Info</key>
         <key alias="innerMargin">Inner margin</key>

--- a/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
@@ -330,9 +330,15 @@ namespace Umbraco.Web.Models.Mapping
                 {
                     new ContentPropertyDisplay
                     {
+                        Alias = string.Format("{0}id", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
+                        Label = _localizedTextService.Localize("general/id"),
+                        Value = new List<string> {member.Id.ToString(), member.Key.ToString()},
+                        View = "idwithguid"
+                    },
+                    new ContentPropertyDisplay
+                    {
                         Alias = string.Format("{0}doctype", Constants.PropertyEditors.InternalGenericPropertiesPrefix),
                         Label = _localizedTextService.Localize("content/membertype"),
-                        //Value = localizedText.UmbracoDictionaryTranslate(display.ContentTypeName),
                         Value = _localizedTextService.UmbracoDictionaryTranslate(member.ContentType.Name),
                         View = PropertyEditorResolver.Current.GetByAlias(Constants.PropertyEditors.NoEditAlias).ValueEditor.View
                     },


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3275
- [x] I have added steps to test this contribution in the description below

### Description
Fixes #3275, and also applies to users. Adds the user ID and GUID fields to the user and member properties area. The design is below. 

Users:
![image](https://user-images.githubusercontent.com/514825/46916847-1cdd5700-cfb8-11e8-9431-a0de2845d8b9.png)

Members: 
![image](https://user-images.githubusercontent.com/514825/47008071-7cab3d80-d131-11e8-88a0-8938534ba5d0.png)

There was some discussion on the issue as to why this was originally removed, and whether some of the other fields should be added back too, so let me know if anything else needs adding or this is indeed redundant :) 
