### PR TITLE
Setting hide-alias to false still hides the alias

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -252,7 +252,7 @@ Use this directive to construct a header inside the main editor window.
                 icon: "=",
                 hideIcon: "@",
                 alias: "=",
-                hideAlias: "@",
+                hideAlias: "=",
                 description: "=",
                 hideDescription: "@",
                 descriptionLocked: "@",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description

When using umb-editor-header setting hide-alias to false still hides the alias.

I would expect that it would be visible. The only thing that works to make it visible to is removing the hide-alias attribute.

This PR fixes this. 

Dave