### PR TITLE
added propertyAlias parameter to resolveFile method (#2898 take 2)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/canvasdesigner/editors/background.js
+++ b/src/Umbraco.Web.UI.Client/src/canvasdesigner/editors/background.js
@@ -131,7 +131,7 @@ angular.module("Umbraco.canvasdesigner")
                         angular.forEach(child.properties, function (property) {       
                             if (property.alias == "umbracoFile" && property.value)
                             {
-                                child.thumbnail = mediaHelper.resolveFile(child, true);
+                                child.thumbnail = mediaHelper.resolveFile(child, true, property.alias);
                                 child.image = property.value;
                             }
                         })

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
@@ -165,8 +165,8 @@ Use this directive to generate a thumbnail grid of media items.
                         item.extension = mediaHelper.getFileExtension(item.image);
                     // handle full media object
                     } else {
-                        item.thumbnail = mediaHelper.resolveFile(item, true);
-                        item.image = mediaHelper.resolveFile(item, false);
+                        item.thumbnail = mediaHelper.resolveFile(item, true, "umbracoFile");
+                        item.image = mediaHelper.resolveFile(item, false, "umbracoFile");
 
                         var fileProp = _.find(item.properties, function (v) {
                             return (v.alias === "umbracoFile");

--- a/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
@@ -177,38 +177,39 @@ function mediaHelper(umbRequestHelper) {
          * 
          * @param {object} mediaEntity A media Entity returned from the entityResource
          * @param {boolean} thumbnail Whether to return the thumbnail url or normal url
+         * @param {string} propertyAlias The propertyAlias to look for.
          */
         /*jshint loopfunc: true */
-        resolveFile : function(mediaItem, thumbnail){
-            
-            function iterateProps(props){
+        resolveFile: function (mediaItem, thumbnail, propertyAlias) {
+
+            function iterateProps(props) {
                 var res = null;
-                for(var resolver in _mediaFileResolvers) {
-                    var property = _.find(props, function(prop){ return prop.editor === resolver; });
-                    if(property){
+                for (var resolver in _mediaFileResolvers) {
+                    var property = _.find(props, function (prop) { return prop.editor === resolver && (propertyAlias === undefined || prop.alias === propertyAlias); });
+                    if (property) {
                         res = _mediaFileResolvers[resolver](property, mediaItem, thumbnail);
                         break;
                     }
                 }
 
-                return res;    
+                return res;
             }
 
             //we either have properties raw on the object, or spread out on tabs
             var result = "";
-            if(mediaItem.properties){
+            if (mediaItem.properties) {
                 result = iterateProps(mediaItem.properties);
-            }else if(mediaItem.tabs){
-                for(var tab in mediaItem.tabs) {
-                    if(mediaItem.tabs[tab].properties){
+            } else if (mediaItem.tabs) {
+                for (var tab in mediaItem.tabs) {
+                    if (mediaItem.tabs[tab].properties) {
                         result = iterateProps(mediaItem.tabs[tab].properties);
-                        if(result){
+                        if (result) {
                             break;
                         }
                     }
                 }
             }
-            return result;            
+            return result;
         },
 
         /*jshint loopfunc: true */

--- a/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
@@ -150,8 +150,8 @@ function umbPhotoFolderHelper($compile, $log, $timeout, $filter, imageHelper, me
             img.isFolder = !mediaHelper.hasFilePropertyType(img);
 
             if (!img.isFolder) {
-                img.thumbnail = mediaHelper.resolveFile(img, true);
-                img.image = mediaHelper.resolveFile(img, false);
+                img.thumbnail = mediaHelper.resolveFile(img, true, "umbracoFile");
+                img.image = mediaHelper.resolveFile(img, false, "umbracoFile");
             }
         },
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.controller.js
@@ -132,7 +132,7 @@ angular.module("umbraco").controller("Umbraco.Dialogs.LinkPickerController",
 						$scope.target.id = media.id;
 						$scope.target.isMedia = true;
 						$scope.target.name = media.name;
-						$scope.target.url = mediaHelper.resolveFile(media);
+						$scope.target.url = mediaHelper.resolveFile(media, false, "umbracoFile");
 					}
 				});
 			});

--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/mediapicker.controller.js
@@ -104,7 +104,7 @@ angular.module("umbraco")
                         image.cssclass = ($scope.dialogData.selection.indexOf(image) > -1) ? "selected" : "";
                     } else if ($scope.showDetails) {
                         $scope.target = image;
-                        $scope.target.url = mediaHelper.resolveFile(image);
+                        $scope.target.url = mediaHelper.resolveFile(image, false, "umbracoFile");
                     } else {
                         $scope.submit(image);
                     }

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -118,7 +118,7 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 						$scope.model.target.udi = media.udi;
 						$scope.model.target.isMedia = true;
 						$scope.model.target.name = media.name;
-						$scope.model.target.url = mediaHelper.resolveFile(media);
+						$scope.model.target.url = mediaHelper.resolveFile(media, false, "umbracoFile");
 
 						$scope.mediaPickerOverlay.show = false;
 						$scope.mediaPickerOverlay = null;

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -88,7 +88,7 @@ angular.module("umbraco")
                                 $scope.target = node;
                                 if (ensureWithinStartNode(node)) {
                                     selectImage(node);
-                                    $scope.target.url = mediaHelper.resolveFile(node);
+                                    $scope.target.url = mediaHelper.resolveFile(node, false, "umbracoFile");
                                     $scope.target.altText = altText;
                                     $scope.openDetailsDialog();
                                 }
@@ -192,7 +192,7 @@ angular.module("umbraco")
                         if (image.image) {
                             $scope.target.url = image.image;
                         } else {
-                            $scope.target.url = mediaHelper.resolveFile(image);
+                            $scope.target.url = mediaHelper.resolveFile(image, false, "umbracoFile");
                         }
 
                         $scope.openDetailsDialog();
@@ -239,7 +239,7 @@ angular.module("umbraco")
                     if (files.length === 1 && $scope.model.selectedImages.length === 0) {
                         var image = $scope.images[$scope.images.length - 1];
                         $scope.target = image;
-                        $scope.target.url = mediaHelper.resolveFile(image);
+                        $scope.target.url = mediaHelper.resolveFile(image, false, "umbracoFile");
                         selectImage(image);
                     }
                 });


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #2898 
- [x] I have added steps to test this contribution in the description below

### Description
I added a propertyAlias parameter to the resolveFile method as suggested by @nul800sebastiaan in https://github.com/umbraco/Umbraco-CMS/pull/2956#issuecomment-424998226.

### To test
Add an upload (or image cropper) property to a media doctype. Try to link to the media, before resolveFile would return null, because it would hit the new upload property (being empty). After this, resolveFile is instructed to only look for the property called umbracoAlias, and returns the right url.

![image](https://user-images.githubusercontent.com/3726467/47387298-32b4ef80-d70f-11e8-96cd-72bdeed9a751.png)

Gif before: https://i.imgur.com/AmbCcQn.gifv

Gif after: https://i.imgur.com/4QSgCYZ.gifv
