### PR TITLE
Fix dropdown validation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
@@ -42,10 +42,6 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.DropdownFlexibleCo
             $scope.model.value = [$scope.model.singleDropdownValue];
         }
 
-        $scope.updateMultipleDropdownValue = function () {
-            $scope.model.value = $scope.model.multipleDropdownValue;
-        }
-
         if (angular.isArray($scope.model.config.items)) {
             //PP: I dont think this will happen, but we have tests that expect it to happen..
             //if array is simple values, convert to array of objects

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
@@ -42,6 +42,10 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.DropdownFlexibleCo
             $scope.model.value = [$scope.model.singleDropdownValue];
         }
 
+        $scope.updateMultipleDropdownValue = function () {
+            $scope.model.value = $scope.model.multipleDropdownValue;
+        }
+
         if (angular.isArray($scope.model.config.items)) {
             //PP: I dont think this will happen, but we have tests that expect it to happen..
             //if array is simple values, convert to array of objects
@@ -74,8 +78,16 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.DropdownFlexibleCo
         // if we run in single mode we'll store the value in a local variable
         // so we can pass an array as the model as our PropertyValueEditor expects that
         $scope.model.singleDropdownValue = "";
-        if ($scope.model.config.multiple === "0") {
+        if ($scope.model.config.multiple === "0" && $scope.model.value) {
             $scope.model.singleDropdownValue = Array.isArray($scope.model.value) ? $scope.model.value[0] : $scope.model.value;
         }
 
+        // if we run in multiple mode, make sure the model is an array (in case the property was previously saved in single mode)
+        // also explicitly set the model to null if it's an empty array, so mandatory validation works on the client
+        if ($scope.model.config.multiple === "1" && $scope.model.value) {
+            $scope.model.value = !Array.isArray($scope.model.value) ? [$scope.model.value] : $scope.model.value;
+            if ($scope.model.value.length === 0) {
+                $scope.model.value = null;
+            }
+        }
     });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.html
@@ -5,7 +5,8 @@
             ng-switch-default
             ng-change="updateSingleDropdownValue()"
             ng-model="model.singleDropdownValue"
-            ng-options="item.id as item.value for item in model.config.items">
+            ng-options="item.id as item.value for item in model.config.items"
+            ng-required="model.validation.mandatory">
         <option></option>
     </select>
 
@@ -15,5 +16,6 @@
             ng-switch-when="1"
             multiple
             ng-model="model.value"
-            ng-options="item.id as item.value for item in model.config.items"></select>
+            ng-options="item.id as item.value for item in model.config.items"
+            ng-required="model.validation.mandatory"></select>
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3500

### Description

#3500 outlines the steps to reproduce/test. 

As mentioned on the issue, this is also a problem for content and media, although slightly smaller for content because the validation error caught on publish. But it makes sense to enforce it on save.

This fix only makes the mandatory validation work. The regex validations won't work for members or media, since they're only evaluated on publish (which is only for content).

A demo of the fix:

![dropdown validation](https://user-images.githubusercontent.com/7405322/47919602-0ab45180-deb0-11e8-9878-ba35b3425c7f.gif)

...as you can see, the same problem exists for checkbox lists. I'll have a look at fixing that next.