### PR TITLE
Fix the notifications footer

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/notify.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/notify.html
@@ -1,44 +1,46 @@
 <div ng-controller="Umbraco.Editors.Content.CreateNotifyController as vm">
     <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
-    <div class="umb-pane" ng-show="!vm.loading">
-        <form name="notifyForm"
-              novalidate
-              val-form-manager>
-            <div ng-show="vm.saveError" ng-cloak>
-                <div class="alert alert-error">
-                    <div><strong>{{vm.saveError.errorMsg}}</strong></div>
-                    <div>{{vm.saveError.data.message}}</div>
+    <div class="umb-dialog-body">
+        <div class="umb-pane" ng-show="!vm.loading">
+            <form name="notifyForm"
+                  novalidate
+                  val-form-manager>
+                <div ng-show="vm.saveError" ng-cloak>
+                    <div class="alert alert-error">
+                        <div><strong>{{vm.saveError.errorMsg}}</strong></div>
+                        <div>{{vm.saveError.data.message}}</div>
+                    </div>
                 </div>
-            </div>
-            <div ng-show="vm.saveSuccces" ng-cloak>
-                <div class="alert alert-success">
-                    <localize key="notify_notificationsSavedFor"></localize><strong> {{currentNode.name}}</strong>
+                <div ng-show="vm.saveSuccces" ng-cloak>
+                    <div class="alert alert-success">
+                        <localize key="notify_notificationsSavedFor"></localize><strong> {{currentNode.name}}</strong>
+                    </div>
                 </div>
-            </div>
-            <div ng-cloak>
-                <div class="block-form" ng-show="!vm.loading">
-                    <h5><localize key="notify_notifySet">Set your notification for</localize> {{ currentNode.name }}</h5>
-                    <umb-control-group>
-                        <umb-permission ng-repeat="option in vm.notifyOptions"
-                                        name="option.name"
-                                        description="option.description"
-                                        selected="option.checked">
-                        </umb-permission>
-                    </umb-control-group>
+                <div ng-cloak>
+                    <div class="block-form" ng-show="!vm.loading">
+                        <h5><localize key="notify_notifySet">Set your notification for</localize> {{ currentNode.name }}</h5>
+                        <umb-control-group>
+                            <umb-permission ng-repeat="option in vm.notifyOptions"
+                                            name="option.name"
+                                            description="option.description"
+                                            selected="option.checked">
+                            </umb-permission>
+                        </umb-control-group>
+                    </div>
                 </div>
-            </div>
-            <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
-                <umb-button label-key="general_cancel"
-                            action="vm.cancel()"
-                            type="button"
-                            button-style="link">
-                </umb-button>
-                <umb-button label-key="buttons_save"
-                            type="button"
-                            action="vm.save(vm.notifyOptions)"
-                            button-style="success">
-                </umb-button>
-            </div>
-        </form>
+            </form>
+        </div>
+    </div>
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+        <umb-button label-key="general_cancel"
+                    action="vm.cancel()"
+                    type="button"
+                    button-style="link">
+        </umb-button>
+        <umb-button label-key="buttons_save"
+                    type="button"
+                    action="vm.save(vm.notifyOptions)"
+                    button-style="success">
+        </umb-button>
     </div>
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3465
- [x] I have added steps to test this contribution in the description below

### Description

Pretty easy to test this one:

1. Open the notifications dialog on a small-ish screen.
2. Verify that the footer sticks to the bottom of the dialog.

Here's what it should look like:

![notifications scroll after](https://user-images.githubusercontent.com/7405322/47621041-27d4d300-daf2-11e8-9250-a34e21502295.gif)
