### PR TITLE
Create doctype collections under the chosen parent

### DIFF
--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -209,20 +209,6 @@ namespace Umbraco.Web.Editors
         
         public DocumentTypeCollectionDisplay PostCreateCollection(int parentId, string collectionName, bool collectionCreateTemplate, string collectionItemName, bool collectionItemCreateTemplate, string collectionIcon, string collectionItemIcon)
         {
-            var storeInContainer = false;
-            var allowUnderDocType = -1;
-            // check if it's a folder
-            if (Services.ContentTypeService.GetContentType(parentId) == null)
-            {
-                storeInContainer = true;
-            } else
-            {
-                // if it's not a container, we'll change the parentid to the root,
-                // and use the parent id as the doc type the collection should be allowed under
-                allowUnderDocType = parentId;
-                parentId = -1;
-            }
-
             // create item doctype
             var itemDocType = new ContentType(parentId);
             itemDocType.Name = collectionItemName;
@@ -260,19 +246,15 @@ namespace Umbraco.Web.Editors
             // save collection doctype
             Services.ContentTypeService.Save(collectionDocType);
 
-            // test if the parent id exist and then allow the collection underneath
-            if (storeInContainer == false && allowUnderDocType != -1)
+            // test if the parent exist and then allow the collection underneath
+            var parentCt = Services.ContentTypeService.GetContentType(parentId);
+            if (parentCt != null)
             {
-                var parentCt = Services.ContentTypeService.GetContentType(allowUnderDocType);
-                if (parentCt != null)
-                {
-                    var allowedCts = parentCt.AllowedContentTypes.ToList();
-                    allowedCts.Add(new ContentTypeSort(collectionDocType.Id, allowedCts.Count()));
-                    parentCt.AllowedContentTypes = allowedCts;
-                    Services.ContentTypeService.Save(parentCt);
-                }
+                var allowedCts = parentCt.AllowedContentTypes.ToList();
+                allowedCts.Add(new ContentTypeSort(collectionDocType.Id, allowedCts.Count()));
+                parentCt.AllowedContentTypes = allowedCts;
+                Services.ContentTypeService.Save(parentCt);
             }
-
 
             return new DocumentTypeCollectionDisplay
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3217
- [x] I have added steps to test this contribution in the description below

### Description

See #3217 for steps to reproduce.

To test this PR:

1. Create a doctype collection under a folder and verify that the doctypes are created under the folder.
2. Create a doctype collection under another doctype and verify that the doctypes are created under the chosen doctype.
3. Create a doctype collection in the root and verify that the doctypes are created in the root.

![doc type collection after 1](https://user-images.githubusercontent.com/7405322/47410638-c9f96180-d766-11e8-92fd-679b49eb2b4b.gif)

![doc type collection after 2](https://user-images.githubusercontent.com/7405322/47410641-cbc32500-d766-11e8-8cef-b685e3e1b53c.gif)
