### PR TITLE
Fix user email validation in IE and Edge 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -19,7 +19,7 @@
                            name="email"
                            id="email"
                            val-email
-                           required
+                           ng-required="true"
                            val-server-field="Email" />
                     <span class="help-inline" val-msg-for="email" val-toggle-msg="required"><localize key="general_required">Required</localize></span>
                     <span class="help-inline" val-msg-for="email" val-toggle-msg="valServerField"></span>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3440 and https://github.com/umbraco/Umbraco-CMS/issues/3071
- [x] I have added steps to test this contribution in the description below

### Description

Seems we need to use `ng-required` instead of `required` on `<input type="email" />` in IE and Edge. It works fine in Chrome (as expected).

Curious note. In V8 this is not a problem. I'm guessing the Angular version was bumped and that has solved the problem implicitly. This fix however should work just as fine in V8.

See #3071 and #3440 for steps to reproduce/test.