### PR TITLE
Removed joke from default 404 page

### DIFF
--- a/src/Umbraco.Web/Routing/PublishedContentNotFoundHandler.cs
+++ b/src/Umbraco.Web/Routing/PublishedContentNotFoundHandler.cs
@@ -42,7 +42,6 @@ namespace Umbraco.Web.Routing
 			if (!string.IsNullOrWhiteSpace(_message))
 				response.Write("<p>" + _message + "</p>");
 			response.Write("<p>This page can be replaced with a custom 404. Check the documentation for \"custom 404\".</p>");
-			response.Write("<p style=\"border-top: 1px solid #ccc; padding-top: 10px\"><small>This page is intentionally left ugly ;-)</small></p>");
 			response.Write("</body></html>");
 		}
 


### PR DESCRIPTION
We had a client object to the wording of the 404 page, so I've removed the joke at the end so that the default page appears a little more professional.