### PR TITLE
Xml comments for ImageCropMode

### DIFF
--- a/src/Umbraco.Web/Models/ImageCropMode.cs
+++ b/src/Umbraco.Web/Models/ImageCropMode.cs
@@ -2,11 +2,34 @@ namespace Umbraco.Web.Models
 {
     public enum ImageCropMode
     {
+        /// <summary>
+        /// Resizes the image to the given dimensions. If the set dimensions do not match the aspect ratio of the original image then the output is cropped to match the new aspect ratio.
+        /// </summary>
         Crop,
+
+        /// <summary>
+        /// Resizes the image to the given dimensions. If the set dimensions do not match the aspect ratio of the original image then the output is resized to the maximum possible value in each direction while aintaining the original aspect ratio.
+        /// </summary>
         Max,
+
+        /// <summary>
+        /// Resizes the image to the given dimensions. If the set dimensions do not match the aspect ratio of the original image then the output is stretched to match the new aspect ratio.
+        /// </summary>
         Stretch,
+
+        /// <summary>
+        /// Passing a single dimension will automatically preserve the aspect ratio of the original image. If the requested aspect ratio is different then the image will be padded to fit.
+        /// </summary>
         Pad,
+
+        /// <summary>
+        /// When upscaling an image the image pixels themselves are not resized, rather the image is padded to fit the given dimensions.
+        /// </summary>
         BoxPad,
+
+        /// <summary>
+        /// Resizes the image until the shortest side reaches the set given dimension. This will maintain the aspect ratio of the original image. Upscaling is disabled in this mode and the original image will be returned if attempted.
+        /// </summary>
         Min
     }
 }


### PR DESCRIPTION
#3309

Added XML comments for ImageCropMode. I copied/pasted the text from the documentation at http://imageprocessor.org/imageprocessor-web/imageprocessingmodule/resize/

To test, get intellisense for the ImageCropMode enum, like so:

![image](https://user-images.githubusercontent.com/3726467/47014839-abcea880-d14b-11e8-92d1-a4eef9b51cd5.png)
