### PR TITLE
Make sure indexes are created as unique when using .Unique() syntax builder (#3319)

### DIFF
--- a/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/DefinitionFactory.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/DefinitionFactory.cs
@@ -158,8 +158,7 @@ namespace Umbraco.Core.Persistence.DatabaseModelDefinitions
                                      Name = indexName,
                                      IndexType = attribute.IndexType,
                                      ColumnName = columnName,
-                                     TableName = tableName,
-                                     IsClustered = attribute.IndexType == IndexTypes.Clustered,                                    
+                                     TableName = tableName,                                                                     
                                  };
 
             if (string.IsNullOrEmpty(attribute.ForColumns) == false)

--- a/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/DefinitionFactory.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/DefinitionFactory.cs
@@ -159,8 +159,7 @@ namespace Umbraco.Core.Persistence.DatabaseModelDefinitions
                                      IndexType = attribute.IndexType,
                                      ColumnName = columnName,
                                      TableName = tableName,
-                                     IsClustered = attribute.IndexType == IndexTypes.Clustered,
-                                     IsUnique = attribute.IndexType == IndexTypes.UniqueNonClustered
+                                     IsClustered = attribute.IndexType == IndexTypes.Clustered,                                    
                                  };
 
             if (string.IsNullOrEmpty(attribute.ForColumns) == false)

--- a/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/IndexDefinition.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/IndexDefinition.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Core.Persistence.DatabaseModelDefinitions
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
         public virtual string ColumnName { get; set; }
-        public virtual bool IsUnique { get; set; }
+        
         public bool IsClustered { get; set; }
         public virtual ICollection<IndexColumnDefinition> Columns { get; set; }
         public IndexTypes IndexType { get; set; }

--- a/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/IndexDefinition.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/IndexDefinition.cs
@@ -14,8 +14,7 @@ namespace Umbraco.Core.Persistence.DatabaseModelDefinitions
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
         public virtual string ColumnName { get; set; }
-        
-        public bool IsClustered { get; set; }
+               
         public virtual ICollection<IndexColumnDefinition> Columns { get; set; }
         public IndexTypes IndexType { get; set; }
     }

--- a/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/IndexDefinition.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/IndexDefinition.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Umbraco.Core.Persistence.DatabaseAnnotations;
 
@@ -14,7 +15,12 @@ namespace Umbraco.Core.Persistence.DatabaseModelDefinitions
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
         public virtual string ColumnName { get; set; }
-               
+
+        [Obsolete("Use the IndexType property instead and set it to IndexTypes.UniqueNonClustered")]
+        public virtual bool IsUnique { get; set; }
+
+        [Obsolete("Use the IndexType property instead and set it to IndexTypes.Clustered")]
+        public bool IsClustered { get; set; }
         public virtual ICollection<IndexColumnDefinition> Columns { get; set; }
         public IndexTypes IndexType { get; set; }
     }

--- a/src/Umbraco.Core/Persistence/Migrations/Syntax/Alter/Column/AlterColumnBuilder.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Syntax/Alter/Column/AlterColumnBuilder.cs
@@ -140,8 +140,7 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Alter.Column
             {
                 Name = indexName,
                 SchemaName = Expression.SchemaName,
-                TableName = Expression.TableName,
-                IsUnique = true,
+                TableName = Expression.TableName,                
                 IndexType = IndexTypes.UniqueNonClustered
             });
 

--- a/src/Umbraco.Core/Persistence/Migrations/Syntax/Alter/Column/AlterColumnBuilder.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Syntax/Alter/Column/AlterColumnBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.Migrations.Syntax.Alter.Expressions;
 using Umbraco.Core.Persistence.Migrations.Syntax.Expressions;
@@ -140,8 +141,11 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Alter.Column
                 Name = indexName,
                 SchemaName = Expression.SchemaName,
                 TableName = Expression.TableName,
-                IsUnique = true
+                IsUnique = true,
+                IndexType = IndexTypes.UniqueNonClustered
             });
+
+            
 
             index.Index.Columns.Add(new IndexColumnDefinition
                                         {

--- a/src/Umbraco.Core/Persistence/Migrations/Syntax/Alter/Table/AlterTableBuilder.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Syntax/Alter/Table/AlterTableBuilder.cs
@@ -125,8 +125,7 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Alter.Table
             {
                 Name = indexName,
                 SchemaName = Expression.SchemaName,
-                TableName = Expression.TableName,
-                IsUnique = true,
+                TableName = Expression.TableName,               
                 IndexType = IndexTypes.UniqueNonClustered
             });
 

--- a/src/Umbraco.Core/Persistence/Migrations/Syntax/Alter/Table/AlterTableBuilder.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Syntax/Alter/Table/AlterTableBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.Migrations.Syntax.Alter.Expressions;
 using Umbraco.Core.Persistence.Migrations.Syntax.Expressions;
@@ -125,7 +126,8 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Alter.Table
                 Name = indexName,
                 SchemaName = Expression.SchemaName,
                 TableName = Expression.TableName,
-                IsUnique = true
+                IsUnique = true,
+                IndexType = IndexTypes.UniqueNonClustered
             });
 
             index.Index.Columns.Add(new IndexColumnDefinition

--- a/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Column/CreateColumnBuilder.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Column/CreateColumnBuilder.cs
@@ -115,8 +115,7 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Create.Column
             {
                 Name = indexName,
                 SchemaName = Expression.SchemaName,
-                TableName = Expression.TableName,
-                IsUnique = true,
+                TableName = Expression.TableName,               
                 IndexType = IndexTypes.UniqueNonClustered
             });
 

--- a/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Column/CreateColumnBuilder.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Column/CreateColumnBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.Migrations.Syntax.Expressions;
 using Umbraco.Core.Persistence.SqlSyntax;
@@ -115,7 +116,8 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Create.Column
                 Name = indexName,
                 SchemaName = Expression.SchemaName,
                 TableName = Expression.TableName,
-                IsUnique = true
+                IsUnique = true,
+                IndexType = IndexTypes.UniqueNonClustered
             });
 
             index.Index.Columns.Add(new IndexColumnDefinition

--- a/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Index/CreateIndexBuilder.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Index/CreateIndexBuilder.cs
@@ -47,8 +47,7 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Create.Index
         }
 
         ICreateIndexOnColumnSyntax ICreateIndexColumnOptionsSyntax.Unique()
-        {
-            Expression.Index.IsUnique = true;
+        {           
             //if it is Unique then it must be unique nonclustered and set the other flags
             Expression.Index.IndexType = IndexTypes.UniqueNonClustered;
             Expression.Index.IsClustered = false;
@@ -59,26 +58,23 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Create.Index
         {
             Expression.Index.IndexType = IndexTypes.NonClustered;
             Expression.Index.IsClustered = false;
-            Expression.Index.IndexType = IndexTypes.NonClustered;
-            Expression.Index.IsUnique = false;
+           
             return this;
         }
 
         public ICreateIndexOnColumnSyntax Clustered()
-        {
-            Expression.Index.IndexType = IndexTypes.Clustered;
-            Expression.Index.IsClustered = true;
+        {           
             //if it is clustered then we have to change the index type set the other flags
             Expression.Index.IndexType = IndexTypes.Clustered;
             Expression.Index.IsClustered = true;
-            Expression.Index.IsUnique = false;
+           
             return this;
         }
 
         ICreateIndexOnColumnSyntax ICreateIndexOptionsSyntax.Unique()
         {
             Expression.Index.IndexType = IndexTypes.UniqueNonClustered;
-            Expression.Index.IsUnique = true;
+           
             return this;
         }
     }

--- a/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Index/CreateIndexBuilder.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Index/CreateIndexBuilder.cs
@@ -47,34 +47,26 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Create.Index
         }
 
         ICreateIndexOnColumnSyntax ICreateIndexColumnOptionsSyntax.Unique()
-        {           
-            //if it is Unique then it must be unique nonclustered and set the other flags
-            Expression.Index.IndexType = IndexTypes.UniqueNonClustered;
-            Expression.Index.IsClustered = false;
+        {                       
+            Expression.Index.IndexType = IndexTypes.UniqueNonClustered;            
             return this;
         }
 
         public ICreateIndexOnColumnSyntax NonClustered()
         {
-            Expression.Index.IndexType = IndexTypes.NonClustered;
-            Expression.Index.IsClustered = false;
-           
+            Expression.Index.IndexType = IndexTypes.NonClustered;            
             return this;
         }
 
         public ICreateIndexOnColumnSyntax Clustered()
         {           
-            //if it is clustered then we have to change the index type set the other flags
-            Expression.Index.IndexType = IndexTypes.Clustered;
-            Expression.Index.IsClustered = true;
-           
-            return this;
+           Expression.Index.IndexType = IndexTypes.Clustered;           
+           return this;
         }
 
         ICreateIndexOnColumnSyntax ICreateIndexOptionsSyntax.Unique()
         {
-            Expression.Index.IndexType = IndexTypes.UniqueNonClustered;
-           
+            Expression.Index.IndexType = IndexTypes.UniqueNonClustered;           
             return this;
         }
     }

--- a/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Table/CreateTableBuilder.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Table/CreateTableBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.Migrations.Syntax.Create.Expressions;
 using Umbraco.Core.Persistence.Migrations.Syntax.Expressions;
@@ -165,7 +166,8 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Create.Table
                 Name = indexName,
                 SchemaName = Expression.SchemaName,
                 TableName = Expression.TableName,
-                IsUnique = true
+                IsUnique = true,
+                IndexType = IndexTypes.UniqueNonClustered
             });
 
             index.Index.Columns.Add(new IndexColumnDefinition

--- a/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Table/CreateTableBuilder.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Syntax/Create/Table/CreateTableBuilder.cs
@@ -165,8 +165,7 @@ namespace Umbraco.Core.Persistence.Migrations.Syntax.Create.Table
             {
                 Name = indexName,
                 SchemaName = Expression.SchemaName,
-                TableName = Expression.TableName,
-                IsUnique = true,
+                TableName = Expression.TableName,                
                 IndexType = IndexTypes.UniqueNonClustered
             });
 

--- a/src/Umbraco.Tests/Persistence/SyntaxProvider/SqlCeSyntaxProviderTests.cs
+++ b/src/Umbraco.Tests/Persistence/SyntaxProvider/SqlCeSyntaxProviderTests.cs
@@ -89,7 +89,7 @@ WHERE (([umbracoNode].[nodeObjectType] = @0))) x)".Replace(Environment.NewLine, 
             var sqlSyntax = new SqlServerSyntaxProvider();
 
             var indexDefinition = CreateIndexDefinition();
-            indexDefinition.IsClustered = false;
+            indexDefinition.IndexType = IndexTypes.Clustered;
 
             var actual = sqlSyntax.Format(indexDefinition);
             Assert.AreEqual("CREATE CLUSTERED INDEX [IX_A] ON [TheTable] ([A])", actual);


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3319
- [x] I have added steps to test this contribution in the description below

### Description
When using migrations to create your own database table there is a Unique method in the syntax builder to create a unique index on a table. However this does not create the index as unique but as a non unique index.

To reproduce drop the following code in the App_code folder of your umbraco installation

```
using System;
using System.Linq;
using Semver;
using Umbraco.Core;
using Umbraco.Core.Logging;
using Umbraco.Core.Persistence.Migrations;
using Umbraco.Core.Persistence.SqlSyntax;

public class MigrationEvents : ApplicationEventHandler
{
    protected override bool ExecuteWhenApplicationNotConfigured => false;

    protected override bool ExecuteWhenDatabaseNotConfigured => false;

    protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
    {
       this.ApplyMigrations(applicationContext);
    }

    public void ApplyMigrations(ApplicationContext applicationContext)
    {
        var targetVersion = new SemVersion(2);

        var currentVersion = new SemVersion(0);

        var migrations = applicationContext.Services.MigrationEntryService.GetAll("IndexFix");
        var latest = migrations.OrderByDescending(x => x.Version).FirstOrDefault();
        if (latest != null)
            currentVersion = latest.Version;

        if (targetVersion == currentVersion)
            return;

        var migrationRunner = new MigrationRunner(
            applicationContext.Services.MigrationEntryService,
            applicationContext.ProfilingLogger.Logger,
            currentVersion,
            targetVersion,
            "IndexFix");

        try
        {
            migrationRunner.Execute(applicationContext.DatabaseContext.Database);
        }
        catch (Exception ex)
        {
            applicationContext.ProfilingLogger
                .Logger.Error<MigrationEvents>($"Error running IndexFix Migration version {targetVersion}", ex);
        }
    }
}

[Migration("1.0.0", 1, "IndexFix")]
internal class CreateMyTable : MigrationBase
{
   public CreateMyTable(ISqlSyntaxProvider sqlSyntax, ILogger logger)
        : base(sqlSyntax, logger)
    {
    }

   public override void Up()
    {
        this.Create.Table("MyTable")
            .WithColumn("Id").AsInt32().Identity().PrimaryKey($"PK_MyTable")
            .WithColumn("Key").AsGuid().NotNullable().Unique("UK_MyTable_Key")
            .WithColumn("Name").AsString(255).NotNullable();

      
    }

    
    public override void Down()
    {

    }
}

[Migration("2.0.0", 1, "IndexFix")]
internal class AlterMyTable : MigrationBase
{
    public AlterMyTable(ISqlSyntaxProvider sqlSyntax, ILogger logger)
        : base(sqlSyntax, logger)
    {
    }

    public override void Up()
    {
        this.Alter.Table("MyTable").AlterColumn("Name").AsString(255).Unique("UK_MyTable_Name");
    }

    public override void Down()
    {

    }
}
```

After you started your website run the following query on the database

`SELECT * FROM INFORMATION_SCHEMA.INDEXES WHERE  TABLE_NAME = N'myTable'`

Before the fix this will list the indexes as non unique

![non unique](https://user-images.githubusercontent.com/1193822/47224844-da06ef00-d3bc-11e8-93bd-3fd0c6821c3b.jpg)

After the fix is applied the same migration will create the index as unique

![unique](https://user-images.githubusercontent.com/1193822/47224879-f440cd00-d3bc-11e8-9b85-8b486d77b593.jpg)

For resetting the migration code so you can run it again for testing you can reset it by running this query on the database

```
DELETE FROM umbracoMigration WHERE name = 'IndexFix'
GO
DROP TABLE MyTable
GO
```
