### PR TITLE
Make sure to check the dirty state of the umbContent app viewModel when saving

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.controller.js
@@ -22,8 +22,12 @@
             //determine a variant is 'dirty' (meaning it will show up as save-able) if it's
             // * the active one
             // * it's editor is in a $dirty state
+            // * it's umbContent app viewModel (if any) is in a $dirty state
             // * it is in NotCreated state
-            return (variant.active || variant.isDirty);
+            var contentApp = _.find(variant.apps, function(app) {
+                return app.alias === "umbContent";
+            });
+            return (variant.active || variant.isDirty || (contentApp && contentApp.viewModel && contentApp.viewModel.isDirty));
         }
 
         function pristineVariantFilter(variant) {


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3403
- [x] I have added steps to test this contribution in the description below

### Description

As described in #3403 the real problem is the variant cloning going on in [this line](https://github.com/umbraco/Umbraco-CMS/blob/temp8/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js#L197). However I'm not sure what will happen if I simply don't clone the variant. I have tested it and it seems to work fine, but there might be some consequences elsewhere that I can't see right now.

So... this is a workaround.

To test it, edit content in multiple language variants and then hit save or publish. Verify that the dialog has all edited language variants as selectable.

Make sure to test both regular editing and split view editing.

Here's how it should look in regular editing:
![unsaved changes after 1](https://user-images.githubusercontent.com/7405322/47365758-85c17f00-d6dc-11e8-8f39-28575874ad4e.gif)

...and here's split view editing:
![unsaved changes after 2](https://user-images.githubusercontent.com/7405322/47365772-8c4ff680-d6dc-11e8-9b96-599ddd03e239.gif)
