### PR TITLE
WIP: 3421 - Document type collection labels are not placed correctly

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -85,16 +85,28 @@
             <umb-control-group label="Name of the Parent Document Type" hide-label="false">
                 <input type="text" name="collectionName" ng-model="model.collectionName" class="umb-textstring textstring input-block-level" umb-auto-focus required />
                 <span ng-if="model.disableTemplates === false">
-                    <umb-toggle on-click="model.collectionCreateTemplate = !model.collectionCreateTemplate" checked="model.collectionCreateTemplate"></umb-toggle>
-                    <label>Create template for the Parent Document Type</label>
+                    <umb-toggle
+                        on-click="model.collectionCreateTemplate = !model.collectionCreateTemplate"
+                        checked="model.collectionCreateTemplate"
+                        label-on="Create template for the Parent Document Type"
+                        label-off="Create template for the Parent Document Type"
+                        show-labels="true"
+                        label-position="right">
+                    </umb-toggle>
                 </span>
             </umb-control-group>
 
             <umb-control-group label="Name of the Item Document Type" hide-label="false">
                 <input type="text" name="collectionItemName" ng-model="model.collectionItemName" class="umb-textstring textstring input-block-level" required />
                 <span ng-if="model.disableTemplates === false">
-                    <umb-toggle on-click="model.collectionItemCreateTemplate = !model.collectionItemCreateTemplate" checked="model.collectionItemCreateTemplate"></umb-toggle>
-                    <label>Create template for the Item Document Type</label>
+                    <umb-toggle
+                        on-click="model.collectionItemCreateTemplate = !model.collectionItemCreateTemplate"
+                        checked="model.collectionItemCreateTemplate"
+                        label-on="Create template for the Item Document Type"
+                        label-off="Create template for the Item Document Type"
+                        show-labels="true"
+                        label-position="right">
+                    </umb-toggle>
                 </span>
             </umb-control-group>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues/3421) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3421
- [ ] I have added steps to test this contribution in the description below

### Description
The labels for the toggles to enable templates in the "doctype collection" are placed at little weird currently.

This is what it looked like before
![labels-before](https://user-images.githubusercontent.com/1932158/47438925-b02e3d80-d7ab-11e8-9506-2dd70b8c4562.jpg)


This is what it looks like after
![labels-after](https://user-images.githubusercontent.com/1932158/47438938-b6241e80-d7ab-11e8-96c3-82fbcda64f9e.png)

However this PR is still work in progress since clicking the labels just closes the menu instead of toggling between true/false...I need to figure out why this happens since it's not the expected behaviour and usually it works out of the box.