### PR TITLE
Huntsman case - AuditLog was not returning NodeId from DB

### DIFF
--- a/src/Umbraco.Core/Persistence/PetaPoco.cs
+++ b/src/Umbraco.Core/Persistence/PetaPoco.cs
@@ -808,10 +808,10 @@ namespace Umbraco.Core.Persistence
 		public Page<T> Page<T>(long page, long itemsPerPage, string sql, params object[] args)
 		{
 			string sqlCount, sqlPage;
-			BuildPageQueries<T>((page-1)*itemsPerPage, itemsPerPage, sql, ref args, out sqlCount, out sqlPage);
+            BuildPageQueries<T>(itemsPerPage.Equals(int.MaxValue) ? 0 : (page - 1) * itemsPerPage, itemsPerPage, sql, ref args, out sqlCount, out sqlPage);
 
-			// Save the one-time command time out and use it for both queries
-			int saveTimeout = OneTimeCommandTimeout;
+            // Save the one-time command time out and use it for both queries
+            int saveTimeout = OneTimeCommandTimeout;
 
 			// Setup the paged result
 			var result = new Page<T>();

--- a/src/Umbraco.Core/Persistence/Repositories/AuditRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/AuditRepository.cs
@@ -47,6 +47,7 @@ namespace Umbraco.Core.Persistence.Repositories
             var sql = GetBaseQuery(false);
 
             if (query == null) query = new Query<IAuditItem>();
+            var queryHasWhereClause = query.GetWhereClauses().Any();
             var translatorIds = new SqlTranslator<IAuditItem>(sql, query);
             var translatedQuery = translatorIds.Translate();
 
@@ -65,8 +66,8 @@ namespace Umbraco.Core.Persistence.Repositories
                     filterSql.Append(string.Format("({0})", filterClaus.Item1), filterClaus.Item2);
                     first = false;
                 }
-
-                translatedQuery = GetFilteredSqlForPagedResults(translatedQuery, filterSql);
+                
+                translatedQuery = GetFilteredSqlForPagedResults(translatedQuery, filterSql, queryHasWhereClause);
             }
 
             if (auditTypeFilter.Length > 0)
@@ -82,8 +83,8 @@ namespace Umbraco.Core.Persistence.Repositories
                     filterSql.Append("(logHeader = @logHeader)", new {logHeader = filterClaus.ToString() });
                     first = false;
                 }
-
-                translatedQuery = GetFilteredSqlForPagedResults(translatedQuery, filterSql);
+                
+                translatedQuery = GetFilteredSqlForPagedResults(translatedQuery, filterSql, queryHasWhereClause || hasCustomFilter);
             }
 
             if (orderDirection == Direction.Descending)
@@ -169,14 +170,17 @@ namespace Umbraco.Core.Persistence.Repositories
         }
         #endregion
 
-        private Sql GetFilteredSqlForPagedResults(Sql sql, Sql filterSql)
+        private Sql GetFilteredSqlForPagedResults(Sql sql, Sql filterSql, bool hasWhereClause)
         {
             Sql filteredSql;
 
             // Apply filter
             if (filterSql != null)
             {
-                var sqlFilter = " WHERE " + filterSql.SQL.TrimStart("AND ");
+                //ensure we don't append a WHERE if there is already one
+                var sqlFilter = hasWhereClause
+                    ? filterSql.SQL
+                    : " WHERE " + filterSql.SQL.TrimStart("AND ");
 
                 //NOTE: this is certainly strange - NPoco handles this much better but we need to re-create the sql
                 // instance a couple of times to get the parameter order correct, for some reason the first

--- a/src/Umbraco.Core/Persistence/Repositories/AuditRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/AuditRepository.cs
@@ -97,7 +97,7 @@ namespace Umbraco.Core.Persistence.Repositories
             totalRecords = pagedResult.TotalItems;
 
             var pages = pagedResult.Items.Select(
-                dto => new AuditItem(dto.Id, dto.Comment, Enum<AuditType>.ParseOrNull(dto.Header) ?? AuditType.Custom, dto.UserId)).ToArray();
+                dto => new AuditItem(dto.NodeId, dto.Comment, Enum<AuditType>.ParseOrNull(dto.Header) ?? AuditType.Custom, dto.UserId)).ToArray();
 
             //Mapping the DateStamp
             for (int i = 0; i < pages.Length; i++)

--- a/src/Umbraco.Core/Persistence/Repositories/AuditRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/AuditRepository.cs
@@ -179,7 +179,7 @@ namespace Umbraco.Core.Persistence.Repositories
             {
                 //ensure we don't append a WHERE if there is already one
                 var sqlFilter = hasWhereClause
-                    ? filterSql.SQL
+                    ? " AND " + filterSql.SQL.TrimStart(" AND ")
                     : " WHERE " + filterSql.SQL.TrimStart("AND ");
 
                 //NOTE: this is certainly strange - NPoco handles this much better but we need to re-create the sql


### PR DESCRIPTION
This was a hunstman case - https://umbraco.zendesk.com/agent/tickets/39085
And needs an internal review/sanity check please.

The customer was following along the tutorial about creating a custom dashboard, so do the same & ensure you get back the correct IDs in order to then use the entity id to get further details about the item as mentioned in the tutorial.

https://our.umbraco.com/documentation/tutorials/Creating-a-Custom-Dashboard/
