### PR TITLE
Fix javascript errors

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulpfile.js
+++ b/src/Umbraco.Web.UI.Client/gulpfile.js
@@ -52,7 +52,7 @@ function processLess(files, out) {
 
     var processors = [
          autoprefixer,
-         cssnano({zindex: false}),
+         cssnano({zindex: false})
     ];
 
     return gulp.src(files)
@@ -329,7 +329,7 @@ gulp.task('dependencies', function () {
             "src":  [
                 "./node_modules/moment/min/moment.min.js",
                 "./node_modules/moment/min/moment-with-locales.js",
-                "./node_modules/moment/min/moment-with-locales.min.js",
+                "./node_modules/moment/min/moment-with-locales.min.js"
             ],
             "base": "./node_modules/moment/min"
         },

--- a/src/Umbraco.Web.UI/Umbraco/js/UmbracoSpeechBubbleBackEnd.js
+++ b/src/Umbraco.Web.UI/Umbraco/js/UmbracoSpeechBubbleBackEnd.js
@@ -8,21 +8,21 @@ function UmbracoSpeechBubble(id) {
     this.GenerateSpeechBubble();
 }
 
-UmbracoSpeechBubble.prototype.GenerateSpeechBubble = function() {
+UmbracoSpeechBubble.prototype.GenerateSpeechBubble = function () {
 
     var sbHtml = document.getElementById(this.id);
 
     sbHtml.innerHTML = '' +
-            '<div class="speechBubbleTop"></div>' +
-            '<div class="speechBubbleContent">' +
-	        '<img id="' + this.id + 'Icon" style="float: left; margin: 0px 5px 10px 3px;" />' +
-            '                      <img class="speechClose" onClick="UmbSpeechBubble.Hide();" id="' + this.id + 'close" src="/umbraco/images/speechBubble/speechBubble_close.gif" width="18" height="18" border="0" alt="Close"' +
-            '                        onmouseover="this.src = \'/umbraco/images/speechBubble/speechBubble_close_over.gif\';" onmouseout="this.src=\'images/speechBubble/speechBubble_close.gif\';">' +
-            '                  <div style="float: right; width: 186px; margin-right: 10px;"><h3 id="' + this.id + 'Header">The header!</h3>' +
-            '                  <p style="width: 185px" id="' + this.id + 'Message">Default Text Container!<br /></p></div><br style="clear: both" />' +
-            '</div>' +
-            '<div class="speechBubbleBottom"></div>'
-}
+        '<div class="speechBubbleTop"></div>' +
+        '<div class="speechBubbleContent">' +
+        '<img id="' + this.id + 'Icon" style="float: left; margin: 0px 5px 10px 3px;" />' +
+        '                      <img class="speechClose" onClick="UmbSpeechBubble.Hide();" id="' + this.id + 'close" src="/umbraco/images/speechBubble/speechBubble_close.gif" width="18" height="18" border="0" alt="Close"' +
+        '                        onmouseover="this.src = \'/umbraco/images/speechBubble/speechBubble_close_over.gif\';" onmouseout="this.src=\'images/speechBubble/speechBubble_close.gif\';">' +
+        '                  <div style="float: right; width: 186px; margin-right: 10px;"><h3 id="' + this.id + 'Header">The header!</h3>' +
+        '                  <p style="width: 185px" id="' + this.id + 'Message">Default Text Container!<br /></p></div><br style="clear: both" />' +
+        '</div>' +
+        '<div class="speechBubbleBottom"></div>';
+};
 
 UmbracoSpeechBubble.prototype.ShowMessage = function (icon, header, message, dontAutoHide) {
     var speechBubble = jQuery("#" + this.id);
@@ -46,7 +46,7 @@ UmbracoSpeechBubble.prototype.ShowMessage = function (icon, header, message, don
             jQuery(".speechClose").show();
         }
     }
-}
+};
 
 UmbracoSpeechBubble.prototype.Hide = function () {
     if (!this.ie) {
@@ -54,7 +54,7 @@ UmbracoSpeechBubble.prototype.Hide = function () {
     } else {
         jQuery("#" + this.id).hide();
     }
-}
+};
 
 // Initialize
 var UmbSpeechBubble = null


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is:
- [x] I have added steps to test this contribution in the description below

### Description
I noticed that latest source code in `temp8` branch has a few javascript errors. Most of them are regarding ESLint warning about "Empty block statement", "Expected '!==' and instead saw '!='.", "Expected '===' and instead saw '=='." or "Mixed spaces and tabs.".

For now I have fixed some missing semicolons and removed some commas.