### PR TITLE
Ensure that the sort order of crops is saved

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -69,4 +69,8 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	        //there was an error, do the highlight (will be set back by the directive)
 	        $scope.hasError = true;
         };
+
+	    $scope.sortableOptions = {
+	        axis: 'y'
+	    }
 	});

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -58,7 +58,7 @@
 
     </div>
 
-    <div ui-sortable="sortableOptions" class="umb-cropsizes__sortable">
+    <div ui-sortable="sortableOptions" class="umb-cropsizes__sortable" ng-model="model.value">
         <div class="control-group umb-prevalues-multivalues__listitem" ng-repeat="item in model.value">
             <i class="icon icon-navigation handle"></i>
             <div class="umb-prevalues-multivalues__left">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3719

### Description

See #3719 for a (brief) description. To test this PR:

1. Change the sort order of crops on an image cropper data type.
2. Save the data type.
3. Reload and verify that the sort order was persisted.
4. Verify that the sort order is also applied when editing an image.

![imagecropper-crop-sorting-after](https://user-images.githubusercontent.com/7405322/48761860-f642c800-eca9-11e8-9d97-17f2ca7330e6.gif)
