### PR TITLE
Don't let the users empty the recycle bin without delete permissions

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -839,7 +839,7 @@ namespace Umbraco.Web.Editors
         /// </remarks>
         [HttpDelete]
         [HttpPost]
-        [EnsureUserPermissionForContent(Constants.System.RecycleBinContent)]
+        [EnsureUserPermissionForContent(Constants.System.RecycleBinContent, 'D')]
         public HttpResponseMessage EmptyRecycleBin()
         {
             Services.ContentService.EmptyRecycleBin();

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -347,7 +347,7 @@ namespace Umbraco.Web.Trees
             if (RecycleBinId.ToInvariantString() == id)
             {
                 // get the default assigned permissions for this user
-                var actions = ActionsResolver.Current.FromActionSymbols(Security.CurrentUser.GetPermissions("-1", Services.UserService)).ToList();
+                var actions = ActionsResolver.Current.FromActionSymbols(Security.CurrentUser.GetPermissions(Constants.System.RecycleBinContentString, Services.UserService)).ToList();
 
                 var menu = new MenuItemCollection();
                 // only add empty recycle bin if the current user is allowed to delete by default 

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -346,8 +346,15 @@ namespace Umbraco.Web.Trees
         {
             if (RecycleBinId.ToInvariantString() == id)
             {
+                // get the default assigned permissions for this user
+                var actions = ActionsResolver.Current.FromActionSymbols(Security.CurrentUser.GetPermissions("-1", Services.UserService)).ToList();
+
                 var menu = new MenuItemCollection();
-                menu.Items.Add<ActionEmptyTranscan>(ui.Text("actions", "emptyTrashcan"));
+                // only add empty recycle bin if the current user is allowed to delete by default 
+                if (actions.Contains(ActionDelete.Instance))
+                {
+                    menu.Items.Add<ActionEmptyTranscan>(ui.Text("actions", "emptyTrashcan"));
+                }
                 menu.Items.Add<ActionRefresh>(ui.Text("actions", ActionRefresh.Instance.Alias), true);
                 return menu;
             }

--- a/src/Umbraco.Web/WebApi/Filters/EnsureUserPermissionForContentAttribute.cs
+++ b/src/Umbraco.Web/WebApi/Filters/EnsureUserPermissionForContentAttribute.cs
@@ -40,6 +40,12 @@ namespace Umbraco.Web.WebApi.Filters
             _nodeId = nodeId;
         }
 
+        public EnsureUserPermissionForContentAttribute(int nodeId, char permissionToCheck)
+            : this(nodeId)
+        {
+            _permissionToCheck = permissionToCheck;
+        }
+
         public EnsureUserPermissionForContentAttribute(string paramName)
         {
             if (string.IsNullOrWhiteSpace(paramName)) throw new ArgumentException("Value cannot be null or whitespace.", "paramName");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Currently anyone can empty the recycle bin, regardless of what permissions are assigned to their user roles. 

However, if you don't have delete permissions, you can't delete a specific node from the recycle (unless you created the node originally).

![empty-recycle-bin-before](https://user-images.githubusercontent.com/7405322/48626320-dcf00200-e9b1-11e8-95cc-0ca3e0c7b6d5.gif)

This PR ensures that only users with delete permissions can empty the recycle bin.

### Steps to test

1. Create a user with only "Browse" permissions and log the user into Umbraco.
2. Verify that the user can't empty the recycle bin.

![empty-recycle-bin-after](https://user-images.githubusercontent.com/7405322/48626329-e1b4b600-e9b1-11e8-8a66-4dfadd3a0fe4.gif)

