### PR TITLE
Prevent error label from moving input box

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/forms/umb-validation-label.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms/umb-validation-label.less
@@ -1,5 +1,5 @@
 .umb-validation-label {
-   position: relative;
+   position: absolute;
    padding: 1px 5px;
    background: @red;
    color: @white;


### PR DESCRIPTION
Currently if you have a validation error on a Forms field it moves the input box like this:
![relative](https://user-images.githubusercontent.com/36075913/47507563-afacaa00-d872-11e8-989e-253a5fa75ac7.PNG)

This change would make the box expand instead and keep the input box in place:
![absolute](https://user-images.githubusercontent.com/36075913/47507564-b0454080-d872-11e8-9d08-e95d0a44617f.PNG)
