### PR TITLE
3324 - Suggestion: Align image cropper property editor UI with color picker and checkbox lists

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
@@ -5,6 +5,10 @@
     .umb-overlay & {
         width: 500px;
     }
+
+    p{
+        margin: 7px 0;
+    }
 }
 
 .umb-prevalues-multivalues__left {

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -23,7 +23,7 @@
     margin-top: 0px;
     margin-bottom: 15px;
     font-size: 14px;
-    color: @gray-7; 
+    color: @gray-7;
 }
 
 h5{
@@ -134,7 +134,7 @@ h5.-black {
   padding-bottom: 0;
 }
 
-.block-form .umb-control-group label .help-block, 
+.block-form .umb-control-group label .help-block,
 .block-form .umb-control-group label small {
   font-size: 13px;
   padding-top: 2px;
@@ -243,9 +243,9 @@ label:not([for]) {
 }
 
 .umb-version {
-    color: @gray-7; 
-    position: absolute; 
-    bottom: 5px; 
+    color: @gray-7;
+    position: absolute;
+    bottom: 5px;
     right: 20px;
 }
 
@@ -652,4 +652,15 @@ input[type=checkbox]:checked + .input-label--small {
 .bootstrap-datetimepicker-widget th,
 .bootstrap-datetimepicker-widget td span {
 	border-radius: 0 !important;
+}
+
+.visuallyhidden{
+    position: absolute !important;
+	clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+	clip: rect(1px, 1px, 1px, 1px);
+	padding:0 !important;
+	border:0 !important;
+	height: 1px !important;
+	width: 1px !important;
+	overflow: hidden;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -220,6 +220,10 @@ div.umb-codeeditor .umb-btn-toolbar {
 .umb-prevalues-multivalues.umb-cropsizes{
     max-width: none;
     width: 100%;
+
+    .umb-overlay__form &{
+        width: 100%;
+    }
 }
 
 .umb-cropsizes{

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -229,6 +229,12 @@ div.umb-codeeditor .umb-btn-toolbar {
        display: inline-block;
        margin: 6px 0 0;
    }
+
+   &__input{
+       &--narrow{
+           width: 95px;
+       }
+   }
 }
 
 

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -176,7 +176,7 @@ div.umb-codeeditor .umb-btn-toolbar {
             margin-bottom: 0;
             vertical-align: middle;
             padding: 6px 10px;
-            background: @grayMed;
+            background: #f7f7f7;
             flex: 0 0 auto;
         }
 
@@ -207,7 +207,7 @@ div.umb-codeeditor .umb-btn-toolbar {
         padding: 6px 10px;
         font-family: monospace;
         border: 1px solid #dfdfe1;
-        background: @grayMed;
+        background: #f7f7f7;
         margin: 0 15px 0 3px;
         border-radius: 3px;
     }
@@ -243,16 +243,27 @@ div.umb-codeeditor .umb-btn-toolbar {
 
    &__input{
        margin: 0 15px 0 0;
+       width: ~"calc(100% - 15px)";
 
        &--narrow{
-           width: 95px;
+           max-width: 95px;
+           width: 100%;
        }
 
        &-wrap{
            position: relative;
+           max-width: 206px;
+           width: 100%;
+
+           &--narrow{
+               margin: 0 15px 0 0;
+               max-width: 95px;
+               width: 100%;
+           }
 
            &--icon{
-            margin: 0 15px 0 0;
+            padding: 0 15px 0 0;
+            width: ~"calc(100% + 15px)"; // Use an escape string in order to make use of CSS native calc function instead of the one built into less
 
                &:after{
                    content:"\00D7";
@@ -260,7 +271,7 @@ div.umb-codeeditor .umb-btn-toolbar {
                    bottom: -9px;
                    top: 0;
                    margin: auto;
-                   right: -1px;
+                   right: 0;
                    width: 5px;
                    height: 5px;
                }

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -218,6 +218,8 @@ div.umb-codeeditor .umb-btn-toolbar {
 // --------------------------------------------------
 
 .umb-cropsizes{
+    float: left;
+
     .control-group{
         label{
             display: block;
@@ -227,9 +229,6 @@ div.umb-codeeditor .umb-btn-toolbar {
    &__add{
        display: flex;
        align-items: center;
-       float: left;
-       clear: both;
-       width: 100%;
    }
 
    &__times{

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -240,6 +240,10 @@ div.umb-codeeditor .umb-btn-toolbar {
    &__sortable{
        max-width: 500px;
        width: 100%;
+
+       @media (min-width: 1101px) and (max-width: 1300px), (max-width: 930px){
+           max-width: none;
+       }
    }
 
    &__controls{
@@ -250,6 +254,11 @@ div.umb-codeeditor .umb-btn-toolbar {
        margin: 0 15px 0 0;
        width: ~"calc(100% - 15px)";
 
+       @media (min-width: 1101px) and (max-width: 1300px), (max-width: 930px){
+           margin: 0;
+           width: 100%;
+       }
+
        &--narrow{
            max-width: 95px;
            width: 100%;
@@ -259,6 +268,12 @@ div.umb-codeeditor .umb-btn-toolbar {
            position: relative;
            max-width: 206px;
            width: 100%;
+
+            @media (min-width: 1101px) and (max-width: 1300px), (max-width: 930px){
+                max-width: none;
+                flex: 1 1 100%;
+                margin: 0 0 20px;
+            }
 
            &--narrow{
                margin: 0 15px 0 0;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -233,6 +233,10 @@ div.umb-codeeditor .umb-btn-toolbar {
    &__input{
        &--narrow{
            width: 95px;
+
+           &:last-of-type{
+               margin: 0 11px 0 0;
+           }
        }
    }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -227,6 +227,9 @@ div.umb-codeeditor .umb-btn-toolbar {
    &__add{
        display: flex;
        align-items: center;
+       float: left;
+       clear: both;
+       width: 100%;
    }
 
    &__times{

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -240,6 +240,7 @@ div.umb-codeeditor .umb-btn-toolbar {
    &__sortable{
        max-width: 500px;
        width: 100%;
+       min-width: 66.6%;
 
        @media (min-width: 1101px) and (max-width: 1300px), (max-width: 930px){
            max-width: none;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -217,6 +217,11 @@ div.umb-codeeditor .umb-btn-toolbar {
 // Image Cropper
 // --------------------------------------------------
 
+.umb-prevalues-multivalues.umb-cropsizes{
+    max-width: none;
+    width: 100%;
+}
+
 .umb-cropsizes{
     float: left;
 
@@ -229,11 +234,12 @@ div.umb-codeeditor .umb-btn-toolbar {
    &__add{
        display: flex;
        align-items: center;
+       flex-wrap: wrap;
    }
 
-   &__times{
-       display: inline-block;
-       margin: 6px 0 0;
+   &__sortable{
+       max-width: 500px;
+       width: 100%;
    }
 
    &__controls{

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -102,11 +102,11 @@ div.umb-codeeditor {
   border: 1px solid @gray-8;
 }
 div.umb-codeeditor .umb-el-wrap {
-  padding: 0px;
+  padding: 0;
 }
 div.umb-codeeditor .umb-btn-toolbar {
-  padding: 0px;
-  margin: 0px;
+  padding: 0;
+  margin: 0;
   border-bottom: @gray-8 1px solid;
   background: @gray-10;
 }
@@ -122,7 +122,7 @@ div.umb-codeeditor .umb-btn-toolbar {
         position: absolute;
     }
 }
-.mce-tinymce{border: 1px solid @gray-8 !important; border-radius: 0px !important;}
+.mce-tinymce{border: 1px solid @gray-8 !important; border-radius: 0 !important;}
 .mce-panel{background: @gray-10 !important; border-color: @gray-8 !important;}
 .mce-btn-group, .mce-btn{border: none !important; background: none !important;}
 .mce-ico{font-size: 12px !important; color: @gray-1 !important;}
@@ -176,7 +176,7 @@ div.umb-codeeditor .umb-btn-toolbar {
             margin-bottom: 0;
             vertical-align: middle;
             padding: 6px 10px;
-            background: #f7f7f7;
+            background: @grayMed;
             flex: 0 0 auto;
         }
 
@@ -203,11 +203,11 @@ div.umb-codeeditor .umb-btn-toolbar {
     }
 
     label {
-        border: 1px solid #fff;
+        border: 1px solid @white;
         padding: 6px 10px;
         font-family: monospace;
         border: 1px solid #dfdfe1;
-        background: #f7f7f7;
+        background: @grayMed;
         margin: 0 15px 0 3px;
         border-radius: 3px;
     }
@@ -735,8 +735,8 @@ div.umb-codeeditor .umb-btn-toolbar {
 
 
 .umb-photo-folder .picrow div, .umb-photo-preview{
-  margin: 0px;
-  padding: 0px;
+  margin: 0;
+  padding: 0;
   border: none;
   display: inline-block;
   vertical-align: top;
@@ -773,9 +773,9 @@ div.umb-codeeditor .umb-btn-toolbar {
 //this is a temp hack, to provide selectors in the dialog:
 .umb-photo-folder .pic:hover .selector-overlay {
   position: absolute;
-  bottom: 0px;
-  left: 0px;
-  right: 0px;
+  bottom: 0;
+  left: 0;
+  right: 0;
   padding: 5px;
   background: @black;
   z-index: 100;
@@ -855,7 +855,7 @@ div.umb-codeeditor .umb-btn-toolbar {
 .umb-fileupload ul {
   list-style: none;
   vertical-align: middle;
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .umb-fileupload label {

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -257,6 +257,7 @@ div.umb-codeeditor .umb-btn-toolbar {
        @media (min-width: 1101px) and (max-width: 1300px), (max-width: 930px){
            margin: 0;
            width: 100%;
+           max-width: 220px;
        }
 
        &--narrow{

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -213,6 +213,24 @@ div.umb-codeeditor .umb-btn-toolbar {
     }
 }
 
+//
+// Image Cropper
+// --------------------------------------------------
+
+.umb-cropsizes{
+    .control-group{
+        label{
+            display: inline-block;
+            width: 100%;
+        }
+   }
+
+   &__times{
+       display: inline-block;
+       margin: 6px 0 0;
+   }
+}
+
 
 //
 // Media picker

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -220,9 +220,13 @@ div.umb-codeeditor .umb-btn-toolbar {
 .umb-cropsizes{
     .control-group{
         label{
-            display: inline-block;
-            width: 100%;
+            display: block;
         }
+   }
+
+   &__add{
+       display: flex;
+       align-items: center;
    }
 
    &__times{
@@ -230,12 +234,33 @@ div.umb-codeeditor .umb-btn-toolbar {
        margin: 6px 0 0;
    }
 
+   &__controls{
+       margin: 24px 0 0;
+   }
+
    &__input{
+       margin: 0 15px 0 0;
+
        &--narrow{
            width: 95px;
+       }
 
-           &:last-of-type{
-               margin: 0 11px 0 0;
+       &-wrap{
+           position: relative;
+
+           &--icon{
+            margin: 0 15px 0 0;
+
+               &:after{
+                   content:"\00D7";
+                   position: absolute;
+                   bottom: -9px;
+                   top: 0;
+                   margin: auto;
+                   right: -1px;
+                   width: 5px;
+                   height: 5px;
+               }
            }
        }
    }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -5,6 +5,8 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	        $scope.model.value = [];
 	    }
 
+        $scope.editMode = false;
+
 	    $scope.remove = function (item, evt) {
 	        evt.preventDefault();
 	        $scope.model.value = _.reject($scope.model.value, function (x) {
@@ -13,29 +15,39 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	    };
 
 	    $scope.edit = function (item, evt) {
-	        evt.preventDefault();
+            evt.preventDefault();
+            $scope.editMode = true;
+
 	        $scope.newItem = item;
 	    };
 
 	    $scope.cancel = function (evt) {
-	        evt.preventDefault();
+            evt.preventDefault();
+            $scope.editMode = false;
+
 	        $scope.newItem = null;
 	    };
 
 	    $scope.add = function (evt) {
-	        evt.preventDefault();
+            evt.preventDefault();
+
+            $scope.editMode = false;
 
 	        if ($scope.newItem && $scope.newItem.alias &&
                 angular.isNumber($scope.newItem.width) && angular.isNumber($scope.newItem.height) &&
                 $scope.newItem.width > 0 && $scope.newItem.height > 0) {
 
-	            var exists = _.find($scope.model.value, function (item) { return $scope.newItem.alias === item.alias; });
+                var exists = _.find($scope.model.value, function (item) { return $scope.newItem.alias === item.alias; });
+
 	            if (!exists) {
 	                $scope.model.value.push($scope.newItem);
 	                $scope.newItem = {};
 	                $scope.hasError = false;
 	                return;
-	            }
+                }
+                else{
+                    $scope.newItem = null;
+                }
 	        }
 
 	        //there was an error, do the highlight (will be set back by the directive)

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -6,6 +6,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	    }
 
         $scope.editMode = false;
+        $scope.setFocus = false;
 
 	    $scope.remove = function (item, evt) {
 	        evt.preventDefault();
@@ -17,6 +18,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	    $scope.edit = function (item, evt) {
             evt.preventDefault();
             $scope.editMode = true;
+            $scope.setFocus = false;
 
 	        $scope.newItem = item;
 	    };
@@ -24,14 +26,25 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	    $scope.cancel = function (evt) {
             evt.preventDefault();
             $scope.editMode = false;
+            $scope.setFocus = true;
 
 	        $scope.newItem = null;
 	    };
+
+        $scope.change = function () {
+            // Listen to the change event and set focus 2 false
+            if($scope.setFocus){
+                $scope.setFocus = false;
+                return;
+            }
+        }
 
 	    $scope.add = function (evt) {
             evt.preventDefault();
 
             $scope.editMode = false;
+
+            $scope.setFocus = true;
 
 	        if ($scope.newItem && $scope.newItem.alias &&
                 angular.isNumber($scope.newItem.width) && angular.isNumber($scope.newItem.height) &&
@@ -42,15 +55,18 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	            if (!exists) {
 	                $scope.model.value.push($scope.newItem);
 	                $scope.newItem = {};
-	                $scope.hasError = false;
+                    $scope.hasError = false;
+                    $scope.cropAdded = false;
 	                return;
                 }
                 else{
                     $scope.newItem = null;
+                    $scope.hasError = false;
+                    return;
                 }
 	        }
 
 	        //there was an error, do the highlight (will be set back by the directive)
 	        $scope.hasError = true;
-	    };
+        };
 	});

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -1,5 +1,5 @@
 angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesController",
-	function ($scope, $timeout) {
+	function ($scope) {
 
 	    if (!$scope.model.value) {
 	        $scope.model.value = [];
@@ -25,7 +25,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	    $scope.add = function (evt) {
 	        evt.preventDefault();
 
-	        if ($scope.newItem && $scope.newItem.alias && 
+	        if ($scope.newItem && $scope.newItem.alias &&
                 angular.isNumber($scope.newItem.width) && angular.isNumber($scope.newItem.height) &&
                 $scope.newItem.width > 0 && $scope.newItem.height > 0) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -1,24 +1,51 @@
 <div ng-controller="Umbraco.PrevalueEditors.CropSizesController" class="umb-editor umb-prevalues-multivalues umb-cropsizes">
 
-    <div class="form" ng-show="newItem">
-        <h4><localize key="imagecropper_defineCrop">Define crop</localize></h4>
-        <p>
+    <!-- ng-show="newItem" -->
+
+    <div class="form">
+        <!-- <h4><localize key="imagecropper_defineCrop">Define crop</localize></h4> -->
+        <!-- <p>
             <localize key="imagecropper_defineCropDescription">Give the crop an alias and it's default width and height</localize>.
-        </p>
+        </p> -->
 
         <div class="control-group">
-            <label><localize key="general_alias">Alias</localize></label>
-            <input name="newItem.alias" type="text"
-                    ng-model="newItem.alias" val-highlight="{{hasError}}" />
+            <label for="addcropalias"><localize key="general_alias">Alias</localize></label>
+            <input
+                id="addcropalias"
+                name="newItem.alias"
+                type="text"
+                ng-model="newItem.alias"
+                val-highlight="{{hasError}}"
+                localize="placeholder"
+                placeholder="@general_alias"
+            />
         </div>
 
         <div class="control-group">
-            <label><localize key="general_size">Size</localize></label>
-            <input name="newItem.width" type="number" localize="placeholder" placeholder="@general_width"
-                    ng-model="newItem.width" class="umb-editor-small" val-highlight="{{hasError}}" />
-            &times;
-            <input name="newItem.height" type="number" localize="placeholder" placeholder="@general_height"
-                    ng-model="newItem.height" class="umb-editor-small" val-highlight="{{hasError}}" />
+            <p><localize key="general_size">Size</localize></p>
+            <label for="addcropwidth" class="visuallyhidden">Crop width</label>
+            <input
+                name="newItem.width"
+                type="number"
+                localize="placeholder"
+                placeholder="@general_width"
+                ng-model="newItem.width"
+                class="umb-editor-small"
+                val-highlight="{{hasError}}"
+                id="addcropwidth"
+            />
+            <span class="umb-cropsizes__times">&times;</span>
+            <label for="addcropheight" class="visuallyhidden">Crop height</label>
+            <input
+                name="newItem.height"
+                type="number"
+                localize="placeholder"
+                placeholder="@general_height"
+                ng-model="newItem.height"
+                class="umb-editor-small"
+                val-highlight="{{hasError}}"
+                id="addcropheight"
+            />
         </div>
 
         <div class="control-group">
@@ -26,6 +53,10 @@
             <a href class="btn btn-link" ng-click="cancel($event)"><localize key="general_cancel">Cancel</localize></a>
         </div>
     </div>
+
+    <!-- <div class="control-group" ng-hide="newItem">
+            <button class="btn" ng-click="newItem = {}" prevent-default><localize key="imagecropper_addCrop">Add new crop</localize></button>
+        </div> -->
 
     <div ui-sortable="sortableOptions">
         <div class="control-group umb-prevalues-multivalues__listitem" ng-repeat="item in model.value">
@@ -38,10 +69,6 @@
                 <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></a>
             </div>
         </div>
-    </div>
-
-    <div class="control-group" ng-hide="newItem">
-        <button class="btn" ng-click="newItem = {}" prevent-default><localize key="imagecropper_addCrop">Add new crop</localize></button>
     </div>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -56,7 +56,7 @@
 
     </div>
 
-    <div ui-sortable="sortableOptions">
+    <div ui-sortable="sortableOptions" class="umb-cropsizes__sortable">
         <div class="control-group umb-prevalues-multivalues__listitem" ng-repeat="item in model.value">
             <i class="icon icon-navigation handle"></i>
             <div class="umb-prevalues-multivalues__left">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -30,7 +30,7 @@
                 localize="placeholder"
                 placeholder="@general_width"
                 ng-model="newItem.width"
-                class="umb-editor-small"
+                class="umb-cropsizes__input umb-cropsizes__input--narrow"
                 val-highlight="{{hasError}}"
                 id="addcropwidth"
             />
@@ -42,7 +42,7 @@
                 localize="placeholder"
                 placeholder="@general_height"
                 ng-model="newItem.height"
-                class="umb-editor-small"
+                class="umb-cropsizes__input umb-cropsizes__input--narrow"
                 val-highlight="{{hasError}}"
                 id="addcropheight"
             />

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -9,7 +9,7 @@
         </p> -->
 
         <div class="control-group">
-            <label for="addcropalias"><localize key="general_alias">Alias</localize></label>
+            <label for="addcropalias" class="visuallyhidden"><localize key="general_alias">Alias</localize></label>
             <input
                 id="addcropalias"
                 name="newItem.alias"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -47,9 +47,10 @@
                 id="addcropheight"
             />
 
-            <button class="btn btn-info add" ng-click="add($event)"><localize key="general_add">Add</localize></button>
+            <button class="btn btn-info add" ng-hide="editMode" ng-click="add($event)"><localize key="general_add">Add</localize></button>
+            <button class="btn btn-info add" ng-show="editMode" ng-click="add($event)"><localize key="general_update">Update</localize></button>
 
-            <a href class="btn btn-link" ng-click="cancel($event)"><localize key="general_cancel">Cancel</localize></a>
+            <a href class="btn btn-link" ng-show="editMode" ng-click="cancel($event)"><localize key="general_cancel">Cancel</localize></a>
         </div>
     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -29,6 +29,7 @@
                 class="umb-cropsizes__input umb-cropsizes__input--narrow"
                 val-highlight="{{hasError}}"
                 id="addcropwidth"
+                min="0"
             />
         </div>
 
@@ -43,6 +44,7 @@
                 class="umb-cropsizes__input umb-cropsizes__input--narrow"
                 val-highlight="{{hasError}}"
                 id="addcropheight"
+                min="0"
             />
         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -46,17 +46,12 @@
                 val-highlight="{{hasError}}"
                 id="addcropheight"
             />
-        </div>
 
-        <div class="control-group">
-            <button class="btn" ng-click="add($event)"><localize key="imagecropper_saveCrop">Save crop</localize></button>
+            <button class="btn btn-info add" ng-click="add($event)"><localize key="general_add">Add</localize></button>
+
             <a href class="btn btn-link" ng-click="cancel($event)"><localize key="general_cancel">Cancel</localize></a>
         </div>
     </div>
-
-    <!-- <div class="control-group" ng-hide="newItem">
-            <button class="btn" ng-click="newItem = {}" prevent-default><localize key="imagecropper_addCrop">Add new crop</localize></button>
-        </div> -->
 
     <div ui-sortable="sortableOptions">
         <div class="control-group umb-prevalues-multivalues__listitem" ng-repeat="item in model.value">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -30,6 +30,7 @@
                 val-highlight="{{hasError}}"
                 id="addcropwidth"
                 min="0"
+                pattern="[0-9]*"
             />
         </div>
 
@@ -45,6 +46,7 @@
                 val-highlight="{{hasError}}"
                 id="addcropheight"
                 min="0"
+                pattern="[0-9]*"
             />
         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -1,62 +1,57 @@
 <div ng-controller="Umbraco.PrevalueEditors.CropSizesController" class="umb-editor umb-prevalues-multivalues umb-cropsizes">
 
-    <div class="form">
-        <!-- <h4><localize key="imagecropper_defineCrop">Define crop</localize></h4> -->
-        <!-- <p>
-            <localize key="imagecropper_defineCropDescription">Give the crop an alias and it's default width and height</localize>.
-        </p> -->
+    <div class="control-group umb-cropsizes__add">
 
-        <div class="control-group umb-cropsizes__add">
-
-            <div class="umb-cropsizes__input-wrap">
-                <label for="addcropalias"><localize key="general_alias">Alias</localize></label>
-                <input
-                    id="addcropalias"
-                    name="newItem.alias"
-                    type="text"
-                    ng-model="newItem.alias"
-                    class="umb-cropsizes__input"
-                    val-highlight="{{hasError}}"
-                    localize="placeholder"
-                    placeholder="@general_alias"
-                />
-            </div>
-
-            <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--icon">
-                <label for="addcropwidth"><localize key="general_width">Width</localize></label>
-                <input
-                    name="newItem.width"
-                    type="number"
-                    localize="placeholder"
-                    placeholder="@general_width"
-                    ng-model="newItem.width"
-                    class="umb-cropsizes__input umb-cropsizes__input--narrow"
-                    val-highlight="{{hasError}}"
-                    id="addcropwidth"
-                />
-            </div>
-
-            <div class="umb-cropsizes__input-wrap">
-                <label for="addcropheight"><localize key="general_height">Height</localize></label>
-                <input
-                    name="newItem.height"
-                    type="number"
-                    localize="placeholder"
-                    placeholder="@general_height"
-                    ng-model="newItem.height"
-                    class="umb-cropsizes__input umb-cropsizes__input--narrow"
-                    val-highlight="{{hasError}}"
-                    id="addcropheight"
-                />
-            </div>
-
-            <div class="umb-cropsizes__controls">
-                <button class="btn btn-info add" ng-hide="editMode" ng-click="add($event)"><localize key="general_add">Add</localize></button>
-                <button class="btn btn-info add" ng-show="editMode" ng-click="add($event)"><localize key="general_update">Update</localize></button>
-                <a href class="btn btn-link" ng-show="editMode" ng-click="cancel($event)"><localize key="general_cancel">Cancel</localize></a>
-            </div>
-
+        <div class="umb-cropsizes__input-wrap">
+            <label for="addcropalias"><localize key="general_alias">Alias</localize></label>
+            <input
+                id="addcropalias"
+                name="newItem.alias"
+                type="text"
+                ng-model="newItem.alias"
+                class="umb-cropsizes__input"
+                val-highlight="{{hasError}}"
+                localize="placeholder"
+                placeholder="@general_alias"
+                focus-when="{{setFocus}}"
+                ng-change="change()"
+            />
         </div>
+
+        <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow umb-cropsizes__input-wrap--icon">
+            <label for="addcropwidth"><localize key="general_width">Width</localize></label>
+            <input
+                name="newItem.width"
+                type="number"
+                localize="placeholder"
+                placeholder="@general_width"
+                ng-model="newItem.width"
+                class="umb-cropsizes__input umb-cropsizes__input--narrow"
+                val-highlight="{{hasError}}"
+                id="addcropwidth"
+            />
+        </div>
+
+        <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow">
+            <label for="addcropheight"><localize key="general_height">Height</localize></label>
+            <input
+                name="newItem.height"
+                type="number"
+                localize="placeholder"
+                placeholder="@general_height"
+                ng-model="newItem.height"
+                class="umb-cropsizes__input umb-cropsizes__input--narrow"
+                val-highlight="{{hasError}}"
+                id="addcropheight"
+            />
+        </div>
+
+        <div class="umb-cropsizes__controls">
+            <button class="btn btn-info add" ng-hide="editMode" ng-click="add($event)"><localize key="general_add">Add</localize></button>
+            <button class="btn btn-info add" ng-show="editMode" ng-click="add($event)"><localize key="general_update">Update</localize></button>
+            <a href class="btn btn-link" ng-show="editMode" ng-click="cancel($event)"><localize key="general_cancel">Cancel</localize></a>
+        </div>
+
     </div>
 
     <div ui-sortable="sortableOptions">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -1,19 +1,4 @@
-<div ng-controller="Umbraco.PrevalueEditors.CropSizesController" class="umb-editor umb-cropsizes">
-
-
-    <div class="control-group" ng-if="model.value.length > 0">
-        <ul class="unstyled list-icons"
-            ui-sortable
-            ng-model="model.value">
-            <li ng-repeat="node in model.value">
-                <a href=""><i class="icon icon-delete red hover-show pull-right" ng-click="remove(node, $event)"></i></a>
-                <i class="icon icon-picture handle hover-hide"></i>
-
-                <a href prevent-default ng-click="edit(node, $event)">{{node.alias}}</a>
-                <br /><small>{{node.width}}px &times; {{node.height}}px</small>
-            </li>
-        </ul>
-    </div>
+<div ng-controller="Umbraco.PrevalueEditors.CropSizesController" class="umb-editor umb-prevalues-multivalues umb-cropsizes">
 
     <div class="form" ng-show="newItem">
         <h4><localize key="imagecropper_defineCrop">Define crop</localize></h4>
@@ -24,21 +9,34 @@
         <div class="control-group">
             <label><localize key="general_alias">Alias</localize></label>
             <input name="newItem.alias" type="text"
-                   ng-model="newItem.alias" val-highlight="{{hasError}}" />
+                    ng-model="newItem.alias" val-highlight="{{hasError}}" />
         </div>
 
         <div class="control-group">
             <label><localize key="general_size">Size</localize></label>
             <input name="newItem.width" type="number" localize="placeholder" placeholder="@general_width"
-                   ng-model="newItem.width" class="umb-editor-small" val-highlight="{{hasError}}" />
+                    ng-model="newItem.width" class="umb-editor-small" val-highlight="{{hasError}}" />
             &times;
             <input name="newItem.height" type="number" localize="placeholder" placeholder="@general_height"
-                   ng-model="newItem.height" class="umb-editor-small" val-highlight="{{hasError}}" />
+                    ng-model="newItem.height" class="umb-editor-small" val-highlight="{{hasError}}" />
         </div>
 
         <div class="control-group">
             <button class="btn" ng-click="add($event)"><localize key="imagecropper_saveCrop">Save crop</localize></button>
             <a href class="btn btn-link" ng-click="cancel($event)"><localize key="general_cancel">Cancel</localize></a>
+        </div>
+    </div>
+
+    <div ui-sortable="sortableOptions">
+        <div class="control-group umb-prevalues-multivalues__listitem" ng-repeat="item in model.value">
+            <i class="icon icon-navigation handle"></i>
+            <div class="umb-prevalues-multivalues__left">
+                <p><span>{{item.alias}}</span> <small>({{item.width}}px &times; {{item.height}}px)</small></p>
+            </div>
+            <div class="umb-prevalues-multivalues__right">
+                <a href="#" prevent-default class="umb-node-preview__action umb-node-preview__action--red" ng-click="edit(item, $event)" class="umb-prevalues-multivalues__action">Edit</a>
+                <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></a>
+            </div>
         </div>
     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -1,56 +1,61 @@
 <div ng-controller="Umbraco.PrevalueEditors.CropSizesController" class="umb-editor umb-prevalues-multivalues umb-cropsizes">
 
-    <!-- ng-show="newItem" -->
-
     <div class="form">
         <!-- <h4><localize key="imagecropper_defineCrop">Define crop</localize></h4> -->
         <!-- <p>
             <localize key="imagecropper_defineCropDescription">Give the crop an alias and it's default width and height</localize>.
         </p> -->
 
-        <div class="control-group">
-            <label for="addcropalias" class="visuallyhidden"><localize key="general_alias">Alias</localize></label>
-            <input
-                id="addcropalias"
-                name="newItem.alias"
-                type="text"
-                ng-model="newItem.alias"
-                val-highlight="{{hasError}}"
-                localize="placeholder"
-                placeholder="@general_alias"
-            />
-        </div>
+        <div class="control-group umb-cropsizes__add">
 
-        <div class="control-group">
-            <p><localize key="general_size">Size</localize></p>
-            <label for="addcropwidth" class="visuallyhidden">Crop width</label>
-            <input
-                name="newItem.width"
-                type="number"
-                localize="placeholder"
-                placeholder="@general_width"
-                ng-model="newItem.width"
-                class="umb-cropsizes__input umb-cropsizes__input--narrow"
-                val-highlight="{{hasError}}"
-                id="addcropwidth"
-            />
-            <span class="umb-cropsizes__times">&times;</span>
-            <label for="addcropheight" class="visuallyhidden">Crop height</label>
-            <input
-                name="newItem.height"
-                type="number"
-                localize="placeholder"
-                placeholder="@general_height"
-                ng-model="newItem.height"
-                class="umb-cropsizes__input umb-cropsizes__input--narrow"
-                val-highlight="{{hasError}}"
-                id="addcropheight"
-            />
+            <div class="umb-cropsizes__input-wrap">
+                <label for="addcropalias"><localize key="general_alias">Alias</localize></label>
+                <input
+                    id="addcropalias"
+                    name="newItem.alias"
+                    type="text"
+                    ng-model="newItem.alias"
+                    class="umb-cropsizes__input"
+                    val-highlight="{{hasError}}"
+                    localize="placeholder"
+                    placeholder="@general_alias"
+                />
+            </div>
 
-            <button class="btn btn-info add" ng-hide="editMode" ng-click="add($event)"><localize key="general_add">Add</localize></button>
-            <button class="btn btn-info add" ng-show="editMode" ng-click="add($event)"><localize key="general_update">Update</localize></button>
+            <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--icon">
+                <label for="addcropwidth"><localize key="general_width">Width</localize></label>
+                <input
+                    name="newItem.width"
+                    type="number"
+                    localize="placeholder"
+                    placeholder="@general_width"
+                    ng-model="newItem.width"
+                    class="umb-cropsizes__input umb-cropsizes__input--narrow"
+                    val-highlight="{{hasError}}"
+                    id="addcropwidth"
+                />
+            </div>
 
-            <a href class="btn btn-link" ng-show="editMode" ng-click="cancel($event)"><localize key="general_cancel">Cancel</localize></a>
+            <div class="umb-cropsizes__input-wrap">
+                <label for="addcropheight"><localize key="general_height">Height</localize></label>
+                <input
+                    name="newItem.height"
+                    type="number"
+                    localize="placeholder"
+                    placeholder="@general_height"
+                    ng-model="newItem.height"
+                    class="umb-cropsizes__input umb-cropsizes__input--narrow"
+                    val-highlight="{{hasError}}"
+                    id="addcropheight"
+                />
+            </div>
+
+            <div class="umb-cropsizes__controls">
+                <button class="btn btn-info add" ng-hide="editMode" ng-click="add($event)"><localize key="general_add">Add</localize></button>
+                <button class="btn btn-info add" ng-show="editMode" ng-click="add($event)"><localize key="general_update">Update</localize></button>
+                <a href class="btn btn-link" ng-show="editMode" ng-click="cancel($event)"><localize key="general_cancel">Cancel</localize></a>
+            </div>
+
         </div>
     </div>
 

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1298,8 +1298,6 @@ To manage your website, simply open the Umbraco back office and start adding con
     </area>
     <area alias="imagecropper">
         <key alias="reset">Reset crop</key>
-        <key alias="defineCrop">Define crop</key>
-        <key alias="defineCropDescription">Give the crop an alias and its default width and height</key>
         <key alias="saveCrop">Save crop</key>
         <key alias="addCrop">Add new crop</key>
         <key alias="updateEditCrop">Done</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1296,8 +1296,6 @@ To manage your website, simply open the Umbraco back office and start adding con
     </area>
     <area alias="imagecropper">
         <key alias="reset">Reset crop</key>
-        <key alias="defineCrop">Define crop</key>
-        <key alias="defineCropDescription">Give the crop an alias and its default width and height</key>
         <key alias="saveCrop">Save crop</key>
         <key alias="addCrop">Add new crop</key>
         <key alias="updateEditCrop">Done</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -1039,8 +1039,6 @@
     </area>
     <area alias="imagecropper">
         <key alias="reset">Reiniciar</key>
-        <key alias="defineCrop">Definir corte</key>
-        <key alias="defineCropDescription">Da al corte un alias y su anchura y altura por defecto</key>
         <key alias="saveCrop">Guardar corte</key>
         <key alias="addCrop">Añadir nuevo corte</key>
     </area>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -1286,7 +1286,6 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
   <area alias="imagecropper">
     <key alias="reset">Réinitialiser</key>
     <key alias="defineCrop">Définir le recadrage</key>
-    <key alias="defineCropDescription">Donnez un alias au recadrage ainsi que sa largeur et sa hauteur par défaut</key>
     <key alias="saveCrop">Sauvegarder le recadrage</key>
     <key alias="addCrop">Ajouter un nouveau recadrage</key>
   </area>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -1022,8 +1022,6 @@ Naciśnij przycisk <strong>instaluj</strong>, aby zainstalować bazę danych Umb
   </area>
   <area alias="imagecropper">
     <key alias="reset">Resetuj</key>
-    <key alias="defineCrop">Zdefiniuj przycięcie</key>
-    <key alias="defineCropDescription">Ustaw alias dla przycięcia, a także jego domyślną szerokość i długość</key>
     <key alias="saveCrop">Zapisz przycięcie</key>
     <key alias="addCrop">Dodaj nowe przycięcie</key>
   </area>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -879,8 +879,6 @@
   </area>
   <area alias="imagecropper">
     <key alias="reset">Сбросить</key>
-    <key alias="defineCrop">Задать рамку</key>
-    <key alias="defineCropDescription">Задайте рамке имя (алиас), а также ширину и высоту по-умолчанию</key>
     <key alias="saveCrop">Сохранить рамку</key>
     <key alias="addCrop">Добавить новую рамку</key>
   </area>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -645,8 +645,6 @@
   </area>
   <area alias="imagecropper">
     <key alias="reset">Återställ</key>
-    <key alias="defineCrop">Definiera beskräning</key>
-    <key alias="defineCropDescription">Ge beskärningen ett alias och dess standardbredd och -höjd</key>
     <key alias="saveCrop">spara beskärning</key>
     <key alias="addCrop">Lägg till ny beskärning</key>
   </area>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -999,8 +999,6 @@
   </area>
   <area alias="imagecropper">
     <key alias="reset">Reset</key>
-    <key alias="defineCrop">Define crop</key>
-    <key alias="defineCropDescription">Give the crop an alias and its default width and height</key>
     <key alias="saveCrop">Save crop</key>
     <key alias="addCrop">Add new crop</key>
   </area>

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -229,7 +229,7 @@ namespace Umbraco.Web.PropertyEditors
 
         internal class ImageCropperPreValueEditor : PreValueEditor
         {
-            [PreValueField("crops", "Crop sizes", "views/propertyeditors/imagecropper/imagecropper.prevalues.html")]
+            [PreValueField("crops", "Define crops", "views/propertyeditors/imagecropper/imagecropper.prevalues.html", Description = "Give the crop an alias and it's default width and height")]
             public string Crops { get; set; }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/3324) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3324
- [x] I have added steps to test this contribution in the description below

### Description

The UI for defining crops on an image cropper property editor is a bit out of date and out of touch with the current UI. Therefore I'm currently working on aligning it a bit more with what we currently have when defining color pickers, checkbox lists etc.

I think I'm done with this PR - Below examples on before and after can be seen. If this PR is accepted then please let me know if I should spend some extra time removing the dictionary items, which are no longer in use because of these changes before the PR is merged - Currently there still is some code that is commented out, which is used for a heading and some text description. This should of course be deleted but keeping it for now to remember, which translation keys that maybe need to be deleted. The deletions can of course be done in another PR but it might be better to have it done in this one.

**Editor experience before**
![crop-prop-editor-before](https://user-images.githubusercontent.com/1932158/47113961-b9268880-d25a-11e8-969e-5837a72bff53.gif)

**Editor experience after**
![crop-prop-editor-after](https://user-images.githubusercontent.com/1932158/47113979-cb082b80-d25a-11e8-88a0-f392d0133e88.gif)

