### PR TITLE
Localized parts of the codefile and template resources

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/codefile.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/codefile.resource.js
@@ -106,13 +106,16 @@ function codefileResource($q, $http, umbDataFormatter, umbRequestHelper, localiz
          *
          */
         deleteByPath: function (type, virtualpath) {
+
+            var promise = localizationService.localize("codefile_deleteItemFailed", [virtualpath]);
+
             return umbRequestHelper.resourcePromise(
                 $http.post(
                     umbRequestHelper.getApiUrl(
                         "codeFileApiBaseUrl",
                         "Delete",
                         [{ type: type }, { virtualPath: virtualpath}])),
-                "Failed to delete item: " + virtualpath);
+                promise);
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/common/resources/codefile.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/codefile.resource.js
@@ -3,7 +3,7 @@
     * @name umbraco.resources.codefileResource
     * @description Loads in data for files that contain code such as js scripts, partial views and partial view macros
     **/
-function codefileResource($q, $http, umbDataFormatter, umbRequestHelper) {
+function codefileResource($q, $http, umbDataFormatter, umbRequestHelper, localizationService) {
 
     return {
 
@@ -236,13 +236,19 @@ function codefileResource($q, $http, umbDataFormatter, umbRequestHelper) {
          *
          */
 
-        createContainer: function(type, parentId, name) {
+        createContainer: function (type, parentId, name) {
+
+            // Is the parent ID numeric?
+            var key = "codefile_createFolderFailedBy" + (isNaN(parseInt(parentId)) ? "Name" : "Id");
+
+            var promise = localizationService.localize(key, [parentId]);
+
             return umbRequestHelper.resourcePromise(
                 $http.post(umbRequestHelper.getApiUrl(
                     "codeFileApiBaseUrl", 
                     "PostCreateContainer", 
                     { type: type, parentId: parentId, name: encodeURIComponent(name) })),
-                'Failed to create a folder under parent id ' + parentId);
+                promise);
         }
 
     };

--- a/src/Umbraco.Web.UI.Client/src/common/resources/template.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/template.resource.js
@@ -3,7 +3,7 @@
     * @name umbraco.resources.templateResource
     * @description Loads in data for templates
     **/
-function templateResource($q, $http, umbDataFormatter, umbRequestHelper) {
+function templateResource($q, $http, umbDataFormatter, umbRequestHelper, localizationService) {
 
     return {
 
@@ -152,13 +152,16 @@ function templateResource($q, $http, umbDataFormatter, umbRequestHelper) {
          *
          */
         deleteById: function(id) {
+
+            var promise = localizationService.localize("template_deleteByIdFailed", [id]);
+
             return umbRequestHelper.resourcePromise(
                 $http.post(
                     umbRequestHelper.getApiUrl(
                         "templateApiBaseUrl",
                         "DeleteById",
                         [{ id: id }])),
-                "Failed to delete item " + id);
+                promise);
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/views/partialviews/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviews/create.html
@@ -57,7 +57,7 @@
                     </div>
                 </div>
 
-                <umb-control-group label="Enter a folder name" hide-label="false">
+                <umb-control-group label="@create_enterFolderName" localize="label" hide-label="false">
                     <input type="text" name="folderName" ng-model="vm.folderName" class="umb-textstring textstring input-block-level" umb-auto-focus required />
                 </umb-control-group>
 

--- a/src/Umbraco.Web.UI.Client/src/views/partialviews/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviews/delete.controller.js
@@ -12,6 +12,9 @@ function PartialViewsDeleteController($scope, codefileResource, treeService, nav
 
         //mark it for deletion (used in the UI)
         $scope.currentNode.loading = true;
+
+        // Reset the error message
+        $scope.error = null;
         
         codefileResource.deleteByPath('partialViews', $scope.currentNode.id)
             .then(function() {
@@ -21,6 +24,9 @@ function PartialViewsDeleteController($scope, codefileResource, treeService, nav
                 //TODO: Need to sync tree, etc...
                 treeService.removeNode($scope.currentNode);
                 navigationService.hideMenu();
+            }, function (err) {
+                $scope.currentNode.loading = false;
+                $scope.error = err;
             });
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/partialviews/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviews/delete.html
@@ -1,6 +1,13 @@
 <div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.PartialViews.DeleteController">
     <div class="umb-dialog-body">
 
+        <div ng-show="error">
+            <div class="alert alert-error">
+                <div><strong>{{error.errorMsg}}</strong></div>
+                <div>{{error.data.message}}</div>
+            </div>
+        </div>
+
         <p class="umb-abstract">
         	<localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong> ?
         </p>

--- a/src/Umbraco.Web.UI.Client/src/views/templates/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/delete.controller.js
@@ -12,6 +12,10 @@ function TemplatesDeleteController($scope, templateResource , treeService, navig
 
         //mark it for deletion (used in the UI)
         $scope.currentNode.loading = true;
+
+        // Reset the error message
+        $scope.error = null;
+
         templateResource.deleteById($scope.currentNode.id).then(function () {
             $scope.currentNode.loading = false;
 
@@ -21,6 +25,9 @@ function TemplatesDeleteController($scope, templateResource , treeService, navig
             //TODO: Need to sync tree, etc...
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu();
+        }, function (err) {
+            $scope.currentNode.loading = false;
+            $scope.error = err;
         });
 
     };

--- a/src/Umbraco.Web.UI.Client/src/views/templates/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/delete.html
@@ -1,11 +1,18 @@
 <div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.Templates.DeleteController">
     <div class="umb-dialog-body">
 
+        <div ng-show="error">
+            <div class="alert alert-error">
+                <div><strong>{{error.errorMsg}}</strong></div>
+                <div>{{error.data.message}}</div>
+            </div>
+        </div>
+
         <p class="umb-abstract">
             <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize>&nbsp;<strong>{{currentNode.name}}</strong> ?
         </p>
 
-        <umb-confirm on-confirm="performDelete" on-cancel="cancel">    
+        <umb-confirm on-confirm="performDelete" on-cancel="cancel">
         </umb-confirm>
 
     </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -182,6 +182,7 @@
   <area alias="codefile">
     <key alias="createFolderFailedById">Oprettelse af mappen under parent med ID %0% fejlede</key>
     <key alias="createFolderFailedByName">Oprettelse af mappen under parent med navnet %0% fejlede</key>
+      <key alias="deleteItemFailed">Sletning af filen/mappen fejlede: %0%</key>
   </area>
   <area alias="content">
     <key alias="isPublished" version="7.2">Udgivet</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1157,6 +1157,7 @@ Mange hilsner fra Umbraco robotten
   </area>
 
   <area alias="template">
+    <key alias="deleteByIdFailed">Sletning af skabelonen med ID %0% fejlede</key>
     <key alias="edittemplate">Rediger skabelon</key>
 
     <key alias="insertSections">Sektioner</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -179,6 +179,10 @@
     <key alias="validationErrorPropertyWithMoreThanOneMapping">Overførsel af egenskaber kunne ikke fuldføres, da en eller flere egenskaber er indstillet til at blive overført mere end én gang.</key>
     <key alias="validDocTypesNote">Kun andre dokumenttyper, der er gyldige på denne placering, vises.</key>
   </area>
+  <area alias="codefile">
+    <key alias="createFolderFailedById">Oprettelse af mappen under parent med ID %0% fejlede</key>
+    <key alias="createFolderFailedByName">Oprettelse af mappen under parent med navnet %0% fejlede</key>
+  </area>
   <area alias="content">
     <key alias="isPublished" version="7.2">Udgivet</key>
     <key alias="about">Om siden</key>
@@ -279,6 +283,7 @@
     <key alias="chooseNode">Hvor ønsker du at oprette den nye %0%</key>
     <key alias="createUnder">Opret under</key>
     <key alias="createContentBlueprint">Vælg den dokumenttype, du vil oprette en indholdsskabelon til</key>
+    <key alias="enterFolderName">Angiv et navn for mappen</key>
     <key alias="updateData">Vælg en type og skriv en titel</key>
     <key alias="noDocumentTypes" version="7.0"><![CDATA[Der kunne ikke findes nogen tilladte dokument typer. Du skal tillade disse i indstillinger under <strong>"dokument typer"</strong>.]]></key>
     <key alias="noMediaTypes" version="7.0"><![CDATA[Der kunne ikke findes nogen tilladte media typer. Du skal tillade disse i indstillinger under <strong>"media typer"</strong>.]]></key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -185,6 +185,10 @@
         <key alias="validationErrorPropertyWithMoreThanOneMapping">Could not complete property mapping as one or more properties have more than one mapping defined.</key>
         <key alias="validDocTypesNote">Only alternate types valid for the current location are displayed.</key>
     </area>
+    <area alias="codefile">
+        <key alias="createFolderFailedById">Failed to create a folder under parent with ID %0%</key>
+        <key alias="createFolderFailedByName">Failed to create a folder under parent with name %0%</key>
+    </area>
     <area alias="content">
         <key alias="isPublished" version="7.2">Is Published</key>
         <key alias="about">About this page</key>
@@ -287,6 +291,7 @@
         <key alias="chooseNode">Where do you want to create the new %0%</key>
         <key alias="createUnder">Create an item under</key>
         <key alias="createContentBlueprint">Select the document type you want to make a content template for</key>
+        <key alias="enterFolderName">Enter a folder name</key>
         <key alias="updateData">Choose a type and a title</key>
         <key alias="noDocumentTypes" version="7.0"><![CDATA[There are no allowed document types available. You must enable these in the settings section under <strong>"document types"</strong>.]]></key>
         <key alias="noMediaTypes" version="7.0"><![CDATA[There are no allowed media types available. You must enable these in the settings section under <strong>"media types"</strong>.]]></key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1482,6 +1482,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     </area>
 
     <area alias="template">
+        <key alias="deleteByIdFailed">Failed to delete template with ID %0%</key>
         <key alias="edittemplate">Edit template</key>
 
         <key alias="insertSections">Sections</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -188,6 +188,7 @@
     <area alias="codefile">
         <key alias="createFolderFailedById">Failed to create a folder under parent with ID %0%</key>
         <key alias="createFolderFailedByName">Failed to create a folder under parent with name %0%</key>
+        <key alias="deleteItemFailed">Failed to delete item: %0%</key>
     </area>
     <area alias="content">
         <key alias="isPublished" version="7.2">Is Published</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1479,6 +1479,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="styles">Styles</key>
     </area>
     <area alias="template">
+        <key alias="deleteByIdFailed">Failed to delete template with ID %0%</key>
         <key alias="edittemplate">Edit template</key>
 
         <key alias="insertSections">Sections</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -186,6 +186,10 @@
         <key alias="validationErrorPropertyWithMoreThanOneMapping">Could not complete property mapping as one or more properties have more than one mapping defined.</key>
         <key alias="validDocTypesNote">Only alternate types valid for the current location are displayed.</key>
     </area>
+    <area alias="codefile">
+        <key alias="createFolderFailedById">Failed to create a folder under parent with ID %0%</key>
+        <key alias="createFolderFailedByName">Failed to create a folder under parent with name %0%</key>
+    </area>
     <area alias="content">
         <key alias="isPublished" version="7.2">Is Published</key>
         <key alias="about">About this page</key>
@@ -288,6 +292,7 @@
         <key alias="chooseNode">Where do you want to create the new %0%</key>
         <key alias="createUnder">Create an item under</key>
         <key alias="createContentBlueprint">Select the document type you want to make a content template for</key>
+        <key alias="enterFolderName">Enter a folder name</key>
         <key alias="updateData">Choose a type and a title</key>
         <key alias="noDocumentTypes" version="7.0"><![CDATA[There are no allowed document types available. You must enable these in the settings section under <strong>"document types"</strong>.]]></key>
         <key alias="noMediaTypes" version="7.0"><![CDATA[There are no allowed media types available. You must enable these in the settings section under <strong>"media types"</strong>.]]></key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -189,6 +189,7 @@
     <area alias="codefile">
         <key alias="createFolderFailedById">Failed to create a folder under parent with ID %0%</key>
         <key alias="createFolderFailedByName">Failed to create a folder under parent with name %0%</key>
+        <key alias="deleteItemFailed">Failed to delete item: %0%</key>
     </area>
     <area alias="content">
         <key alias="isPublished" version="7.2">Is Published</key>


### PR DESCRIPTION
**When creating a new partial view folder:**
Both the label and error message are now localized.
![image](https://user-images.githubusercontent.com/3634580/47811119-4f6fa980-dd45-11e8-97df-b727e0f258cf.png)

**When deleting a partial view (or folder) fails:**
There was no error handling for the request to delete an item or folder. Not there is - and it's localized.
![image](https://user-images.githubusercontent.com/3634580/47811061-1b948400-dd45-11e8-9a46-6f0e7b1f64cb.png)

**When deleting a template:**
There was no error handling for the request to delete a template. Not there is - and it's localized.
![image](https://user-images.githubusercontent.com/3634580/47811297-b2614080-dd45-11e8-85f2-42f44158772a.png)


