### PR TITLE
Video heading shows when no videos are on the page

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
@@ -1,17 +1,17 @@
 <h3>Hours of Umbraco training videos are only a click away</h3>
 <p>Want to master Umbraco? Spend a couple of minutes learning some best practices by watching one of these videos about using Umbraco. And visit <a href="https://umbraco.tv" target="_blank">umbraco.tv</a> for even more Umbraco videos</p>
 
-<div class="row-fluid" 
-	ng-init="init('https://umbraco.com/feeds/videos/members')" 
-	ng-controller="Umbraco.Dashboard.StartupVideosController">
+<div class="row-fluid"
+     ng-init="init('https://umbraco.com/feeds/videos/members')"
+     ng-controller="Umbraco.Dashboard.StartupVideosController">
 
-    <div ng-show="videos.length">
+    <div ng-show="videos.length !== 0">
         <h4>To get you started:</h4>
-        <ul class="thumbnails" >
+        <ul class="thumbnails">
             <li class="span2" ng-repeat="video in videos">
                 <div class="thumbnail" style="margin-right: 20px">
                     <a target="_blank" href="{{video.link}}" title="{{video.title}}">
-                        <img ng-src="{{video.thumbnail}}"  alt="{{video.title}}">
+                        <img ng-src="{{video.thumbnail}}" alt="{{video.title}}">
                     </a>
                 </div>
             </li>

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMemberGroup.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMemberGroup.aspx.cs
@@ -67,7 +67,7 @@ namespace umbraco.presentation.members
 			_memberGroup.Text = NameTxt.Text;
             memberGroupName.Value = NameTxt.Text;
             _memberGroup.Save();
-            this.ClientTools.ShowSpeechBubble(speechBubbleIcon.save, ui.Text("speechBubbles", "Member group saved", base.getUser()),"");
+            this.ClientTools.ShowSpeechBubble(speechBubbleIcon.save, ui.Text("buttons", "save", base.getUser()),"");
 
             ClientTools
                 .RefreshTree(TreeDefinitionCollection.Instance.FindTree<loadMemberGroups>().Tree.Alias);

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMemberGroup.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMemberGroup.aspx.cs
@@ -67,7 +67,7 @@ namespace umbraco.presentation.members
 			_memberGroup.Text = NameTxt.Text;
             memberGroupName.Value = NameTxt.Text;
             _memberGroup.Save();
-            this.ClientTools.ShowSpeechBubble(speechBubbleIcon.save, ui.Text("buttons", "save", base.getUser()),"");
+            this.ClientTools.ShowSpeechBubble(speechBubbleIcon.save, ui.Text("speechBubbles", "editMemberGroupSaved", base.getUser()),"");
 
             ClientTools
                 .RefreshTree(TreeDefinitionCollection.Instance.FindTree<loadMemberGroups>().Tree.Alias);

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMemberGroup.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/members/EditMemberGroup.aspx.cs
@@ -67,7 +67,7 @@ namespace umbraco.presentation.members
 			_memberGroup.Text = NameTxt.Text;
             memberGroupName.Value = NameTxt.Text;
             _memberGroup.Save();
-            this.ClientTools.ShowSpeechBubble(speechBubbleIcon.save, ui.Text("speechBubbles", "editMemberGroupSaved", base.getUser()),"");
+            this.ClientTools.ShowSpeechBubble(speechBubbleIcon.save, ui.Text("speechBubbles", "Member group saved", base.getUser()),"");
 
             ClientTools
                 .RefreshTree(TreeDefinitionCollection.Instance.FindTree<loadMemberGroups>().Tree.Alias);


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/3386) for the proposed changes in this PR, the link is:
- [x] I have added steps to test this contribution in the description below

### Description
When you're on the Member section of the back office, the video dashboard for Umbraco tv shows a heading 'To get started:' even when no videos are actually there to view.
![image](https://user-images.githubusercontent.com/37150989/47301258-67914b80-d616-11e8-82fb-b406d922267a.png)

I've put in some conditional logic so that if there are no videos, you do not get the headings. 
![image](https://user-images.githubusercontent.com/37150989/47301302-7d9f0c00-d616-11e8-9892-f0d2db68394f.png)
