### PR TITLE
Fix for #3296. Large paged Listview sorted by custom property has bla…

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
@@ -382,10 +382,12 @@ namespace Umbraco.Core.Persistence.Repositories
                 if (orderDirection == Direction.Descending)
                 {
                     sortedSql.OrderByDescending("CustomPropData.CustomPropVal");
+                    sortedSql.OrderByDescending("umbracoNode.id");
                 }
                 else
                 {
                     sortedSql.OrderBy("CustomPropData.CustomPropVal");
+                    sortedSql.OrderBy("umbracoNode.id");
                 }
             }
 


### PR DESCRIPTION
…nk custom properties

### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3296
- [x] I have added steps to test this contribution in the description below

### Description
 The fix adds ordering by NodeId to the GetSortedSqlForPagedResults function in ~\Umbraco.Core\Persistence\Repositories\VersionableRepositoryBase.cs when custom properties were used. 

Before they were only ordered by CustomPropData.CustomPropVal which created an problem when the custom property had values that did not create a unique order. 

I have added umbracoNode.id ordering to the default SQL query. I have also matched the OrderBy  and OrderByDescending of the custom property so the list will be truly reversed. 

Steps to reproduce are outlined in the bug  #3296 but I will put that here as well. 

I started with a new instance of dev-v7 and pointed it to a clean SQL Server database.

I created a News Listing doc type and a News Article doc type.

The News Article doc type had one custom property which was Article Date. This was mandatory and was a date field.

For the News Listing doc type I enabled the list view, then updated the list view to show 4 articles per page, to get the paging effect without too many articles need to be added, I also added the article date to the Columns Displayed, and then changed the Order By to the article date as well.

![umbraco_orderingbycustompropval_bug02](https://user-images.githubusercontent.com/1418130/46933042-23de9500-d09e-11e8-8817-6a1382a883fb.png)

I then entered 30 news articles that mostly had the same article date.

Note that this bug doesn't happen as soon as have enough articles to trigger the paging. When I had 20 articles, I couldn't get it to work, but when I got to 30 it started. I also changed the dates on some of the articles to try and mix up the data a bit.

Because the ordering out of the SQL Server can be a bit tricky you do just need to keep adding items to the list view until the ordering breaks. I couldn't pick an exact moment where it breaks but the more pages you have the more likely it seems to break. 


<!-- Thanks for contributing to Umbraco CMS! -->
