### PR TITLE
Fixed strange Email validation behaviour in the backend

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/EmailValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/EmailValidator.cs
@@ -16,9 +16,9 @@ namespace Umbraco.Core.PropertyEditors
             var asString = value.ToString();
 
             // This is not the ffficial RFC 5322 regular expression, but it's a version which comes pretty close to. (Inspired by: https://www.regular-expressions.info/email.html)
-            var emailSyntax = @"^[a-z][a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@([a-z0-9]([a-z0-9-]*[a-z0-9])\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$";
-
-            if (!string.IsNullOrEmpty(asString) && !Regex.IsMatch(asString, emailSyntax, RegexOptions.IgnoreCase))
+            var emailSyntax = @"^[a-z0-9][a-z0-9!#$%&'*+\/=?^_`{|}~.-]*@([a-z0-9]([a-z0-9-]*)\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$";
+            var isMatch = Regex.IsMatch(asString, emailSyntax, RegexOptions.IgnoreCase);
+            if (!string.IsNullOrEmpty(asString) && !isMatch)
             {
                 // TODO: localize these!
                 yield return new ValidationResult("Email is invalid", new[] { "value" });

--- a/src/Umbraco.Core/PropertyEditors/EmailValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/EmailValidator.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Core.PropertyEditors
             var asString = value.ToString();
 
             // This is not the ffficial RFC 5322 regular expression, but it's a version which comes pretty close to. (Inspired by: https://www.regular-expressions.info/email.html)
-            var emailSyntax = @"^[a-z0-9][a-z0-9!#$%&'*+\/=?^_`{|}~.-]*@([a-z0-9]([a-z0-9-]*)\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$";
+            var emailSyntax = @"^[a-z0-9][a-z0-9!#$%&'*+\/=?^_`{|}~.-]*@([a-z0-9]([a-z0-9-]*)\.)*([a-z0-9]([a-z0-9-]*[a-z0-9]))+$";
             var isMatch = Regex.IsMatch(asString, emailSyntax, RegexOptions.IgnoreCase);
             if (!string.IsNullOrEmpty(asString) && !isMatch)
             {

--- a/src/Umbraco.Core/PropertyEditors/EmailValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/EmailValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
 using Umbraco.Core.Models;
 
 namespace Umbraco.Core.PropertyEditors
@@ -14,9 +15,10 @@ namespace Umbraco.Core.PropertyEditors
         {
             var asString = value.ToString();
 
-            var emailVal = new EmailAddressAttribute();
+            // This is not the ffficial RFC 5322 regular expression, but it's a version which comes pretty close to. (Inspired by: https://www.regular-expressions.info/email.html)
+            var emailSyntax = @"^[a-z][a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@([a-z0-9]([a-z0-9-]*[a-z0-9])\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$";
 
-            if (asString != string.Empty && emailVal.IsValid(asString) == false)
+            if (!string.IsNullOrEmpty(asString) && !Regex.IsMatch(asString, emailSyntax, RegexOptions.IgnoreCase))
             {
                 // TODO: localize these!
                 yield return new ValidationResult("Email is invalid", new[] { "value" });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valemail.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valemail.directive.js
@@ -48,7 +48,7 @@ angular.module('umbraco.directives.validation')
     .directive("valEmail", valEmail)
     .factory('valEmailExpression', function () {
         // This syntax should correspond to the Core validation in EmailValidator.cs and the default backend Email Validation in propertysettings.controller.js (validationTypes)
-        var emailSyntax = "^[a-z][a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@([a-z0-9]([a-z0-9-]*[a-z0-9])\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$";
+        var emailSyntax = "^[a-z0-9][a-z0-9!#$%&'*+\/=?^_`{|}~.-]*@([a-z0-9]([a-z0-9-]*)\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$";
         var emailRegex = new RegExp(emailSyntax, "i");
         return {
             EMAIL_REGEXP: emailRegex

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valemail.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valemail.directive.js
@@ -48,7 +48,7 @@ angular.module('umbraco.directives.validation')
     .directive("valEmail", valEmail)
     .factory('valEmailExpression', function () {
         // This syntax should correspond to the Core validation in EmailValidator.cs and the default backend Email Validation in propertysettings.controller.js (validationTypes)
-        var emailSyntax = "^[a-z0-9][a-z0-9!#$%&'*+\/=?^_`{|}~.-]*@([a-z0-9]([a-z0-9-]*)\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$";
+        var emailSyntax = "^[a-z0-9][a-z0-9!#$%&'*+\/=?^_`{|}~.-]*@([a-z0-9]([a-z0-9-]*)\.)*([a-z0-9]([a-z0-9-]*[a-z0-9]))+$";
         var emailRegex = new RegExp(emailSyntax, "i");
         return {
             EMAIL_REGEXP: emailRegex

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valemail.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valemail.directive.js
@@ -12,7 +12,7 @@ function valEmail(valEmailExpression) {
         link: function (scope, elm, attrs, ctrl) {
             
             var patternValidator = function (viewValue) {
-                //NOTE: we don't validate on empty values, use required validator for that
+                //NOTE: We validate only if the viewValue has a value. If it is empty (null or undefined), we'll consider it OK and the let the "Required" validator handle it.
                 if (!viewValue || valEmailExpression.EMAIL_REGEXP.test(viewValue)) {
                     // it is valid
                     ctrl.$setValidity('valEmail', true);
@@ -47,7 +47,9 @@ function valEmail(valEmailExpression) {
 angular.module('umbraco.directives.validation')
     .directive("valEmail", valEmail)
     .factory('valEmailExpression', function () {
-        var emailRegex = /^[a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
+        // This syntax should correspond to the Core validation in EmailValidator.cs and the default backend Email Validation in propertysettings.controller.js (validationTypes)
+        var emailSyntax = "^[a-z][a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@([a-z0-9]([a-z0-9-]*[a-z0-9])\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$";
+        var emailRegex = new RegExp(emailSyntax, "i");
         return {
             EMAIL_REGEXP: emailRegex
         };

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
@@ -56,8 +56,9 @@ function valPropertyMsg(serverValidationManager) {
                 //if there's not already a watch
                 if (!watcher) {
                     watcher = scope.$watch("property.value", function (newValue, oldValue) {
-                        
-                        if (!newValue || angular.equals(newValue, oldValue)) {
+                        // Uncommented the !newValue, because otherwise it would not allow for the field to be emptied in order to evaluate. This was illogical.
+                        // We'll just check that there is a value and if it's unchanged then do nothing.
+                        if ((typeof newValue !== "undefined" && newValue !== null) && angular.equals(newValue, oldValue)) {
                             return;
                         }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
@@ -58,7 +58,7 @@ function valPropertyMsg(serverValidationManager) {
                     watcher = scope.$watch("property.value", function (newValue, oldValue) {
                         // Uncommented the !newValue, because otherwise it would not allow for the field to be emptied in order to evaluate. This was illogical.
                         // We'll just check that there is a value and if it's unchanged then do nothing.
-                        if ((typeof newValue !== "undefined" && newValue !== null) && angular.equals(newValue, oldValue)) {
+                        if (newValue && angular.equals(newValue, oldValue)) {
                             return;
                         }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valserver.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valserver.directive.js
@@ -33,8 +33,8 @@ function valServer(serverValidationManager) {
                     watcher = scope.$watch(function () {
                         return modelCtrl.$modelValue;
                     }, function (newValue, oldValue) {
-
-                        if (!newValue || angular.equals(newValue, oldValue)) {
+                        /* Is newValue is undefined then the field could is empty and the status is reset to Validity = true */
+                        if ((typeof newValue !== "undefined" && newValue !== null) && angular.equals(newValue, oldValue)) {
                             return;
                         }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valserver.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valserver.directive.js
@@ -33,8 +33,8 @@ function valServer(serverValidationManager) {
                     watcher = scope.$watch(function () {
                         return modelCtrl.$modelValue;
                     }, function (newValue, oldValue) {
-                        /* Is newValue is undefined then the field could is empty and the status is reset to Validity = true */
-                        if ((typeof newValue !== "undefined" && newValue !== null) && angular.equals(newValue, oldValue)) {
+                        /* If the newValue has a value which is the same as oldValue, then we ignore - otherwise we set Validity = true */
+                        if (newValue && angular.equals(newValue, oldValue)) {
                             return;
                         }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -534,7 +534,7 @@ input.umb-group-builder__group-title-input {
         border: 1px solid @gray-7;
         margin: 10px 0 0;
         padding: 6px;
-        max-height: 32px;
+        max-height: 64px;
     }
 
     .umb-dropdown {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.controller.js
@@ -22,7 +22,7 @@
             {
                 "name": localizationService.localize("validation_validateAsEmail"),
                 "key": "email",
-                "pattern": "[a-zA-Z0-9_\.\+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-\.]+",
+                "pattern": "^[a-z][a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@([a-z0-9]([a-z0-9-]*[a-z0-9])\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$",
                 "enableEditing": true
             },
             {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.controller.js
@@ -22,7 +22,7 @@
             {
                 "name": localizationService.localize("validation_validateAsEmail"),
                 "key": "email",
-                "pattern": "^[a-z0-9][a-z0-9!#$%&'*+\/=?^_`{|}~.-]*@([a-z0-9]([a-z0-9-]*)\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$",
+                "pattern": "^[a-z0-9][a-z0-9!#$%&'*+\/=?^_`{|}~.-]*@([a-z0-9]([a-z0-9-]*)\.)*([a-z0-9]([a-z0-9-]*[a-z0-9]))+$",
                 "enableEditing": true
             },
             {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.controller.js
@@ -22,7 +22,7 @@
             {
                 "name": localizationService.localize("validation_validateAsEmail"),
                 "key": "email",
-                "pattern": "^[a-z][a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@([a-z0-9]([a-z0-9-]*[a-z0-9])\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$",
+                "pattern": "^[a-z0-9][a-z0-9!#$%&'*+\/=?^_`{|}~.-]*@([a-z0-9]([a-z0-9-]*)\.)+([a-z0-9]([a-z0-9-]*[a-z0-9]))+$",
                 "enableEditing": true
             },
             {


### PR DESCRIPTION

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/3013

### Changes:

1) Synkronized the email validation patterns to fix irregularities between frontend and backend validation. (had to adapt the regex pattern to work with both angular and .NET)
2) Aligned this regular expression with the default "Email pattern"-validation in the Umbraco backend.
3) Changed size of backend  validation-box for regex-patterns (2 rows instead of 1 row)
4) Bugfixed the valpropertymsg and valserver directives to ignore an empty string, since this is handled by the valrequired-directive.

### Tests

- I tested on the backend validating email-datatypes with and without "required" validation. 
- On string-datatypes with combinations of email-regex-validation and "required"-validation.

...this is my first pull-request, so be gentle. And let me know if I overlooked something in the process. :-)
