### PR TITLE
Fix the mardown editor button bar in split view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
@@ -8,6 +8,10 @@ function MarkdownEditorController($scope, $element, assetsService, editorService
         $scope.model.value = $scope.model.config.defaultValue;
     }
 
+    // create a unique ID for the markdown editor, so the button bar bindings can handle split view
+    // - must be bound on scope, not scope.model - otherwise it won't work, because $scope.model is used in both sides of the split view
+    $scope.editorId = $scope.model.alias + _.uniqueId("-");
+
     function openMediaPicker(callback) {
         var mediaPicker = {
             disableFolderSelect: true,
@@ -40,7 +44,7 @@ function MarkdownEditorController($scope, $element, assetsService, editorService
                 $timeout(function () {
                     $scope.markdownEditorInitComplete = false;
                     var converter2 = new Markdown.Converter();
-                    var editor2 = new Markdown.Editor(converter2, "-" + $scope.model.alias);
+                    var editor2 = new Markdown.Editor(converter2, "-" + $scope.editorId);
                     editor2.run();
 
                     //subscribe to the image dialog clicks

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.html
@@ -1,8 +1,8 @@
 <div class="wmd-panel" ng-controller="Umbraco.PropertyEditors.MarkdownEditorController">
-   <div id="wmd-button-bar-{{model.alias}}"></div>
+   <div id="wmd-button-bar-{{editorId}}"></div>
 
-   <textarea class="wmd-input" id="wmd-input-{{model.alias}}" ng-model="model.value"></textarea>
+   <textarea class="wmd-input" id="wmd-input-{{editorId}}" ng-model="model.value"></textarea>
 
-   <div class="wmd-panel wmd-preview" id="wmd-preview-{{model.alias}}" ng-show="model.config.preview"></div>
+   <div class="wmd-panel wmd-preview" id="wmd-preview-{{editorId}}" ng-show="model.config.preview"></div>
 
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3010

### Description

By binding the markdown editor button bar to a unique editor ID instead of the property alias, the button bar works in split view.

This is before:

![image](https://user-images.githubusercontent.com/7405322/48336315-4b565c80-e660-11e8-8284-c6a4fb03d49a.png)

And this is after:

![image](https://user-images.githubusercontent.com/7405322/48336353-61fcb380-e660-11e8-8798-4d5036fff47e.png)

I have also verified that this works with non variant properties.