### PR TITLE
Added new "CssClass" property to the "Tab" class

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs umb-nav-tabs">
-  <li data-element="tab-{{tab.alias}}" ng-class="{'tab-error': tabHasError}" ng-repeat="tab in model" val-tab>
-    <a data-toggle="tab" href="#tab{{tab.id}}{{idSuffix}}">{{ tab.label }}</a>
+  <li data-element="tab-{{tab.alias}}" ng-class="{'tab-error': tabHasError}" class="{{tab.cssClass}}" ng-repeat="tab in model" val-tab>
+    <a data-toggle="tab" href="#tab{{tab.id}}{{idSuffix}}"><span>{{ tab.label }}</span></a>
   </li>
 </ul>

--- a/src/Umbraco.Web/Models/ContentEditing/Tab.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/Tab.cs
@@ -23,5 +23,8 @@ namespace Umbraco.Web.Models.ContentEditing
 
         [DataMember(Name = "properties")]
         public IEnumerable<T> Properties { get; set; }
+
+        [DataMember(Name = "cssClass")]
+        public string CssClass { get; set; }
     }
 }


### PR DESCRIPTION
In some cases it could be ideal to customize a specific tab. In a particular case I have right now, a content item has a property with external data. If the property doesn't have any data, I'd like to dim the tab so editors know that this content item doesn't have any external data.

This could be accomplished by adding a custom CSS class to the tab, which is why this PR introduces a new `CssClass` property for the `Tab` class, as well as exposes that property in the Angular view.

For a simple dummy example, we could make one tab bold and give another an icon:

![image](https://user-images.githubusercontent.com/3634580/47519269-7f263980-d88d-11e8-8abd-9b976cdb9239.png)

And the code for the above example could be like:

```c#
EditorModelEventManager.SendingContentModel += (sender, e) => {

    foreach (var tab in e.Model.Tabs) {

        if (tab.Label == "Umbraco") {
            tab.CssClass = "h5yr";
        }

        if (tab.Label == "Design") {
            tab.CssClass = "design";
        }

    }

};
```

As part of the PR, I've also introduced a `<span>` element inside the `<a>` element. The `<a>` element has both the border and the background color, so the `<span>` element makes sure we can target an element inside the border.

As such, the CSS from my example looks like:

```CSS
.nav-tabs > li.h5yr {
    font-weight: bold;
}

.nav-tabs > li.design a span:after {
    text-decoration: inherit;
    display: inline-block;
    speak: none;
    content: "\e012";
    font-family: icomoon;
    padding-left: 5px;
}
```

I'm not convinced `CssClass` is the best name for the property, so feel free to suggest a better name ;)