### PR TITLE
server side validation for variant node name

### DIFF
--- a/src/Umbraco.Web/Editors/Filters/ContentItemValidationHelper.cs
+++ b/src/Umbraco.Web/Editors/Filters/ContentItemValidationHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -36,9 +37,9 @@ namespace Umbraco.Web.Editors.Filters
     /// If any severe errors occur then the response gets set to an error and execution will not continue. Property validation
     /// errors will just be added to the ModelState.
     /// </remarks>
-    internal class ContentItemValidationHelper<TPersisted, TModelSave>: ContentItemValidationHelper
+    internal class ContentItemValidationHelper<TPersisted, TModelSave> : ContentItemValidationHelper
         where TPersisted : class, IContentBase
-        where TModelSave: IContentSave<TPersisted>
+        where TModelSave : IContentSave<TPersisted>
     {
         public ContentItemValidationHelper(ILogger logger, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, umbracoContextAccessor)
         {
@@ -81,6 +82,17 @@ namespace Umbraco.Web.Editors.Filters
         {
             var persistedContent = model.PersistedContent;
             return ValidateProperties(modelWithProperties.Properties.ToList(), persistedContent.Properties.ToList(), actionContext);
+        }
+
+        public virtual bool ValidateName(TModelSave model, IContentProperties<ContentPropertyBasic> modelWithProperties, ModelStateDictionary modelState)
+        {
+            if (string.IsNullOrEmpty(model.PersistedContent.Name))
+            {
+                var message = $"variant node name was not set";
+                modelState.AddValidationError(new ValidationResult(message), "");
+                return false;
+            }
+            return true;
         }
 
         /// <summary>
@@ -158,7 +170,7 @@ namespace Umbraco.Web.Editors.Filters
 
                     modelState.AddPropertyError(r, p.Alias, p.Culture);
                 }
-                    
+
             }
 
             return modelState.IsValid;

--- a/src/Umbraco.Web/Editors/Filters/ContentItemValidationHelper.cs
+++ b/src/Umbraco.Web/Editors/Filters/ContentItemValidationHelper.cs
@@ -84,12 +84,12 @@ namespace Umbraco.Web.Editors.Filters
             return ValidateProperties(modelWithProperties.Properties.ToList(), persistedContent.Properties.ToList(), actionContext);
         }
 
-        public virtual bool ValidateName(TModelSave model, IContentProperties<ContentPropertyBasic> modelWithProperties, ModelStateDictionary modelState)
+        public virtual bool ValidateVariantName(ContentVariantSave variant, ModelStateDictionary modelState)
         {
-            if (string.IsNullOrEmpty(model.PersistedContent.Name))
+            if (string.IsNullOrEmpty(variant.Name))
             {
-                var message = $"variant node name was not set";
-                modelState.AddValidationError(new ValidationResult(message), "");
+                var message = $"node name was not set for variant {variant.Culture}";
+                modelState.AddValidationError(new ValidationResult(message), string.Empty);
                 return false;
             }
             return true;

--- a/src/Umbraco.Web/Editors/Filters/ContentSaveValidationAttribute.cs
+++ b/src/Umbraco.Web/Editors/Filters/ContentSaveValidationAttribute.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Web.Editors.Filters
             //validate for each variant that is being updated
             foreach (var variant in model.Variants.Where(x => x.Save))
             {
-                if (contentItemValidator.ValidateProperties(model, variant, actionContext))
+                if (contentItemValidator.ValidateName(model, variant, actionContext.ModelState) && contentItemValidator.ValidateProperties(model, variant, actionContext))
                     contentItemValidator.ValidatePropertyData(model, variant, variant.PropertyCollectionDto, actionContext.ModelState);
             }
         }

--- a/src/Umbraco.Web/Editors/Filters/ContentSaveValidationAttribute.cs
+++ b/src/Umbraco.Web/Editors/Filters/ContentSaveValidationAttribute.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Web.Editors.Filters
             //validate for each variant that is being updated
             foreach (var variant in model.Variants.Where(x => x.Save))
             {
-                if (contentItemValidator.ValidateName(model, variant, actionContext.ModelState) && contentItemValidator.ValidateProperties(model, variant, actionContext))
+                if (contentItemValidator.ValidateVariantName(variant, actionContext.ModelState) && contentItemValidator.ValidateProperties(model, variant, actionContext))
                     contentItemValidator.ValidatePropertyData(model, variant, variant.PropertyCollectionDto, actionContext.ModelState);
             }
         }


### PR DESCRIPTION
This fixes: https://github.com/umbraco/Umbraco-CMS/issues/3396

### Description
Normally the client side validation catches missing node names but there is a chance it will slip through to the server.

I've added an extra check on the server side as a fall back to ensure that the node name is set for all variants.

This results in the following error message being shown.

![image](https://user-images.githubusercontent.com/22012032/48301172-6189de80-e4e1-11e8-85c3-75fc0036b95b.png)

### Testing

Create a Document Type with an extra variant culture. Add a new node to the content tree using this Document Type.

Edit the node name for the variant that is visible, leave the extra variant node name empty.

Click save and publish while viewing the node that has a name.  Be sure to check the box for both variants to be published in teh 'Ready to publish' modal and click publish.

You should see that validation has failed.