### PR TITLE
Re-adding the language keys for login greeting on a Sunday

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
@@ -537,6 +537,7 @@
     <key alias="renewSession">Obnovte nyní pro uložení práce</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Šťastnou super neděli</key>
     <key alias="greeting1">Šťastné šílené pondělí</key>
     <key alias="greeting2">Šťastné husté úterý</key>
     <key alias="greeting3">Šťastnou překrásnou středu</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -720,6 +720,7 @@
     <key alias="renewSession">Forny for at gemme dine ændringer</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Så er det søndag!</key>
     <key alias="greeting1">Smil, det er mandag!</key>
     <key alias="greeting2">Hurra, det er tirsdag!</key>
     <key alias="greeting3">Hvilken herlig onsdag!</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
@@ -535,6 +535,7 @@ Wenn Sie sich für Runway entscheiden, können Sie optional Blöcke nutzen, die 
     <key alias="renewSession">Erneuern Sie, um Ihre Arbeit zu speichern ...</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Einen wunderbaren Sonntag</key>
     <key alias="greeting1">Schönen Montag</key>
     <key alias="greeting2">Einen großartigen Dienstag</key>
     <key alias="greeting3">Wunderbaren Mittwoch</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -801,6 +801,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="renewSession">Renew now to save your work</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Happy super Sunday</key>
     <key alias="greeting1">Happy manic Monday </key>
     <key alias="greeting2">Happy tubular Tuesday</key>
     <key alias="greeting3">Happy wonderful Wednesday</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -816,6 +816,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="renewSession">Renew now to save your work</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Happy super Sunday</key>
     <key alias="greeting1">Happy manic Monday </key>
     <key alias="greeting2">Happy tubular Tuesday</key>
     <key alias="greeting3">Happy wonderful Wednesday</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/es.xml
@@ -696,6 +696,7 @@
     <key alias="renewSession">Renovar su sesión para guardar sus cambios</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Feliz super domingo</key>
     <key alias="greeting1">Feliz lunes</key>
     <key alias="greeting2">Tremendo martes</key>
     <key alias="greeting3">Maravilloso miércoles</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
@@ -769,6 +769,7 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="renewSession">Renouvellez votre session maintenant pour sauvegarder votre travail</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Joyeux dimanche détonnant</key>
     <key alias="greeting1">Joyeux lundi lumineux</key>
     <key alias="greeting2">Joyeux mardi magique</key>
     <key alias="greeting3">Joyeux mercredi merveilleux</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ja.xml
@@ -615,6 +615,7 @@ Runwayをインストールして作られた新しいウェブサイトがど�
     <key alias="renewSession">作業を保存して今すぐ更新</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">ハッピー スーパー日曜日</key>
     <key alias="greeting1">ハッピー マニアック月曜日</key>
     <key alias="greeting2">ハッピー最高の火曜日</key>
     <key alias="greeting3">ハッピー ワンダフル水曜日</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -511,6 +511,7 @@
     <key alias="renewSession">Forny innlogging for å lagre</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Da er det søndag!</key>
     <key alias="greeting1">Smil, det er mandag!</key>
     <key alias="greeting2">Hurra, det er tirsdag!</key>
     <key alias="greeting3">For en herlig onsdag!</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -609,6 +609,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="renewSession">Vernieuw je sessie om je wijzigingen te behouden</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Goede zondag</key>
     <key alias="greeting1">Fijne maandag</key>
     <key alias="greeting2">Fijne dinsdag</key>
     <key alias="greeting3">Fijne woensdag</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/pl.xml
@@ -736,6 +736,7 @@ Naciśnij przycisk <strong>instaluj</strong>, aby zainstalować bazę danych Umb
     <key alias="renewSession">Wznów sesję teraz, aby zapisać swoją pracę</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Szczęśliwej super niedzieli</key>
     <key alias="greeting1">Szczęśliwego maniakalnego poniedziałku </key>
     <key alias="greeting2">Szczęśliwego świetnego wtorku</key>
     <key alias="greeting3">Szczęśliwej niesamowitej środy</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
@@ -912,6 +912,7 @@
   </area>
   <area alias="login">
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">umbraco.com</a></p>]]></key>
+    <key alias="greeting0">Сегодня же выходной!</key>
     <key alias="greeting1">Понедельник — день тяжелый...</key>
     <key alias="greeting2">Вот уже вторник...</key>
     <key alias="greeting3">Берегите окружающую среду</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
@@ -502,6 +502,7 @@
   </area>
   <area alias="login">
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="http://umbraco.com" style="text-decoration: none" target="_blank">umbraco.com</a></p> ]]></key>
+    <key alias="greeting0">Happy super Sunday</key>
     <key alias="greeting1">Happy manic Monday</key>
     <key alias="greeting2">Happy tremendous Tuesday</key>
     <key alias="greeting3">Happy wonderful Wednesday</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
@@ -529,6 +529,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="renewSession">İşinizi kaydetmek için şimdi Yenile</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Pazar</key>
     <key alias="greeting1">Pazartesi </key>
     <key alias="greeting2">Salı</key>
     <key alias="greeting3">Çarşamba</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/zh.xml
@@ -638,6 +638,7 @@
     <key alias="renewSession">已更新，继续工作。</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">星期一快乐</key>
     <key alias="greeting1">星期二快乐</key>
     <key alias="greeting2">星期三快乐</key>
     <key alias="greeting3">星期四快乐</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
@@ -625,6 +625,7 @@
     <key alias="renewSession">已更新，繼續工作。</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">超級星期天快樂</key>
     <key alias="greeting1">瘋狂星期一快樂</key>
     <key alias="greeting2">熱鬧星期二快樂</key>
     <key alias="greeting3">美妙星期三快樂</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nb.xml
@@ -511,6 +511,7 @@
     <key alias="renewSession">Forny innlogging for å lagre</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Da er det søndag!</key>
     <key alias="greeting1">Smil, det er mandag!</key>
     <key alias="greeting2">Hurra, det er tirsdag!</key>
     <key alias="greeting3">For en herlig onsdag!</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh_tw.xml
@@ -625,6 +625,7 @@
     <key alias="renewSession">已更新，繼續工作。</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">超級星期天快樂</key>
     <key alias="greeting1">瘋狂星期一快樂</key>
     <key alias="greeting2">熱鬧星期二快樂</key>
     <key alias="greeting3">美妙星期三快樂</key>


### PR DESCRIPTION
### Description
Tried logging in on a Sunday and the login message is [login_greeting0].  This is because the language keys for greeting0 were accidentally removed in a recent tidy up.  I have recovered those from this history and added back.