### PR TITLE
Clear the add user form when state is inviteUser so that it is not pr…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -180,7 +180,7 @@
                 $location.search("invite", null);
             }
             else if (state === "inviteUser") {
-                clearAddUserForm();
+                clearAddUserFormName();
 
                 $location.search("create", null);
                 $location.search("invite", "true");
@@ -536,6 +536,7 @@
 
                 usersResource.inviteUser(vm.newUser)
                     .then(function (saved) {
+
                         //success
                         vm.page.createButtonState = "success";
                         vm.newUser = saved;
@@ -691,6 +692,14 @@
             vm.newUser.email = "";
             vm.newUser.userGroups = [];
             vm.newUser.message = "";
+            // clear button state
+            vm.page.createButtonState = "init";
+        }
+
+        function clearAddUserFormName() {
+            // clear form data
+            vm.newUser.name = "";
+            vm.newUser.email = "";
             // clear button state
             vm.page.createButtonState = "init";
         }

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -180,6 +180,8 @@
                 $location.search("invite", null);
             }
             else if (state === "inviteUser") {
+                clearAddUserForm();
+
                 $location.search("create", null);
                 $location.search("invite", "true");
             }


### PR DESCRIPTION
…e-filled with details from previously invited user

https://github.com/umbraco/Umbraco-CMS/issues/3631

####Description for testing
To test we will now see that after inviting a user, and clicking the invite another user button, the invite user form is not pre-filed with the details of the user that was just invited.
The user form can then be filled in as usual and this user can then be invited.
this process can be repeated, and all users are invited by email with the correct details, which are also shown in the user section.
