### PR TITLE
3381 - Media picker: Trashed media warning looks weird

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -235,6 +235,18 @@ div.umb-codeeditor .umb-btn-toolbar {
     }
 }
 
+.umb-mediapicker .label{
+    &__trashed{
+        background-color: @orange;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        z-index: 1;
+        transform: translate3d(-50%,-50%,0);
+        margin: 0;
+    }
+}
+
 .umb-mediapicker .picked-image {
   position: absolute;
   bottom: 10px;
@@ -333,7 +345,7 @@ div.umb-codeeditor .umb-btn-toolbar {
     background-image: url(../img/checkered-background.png);
 }
 
-.umb-sortable-thumbnails li img.trashed {
+.umb-sortable-thumbnails li .trashed {
     opacity:0.3;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -9,7 +9,7 @@
 
                 <p class="label label__trashed" ng-if="image.trashed">
                     <localize key="mediaPicker_trashed"></localize>
-                    <i class="icon-trash"></i>
+                    <i class="icon-trash" aria-hidden="true"></i>
                 </p>
 
                 <!-- IMAGE -->

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -2,12 +2,16 @@
 
     <p ng-if="(images|filter:{trashed:true}).length == 1"><localize key="mediaPicker_pickedTrashedItem"></localize></p>
     <p ng-if="(images|filter:{trashed:true}).length > 1"><localize key="mediaPicker_pickedTrashedItems"></localize></p>
-    
+
     <div data-element="sortable-thumbnails" class="flex flex-wrap error">
         <ul ui-sortable="sortableOptions" ng-model="images" class="umb-sortable-thumbnails">
             <li data-element="sortable-thumbnail-{{$index}}" class="umb-sortable-thumbnails__wrapper" ng-repeat="image in images track by $index">
 
-                <span class="label trashed" ng-if="image.trashed"><localize key="mediaPicker_trashed"></localize></span>
+                <p class="label label__trashed" ng-if="image.trashed">
+                    <localize key="mediaPicker_trashed"></localize>
+                    <i class="icon-trash"></i>
+                </p>
+
                 <!-- IMAGE -->
                 <img ng-class="{'trashed': image.trashed}" ng-src="{{image.thumbnail}}" alt="" ng-show="image.thumbnail" title="{{image.trashed ? 'Trashed: ' + image.name : image.name}}" />
 
@@ -16,13 +20,13 @@
                 <img ng-class="{'trashed': image.trashed}" ng-if="image.extension === 'svg'" ng-src="{{image.file}}" alt="" />
 
                 <!-- FILE -->
-                <span class="umb-icon-holder" ng-hide="image.thumbnail || image.metaData.umbracoExtension.Value === 'svg' || image.extension === 'svg'">
+                <div ng-class="{'trashed': image.trashed}" class="umb-icon-holder" ng-hide="image.thumbnail || image.metaData.umbracoExtension.Value === 'svg' || image.extension === 'svg'">
                     <span class="file-icon">
                         <i class="icon {{image.icon}} large"></i>
                         <span>.{{image.extension}}</span>
                     </span>
                     <small>{{image.name}}</small>
-                </span>
+                </div>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
                     <a class="umb-sortable-thumbnails__action" data-element="action-edit" href="" ng-click="goToItem(image)">


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/3381) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3381
- [x] I have added steps to test this contribution in the description below

### Description

So before the "trashed" label could be a bit hard to see and it was placed a little odd within the "image frame". This PR fixes that and it also make sure to dim the icons representing deleted media type that are not images. I also added the trashcan icon to the label text btw.

**Before**
![trashed-warning-before](https://user-images.githubusercontent.com/1932158/47293127-7c1b1700-d609-11e8-8cc3-bf99d39e8dbc.png)

**After - Orange**
I have used the orange color variable currently, which is the same orange being used when the notification service is throwing error

![trashed-warning-after-orange](https://user-images.githubusercontent.com/1932158/47293157-9fde5d00-d609-11e8-850c-552b9766ab9a.png)

**After - Red**
This is what it could like using the red color, which is the one being used in the notification service for shaowing errors as well.

![trashed-warning-after-red](https://user-images.githubusercontent.com/1932158/47293337-24c97680-d60a-11e8-9cbf-000ca4b4d998.png)


So before merging we need to decide if it's the red or orange color? If this change is accepted of course :)