### PR TITLE
Honour 'Order Direction' passed into GetPagedResultsByQuery

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/EntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/EntityRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -64,7 +64,8 @@ namespace Umbraco.Core.Persistence.Repositories
             }, objectTypeId);
             var translator = new SqlTranslator<IUmbracoEntity>(sqlClause, query);
             var entitySql = translator.Translate();
-            var pagedSql = entitySql.Append(GetGroupBy(isContent, isMedia, false)).OrderBy("umbracoNode.id");
+            var pagedSql = entitySql.Append(GetGroupBy(isContent, isMedia, false));
+            pagedSql = (orderDirection == Direction.Descending) ? pagedSql.OrderByDescending("umbracoNode.id") : pagedSql.OrderBy("umbracoNode.id");
 
             IEnumerable<IUmbracoEntity> result;
 
@@ -80,8 +81,8 @@ namespace Umbraco.Core.Persistence.Repositories
                 foreach (var idGroup in ids)
                 {
                     var propSql = GetPropertySql(Constants.ObjectTypes.Media)
-                        .Where("contentNodeId IN (@ids)", new {ids = idGroup})
-                        .OrderBy("contentNodeId");
+                        .Where("contentNodeId IN (@ids)", new { ids = idGroup });
+                    propSql = (orderDirection == Direction.Descending) ? propSql.OrderByDescending("contentNodeId") : propSql.OrderBy("contentNodeId");
 
                     //This does NOT fetch all data into memory in a list, this will read
                     // over the records as a data reader, this is much better for performance and memory,


### PR DESCRIPTION
Wanting to update the MiniListView so that you can change the sort order of the results, so that the most recent items are first, eg sort by descending, however chasing this through to the Entity Repository GetPagedResultsByQuery although the sort direction is passed at each stage, inside this method it is ignored... is this the best way to add it back in?

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: <!-- link to the issue here! -->
This is kind of related to this issue, it's a first step: https://github.com/umbraco/Umbraco-CMS/issues/2957

### Description
<!-- A description of the changes proposed in the pull-request and how to test these changes -->
The change here is to implement OrderByDescending in the GetPagedResultsByQuery in the EntityRepository, it's passed in, but does not appear to be implemented.

One way to test would be to setup a listview, and create a picker, to pick from it (eg invoking the MiniListView) 

and tweak the hardcoded order direction

var miniListView = {
                    node: node,
                    loading: true,
                    pagination: {
                        pageSize: 10,
                        pageNumber: 1,
                        filter: '',
                        orderDirection: "Ascending",
                        orderBy: "SortOrder",
                        orderBySystemField: true
                    }
                };

in the MiniListViewDirective to be Descending

switching between the two here (and clearing cache), should order the results displayed in the picker to be ordered in the alternative direction.

(I kind of think the default setting for the MiniListView should be descending - so as an editor, you always see the most recent things first...but that's probably a larger conversation - but for the time being, unless I've totally misunderstood, this is 'worth' implementing, because you'd **sort** of expect it to work?)

<!-- Thanks for contributing to Umbraco CMS! -->
