### PR TITLE
Localized umb-generate-alias placeholder texts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
@@ -48,7 +48,7 @@ the directive will use {@link umbraco.directives.directive:umbLockedField umbLoc
 **/
 
 angular.module("umbraco.directives")
-    .directive('umbGenerateAlias', function ($timeout, entityResource) {
+    .directive('umbGenerateAlias', function ($timeout, entityResource, localizationService) {
         return {
             restrict: 'E',
             templateUrl: 'views/components/umb-generate-alias.html',
@@ -67,7 +67,21 @@ angular.module("umbraco.directives")
                 var updateAlias = false;
 
                 scope.locked = true;
-                scope.placeholderText = "Enter alias...";
+
+                scope.labels = {
+                    idle: "Enter alias...",
+                    busy: "Generating alias...",
+                };
+                
+                scope.placeholderText = scope.labels.idle;
+                
+                localizationService.localize('placeholders_enterAlias').then(function (value) {
+                    scope.labels.idle = scope.placeholderText = value;
+                });
+
+                localizationService.localize('placeholders_generatingAlias').then(function (value) {
+                    scope.labels.busy = value;
+                });
 
                 function generateAlias(value) {
 
@@ -78,7 +92,7 @@ angular.module("umbraco.directives")
                   if( value !== undefined && value !== "" && value !== null) {
 
                       scope.alias = "";
-                    scope.placeholderText = "Generating Alias...";
+                    scope.placeholderText = scope.labels.busy;
 
                     generateAliasTimeout = $timeout(function () {
                        updateAlias = true;
@@ -92,7 +106,7 @@ angular.module("umbraco.directives")
                   } else {
                     updateAlias = true;
                     scope.alias = "";
-                    scope.placeholderText = "Enter alias...";
+                    scope.placeholderText = scope.labels.idle;
                   }
 
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
@@ -70,7 +70,7 @@ angular.module("umbraco.directives")
 
                 scope.labels = {
                     idle: "Enter alias...",
-                    busy: "Generating alias...",
+                    busy: "Generating alias..."
                 };
                 
                 scope.placeholderText = scope.labels.idle;

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -126,12 +126,21 @@ function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogServ
 
             /** The default error callback used if one is not supplied in the opts */
             function defaultError(data, status, headers, config) {
-                return {
+
+                var err = {
                     //NOTE: the default error message here should never be used based on the above docs!
                     errorMsg: (angular.isString(opts) ? opts : 'An error occurred!'),
                     data: data,
                     status: status
                 };
+
+                // if "opts" is a promise, we set "err.errorMsg" to be that promise
+                if (typeof(opts) == "object" && typeof(opts.then) == "function") {
+                    err.errorMsg = opts;
+                }
+
+                return err;
+
             }
 
             //create the callbacs based on whats been passed in.

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
@@ -1,4 +1,17 @@
-﻿.umb-multiple-textbox .textbox-wrapper {
+﻿.umb-multiple-textbox{
+    &__confirm{
+        position: relative;
+
+        &-action{
+            margin: 0;
+            padding: 2px;
+            background: transparent;
+            border: 0 none;
+        }
+    }
+}
+
+.umb-multiple-textbox .textbox-wrapper {
     align-items: center;
     margin-bottom: 15px;
 }
@@ -7,7 +20,7 @@
     margin-bottom: 0;
 }
 
-.umb-multiple-textbox .textbox-wrapper i {
+.umb-multiple-textbox .textbox-wrapper i:not(.icon-delete, .icon-check) {
     margin-right: 5px;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -594,7 +594,7 @@ div.help {
     text-align: center;
     text-shadow: 0 1px 0 @white;
     background-color: @gray-10;
-    border: 1px solid @gray-8;
+    border: 1px solid @purple-l3;
   }
   .add-on,
   .btn,

--- a/src/Umbraco.Web.UI.Client/src/less/hacks.less
+++ b/src/Umbraco.Web.UI.Client/src/less/hacks.less
@@ -202,7 +202,7 @@ pre {
   //font-size: @baseFontSize - 1; // 14px to 13px
   color: @gray-2;
   line-height: @baseLineHeight;
-  white-space: pre-line; // 1
+  white-space: pre-wrap; // 1
   overflow-x: auto; // 1
   background-color: @gray-10;
   border: 1px solid @gray-8;

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/login.controller.js
@@ -207,7 +207,7 @@
             }
         }
 
-        $scope.allowPasswordReset = Umbraco.Sys.ServerVariables.umbracoSettings.allowPasswordReset;
+        $scope.allowPasswordReset = Umbraco.Sys.ServerVariables.umbracoSettings.canSendRequiredEmail && Umbraco.Sys.ServerVariables.umbracoSettings.allowPasswordReset;
 
         $scope.showLogin = function () {
             $scope.errorMsg = "";

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.controller.js
@@ -2,6 +2,9 @@
 
     var backspaceHits = 0;
 
+    // Set the visible prompt to -1 to ensure it will not be visible
+    $scope.promptIsVisible = "-1";
+
     $scope.sortableOptions = {
         axis: 'y',
         containment: 'parent',
@@ -89,6 +92,9 @@
     };
 
     $scope.remove = function (index) {
+        // Make sure not to trigger other prompts when remove is triggered
+        $scope.hidePrompt();
+
         var remainder = [];
         for (var x = 0; x < $scope.model.value.length; x++) {
             if (x !== index) {
@@ -97,6 +103,20 @@
         }
         $scope.model.value = remainder;
     };
+
+    $scope.showPrompt = function (idx, item){
+
+        var i = $scope.model.value.indexOf(item);
+
+        // Make the prompt visible for the clicked tag only
+        if (i === idx) {
+            $scope.promptIsVisible = i;
+        }
+    }
+
+    $scope.hidePrompt = function(){
+        $scope.promptIsVisible = "-1";
+    }
 
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
@@ -5,11 +5,20 @@
       <input type="text" name="item_{{$index}}" ng-model="item.value" class="umb-editor umb-textstring textstring"
              ng-keyup="addRemoveOnKeyDown($event, $index)" focus-when="{{item.hasFocus}}"/>
       <i class="icon icon-navigation handle" localize="title" title="@general_move"></i>
-      <a prevent-default href="" class="remove" localize="title" title="@content_removeTextBox"
-         ng-show="model.value.length > model.config.min"
-         ng-click="remove($index)">
-        <i class="icon icon-remove"></i>
-      </a>
+
+    <div class="umb-multiple-textbox__confirm" ng-show="model.value.length > model.config.min">
+        <button class="umb-multiple-textbox__confirm-action" type="button" prevet-default ng-click="showPrompt($index, item)" localize="title" title="@content_removeTextBox">
+            <i class="icon-trash"></i>
+        </button>
+
+        <umb-confirm-action
+            ng-if="promptIsVisible === $index"
+            direction="left"
+            on-confirm="remove($index)"
+            on-cancel="hidePrompt()">
+        </umb-confirm-action>
+    </div>
+
     </div>
   </div>
   <a prevent-default href="" class="add-link" localize="title" title="@content_addTextBox"

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -443,6 +443,8 @@
     <key alias="email">Indtast din e-mail</key>
     <key alias="enterMessage">Indtast en besked...</key>
     <key alias="usernameHint">Dit brugernavn er typisk din e-mailadresse</key>
+    <key alias="enterAlias">Indtast alias...</key>
+    <key alias="generatingAlias">Genererer alias...</key>
   </area>
   <area alias="editcontenttype">
     <key alias="allowAtRoot" version="7.2">Tillad på rodniveau</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -464,6 +464,8 @@
         <key alias="enterMessage">Enter a message...</key>
         <key alias="usernameHint">Your username is usually your email</key>
         <key alias="anchor">#value or ?key=value</key>
+        <key alias="enterAlias">Enter alias...</key>
+        <key alias="generatingAlias">Generating alias...</key>
     </area>
     <area alias="editcontenttype">
         <key alias="allowAtRoot" version="7.2">Allow at root</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -464,6 +464,8 @@
         <key alias="enterMessage">Enter a message...</key>
         <key alias="usernameHint">Your username is usually your email</key>
         <key alias="anchor">#value or ?key=value</key>
+        <key alias="enterAlias">Enter alias...</key>
+        <key alias="generatingAlias">Generating alias...</key>
     </area>
     <area alias="editcontenttype">
         <key alias="allowAtRoot" version="7.2">Allow at root</key>

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -52,7 +52,7 @@ namespace Umbraco.Web.Editors
             var keepOnlyKeys = new Dictionary<string, string[]>
             {
                 {"umbracoUrls", new[] {"authenticationApiBaseUrl", "serverVarsJs", "externalLoginsUrl", "currentUserApiBaseUrl"}},
-                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage"}},
+                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "canSendRequiredEmail"}},
                 {"application", new[] {"applicationPath", "cacheBuster"}},
                 {"isDebuggingEnabled", new string[] { }},
                 {"features", new [] {"disabledFeatures"}}
@@ -311,6 +311,7 @@ namespace Umbraco.Web.Editors
                         {"allowPasswordReset", UmbracoConfig.For.UmbracoSettings().Security.AllowPasswordReset},
                         {"loginBackgroundImage",  UmbracoConfig.For.UmbracoSettings().Content.LoginBackgroundImage},
                         {"showUserInvite", EmailSender.CanSendRequiredEmail},
+                        {"canSendRequiredEmail", EmailSender.CanSendRequiredEmail},
                     }
                 },
                 {

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -576,7 +576,7 @@ namespace Umbraco.Web.Editors
         [FileUploadCleanupFilter]
         [ContentPostValidate]
         public ContentItemDisplay PostSaveBlueprint(
-            [ModelBinder(typeof(ContentItemBinder))] ContentItemSave contentItem)
+            [ModelBinder(typeof(BlueprintItemBinder))] ContentItemSave contentItem)
         {
             var contentItemDisplay = PostSaveInternal(contentItem,
                 content =>

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -823,6 +823,7 @@
     </Compile>
     <Compile Include="WebApi\AngularJsonMediaTypeFormatter.cs" />
     <Compile Include="WebApi\AngularJsonOnlyConfigurationAttribute.cs" />
+    <Compile Include="WebApi\Binders\BlueprintItemBinder.cs" />
     <Compile Include="WebApi\Binders\MemberBinder.cs" />
     <Compile Include="WebApi\EnableDetailedErrorsAttribute.cs" />
     <Compile Include="WebApi\Filters\AngularAntiForgeryHelper.cs" />

--- a/src/Umbraco.Web/WebApi/Binders/BlueprintItemBinder.cs
+++ b/src/Umbraco.Web/WebApi/Binders/BlueprintItemBinder.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Web.Models.ContentEditing;
+
+namespace Umbraco.Web.WebApi.Binders
+{
+    internal class BlueprintItemBinder : ContentItemBinder
+    {
+        public BlueprintItemBinder(ApplicationContext applicationContext)
+            : base(applicationContext)
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public BlueprintItemBinder()
+            : this(ApplicationContext.Current)
+        {
+        }
+
+        protected override IContent GetExisting(ContentItemSave model)
+        {
+            return ApplicationContext.Services.ContentService.GetBlueprintById(Convert.ToInt32(model.Id));
+        }        
+    }
+}


### PR DESCRIPTION
For instance when creating a new document type, the placeholder text for entering the name and description are both localized, but the placeholder text for the alias isn't.

![image](https://user-images.githubusercontent.com/3634580/47266677-30e60300-d53a-11e8-9cfc-e1faf66585e3.png)

The field for entering the alias is handled by the `<umb-generate-alias />` directive. With this PR, that `<umb-generate-alias />` is now localized. I've provided translations for `en`, `en-US` and of course also `da`.
