### PR TITLE
#3704 Changes button text for dialogs to be more "in context" 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
@@ -463,7 +463,7 @@ Opens an overlay to show a custom YSOD. </br>
                  scope.model.closeButtonLabel = localizationService.localize("general_close");
              }
              if (!scope.model.submitButtonLabelKey && !scope.model.submitButtonLabel) {
-                 scope.model.submitButtonLabel = localizationService.localize("general_submit");
+                 scope.model.submitButtonLabel = localizationService.localize("general_continue");
              }
          }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -505,6 +505,7 @@
           scope.propertySettingsDialogModel.contentType = scope.contentType;
           scope.propertySettingsDialogModel.contentTypeName = scope.model.name;
           scope.propertySettingsDialogModel.view = "views/common/overlays/contenttypeeditor/propertysettings/propertysettings.html";
+          scope.propertySettingsDialogModel.submitButtonLabelKey = "buttons_save";
           scope.propertySettingsDialogModel.show = true;
 
           // set state to active to access the preview

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.controller.js
@@ -110,6 +110,7 @@
                 vm.editorSettingsOverlay.title = "Editor settings";
                 vm.editorSettingsOverlay.view = "views/common/overlays/contenttypeeditor/editorsettings/editorsettings.html";
                 vm.editorSettingsOverlay.dataType = dataType;
+                vm.editorSettingsOverlay.submitButtonLabelKey = "buttons_save";
                 vm.editorSettingsOverlay.show = true;
 
                 vm.editorSettingsOverlay.submit = function (model) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/embed/embed.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/embed/embed.controller.js
@@ -7,10 +7,12 @@
       var origWidth = 500;
       var origHeight = 300;
 
+      $scope.model.submitButtonLabelKey = "general_insert";
+       $scope.model.disableSubmitButton = true;
       if(!$scope.model.title) {
           $scope.model.title = localizationService.localize("general_embed");
       }
-
+       
       $scope.model.embed = {
          url: "",
          width: 360,
@@ -27,7 +29,8 @@
 
       function showPreview() {
 
-         if ($scope.model.embed.url) {
+          if ($scope.model.embed.url) {
+           
             $scope.model.embed.show = true;
             $scope.model.embed.preview = "<div class=\"umb-loader\" style=\"height: 10px; margin: 10px 0px;\"></div>";
             $scope.model.embed.info = "";
@@ -59,6 +62,7 @@
                         $scope.model.embed.preview = data.Markup;
                         $scope.model.embed.supportsDimensions = data.SupportsDimensions;
                         $scope.model.embed.success = true;
+                        $scope.model.disableSubmitButton = false;
                         break;
                   }
                })

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -1,7 +1,9 @@
 //used for the media picker dialog
 angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 	function ($scope, eventsService, dialogService, entityResource, contentResource, mediaHelper, userService, localizationService, tinyMceService) {
-		var dialogOptions = $scope.model;
+        var dialogOptions = $scope.model;
+
+        $scope.model.submitButtonLabelKey = dialogOptions.currentTarget ? "general_update" : "general_insert"; 
 
 		var searchText = "Search...";
 		localizationService.localize("general_search").then(function (value) {
@@ -109,7 +111,8 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
 				$scope.mediaPickerOverlay = {
 					view: "mediapicker",
 					startNodeId: userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0],
-					startNodeIsVirtual: userData.startMediaIds.length !== 1,
+                    startNodeIsVirtual: userData.startMediaIds.length !== 1,
+                    submitButtonLabelKey: 'buttons_select',
 					show: true,
 					submit: function (model) {
 						var media = model.selectedImages[0];

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/macropicker/macropicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/macropicker/macropicker.controller.js
@@ -8,14 +8,15 @@ function MacroPickerController($scope, entityResource, macroResource, umbPropEdi
     $scope.macros = [];
     $scope.model.selectedMacro = null;
     $scope.model.macroParams = [];
-
+    $scope.model.submitButtonLabelKey = "general_insert";
+    $scope.model.disableSubmitButton = true;
     $scope.wizardStep = "macroSelect";
     $scope.noMacroParams = false;
 
     $scope.selectMacro = function (macro) {
 
         $scope.model.selectedMacro = macro;
-
+        $scope.model.disableSubmitButton = false;
         if ($scope.wizardStep === "macroSelect") {
             editParams(true);
         } else {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -18,10 +18,8 @@ angular.module("umbraco")
             $scope.lastOpenedNode = localStorageService.get("umbLastOpenedMediaNodeId");
             $scope.lockedFolder = true;
 
-            console.log('details:',$scope.showDetails);
-
             if ($scope.showDetails) {
-                // hide submit since the "insertion" of the picked media will be done from the details view.
+                // hide submit-button since the "insertion" of the picked media will be done from the details view.
                 $scope.hideSubmitButton = true;
                 $scope.model.hideSubmitButton = true;
             }

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -8,7 +8,7 @@ angular.module("umbraco")
             }
 
             var dialogOptions = $scope.model;
-
+            
             $scope.disableFolderSelect = dialogOptions.disableFolderSelect;
             $scope.onlyImages = dialogOptions.onlyImages;
             $scope.showDetails = dialogOptions.showDetails;
@@ -18,6 +18,14 @@ angular.module("umbraco")
             $scope.lastOpenedNode = localStorageService.get("umbLastOpenedMediaNodeId");
             $scope.lockedFolder = true;
 
+            console.log('details:',$scope.showDetails);
+
+            if ($scope.showDetails) {
+                // hide submit since the "insertion" of the picked media will be done from the details view.
+                $scope.hideSubmitButton = true;
+                $scope.model.hideSubmitButton = true;
+            }
+            
             var umbracoSettings = Umbraco.Sys.ServerVariables.umbracoSettings;
             var allowedUploadFiles = mediaHelper.formatFileTypes(umbracoSettings.allowedUploadFiles);
             if ($scope.onlyImages) {
@@ -271,6 +279,7 @@ angular.module("umbraco")
 
                 $scope.mediaPickerDetailsOverlay = {};
                 $scope.mediaPickerDetailsOverlay.show = true;
+                $scope.mediaPickerDetailsOverlay.submitButtonLabelKey = "general_insert";
 
                 $scope.mediaPickerDetailsOverlay.submit = function(model) {
                     $scope.model.selectedImages.push($scope.target);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -127,7 +127,8 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         },
         treeAlias: $scope.model.config.startNode.type,
         section: $scope.model.config.startNode.type,
-        idType: "int"
+        idType: "int",
+        submitButtonLabelKey : "buttons_select"
     };
 
     //since most of the pre-value config's are used in the dialog options (i.e. maxNumber, minNumber, etc...) we'll merge the 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
@@ -18,6 +18,7 @@ angular.module("umbraco")
             $scope.mediaPickerOverlay.showDetails = true;
             $scope.mediaPickerOverlay.disableFolderSelect = true;
             $scope.mediaPickerOverlay.onlyImages = true;
+            $scope.mediaPickerOverlay.hideSubmitButton = true; // hide since new overlay opens after selection of media.
             $scope.mediaPickerOverlay.show = true;
 
             $scope.mediaPickerOverlay.submit = function(model) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -108,6 +108,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                multiPicker: multiPicker,
                onlyImages: onlyImages,
                disableFolderSelect: disableFolderSelect,
+               submitButtonLabelKey: "buttons_select",
                show: true,
                submit: function(model) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -13,11 +13,18 @@
                 </p>
 
                 <!-- IMAGE -->
-                <img ng-class="{'trashed': media.trashed}" ng-src="{{media.thumbnail}}" alt="" ng-show="media.thumbnail" title="{{media.trashed ? 'Trashed: ' + media.name : media.name}}" />
+                <img ng-if="media.thumbnail"
+                     ng-class="{'trashed': media.trashed}" ng-src="{{media.thumbnail}}"
+                     alt="" title="{{media.trashed ? 'Trashed: ' + media.name : media.name}}" />
 
                 <!-- SVG -->
-                <img ng-class="{'trashed': media.trashed}" ng-if="media.metaData.umbracoExtension.Value === 'svg'" ng-src="{{media.metaData.umbracoFile.Value}}" alt="" title="{{media.trashed ? 'Trashed: ' + media.name : media.name}}" />
-                <img ng-class="{'trashed': media.trashed}" ng-if="media.extension === 'svg'" ng-src="{{media.file}}" alt="" />
+                <img ng-if="!media.thumbnail && media.metaData.umbracoExtension.Value === 'svg'"
+                     ng-class="{'trashed': media.trashed}" ng-src="{{media.metaData.umbracoFile.Value}}"
+                     alt="" title="{{media.trashed ? 'Trashed: ' + media.name : media.name}}" />
+                <img ng-if="!media.thumbnail && media.metaData.umbracoExtension.Value !== 'svg' && media.extension === 'svg'"
+                     ng-class="{'trashed': media.trashed}" ng-src="{{media.file}}"
+                     alt=""
+                     title="{{media.trashed ? 'Trashed: ' + media.name : media.name}}" />
 
                 <!-- FILE -->
                 <div ng-class="{'trashed': media.trashed}" class="umb-icon-holder" ng-hide="media.thumbnail || media.metaData.umbracoExtension.Value === 'svg' || media.extension === 'svg'">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/membergrouppicker/membergrouppicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/membergrouppicker/membergrouppicker.controller.js
@@ -23,6 +23,7 @@ function memberGroupPicker($scope, dialogService){
       $scope.memberGroupPicker.multiPicker = true;
       $scope.memberGroupPicker.view = "memberGroupPicker";
       $scope.memberGroupPicker.show = true;
+      $scope.memberGroupPicker.submitButtonLabelKey = "buttons_select";
 
       $scope.memberGroupPicker.submit = function(model) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/memberpicker/memberpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/memberpicker/memberpicker.controller.js
@@ -29,7 +29,8 @@ function memberPickerController($scope, dialogService, entityResource, $log, ico
                 $scope.add(data);
             }
             angularHelper.getCurrentForm($scope).$setDirty();
-        }
+        },
+        submitButtonLabelKey: "buttons_select"
     };
 
     //since most of the pre-value config's are used in the dialog options (i.e. maxNumber, minNumber, etc...) we'll merge the


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3704

### Description
This PR changed the button text for dialogs to be more "in context" depending on what the user is doing in the backoffice.

First of all it changes the defualt text of the "submit"-button in a umbOverlay to "general_continue" instead of "general_submit" which would make more scene in most cases.

I also changed to texts for the "submit"-button to be "context aware":

Senario -> "New button text"

#### Content Section:

- Media Pickers -> "Select"
- Image Picker (RTE/Grid) -> "Insert"
- Member Picker -> "Select"
- Member Groups Picker -> "Select"
- Link (RTE) -> "Insert" (for new), "Update" (when editing)
- Insert macro (Grid) -> "Insert" (disabled in first step when choosing macro)
- Insert Embed (Grid) -> "Insert" (disabled until valid content is entered)

#### Settings section
- Add Property -> "Save"
- Edit data type settings -> "Save"

Might be more places where we could change the text but these where the ones I found now.
