### PR TITLE
Fix field label alignment in "change document type"

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/dialogs/ChangeDocType.aspx
+++ b/src/Umbraco.Web.UI/umbraco/dialogs/ChangeDocType.aspx
@@ -19,7 +19,7 @@
     .umb-dialog .umb-control-group .umb-el-wrap { overflow: hidden; }
     .umb-dialog .umb-control-group .umb-el-wrap label { float: left; width: 140px; font-weight: bold; }
     .umb-dialog .umb-control-group .umb-el-wrap label:after { content:":"; }
-    .umb-dialog .umb-control-group .umb-el-wrap .controls-row { float: left; width: 280px; padding-top: 8px; }
+    .umb-dialog .umb-control-group .umb-el-wrap .controls-row { float: left; width: 280px; padding-bottom: 8px; }
     .umb-dialog .umb-control-group .umb-el-wrap .controls-row select { width: auto; }
     </style>
 
@@ -118,4 +118,3 @@
     </div>
      
 </asp:Content>
-  


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3393
- [x] I have added steps to test this contribution in the description below

### Description

This PR fixes the local styling in the "change document type" dialog, so the field labels align correctly with the values and inputs:

![change doctype after](https://user-images.githubusercontent.com/7405322/47312441-a5a16600-d63c-11e8-99dd-1b761415da2c.png)

To test it, simply open the dialog and check the label alignment 😄 