### PR TITLE
V8: Add ellipsis on actions that invokes dialogs

### DIFF
--- a/src/Umbraco.Tests/Composing/ActionCollectionTests.cs
+++ b/src/Umbraco.Tests/Composing/ActionCollectionTests.cs
@@ -49,6 +49,8 @@ namespace Umbraco.Tests.Composing
             public bool ShowInNotifier => false;
 
             public bool CanBePermissionAssigned => true;
+
+            public bool OpensDialog => true;
         }
 
         public class NonSingletonAction : IAction
@@ -66,6 +68,8 @@ namespace Umbraco.Tests.Composing
             public bool ShowInNotifier => false;
 
             public bool CanBePermissionAssigned => true;
+
+            public bool OpensDialog => true;
         }
 
         #endregion

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-actions.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-actions.less
@@ -51,6 +51,15 @@
     text-decoration: none;
 }
 
+.umb-action {
+    &.-opens-dialog {
+        .menu-label:after {
+            // adds an ellipsis (...) after the menu label for actions that open a dialog
+            content: '\2026';
+        }
+    }
+}
+
 .umb-actions-child {
 
     .umb-action {

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-contextmenu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-contextmenu.html
@@ -5,7 +5,7 @@
 
     <div class='umb-modalcolumn-body'>
         <ul class="umb-actions">
-            <li data-element="action-{{action.alias}}" ng-click="executeMenuItem(action)" class="umb-action" ng-class="{sep:action.seperator}" ng-repeat="action in menuActions">
+            <li data-element="action-{{action.alias}}" ng-click="executeMenuItem(action)" class="umb-action" ng-class="{sep:action.seperator, '-opens-dialog': action.opensDialog}" ng-repeat="action in menuActions">
                 <a class="umb-action-link" prevent-default>
                     <i class="icon icon-{{action.cssclass}}"></i>
                     <span class="menu-label">{{action.name}}</span>

--- a/src/Umbraco.Web/Models/Trees/MenuItem.cs
+++ b/src/Umbraco.Web/Models/Trees/MenuItem.cs
@@ -38,6 +38,7 @@ namespace Umbraco.Web.Models.Trees
             SeperatorBefore = false;
             Icon = legacyMenu.Icon;
             Action = legacyMenu;
+            OpensDialog = legacyMenu.OpensDialog;
         }
         #endregion
 
@@ -71,6 +72,10 @@ namespace Umbraco.Web.Models.Trees
 
         [DataMember(Name = "cssclass")]
         public string Icon { get; set; }
+
+        [DataMember(Name = "opensDialog")]
+        public bool OpensDialog { get; set; }
+
         #endregion
 
         #region Constants

--- a/src/Umbraco.Web/_Legacy/Actions/Action.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/Action.cs
@@ -174,6 +174,7 @@ namespace Umbraco.Web._Legacy.Actions
         public string Alias { get; set; }
         public string JsFunctionName { get; set; }
         public string JsSource { get; set; }
+        public bool OpensDialog { get; set; }
 
         public PlaceboAction() { }
         public PlaceboAction(IAction legacyAction)
@@ -185,6 +186,7 @@ namespace Umbraco.Web._Legacy.Actions
             Alias = legacyAction.Alias;
             JsFunctionName = legacyAction.JsFunctionName;
             JsSource = legacyAction.JsSource;
+            OpensDialog = legacyAction.OpensDialog;
         }
     }
 

--- a/src/Umbraco.Web/_Legacy/Actions/ActionAssignDomain.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionAssignDomain.cs
@@ -69,6 +69,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionBrowse.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionBrowse.cs
@@ -60,6 +60,8 @@ namespace Umbraco.Web._Legacy.Actions
             get { return ""; }
         }
 
+        public bool OpensDialog => false;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionChangeDocType.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionChangeDocType.cs
@@ -83,6 +83,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionCopy.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionCopy.cs
@@ -83,6 +83,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionCreateBlueprintFromContent.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionCreateBlueprintFromContent.cs
@@ -20,6 +20,7 @@ namespace Umbraco.Web._Legacy.Actions
         public string Alias { get; private set; }
         public string JsFunctionName { get; private set; }
         public string JsSource { get; private set; }
+        public bool OpensDialog => true;
 
         public ActionCreateBlueprintFromContent()
         {

--- a/src/Umbraco.Web/_Legacy/Actions/ActionDelete.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionDelete.cs
@@ -77,6 +77,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionEmptyTranscan.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionEmptyTranscan.cs
@@ -73,6 +73,8 @@ namespace Umbraco.Web._Legacy.Actions
             }
         }
 
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionExport.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionExport.cs
@@ -71,6 +71,8 @@ namespace Umbraco.Web._Legacy.Actions
             }
         }
 
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionImport.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionImport.cs
@@ -72,6 +72,8 @@
             }
         }
 
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionMove.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionMove.cs
@@ -83,6 +83,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionNew.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionNew.cs
@@ -70,6 +70,8 @@ namespace Umbraco.Web._Legacy.Actions
             }
         }
 
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionNotify.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionNotify.cs
@@ -76,6 +76,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return false;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionNull.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionNull.cs
@@ -51,6 +51,8 @@
             get { return string.Empty; }
         }
 
+        public bool OpensDialog => false;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionPackage.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionPackage.cs
@@ -75,6 +75,8 @@ namespace Umbraco.Web._Legacy.Actions
             }
         }
 
+        public bool OpensDialog => false;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionPackageCreate.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionPackageCreate.cs
@@ -75,6 +75,8 @@ namespace Umbraco.Web._Legacy.Actions
             }
         }
 
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionProtect.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionProtect.cs
@@ -83,6 +83,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionPublish.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionPublish.cs
@@ -77,6 +77,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionRePublish.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionRePublish.cs
@@ -74,6 +74,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return false;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionRefresh.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionRefresh.cs
@@ -81,6 +81,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return false;
             }
         }
+
+        public bool OpensDialog => false;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionRestore.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionRestore.cs
@@ -27,6 +27,8 @@
 
         public bool CanBePermissionAssigned => false;
 
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionRights.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionRights.cs
@@ -83,6 +83,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionRollback.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionRollback.cs
@@ -82,6 +82,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionSort.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionSort.cs
@@ -83,6 +83,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionToPublish.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionToPublish.cs
@@ -78,6 +78,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => false;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionTranslate.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionTranslate.cs
@@ -77,6 +77,8 @@ namespace Umbraco.Web._Legacy.Actions
             }
         }
 
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ActionUnPublish.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionUnPublish.cs
@@ -76,6 +76,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return false;
             }
         }
+
+        public bool OpensDialog => false;
+
         #endregion
     }
 

--- a/src/Umbraco.Web/_Legacy/Actions/ActionUpdate.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ActionUpdate.cs
@@ -77,6 +77,9 @@ namespace Umbraco.Web._Legacy.Actions
                 return true;
             }
         }
+
+        public bool OpensDialog => false;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/ContextMenuSeperator.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/ContextMenuSeperator.cs
@@ -46,6 +46,8 @@
             get { return false; }
         }
 
+        public bool OpensDialog => false;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/_Legacy/Actions/IAction.cs
+++ b/src/Umbraco.Web/_Legacy/Actions/IAction.cs
@@ -14,5 +14,9 @@ namespace Umbraco.Web._Legacy.Actions
         /// A path to a supporting JavaScript file for the IAction. A script tag will be rendered out with the reference to the JavaScript file.
         /// </summary>
         string JsSource { get; }
+        /// <summary>
+        /// Whether or not the action opens a dialog when invoked
+        /// </summary>
+        bool OpensDialog { get; }
     }
 }

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionDeleteRelationType.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionDeleteRelationType.cs
@@ -78,6 +78,8 @@ namespace umbraco.cms.presentation.developer.RelationTypes.TreeMenu
             get { return "javascript:actionDeleteRelationType(UmbClientMgr.mainTree().getActionNode().nodeId,UmbClientMgr.mainTree().getActionNode().nodeName);"; }
         }
 
+        public bool OpensDialog => true;
+
         #endregion
     }
 }

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionNewRelationType.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/developer/RelationTypes/TreeMenu/ActionNewRelationType.cs
@@ -78,6 +78,8 @@ namespace umbraco.cms.presentation.developer.RelationTypes.TreeMenu
             get { return "javascript:actionNewRelationType();"; }
         }
 
+        public bool OpensDialog => true;
+
         #endregion
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3437
- [x] I have added steps to test this contribution in the description below

### Description

As outlined in #3437 it should be possible to add ellipsis on actions that invokes dialogs.

This PR introduces `OpensDialog` on `IAction`. If `OpensDialog` is set to `true` in an implementation of `IAction`, the action will be displayed with ellipsis in the UI:

![action ellipsis](https://user-images.githubusercontent.com/7405322/47517212-cd383e80-d887-11e8-80f2-a0b638f9957f.png)

I have implemented `OpensDialog` in all existing actions. Unfortunately there are a lot of features involving context menus that currently do not work (specially in the Settings section), so it's not possible to test all of the actions. But if it turns out one is missing the ellipsis (or got it by mistake), it shouldn't be a huge task to track it down and correct the `OpensDialog` property for that particular action.