### PR TITLE
WIP: 3364 - Suggestion: Make use of confirm action directive on repeatable textstring when deleting

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.controller.js
@@ -2,6 +2,9 @@
 
     var backspaceHits = 0;
 
+    // Set the visible prompt to -1 to ensure it will not be visible
+    $scope.promptIsVisible = "-1";
+
     $scope.sortableOptions = {
         axis: 'y',
         containment: 'parent',
@@ -97,6 +100,20 @@
         }
         $scope.model.value = remainder;
     };
+
+    $scope.showPrompt = function (idx, item){
+
+        var i = $scope.model.value.indexOf(item);
+
+        // Make the prompt visible for the clicked tag only
+        if (i === idx) {
+            $scope.promptIsVisible = i;
+        }
+    }
+
+    $scope.hidePrompt = function(){
+        $scope.promptIsVisible = "-1";
+    }
 
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
@@ -10,6 +10,20 @@
          ng-click="remove($index)">
         <i class="icon icon-remove"></i>
       </a>
+
+    <div style="position: relative">
+        <button type="button" prevet-default ng-click="showPrompt($index, item)" localize="title" title="@content_removeTextBox">
+            <i class="icon-trash"></i>
+        </button>
+
+        <umb-confirm-action
+            ng-if="promptIsVisible === $index"
+            direction="left"
+            on-confirm="remove($index)"
+            on-cancel="hidePrompt()">
+        </umb-confirm-action>
+    </div>
+
     </div>
   </div>
   <a prevent-default href="" class="add-link" localize="title" title="@content_addTextBox"


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/3364) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3364
- [ ] I have added steps to test this contribution in the description below

### Description
This is still work in progress but basically I suggest that the "umbConfirmAction" directive is being used instead of the current way of deleting the text entries, which does not warn the editor before removing things.

Still WIP.