### PR TITLE
Move member group picker property data store from NVarchar to NText

### DIFF
--- a/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenThirteenZero/UpdateMemberGroupPickerData.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenThirteenZero/UpdateMemberGroupPickerData.cs
@@ -1,0 +1,36 @@
+﻿using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenThirteenZero
+{
+    /// <summary>
+    /// Migrates member group picker properties from NVarchar to NText. See https://github.com/umbraco/Umbraco-CMS/issues/3268.
+    /// </summary>
+    [Migration("7.13.0", 1, Constants.System.UmbracoMigrationName)]
+    public class UpdateMemberGroupPickerData : MigrationBase
+    {
+        public UpdateMemberGroupPickerData(ISqlSyntaxProvider sqlSyntax, ILogger logger) : base(sqlSyntax, logger)
+        {
+        }
+
+        public override void Up()
+        {
+            // move the data for all member group properties from the NVarchar to the NText column and clear the NVarchar column
+            Execute.Sql(@"UPDATE cmsPropertyData SET dataNtext = dataNvarchar, dataNvarchar = NULL
+                WHERE dataNtext IS NULL AND id IN (
+	                SELECT id FROM cmsPropertyData WHERE propertyTypeId in (
+		                SELECT id from cmsPropertyType where dataTypeID IN (
+			                SELECT nodeId FROM cmsDataType WHERE propertyEditorAlias = 'Umbraco.MemberGroupPicker'
+		                )
+	                )
+                )");
+
+            // ensure that all exising member group properties are defined as NText
+            Execute.Sql("UPDATE cmsDataType SET dbType = 'Ntext' WHERE propertyEditorAlias = 'Umbraco.MemberGroupPicker'");
+        }
+
+        public override void Down()
+        {
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -572,6 +572,7 @@
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenEightZero\AddInstructionCountColumn.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenEightZero\AddCmsMediaTable.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenEightZero\AddUserLoginTable.cs" />
+    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenThirteenZero\UpdateMemberGroupPickerData.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\RenameTrueFalseField.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\SetDefaultTagsStorageType.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenNineZero\AddUmbracoAuditTable.cs" />

--- a/src/Umbraco.Web/PropertyEditors/MemberGroupPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MemberGroupPickerPropertyEditor.cs
@@ -8,7 +8,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-     [PropertyEditor(Constants.PropertyEditors.MemberGroupPickerAlias, "Member Group Picker", "membergrouppicker", Group="People", Icon="icon-users")]
+    [PropertyEditor(Constants.PropertyEditors.MemberGroupPickerAlias, "Member Group Picker", PropertyEditorValueTypes.Text, "membergrouppicker", Group="People", Icon="icon-users")]
     public class MemberGroupPickerPropertyEditor : PropertyEditor
     {
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3268

### Description

This PR changes the data store for member group picker properties from NVarchar to NText as requested in #3268.

It consists of two parts:

1. Changing the value type of `MemberGroupPickerPropertyEditor` to `Text`. This ensures that newly created member group picker properties store their values as NText.
2. Migrating all existing member group picker property data and all member group picker data types.

### To test

1. Create a few pieces of content containing selected member groups in a member group picker property.
2. Given the SQL below, verify that all member group picker data is stored in the dataNvarchar column.
```sql
SELECT id, dataNvarchar, dataNtext FROM cmsPropertyData WHERE propertyTypeId in (
	SELECT id from cmsPropertyType where dataTypeID IN (
		SELECT nodeId FROM cmsDataType WHERE propertyEditorAlias = 'Umbraco.MemberGroupPicker'
	)
)
```
3. Stop the site, change the `umbracoConfigurationStatus` app setting to `7.12.4` and restart the site.
4. Complete the Umbraco upgrade.
5. Using the SQL above, verify that all member group picker data is now stored in the dataNtext column, and that the dataNvarchar column is null.
6. Edit the member group picker property on some of the migrated content. Using the SQL above, verify that the updated data is written to the dataNtext column.
7. Create a new member group picker datatype and add it to a document type (new or existing, doesn't matter).
8. Create some content based on the document type from the previous step. Using the SQL above, verify that the member group picker data is written to the dataNtext column.