### PR TITLE
Updated absolute-positioned validation error message to be readable

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/forms/umb-validation-label.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms/umb-validation-label.less
@@ -1,5 +1,7 @@
 .umb-validation-label {
    position: absolute;
+   top: 27px;
+   width: 200px;
    padding: 1px 5px;
    background: @red;
    color: @white;


### PR DESCRIPTION
Updated absolute-positioned validation error message to be readable when document types are attempting save with duplicate alias

### Prerequisites

- Create new document using an alias that already exists
- Error message is a little warped and almost unreadable
![image](https://user-images.githubusercontent.com/6873029/48194882-243d1980-e346-11e8-8573-87ab16ae62cb.png)

### Description

- Upper bar error message should now be readable and displaying correctly
