### PR TITLE
Fix publish dates issues

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -253,9 +253,9 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, notifica
                 }
             }
 
-            // If we have a scheduled publish or unpublish date change the default button to 
+            // If we have a scheduled publish date change the default button to 
             // "save" and update the label to "save and schedule
-            if(args.content.releaseDate || args.content.removeDate) {
+            if(args.content.releaseDate) {
 
                 // if save button is alread the default don't change it just update the label
                 if (buttons.defaultButton && buttons.defaultButton.letter === "A") {

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1079,8 +1079,10 @@ Mange hilsner fra Umbraco robotten
     <key alias="dictionaryItemSaved">Ordbogsnøgle gemt</key>
     <key alias="editContentPublishedHeader">Indhold publiceret</key>
     <key alias="editContentPublishedText">og nu synligt for besøgende</key>
+    <key alias="editContentPublishedWithExpireDateText">og nu synligt for besøgende indtil {0}</key>
     <key alias="editContentSavedHeader">Indhold gemt</key>
     <key alias="editContentSavedText">Husk at publicere for at gøre det synligt for besøgende</key>
+    <key alias="editContentSavedWithReleaseDateText">Ændringerne bliver publiceret den {0}</key>
     <key alias="editContentSendToPublish">Send til Godkendelse</key>
     <key alias="editContentSendToPublishText">Rettelser er blevet sendt til godkendelse</key>
     <key alias="editMediaSaved">Medie gemt</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1397,8 +1397,10 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="editContentPublishedFailedByParent">Publishing failed because the parent page isn't published</key>
         <key alias="editContentPublishedHeader">Content published</key>
         <key alias="editContentPublishedText">and visible on the website</key>
+        <key alias="editContentPublishedWithExpireDateText">and visible on the website until {0}</key>
         <key alias="editContentSavedHeader">Content saved</key>
         <key alias="editContentSavedText">Remember to publish to make changes visible</key>
+        <key alias="editContentSavedWithReleaseDateText">Changes will be published on {0}</key>
         <key alias="editContentSendToPublish">Sent For Approval</key>
         <key alias="editContentSendToPublishText">Changes have been sent for approval</key>
         <key alias="editMediaSaved">Media saved</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1396,8 +1396,10 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="editContentPublishedFailedByParent">Publishing failed because the parent page isn't published</key>
         <key alias="editContentPublishedHeader">Content published</key>
         <key alias="editContentPublishedText">and visible on the website</key>
+        <key alias="editContentPublishedWithExpireDateText">and visible on the website until {0}</key>
         <key alias="editContentSavedHeader">Content saved</key>
         <key alias="editContentSavedText">Remember to publish to make changes visible</key>
+        <key alias="editContentSavedWithReleaseDateText">Changes will be published on {0}</key>
         <key alias="editContentSendToPublish">Sent For Approval</key>
         <key alias="editContentSendToPublishText">Changes have been sent for approval</key>
         <key alias="editMediaSaved">Media saved</key>

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -697,7 +697,8 @@ namespace Umbraco.Web.Editors
                         display.AddSuccessNotification(
                             Services.TextService.Localize("speechBubbles/editContentSavedHeader"),
                             contentItem.ReleaseDate.HasValue
-                                ? string.Format(Services.TextService.Localize("speechBubbles/editContentSavedWithReleaseDateText"), contentItem.ReleaseDate.Value.ToLongDateString())
+                                ? string.Format(Services.TextService.Localize("speechBubbles/editContentSavedWithReleaseDateText"),
+                                    $"{contentItem.ReleaseDate.Value.ToLongDateString()} {contentItem.ReleaseDate.Value.ToString("HH:mm")}")
                                 : Services.TextService.Localize("speechBubbles/editContentSavedText")
                         );
                     }
@@ -1052,7 +1053,8 @@ namespace Umbraco.Web.Editors
                     display.AddSuccessNotification(
                             Services.TextService.Localize("speechBubbles/editContentPublishedHeader"),
                             expireDate.HasValue
-                                ? string.Format(Services.TextService.Localize("speechBubbles/editContentPublishedWithExpireDateText"), expireDate.Value.ToLongDateString())
+                                ? string.Format(Services.TextService.Localize("speechBubbles/editContentPublishedWithExpireDateText"),
+                                    $"{expireDate.Value.ToLongDateString()} {expireDate.Value.ToString("HH:mm")}")
                                 : Services.TextService.Localize("speechBubbles/editContentPublishedText")
                     );
                     break;

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -696,7 +696,10 @@ namespace Umbraco.Web.Editors
                     {
                         display.AddSuccessNotification(
                             Services.TextService.Localize("speechBubbles/editContentSavedHeader"),
-                            Services.TextService.Localize("speechBubbles/editContentSavedText"));
+                            contentItem.ReleaseDate.HasValue
+                                ? string.Format(Services.TextService.Localize("speechBubbles/editContentSavedWithReleaseDateText"), contentItem.ReleaseDate.Value.ToLongDateString())
+                                : Services.TextService.Localize("speechBubbles/editContentSavedText")
+                        );
                     }
                     else
                     {
@@ -718,7 +721,7 @@ namespace Umbraco.Web.Editors
                     break;
                 case ContentSaveAction.Publish:
                 case ContentSaveAction.PublishNew:
-                    ShowMessageForPublishStatus(publishStatus.Result, display);
+                    ShowMessageForPublishStatus(publishStatus.Result, display, contentItem.ExpireDate);
                     break;
             }
 
@@ -759,7 +762,7 @@ namespace Umbraco.Web.Editors
             if (publishResult.Success == false)
             {
                 var notificationModel = new SimpleNotificationModel();
-                ShowMessageForPublishStatus(publishResult.Result, notificationModel);
+                ShowMessageForPublishStatus(publishResult.Result, notificationModel, foundContent.ExpireDate);
                 return Request.CreateValidationErrorResponse(notificationModel);
             }
 
@@ -1040,15 +1043,18 @@ namespace Umbraco.Web.Editors
             return toMove;
         }
 
-        private void ShowMessageForPublishStatus(PublishStatus status, INotificationModel display)
+        private void ShowMessageForPublishStatus(PublishStatus status, INotificationModel display, DateTime? expireDate)
         {
             switch (status.StatusType)
             {
                 case PublishStatusType.Success:
-                case PublishStatusType.SuccessAlreadyPublished:
+                case PublishStatusType.SuccessAlreadyPublished:                    
                     display.AddSuccessNotification(
                             Services.TextService.Localize("speechBubbles/editContentPublishedHeader"),
-                            Services.TextService.Localize("speechBubbles/editContentPublishedText"));
+                            expireDate.HasValue
+                                ? string.Format(Services.TextService.Localize("speechBubbles/editContentPublishedWithExpireDateText"), expireDate.Value.ToLongDateString())
+                                : Services.TextService.Localize("speechBubbles/editContentPublishedText")
+                    );
                     break;
                 case PublishStatusType.FailedPathNotPublished:
                     display.AddWarningNotification(


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/2905 and https://github.com/umbraco/Umbraco-CMS/issues/3267

### Description

This PR fixes two things concerning the "Save and publish" button:

1. The default action remains "Save and publish" even if an expiry date is set (as outlined in both #2905 and #3267). The default action only changes to "Save and schedule" when a publish date is set.
2. The notifications from the server now contain the release or expiry dates (as outlined in #2905).

To test the PR, simply apply release and expiry dates to various pieces of content and verify that the 
"Save and publish" button and the notifications behave as it is so nicely outlined in #2905.

Here's how it looks when an expiry date is set:

![save and publish with expire date](https://user-images.githubusercontent.com/7405322/47964550-0157f000-e03c-11e8-9095-ab9cdd878428.gif)

...and here's how it looks with a release date set:

![save and publish with release date](https://user-images.githubusercontent.com/7405322/47964553-09179480-e03c-11e8-823b-2ba101b4ad49.gif)

I have added translations for en-GB, en-US and da-DK.