### PR TITLE
Localize document type scaffolds for nested content

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -347,6 +347,9 @@ namespace Umbraco.Web.Editors
 
             var emptyContent = Services.ContentService.CreateContent("", parentId, contentType.Alias, UmbracoUser.Id);
             var mapped = AutoMapperExtensions.MapWithUmbracoContext<IContent, ContentItemDisplay>(emptyContent, UmbracoContext);
+            // translate the content type name if applicable
+            mapped.ContentTypeName = Services.TextService.UmbracoDictionaryTranslate(mapped.ContentTypeName);
+            mapped.DocumentType.Name = Services.TextService.UmbracoDictionaryTranslate(mapped.DocumentType.Name);
 
             //remove this tab if it exists: umbContainerView
             var containerTab = mapped.Tabs.FirstOrDefault(x => x.Alias == Constants.Conventions.PropertyGroups.ListViewGroupName);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3483

### Description

This PR adds localization to the nested content item picker, as outlined in #3483.

#### Before

![nc-translation-before](https://user-images.githubusercontent.com/7405322/48611427-8d481100-e986-11e8-83f3-8283827eb8c5.png)

#### After

![nc-translation-after](https://user-images.githubusercontent.com/7405322/48611438-91742e80-e986-11e8-97d2-07b74a179104.png)

### Positive, unintended side effect

As-is the document type name isn't localized on the info tab of content items:

![nc-translation-doctype-info-before](https://user-images.githubusercontent.com/7405322/48611504-b4064780-e986-11e8-9283-bb7eca382097.png)

With this PR, they are:

![nc-translation-doctype-info-after](https://user-images.githubusercontent.com/7405322/48611516-b9fc2880-e986-11e8-8b7e-761a8bc67a24.png)

