### PR TITLE
3564 - Make reuse of property editors priority over creating new editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.controller.js
@@ -60,31 +60,18 @@
                     vm.tabs = [{
                         active: true,
                         id: 1,
-                        label: vm.labels.availableDataTypes,
-                        alias: "Default",
-                        typesAndEditors: []
-                    }, {
-                        active: false,
-                        id: 2,
                         label: vm.labels.reuse,
                         alias: "Reuse",
                         userConfigured: []
+                    }, {
+                        active: false,
+                        id: 2,
+                        label: vm.labels.availableDataTypes,
+                        alias: "Default",
+                        typesAndEditors: []
                     }];
 
                 });
-        }
-
-        function getGroupedPropertyEditors() {
-
-            vm.loading = true;
-
-            dataTypeResource.getGroupedPropertyEditors().then(function(data) {
-                vm.tabs[0].typesAndEditors = data;
-                vm.typesAndEditors = data;
-                vm.tabsLoaded = vm.tabsLoaded + 1;
-                checkIfTabContentIsLoaded();
-            });
-
         }
 
         function getGroupedDataTypes() {
@@ -92,7 +79,7 @@
             vm.loading = true;
 
             dataTypeResource.getGroupedDataTypes().then(function(data) {
-                vm.tabs[1].userConfigured = data;
+                vm.tabs[0].userConfigured = data;
                 vm.userConfigured = data;
                 vm.tabsLoaded = vm.tabsLoaded + 1;
                 checkIfTabContentIsLoaded();
@@ -100,6 +87,18 @@
 
         }
 
+        function getGroupedPropertyEditors() {
+
+            vm.loading = true;
+
+            dataTypeResource.getGroupedPropertyEditors().then(function (data) {
+                vm.tabs[1].typesAndEditors = data;
+                vm.typesAndEditors = data;
+                vm.tabsLoaded = vm.tabsLoaded + 1;
+                checkIfTabContentIsLoaded();
+            });
+
+        }
         function checkIfTabContentIsLoaded() {
             if (vm.tabsLoaded === 2) {
                 vm.loading = false;

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1469,8 +1469,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="compositionsDescription">Inherit tabs and properties from an existing document type. New tabs will be added to the current document type or merged if a tab with an identical name exists.</key>
     <key alias="compositionInUse">This content type is used in a composition, and therefore cannot be composed itself.</key>
     <key alias="noAvailableCompositions">There are no content types available to use as a composition.</key>
-    <key alias="availableEditors">Available editors</key>
-    <key alias="reuse">Reuse</key>
+    <key alias="availableEditors">Create new</key>
+    <key alias="reuse">Use existing</key>
     <key alias="editorSettings">Editor settings</key>
     <key alias="configuration">Configuration</key>
     <key alias="yesDelete">Yes, delete</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1493,8 +1493,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="compositionsDescription">Inherit tabs and properties from an existing document type. New tabs will be added to the current document type or merged if a tab with an identical name exists.</key>
     <key alias="compositionInUse">This content type is used in a composition, and therefore cannot be composed itself.</key>
     <key alias="noAvailableCompositions">There are no content types available to use as a composition.</key>
-    <key alias="availableEditors">Available editors</key>
-    <key alias="reuse">Reuse</key>
+    <key alias="availableEditors">Create new</key>
+    <key alias="reuse">Use existing</key>
     <key alias="editorSettings">Editor settings</key>
     <key alias="configuration">Configuration</key>
     <key alias="yesDelete">Yes, delete</key>


### PR DESCRIPTION
### Prerequisites
- [x] I have added steps to test this contribution in the description below

### Description
When adding a new property editor it now shows in the updated order so you now reuse the previously created editors by default.

Relates to issue https://github.com/umbraco/Umbraco-CMS/issues/3564