### PR TITLE
umbRequestHelper.resourcePromise does not supports the error message being a promise

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -126,12 +126,21 @@ function umbRequestHelper($http, $q, umbDataFormatter, angularHelper, dialogServ
 
             /** The default error callback used if one is not supplied in the opts */
             function defaultError(data, status, headers, config) {
-                return {
+
+                var err = {
                     //NOTE: the default error message here should never be used based on the above docs!
                     errorMsg: (angular.isString(opts) ? opts : 'An error occurred!'),
                     data: data,
                     status: status
                 };
+
+                // if "opts" is a promise, we set "err.errorMsg" to be that promise
+                if (typeof(opts) == "object" && typeof(opts.then) == "function") {
+                    err.errorMsg = opts;
+                }
+
+                return err;
+
             }
 
             //create the callbacs based on whats been passed in.


### PR DESCRIPTION
The `resourcePromise` function in the `umbRequestHelper` service is being used (among other things) for error handling on HTTP requests. It supports a second `opts` parameter, which is the options for the method.

If the `opts` is just a string, it will be used as the error message should the request fail. This is used a lot through the Angular code - eg. here:

https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js#L217

While this allows to specify a custom error message, it doesn't support that error message to be translated. With this PR, I've added support for alternatively specifying an Angular promise instead.

Assuming the promise comes from the `localizationService.localize` method, the promise is then passed on to the Angular view, which then will show the result of the promise (AKA the localized error message).