### PR TITLE
Remove the default action from tree menus if it isn't allowed

### DIFF
--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -375,6 +375,11 @@ namespace Umbraco.Web.Trees
             foreach (var m in notAllowed)
             {
                 menuWithAllItems.Items.Remove(m);
+                // if the disallowed action is set as default action, make sure to reset the default action as well
+                if (menuWithAllItems.DefaultMenuAlias == m.Alias)
+                {
+                    menuWithAllItems.DefaultMenuAlias = null;
+                }
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3601

### Description

See #3601. To test this PR:

1. Follow the steps to reproduce in #3601 
2. Also verify that this PR works if you revoke everything but browse permissions on a single node for a user group that is otherwise able to create.

There are a few other user permissions I'd like to discuss (among those the ability to empty the recycle bin with only browse permissions!), but I will open a new issue for that. 