### PR TITLE
Turning auto complete off on Password field

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -32,6 +32,7 @@
                                ng-pattern="passwordPattern"
                                autocorrect="off"
                                autocapitalize="off"
+                               autocomplete="off"
                                required
                                ng-model="installer.current.model.password" id="password" />
                         <small class="inline-help">At least {{installer.current.model.minCharLength}} characters long</small>


### PR DESCRIPTION
### Prerequisites

- [ X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3569

### Description
Install 2 instances of Umbraco from scratch. The first needs to be completed, on the second install, the password will be displayed in plain english. This fix prevents that. 

Although this issue is for V8, it is also present in V7



<!-- Thanks for contributing to Umbraco CMS! -->
