### PR TITLE
#3373 fixes error when going to forms section when forms is not installed

### DIFF
--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Web.Trees
             //find all tree definitions that have the current application alias
             var appTrees = Services.ApplicationTreeService.GetApplicationTrees(application, onlyInitialized).ToArray();
 
-            if (string.IsNullOrEmpty(tree) == false || appTrees.Length == 1 || appTrees.Any() == false)
+            if (string.IsNullOrEmpty(tree) == false || appTrees.Length == 1)
             {
                 var apptree = string.IsNullOrEmpty(tree) == false 
                     ? appTrees.SingleOrDefault(x => x.Alias == tree)


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes: #3373 
- [x] I have added steps to test this contribution in the description below

### Description

This PR fixes #3373 the error when going to the forms section is gone. All other trees seem to be working