### PR TITLE
V8 - #3433 - Use toggle for allow varying by culture

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -1994,7 +1994,7 @@ namespace Umbraco.Core.Services.Implement
             if (raiseEvents && published.Any())
                 scope.Events.Dispatch(Published, this, new PublishEventArgs<IContent>(published, false, false), "Published");
 
-            Audit(AuditType.Sort, "Sorting content performed by user", userId, 0);
+            Audit(AuditType.Sort, userId, 0, "Sorting content performed by user");
             return true;
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -48,7 +48,8 @@
             "shortcuts_toggleListView",
             "shortcuts_toggleAllowAsRoot",
             "shortcuts_addChildNode",
-            "shortcuts_addTemplate"
+            "shortcuts_addTemplate",
+            "shortcuts_toggleAllowCultureVariants"
         ];
 
         onInit();
@@ -81,6 +82,7 @@
             vm.labels.allowAsRoot = values[11];
             vm.labels.addChildNode = values[12];
             vm.labels.addTemplate = values[13];
+            vm.labels.allowCultureVariants = values[14];
 
             var buttons = [
                 {
@@ -161,6 +163,10 @@
                         {
                             "description": vm.labels.addChildNode,
                             "keys": [{ "key": "alt" }, { "key": "shift" }, { "key": "c" }]
+                        },
+                        {
+                            "description": vm.labels.allowCultureVariants,
+                            "keys": [{ "key": "alt" }, { "key": "shift" }, { "key": "v" }]
                         }
                     ]
                 },

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
@@ -23,7 +23,8 @@
 
         vm.addChild = addChild;
         vm.removeChild = removeChild;
-        vm.toggle = toggle;
+        vm.toggleAllowAsRoot = toggleAllowAsRoot;
+        vm.toggleAllowCultureVariants = toggleAllowCultureVariants;
 
         /* ---------- INIT ---------- */
 
@@ -86,13 +87,22 @@
         /**
          * Toggle the $scope.model.allowAsRoot value to either true or false
          */
-        function toggle(){
+        function toggleAllowAsRoot(){
             if($scope.model.allowAsRoot){
                 $scope.model.allowAsRoot = false;
                 return;
             }
 
             $scope.model.allowAsRoot = true;
+        }
+
+        function toggleAllowCultureVariants() {
+            if ($scope.model.allowCultureVariant) {
+                $scope.model.allowCultureVariant = false;
+                return;
+            }
+
+            $scope.model.allowCultureVariant = true;
         }
 
     }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
@@ -10,11 +10,10 @@
                     <small><localize key="contentTypeEditor_allowAsRootDescription" /></small>
                 </div>
                 <div class="sub-view-column-right">
-                    <umb-toggle
-                        data-element="permissions-allow-as-root"
-                        checked="model.allowAsRoot"
-                        on-click="vm.toggleAllowAsRoot()"
-                        hotkey="alt+shift+r">
+                    <umb-toggle data-element="permissions-allow-as-root"
+                                checked="model.allowAsRoot"
+                                on-click="vm.toggleAllowAsRoot()"
+                                hotkey="alt+shift+r">
                     </umb-toggle>
                 </div>
 
@@ -28,24 +27,29 @@
                 </div>
 
                 <div class="sub-view-column-right">
-                    <umb-child-selector
-                        selected-children="vm.selectedChildren"
-                        available-children="vm.contentTypes"
-                        parent-name="model.name"
-                        parent-icon="model.icon"
-                        parent-id="model.id"
-                        on-add="vm.addChild"
-                        on-remove="vm.removeChild">
+                    <umb-child-selector selected-children="vm.selectedChildren"
+                                        available-children="vm.contentTypes"
+                                        parent-name="model.name"
+                                        parent-icon="model.icon"
+                                        parent-id="model.id"
+                                        on-add="vm.addChild"
+                                        on-remove="vm.removeChild">
                     </umb-child-selector>
                 </div>
+
+            </div>
+
+            <div class="sub-view-column-section">
+
+                <h5>Content Type Variation</h5>
+                <small>Define the rules for how this content type's properties can be varied</small>
 
             </div>
 
             <div class="sub-view-columns">
 
                 <div class="sub-view-column-left">
-                    <h5>Content Type Variation</h5>
-                    <small>Define the rules for how this content type's properties can be varied</small>
+                    <label>Allow varying by Culture</label>
                 </div>
                 <div class="sub-view-column-right">
                     <umb-toggle data-element="permissions-allow-culture-variant"
@@ -53,13 +57,11 @@
                                 on-click="vm.toggleAllowCultureVariants()"
                                 hotkey="alt+shift+v">
                     </umb-toggle>
-                    <label class="checkbox no-indent">                       
-                        Allow varying by Culture
-                    </label>
+
                 </div>
 
             </div>
-            
+
         </umb-box-content>
     </umb-box>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
@@ -41,15 +41,15 @@
 
             <div class="sub-view-column-section">
 
-                <h5>Content Type Variation</h5>
-                <small>Define the rules for how this content type's properties can be varied</small>
+                <h5><localize key="contentTypeEditor_variantsHeading" /></h5>
+                <small><localize key="contentTypeEditor_variantsDescription" /></small>
 
             </div>
 
             <div class="sub-view-columns">
 
                 <div class="sub-view-column-left">
-                    <label>Allow varying by Culture</label>
+                    <label><localize key="contentTypeEditor_allowVaryByCulture" /></label>
                 </div>
                 <div class="sub-view-column-right">
                     <umb-toggle data-element="permissions-allow-culture-variant"

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
@@ -13,7 +13,7 @@
                     <umb-toggle
                         data-element="permissions-allow-as-root"
                         checked="model.allowAsRoot"
-                        on-click="vm.toggle()"
+                        on-click="vm.toggleAllowAsRoot()"
                         hotkey="alt+shift+r">
                     </umb-toggle>
                 </div>
@@ -48,8 +48,12 @@
                     <small>Define the rules for how this content type's properties can be varied</small>
                 </div>
                 <div class="sub-view-column-right">
-                    <label class="checkbox no-indent">
-                        <input type="checkbox" ng-model="model.allowCultureVariant" />
+                    <umb-toggle data-element="permissions-allow-culture-variant"
+                                checked="model.allowCultureVariant"
+                                on-click="vm.toggleAllowCultureVariants()"
+                                hotkey="alt+shift+v">
+                    </umb-toggle>
+                    <label class="checkbox no-indent">                       
                         Allow varying by Culture
                     </label>
                 </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -680,6 +680,7 @@
     <key alias="moveLineDown">Move Lines Down</key>
     <key alias="generalHeader">General</key>
     <key alias="editorHeader">Editor</key>
+    <key alias="toggleAllowCultureVariants">Toggle allow culture variants</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">Background colour</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1483,6 +1483,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="tabHasNoSortOrder">tab has no sort order</key>
     <key alias="compositionUsageHeading">Where is this composition used?</key>
     <key alias="compositionUsageSpecification">This composition is currently used in the composition of the following content types:</key>
+    <key alias="variantsHeading">Content Type Variation</key>
+    <key alias="variantsDescription">Define the rules for how this content type's properties can be varied</key>
+    <key alias="allowVaryByCulture">Allow varying by Culture</key>
   </area>
   <area alias="modelsBuilder">
     <key alias="buildingModels">Building models</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1505,6 +1505,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="tabHasNoSortOrder">tab has no sort order</key>
     <key alias="compositionUsageHeading">Where is this composition used?</key>
     <key alias="compositionUsageSpecification">This composition is currently used in the composition of the following content types:</key>
+    <key alias="variantsHeading">Content Type Variation</key>
+    <key alias="variantsDescription">Define the rules for how this content type's properties can be varied</key>
+    <key alias="allowVaryByCulture">Allow varying by Culture</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -700,6 +700,7 @@
     <key alias="moveLineDown">Move Lines Down</key>
     <key alias="generalHeader">General</key>
     <key alias="editorHeader">Editor</key>
+    <key alias="toggleAllowCultureVariants">Toggle allow culture variants</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">Background color</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3433 
- [x] I have added steps to test this contribution in the description below

### Description

I have changed the checkbox to umb-toggle for enabling varying by culture. I had to change the markup a bit so please give your input
This is how it looks
![allow varying by culture](https://user-images.githubusercontent.com/1193822/47496232-7b2af500-d856-11e8-9613-be155f36b1f0.jpg)

I also added keys to the language files for the static text.
And the short cut for enabling it has been added to the short cut overview

