### PR TITLE
Changed font-awesome verison from 4.2 to 4.7

### DIFF
--- a/src/Umbraco.Web.UI.Client/bower.json
+++ b/src/Umbraco.Web.UI.Client/bower.json
@@ -31,7 +31,7 @@
     "moment": "~2.10.3",
     "ace-builds": "^1.2.3",
     "clipboard": "1.7.1",
-    "font-awesome": "~4.2"
+    "font-awesome": "~4.7"
   },
   "install": {
     "path": "lib-bower",
@@ -43,11 +43,11 @@
     ],
     "sources": {
       "moment": [
-          "bower_components/moment/min/moment.min.js",
-          "bower_components/moment/min/moment-with-locales.js",
-          "bower_components/moment/min/moment-with-locales.min.js",
-          "bower_components/moment/locale/*.js"
-        ],
+        "bower_components/moment/min/moment.min.js",
+        "bower_components/moment/min/moment-with-locales.js",
+        "bower_components/moment/min/moment-with-locales.min.js",
+        "bower_components/moment/locale/*.js"
+      ],
       "underscore": [
         "bower_components/underscore/underscore-min.js",
         "bower_components/underscore/underscore-min.map"


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3326
- [x] I have added steps to test this contribution in the description below

### Description

I updated the bower.json file to use the version 4.7 instead of the version 4.2 of font-awesome. After a build of Belle (so running bower and gulp), the files of font-awesome gets updated with the version 4.7.

To test this, just check the content of the font-awesome.min.css file to see if the comment indicates that version 4.7 is used.

(The change made for moment.js just relates to indentation, I didn't change anything at these lines).
