### PR TITLE
Change button-divs to real buttons, in order to prevent overlays from…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -25,9 +25,10 @@
 
              <p><strong><localize key="grid_chooseLayout" /></strong></p>
 
-            <div class="preview-rows layout"
-                 ng-repeat="template in model.config.items.templates"
-                 ng-click="addTemplate(template)">
+            <button class="preview-rows layout"
+                    type="button"
+                    ng-repeat="template in model.config.items.templates"
+                    ng-click="addTemplate(template)">
 
                 <div class="preview-row">
 
@@ -47,7 +48,7 @@
 
                 <small>{{template.name}}</small>
 
-            </div> <!-- .templates-preview-rows -->
+            </button> <!-- .templates-preview-rows -->
 
         </div> <!-- .templates-preview -->
         <!-- template picker end -->
@@ -68,15 +69,15 @@
                         <!-- ng-mouseenter="setCurrentRow(row)" -->
                         <!-- ng-mouseleave="disableCurrentRow()"  -->
                         <div class="umb-row"
-                             ng-repeat="row in section.rows"
-                             ng-click="clickRow($index, section.rows)"
-                             ng-class="{
-                                     '-has-config': row.hasConfig,
-                                     '-active': row.active,
-                                     '-active-child': row.hasActiveChild}"
-                             on-outside-click="clickOutsideRow($index, section.rows)"
-                             bind-click-on="{{row.active}}"
-                             data-rowid="{{row.$uniqueId}}">
+                                ng-repeat="row in section.rows"
+                                ng-click="clickRow($index, section.rows)"
+                                ng-class="{
+                                        '-has-config': row.hasConfig,
+                                        '-active': row.active,
+                                        '-active-child': row.hasActiveChild}"
+                                on-outside-click="clickOutsideRow($index, section.rows)"
+                                bind-click-on="{{row.active}}"
+                                data-rowid="{{row.$uniqueId}}">
 
                             <div class="umb-row-title-bar">
 
@@ -265,10 +266,11 @@
 
                         <p ng-hide="section.rows.length > 0"><strong><localize key="grid_addRows" /></strong></p>
 
-                        <div class="preview-rows columns"
-                             ng-repeat="layout in  section.$allowedLayouts"
-                             ng-show="layout.areas.length > 0"
-                             ng-click="addRow(section, layout)">
+                        <button class="preview-rows columns"
+                                type="button"
+                                ng-repeat="layout in  section.$allowedLayouts"
+                                ng-show="layout.areas.length > 0"
+                                ng-click="addRow(section, layout)">
 
                             <div class="preview-row">
 
@@ -286,7 +288,7 @@
 
                             <small>{{layout.label || layout.name}}</small>
 
-                        </div> <!-- .templates-preview-rows -->
+                        </button> <!-- .templates-preview-rows -->
 
                     </div> <!-- .templates-preview -->
                     <!-- column tools end -->


### PR DESCRIPTION
… closing when clicking on them.

### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3391
- [x] I have added steps to test this contribution in the description below

### Description
I changed the divs used to add layouts and rows in the grid editors to buttons, because divs make an overlay close when clicked upon.

I know the grid probably isn't supposed to be used in an overlay, but it's a simple change, and it also makes the grid more accessible, since you can tab to buttons etc. 

### To test
In order to test this, you need to add a grid property to a document type. Install Doc Type Grid Editor, add an element to your grid using the default Doc Type Grid Editor (as it allows all the existing doctypes to be used). Select you current doctype (the one containing the grid property), and start adding content.

Before this fix, the overlay for editing the doc type grid editor would close. Now it stays open, and lets you add content to a grid inside a grid :)

![image](https://user-images.githubusercontent.com/3726467/47385028-36457800-d709-11e8-9742-0d610c84b806.png)


Some gifs:
Before:
https://i.imgur.com/AigBpi7.gifv

After:
https://i.imgur.com/nmxJTsn.gifv


<!-- Thanks for contributing to Umbraco CMS! -->
