### PR TITLE
V8: Sort the dictionary items alphabetically

### DIFF
--- a/src/Umbraco.Web/Editors/DictionaryController.cs
+++ b/src/Umbraco.Web/Editors/DictionaryController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Web.Http;
@@ -194,7 +195,7 @@ namespace Umbraco.Web.Editors
 
             const int level = 0;
 
-            foreach (var dictionaryItem in Services.LocalizationService.GetRootDictionaryItems())
+            foreach (var dictionaryItem in Services.LocalizationService.GetRootDictionaryItems().OrderBy(ItemSort()))
             {
                 var item = Mapper.Map<IDictionaryItem, DictionaryOverviewDisplay>(dictionaryItem);
                 item.Level = 0;
@@ -220,8 +221,7 @@ namespace Umbraco.Web.Editors
         /// </param>
         private void GetChildItemsForList(IDictionaryItem dictionaryItem, int level, List<DictionaryOverviewDisplay> list)
         {
-            foreach (var childItem in Services.LocalizationService.GetDictionaryItemChildren(
-                dictionaryItem.Key))
+            foreach (var childItem in Services.LocalizationService.GetDictionaryItemChildren(dictionaryItem.Key).OrderBy(ItemSort()))
             {
                 var item = Mapper.Map<IDictionaryItem, DictionaryOverviewDisplay>(childItem);
                 item.Level = level;
@@ -230,5 +230,7 @@ namespace Umbraco.Web.Editors
                 GetChildItemsForList(childItem, level + 1, list);
             }
         }
+
+        private Func<IDictionaryItem, string> ItemSort() => item => item.ItemKey;
     }
 }

--- a/src/Umbraco.Web/Trees/DictionaryTreeController.cs
+++ b/src/Umbraco.Web/Trees/DictionaryTreeController.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net.Http.Formatting;
 using Umbraco.Core;
+using Umbraco.Core.Models;
 using Umbraco.Core.Services;
 using Umbraco.Web.Actions;
 
@@ -52,10 +53,12 @@ namespace Umbraco.Web.Trees
 
             var nodes = new TreeNodeCollection();
 
+            Func<IDictionaryItem, string> ItemSort() => item => item.ItemKey;
+
             if (id == Constants.System.Root.ToInvariantString())
             {
                 nodes.AddRange(
-                    Services.LocalizationService.GetRootDictionaryItems().Select(
+                    Services.LocalizationService.GetRootDictionaryItems().OrderBy(ItemSort()).Select(
                         x => CreateTreeNode(
                             x.Id.ToInvariantString(),
                             id,
@@ -71,7 +74,7 @@ namespace Umbraco.Web.Trees
                 if (parentDictionary == null)
                     return nodes;
 
-                nodes.AddRange(Services.LocalizationService.GetDictionaryItemChildren(parentDictionary.Key).ToList().OrderByDescending(item => item.Key).Select(
+                nodes.AddRange(Services.LocalizationService.GetDictionaryItemChildren(parentDictionary.Key).ToList().OrderBy(ItemSort()).Select(
                     x => CreateTreeNode(
                         x.Id.ToInvariantString(),
                         id,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The items in the dictionary tree and on the dashboard aren't sorted alphabetically. I'm guessing that's an oversight 😄 

This PR fixes it.

Here's what it looks like today:

![dictionary sort before](https://user-images.githubusercontent.com/7405322/48072617-38b1d280-e1dd-11e8-938a-9fdbb57cf2ed.png)

...and here's what it looks like with this PR applied:

![dictionary sort after](https://user-images.githubusercontent.com/7405322/48072628-41a2a400-e1dd-11e8-8961-5f7029b18713.png)

