### PR TITLE
Mediatyperesource localized

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
@@ -243,22 +243,26 @@ function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter, locali
 
         createContainer: function(parentId, name) {
 
+            var promise = localizationService.localize("media_createFolderFailed", [parentId]);
+
             return umbRequestHelper.resourcePromise(
                  $http.post(
                     umbRequestHelper.getApiUrl(
                        "mediaTypeApiBaseUrl",
                        "PostCreateContainer",
                         { parentId: parentId, name: encodeURIComponent(name) })),
-                'Failed to create a folder under parent id ' + parentId);
+                promise);
         },
 
         renameContainer: function (id, name) {
+
+            var promise = localizationService.localize("media_renameFolderFailed", [id]);
 
             return umbRequestHelper.resourcePromise(
                 $http.post(umbRequestHelper.getApiUrl("mediaTypeApiBaseUrl",
                     "PostRenameContainer",
                     { id: id, name: name })),
-                "Failed to rename the folder with id " + id
+                promise
             );
 
         }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
@@ -3,7 +3,7 @@
     * @name umbraco.resources.mediaTypeResource
     * @description Loads in data for media types
     **/
-function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
+function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter, localizationService) {
 
     return {
 
@@ -208,13 +208,15 @@ function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
                 throw "args.id cannot be null";
             }
 
+            var promise = localizationService.localize("media_moveFailed");
+
             return umbRequestHelper.resourcePromise(
                 $http.post(umbRequestHelper.getApiUrl("mediaTypeApiBaseUrl", "PostMove"),
                     {
                         parentId: args.parentId,
                         id: args.id
                     }),
-                'Failed to move content');
+                promise);
         },
 
         copy: function (args) {

--- a/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
@@ -230,13 +230,15 @@ function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter, locali
                 throw "args.id cannot be null";
             }
 
+            var promise = localizationService.localize("media_copyFailed");
+
             return umbRequestHelper.resourcePromise(
                 $http.post(umbRequestHelper.getApiUrl("mediaTypeApiBaseUrl", "PostCopy"),
                     {
                         parentId: args.parentId,
                         id: args.id
                     }),
-                'Failed to copy content');
+                promise);
         },
 
         createContainer: function(parentId, name) {

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.controller.js
@@ -37,8 +37,7 @@ function MediaTypesCreateController($scope, $location, navigationService, mediaT
                 var section = appState.getSectionState("currentSection");
 
             }, function(err) {
-
-               //TODO: Handle errors
+                $scope.error = err;
             });
         };
     }

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.html
@@ -27,6 +27,13 @@
               ng-submit="createContainer()"
               val-form-manager>
 
+            <div ng-show="error">
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
+            </div>
+
             <umb-control-group label="Enter a folder name" hide-label="false">
                 <input type="text" name="folderName" ng-model="model.folderName" class="umb-textstring textstring input-block-level" required />
             </umb-control-group>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -267,6 +267,7 @@
     <key alias="maxFileSize">Maks filstørrelse er</key>
     <key alias="mediaRoot">Medie rod</key>
     <key alias="moveFailed">Flytning af mediet fejlede</key>
+    <key alias="copyFailed">Kopiering af mediet fejlede</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Opret et nyt medlem</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -268,6 +268,8 @@
     <key alias="mediaRoot">Medie rod</key>
     <key alias="moveFailed">Flytning af mediet fejlede</key>
     <key alias="copyFailed">Kopiering af mediet fejlede</key>
+    <key alias="createFolderFailed">Oprettelse af mappen under parent med id %0% fejlede</key>
+    <key alias="renameFolderFailed">Omdøbning af mappen med id %0% fejlede</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Opret et nyt medlem</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -266,6 +266,7 @@
     <key alias="disallowedFileType">Kan ikke uploade denne fil, den har ikke en godkendt filtype</key>
     <key alias="maxFileSize">Maks filstørrelse er</key>
     <key alias="mediaRoot">Medie rod</key>
+    <key alias="moveFailed">Flytning af mediet fejlede</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Opret et nyt medlem</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -274,6 +274,7 @@
         <key alias="disallowedFileType">Cannot upload this file, it does not have an approved file type</key>
         <key alias="maxFileSize">Max file size is</key>
         <key alias="mediaRoot">Media root</key>
+        <key alias="moveFailed">Failed to move media</key>
     </area>
     <area alias="member">
         <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -275,6 +275,7 @@
         <key alias="maxFileSize">Max file size is</key>
         <key alias="mediaRoot">Media root</key>
         <key alias="moveFailed">Failed to move media</key>
+        <key alias="copyFailed">Failed to copy media</key>
     </area>
     <area alias="member">
         <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -276,6 +276,8 @@
         <key alias="mediaRoot">Media root</key>
         <key alias="moveFailed">Failed to move media</key>
         <key alias="copyFailed">Failed to copy media</key>
+        <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>
+        <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>
     </area>
     <area alias="member">
         <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -275,6 +275,7 @@
         <key alias="disallowedFileType">Cannot upload this file, it does not have an approved file type</key>
         <key alias="maxFileSize">Max file size is</key>
         <key alias="mediaRoot">Media root</key>
+        <key alias="moveFailed">Failed to move media</key>
     </area>
     <area alias="member">
         <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -276,6 +276,7 @@
         <key alias="maxFileSize">Max file size is</key>
         <key alias="mediaRoot">Media root</key>
         <key alias="moveFailed">Failed to move media</key>
+        <key alias="copyFailed">Failed to copy media</key>
     </area>
     <area alias="member">
         <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -277,6 +277,8 @@
         <key alias="mediaRoot">Media root</key>
         <key alias="moveFailed">Failed to move media</key>
         <key alias="copyFailed">Failed to copy media</key>
+        <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>
+        <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>
     </area>
     <area alias="member">
         <key alias="createNewMember">Create a new member</key>


### PR DESCRIPTION
Since we now have https://github.com/umbraco/Umbraco-CMS/pull/3377, I've localized a bit of `mediaTypeResource` (for `en`, `en-US` and `da`).

There are still parts left be localized, but this is a first step towards localizing the entire resource.

**Move failed:**
![image](https://user-images.githubusercontent.com/3634580/47271337-90630380-d578-11e8-8fda-eadecdd93139.png)

**Copy failed:**
![image](https://user-images.githubusercontent.com/3634580/47271350-b7213a00-d578-11e8-81da-4c93e63daeff.png)

**Rename failed:**
![image](https://user-images.githubusercontent.com/3634580/47271321-745f6200-d578-11e8-946c-a980cdf8db7b.png)

**Create failed:**
![image](https://user-images.githubusercontent.com/3634580/47271319-6578af80-d578-11e8-9693-b843de090db9.png)
