### PR TITLE
V8: Fix sort missing culture

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -23,7 +23,7 @@
   * </pre>
   **/
 
-function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
+function contentResource($q, $http, $routeParams, umbDataFormatter, umbRequestHelper) {
 
     /** internal method process the saving of data and post processing the result */
     function saveContentItem(content, action, files, restApiUrl, showNotifications) {
@@ -607,7 +607,10 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
             else if (options.orderDirection === "desc") {
                 options.orderDirection = "Descending";
             }
-
+            if (!options.cultureName) {
+                // must send a culture to the content API to handle variant data correctly
+                options.cultureName = $routeParams.mculture;
+            }
             //converts the value to a js bool
             function toBool(v) {
                 if (angular.isNumber(v)) {


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3359
- [x] I have added steps to test this contribution in the description below

### Description

While the nature of the error (and thus the fix for it) has changed since #3359 was created, the steps to reproduce are still the same: 

1. Create some variant content nodes under a parent node
2. Choose "Sort" from the parent node context menu
3. Verify that the sort dialog works and that nothing blows up :)
4. Do the same for non-variant content 
