### PR TITLE
Unable to find suitable version for font-awesome

### DIFF
--- a/src/Umbraco.Web.UI.Client/bower.json
+++ b/src/Umbraco.Web.UI.Client/bower.json
@@ -31,7 +31,10 @@
     "moment": "~2.10.3",
     "ace-builds": "^1.2.3",
     "clipboard": "1.7.1",
-    "font-awesome": "~4.2"
+    "font-awesome": "~4.7"
+  },
+  "resolutions": {
+    "font-awesome": "~4.7"
   },
   "install": {
     "path": "lib-bower",

--- a/src/Umbraco.Web.UI.Client/bower.json
+++ b/src/Umbraco.Web.UI.Client/bower.json
@@ -31,7 +31,7 @@
     "moment": "~2.10.3",
     "ace-builds": "^1.2.3",
     "clipboard": "1.7.1",
-    "font-awesome": "~4.7"
+    "font-awesome": "~4.2"
   },
   "install": {
     "path": "lib-bower",


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3430 
- [x] I have added steps to test this contribution in the description below

### Description
bootstrap-social#~4.8.0 has a dependency on version 4.2 of font-awsome.

I want to update bootstrap-social to version 5, other depencies collide.

For now, rollback to font-awsome will solve the problem.


