### PR TITLE
Data type editing on a mobile needed some style changes.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -2,7 +2,12 @@
 // Container styles
 // --------------------------------------------------
 .umb-property-editor {
-  min-width:66.6%;
+    @media (max-width: 800px) {
+        width: 100%;
+    }
+    @media (min-width: 800px) {
+      min-width:66.6%;
+    }
 
 	&-pull {
 		float:left;

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-editor.html
@@ -1,3 +1,3 @@
-<div class="umb-property-editor" ng-class="{'-not-clickable': preview}">
+<div class="umb-property-editor dib" ng-class="{'-not-clickable': preview}">
     <div ng-include="propertyEditorView"></div>
 </div>


### PR DESCRIPTION
When typing to configure some of the data types on a small width screen ( mobile or very narrow browser window ) the editing controls for some of the data types did not wrap underneath the titles and in some cases they disappeared completely.

### Description

Issue: #3327 

This adds a 100% width on small screen sizes and then reverts back to the original 60% width after 800px's.