### PR TITLE
#3215 Adds ability to create template from doctype editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.controller.js
@@ -9,7 +9,7 @@
 (function() {
     'use strict';
 
-    function TemplatesController($scope, entityResource, contentTypeHelper, $routeParams) {
+    function TemplatesController($scope, entityResource, contentTypeHelper, templateResource, $routeParams) {
 
         /* ----------- SCOPE VARIABLES ----------- */
 
@@ -21,22 +21,51 @@
 
         /* ---------- INIT ---------- */
 
-        init();
+        init(function () {
 
-        function init() {
+            // update placeholder template information on new doc types
+            if (!$routeParams.notemplate && $scope.model.id === 0) {
+                vm.updateTemplatePlaceholder = true;
+                vm.availableTemplates = contentTypeHelper.insertTemplatePlaceholder(vm.availableTemplates);
+            }
+        });
+
+        function init(callback) {
 
             entityResource.getAll("Template").then(function(templates){
 
                 vm.availableTemplates = templates;
 
-                // update placeholder template information on new doc types
-                if (!$routeParams.notemplate && $scope.model.id === 0) {
-                  vm.updateTemplatePlaceholder = true;
-                  vm.availableTemplates = contentTypeHelper.insertTemplatePlaceholder(vm.availableTemplates);
-                }
+                callback();
 
             });
 
+        }
+
+        vm.createTemplate = function () {
+            templateResource.getScaffold(-1).then(function (template) {
+
+                template.alias = $scope.model.alias;
+                template.name = $scope.model.name;
+
+                templateResource.save(template).then(function (savedTemplate) {
+
+                    init(function () {
+
+                        var newTemplate = vm.availableTemplates.filter(function (t) { return t.id === savedTemplate.id });
+                        if (newTemplate.length > 0) {
+                            $scope.model.allowedTemplates.push(newTemplate[0]);
+
+                            if ($scope.model.defaultTemplate === null) {
+                                $scope.model.defaultTemplate = newTemplate[0];
+                            }
+                        }
+
+                    });
+
+                });
+
+            });
         }
 
     }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
@@ -16,6 +16,11 @@
                            alias="model.alias"
                            update-placeholder="vm.updateTemplatePlaceholder">
         </umb-grid-selector>
+
+        <button type="button" ng-click="vm.createTemplate()" class="btn btn-info">
+            <i class="icon icon-add"></i>
+            <localize key="shortcuts_addTemplate">Add template</localize>
+        </button>
     </div>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
@@ -17,7 +17,7 @@
                            update-placeholder="vm.updateTemplatePlaceholder">
         </umb-grid-selector>
 
-        <button type="button" ng-click="vm.createTemplate()" class="btn btn-info" ng-if="model.allowedTemplates.length == 0">
+        <button type="button" ng-click="vm.createTemplate()" class="btn btn-info" ng-show="model.allowedTemplates.length == 0">
             <i class="icon icon-add"></i>
             <localize key="shortcuts_addTemplate">Add template</localize>
         </button>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
@@ -17,7 +17,7 @@
                            update-placeholder="vm.updateTemplatePlaceholder">
         </umb-grid-selector>
 
-        <button type="button" ng-click="vm.createTemplate()" class="btn btn-info">
+        <button type="button" ng-click="vm.createTemplate()" class="btn btn-info" ng-if="model.allowedTemplates.length == 0">
             <i class="icon icon-add"></i>
             <localize key="shortcuts_addTemplate">Add template</localize>
         </button>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3215 
- [x] I have added steps to test this contribution in the description below

### Description
I added a button for creating a new template in the template view of the doctype editor. The button uses the template resource to fetch a template scaffold, and then save a new template. After saving, the template gets selected as allowed, and if there is no default template selected, the new template will also be the default.

https://i.imgur.com/KQbmjGH.gifv

<!-- Thanks for contributing to Umbraco CMS! -->
