### PR TITLE
3492 Added a property "Tooltip" to the tabs which can then be set in the the EditorModel Events

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs umb-nav-tabs">
-  <li data-element="tab-{{tab.alias}}" ng-class="{'tab-error': tabHasError}" class="{{tab.cssClass}}" ng-repeat="tab in model" val-tab>
+  <li data-element="tab-{{tab.alias}}" ng-class="{'tab-error': tabHasError}" class="{{tab.cssClass}}" title="{{tab.tooltip}}" ng-repeat="tab in model" val-tab>
     <a data-toggle="tab" href="#tab{{tab.id}}{{idSuffix}}"><span>{{ tab.label }}</span></a>
   </li>
 </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs umb-nav-tabs">
-  <li data-element="tab-{{tab.alias}}" ng-class="{'tab-error': tabHasError}" class="{{tab.cssClass}}" title="{{tab.tooltip}}" ng-repeat="tab in model" val-tab>
-    <a data-toggle="tab" href="#tab{{tab.id}}{{idSuffix}}"><span>{{ tab.label }}</span></a>
+  <li data-element="tab-{{tab.alias}}" ng-class="{'tab-error': tabHasError}" class="{{tab.cssClass}}" ng-repeat="tab in model" val-tab>
+    <a data-toggle="tab" href="#tab{{tab.id}}{{idSuffix}}" title="{{tab.tooltip}}"><span>{{ tab.label }}</span></a>
   </li>
 </ul>

--- a/src/Umbraco.Web/Models/ContentEditing/Tab.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/Tab.cs
@@ -26,5 +26,8 @@ namespace Umbraco.Web.Models.ContentEditing
 
         [DataMember(Name = "cssClass")]
         public string CssClass { get; set; }
+
+        [DataMember(Name = "tooltip")]
+        public string Tooltip { get; set; }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [ ] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3492
- [ ] I have added steps to test this contribution in the description below

### Description
This is taking some inspiration from the PR https://github.com/umbraco/Umbraco-CMS/pull/3449
I have created a property called "Tooltip" in the Tab class. This can then be set via the EditorModelEvent like

 
![image](https://user-images.githubusercontent.com/3941753/47794970-7617eb00-dd19-11e8-99e8-484231f8aa74.png)

Let me know if this is any good :-)

Poornima

<!-- Thanks for contributing to Umbraco CMS! -->
