### PR TITLE
V8: Fix the media picker folder creation and "sub folders" toggle button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -116,10 +116,10 @@ angular.module("umbraco")
             };
 
             $scope.submitFolder = function() {
-                if ($scope.newFolderName) {
+                if ($scope.model.newFolderName) {
                     $scope.creatingFolder = true;
                     mediaResource
-                        .addFolder($scope.newFolderName, $scope.currentFolder.id)
+                        .addFolder($scope.model.newFolderName, $scope.currentFolder.id)
                         .then(function(data) {
                             //we've added a new folder so lets clear the tree cache for that specific item
                             treeService.clearCache({
@@ -129,7 +129,7 @@ angular.module("umbraco")
                             $scope.creatingFolder = false;
                             $scope.gotoFolder(data);
                             $scope.showFolderInput = false;
-                            $scope.newFolderName = "";
+                            $scope.model.newFolderName = "";
                         });
                 } else {
                     $scope.showFolderInput = false;

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -4,9 +4,12 @@ angular.module("umbraco")
         function($scope, mediaResource, entityResource, mediaHelper, mediaTypeHelper, eventsService, treeService, localStorageService, localizationService, editorService) {
 
             if (!$scope.model.title) {
-                localizationService.localize("defaultdialogs_selectMedia")
-                    .then(function(data){
-                        $scope.model.title = data;
+                localizationService.localizeMany(["defaultdialogs_selectMedia", "general_includeFromsubFolders"])
+                    .then(function (data) {
+                        $scope.labels = {
+                            title: data[0],
+                            includeSubFolders: data[1]
+                        }
                     });
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
@@ -68,7 +68,7 @@
                                 <i class="icon icon-add small"></i>
                             </a>
     
-                            <input type="text" class="umb-breadcrumbs__add-ancestor" ng-show="showFolderInput" ng-model="newFolderName" ng-keydown="enterSubmitFolder($event)"
+                            <input type="text" class="umb-breadcrumbs__add-ancestor" ng-show="showFolderInput" ng-model="model.newFolderName" ng-keydown="enterSubmitFolder($event)"
                                 on-blur="submitFolder()" focus-when="{{showFolderInput}}" />
                         </li>
                     </ul>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As mentioned in #3622, the folder creation feature is broken in the media picker dialog. This PR fixes it, and also improves a bit on the "include sub folders" toggle button.

### To test the folder creation

Verify that folders can be created in the media picker dialog:

![media picker folder creation](https://user-images.githubusercontent.com/7405322/48509607-dba7c380-e851-11e8-9b01-ca1d1b391c06.gif)

### To test the toggle button improvement

This is how the toggle button looks today:

![image](https://user-images.githubusercontent.com/7405322/48509702-19a4e780-e852-11e8-9f01-ef22fbe60cfe.png)

Verify that this PR:

1. Places toggle button label inline with the toggle button.
2. Allows the toggle button to be toggled by clicking the label.

![image](https://user-images.githubusercontent.com/7405322/48509871-9041e500-e852-11e8-844a-1a1cc591145f.png)


