### PR TITLE
U4-11136 Changing tabs in the editor picker maintains focus on the search input field

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/editorpicker/editorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/editorpicker/editorpicker.controller.js
@@ -10,7 +10,7 @@
 (function() {
     "use strict";
 
-    function EditorPickerOverlay($scope, dataTypeResource, dataTypeHelper, contentTypeResource, localizationService) {
+    function EditorPickerOverlay($scope, $element, dataTypeResource, dataTypeHelper, contentTypeResource, localizationService) {
 
         var vm = this;
 
@@ -29,13 +29,15 @@
             id: 1,
             label: localizationService.localize("contentTypeEditor_availableEditors"),
             alias: "Default",
-            typesAndEditors: []
+            typesAndEditors: [],
+            clickEvent: updateFocus
         }, {
             active: false,
             id: 2,
             label: localizationService.localize("contentTypeEditor_reuse"),
             alias: "Reuse",
-            userConfigured: []
+            userConfigured: [],
+            clickEvent: updateFocus
         }];
 
         vm.filterItems = filterItems;
@@ -43,6 +45,10 @@
         vm.hideDetailsOverlay = hideDetailsOverlay;
         vm.pickEditor = pickEditor;
         vm.pickDataType = pickDataType;
+
+        function updateFocus() {
+            $element.find('.editor-overlay-search').focus();
+        }
 
         function activate() {
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/editorpicker/editorpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/editorpicker/editorpicker.html
@@ -3,7 +3,8 @@
     <div class="umb-control-group -no-border">
         <div class="form-search">
             <i class="icon-search"></i>
-            <input type="text"
+            <input class="editor-overlay-search"
+                   type="text"
                    style="width: 100%"
                    ng-change="vm.filterItems()"
                    ng-model="vm.searchTerm"

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs umb-nav-tabs">
-  <li data-element="tab-{{tab.alias}}" ng-class="{'tab-error': tabHasError}" class="{{tab.cssClass}}" ng-repeat="tab in model" val-tab>
+  <li data-element="tab-{{tab.alias}}" ng-class="{'tab-error': tabHasError}" class="{{tab.cssClass}}" ng-repeat="tab in model" val-tab ng-click="tab.clickEvent()">
     <a data-toggle="tab" href="#tab{{tab.id}}{{idSuffix}}" title="{{tab.tooltip}}"><span>{{ tab.label }}</span></a>
   </li>
 </ul>


### PR DESCRIPTION
https://issues.umbraco.org/issue/U4-11136

### Description

Added a click event to the umb-nav-tabs directive
Updated the editor picker controller to pass a click event through the umb-nav-tabs directive to ensure the search field maintained focus when changing tabs

