### PR TITLE
<pre> elements should at least have white-space: pre-wrap

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/hacks.less
+++ b/src/Umbraco.Web.UI.Client/src/less/hacks.less
@@ -202,7 +202,7 @@ pre {
   //font-size: @baseFontSize - 1; // 14px to 13px
   color: @gray-2;
   line-height: @baseLineHeight;
-  white-space: pre-line; // 1
+  white-space: pre-wrap; // 1
   overflow-x: auto; // 1
   background-color: @gray-10;
   border: 1px solid @gray-8;


### PR DESCRIPTION
I can see that @madsrasmussen a while ago made a commit so that `<pre>` have `white-space: pre-line;` rather than `white-space: pre;` as it used to.

https://github.com/umbraco/Umbraco-CMS/commit/91b925f95c0c102df8d5e943d10d70a701c3439d

The original `white-space: pre;` makes sure that the value is shown at it's written in the HTML (including indentation - eg. when showing JSON), which has the side effect that long lines are not wrapped.

`white-space: pre-line;` makes sure that lines are wrapped, but also ruins any indentation. On the other hand, `white-space: pre-wrap;` keeps the indentation, but still wraps long lines.

I use `<pre>` elements a lot for debugging and outputting JSON, so I usually end up changing to `white-space: pre-wrap;` in each Umbraco installation I'm working on. But this might as well be added to Umbraco for others as well.