### PR TITLE
Disable Gravatar images when FIPS is enabled

### DIFF
--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.IO;
@@ -36,8 +37,11 @@ namespace Umbraco.Core.Models
         /// </returns>
         internal static string[] GetUserAvatarUrls(this IUser user, ICacheProvider staticCache)
         {
-            //check if the user has explicitly removed all avatars including a gravatar, this will be possible and the value will be "none"
-            if (user.Avatar == "none")
+            // If FIPS is required, never check the Gravatar service as it only supports MD5 hashing.  
+            // Unfortunately, if the FIPS setting is enabled on Windows, using MD5 will throw an exception
+            // and the website will not run.
+            // Also, check if the user has explicitly removed all avatars including a gravatar, this will be possible and the value will be "none"
+            if (user.Avatar == "none" || CryptoConfig.AllowOnlyFipsAlgorithms)
             {
                 return new string[0];
             }


### PR DESCRIPTION
Gravatar image URLs require an MD5 hash of the email be generated.  On a FIPS-enabled server, the MD5 algorithm is not available.  As Gravatar doesn't offer any other method for getting user images, enabling FIPS means that no user images will be available.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: #3727 

### Description
These changes make it possible to run Umbraco on a FIPS-enabled Windows server.  To test this:

Follow the steps at https://our.umbraco.com/documentation/Getting-Started/Setup/Install/install-umbraco-manually to install Umbraco 7.12.4.

Browse the front and log in to the back-office to ensure the site is up and running correctly.

Follow the steps at https://our.umbraco.com/documentation/Reference/Security/Setup-Umbraco-for-a-Fips-Server/ to add needed code for enabling FIPS compliance in Lucene.NET, as well as the steps for how to setup a FIPS-enabled machine.  Note that instead of using an assembly attribute on a website project, you can also add a custom class to a new assembly which extends ApplicationEventHandler and sets the FIPS compliance in the OnApplicationInitializing method.  Then compile that into a DLL and add it to the BIN folder of the website.

Browse the front-office and ensure it still works.

Try to log in to the back-office.  If you are able to log in successfully, the fix is working.  If it is not working, you will not be able to log in, and when looking at the HTTP response in the browser's Dev tools, you'll see an error about the MD5 algorithm not being available.
