### PR TITLE
V8: Fix and clean up the restore content dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/restore.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/restore.html
@@ -19,7 +19,7 @@
 
 		    <div ng-show="success">
 		        <div class="alert alert-success">
-                    <strong>{{source.name}}</strong> was moved underneath&nbsp;<strong>{{target.name}}</strong>
+                    <strong>{{source.name}}</strong> <localize key="editdatatype_wasMoved">was moved underneath</localize> <strong>{{target.name}}</strong>
 		        </div>
 		        <button class="btn btn-primary" ng-click="close()">Ok</button>
 		    </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/restore.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/restore.html
@@ -21,7 +21,7 @@
 		        <div class="alert alert-success">
                     <strong>{{source.name}}</strong> <localize key="editdatatype_wasMoved">was moved underneath</localize> <strong>{{target.name}}</strong>
 		        </div>
-		        <button class="btn btn-primary" ng-click="close()">Ok</button>
+		        <button class="btn btn-primary" ng-click="close()"><localize key="general_ok">Ok</localize></button>
 		    </div>
 
 		</umb-pane>

--- a/src/Umbraco.Web.UI.Client/src/views/content/restore.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/restore.html
@@ -2,25 +2,33 @@
 	<div class="umb-dialog-body">
 		<umb-pane>
 
-            <p class="abstract" ng-hide="error != null || success == true">
-                <localize key="actions_restore">Restore</localize> <strong>{{currentNode.name}}</strong> <localize key="general_under">under</localize> <strong>{{target.name}}</strong>?
+		    <umb-load-indicator
+		        ng-show="loading">
+		    </umb-load-indicator>
+
+		    <p class="abstract" ng-hide="loading || error != null || success">
+                <localize key="actions_restore">Restore</localize> <strong>{{source.name}}</strong> <localize key="general_under">under</localize> <strong>{{target.name}}</strong>?
             </p>
 
-			<div class="alert alert-error" ng-show="error != null">
-				<div><strong>{{error.errorMsg}}</strong></div>
-				<div>{{error.data.Message}}</div>
-			</div>
+		    <div ng-show="error">
+		        <div class="alert alert-error">
+		            <div><strong>{{error.errorMsg}}</strong></div>
+		            <div>{{error.data.Message}}</div>
+		        </div>
+		    </div>
 
-			<div class="alert alert-success" ng-show="success == true">
-				<p><strong>{{currentNode.name}}</strong> <localize key="editdatatype_wasMoved">was moved underneath</localize> <strong>{{target.name}}</strong></p>
-				<button class="btn btn-primary" ng-click="nav.hideDialog()"><localize key="general_ok">OK</localize></button>
-			</div>
+		    <div ng-show="success">
+		        <div class="alert alert-success">
+                    <strong>{{source.name}}</strong> was moved underneath&nbsp;<strong>{{target.name}}</strong>
+		        </div>
+		        <button class="btn btn-primary" ng-click="close()">Ok</button>
+		    </div>
 
 		</umb-pane>
 	</div>
 
-	<div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success == true">
-		<a class="btn btn-link" ng-click="nav.hideDialog()"><localize key="general_cancel">Cancel</localize></a>
+	<div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="loading || success">
+		<a class="btn btn-link" ng-click="close()"><localize key="general_cancel">Cancel</localize></a>
 		<button class="btn btn-primary" ng-click="restore()" ng-show="error == null"><localize key="actions_restore">Restore</localize></button>
 	</div>
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There are a few issues with the restore content dialog:

1. There is no "loading" state in the dialog, resulting in a fair bit of flickering between states.
2. Restoring a child to a parent that's also in trash, or to a parent that doesn't exist anymore, produces a weird error message.
3. The cancel buttons do not work.
4. The name of the target node for the restore operation is missing.
5. The success message is "old-style".
6. If the source node is not selected for editing when invoking the restore operation, the wrong source name occurs in the success message.

Here's a demo of the issues above:

![content-restore-cleanup-before](https://user-images.githubusercontent.com/7405322/49043296-e99f0200-f1ca-11e8-817d-9dd9869764ba.gif)

This PR fixes all the listed issues:

![content-restore-cleanup-after](https://user-images.githubusercontent.com/7405322/49043313-f6235a80-f1ca-11e8-938e-e7b9e446cbb5.gif)
