### PR TITLE
V8: Markdown editor - fix the redo button + remove the button hover flicker

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/markdown/markdown.css
+++ b/src/Umbraco.Web.UI.Client/lib/markdown/markdown.css
@@ -26,6 +26,11 @@
 	width: 100%;
 }
 
+/* unset the negative margin applied in button-groups.less to avoid flickering when hovering the button bar */
+.wmd-panel .btn-toolbar .btn-group>.btn+.btn {
+    margin-left: 0;
+}
+
 /*
 .icon-link,
 .icon-blockquote,

--- a/src/Umbraco.Web.UI.Client/lib/markdown/markdown.editor.js
+++ b/src/Umbraco.Web.UI.Client/lib/markdown/markdown.editor.js
@@ -1390,7 +1390,7 @@
                 "Redo - Ctrl+Y" :
                 "Redo - Ctrl+Shift+Z"; // mac and other non-Windows platforms
 
-            buttons.redo = makeButton("wmd-redo-button", redoTitle, "icon-share-alt", null, group4);
+            buttons.redo = makeButton("wmd-redo-button", redoTitle, "icon-redo", null, group4);
             buttons.redo.execute = function (manager) { if (manager) manager.redo(); };
 
             if (helpOptions) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR contains two tiny fixes for the markdown editor. 

Please notice you need to run a `gulp build` to test it, as the PR updates a few bits of the markdown editor from the `lib` folder.

### The redo button icon is really weird

The redo button icon is changed from this:

![markdown-editor-redo-before](https://user-images.githubusercontent.com/7405322/48338914-316c4800-e667-11e8-8676-37f9a48eeb17.png)

To this:

![markdown-editor-redo-after](https://user-images.githubusercontent.com/7405322/48338921-34ffcf00-e667-11e8-9477-7a5c4ea858ae.png)

### The button bar flickers when hovered

When you hover the button bar, there is some CSS margin changing going on that makes the button bar flicker a little:

![markdown-button-hover-before](https://user-images.githubusercontent.com/7405322/48338987-59f44200-e667-11e8-94ec-d2e2e71903dc.gif)

Here's how it looks with this PR applied:

![markdown-editor-button-hover-after](https://user-images.githubusercontent.com/7405322/48339020-69738b00-e667-11e8-8ada-061d1206659b.gif)



