### PR TITLE
#3450 - Use UmbracoFilesystemProvider to save package

### DIFF
--- a/src/umbraco.cms/businesslogic/Packager/PackageInstance/CreatedPackage.cs
+++ b/src/umbraco.cms/businesslogic/Packager/PackageInstance/CreatedPackage.cs
@@ -347,21 +347,12 @@ namespace umbraco.cms.businesslogic.packager
                 _packageManifest.Save(manifestFileName);
                 _packageManifest = null;
 
-
-                //string packPath = Settings.PackagerRoot.Replace(System.IO.Path.DirectorySeparatorChar.ToString(), "/") + "/" + pack.Name.Replace(' ', '_') + "_" + pack.Version.Replace(' ', '_') + "." + Settings.PackageFileExtension;
-
-                // check if there's a packages directory below media
-                var packagesDirectory = SystemDirectories.Media + "/created-packages";
-                if (Directory.Exists(IOHelper.MapPath(packagesDirectory)) == false)
-                {
-                    Directory.CreateDirectory(IOHelper.MapPath(packagesDirectory));
-                }
-
-
+                var packagesDirectory = "created-packages";
                 var packPath = packagesDirectory + "/" + (pack.Name + "_" + pack.Version).Replace(' ', '_') + "." + Settings.PackageFileExtension;
-                utill.ZipPackage(localPath, IOHelper.MapPath(packPath));
+                var packContents = utill.ZipPackage(localPath);
+                UmbracoMediaFile.Save(packContents, packPath);
 
-                pack.PackagePath = packPath;
+                pack.PackagePath = SystemDirectories.Media + "/" + packPath;
 
                 if (pack.PackageGuid.Trim() == "")
                     pack.PackageGuid = Guid.NewGuid().ToString();
@@ -374,9 +365,8 @@ namespace umbraco.cms.businesslogic.packager
 
                 package.FireAfterPublish(e);
             }
-
         }
-        
+
         private void AddDocumentType(DocumentType dt, ref List<DocumentType> dtl)
         {
             if (dt.MasterContentType != 0 && dt.Parent.nodeObjectType == Constants.ObjectTypes.DocumentTypeGuid)

--- a/src/umbraco.cms/businesslogic/Packager/PackageInstance/utill.cs
+++ b/src/umbraco.cms/businesslogic/Packager/PackageInstance/utill.cs
@@ -283,7 +283,7 @@ namespace umbraco.cms.businesslogic.packager
             // find number of chars to remove from orginal file path
 
             using (var memoryStream = new MemoryStream())
-            {   
+            {
                 using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
                 {
                     foreach (string file in ar)
@@ -301,7 +301,37 @@ namespace umbraco.cms.businesslogic.packager
                     memoryStream.CopyTo(fileStream);
                 }
             }
+        }
 
+        /// <summary>
+        /// Zips the package.
+        /// </summary>
+        /// <returns>The package in a byte array.</returns>
+        /// <param name="Path">The path.</param>
+        public static byte[] ZipPackage(string Path)
+        {
+            ArrayList ar = GenerateFileList(Path);
+            // generate file list
+            // find number of chars to remove from orginal file path
+
+            byte[] package;
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
+                {
+                    foreach (string file in ar)
+                    {
+                        if (file.EndsWith(@"/") != true) // it's not a directory
+                        {
+                            archive.CreateEntryFromFile(file, System.IO.Path.GetFileName(file));
+                        }
+                    }
+                }
+
+                package = memoryStream.ToArray();
+            }
+
+            return package;
         }
 
         private static ArrayList GenerateFileList(string Dir)


### PR DESCRIPTION
### Prerequisites

- [ ] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3450
- [ ] I have added steps to test this contribution in the description below

### Description
I added a function that creates a zip file of the package and returns it as a byte array. This byte array is then passed to `UmbracoMediaFile.Save(..)` which saves the package into the correct Media storage location.
Tested with the local filesystem and the UmbracoFileSystemProviders.Azure package.
