### PR TITLE
Changes add-button to a button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -37,9 +37,9 @@
         </div>
 
         <div class="umb-nested-content__footer-bar" ng-hide="nodes.length >= maxItems">
-            <a class="umb-nested-content__icon" ng-click="openNodeTypePicker($event)" prevent-default>
+            <button type="button" class="umb-nested-content__icon" ng-click="openNodeTypePicker($event)" prevent-default>
                 <i class="icon icon-add"></i>
-            </a>
+            </button>
         </div>
 
     </ng-form>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -37,9 +37,9 @@
         </div>
 
         <div class="umb-nested-content__footer-bar" ng-hide="nodes.length >= maxItems">
-            <button type="button" class="umb-nested-content__icon" ng-click="openNodeTypePicker($event)" prevent-default>
+            <a href class="umb-nested-content__icon" ng-click="openNodeTypePicker($event)" prevent-default>
                 <i class="icon icon-add"></i>
-            </button>
+            </a>
         </div>
 
     </ng-form>


### PR DESCRIPTION
Makes it possible to tab to the button.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: #3633 

### Description
Changed the `<a>` to a `<button>` which makes it possible to tab to the add-button, for adding Nested Content values using only the keyboard.



<!-- Thanks for contributing to Umbraco CMS! -->
