### PR TITLE
Update the method determining whether to installation is fresh or not by taking into account empty database

### DIFF
--- a/src/Umbraco.Core/DatabaseContext.cs
+++ b/src/Umbraco.Core/DatabaseContext.cs
@@ -461,7 +461,7 @@ namespace Umbraco.Core
         /// </remarks>
         /// <param name="connectionString"></param>
         /// <param name="providerName"></param>
-        private void SaveConnectionString(string connectionString, string providerName)
+        internal void SaveConnectionString(string connectionString, string providerName)
         {
             //Set the connection string for the new datalayer
             var connectionStringSettings = string.IsNullOrEmpty(providerName)

--- a/src/Umbraco.Web/Install/InstallHelper.cs
+++ b/src/Umbraco.Web/Install/InstallHelper.cs
@@ -1,14 +1,9 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Web;
-using System.Web.Script.Serialization;
-using System.Web.UI;
-using Semver;
 using umbraco.BusinessLogic;
 using Umbraco.Core;
 using Umbraco.Core.Configuration;
@@ -113,14 +108,18 @@ namespace Umbraco.Web.Install
                     {
                         // check that it's a valid Guid
                         if (installId == Guid.Empty)
+                        {
                             installId = Guid.NewGuid();
+                        }
                     }
                 }
                 installCookie.SetValue(installId.ToString());
 
                 string dbProvider = string.Empty;
                 if (IsBrandNewInstall == false)
+                {
                     dbProvider = ApplicationContext.Current.DatabaseContext.DatabaseProvider.ToString();
+                }
 
                 org.umbraco.update.CheckForUpgrade check = new org.umbraco.update.CheckForUpgrade();
                 check.Install(installId,
@@ -149,6 +148,16 @@ namespace Umbraco.Web.Install
             get
             {
                 var databaseSettings = ConfigurationManager.ConnectionStrings[Constants.System.UmbracoConnectionName];
+
+                if (_umbContext.Application.DatabaseContext.IsConnectionStringConfigured(databaseSettings)
+                    && !_umbContext.Application.DatabaseContext.SqlSyntax.GetTablesInSchema(_umbContext.Application.DatabaseContext.Database).Any())
+                {
+                    GlobalSettings.ConfigurationStatus = string.Empty;
+                    _umbContext.Application.DatabaseContext.SaveConnectionString(string.Empty, string.Empty);
+
+                    return true;
+                }
+
                 if (GlobalSettings.ConfigurationStatus.IsNullOrWhiteSpace()
                     && _umbContext.Application.DatabaseContext.IsConnectionStringConfigured(databaseSettings) == false)
                 {
@@ -193,7 +202,9 @@ namespace Umbraco.Web.Install
         internal IEnumerable<Package> GetStarterKits()
         {
             if (_httpClient == null)
+            {
                 _httpClient = new HttpClient();
+            }
 
             var packages = new List<Package>();
             try


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3753

### Description

Following the feature request aforementioned, I made these two minor changes to allow Umbraco to get installed when a connection string referring to an empty database is set.

Basically, I made two changes:

- "SaveConnectionString" in "DatabaseContext" is now internal.
- The property "IsBrandNewInstall" of "InstallHelper" now checks whether a connection string has been defined and if this one points to an empty database. If it's the case, the version and connection string are cleaned from the web.config to force a brand new installation.


