### PR TITLE
V8: Make Nested Content support content variants

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -173,13 +173,17 @@ namespace Umbraco.Web.PropertyEditors
                             {
                                 // create a temp property with the value
                                 var tempProp = new Property(propType);
-                                tempProp.SetValue(propValues[propAlias] == null ? null : propValues[propAlias].ToString());
+                                // if the property varies by culture, make sure we save using the current culture
+                                var propCulture = propType.VariesByCulture() || propType.VariesByCultureAndSegment()
+                                    ? culture
+                                    : null;
+                                tempProp.SetValue(propValues[propAlias] == null ? null : propValues[propAlias].ToString(), propCulture);
 
                                 // convert that temp property, and store the converted value
                                 var propEditor = _propertyEditors[propType.PropertyEditorAlias];
                                 var tempConfig = dataTypeService.GetDataType(propType.DataTypeId).Configuration;
                                 var valEditor = propEditor.GetValueEditor(tempConfig);
-                                var convValue = valEditor.ToEditor(tempProp, dataTypeService);
+                                var convValue = valEditor.ToEditor(tempProp, dataTypeService, propCulture);
                                 propValues[propAlias] = convValue == null ? null : JToken.FromObject(convValue);
                             }
                             catch (InvalidOperationException)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Nested Content doesn't play nice with content variants right now, as the following shows:

![nested-content-variant-before](https://user-images.githubusercontent.com/7405322/49008314-d0b43380-f16d-11e8-8deb-e54a033b42c0.gif)

If one of the items in the Nested Content property is a content variant, it blows up when saving and subsequently the content is broken.

With this PR it becomes possible to use content variants in Nested Content. Here's the initial creation in the default language variant, using items of mixed variance:

![nested-content-variant-after-1](https://user-images.githubusercontent.com/7405322/49008432-17a22900-f16e-11e8-92c3-a9afb65bd788.gif)

...and editing another language variant:

![nested-content-variant-after-2](https://user-images.githubusercontent.com/7405322/49008456-2e488000-f16e-11e8-92e3-5c47d4ec6be4.gif)
