### PR TITLE
Fix the changing source name when copying a node

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.copy.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.copy.controller.js
@@ -25,11 +25,11 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.CopyController",
             $scope.treeModel.hideHeader = userData.startContentIds.length > 0 && userData.startContentIds.indexOf(-1) == -1;
 	    });
 
-	    var node = $scope.currentNode;
+	    $scope.source = _.clone($scope.currentNode);
 
         function treeLoadedHandler(args) {
-            if (node && node.path) {
-                $scope.dialogTreeApi.syncTree({ path: node.path, activate: false });
+            if ($scope.source && $scope.source.path) {
+                $scope.dialogTreeApi.syncTree({ path: $scope.source.path, activate: false });
             }
         }
 
@@ -107,7 +107,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.CopyController",
 	        $scope.busy = true;
 	        $scope.error = false;
 
-	        contentResource.copy({ parentId: $scope.target.id, id: node.id, relateToOriginal: $scope.relateToOriginal, recursive: $scope.recursive })
+	        contentResource.copy({ parentId: $scope.target.id, id: $scope.source.id, relateToOriginal: $scope.relateToOriginal, recursive: $scope.recursive })
                 .then(function (path) {
                     $scope.error = false;
                     $scope.success = true;

--- a/src/Umbraco.Web.UI.Client/src/views/content/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/copy.html
@@ -11,14 +11,14 @@
 
             <div ng-show="success">
                 <div class="alert alert-success">
-                    <strong>{{currentNode.name}}</strong> was copied to
+                    <strong>{{source.name}}</strong> was copied to
                     <strong>{{target.name}}</strong>
                 </div>
                 <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
             </div>
 
             <p class="abstract" ng-hide="success">
-                Choose where to copy <strong>{{currentNode.name}}</strong> to in the tree structure below
+                Choose where to copy <strong>{{source.name}}</strong> to in the tree structure below
             </p>
 
             <div class="umb-loader-wrapper" ng-show="busy">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

(similar problem as in #3756, only for copying items.)

When copying a node, the name of the copied node sometimes changes after the copy operation.

![copy-source-name-before](https://user-images.githubusercontent.com/7405322/48979335-b456bf00-f0b9-11e8-84f6-46b04fdf73e1.gif)

To reproduce this:

1. Open any node in the content tree.
2. Pick "copy" on another node (without opening the node first).
3. Observe how the node name flickers from the copied node to the selected node in the success message.

With this PR, the same copy operation looks something like this:

![copy-source-name-after](https://user-images.githubusercontent.com/7405322/48979343-dc462280-f0b9-11e8-8788-60f69d68865b.gif)
