### PR TITLE
Issue: #3569 - Turning autocomplete off on the password field

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -32,6 +32,7 @@
                                ng-pattern="passwordPattern"
                                autocorrect="off"
                                autocapitalize="off"
+                               autocomplete="off"
                                required
                                ng-model="installer.current.model.password" id="password" />
                         <small class="inline-help">At least {{installer.current.model.minCharLength}} characters long</small>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3569

### Description
Install Umbraco and complete the installation. Then do another install of Umbraco and this will stop the autocomplete from showing your password in plain text. 



<!-- Thanks for contributing to Umbraco CMS! -->
