### PR TITLE
Fix missing "opens dialog dots" for menu items created using the MenuItemList helper methods

### DIFF
--- a/src/Umbraco.Web/Models/Trees/MenuItemList.cs
+++ b/src/Umbraco.Web/Models/Trees/MenuItemList.cs
@@ -44,10 +44,11 @@ namespace Umbraco.Web.Models.Trees
         /// <typeparam name="T"></typeparam>
         /// <param name="hasSeparator"></param>
         /// <param name="name">The text to display for the menu item, will default to the IAction alias if not specified</param>
-        public MenuItem Add<T>(string name, bool hasSeparator = false)
+        /// <param name="opensDialog">Whether or not this action opens a dialog</param>
+        public MenuItem Add<T>(string name, bool hasSeparator = false, bool opensDialog = false)
             where T : IAction
         {
-            var item = CreateMenuItem<T>(name, hasSeparator);
+            var item = CreateMenuItem<T>(name, hasSeparator, opensDialog);
             if (item != null)
             {
                 Add(item);
@@ -62,11 +63,11 @@ namespace Umbraco.Web.Models.Trees
         /// <typeparam name="T"></typeparam>
         /// <param name="hasSeparator"></param>
         /// <param name="textService">The <see cref="ILocalizedTextService"/> used to localize the action name based on it's alias</param>
-        /// <param name="opensDialog"></param>
+        /// <param name="opensDialog">Whether or not this action opens a dialog</param>
         public MenuItem Add<T>(ILocalizedTextService textService, bool hasSeparator = false, bool opensDialog = false)
             where T : IAction
         {
-            var item = CreateMenuItem<T>(textService, hasSeparator);
+            var item = CreateMenuItem<T>(textService, hasSeparator, opensDialog);
             if (item != null)
             {
                 Add(item);
@@ -75,14 +76,15 @@ namespace Umbraco.Web.Models.Trees
             return null;
         }
         
-        internal MenuItem CreateMenuItem<T>(string name, bool hasSeparator = false)
+        internal MenuItem CreateMenuItem<T>(string name, bool hasSeparator = false, bool opensDialog = false)
             where T : IAction
         {
             var item = Current.Actions.GetAction<T>();
             if (item == null) return null;
             var menuItem = new MenuItem(item, name)
             {
-                SeperatorBefore = hasSeparator
+                SeperatorBefore = hasSeparator,
+                OpensDialog = opensDialog
             };
 
             return menuItem;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#3437 calls for ellipsis markers on all menu items that spawn a dialog. 

I noticed these are missing on the dictionary tree. Turns out a lot of the menu item methods on `MenuItemList` do not handle the `opensDialog` option menu items, and these are used by the dictionary tree (and most likely a whole bunch of other trees).

This is how the menu looks for the dictionary tree root before this PR:

![dictionary menu before](https://user-images.githubusercontent.com/7405322/48071352-6f3a1e00-e1da-11e8-8630-f06ce5e1f488.png)

..and this is after:

![dictionary menu after](https://user-images.githubusercontent.com/7405322/48071367-74976880-e1da-11e8-8923-607b418206bc.png)
