### PR TITLE
Allow the "hideHeader" property of the treepicker dialog to be confgurable

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/treepicker.controller.js
@@ -8,7 +8,7 @@ angular.module("umbraco").controller("Umbraco.Dialogs.TreePickerController",
 	    $scope.section = dialogOptions.section;
 	    $scope.treeAlias = dialogOptions.treeAlias;
 	    $scope.multiPicker = dialogOptions.multiPicker;
-	    $scope.hideHeader = true; 	    	    
+        $scope.hideHeader = (typeof dialogOptions.hideHeader) === "boolean" ? dialogOptions.hideHeader : true;; 	    	    
         $scope.searchInfo = {
             searchFromId: dialogOptions.startNodeId,
             searchFromName: null,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3628

### Description

This feature can be tested by displaying the "content picker" like this:

`dialogService.contentPicker({ hideHeader: false, ... })`
