### PR TITLE
V8: Fix the OK button for move and close success messages

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/copy.html
@@ -14,7 +14,7 @@
                     <strong>{{currentNode.name}}</strong> was copied to
                     <strong>{{target.name}}</strong>
                 </div>
-                <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
+                <button class="btn btn-primary" ng-click="closeDialog()">Ok</button>
             </div>
 
             <p class="abstract" ng-hide="success">

--- a/src/Umbraco.Web.UI.Client/src/views/content/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/move.html
@@ -13,7 +13,7 @@
                 <div class="alert alert-success">
                     <strong>{{currentNode.name}}</strong> was moved underneath&nbsp;<strong>{{target.name}}</strong>
                 </div>
-                <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
+                <button class="btn btn-primary" ng-click="close()">Ok</button>
             </div>
 
             <p class="abstract" ng-hide="success">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The OK buttons for move and close success messages doesn't work.

![image](https://user-images.githubusercontent.com/7405322/48979196-5628dc80-f0b7-11e8-9884-c5c4bdf909e4.png)

To test this PR, simply move and copy some stuff around and verify that the OK button indeed closes the dialog.