### PR TITLE
Border color for .add-on should be @purple-l3

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -594,7 +594,7 @@ div.help {
     text-align: center;
     text-shadow: 0 1px 0 @white;
     background-color: @gray-10;
-    border: 1px solid @gray-8;
+    border: 1px solid @purple-l3;
   }
   .add-on,
   .btn,


### PR DESCRIPTION
For the date picker (and possibly other input fields), an icon is shown either before or after the input field. The element with the icon does however still use the old gray border color, which then doesn't match the new purple border color used in other elements (including the rest of the input field).

![image](https://user-images.githubusercontent.com/3634580/47254397-36701a00-d462-11e8-9d16-a981a223fa15.png)

