### PR TITLE
V8- #3419 - Fix dictionary tree 

### DIFF
--- a/src/Umbraco.Tests/UI/LegacyDialogTests.cs
+++ b/src/Umbraco.Tests/UI/LegacyDialogTests.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Tests.UI
             }
         }
         
-        [TestCase(typeof(macroTasks), Constants.Applications.Packages)]
+        [TestCase(typeof(macroTasks), Constants.Applications.Settings)]
         [TestCase(typeof(CreatedPackageTasks), Constants.Applications.Packages)]
         public void Check_Assigned_Apps_For_Tasks(Type taskType, string app)
         {

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.edit.controller.js
@@ -19,10 +19,8 @@ function DictionaryEditController($scope, $routeParams, $location, dictionaryRes
     vm.page.menu.currentSection = appState.getSectionState("currentSection");
     vm.page.menu.currentNode = null;
     vm.description = "";
-    vm.showBackButton = true;
-
+    
     vm.save = saveDictionary;
-    vm.back = back;
   
     function loadDictionary() {
 
@@ -102,11 +100,7 @@ function DictionaryEditController($scope, $routeParams, $location, dictionaryRes
                     });
         }
     }
-
-    function back() {
-        $location.path("settings/dictionary/list");
-    }
-
+    
     $scope.$watch("vm.content.name", function (newVal, oldVal) {
         //when the value changes, we need to set the name dirty
         if (newVal && (newVal !== oldVal) && typeof(oldVal) !== "undefined") {

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/edit.html
@@ -12,8 +12,7 @@
                 hide-icon="true"
                 hide-description="true"
                 hide-alias="true"
-                on-back="vm.back()"
-                show-back-button="vm.showBackButton">
+                >
             </umb-editor-header>
             
             <umb-editor-container class="form-horizontal">

--- a/src/Umbraco.Web/Models/Trees/SectionRootNode.cs
+++ b/src/Umbraco.Web/Models/Trees/SectionRootNode.cs
@@ -28,6 +28,7 @@ namespace Umbraco.Web.Models.Trees
     {
         private static readonly string RootId = Core.Constants.System.Root.ToString(CultureInfo.InvariantCulture);
         private bool _isGroup;
+        private bool _alwaysShow;
 
         /// <summary>
         /// Creates a group node for grouped multiple trees
@@ -87,13 +88,15 @@ namespace Umbraco.Web.Models.Trees
         /// <param name="menuUrl"></param>
         /// <param name="title"></param>
         /// <param name="children"></param>
+        /// <param name="alwaysShowRootNode"></param>
         /// <returns></returns>
-        public static TreeRootNode CreateSingleTreeRoot(string nodeId, string getChildNodesUrl, string menuUrl, string title, TreeNodeCollection children)
+        public static TreeRootNode CreateSingleTreeRoot(string nodeId, string getChildNodesUrl, string menuUrl, string title, TreeNodeCollection children, bool alwaysShowRootNode = false)
         {
             return new TreeRootNode(nodeId, getChildNodesUrl, menuUrl)
             {
                 Children = children,
-                Name = title
+                Name = title,               
+                _alwaysShow = alwaysShowRootNode
             };
         }
 
@@ -150,6 +153,6 @@ namespace Umbraco.Web.Models.Trees
         /// This is used in the UI to configure a full screen section/app
         /// </remarks>
         [DataMember(Name = "containsTrees")]
-        public bool ContainsTrees => Children.Count > 0;
+        public bool ContainsTrees => Children.Count > 0 || _alwaysShow;
     }
 }

--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Web.Trees
             var groupedTrees = Services.ApplicationTreeService.GetGroupedApplicationTrees(application, onlyInitialized);
             var allTrees = groupedTrees.Values.SelectMany(x => x).ToList();
 
-            if (string.IsNullOrEmpty(tree) == false || allTrees.Count <= 1)
+            if (string.IsNullOrEmpty(tree) == false)
             {
                 var apptree = !tree.IsNullOrWhiteSpace()
                     ? allTrees.FirstOrDefault(x => x.Alias == tree)

--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -171,12 +171,17 @@ namespace Umbraco.Web.Trees
                     throw new InvalidOperationException("Could not create root node for tree " + configTree.Alias);
                 }
 
+                var treeAttribute = configTree.GetTreeAttribute();
+
                 var sectionRoot = TreeRootNode.CreateSingleTreeRoot(
                     rootId,
                     rootNode.Result.ChildNodesUrl,
                     rootNode.Result.MenuUrl,
                     rootNode.Result.Name,
-                    byControllerAttempt.Result);
+                    byControllerAttempt.Result,
+                    treeAttribute.AlwaysShowRootItem);
+
+               
 
                 //assign the route path based on the root node, this means it will route there when the section is navigated to
                 //and no dashboards will be available for this section

--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Web.Trees
             var groupedTrees = Services.ApplicationTreeService.GetGroupedApplicationTrees(application, onlyInitialized);
             var allTrees = groupedTrees.Values.SelectMany(x => x).ToList();
 
-            if (string.IsNullOrEmpty(tree) == false)
+            if (string.IsNullOrEmpty(tree) == false || allTrees.Count <= 1)
             {
                 var apptree = !tree.IsNullOrWhiteSpace()
                     ? allTrees.FirstOrDefault(x => x.Alias == tree)

--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Web.Trees
             var groupedTrees = Services.ApplicationTreeService.GetGroupedApplicationTrees(application, onlyInitialized);
             var allTrees = groupedTrees.Values.SelectMany(x => x).ToList();
 
-            if (string.IsNullOrEmpty(tree) == false || allTrees.Count <= 1)
+            if (string.IsNullOrEmpty(tree) == false || allTrees.Count == 1)
             {
                 var apptree = !tree.IsNullOrWhiteSpace()
                     ? allTrees.FirstOrDefault(x => x.Alias == tree)

--- a/src/Umbraco.Web/Trees/DictionaryTreeController.cs
+++ b/src/Umbraco.Web/Trees/DictionaryTreeController.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Web.Trees
     [UmbracoTreeAuthorize(Constants.Trees.Dictionary)]
     [Mvc.PluginController("UmbracoTrees")]
     [CoreTree(TreeGroup = Constants.Trees.Groups.Settings)]
-    [Tree(Constants.Applications.Translation, Constants.Trees.Dictionary, null, sortOrder: 0)]
+    [Tree(Constants.Applications.Translation, Constants.Trees.Dictionary, null, alwaysShowRootItem: true)]
     public class DictionaryTreeController : TreeController
     {
         protected override TreeNode CreateRootNode(FormDataCollection queryStrings)

--- a/src/Umbraco.Web/Trees/TreeAttribute.cs
+++ b/src/Umbraco.Web/Trees/TreeAttribute.cs
@@ -28,13 +28,15 @@ namespace Umbraco.Web.Trees
         /// <param name="iconOpen">The icon open.</param>
         /// <param name="initialize">if set to <c>true</c> [initialize].</param>
         /// <param name="sortOrder">The sort order.</param>
+        /// <param name="alwaysShowRootItem">Always show the root item</param>
         public TreeAttribute(string appAlias,
             string alias,
             string title,
             string iconClosed = "icon-folder",
             string iconOpen = "icon-folder-open",
             bool initialize = true,
-            int sortOrder = 0)
+            int sortOrder = 0,
+            bool alwaysShowRootItem = false)
         {
             ApplicationAlias = appAlias;
             Alias = alias;
@@ -43,6 +45,7 @@ namespace Umbraco.Web.Trees
             IconOpen = iconOpen;
             Initialize = initialize;
             SortOrder = sortOrder;
+            AlwaysShowRootItem = alwaysShowRootItem;
         }
 
 
@@ -54,5 +57,7 @@ namespace Umbraco.Web.Trees
         public string IconOpen { get; private set; }
         public bool Initialize { get; private set; }
         public int SortOrder { get; private set; }
+
+        public bool AlwaysShowRootItem { get; private set; }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3419 
- [x] I have added steps to test this contribution in the description below

### Description

The current fix makes the dictionary tree work in the translation section without it having items. It also fixes the error when you try to move it to the settings section.

I also removed the back arrow on the edit screen of a dictionary item, because it doesn't make sence if you would be taken back to the settings section when you are editing it in the translation section.

But there are a couple of side effects. In the users section the tree now becomes visible. And in the content and media section a folder is added creating a extra level in the tree.

A positive side affect is that it fixes : #3373 

So with this fix applied I created a dictionary item and switched back to temp8. Now that I had a dictionary item the tree showed up correctly in the translation section

Could use some pointers on this one
