### PR TITLE
Don't add the "Notifications" tree menu item if Umbraco can't send emails

### DIFF
--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -235,7 +235,10 @@ namespace Umbraco.Web.Trees
             menu.Items.Add<ActionRights>(ui.Text("actions", ActionRights.Instance.Alias), true);
             menu.Items.Add<ActionProtect>(ui.Text("actions", ActionProtect.Instance.Alias), true).ConvertLegacyMenuItem(item, "content", "content");
 
-            menu.Items.Add<ActionNotify>(ui.Text("actions", ActionNotify.Instance.Alias), true);
+            if (EmailSender.CanSendRequiredEmail)
+            {
+                menu.Items.Add<ActionNotify>(ui.Text("actions", ActionNotify.Instance.Alias), true);
+            }
             menu.Items.Add<ActionSendToTranslate>(ui.Text("actions", ActionSendToTranslate.Instance.Alias)).ConvertLegacyMenuItem(item, "content", "content");
 
             menu.Items.Add<RefreshNode, ActionRefresh>(ui.Text("actions", ActionRefresh.Instance.Alias), true);


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3390
- [x] I have added steps to test this contribution in the description below

### Description

This PR hides the notification option in the tree menu if SMTP isn't configured.

To test:

1. Remove the SMTP configuration from web.config.
2. Verify that "Notifications" is not present in the menu.
3. Add the SMTP configuration (remember to use an email that's not noreply@example.com).
4. Verify that "Notifications" is present in the menu.