### PR TITLE
Change to "MoveToRecycleBinDo" function of the MediaService and IMediaService

### DIFF
--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -32,7 +32,8 @@ namespace Umbraco.Core.Services
         /// <param name="media">The <see cref="IMedia"/> to move</param>
         /// <param name="parentId">Id of the Media's new Parent</param>
         /// <param name="userId">Id of the User moving the Media</param>
-        Attempt<OperationStatus> MoveOp(IMedia media, int parentId, int userId = 0);
+        /// <returns>True if moving succeeded, otherwise False</returns>
+        Attempt<OperationStatus> Move(IMedia media, int parentId, int userId = 0);
 
         /// <summary>
         /// Permanently deletes an <see cref="IMedia"/> object
@@ -276,6 +277,7 @@ namespace Umbraco.Core.Services
         /// <param name="parentId">Id of the Media's new Parent</param>
         /// <param name="userId">Id of the User moving the Media</param>
         void Move(IMedia media, int parentId, int userId = 0);
+
 
         /// <summary>
         /// Deletes an <see cref="IMedia"/> object by moving it to the Recycle Bin

--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -27,6 +27,14 @@ namespace Umbraco.Core.Services
         Attempt<OperationStatus> MoveToRecycleBin(IMedia media, int userId = 0);
 
         /// <summary>
+        /// Moves an <see cref="IMedia"/> object to a new location
+        /// </summary>
+        /// <param name="media">The <see cref="IMedia"/> to move</param>
+        /// <param name="parentId">Id of the Media's new Parent</param>
+        /// <param name="userId">Id of the User moving the Media</param>
+        Attempt<OperationStatus> MoveOp(IMedia media, int parentId, int userId = 0);
+
+        /// <summary>
         /// Permanently deletes an <see cref="IMedia"/> object
         /// </summary>
         /// <remarks>

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -465,7 +465,7 @@ namespace Umbraco.Core.Services
                 return repository.GetByQuery(query);
             }
         }
-
+        
         [Obsolete("Use the overload with 'long' parameter types instead")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IEnumerable<IMedia> GetPagedChildren(int id, int pageIndex, int pageSize, out int totalChildren,
@@ -758,7 +758,8 @@ namespace Umbraco.Core.Services
         /// <param name="media">The <see cref="IMedia"/> to move</param>
         /// <param name="parentId">Id of the Media's new Parent</param>
         /// <param name="userId">Id of the User moving the Media</param>
-        public Attempt<OperationStatus> MoveOp(IMedia media, int parentId, int userId = 0)
+        /// <returns>True if moving succeeded, otherwise False</returns>
+        public Attempt<OperationStatus> Move(IMedia media, int parentId, int userId = 0)
         {
             //TODO: This all needs to be on the repo layer in one transaction!
 
@@ -1486,7 +1487,7 @@ namespace Umbraco.Core.Services
 
         void IMediaService.Move(IMedia media, int parentId, int userId)
         {
-            MoveOp(media, parentId, userId);
+            Move(media, parentId, userId);
         }
 
 

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -1104,6 +1104,13 @@ namespace Umbraco.Core.Services
                     var moveEventArgs = new MoveEventArgs<IMedia>(moveEventInfo);
                     if (uow.Events.DispatchCancelable(Trashing, this, moveEventArgs, "Trashing"))
                     {
+                        if (moveEventArgs.Messages.Count > 0)
+                        {
+                            foreach (var message in moveEventArgs.Messages.GetAll())
+                            {
+                                evtMsgs.Add(message);
+                            }
+                        }
                         uow.Commit();
                         return OperationStatus.Cancelled(evtMsgs);
                     }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
@@ -115,14 +115,13 @@ function mediaResource($q, $http, umbDataFormatter, umbRequestHelper) {
                         }),
                         {
                         error: function(data){
-
                             var errorMsg = 'Failed to move media';
-                            if (data.id != undefined && data.parentid != undefined) {
-                                if (data.parentId === data.id) {
+                            if (data.id !== undefined && data.parentId !== undefined) {
+                                if (data.id === data.parentId) {
                                     errorMsg = 'Media can\'t be moved into itself';
                                 }
                             }
-                            else if (data != undefined) {
+                            else if (data.notifications !== undefined) {
                                 if (data.notifications.length > 0) {
                                     if (data.notifications[0].header.length > 0) {
                                         errorMsg = data.notifications[0].header;

--- a/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
@@ -115,10 +115,22 @@ function mediaResource($q, $http, umbDataFormatter, umbRequestHelper) {
                         }),
                         {
                         error: function(data){
-                            var errorMsg = 'Failed to move media';
 
-                            if(data.parentId === data.id){
-                                errorMsg = 'Media can\'t be moved into itself';
+                            var errorMsg = 'Failed to move media';
+                            if (data.id != undefined && data.parentid != undefined) {
+                                if (data.parentId === data.id) {
+                                    errorMsg = 'Media can\'t be moved into itself';
+                                }
+                            }
+                            else if (data != undefined) {
+                                if (data.notifications.length > 0) {
+                                    if (data.notifications[0].header.length > 0) {
+                                        errorMsg = data.notifications[0].header;
+                                    }
+                                    if (data.notifications[0].message.length > 0) {
+                                        errorMsg = errorMsg + ": " + data.notifications[0].message;
+                                    }
+                                }
                             }
 
                             return {

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -276,6 +276,7 @@
         <key alias="maxFileSize">Max file size is</key>
         <key alias="mediaRoot">Media root</key>
         <key alias="moveFailed">Failed to move media</key>
+        <key alias="moveToSameFolderFailed">Parent and destination folders cannot be the same</key>
         <key alias="copyFailed">Failed to copy media</key>
         <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>
         <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>

--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -449,18 +449,12 @@ namespace Umbraco.Web.Editors
             var toMove = ValidateMoveOrCopy(move);
             var destinationParentID = move.ParentId;
             var sourceParentID = toMove.ParentId;
+            
+            var moveResult = Services.MediaService.WithResult().Move(toMove, move.ParentId);
 
-            //Services.MediaService.Move(toMove, move.ParentId);
-            var moveResult = Services.MediaService.WithResult().MoveOp(toMove, move.ParentId);
-            //var response = Request.CreateResponse(HttpStatusCode.OK);
-            //response.Content = new StringContent(toMove.Path, Encoding.UTF8, "application/json");
-            //return response;
             if (sourceParentID == destinationParentID)
             {
-                return Request.CreateValidationErrorResponse(new SimpleNotificationModel(new Notification("Error: ","Parent and destination folders cannot be the same",SpeechBubbleIcon.Error)));
-                //var response = Request.CreateResponse(HttpStatusCode.OK);
-                //response.Content = new StringContent(toMove.Path, Encoding.UTF8, "application/json");
-                //return response;
+                return Request.CreateValidationErrorResponse(new SimpleNotificationModel(new Notification("",Services.TextService.Localize("media/moveToSameFolderFailed"),SpeechBubbleIcon.Error)));
             }
             if (moveResult == false)
             {

--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -447,12 +447,31 @@ namespace Umbraco.Web.Editors
         public HttpResponseMessage PostMove(MoveOrCopy move)
         {
             var toMove = ValidateMoveOrCopy(move);
+            var destinationParentID = move.ParentId;
+            var sourceParentID = toMove.ParentId;
 
-            Services.MediaService.Move(toMove, move.ParentId);
-
-            var response = Request.CreateResponse(HttpStatusCode.OK);
-            response.Content = new StringContent(toMove.Path, Encoding.UTF8, "application/json");
-            return response;
+            //Services.MediaService.Move(toMove, move.ParentId);
+            var moveResult = Services.MediaService.WithResult().MoveOp(toMove, move.ParentId);
+            //var response = Request.CreateResponse(HttpStatusCode.OK);
+            //response.Content = new StringContent(toMove.Path, Encoding.UTF8, "application/json");
+            //return response;
+            if (sourceParentID == destinationParentID)
+            {
+                return Request.CreateValidationErrorResponse(new SimpleNotificationModel(new Notification("Error: ","Parent and destination folders cannot be the same",SpeechBubbleIcon.Error)));
+                //var response = Request.CreateResponse(HttpStatusCode.OK);
+                //response.Content = new StringContent(toMove.Path, Encoding.UTF8, "application/json");
+                //return response;
+            }
+            if (moveResult == false)
+            {
+                return Request.CreateValidationErrorResponse(new SimpleNotificationModel());
+            }
+            else
+            {
+                var response = Request.CreateResponse(HttpStatusCode.OK);
+                response.Content = new StringContent(toMove.Path, Encoding.UTF8, "application/json");
+                return response;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3387
- [x] I have added steps to test this contribution in the description below

### Description
<!-- A description of the changes proposed in the pull-request -->

- Made a small change to "MoveToRecycleBinDo" function of the MediaService.cs file to get the notifications working in the backoffice for event cancellations.

- Minor changes to  IMediaService.cs, MediaService.cs (Added a new function MoveOp to return an Attempt), media.resources.js (Added code to handle cancellation/error messages) and MediaController.cs (Made a minor change to call the new function)

<!-- Make sure to link to the related issue number so we can easily find it in the issue tracker -->


<!-- Thanks for contributing to Umbraco CMS! -->
