### PR TITLE
EntityRepository is fetching all property data for media

### DIFF
--- a/src/Umbraco.Core/Persistence/Factories/MediaFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/MediaFactory.cs
@@ -140,6 +140,9 @@ namespace Umbraco.Core.Persistence.Factories
         /// <returns></returns>
         internal static bool TryMatch(string text, out string mediaPath)
         {
+            //TODO: In v8 we should allow exposing this via the property editor in a much nicer way so that the property editor
+            // can tell us directly what any URL is for a given property if it contains an asset
+
             mediaPath = null;
 
             if (string.IsNullOrWhiteSpace(text))

--- a/src/Umbraco.Core/Persistence/Repositories/EntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/EntityRepository.cs
@@ -359,7 +359,7 @@ namespace Umbraco.Core.Persistence.Repositories
 
         internal IEnumerable<IUmbracoEntity> GetByQueryInternal(IQuery<IUmbracoEntity> query, Guid objectTypeId, bool includePropertyData)
         {
-	        var isContent = objectTypeId == Constants.ObjectTypes.DocumentGuid || objectTypeId == Constants.ObjectTypes.DocumentBlueprintGuid;
+            var isContent = objectTypeId == Constants.ObjectTypes.DocumentGuid || objectTypeId == Constants.ObjectTypes.DocumentBlueprintGuid;
             var isMedia = objectTypeId == Constants.ObjectTypes.MediaGuid;
 
             var sqlClause = GetBaseWhere(GetBase, isContent, isMedia, null, objectTypeId);

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -207,6 +207,9 @@ namespace Umbraco.Web.Trees
             return HasPathAccess(entity, queryStrings);
         }
 
+        internal override IEnumerable<IUmbracoEntity> GetChildrenFromEntityService(int entityId)
+            => Services.EntityService.GetChildren(entityId, UmbracoObjectType).ToList();
+
         /// <summary>
         /// Returns a collection of all menu items that can be on a content node
         /// </summary>

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -11,12 +10,12 @@ using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.EntityBase;
-using Umbraco.Core.Persistence;
 using Umbraco.Web.Models.Trees;
 using Umbraco.Web.WebApi.Filters;
 using umbraco;
 using umbraco.BusinessLogic.Actions;
 using System.Globalization;
+using Umbraco.Core.Services;
 
 namespace Umbraco.Web.Trees
 {
@@ -203,7 +202,11 @@ namespace Umbraco.Web.Trees
                 entityId = entity.Id;
             }
 
-            return Services.EntityService.GetChildren(entityId, UmbracoObjectType).ToList();
+            // Not pretty having to cast the service, but it is the only way to get to use an internal method that we
+            // do not want to make public on the interface. Unfortunately also prevents this from being unit tested.
+            // See this issue for details on why we need this:
+            // https://github.com/umbraco/Umbraco-CMS/issues/3457
+            return ((EntityService)Services.EntityService).GetChildrenWithoutPropertyData(entityId, UmbracoObjectType).ToList();
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -202,12 +202,15 @@ namespace Umbraco.Web.Trees
                 entityId = entity.Id;
             }
 
-            // Not pretty having to cast the service, but it is the only way to get to use an internal method that we
-            // do not want to make public on the interface. Unfortunately also prevents this from being unit tested.
-            // See this issue for details on why we need this:
-            // https://github.com/umbraco/Umbraco-CMS/issues/3457
-            return ((EntityService)Services.EntityService).GetChildrenWithoutPropertyData(entityId, UmbracoObjectType).ToList();
+            return GetChildrenFromEntityService(entityId);
         }
+
+        /// <summary>
+        /// Abstract method to fetch the entities from the entity service
+        /// </summary>
+        /// <param name="entityId"></param>
+        /// <returns></returns>
+        internal abstract IEnumerable<IUmbracoEntity> GetChildrenFromEntityService(int entityId);
 
         /// <summary>
         /// Returns true or false if the current user has access to the node based on the user's allowed start node (path) access

--- a/src/Umbraco.Web/Trees/MediaTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTreeController.cs
@@ -173,5 +173,12 @@ namespace Umbraco.Web.Trees
         {
             return _treeSearcher.ExamineSearch(Umbraco, query, UmbracoEntityTypes.Media, pageSize, pageIndex, out totalFound, searchFrom);
         }
+
+        internal override IEnumerable<IUmbracoEntity> GetChildrenFromEntityService(int entityId)
+            // Not pretty having to cast the service, but it is the only way to get to use an internal method that we
+            // do not want to make public on the interface. Unfortunately also prevents this from being unit tested.
+            // See this issue for details on why we need this:
+            // https://github.com/umbraco/Umbraco-CMS/issues/3457
+            => ((EntityService)Services.EntityService).GetMediaChildrenWithoutPropertyData(entityId).ToList();
     }
 }


### PR DESCRIPTION
connect #3457 

### Changes

- Adds internal methods for getting media entities through the entity repository/service without fetching all property data.
- Ensures the trees use this method to avoid fetching property data in the media tree.

This is not the prettiest way to do it since it requires casting of the service/repo to use the internal methods. It is however a way of preventing this becoming a breaking change in the APIs.
This should be fixed when merged to V8, to we make sure we do not do this in the `EntityRepository` for media items.

### Test

- Ensure that the content and media tree renders as expected (they render nodes without throwing errors).
- Ensure that the "folder browser" feature on media folders still work (this feature may be the reason why this property data was added initially? - and it should still work fine since this feature uses paging)