### PR TITLE
Remove the default SMTP configuration

### DIFF
--- a/src/Umbraco.Core/Configuration/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/GlobalSettings.cs
@@ -70,7 +70,8 @@ namespace Umbraco.Core.Configuration
 
             var config = WebConfigurationManager.OpenWebConfiguration(appPath);
             var settings = (MailSettingsSectionGroup)config.GetSectionGroup("system.net/mailSettings");
-            if (settings == null || settings.Smtp == null) return false;
+            // note: "noreply@example.com" is/was the sample SMTP from email - we'll regard that as "not configured"
+            if (settings == null || settings.Smtp == null || "noreply@example.com".Equals(settings.Smtp.From, StringComparison.OrdinalIgnoreCase)) return false;
             if (settings.Smtp.SpecifiedPickupDirectory != null && string.IsNullOrEmpty(settings.Smtp.SpecifiedPickupDirectory.PickupDirectoryLocation) == false)
                 return true;
             if (settings.Smtp.Network != null && string.IsNullOrEmpty(settings.Smtp.Network.Host) == false)

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -80,9 +80,14 @@
 
     <system.net>
         <mailSettings>
+            <!--
+            If you need Umbraco to send out system mails (like reset password and invite user),
+            you must configure your SMTP host here - for example:
+
             <smtp from="noreply@example.com">
                 <network host="127.0.0.1" userName="username" password="password" />
             </smtp>
+            -->
         </mailSettings>
     </system.net>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3302
- [x] I have added steps to test this contribution in the description below

### Description

As described in #3302 it's easy to end up deploying a site with the default SMTP configuration enabled - e.g. if you're not sending mails yourself or if you're using a transactional mail provider for it.

This PR does two things:

1. Comments out the SMTP configuration in the default web.config with an instruction to enable it and configure it correctly if system mails are required.
2. Regards the current default configuration (`from="noreply@example.com"`) as "not configured".

To test:

1. On an existing site (with the default SMTP configuration active) ensure that "Invite user" is not an option.
2. On a newly created site, verify that the SMTP configuration is commented out.