### PR TITLE
Don't show "Create" and "Sort" for deleted items in the media tree

### DIFF
--- a/src/Umbraco.Web/Trees/MediaTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTreeController.cs
@@ -130,21 +130,25 @@ namespace Umbraco.Web.Trees
                 return menu;
             }
 
-            //return a normal node menu:
-            menu.Items.Add<ActionNew>(ui.Text("actions", ActionNew.Instance.Alias));
-            menu.Items.Add<ActionMove>(ui.Text("actions", ActionMove.Instance.Alias));
-            menu.Items.Add<ActionDelete>(ui.Text("actions", ActionDelete.Instance.Alias));
-            menu.Items.Add<ActionSort>(ui.Text("actions", ActionSort.Instance.Alias)).ConvertLegacyMenuItem(item, "media", "media");
-            menu.Items.Add<ActionRefresh>(ui.Text("actions", ActionRefresh.Instance.Alias), true);
-
-            //if the media item is in the recycle bin, don't have a default menu, just show the regular menu
+            //if the media item is in the recycle bin, we don't have a default menu and we need to show a limited menu
             if (item.Path.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Contains(RecycleBinId.ToInvariantString()))
             {
+                menu.Items.Add<ActionRestore>(ui.Text("actions", ActionRestore.Instance.Alias));
+                menu.Items.Add<ActionMove>(ui.Text("actions", ActionMove.Instance.Alias));
+                menu.Items.Add<ActionDelete>(ui.Text("actions", ActionDelete.Instance.Alias));
+                menu.Items.Add<RefreshNode, ActionRefresh>(ui.Text("actions", ActionRefresh.Instance.Alias), true);
+
                 menu.DefaultMenuAlias = null;
-                menu.Items.Insert(2, new MenuItem(ActionRestore.Instance, ui.Text("actions", ActionRestore.Instance.Alias)));
             }
             else
             {
+                //return a normal node menu:
+                menu.Items.Add<ActionNew>(ui.Text("actions", ActionNew.Instance.Alias));
+                menu.Items.Add<ActionMove>(ui.Text("actions", ActionMove.Instance.Alias));
+                menu.Items.Add<ActionDelete>(ui.Text("actions", ActionDelete.Instance.Alias));
+                menu.Items.Add<ActionSort>(ui.Text("actions", ActionSort.Instance.Alias)).ConvertLegacyMenuItem(item, "media", "media");
+                menu.Items.Add<ActionRefresh>(ui.Text("actions", ActionRefresh.Instance.Alias), true);
+
                 //set the default to create
                 menu.DefaultMenuAlias = ActionNew.Instance.Alias;
             }
@@ -179,6 +183,6 @@ namespace Umbraco.Web.Trees
             // do not want to make public on the interface. Unfortunately also prevents this from being unit tested.
             // See this issue for details on why we need this:
             // https://github.com/umbraco/Umbraco-CMS/issues/3457
-            => ((EntityService)Services.EntityService).GetMediaChildrenWithoutPropertyData(entityId).ToList();
+            => ((EntityService)Services.EntityService).GetMediaChildrenWithoutPropertyData(entityId).ToList();        
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The menu options for deleted items in the media includes "Create" and "Sort" options. That can't be right:

![image](https://user-images.githubusercontent.com/7405322/49065027-0e23ca00-f21d-11e8-91c5-22e02e058690.png)


This PR limits the menu options for deleted items to: "Restore", "Move", "Delete" and "Reload":

![image](https://user-images.githubusercontent.com/7405322/49064945-c8670180-f21c-11e8-9279-f9c0b8fc9a49.png)

