### PR TITLE
Renamed variable in order to fix issue when using content picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -282,7 +282,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     });
 
     /** Syncs the renderModel based on the actual model.value and returns a promise */
-    function syncRenderModel(validate) {
+    function syncRenderModel(doValidation) {
 
         var valueIds = $scope.model.value ? $scope.model.value.split(',') : [];
 
@@ -324,7 +324,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
 
                         });
 
-                    if (validate) {
+                    if (doValidation) {
                         validate();
                     }
                     
@@ -347,7 +347,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
                     }
                 }
 
-                if (validate) {
+                if (doValidation) {
                     validate();
                 }
 


### PR DESCRIPTION
### Prerequisites

- Attempt to pick content using a content picker (my example was a mandatory field) and an exception is thrown, returning user to the landing screen

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3558

### Description

Apply change and pick content using contentpicker
