### PR TITLE
3381 -  Media picker: Trashed media warning looks weird

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -237,7 +237,7 @@ div.umb-codeeditor .umb-btn-toolbar {
 
 .umb-mediapicker .label{
     &__trashed{
-        background-color: @orange;
+        background-color: @red;
         position: absolute;
         top: 50%;
         left: 50%;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -235,6 +235,18 @@ div.umb-codeeditor .umb-btn-toolbar {
     }
 }
 
+.umb-mediapicker .label{
+    &__trashed{
+        background-color: @orange;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        z-index: 1;
+        transform: translate3d(-50%,-50%,0);
+        margin: 0;
+    }
+}
+
 .umb-mediapicker .picked-image {
   position: absolute;
   bottom: 10px;
@@ -333,7 +345,7 @@ div.umb-codeeditor .umb-btn-toolbar {
     background-image: url(../img/checkered-background.png);
 }
 
-.umb-sortable-thumbnails li img.trashed {
+.umb-sortable-thumbnails li .trashed {
     opacity:0.3;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -16,7 +16,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
         }
 
         function setupViewModel() {
-            $scope.images = [];
+            $scope.mediaItems = [];
             $scope.ids = [];
 
             $scope.isMultiPicker = multiPicker;
@@ -41,7 +41,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                     // on whether it is simply resaved or not.
                     // This is done by remapping the int/guid ids into a new array of items, where we create "Deleted item" placeholders
                     // when there is no match for a selected id. This will ensure that the values being set on save, are the same as before.
-                    
+
                     medias = _.map(ids,
                         function(id) {
                             var found = _.find(medias,
@@ -72,7 +72,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                                 media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
                             }
 
-                            $scope.images.push(media);
+                            $scope.mediaItems.push(media);
 
                             if ($scope.model.config.idType === "udi") {
                                 $scope.ids.push(media.udi);
@@ -89,7 +89,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
         setupViewModel();
 
         $scope.remove = function(index) {
-            $scope.images.splice(index, 1);
+            $scope.mediaItems.splice(index, 1);
             $scope.ids.splice(index, 1);
             $scope.sync();
         };
@@ -117,7 +117,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                            media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
                        }
 
-                       $scope.images.push(media);
+                       $scope.mediaItems.push(media);
 
                        if ($scope.model.config.idType === "udi") {
                            $scope.ids.push(media.udi);
@@ -145,7 +145,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                // content picker. Then we don't have to worry about setting ids, render models, models, we just set one and let the
                // watch do all the rest.
                 $timeout(function(){
-                    angular.forEach($scope.images, function(value, key) {
+                    angular.forEach($scope.mediaItems, function(value, key) {
                         r.push($scope.model.config.idType === "udi" ? value.udi : value.id);
                     });
                     $scope.ids = r;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -9,7 +9,7 @@
 
                 <p class="label label__trashed" ng-if="image.trashed">
                     <localize key="mediaPicker_trashed"></localize>
-                    <i class="icon-trash"></i>
+                    <i class="icon-trash" aria-hidden="true"></i>
                 </p>
 
                 <!-- IMAGE -->

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -2,12 +2,16 @@
 
     <p ng-if="(images|filter:{trashed:true}).length == 1"><localize key="mediaPicker_pickedTrashedItem"></localize></p>
     <p ng-if="(images|filter:{trashed:true}).length > 1"><localize key="mediaPicker_pickedTrashedItems"></localize></p>
-    
+
     <div data-element="sortable-thumbnails" class="flex flex-wrap error">
         <ul ui-sortable="sortableOptions" ng-model="images" class="umb-sortable-thumbnails">
             <li data-element="sortable-thumbnail-{{$index}}" class="umb-sortable-thumbnails__wrapper" ng-repeat="image in images track by $index">
 
-                <span class="label trashed" ng-if="image.trashed"><localize key="mediaPicker_trashed"></localize></span>
+                <p class="label label__trashed" ng-if="image.trashed">
+                    <localize key="mediaPicker_trashed"></localize>
+                    <i class="icon-trash"></i>
+                </p>
+
                 <!-- IMAGE -->
                 <img ng-class="{'trashed': image.trashed}" ng-src="{{image.thumbnail}}" alt="" ng-show="image.thumbnail" title="{{image.trashed ? 'Trashed: ' + image.name : image.name}}" />
 
@@ -16,13 +20,13 @@
                 <img ng-class="{'trashed': image.trashed}" ng-if="image.extension === 'svg'" ng-src="{{image.file}}" alt="" />
 
                 <!-- FILE -->
-                <span class="umb-icon-holder" ng-hide="image.thumbnail || image.metaData.umbracoExtension.Value === 'svg' || image.extension === 'svg'">
+                <div ng-class="{'trashed': image.trashed}" class="umb-icon-holder" ng-hide="image.thumbnail || image.metaData.umbracoExtension.Value === 'svg' || image.extension === 'svg'">
                     <span class="file-icon">
                         <i class="icon {{image.icon}} large"></i>
                         <span>.{{image.extension}}</span>
                     </span>
                     <small>{{image.name}}</small>
-                </span>
+                </div>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
                     <a class="umb-sortable-thumbnails__action" data-element="action-edit" href="" ng-click="goToItem(image)">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -1,35 +1,35 @@
 <div class="umb-editor umb-mediapicker" ng-controller="Umbraco.PropertyEditors.MediaPickerController">
 
-    <p ng-if="(images|filter:{trashed:true}).length == 1"><localize key="mediaPicker_pickedTrashedItem"></localize></p>
-    <p ng-if="(images|filter:{trashed:true}).length > 1"><localize key="mediaPicker_pickedTrashedItems"></localize></p>
+    <p ng-if="(mediaItems|filter:{trashed:true}).length == 1"><localize key="mediaPicker_pickedTrashedItem"></localize></p>
+    <p ng-if="(mediaItems|filter:{trashed:true}).length > 1"><localize key="mediaPicker_pickedTrashedItems"></localize></p>
 
     <div data-element="sortable-thumbnails" class="flex flex-wrap error">
-        <ul ui-sortable="sortableOptions" ng-model="images" class="umb-sortable-thumbnails">
-            <li data-element="sortable-thumbnail-{{$index}}" class="umb-sortable-thumbnails__wrapper" ng-repeat="image in images track by $index">
+        <ul ui-sortable="sortableOptions" ng-model="mediaItems" class="umb-sortable-thumbnails">
+            <li data-element="sortable-thumbnail-{{$index}}" class="umb-sortable-thumbnails__wrapper" ng-repeat="media in mediaItems track by $index">
 
-                <p class="label label__trashed" ng-if="image.trashed">
+                <p class="label label__trashed" ng-if="media.trashed">
                     <localize key="mediaPicker_trashed"></localize>
                     <i class="icon-trash" aria-hidden="true"></i>
                 </p>
 
                 <!-- IMAGE -->
-                <img ng-class="{'trashed': image.trashed}" ng-src="{{image.thumbnail}}" alt="" ng-show="image.thumbnail" title="{{image.trashed ? 'Trashed: ' + image.name : image.name}}" />
+                <img ng-class="{'trashed': media.trashed}" ng-src="{{media.thumbnail}}" alt="" ng-show="media.thumbnail" title="{{media.trashed ? 'Trashed: ' + media.name : media.name}}" />
 
                 <!-- SVG -->
-                <img ng-class="{'trashed': image.trashed}" ng-if="image.metaData.umbracoExtension.Value === 'svg'" ng-src="{{image.metaData.umbracoFile.Value}}" alt="" title="{{image.trashed ? 'Trashed: ' + image.name : image.name}}" />
-                <img ng-class="{'trashed': image.trashed}" ng-if="image.extension === 'svg'" ng-src="{{image.file}}" alt="" />
+                <img ng-class="{'trashed': media.trashed}" ng-if="media.metaData.umbracoExtension.Value === 'svg'" ng-src="{{media.metaData.umbracoFile.Value}}" alt="" title="{{media.trashed ? 'Trashed: ' + media.name : media.name}}" />
+                <img ng-class="{'trashed': media.trashed}" ng-if="media.extension === 'svg'" ng-src="{{media.file}}" alt="" />
 
                 <!-- FILE -->
-                <div ng-class="{'trashed': image.trashed}" class="umb-icon-holder" ng-hide="image.thumbnail || image.metaData.umbracoExtension.Value === 'svg' || image.extension === 'svg'">
+                <div ng-class="{'trashed': media.trashed}" class="umb-icon-holder" ng-hide="media.thumbnail || media.metaData.umbracoExtension.Value === 'svg' || media.extension === 'svg'">
                     <span class="file-icon">
-                        <i class="icon {{image.icon}} large"></i>
-                        <span>.{{image.metaData.umbracoExtension.Value}}</span>
+                        <i class="icon {{media.icon}} large"></i>
+                        <span>.{{media.metaData.umbracoExtension.Value}}</span>
                     </span>
-                    <small>{{image.name}}</small>
+                    <small>{{media.name}}</small>
                 </div>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
-                    <a class="umb-sortable-thumbnails__action" data-element="action-edit" href="" ng-click="goToItem(image)">
+                    <a class="umb-sortable-thumbnails__action" data-element="action-edit" href="" ng-click="goToItem(media)">
                         <i class="icon icon-edit"></i>
                     </a>
                     <a class="umb-sortable-thumbnails__action -red" data-element="action-remove" href="" ng-click="remove($index)">
@@ -38,7 +38,7 @@
                 </div>
             </li>
             <li style="border: none;" class="add-wrapper unsortable" ng-if="showAdd()">
-                <a data-element="sortable-thumbnails-add" href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': (images.length === 0 || isMultiPicker)}" prevent-default>
+                <a data-element="sortable-thumbnails-add" href="#" class="add-link" ng-click="add()" ng-class="{'add-link-square': (mediaItems.length === 0 || isMultiPicker)}" prevent-default>
                     <i class="icon icon-add large"></i>
                 </a>
             </li>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -23,7 +23,7 @@
                 <div ng-class="{'trashed': image.trashed}" class="umb-icon-holder" ng-hide="image.thumbnail || image.metaData.umbracoExtension.Value === 'svg' || image.extension === 'svg'">
                     <span class="file-icon">
                         <i class="icon {{image.icon}} large"></i>
-                        <span>.{{image.extension}}</span>
+                        <span>.{{image.metaData.umbracoExtension.Value}}</span>
                     </span>
                     <small>{{image.name}}</small>
                 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/3381) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3381
- [x] I have added steps to test this contribution in the description below

### Description

So before the "trashed" label could be a bit hard to see and it was placed a little odd within the "image frame". This PR fixes that and it also make sure to dim the icons representing deleted media type that are not images. I also added the trashcan icon to the label text btw.

**Before**
![trashed-warning-before](https://user-images.githubusercontent.com/1932158/47293127-7c1b1700-d609-11e8-8cc3-bf99d39e8dbc.png)

**After - Orange**
I have used the orange color variable currently, which is the same orange being used when the notification service is throwing error

![trashed-warning-after-orange](https://user-images.githubusercontent.com/1932158/47293157-9fde5d00-d609-11e8-850c-552b9766ab9a.png)

**After - Red**
This is what it could like using the red color, which is the one being used in the notification service for shaowing errors as well.

![trashed-warning-after-red](https://user-images.githubusercontent.com/1932158/47293337-24c97680-d60a-11e8-9cbf-000ca4b4d998.png)


So before merging we need to decide if it's the red or orange color? If this change is accepted of course :)