### PR TITLE
Make it possible to fetch more than 2000 entities

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/RepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/RepositoryBase.cs
@@ -258,12 +258,20 @@ namespace Umbraco.Core.Persistence.Repositories
                 //.Where(x => Equals(x, default(TId)) == false)
                 .ToArray();
 
-            if (ids.Length > 2000)
+            // can't query more than 2000 ids at a time... but if someone is really querying 2000+ entities,
+            // the additional overhead of fetching them in groups is minimal compared to the lookup time of each group
+            const int maxParams = 2000;
+            if (ids.Length <= maxParams)
             {
-                throw new InvalidOperationException("Cannot perform a query with more than 2000 parameters");
+                return CachePolicy.GetAll(ids, PerformGetAll);
             }
+            var entities = new List<TEntity>();
+            foreach (var groupOfIds in ids.InGroupsOf(maxParams))
+            {
+                entities.AddRange(CachePolicy.GetAll(groupOfIds.ToArray(), PerformGetAll));
+            }
+            return entities;
 
-            return CachePolicy.GetAll(ids, PerformGetAll);
         }
 
         protected abstract IEnumerable<TEntity> PerformGetByQuery(IQuery<TEntity> query);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/2994

### Description

This PR ensures that we fetch content entities in groups of 2000 if more than 2000 entities are queried by ID, instead of blowing up with an exception.

See #2994 for steps to reproduce, or simply dump this controller in `App_Code` and invoke the `GetSomething` action:

```cs
using System;
using System.Linq;
using System.Threading;
using Umbraco.Web.WebApi;

namespace MySite
{
    public class TestController : UmbracoApiController
    {
        public string GetSomething() {
			var content = Services.ContentService.GetByIds(Enumerable.Range(1, 2001));
			return string.Format("I got {0} entities", content.Count());
        }
    }
}
```