### PR TITLE
V8:  Make it less likely to activate the split view by accident

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -157,7 +157,7 @@ a.umb-variant-switcher__toggle {
 }
 
 .umb-variant-switcher__item {
-    position: relative;
+	position: relative;
 	border-bottom: 1px solid @gray-9;
 }
 
@@ -184,9 +184,9 @@ a.umb-variant-switcher__toggle {
 }
 
 .umb-variant-switcher__item:hover .umb-variant-switcher__split-view:hover {
-    display: block;
-    cursor: pointer;
-    color: @black;
+	display: block;
+	cursor: pointer;
+	color: @black;
 }
 
 .umb-variant-switcher__name-wrapper {
@@ -209,12 +209,12 @@ a.umb-variant-switcher__toggle {
 }
 
 .umb-variant-switcher__split-view {
-    font-size: 24px;
-    color: @gray-7;
-    padding: 4px 4px;
-    position: absolute;
-    right: 6px;
-    bottom: 12px;
+	font-size: 24px;
+	color: @gray-7;
+	padding: 4px 4px;
+	position: absolute;
+	right: 6px;
+	bottom: 12px;
 }
 
 // container

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -186,7 +186,7 @@ a.umb-variant-switcher__toggle {
 .umb-variant-switcher__item:hover .umb-variant-switcher__split-view:hover {
     display: block;
     cursor: pointer;
-    opacity: 1;
+    color: @black;
 }
 
 .umb-variant-switcher__name-wrapper {
@@ -209,9 +209,9 @@ a.umb-variant-switcher__toggle {
 }
 
 .umb-variant-switcher__split-view {
-	font-size: 24px;
-    opacity: 0.4;
-	padding: 4px 4px;
+    font-size: 24px;
+    color: @gray-7;
+    padding: 4px 4px;
     position: absolute;
     right: 6px;
     bottom: 12px;

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -157,9 +157,7 @@ a.umb-variant-switcher__toggle {
 }
 
 .umb-variant-switcher__item {
-	display: flex;
-    justify-content: space-between;
-	align-items: center;
+    position: relative;
 	border-bottom: 1px solid @gray-9;
 }
 
@@ -185,9 +183,10 @@ a.umb-variant-switcher__toggle {
 	cursor: default;
 }
 
-.umb-variant-switcher__item:hover .umb-variant-switcher__split-view {
-	display: block;
-	cursor: pointer;
+.umb-variant-switcher__item:hover .umb-variant-switcher__split-view:hover {
+    display: block;
+    cursor: pointer;
+    opacity: 1;
 }
 
 .umb-variant-switcher__name-wrapper {
@@ -210,9 +209,12 @@ a.umb-variant-switcher__toggle {
 }
 
 .umb-variant-switcher__split-view {
-	font-size: 13px;
-	display: none;
-	padding: 8px 20px;
+	font-size: 24px;
+    opacity: 0.4;
+	padding: 4px 4px;
+    position: absolute;
+    right: 6px;
+    bottom: 12px;
 }
 
 // container

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -44,7 +44,7 @@
                                 <span class="umb-variant-switcher__name">{{variant.language.name}}</span>
                                 <umb-variant-state variant="variant" class="umb-variant-switcher__state"></umb-variant-state>
                             </a>
-                            <div ng-if="splitViewOpen !== true && !variant.active" class="umb-variant-switcher__split-view" ng-click="openInSplitView($event, variant)">Open in split view</div>
+                            <div ng-if="splitViewOpen !== true && !variant.active" class="umb-variant-switcher__split-view icon icon-split" ng-click="openInSplitView($event, variant)" title="Open in split view"></div>
                         </umb-dropdown-item>
                     </umb-dropdown>
 
@@ -79,4 +79,3 @@
     </div>
 
 </div>
-    


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3427
- [x] I have added steps to test this contribution in the description below

### Description

This is a suggestion on how to mend the problem outlined in #3427. It's simply to use an icon instead of the "Open in split view" text (the text is used as title).

Here's how it looks on desktop:
![split view toggle after](https://user-images.githubusercontent.com/7405322/47454776-59872a80-d7d0-11e8-9918-9a56262bbe26.gif)

...and here's how it looks on a device:
![split view toggle after device](https://user-images.githubusercontent.com/7405322/47454793-6441bf80-d7d0-11e8-966a-a25390f7d2e3.gif)

There's still a hover effect on desktop that doesn't get trigged on the device, but at least you can still see you're clicking the split view toggle on the device.
