### PR TITLE
V8: Fix YSODs when moving and copying things in the Settings section

### DIFF
--- a/src/Umbraco.Core/Services/MoveOperationStatusType.cs
+++ b/src/Umbraco.Core/Services/MoveOperationStatusType.cs
@@ -7,7 +7,7 @@
     /// <remarks>
     /// Anything less than 10 = Success!
     /// </remarks>
-    public enum MoveOperationStatusType
+    public enum MoveOperationStatusType : byte
     {
         /// <summary>
         /// The move was successful.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

**TL;DR** the enum `MoveOperationStatusType` must be of type `byte`, otherwise most move and copy operations appear to fail miserably in the UI.

When moving and copying things around in the Settings section, you're usually given this response:

![image](https://user-images.githubusercontent.com/7405322/48998622-6216ac00-f154-11e8-9c92-df6d04e65493.png)

The exception message is: 

`System.InvalidOperationException: Enum Umbraco.Core.Services.MoveOperationStatusType underlying type is not <byte>.`

The move/copy operation actually succeeds, but the success message just doesn't work 😐 because `MoveOperationStatusType` is not of type `byte`:

![image](https://user-images.githubusercontent.com/7405322/48998782-dfdab780-f154-11e8-8b3e-a25e213079c1.png)

