### PR TITLE
V8: Fix the changing source name when moving a node

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.move.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.move.controller.js
@@ -22,11 +22,11 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.MoveController",
             $scope.treeModel.hideHeader = userData.startContentIds.length > 0 && userData.startContentIds.indexOf(-1) == -1;
         });
 
-	    var node = $scope.currentNode;
+	    $scope.source = _.clone($scope.currentNode);
 
         function treeLoadedHandler(args) {
-            if (node && node.path) {
-                $scope.dialogTreeApi.syncTree({ path: node.path, activate: false });
+            if ($scope.source && $scope.source.path) {
+                $scope.dialogTreeApi.syncTree({ path: $scope.source.path, activate: false });
             }
         }
 
@@ -84,7 +84,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.MoveController",
 	        $scope.busy = true;
 	        $scope.error = false;
 
-	        contentResource.move({ parentId: $scope.target.id, id: node.id })
+	        contentResource.move({ parentId: $scope.target.id, id: $scope.source.id })
                 .then(function (path) {
                     $scope.error = false;
                     $scope.success = true;

--- a/src/Umbraco.Web.UI.Client/src/views/content/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/move.html
@@ -13,7 +13,7 @@
                 <div class="alert alert-success">
                     <strong>{{source.name}}</strong> was moved underneath&nbsp;<strong>{{target.name}}</strong>
                 </div>
-                <button class="btn btn-primary" ng-click="close()">Ok</button>
+                <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
             </div>
 
             <p class="abstract" ng-hide="success">

--- a/src/Umbraco.Web.UI.Client/src/views/content/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/move.html
@@ -11,14 +11,14 @@
 
             <div ng-show="success">
                 <div class="alert alert-success">
-                    <strong>{{currentNode.name}}</strong> was moved underneath&nbsp;<strong>{{target.name}}</strong>
+                    <strong>{{source.name}}</strong> was moved underneath&nbsp;<strong>{{target.name}}</strong>
                 </div>
-                <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
+                <button class="btn btn-primary" ng-click="close()">Ok</button>
             </div>
 
             <p class="abstract" ng-hide="success">
                 <localize key="actions_chooseWhereToMove">Choose where to move</localize>
-                <strong>{{currentNode.name}}</strong>
+                <strong>{{source.name}}</strong>
                 <localize key="actions_toInTheTreeStructureBelow">to in the tree structure below</localize>                
             </p>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When moving a node, the name of the moved node sometimes changes after the move operation.

![move-source-name-before](https://user-images.githubusercontent.com/7405322/48979216-a869fd80-f0b7-11e8-8d98-ddbb170144aa.gif)

To reproduce this:

1. Open the parent node of the node you want to move.
2. Pick "move" on the node (without opening the node first).
3. Observe how the node name flickers from the moved node to the selected node in the success message.

With this PR, the same move operation looks something like this:

![move-source-name-after](https://user-images.githubusercontent.com/7405322/48979236-e23b0400-f0b7-11e8-8c4c-524c01b89390.gif)
