### PR TITLE
Link picker overlay: Changed the order of execution to avoid an unnecessary delay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -46,8 +46,8 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 
 				// if a link exists, get the properties to build the anchor name list
 				contentResource.getById(id).then(function (resp) {
-					$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
 					$scope.model.target.url = resp.urls[0];
+					$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
 				});
 			} else if ($scope.model.target.url.length) {
 			    // a url but no id/udi indicates an external link - trim the url to remove the anchor/qs
@@ -87,8 +87,8 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 				$scope.model.target.url = "/";
 			} else {
 				contentResource.getById(args.node.id).then(function (resp) {
-					$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
 					$scope.model.target.url = resp.urls[0];
+					$scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
 				});
 			}
 


### PR DESCRIPTION
I haven't looked into what `tinyMceService.getAnchorNames` actually does behind the scenes, but it may take up to around a second to complete for random pages on my colleagues dev machine (using an Azure database, so there may be some extra latency if it touches the database).

As a result of this, the request to the server and the following callback may be completed *after* the user clicks the Submit button, in which case the returned `model.target` doesn't contain a `url` property (which again may be a breaking change, as I haven't encountered this issue before).

Changing the order of the lines decreases the risk of encountering the issue, but doesn't fix it entirely as the `getById` request it self may cause the same issue.