### PR TITLE
Update umbsections.directive.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
@@ -12,7 +12,7 @@ function sectionsDirective($timeout, $window, navigationService, treeService, se
 
             var sectionItemsWidth = [];
             var evts = [];
-            var maxSections = 7;
+            var maxSections = 8;
 
             //setup scope vars
             scope.maxSections = maxSections;
@@ -46,8 +46,8 @@ function sectionsDirective($timeout, $window, navigationService, treeService, se
                     var sectionsWidth = 0;
                     scope.totalSections = scope.sections.length;
                     scope.maxSections = maxSections;
-                    scope.overflowingSections = 0;
-                    scope.needTray = false;
+                    scope.overflowingSections = scope.maxSections - scope.totalSections;
+                    scope.needTray = scope.sections.length > scope.maxSections;
 
                     // detect how many sections we can show on the screen
                     for (var i = 0; i < sectionItemsWidth.length; i++) {


### PR DESCRIPTION
Update the number of sections to the actual number of sections available at the present time, add a fix to the calculateWidth method so that if less items are allowed than available but there is technically enough room to show them the overflow tray still shows up.

On prior version, try adding translation to your allowed user group sections and reload, you can't see the translation section in the top menu, but the overflow menu button won't show until you shrink the screen.

### Prerequisites

- [ ] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is:
- [ ] I have added steps to test this contribution in the description below

### Description
<!-- A description of the changes proposed in the pull-request -->
<!-- Make sure to link to the related issue number so we can easily find it in the issue tracker -->


<!-- Thanks for contributing to Umbraco CMS! -->
