### PR TITLE
3510 - Fixes Health check false negative in X-XSS-Protection header check 

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2174,7 +2174,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="hSTSSetHeaderInConfigSuccess">The HSTS header has been added to your web.config file.</key>
 
         <key alias="xssProtectionCheckHeaderFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was found.]]></key>
-        <key alias="xssProtectionCheckHeaderFoundWrongCase"><![CDATA[The header <strong>X-XSS-Protection</strong> was found, but is in the wrong case. <br/><br/> There is a risk that a browser may not be fully w3c compliant and when parsing the headers and do a straight string match, instead of a case insensitive one, resulting in the security header not being applied.]]></key>
+        <key alias="xssProtectionCheckHeaderFoundWrongCase"><![CDATA[The header <strong>X-XSS-Protection</strong> was found, but is in the wrong case.<br /><br />There is a risk that a browser may not be fully W3C compliant when parsing the headers and do a straight string match, instead of a case insensitive one, resulting in the security header not being applied.]]></key>
         <key alias="xssProtectionCheckHeaderNotFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was not found.]]></key>
         <key alias="xssProtectionSetHeaderInConfigDescription">Adds the header 'X-XSS-Protection' with the value '1; mode=block' to the httpProtocol/customHeaders section of web.config. </key>
         <key alias="xssProtectionSetHeaderInConfigSuccess">The X-XSS-Protection header has been added to your web.config file.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2158,6 +2158,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="clickJackingCheckHeaderFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMEd by another was found.]]></key>
         <key alias="clickJackingCheckHeaderNotFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMEd by another was not found.]]></key>
         <key alias="setHeaderInConfig">Set Header in Config</key>
+        <key alias="updateHeaderInConfig">Update Header in Config</key>
         <key alias="clickJackingSetHeaderInConfigDescription">Adds a value to the httpProtocol/customHeaders section of web.config to prevent the site being IFRAMEd by other websites.</key>
         <key alias="clickJackingSetHeaderInConfigSuccess">A setting to create a header preventing IFRAMEing of the site by other websites has been added to your web.config file.</key>
         <key alias="setHeaderInConfigError">Could not update web.config file. Error: %0%</key>
@@ -2173,6 +2174,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="hSTSSetHeaderInConfigSuccess">The HSTS header has been added to your web.config file.</key>
 
         <key alias="xssProtectionCheckHeaderFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was found.]]></key>
+        <key alias="xssProtectionCheckHeaderFoundWrongCase"><![CDATA[The header <strong>X-XSS-Protection</strong> was found, but is in the wrong case. <br/><br/> There is a risk that a browser may not be fully w3c compliant and when parsing the headers and do a straight string match, instead of a case insensitive one, resulting in the security header not being applied.]]></key>
         <key alias="xssProtectionCheckHeaderNotFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was not found.]]></key>
         <key alias="xssProtectionSetHeaderInConfigDescription">Adds the header 'X-XSS-Protection' with the value '1; mode=block' to the httpProtocol/customHeaders section of web.config. </key>
         <key alias="xssProtectionSetHeaderInConfigSuccess">The X-XSS-Protection header has been added to your web.config file.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2167,7 +2167,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="hSTSSetHeaderInConfigSuccess">The HSTS header has been added to your web.config file.</key>
 
         <key alias="xssProtectionCheckHeaderFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was found.]]></key>
-        <key alias="xssProtectionCheckHeaderFoundWrongCase"><![CDATA[The header <strong>X-XSS-Protection</strong> was found, but is in the wrong case. <br/><br/> There is a risk that a browser may not be fully w3c compliant and when parsing the headers and do a straight string match, instead of a case insensitive one, resulting in the security header not being applied.]]></key>
+        <key alias="xssProtectionCheckHeaderFoundWrongCase"><![CDATA[The header <strong>X-XSS-Protection</strong> was found, but is in the wrong case.<br /><br />There is a risk that a browser may not be fully W3C compliant when parsing the headers and do a straight string match, instead of a case insensitive one, resulting in the security header not being applied.]]></key>
         <key alias="xssProtectionCheckHeaderNotFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was not found.]]></key>
         <key alias="xssProtectionSetHeaderInConfigDescription">Adds the header 'X-XSS-Protection' with the value '1; mode=block' to the httpProtocol/customHeaders section of web.config. </key>
         <key alias="xssProtectionSetHeaderInConfigSuccess">The X-XSS-Protection header has been added to your web.config file.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2151,6 +2151,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="clickJackingCheckHeaderFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMEd by another was found.]]></key>
         <key alias="clickJackingCheckHeaderNotFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMEd by another was not found.]]></key>
         <key alias="setHeaderInConfig">Set Header in Config</key>
+        <key alias="updateHeaderInConfig">Update Header in Config</key>
         <key alias="clickJackingSetHeaderInConfigDescription">Adds a value to the httpProtocol/customHeaders section of web.config to prevent the site being IFRAMEd by other websites.</key>
         <key alias="clickJackingSetHeaderInConfigSuccess">A setting to create a header preventing IFRAMEing of the site by other websites has been added to your web.config file.</key>
         <key alias="setHeaderInConfigError">Could not update web.config file. Error: %0%</key>
@@ -2166,6 +2167,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="hSTSSetHeaderInConfigSuccess">The HSTS header has been added to your web.config file.</key>
 
         <key alias="xssProtectionCheckHeaderFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was found.]]></key>
+        <key alias="xssProtectionCheckHeaderFoundWrongCase"><![CDATA[The header <strong>X-XSS-Protection</strong> was found, but is in the wrong case. <br/><br/> There is a risk that a browser may not be fully w3c compliant and when parsing the headers and do a straight string match, instead of a case insensitive one, resulting in the security header not being applied.]]></key>
         <key alias="xssProtectionCheckHeaderNotFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was not found.]]></key>
         <key alias="xssProtectionSetHeaderInConfigDescription">Adds the header 'X-XSS-Protection' with the value '1; mode=block' to the httpProtocol/customHeaders section of web.config. </key>
         <key alias="xssProtectionSetHeaderInConfigSuccess">The X-XSS-Protection header has been added to your web.config file.</key>

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
@@ -22,7 +22,6 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         protected readonly string Value;
         protected readonly string LocalizedTextPrefix;
         protected readonly bool MetaTagOptionAvailable;
-        protected readonly bool IgnoreCasing;
 
         public BaseHttpHeaderCheck(HealthCheckContext healthCheckContext,
             string header, string value, string localizedTextPrefix, bool metaTagOptionAvailable) : base(healthCheckContext)

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
@@ -13,14 +13,14 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 {
     public abstract class BaseHttpHeaderCheck : HealthCheck
     {
-        private readonly ILocalizedTextService _textService;
+        protected readonly ILocalizedTextService _textService;
 
-        private const string SetHeaderInConfigAction = "setHeaderInConfig";
+        protected const string SetHeaderInConfigAction = "setHeaderInConfig";
 
-        private readonly string _header;
-        private readonly string _value;
-        private readonly string _localizedTextPrefix;
-        private readonly bool _metaTagOptionAvailable;
+        protected readonly string _header;
+        protected readonly string _value;
+        protected readonly string _localizedTextPrefix;
+        protected readonly bool _metaTagOptionAvailable;
 
         public BaseHttpHeaderCheck(HealthCheckContext healthCheckContext, 
             string header, string value, string localizedTextPrefix, bool metaTagOptionAvailable) : base(healthCheckContext)

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
@@ -13,24 +13,24 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 {
     public abstract class BaseHttpHeaderCheck : HealthCheck
     {
-        protected readonly ILocalizedTextService _textService;
+        protected readonly ILocalizedTextService TextService;
 
         protected const string SetHeaderInConfigAction = "setHeaderInConfig";
 
-        protected readonly string _header;
-        protected readonly string _value;
-        protected readonly string _localizedTextPrefix;
-        protected readonly bool _metaTagOptionAvailable;
+        protected readonly string Header;
+        protected readonly string Value;
+        protected readonly string LocalizedTextPrefix;
+        protected readonly bool MetaTagOptionAvailable;
 
         public BaseHttpHeaderCheck(HealthCheckContext healthCheckContext, 
             string header, string value, string localizedTextPrefix, bool metaTagOptionAvailable) : base(healthCheckContext)
         {
-            _textService = healthCheckContext.ApplicationContext.Services.TextService;
+            TextService = healthCheckContext.ApplicationContext.Services.TextService;
 
-            _header = header;
-            _value = value;
-            _localizedTextPrefix = localizedTextPrefix;
-            _metaTagOptionAvailable = metaTagOptionAvailable;
+            Header = header;
+            Value = value;
+            LocalizedTextPrefix = localizedTextPrefix;
+            MetaTagOptionAvailable = metaTagOptionAvailable;
         }
 
         /// <summary>
@@ -76,18 +76,18 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
                 success = DoHttpHeadersContainHeader(response);
 
                 // If not found, and available, check for meta-tag
-                if (success == false && _metaTagOptionAvailable)
+                if (success == false && MetaTagOptionAvailable)
                 {
                     success = DoMetaTagsContainKeyForHeader(response);
                 }
 
                 message = success
-                    ? _textService.Localize(string.Format("healthcheck/{0}CheckHeaderFound", _localizedTextPrefix))
-                    : _textService.Localize(string.Format("healthcheck/{0}CheckHeaderNotFound", _localizedTextPrefix));
+                    ? TextService.Localize(string.Format("healthcheck/{0}CheckHeaderFound", LocalizedTextPrefix))
+                    : TextService.Localize(string.Format("healthcheck/{0}CheckHeaderNotFound", LocalizedTextPrefix));
             }
             catch (Exception ex)
             {
-                message = _textService.Localize("healthcheck/healthCheckInvalidUrl", new[] { url, ex.Message });
+                message = TextService.Localize("healthcheck/healthCheckInvalidUrl", new[] { url, ex.Message });
             }
 
             var actions = new List<HealthCheckAction>();
@@ -95,8 +95,8 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             {
                 actions.Add(new HealthCheckAction(SetHeaderInConfigAction, Id)
                 {
-                    Name = _textService.Localize("healthcheck/setHeaderInConfig"),
-                    Description = _textService.Localize(string.Format("healthcheck/{0}SetHeaderInConfigDescription", _localizedTextPrefix))
+                    Name = TextService.Localize("healthcheck/setHeaderInConfig"),
+                    Description = TextService.Localize(string.Format("healthcheck/{0}SetHeaderInConfigDescription", LocalizedTextPrefix))
                 });
             }
 
@@ -110,7 +110,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 
         private bool DoHttpHeadersContainHeader(WebResponse response)
         {
-            return response.Headers.AllKeys.Contains(_header);
+            return response.Headers.AllKeys.Contains(Header);
         }
 
         private bool DoMetaTagsContainKeyForHeader(WebResponse response)
@@ -122,7 +122,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
                 {
                     var html = reader.ReadToEnd();
                     var metaTags = ParseMetaTags(html);
-                    return metaTags.ContainsKey(_header);
+                    return metaTags.ContainsKey(Header);
                 }
             }
         }
@@ -144,14 +144,14 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             if (success)
             {
                 return
-                    new HealthCheckStatus(_textService.Localize(string.Format("healthcheck/{0}SetHeaderInConfigSuccess", _localizedTextPrefix)))
+                    new HealthCheckStatus(TextService.Localize(string.Format("healthcheck/{0}SetHeaderInConfigSuccess", LocalizedTextPrefix)))
                     {
                         ResultType = StatusResultType.Success
                     };
             }
 
             return
-                new HealthCheckStatus(_textService.Localize("healthcheck/setHeaderInConfigError", new [] { errorMessage }))
+                new HealthCheckStatus(TextService.Localize("healthcheck/setHeaderInConfigError", new [] { errorMessage }))
                 {
                     ResultType = StatusResultType.Error
                 };
@@ -182,22 +182,22 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 
                 var removeHeaderElement = customHeadersElement.Elements("remove")
                     .SingleOrDefault(x => x.Attribute("name") != null &&
-                                          x.Attribute("name")?.Value == _value);
+                                          x.Attribute("name")?.Value == Value);
                 if (removeHeaderElement == null)
                 {
                     removeHeaderElement = new XElement("remove");
-                    removeHeaderElement.Add(new XAttribute("name", _header));
+                    removeHeaderElement.Add(new XAttribute("name", Header));
                     customHeadersElement.Add(removeHeaderElement);
                 }
 
                 var addHeaderElement = customHeadersElement.Elements("add")
                     .SingleOrDefault(x => x.Attribute("name") != null &&
-                                          x.Attribute("name").Value == _header);
+                                          x.Attribute("name").Value == Header);
                 if (addHeaderElement == null)
                 {
                     addHeaderElement = new XElement("add");
-                    addHeaderElement.Add(new XAttribute("name", _header));
-                    addHeaderElement.Add(new XAttribute("value", _value));
+                    addHeaderElement.Add(new XAttribute("name", Header));
+                    addHeaderElement.Add(new XAttribute("value", Value));
                     customHeadersElement.Add(addHeaderElement);
                 }
 

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/XssProtectionCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/XssProtectionCheck.cs
@@ -49,7 +49,6 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         protected HealthCheckStatus CheckForXSSHeader()
         {
             var message = string.Empty;
-            var success = false;
             var resultType = StatusResultType.Error;
 
             // Access the site home page and check for the click-jack protection header or meta tag
@@ -61,7 +60,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
                 var response = request.GetResponse();
 
                 // Check first for header
-                var key = response.Headers.AllKeys.FirstOrDefault(k => _header.InvariantEquals(k));
+                var key = response.Headers.AllKeys.FirstOrDefault(k => Header.InvariantEquals(k));
 
                 if (string.IsNullOrWhiteSpace(key) == false)
                 {
@@ -70,22 +69,22 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
                     if (key.Equals(headerValue, StringComparison.InvariantCulture))
                     {
                         resultType = StatusResultType.Success;
-                        message = _textService.Localize($"healthcheck/{_localizedTextPrefix}CheckHeaderFound");
+                        message = TextService.Localize($"healthcheck/{LocalizedTextPrefix}CheckHeaderFound");
                     }
                     else
                     {
                         resultType = StatusResultType.Warning;
-                        message = _textService.Localize($"healthcheck/{_localizedTextPrefix}CheckHeaderFoundWrongCase");
+                        message = TextService.Localize($"healthcheck/{LocalizedTextPrefix}CheckHeaderFoundWrongCase");
                     }
                 }
                 else
                 {
-                    message = _textService.Localize($"healthcheck/{_localizedTextPrefix}CheckHeaderNotFound");
+                    message = TextService.Localize($"healthcheck/{LocalizedTextPrefix}CheckHeaderNotFound");
                 }
             }
             catch (Exception ex)
             {
-                message = _textService.Localize("healthcheck/healthCheckInvalidUrl", new[] { url, ex.Message });
+                message = TextService.Localize("healthcheck/healthCheckInvalidUrl", new[] { url, ex.Message });
             }
 
             var actions = new List<HealthCheckAction>();
@@ -94,16 +93,16 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
                 case StatusResultType.Warning:
                     actions.Add(new HealthCheckAction(UpdateHeaderInConfigAction, Id)
                     {
-                        Name = _textService.Localize("healthcheck/updateHeaderInConfig"),
-                        Description = _textService.Localize($"healthcheck/{_localizedTextPrefix}SetHeaderInConfigDescription")
+                        Name = TextService.Localize("healthcheck/updateHeaderInConfig"),
+                        Description = TextService.Localize($"healthcheck/{LocalizedTextPrefix}SetHeaderInConfigDescription")
                     });
                     break;
 
                 case StatusResultType.Error:
                     actions.Add(new HealthCheckAction(SetHeaderInConfigAction, Id)
                     {
-                        Name = _textService.Localize("healthcheck/setHeaderInConfig"),
-                        Description = _textService.Localize($"healthcheck/{_localizedTextPrefix}SetHeaderInConfigDescription")
+                        Name = TextService.Localize("healthcheck/setHeaderInConfig"),
+                        Description = TextService.Localize($"healthcheck/{LocalizedTextPrefix}SetHeaderInConfigDescription")
                     });
                     break;
 
@@ -127,14 +126,14 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             if (success)
             {
                 return
-                    new HealthCheckStatus(_textService.Localize(string.Format("healthcheck/{0}SetHeaderInConfigSuccess", _localizedTextPrefix)))
+                    new HealthCheckStatus(TextService.Localize(string.Format("healthcheck/{0}SetHeaderInConfigSuccess", LocalizedTextPrefix)))
                     {
                         ResultType = StatusResultType.Success
                     };
             }
 
             return
-                new HealthCheckStatus(_textService.Localize("healthcheck/setHeaderInConfigError", new[] { errorMessage }))
+                new HealthCheckStatus(TextService.Localize("healthcheck/setHeaderInConfigError", new[] { errorMessage }))
                 {
                     ResultType = StatusResultType.Error
                 };
@@ -165,31 +164,31 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 
 
                 var removeHeaderElement = customHeadersElement.Elements("remove")
-                    .SingleOrDefault(x => _header.InvariantEquals(x.Attribute("name")?.Value));
+                    .SingleOrDefault(x => Header.InvariantEquals(x.Attribute("name")?.Value));
                 if (removeHeaderElement == null)
                 {
                     removeHeaderElement = new XElement("remove");
-                    removeHeaderElement.Add(new XAttribute("name", _header));
+                    removeHeaderElement.Add(new XAttribute("name", Header));
                     customHeadersElement.Add(removeHeaderElement);
                 }
                 else
                 {
-                    removeHeaderElement.Attribute("name").SetValue(_header);
+                    removeHeaderElement.Attribute("name").SetValue(Header);
                 }
 
                 var addHeaderElement1 = customHeadersElement.Elements("add");
                 var addHeaderElement = customHeadersElement.Elements("add")
-                    .SingleOrDefault(x => _header.InvariantEquals(x.Attribute("name")?.Value));
+                    .SingleOrDefault(x => Header.InvariantEquals(x.Attribute("name")?.Value));
                 if (addHeaderElement == null)
                 {
                     addHeaderElement = new XElement("add");
-                    addHeaderElement.Add(new XAttribute("name", _header));
-                    addHeaderElement.Add(new XAttribute("value", _value));
+                    addHeaderElement.Add(new XAttribute("name", Header));
+                    addHeaderElement.Add(new XAttribute("value", Value));
                     customHeadersElement.Add(addHeaderElement);
                 }
                 else
                 {
-                    addHeaderElement.Attribute("name").SetValue(_header);
+                    addHeaderElement.Attribute("name").SetValue(Header);
                 }
 
 

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/XssProtectionCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/XssProtectionCheck.cs
@@ -1,4 +1,14 @@
-﻿namespace Umbraco.Web.HealthCheck.Checks.Security
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using umbraco.IO;
+using Umbraco.Core;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Web.HealthCheck.Checks.Security
 {
     [HealthCheck(
         "F4D2B02E-28C5-4999-8463-05759FA15C3A",
@@ -7,6 +17,8 @@
         Group = "Security")]
     public class XssProtectionCheck : BaseHttpHeaderCheck
     {
+        private const string UpdateHeaderInConfigAction = "updateHeaderInConfig";
+
         // The check is mostly based on the instructions in the OWASP CheatSheet
         // (https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet)
         // and the blogpost of Troy Hunt (https://www.troyhunt.com/understanding-http-strict-transport/)
@@ -15,6 +27,182 @@
         public XssProtectionCheck(HealthCheckContext healthCheckContext)
             : base(healthCheckContext, "X-XSS-Protection", "1; mode=block", "xssProtection", true)
         {
+        }
+
+        public override IEnumerable<HealthCheckStatus> GetStatus()
+        {
+            //return the statuses
+            return new[] { CheckForXSSHeader() };
+        }
+
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            switch (action.Alias)
+            {
+                case UpdateHeaderInConfigAction:
+                    return UpdateHeaderInConfig();
+                default:
+                    return base.ExecuteAction(action);
+            }
+        }
+
+        protected HealthCheckStatus CheckForXSSHeader()
+        {
+            var message = string.Empty;
+            var success = false;
+            var resultType = StatusResultType.Error;
+
+            // Access the site home page and check for the click-jack protection header or meta tag
+            var url = HealthCheckContext.SiteUrl;
+            var request = WebRequest.Create(url);
+            request.Method = "GET";
+            try
+            {
+                var response = request.GetResponse();
+
+                // Check first for header
+                var key = response.Headers.AllKeys.FirstOrDefault(k => _header.InvariantEquals(k));
+
+                if (string.IsNullOrWhiteSpace(key) == false)
+                {
+                    var headerValue = response.Headers[key];
+
+                    if (key.Equals(headerValue, StringComparison.InvariantCulture))
+                    {
+                        resultType = StatusResultType.Success;
+                        message = _textService.Localize($"healthcheck/{_localizedTextPrefix}CheckHeaderFound");
+                    }
+                    else
+                    {
+                        resultType = StatusResultType.Warning;
+                        message = _textService.Localize($"healthcheck/{_localizedTextPrefix}CheckHeaderFoundWrongCase");
+                    }
+                }
+                else
+                {
+                    message = _textService.Localize($"healthcheck/{_localizedTextPrefix}CheckHeaderNotFound");
+                }
+            }
+            catch (Exception ex)
+            {
+                message = _textService.Localize("healthcheck/healthCheckInvalidUrl", new[] { url, ex.Message });
+            }
+
+            var actions = new List<HealthCheckAction>();
+            switch (resultType)
+            {
+                case StatusResultType.Warning:
+                    actions.Add(new HealthCheckAction(UpdateHeaderInConfigAction, Id)
+                    {
+                        Name = _textService.Localize("healthcheck/updateHeaderInConfig"),
+                        Description = _textService.Localize($"healthcheck/{_localizedTextPrefix}SetHeaderInConfigDescription")
+                    });
+                    break;
+
+                case StatusResultType.Error:
+                    actions.Add(new HealthCheckAction(SetHeaderInConfigAction, Id)
+                    {
+                        Name = _textService.Localize("healthcheck/setHeaderInConfig"),
+                        Description = _textService.Localize($"healthcheck/{_localizedTextPrefix}SetHeaderInConfigDescription")
+                    });
+                    break;
+
+                default:
+                    break;
+            }
+
+            return
+                new HealthCheckStatus(message)
+                {
+                    ResultType = resultType,
+                    Actions = actions
+                };
+        }
+
+        private HealthCheckStatus UpdateHeaderInConfig()
+        {
+            var errorMessage = string.Empty;
+            var success = UpdateHeaderToConfigFile(out errorMessage);
+
+            if (success)
+            {
+                return
+                    new HealthCheckStatus(_textService.Localize(string.Format("healthcheck/{0}SetHeaderInConfigSuccess", _localizedTextPrefix)))
+                    {
+                        ResultType = StatusResultType.Success
+                    };
+            }
+
+            return
+                new HealthCheckStatus(_textService.Localize("healthcheck/setHeaderInConfigError", new[] { errorMessage }))
+                {
+                    ResultType = StatusResultType.Error
+                };
+        }
+
+        private bool UpdateHeaderToConfigFile(out string errorMessage)
+        {
+            try
+            {
+                // There don't look to be any useful classes defined in https://msdn.microsoft.com/en-us/library/system.web.configuration(v=vs.110).aspx
+                // for working with the customHeaders section, so working with the XML directly.
+                var configFile = IOHelper.MapPath("~/Web.config");
+                var doc = XDocument.Load(configFile);
+                var systemWebServerElement = doc.XPathSelectElement("/configuration/system.webServer");
+                var httpProtocolElement = systemWebServerElement.Element("httpProtocol");
+                if (httpProtocolElement == null)
+                {
+                    httpProtocolElement = new XElement("httpProtocol");
+                    systemWebServerElement.Add(httpProtocolElement);
+                }
+
+                var customHeadersElement = httpProtocolElement.Element("customHeaders");
+                if (customHeadersElement == null)
+                {
+                    customHeadersElement = new XElement("customHeaders");
+                    httpProtocolElement.Add(customHeadersElement);
+                }
+
+
+                var removeHeaderElement = customHeadersElement.Elements("remove")
+                    .SingleOrDefault(x => _header.InvariantEquals(x.Attribute("name")?.Value));
+                if (removeHeaderElement == null)
+                {
+                    removeHeaderElement = new XElement("remove");
+                    removeHeaderElement.Add(new XAttribute("name", _header));
+                    customHeadersElement.Add(removeHeaderElement);
+                }
+                else
+                {
+                    removeHeaderElement.Attribute("name").SetValue(_header);
+                }
+
+                var addHeaderElement1 = customHeadersElement.Elements("add");
+                var addHeaderElement = customHeadersElement.Elements("add")
+                    .SingleOrDefault(x => _header.InvariantEquals(x.Attribute("name")?.Value));
+                if (addHeaderElement == null)
+                {
+                    addHeaderElement = new XElement("add");
+                    addHeaderElement.Add(new XAttribute("name", _header));
+                    addHeaderElement.Add(new XAttribute("value", _value));
+                    customHeadersElement.Add(addHeaderElement);
+                }
+                else
+                {
+                    addHeaderElement.Attribute("name").SetValue(_header);
+                }
+
+
+                doc.Save(configFile);
+
+                errorMessage = string.Empty;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                errorMessage = ex.Message;
+                return false;
+            }
         }
     }
 }

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/XssProtectionCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/XssProtectionCheck.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             switch (action.Alias)
             {
                 case UpdateHeaderInConfigAction:
-                    return SetHeaderInConfig(true);
+                    return SetHeaderInConfig(false);
                 default:
                     return base.ExecuteAction(action);
             }
@@ -64,9 +64,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 
                 if (string.IsNullOrWhiteSpace(key) == false)
                 {
-                    var headerValue = response.Headers[key];
-
-                    if (key.Equals(headerValue, StringComparison.InvariantCulture))
+                    if (key.Equals(Header, StringComparison.InvariantCulture))
                     {
                         resultType = StatusResultType.Success;
                         message = TextService.Localize($"healthcheck/{LocalizedTextPrefix}CheckHeaderFound");


### PR DESCRIPTION
This PR fixes #3510 by adding a warning message when an X-XSS-Protection header exists in the web.config, but is in the wrong case. It also provides a button to fix the issue.

@Matthew-wise also helped with this.