### PR TITLE
V8: Fix the flickering source name and the close button when moving items in the media tree

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/media.move.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.move.controller.js
@@ -3,7 +3,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
     function ($scope, userService, eventsService, mediaResource, appState, treeService, navigationService) {
 
 	    $scope.dialogTreeApi = {};
-	    var node = $scope.currentNode;
+        $scope.source = _.clone($scope.currentNode);
 
         $scope.treeModel = {
             hideHeader: false
@@ -13,8 +13,8 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
         });
 
         function treeLoadedHandler(args) {
-            if (node && node.path) {
-                $scope.dialogTreeApi.syncTree({ path: node.path, activate: false });
+            if ($scope.source && $scope.source.path) {
+                $scope.dialogTreeApi.syncTree({ path: $scope.source.path, activate: false });
             }
         }
 
@@ -55,7 +55,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
 
 	    $scope.move = function () {
 	        $scope.busy = true;
-	        mediaResource.move({ parentId: $scope.target.id, id: node.id })
+            mediaResource.move({ parentId: $scope.target.id, id: $scope.source.id })
                 .then(function (path) {
 	                $scope.busy = false;
                     $scope.error = false;

--- a/src/Umbraco.Web.UI.Client/src/views/media/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/move.html
@@ -11,14 +11,14 @@
 
 		    <div ng-show="success">
 			    <div class="alert alert-success">
-				    <strong>{{currentNode.name}}</strong> was moved underneath <strong>{{target.name}}</strong>
+                    <strong>{{source.name}}</strong> was moved underneath <strong>{{target.name}}</strong>
 			    </div>
-			    <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
+			    <button class="btn btn-primary" ng-click="close()">Ok</button>
 		    </div>
 
 		    <p class="abstract" ng-hide="success">
                 <localize key="actions_chooseWhereToMove">Choose where to move</localize>
-                <strong>{{currentNode.name}}</strong>
+                <strong>{{source.name}}</strong>
                 <localize key="actions_toInTheTreeStructureBelow">to in the tree structure below</localize>
             </p>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

(same issues as described in #3756 and #3755, only for moving items in the media tree)

When moving a node, the name of the moved node sometimes changes after the move operation. Also, the "OK" button in the success message does nothing:

![move-media-source-name-and-close-before](https://user-images.githubusercontent.com/7405322/49044342-c0cc3c00-f1cd-11e8-9177-c3983f1c6a88.gif)

To reproduce this:

1. Open any other node than the node you want to move.
2. Pick "move" on the node (without opening the node first).
3. Observe how the node name flickers from the moved node to the selected node in the success message.
4. The OK button doesn't close the dialog.

With this PR, the same move operation looks something like this:

![move-media-source-name-and-close-after](https://user-images.githubusercontent.com/7405322/49044389-e6594580-f1cd-11e8-89bd-325ed9ccbc67.gif)
