### PR TITLE
V8 - #3434 - change checkboxes on property type settings to toggle 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
@@ -29,6 +29,8 @@
         vm.submit = submit;
         vm.close = close;
 
+        vm.toggleAllowCultureVariants = toggleAllowCultureVariants;
+
         function onInit() {
 
             userService.getCurrentUser().then(function(user) {
@@ -230,6 +232,15 @@
                 vm.showValidationPattern = false;
             }
 
+        }
+
+        function toggleAllowCultureVariants() {
+            if ($scope.model.property.allowCultureVariant) {
+                $scope.model.property.allowCultureVariant = false;
+                return;
+            }
+
+            $scope.model.property.allowCultureVariant = true;
         }
 
         onInit();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
@@ -31,6 +31,9 @@
 
         vm.toggleAllowCultureVariants = toggleAllowCultureVariants;
         vm.toggleValidation = toggleValidation;
+        vm.toggleShowOnMemberProfile = toggleShowOnMemberProfile;
+        vm.toggleMemberCanEdit = toggleMemberCanEdit;
+        vm.toggleIsSensitiveData = toggleIsSensitiveData;
 
         function onInit() {
 
@@ -251,6 +254,33 @@
             }
 
             $scope.model.property.validation.mandatory = true;
+        }
+
+        function toggleShowOnMemberProfile() {
+            if ($scope.model.property.showOnMemberProfile) {
+                $scope.model.property.showOnMemberProfile = false;
+                return;
+            }
+
+            $scope.model.property.showOnMemberProfile = true;
+        }
+
+        function toggleMemberCanEdit() {
+            if ($scope.model.property.memberCanEdit) {
+                $scope.model.property.memberCanEdit = false;
+                return;
+            }
+
+            $scope.model.property.memberCanEdit = true;
+        }
+
+        function toggleIsSensitiveData() {
+            if ($scope.model.property.isSensitiveData) {
+                $scope.model.property.isSensitiveData = false;
+                return;
+            }
+
+            $scope.model.property.isSensitiveData = true;
         }
 
         onInit();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
@@ -30,6 +30,7 @@
         vm.close = close;
 
         vm.toggleAllowCultureVariants = toggleAllowCultureVariants;
+        vm.toggleValidation = toggleValidation;
 
         function onInit() {
 
@@ -241,6 +242,15 @@
             }
 
             $scope.model.property.allowCultureVariant = true;
+        }
+
+        function toggleValidation() {
+            if ($scope.model.property.validation.mandatory) {
+                $scope.model.property.validation.mandatory = false;
+                return;
+            }
+
+            $scope.model.property.validation.mandatory = true;
         }
 
         onInit();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
@@ -238,49 +238,28 @@
 
         }
 
-        function toggleAllowCultureVariants() {
-            if ($scope.model.property.allowCultureVariant) {
-                $scope.model.property.allowCultureVariant = false;
-                return;
-            }
+        function toggleValue(settingValue) {
+            return !settingValue;
+        }
 
-            $scope.model.property.allowCultureVariant = true;
+        function toggleAllowCultureVariants() {            
+            $scope.model.property.allowCultureVariant = toggleValue($scope.model.property.allowCultureVariant);
         }
 
         function toggleValidation() {
-            if ($scope.model.property.validation.mandatory) {
-                $scope.model.property.validation.mandatory = false;
-                return;
-            }
-
-            $scope.model.property.validation.mandatory = true;
+            $scope.model.property.validation.mandatory = toggleValue($scope.model.property.validation.mandatory);            
         }
 
         function toggleShowOnMemberProfile() {
-            if ($scope.model.property.showOnMemberProfile) {
-                $scope.model.property.showOnMemberProfile = false;
-                return;
-            }
-
-            $scope.model.property.showOnMemberProfile = true;
+            $scope.model.property.showOnMemberProfile = toggleValue($scope.model.property.showOnMemberProfile);           
         }
 
         function toggleMemberCanEdit() {
-            if ($scope.model.property.memberCanEdit) {
-                $scope.model.property.memberCanEdit = false;
-                return;
-            }
-
-            $scope.model.property.memberCanEdit = true;
+            $scope.model.property.memberCanEdit = toggleValue($scope.model.property.memberCanEdit);            
         }
 
         function toggleIsSensitiveData() {
-            if ($scope.model.property.isSensitiveData) {
-                $scope.model.property.isSensitiveData = false;
-                return;
-            }
-
-            $scope.model.property.isSensitiveData = true;
+            $scope.model.property.isSensitiveData = toggleValue($scope.model.property.isSensitiveData);             
         }
 
         onInit();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -106,23 +106,15 @@
                     
                         </div>
                         <div class="umb-control-group clearfix" ng-if="model.contentType === 'documentType' && model.contentTypeAllowCultureVariant">
-                            <div class="sub-view-columns">
-
-                                <div class="sub-view-column-left">
+                           
                                     <h5><localize key="contentTypeEditor_variantsHeading" /></h5>
-                                    
-                                </div>
-
-                                <div class="sub-view-column-right">
+                             
                                     <umb-toggle data-element="permissions-allow-culture-variant"
                                                 checked="model.property.allowCultureVariant"
                                                 on-click="vm.toggleAllowCultureVariants()"
                                     >
                                     </umb-toggle>
-                                </div>
-    
-                            </div>
-                            
+
                         </div>
                     
                         <div class="umb-control-group clearfix" ng-if="model.contentType === 'memberType'">

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -84,9 +84,18 @@
                     
                             <h5><localize key="validation_validation"></localize></h5>
                     
-                            <label class="checkbox no-indent">
-                                <input type="checkbox" ng-model="model.property.validation.mandatory" focus-when="{{vm.focusOnMandatoryField}}" />
+                            <label>                                
                                 <localize key="validation_fieldIsMandatory"></localize>
+                            </label>
+
+                            <umb-toggle data-element="validation_mandatory"
+                                        checked="model.property.validation.mandatory"
+                                        on-click="vm.toggleValidation()"
+                            >
+                            </umb-toggle>
+
+                            <label class="mt3">                                
+                                <localize key="validation_customValidation"></localize>
                             </label>
                     
                             <select class="umb-dropdown" ng-options="validationType.name for validationType in vm.validationTypes" ng-model="vm.selectedValidationType" ng-change="vm.changeValidationType(vm.selectedValidationType)">

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -151,8 +151,8 @@
                             </umb-toggle>
 
                             <label class="mt3" ng-if="vm.showSensitiveData">
-                                <localize key="contentTypeEditor_memberCanEdit"></localize>
-                                <small><localize key="contentTypeEditor_memberCanEditDescription"></localize></small>
+                                <localize key="contentTypeEditor_isSensitiveData"></localize>
+                                <small><localize key="contentTypeEditor_isSensitiveDataDescription"></localize></small>
                             </label>
 
                             <umb-toggle ng-if="vm.showSensitiveData" data-element="settings_is_sensitive_data"

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -106,14 +106,23 @@
                     
                         </div>
                         <div class="umb-control-group clearfix" ng-if="model.contentType === 'documentType' && model.contentTypeAllowCultureVariant">
-                    
-                            <h5>Property Type Variation</h5>
-                    
-                            <label class="checkbox no-indent">
-                                <input type="checkbox" ng-model="model.property.allowCultureVariant" />
-                                Allow varying by Culture
-                            </label>
-                    
+                            <div class="sub-view-columns">
+
+                                <div class="sub-view-column-left">
+                                    <h5><localize key="contentTypeEditor_variantsHeading" /></h5>
+                                    
+                                </div>
+
+                                <div class="sub-view-column-right">
+                                    <umb-toggle data-element="permissions-allow-culture-variant"
+                                                checked="model.property.allowCultureVariant"
+                                                on-click="vm.toggleAllowCultureVariants()"
+                                    >
+                                    </umb-toggle>
+                                </div>
+    
+                            </div>
+                            
                         </div>
                     
                         <div class="umb-control-group clearfix" ng-if="model.contentType === 'memberType'">

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -127,27 +127,40 @@
                         </div>
                     
                         <div class="umb-control-group clearfix" ng-if="model.contentType === 'memberType'">
-                    
+
                             <h5><localize key="general_options"></localize></h5>
-                    
-                            <label class="checkbox no-indent">
-                                <input type="checkbox" ng-model="model.property.showOnMemberProfile">
+
+                            <label class="mt3">
                                 <localize key="contentTypeEditor_showOnMemberProfile"></localize>
                                 <small><localize key="contentTypeEditor_showOnMemberProfileDescription"></localize></small>
                             </label>
-                    
-                            <label class="checkbox no-indent">
-                                <input type="checkbox" ng-model="model.property.memberCanEdit">
+
+                            <umb-toggle data-element="settings_show_member_on_profile"
+                                        checked="model.property.showOnMemberProfile"
+                                        on-click="vm.toggleShowOnMemberProfile()">
+                            </umb-toggle>
+
+                            <label class="mt3">
                                 <localize key="contentTypeEditor_memberCanEdit"></localize>
                                 <small><localize key="contentTypeEditor_memberCanEditDescription"></localize></small>
                             </label>
-                    
-                            <label ng-if="vm.showSensitiveData" class="checkbox no-indent">
-                                <input type="checkbox" ng-model="model.property.isSensitiveData">
-                                <localize key="contentTypeEditor_isSensitiveData"></localize>
-                                <small><localize key="contentTypeEditor_isSensitiveDataDescription"></localize></small>
+
+                            <umb-toggle data-element="settings_member_can_edit"
+                                        checked="model.property.memberCanEdit"
+                                        on-click="vm.toggleMemberCanEdit()">
+                            </umb-toggle>
+
+                            <label class="mt3" ng-if="vm.showSensitiveData">
+                                <localize key="contentTypeEditor_memberCanEdit"></localize>
+                                <small><localize key="contentTypeEditor_memberCanEditDescription"></localize></small>
                             </label>
-                    
+
+                            <umb-toggle ng-if="vm.showSensitiveData" data-element="settings_is_sensitive_data"
+                                        checked="model.property.isSensitiveData"
+                                        on-click="vm.toggleIsSensitiveData()">
+                            </umb-toggle>
+                                                      
+
                         </div>
                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -212,6 +212,11 @@
                                         <localize key="contentTypeEditor_isSensitiveData"></localize>
                                     </div>
 
+                                    <div class="umb-group-builder__property-tag -white" ng-if="property.allowCultureVariant">
+                                        <i class="icon-shuffle umb-group-builder__property-tag-icon"></i>
+                                        <localize key="contentTypeEditor_variantsHeading"></localize>
+                                    </div>
+
                                 </div>
 
                                 <div class="umb-group-builder__property-tags -right">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1812,6 +1812,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="invalidDate">Invalid date</key>
     <key alias="invalidNumber">Not a number</key>
     <key alias="invalidEmail">Invalid email</key>
+    <key alias="customValidation">Custom validation</key>
   </area>
   <area alias="healthcheck">
     <!-- The following keys get these tokens passed in:

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1849,6 +1849,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="invalidNull">Value cannot be null</key>
     <key alias="invalidEmpty">Value cannot be empty</key>
     <key alias="invalidPattern">Value is invalid, it does not match the correct pattern</key>
+    <key alias="customValidation">Custom validation</key>
   </area>
   <area alias="healthcheck">
     <!-- The following keys get these tokens passed in:


### PR DESCRIPTION
…n content type designer

### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: #3434 
- [x] I have added steps to test this contribution in the description below

### Description

I already converted the Allow varying by culture to a toggle. To make it look good I reused the same markup as on the document type permissions.

But now we have classes like sub-view-columns in there. While the end result looks good, the code looks nasty

@madsrasmussen do you have any pointers on how to fix this without using the sub-view css classes before I change the remainging checkboxes like validation and settings for when we are configuring a membertype

Dave