### PR TITLE
Fix the sort order of dictionary items in both the tree and list view

### DIFF
--- a/src/Umbraco.Web/Editors/DictionaryController.cs
+++ b/src/Umbraco.Web/Editors/DictionaryController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Web.Http;
@@ -194,7 +195,7 @@ namespace Umbraco.Web.Editors
 
             const int level = 0;
 
-            foreach (var dictionaryItem in Services.LocalizationService.GetRootDictionaryItems())
+            foreach (var dictionaryItem in Services.LocalizationService.GetRootDictionaryItems().OrderBy(ItemSort()))
             {
                 var item = Mapper.Map<IDictionaryItem, DictionaryOverviewDisplay>(dictionaryItem);
                 item.Level = 0;
@@ -220,8 +221,7 @@ namespace Umbraco.Web.Editors
         /// </param>
         private void GetChildItemsForList(IDictionaryItem dictionaryItem, int level, List<DictionaryOverviewDisplay> list)
         {
-            foreach (var childItem in Services.LocalizationService.GetDictionaryItemChildren(
-                dictionaryItem.Key))
+            foreach (var childItem in Services.LocalizationService.GetDictionaryItemChildren(dictionaryItem.Key).OrderBy(ItemSort()))
             {
                 var item = Mapper.Map<IDictionaryItem, DictionaryOverviewDisplay>(childItem);
                 item.Level = level;
@@ -230,5 +230,7 @@ namespace Umbraco.Web.Editors
                 GetChildItemsForList(childItem, level + 1, list);
             }
         }
+
+        private Func<IDictionaryItem, string> ItemSort() => item => item.ItemKey;
     }
 }

--- a/src/Umbraco.Web/Trees/DictionaryTreeController.cs
+++ b/src/Umbraco.Web/Trees/DictionaryTreeController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net.Http.Formatting;
 using umbraco.BusinessLogic.Actions;
 using Umbraco.Core;
+using Umbraco.Core.Models;
 using Umbraco.Core.Services;
 using Umbraco.Web.Models.Trees;
 using Umbraco.Web.WebApi.Filters;
@@ -50,10 +51,12 @@ namespace Umbraco.Web.Trees
 
             var nodes = new TreeNodeCollection();
 
+            Func<IDictionaryItem, string> ItemSort() => item => item.ItemKey;
+
             if (id == Constants.System.Root.ToInvariantString())
             {
                 nodes.AddRange(
-                    Services.LocalizationService.GetRootDictionaryItems().Select(
+                    Services.LocalizationService.GetRootDictionaryItems().OrderBy(ItemSort()).Select(
                         x => CreateTreeNode(
                             x.Id.ToInvariantString(),
                             id,
@@ -69,7 +72,7 @@ namespace Umbraco.Web.Trees
                 if (parentDictionary == null)
                     return nodes;
 
-                nodes.AddRange(Services.LocalizationService.GetDictionaryItemChildren(parentDictionary.Key).ToList().OrderByDescending(item => item.Key).Select(
+                nodes.AddRange(Services.LocalizationService.GetDictionaryItemChildren(parentDictionary.Key).ToList().OrderBy(ItemSort()).Select(
                     x => CreateTreeNode(
                         x.Id.ToInvariantString(),
                         id,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3705

### Description

This PR fixes the sort order of the dictionary items as reported in #3705. The fix applies to both the tree and the list view.

As-is the dictionary items are sorted seemingly randomly:

![dictionary-sort-before](https://user-images.githubusercontent.com/7405322/48672490-d50d9a80-eb36-11e8-80e8-6350c08366bb.png)

With this PR they are sorted alphabetically:

![dictionary-sort-after](https://user-images.githubusercontent.com/7405322/48672492-e5be1080-eb36-11e8-9b4f-a929705504b8.png)

### Please note

I already submitted the same fix for V8 in #3518 - at the time I wasn't aware that this problem was in the latest V7 code base as well.
