### PR TITLE
Fixes 3710: Removing the usage of HostingEnvironment.MapPath

### DIFF
--- a/src/Umbraco.Web/Macros/MacroRenderer.cs
+++ b/src/Umbraco.Web/Macros/MacroRenderer.cs
@@ -190,7 +190,7 @@ namespace Umbraco.Web.Macros
             var filename = GetMacroFileName(model);
             if (filename == null) return null;
 
-            var mapped = HostingEnvironment.MapPath(filename);
+            var mapped = IOHelper.MapPath(filename);
             if (mapped == null) return null;
 
             var file = new FileInfo(mapped);

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -133,8 +133,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
                 if (registered)
                 {
-                    var localContentDbPath = HostingEnvironment.MapPath("~/App_Data/NuCache.Content.db");
-                    var localMediaDbPath = HostingEnvironment.MapPath("~/App_Data/NuCache.Media.db");
+                    var localContentDbPath = IOHelper.MapPath("~/App_Data/NuCache.Content.db");
+                    var localMediaDbPath = IOHelper.MapPath("~/App_Data/NuCache.Media.db");
                     _localDbExists = System.IO.File.Exists(localContentDbPath) && System.IO.File.Exists(localMediaDbPath);
 
                     // if both local dbs exist then GetTree will open them, else new dbs will be created


### PR DESCRIPTION
As per issue #3710 I've cleaned up some usages of `HostingEnvironment.MapPath` so that it's less likely to explode.