### PR TITLE
Add EditLink Helper Method

### DIFF
--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -1057,11 +1057,26 @@ namespace Umbraco.Web
             BottomLeft = 3
         }
 
-        public IHtmlString EditLink(IPublishedContent thisPage,
-            EditLinkPosition position = EditLinkPosition.TopLeft, string linkColour = "#00aea2", string editMessage = "Edit",
-            int margin = 10, int zindex = 999, string umbracoPath = "/umbraco",
-            int fontSize = 16, string outerPosition = "fixed", string linkPosition = "absolute",
-            string outerClassName = "edit-link-outer", string linkClassName = "edit-link-inner")
+        /// <summary>
+        /// This will render an edit link on the page. You can override all of the default settings to position and style it yourself.
+        /// </summary>
+        /// <param name="contentId">The id of the page which will be edited</param>
+        /// <param name="position">The position of the link, top left etc.</param>
+        /// <param name="linkColour">The CSS colour of the link.</param>
+        /// <param name="editMessage">The text to display in the link</param>
+        /// <param name="margin">The margin around the link</param>
+        /// <param name="zindex">The zindex of the link to make it show above the content on the page</param>
+        /// <param name="umbracoPath">The umbraco path, in case you have changed it</param>
+        /// <param name="fontSize">The font size of the link</param>
+        /// <param name="outerPosition">Position styling for the outer container</param>
+        /// <param name="linkPosition">Position styling for the link inside the container</param>
+        /// <param name="outerClassName">Class name for the outer container</param>
+        /// <param name="linkClassName">Class name for the link</param>
+        /// <returns></returns>
+        public IHtmlString EditLink(int contentId, EditLinkPosition position = EditLinkPosition.TopLeft,
+            string linkColour = "#00aea2", string editMessage = "Edit", int margin = 10, int zindex = 999,
+            string umbracoPath = "/umbraco", int fontSize = 16, string outerPosition = "fixed",
+            string linkPosition = "absolute", string outerClassName = "edit-link-outer", string linkClassName = "edit-link-inner")
         {
             StringBuilder editLinkCode = new StringBuilder();
             var userTicket = new HttpContextWrapper(HttpContext.Current).GetUmbracoAuthTicket();
@@ -1097,28 +1112,28 @@ namespace Umbraco.Web
 
                 string umbracoEditContentUrl = $"{umbracoPath}#/content/content/edit/";
 
-                editLinkCode.Append($"<div");
+                editLinkCode.Append("<div");
                 editLinkCode.Append($" class=\"{outerClassName}\"");
                 if (!string.IsNullOrEmpty(outerStyles))
                 {
                     editLinkCode.Append($" style=\"{outerStyles}\"");
                 }
-                editLinkCode.Append($">");
+                editLinkCode.Append(">");
 
                 string linkStyles = $"color:{linkColour};";
                 linkStyles += $"font-size:{fontSize}px;";
 
-                editLinkCode.Append($"<a ");
+                editLinkCode.Append("<a ");
                 editLinkCode.Append($" class=\"{linkClassName}\"");
                 if (!string.IsNullOrEmpty(linkStyles))
                 {
                     editLinkCode.Append($"style={linkStyles}");
                 }
 
-                editLinkCode.Append($" target=\"_blank\"");
-                editLinkCode.Append($" href =\"{umbracoEditContentUrl}{thisPage.Id}\"");
+                editLinkCode.Append(" target=\"_blank\"");
+                editLinkCode.Append($" href =\"{umbracoEditContentUrl}{contentId}\"");
                 editLinkCode.Append($">{editMessage}</a>");
-                editLinkCode.Append($"</div>");
+                editLinkCode.Append("</div>");
             }
 
             return MvcHtmlString.Create(editLinkCode.ToString());

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Web;
+using System.Web.Mvc;
 using System.Xml.XPath;
 using Umbraco.Core;
 using Umbraco.Core.Dictionary;
@@ -1041,6 +1043,85 @@ namespace Umbraco.Web
         public HtmlString If(bool test, string valueIfTrue)
         {
             return test ? new HtmlString(valueIfTrue) : new HtmlString(string.Empty);
+        }
+
+        #endregion
+
+        #region EditLink
+
+        public enum EditLinkPosition
+        {
+            TopLeft = 0,
+            TopRight = 1,
+            BottomRight = 2,
+            BottomLeft = 3
+        }
+
+        public IHtmlString EditLink(IPublishedContent thisPage,
+            EditLinkPosition position = EditLinkPosition.TopLeft, string linkColour = "#00aea2", string editMessage = "Edit",
+            int margin = 10, int zindex = 999, string umbracoPath = "/umbraco",
+            int fontSize = 16, string outerPosition = "fixed", string linkPosition = "absolute",
+            string outerClassName = "edit-link-outer", string linkClassName = "edit-link-inner")
+        {
+            StringBuilder editLinkCode = new StringBuilder();
+            var userTicket = new HttpContextWrapper(HttpContext.Current).GetUmbracoAuthTicket();
+
+            if (userTicket != null)
+            {
+                string outerStyles = "display:block;";
+                if (outerPosition == "fixed")
+                {
+                    switch (position)
+                    {
+                        case EditLinkPosition.TopLeft:
+                            outerStyles += $"top:{margin}px;";
+                            outerStyles += $"left:{margin}px;";
+                            break;
+                        case EditLinkPosition.TopRight:
+                            outerStyles += $"top:{margin}px;";
+                            outerStyles += $"right:{margin}px;";
+                            break;
+                        case EditLinkPosition.BottomRight:
+                            outerStyles += $"bottom:{margin}px;";
+                            outerStyles += $"right:{margin}px;";
+                            break;
+                        case EditLinkPosition.BottomLeft:
+                            outerStyles += $"bottom:{margin}px;";
+                            outerStyles += $"left:{margin}px;";
+                            break;
+                    }
+                }
+
+                outerStyles += $"z-index:{zindex};";
+                outerStyles += $"position:{outerPosition};";
+
+                string umbracoEditContentUrl = $"{umbracoPath}#/content/content/edit/";
+
+                editLinkCode.Append($"<div");
+                editLinkCode.Append($" class=\"{outerClassName}\"");
+                if (!string.IsNullOrEmpty(outerStyles))
+                {
+                    editLinkCode.Append($" style=\"{outerStyles}\"");
+                }
+                editLinkCode.Append($">");
+
+                string linkStyles = $"color:{linkColour};";
+                linkStyles += $"font-size:{fontSize}px;";
+
+                editLinkCode.Append($"<a ");
+                editLinkCode.Append($" class=\"{linkClassName}\"");
+                if (!string.IsNullOrEmpty(linkStyles))
+                {
+                    editLinkCode.Append($"style={linkStyles}");
+                }
+
+                editLinkCode.Append($" target=\"_blank\"");
+                editLinkCode.Append($" href =\"{umbracoEditContentUrl}{thisPage.Id}\"");
+                editLinkCode.Append($">{editMessage}</a>");
+                editLinkCode.Append($"</div>");
+            }
+
+            return MvcHtmlString.Create(editLinkCode.ToString());
         }
 
         #endregion


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes: #3350
- [x] I have added steps to test this contribution in the description below

### Description
This PR is to add a new helper method to the UmbracoHelper.cs class

You call it from any view like this:

```
@Umbraco.EditLink(Model.Id)
```

And as a result it would render an edit link on the front end, if you are logged into the backoffice.
If you are not logged into the backoffice, then the link will not render.

It would not be added to people's Views by default. They would just need to add it where they wanted to use it.

The styling of this link can be overridden completely. There are many optional parameters to override.

Here is the issue which I raised for this feature #3350 

