### PR TITLE
RelatedLinks2 validation in Nested content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/forms/umb-validation-label.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms/umb-validation-label.less
@@ -1,5 +1,7 @@
 .umb-validation-label {
    position: absolute;
+   top: 27px;
+   width: 200px;
    padding: 1px 5px;
    background: @red;
    color: @white;

--- a/src/Umbraco.Web/Editors/ContentControllerBase.cs
+++ b/src/Umbraco.Web/Editors/ContentControllerBase.cs
@@ -141,7 +141,7 @@ namespace Umbraco.Web.Editors
             where TPersisted : IContentBase 
             where T : ContentPropertyBasic
         {
-            //lasty, if it is not valid, add the modelstate to the outgoing object and throw a 403
+            //lastly, if it is not valid, add the modelstate to the outgoing object and throw a 403
             if (!ModelState.IsValid)
             {
                 display.Errors = ModelState.ToErrorDictionary();

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -386,7 +386,7 @@ namespace Umbraco.Web.PropertyEditors
                             {
                                 if (propValues[propKey] == null)
                                     yield return new ValidationResult("Item " + (i + 1) + " '" + propType.Name + "' cannot be null", new[] { propKey });
-                                else if (propValues[propKey].ToString().IsNullOrWhiteSpace())
+                                else if (propValues[propKey].ToString().IsNullOrWhiteSpace() || (propValues[propKey].Type == JTokenType.Array && !propValues[propKey].HasValues))
                                     yield return new ValidationResult("Item " + (i + 1) + " '" + propType.Name + "' cannot be empty", new[] { propKey });
                             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Link to existing issue: https://github.com/umbraco/Umbraco-CMS/issues/2989

### Description

To replicate the issue:
- create a doctype with nested content: the nested content items must contain a property of "RelatedLinks2" and this property must be marked as mandatory
- on initial load/page refresh, without opening the nested content items, validation messages will show up
- if you expand or work in the nested content items but leave properties blank that should be mandatory, the page will save and publish successfully instead of erroring

The reason for the bug is that initially the nested content item is posted with a RelatedLinks2 property content of an empty string, but once it's been poked it's actually posting an empty array which the validation code is not recognising as missing data. This commit changes that.
