### PR TITLE
Rename MigrationStartupHander to MigrationStartupHandler

### DIFF
--- a/src/Umbraco.Tests/Persistence/Migrations/MigrationStartupHandlerTests.cs
+++ b/src/Umbraco.Tests/Persistence/Migrations/MigrationStartupHandlerTests.cs
@@ -70,7 +70,7 @@ namespace Umbraco.Tests.Persistence.Migrations
             public int CountExecuted { get; set; }
         }
 
-        public class TestMigrationHandler : MigrationStartupHander
+        public class TestMigrationHandler : MigrationStartupHandler
         {
             private readonly string _prodName;
             private readonly Args _changed;

--- a/src/Umbraco.Web/Strategies/Migrations/ClearCsrfCookiesAfterUpgrade.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/ClearCsrfCookiesAfterUpgrade.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Web.Strategies.Migrations
     /// <summary>
     /// After upgrade we clear out the csrf tokens
     /// </summary>
-    public class ClearCsrfCookiesAfterUpgrade : MigrationStartupHander
+    public class ClearCsrfCookiesAfterUpgrade : MigrationStartupHandler
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)
         {

--- a/src/Umbraco.Web/Strategies/Migrations/ClearMediaXmlCacheForDeletedItemsAfterUpgrade.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/ClearMediaXmlCacheForDeletedItemsAfterUpgrade.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Web.Strategies.Migrations
     ///
     /// * If current is less than or equal to 7.0.0
     /// </remarks>
-    public class ClearMediaXmlCacheForDeletedItemsAfterUpgrade : MigrationStartupHander
+    public class ClearMediaXmlCacheForDeletedItemsAfterUpgrade : MigrationStartupHandler
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)
         {

--- a/src/Umbraco.Web/Strategies/Migrations/EnsureListViewDataTypeIsCreated.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/EnsureListViewDataTypeIsCreated.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Web.Strategies.Migrations
     /// <summary>
     /// Creates the built in list view data types
     /// </summary>
-    public class EnsureDefaultListViewDataTypesCreated : MigrationStartupHander
+    public class EnsureDefaultListViewDataTypesCreated : MigrationStartupHandler
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)
         {

--- a/src/Umbraco.Web/Strategies/Migrations/MigrationStartupHandler.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/MigrationStartupHandler.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Web.Strategies.Migrations
     /// <summary>
     /// Base class that can be used to run code after the migration runner has executed
     /// </summary>
-    public abstract class MigrationStartupHander : ApplicationEventHandler
+    public abstract class MigrationStartupHandler : ApplicationEventHandler
     {
         /// <summary>
         /// Ensure this is run when not configured

--- a/src/Umbraco.Web/Strategies/Migrations/MigrationStartupHandler.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/MigrationStartupHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Persistence.Migrations;
 
@@ -57,5 +58,11 @@ namespace Umbraco.Web.Strategies.Migrations
         /// Leaving empty will run for all migration products
         /// </remarks>
         public virtual string[] TargetProductNames { get { return new string[] {}; } }
+    }
+
+    [Obsolete("Name has changed, use MigrationStartupHandler instead")]
+    public abstract class MigrationStartupHander : MigrationStartupHandler
+    {
+
     }
 }

--- a/src/Umbraco.Web/Strategies/Migrations/OverwriteStylesheetFilesFromTempFiles.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/OverwriteStylesheetFilesFromTempFiles.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Web.Strategies.Migrations
     /// files during the migration since other parts of the migration might fail. So once the migration is complete, we'll then copy over the temp
     /// files that this migration created over top of the developer's files. We'll also create a backup of their files.
     /// </summary>
-    public sealed class OverwriteStylesheetFilesFromTempFiles : MigrationStartupHander
+    public sealed class OverwriteStylesheetFilesFromTempFiles : MigrationStartupHandler
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)
         {

--- a/src/Umbraco.Web/Strategies/Migrations/PublishAfterUpgradeToVersionSixth.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/PublishAfterUpgradeToVersionSixth.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Web.Strategies.Migrations
     /// This event ensures that upgrades from (configured) versions lower then 6.0.0
     /// have their publish state updated after the database schema has been migrated.
     /// </summary>
-    public class PublishAfterUpgradeToVersionSixth : MigrationStartupHander
+    public class PublishAfterUpgradeToVersionSixth : MigrationStartupHandler
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)
         {

--- a/src/Umbraco.Web/Strategies/Migrations/RebuildXmlCachesAfterUpgrade.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/RebuildXmlCachesAfterUpgrade.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Web.Strategies.Migrations
     /// - Media & Content Xml : if current is less than, or equal to, 7.3.0 - because 7.3.0 adds .Key to cached items
     /// </para>
     /// </remarks>
-    public class RebuildXmlCachesAfterUpgrade : MigrationStartupHander
+    public class RebuildXmlCachesAfterUpgrade : MigrationStartupHandler
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)
         {

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -784,7 +784,7 @@
     <Compile Include="Strategies\Migrations\ClearCsrfCookiesAfterUpgrade.cs" />
     <Compile Include="Strategies\Migrations\ClearMediaXmlCacheForDeletedItemsAfterUpgrade.cs" />
     <Compile Include="Strategies\Migrations\EnsureListViewDataTypeIsCreated.cs" />
-    <Compile Include="Strategies\Migrations\MigrationStartupHander.cs" />
+    <Compile Include="Strategies\Migrations\MigrationStartupHandler.cs" />
     <Compile Include="Strategies\Migrations\OverwriteStylesheetFilesFromTempFiles.cs" />
     <Compile Include="Strategies\NotificationsHandler.cs" />
     <Compile Include="Strategies\RelateOnCopyHandler.cs" />


### PR DESCRIPTION
### Description
There was a typo on the class name for MigrationStartupHander, should be MigrationStartupHandler. I have corrected the typo and updated the classes using the affected class.