### PR TITLE
Fix #3368 by watching changes and explicitly flagging the form as dirty

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -9,7 +9,7 @@
 (function () {
     "use strict";
 
-    function DocumentTypesEditController($scope, $routeParams, $injector, contentTypeResource, dataTypeResource, editorState, contentEditingHelper, formHelper, navigationService, iconHelper, contentTypeHelper, notificationsService, $filter, $q, localizationService, overlayHelper, eventsService) {
+    function DocumentTypesEditController($scope, $routeParams, $injector, contentTypeResource, dataTypeResource, editorState, contentEditingHelper, formHelper, navigationService, iconHelper, contentTypeHelper, notificationsService, $filter, $q, localizationService, overlayHelper, eventsService, angularHelper) {
 
         var vm = this;
         var localizeSaving = localizationService.localize("general_saving");
@@ -374,6 +374,15 @@
             for (var e in evts) {
                 eventsService.unsubscribe(evts[e]);
             }
+        });
+
+        // #3368 - changes on the other "buttons" do not register on the current form, so we manually have to flag the form as dirty 
+        $scope.$watch("vm.contentType.allowedContentTypes.length + vm.contentType.allowAsRoot + vm.contentType.allowedTemplates.length + vm.contentType.isContainer", function (newVal, oldVal) {
+            if (oldVal === undefined) {
+                // still initializing, ignore
+                return;
+            }
+            angularHelper.getCurrentForm($scope).$setDirty();
         });
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3368
- [x] I have added steps to test this contribution in the description below

### Description

To test this PR:

1. Edit anything in the "List view", "Permissions" or "Templates" sections of the document type editor
2. Navigate away without saving the changes (e.g. select another document type)
3. Verify that the "You have unsaved changes" popup appears

![doctype editor after](https://user-images.githubusercontent.com/7405322/47265931-df387b00-d52f-11e8-82a7-29899c41cb4a.gif)
