### PR TITLE
Fix listview buttons alignment

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
@@ -34,7 +34,7 @@
         </umb-property>
 
         <div class="text-right">
-            <button type="button" class="btn" ng-click="toggleEditListViewDataTypeSettings()"><localize key="general_close">Close</localize></button>
+            <button type="button" class="btn btn-link" ng-click="toggleEditListViewDataTypeSettings()"><localize key="general_close">Close</localize></button>
             <button type="button" class="btn btn-success" ng-click="saveListViewDataType()"><localize key="buttons_saveListView"></localize></button>
         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
@@ -33,8 +33,10 @@
             <umb-editor model="preValue" is-pre-value="true"></umb-editor>
         </umb-property>
 
-        <button type="button" class="btn" ng-click="toggleEditListViewDataTypeSettings()"><localize key="general_close">Close</localize></button>
-        <button type="button" class="btn btn-success" ng-click="saveListViewDataType()"><localize key="buttons_saveListView"></localize></button>
+        <div class="text-right">
+            <button type="button" class="btn" ng-click="toggleEditListViewDataTypeSettings()"><localize key="general_close">Close</localize></button>
+            <button type="button" class="btn btn-success" ng-click="saveListViewDataType()"><localize key="buttons_saveListView"></localize></button>
+        </div>
 
     </div>
   </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When working on a list view related issue, I realized how prone I was to forgetting to save the list view changes I made on the doctype used for testing. I think it has something to do with the current button alignment:

![image](https://user-images.githubusercontent.com/7405322/48864510-1028fb80-edcd-11e8-9f4d-c6e17c78b1c8.png)

The buttons are aligned left, whereas all other save/submit buttons are aligned right (ok, at least most of the save/submit buttons).

Aligning the buttons to the right makes the "Save list view" button less likely to miss when scrolling down to save the changes made to the doctype:

![image](https://user-images.githubusercontent.com/7405322/48864865-313e1c00-edce-11e8-9e72-194d1640ce79.png)

As the screenshot shows, I also changed the secondary action to a "link" button, as this seems to be the approach in other similar windows/dialogs.

*Note: Any changes made to the list view must be saved explicitly by clicking the "Save list view" button - they aren't saved when saving the doctype. This is because the list view is actually a data type that's being edited from within the doctype editor.*

### To test this PR

Edit the "List view settings" on any doctype and observe the changes in the button placement and appearance. 
