### PR TITLE
Include the umbracoApplicationUrl Host in the Healthcheck email notifier

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2191,7 +2191,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Notification email has been set to <strong>%0%</strong>.]]></key>
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
-        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: {0}</key>
+        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: %0%</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Disable URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2191,7 +2191,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Notification email has been set to <strong>%0%</strong>.]]></key>
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
-        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status : {0}</key>
+        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: {0}</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Disable URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2191,7 +2191,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Notification email has been set to <strong>%0%</strong>.]]></key>
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
-        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status</key>
+        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status : {0}</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Disable URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2184,7 +2184,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Notification email has been set to <strong>%0%</strong>.]]></key>
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
-        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: {0}</key>
+        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: %0%</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Disable URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2184,7 +2184,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Notification email has been set to <strong>%0%</strong>.]]></key>
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
-        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status : {0}</key>
+        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: {0}</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Disable URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2184,7 +2184,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Notification email has been set to <strong>%0%</strong>.]]></key>
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
-        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status</key>
+        <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status : {0}</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Disable URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -1855,7 +1855,7 @@
         <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Email de notificación has sido configurado como <strong>%0%</strong>.]]></key>
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[El email de notificación está todavía configurado en su valor por defecto: <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Los resultados de los Chequeos de Salud de Umbraco programados para ejecutarse el %0% a las %1% son:</p>%2%</body></html>]]></key>
-        <key alias="scheduledHealthCheckEmailSubject">Status de los Chequeos de Salud de Umbraco: {0}</key>
+        <key alias="scheduledHealthCheckEmailSubject">Status de los Chequeos de Salud de Umbraco: %0%</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Desactivar URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -1855,7 +1855,7 @@
         <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Email de notificación has sido configurado como <strong>%0%</strong>.]]></key>
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[El email de notificación está todavía configurado en su valor por defecto: <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Los resultados de los Chequeos de Salud de Umbraco programados para ejecutarse el %0% a las %1% son:</p>%2%</body></html>]]></key>
-        <key alias="scheduledHealthCheckEmailSubject">Status de los Chequeos de Salud de Umbraco : {0}</key>
+        <key alias="scheduledHealthCheckEmailSubject">Status de los Chequeos de Salud de Umbraco: {0}</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Desactivar URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -1855,7 +1855,7 @@
         <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Email de notificación has sido configurado como <strong>%0%</strong>.]]></key>
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[El email de notificación está todavía configurado en su valor por defecto: <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Los resultados de los Chequeos de Salud de Umbraco programados para ejecutarse el %0% a las %1% son:</p>%2%</body></html>]]></key>
-        <key alias="scheduledHealthCheckEmailSubject">Status de los Chequeos de Salud de Umbraco</key>
+        <key alias="scheduledHealthCheckEmailSubject">Status de los Chequeos de Salud de Umbraco : {0}</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Desactivar URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -2169,7 +2169,7 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Un email de notification a été envoyé à <strong>%0%</strong>.]]></key>
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[L'adresse email de notification est toujours à sa valeur par défaut : <strong>%0%</strong>.]]></key>
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Les résultats de l'exécution du Umbraco Health Checks planifiée le %0% à %1% sont les suivants :</p>%2%</body></html>]]></key>
-    <key alias="scheduledHealthCheckEmailSubject">Statut du Umbraco Health Check: {0}</key>
+    <key alias="scheduledHealthCheckEmailSubject">Statut du Umbraco Health Check: %0%</key>
   </area>
   <area alias="redirectUrls">
     <key alias="disableUrlTracker">Désactiver URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -2169,7 +2169,7 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Un email de notification a été envoyé à <strong>%0%</strong>.]]></key>
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[L'adresse email de notification est toujours à sa valeur par défaut : <strong>%0%</strong>.]]></key>
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Les résultats de l'exécution du Umbraco Health Checks planifiée le %0% à %1% sont les suivants :</p>%2%</body></html>]]></key>
-    <key alias="scheduledHealthCheckEmailSubject">Statut du Umbraco Health Check : {0}</key>
+    <key alias="scheduledHealthCheckEmailSubject">Statut du Umbraco Health Check: {0}</key>
   </area>
   <area alias="redirectUrls">
     <key alias="disableUrlTracker">Désactiver URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -2169,7 +2169,7 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Un email de notification a été envoyé à <strong>%0%</strong>.]]></key>
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[L'adresse email de notification est toujours à sa valeur par défaut : <strong>%0%</strong>.]]></key>
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Les résultats de l'exécution du Umbraco Health Checks planifiée le %0% à %1% sont les suivants :</p>%2%</body></html>]]></key>
-    <key alias="scheduledHealthCheckEmailSubject">Statut du Umbraco Health Check</key>
+    <key alias="scheduledHealthCheckEmailSubject">Statut du Umbraco Health Check : {0}</key>
   </area>
   <area alias="redirectUrls">
     <key alias="disableUrlTracker">Désactiver URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -869,7 +869,7 @@
     <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Адрес для отправки уведомлений установлен в <strong>%0%</strong>.]]></key>
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Адрес для отправки уведомлений все еще установлен в значение по-умолчанию <strong>%0%</strong>.]]></key>
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Зафиксированы следующие результаты автоматической проверки состояния Umbraco по расписанию, запущенной на %0% в %1%:</p>%2%</body></html>]]></key>
-    <key alias="scheduledHealthCheckEmailSubject">Результат проверки состояния Umbraco: {0}</key>
+    <key alias="scheduledHealthCheckEmailSubject">Результат проверки состояния Umbraco: %0%</key>
   </area>
   <area alias="help">
     <key alias="goTo">перейти к</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -869,7 +869,7 @@
     <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Адрес для отправки уведомлений установлен в <strong>%0%</strong>.]]></key>
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Адрес для отправки уведомлений все еще установлен в значение по-умолчанию <strong>%0%</strong>.]]></key>
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Зафиксированы следующие результаты автоматической проверки состояния Umbraco по расписанию, запущенной на %0% в %1%:</p>%2%</body></html>]]></key>
-    <key alias="scheduledHealthCheckEmailSubject">Результат проверки состояния Umbraco : {0}</key>
+    <key alias="scheduledHealthCheckEmailSubject">Результат проверки состояния Umbraco: {0}</key>
   </area>
   <area alias="help">
     <key alias="goTo">перейти к</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -869,7 +869,7 @@
     <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Адрес для отправки уведомлений установлен в <strong>%0%</strong>.]]></key>
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Адрес для отправки уведомлений все еще установлен в значение по-умолчанию <strong>%0%</strong>.]]></key>
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Зафиксированы следующие результаты автоматической проверки состояния Umbraco по расписанию, запущенной на %0% в %1%:</p>%2%</body></html>]]></key>
-    <key alias="scheduledHealthCheckEmailSubject">Результат проверки состояния Umbraco</key>
+    <key alias="scheduledHealthCheckEmailSubject">Результат проверки состояния Umbraco : {0}</key>
   </area>
   <area alias="help">
     <key alias="goTo">перейти к</key>

--- a/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
@@ -69,22 +69,15 @@ namespace Umbraco.Web.HealthCheck.NotificationMethods
 
             // Include the umbraco Application URL host in the message subject so that
             // you can identify the site that these results are for.
+            var umbracoApplicationUrl = ApplicationContext.Current.UmbracoApplicationUrl;
+            var host = umbracoApplicationUrl;
 
-            string umbracoApplicationUrl = ApplicationContext.Current.UmbracoApplicationUrl;
-            string host = string.Empty;
-            Uri umbracoApplicationUri;
-
-            if (Uri.TryCreate(umbracoApplicationUrl, UriKind.Absolute, out umbracoApplicationUri))
-            {
+            if (Uri.TryCreate(umbracoApplicationUrl, UriKind.Absolute, out var umbracoApplicationUri))
                 host = umbracoApplicationUri.Host;
-            }
             else
-            {
-                host = umbracoApplicationUrl;
-                LogHelper.Warn<EmailNotificationMethod>(string.Format("umbracoApplicationUrl {0} appears to be invalid", umbracoApplicationUrl));
-            }
-            
-            string subject = string.Format(_textService.Localize("healthcheck/scheduledHealthCheckEmailSubject"), host);
+                LogHelper.Debug<EmailNotificationMethod>($"umbracoApplicationUrl {umbracoApplicationUrl} appears to be invalid");
+
+            var subject = _textService.Localize("healthcheck/scheduledHealthCheckEmailSubject", new[] { host });
 
             var mailSender = new EmailSender();
             using (var mailMessage = new MailMessage(UmbracoConfig.For.UmbracoSettings().Content.NotificationEmailAddress,

--- a/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
@@ -70,22 +70,20 @@ namespace Umbraco.Web.HealthCheck.NotificationMethods
             // Include the umbraco Application URL host in the message subject so that
             // you can identify the site that these results are for.
 
-            string umbracoApplicationUrl = UmbracoConfig.For.UmbracoSettings().WebRouting.UmbracoApplicationUrl;
+            string umbracoApplicationUrl = ApplicationContext.Current.UmbracoApplicationUrl;
             string host = string.Empty;
+            Uri umbracoApplicationUri;
 
-            if (string.IsNullOrEmpty(umbracoApplicationUrl) == false)
+            if (Uri.TryCreate(umbracoApplicationUrl, UriKind.Absolute, out umbracoApplicationUri))
             {
-                try
-                {
-                    Uri umbracoApplicationUri = new Uri(umbracoApplicationUrl);
-                    host = umbracoApplicationUri.Host;
-                }
-                catch (UriFormatException uriFormatException)
-                {
-                    LogHelper.WarnWithException<EmailNotificationMethod>(string.Format("{0} is not a valid URL for umbracoApplicationUrl", umbracoApplicationUrl), uriFormatException);
-                }
+                host = umbracoApplicationUri.Host;
             }
-
+            else
+            {
+                host = umbracoApplicationUrl;
+                LogHelper.Warn<EmailNotificationMethod>(string.Format("umbracoApplicationUrl {0} appears to be invalid", umbracoApplicationUrl));
+            }
+            
             string subject = string.Format(_textService.Localize("healthcheck/scheduledHealthCheckEmailSubject"), host);
 
             var mailSender = new EmailSender();

--- a/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
@@ -65,7 +65,16 @@ namespace Umbraco.Web.HealthCheck.NotificationMethods
                 results.ResultsAsHtml(Verbosity)
             });
 
+           
             var subject = _textService.Localize("healthcheck/scheduledHealthCheckEmailSubject");
+
+            // Include the umbraco Application URL in the message subject so that you can identify the
+            // site that these results are for.
+            string umbracoApplicationUrl = UmbracoConfig.For.UmbracoSettings().WebRouting.UmbracoApplicationUrl;
+            if (string.IsNullOrEmpty(umbracoApplicationUrl) == false)
+            {
+                subject += " : " + umbracoApplicationUrl;
+            }
 
             var mailSender = new EmailSender();
             using (var mailMessage = new MailMessage(UmbracoConfig.For.UmbracoSettings().Content.NotificationEmailAddress,


### PR DESCRIPTION
Include the umbracoApplicationUrl Host in the Healthcheck email notifier as when you have multiple sites it is difficult to identify which site that the results are for.

### Prerequisites

- [x] I have added steps to test this contribution in the description below:

1. Set umbracoApplicationUrl correctly in umbracoSettings.config
2. Enabled email notification in HealthChecks.config
3. Setup SMTP details correctly in Web.config
4. Start umbraco solution
5. Received email (screenshot attached) - with modified subject line.

Excerpt from HealthCheck.config looks like:

 <notificationSettings enabled="true" firstRunTime="" periodInHours="1">
    <notificationMethods>
      <notificationMethod alias="email" enabled="true" verbosity="Summary">
        <settings>
          <add key="recipientEmail" value="darren@moriyama.co.uk" />
        </settings>
      </notificationMethod>

Ensure that the firstRunTime attribute is blank for testing.

Note, the notification isn't set right away on startup - it runs on a background scheduled task so may take a minute or two to trigger.

If there's an existing issue for this PR then this fixes: N/A

### Description

Include the umbracoApplicationUrl Host in the Healthcheck email notifier as when you have multiple sites it is difficult to identify which site that the results are for.
![untitled](https://user-images.githubusercontent.com/2164132/48342662-35e53080-e668-11e8-8270-31ba71f9a9be.png)


in the appropriate config/lang.xml file the key scheduledHealthCheckEmailSubject can be modified to contain a token for the host that the healthcheck is running on e.g.:

"Umbraco Health Check Status : {0}"

Also - if you don't want the host in the email subject - you can just remove the token "{0}".



