### PR TITLE
V8: Fix and clean up the restore media dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/media.restore.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.restore.controller.js
@@ -1,62 +1,74 @@
 angular.module("umbraco").controller("Umbraco.Editors.Media.RestoreController",
     function ($scope, relationResource, mediaResource, navigationService, appState, treeService, localizationService) {
 
-		var node = $scope.currentNode;
+        $scope.source = _.clone($scope.currentNode);
 
 		$scope.error = null;
 	    $scope.success = false;
+        $scope.loading = true;
 
-		relationResource.getByChildId(node.id, "relateParentDocumentOnDelete").then(function (data) {
+        relationResource.getByChildId($scope.source.id, "relateParentDocumentOnDelete").then(function (data) {
+            $scope.loading = false;
 
-            if (data.length == 0) {
-                $scope.success = false;
-                $scope.error = {
-                    errorMsg: localizationService.localize('recycleBin_itemCannotBeRestored'),
-                    data: {
-                        Message: localizationService.localize('recycleBin_noRestoreRelation')
-                    }
-                }
+            if (!data.length) {
+                localizationService.localizeMany(["recycleBin_itemCannotBeRestored", "recycleBin_noRestoreRelation"])
+                    .then(function(values) {
+                        $scope.success = false;
+                        $scope.error = {
+                            errorMsg: values[0],
+                            data: {
+                                Message: values[1]
+                            }
+                        }
+                    });
                 return;
             }
 
 		    $scope.relation = data[0];
 
-			if ($scope.relation.parentId == -1) {
+			if ($scope.relation.parentId === -1) {
 				$scope.target = { id: -1, name: "Root" };
 
 			} else {
+			    $scope.loading = true;
 			    mediaResource.getById($scope.relation.parentId).then(function (data) {
+			        $scope.loading = false;
                     $scope.target = data;
-
-                    // make sure the target item isn't in the recycle bin
-                    if ($scope.target.path.indexOf("-20") !== -1) {
-                        $scope.error = {
-                            errorMsg: localizationService.localize('recycleBin_itemCannotBeRestored'),
-                            data: {
-                                Message: localizationService.localize('recycleBin_restoreUnderRecycled').then(function (value) {
-                                    value.replace('%0%', $scope.target.name);
-                                })
-                            }
-                        };
+			        // make sure the target item isn't in the recycle bin
+                    if ($scope.target.path.indexOf("-21") !== -1) {
+                        localizationService.localizeMany(["recycleBin_itemCannotBeRestored", "recycleBin_restoreUnderRecycled"])
+                            .then(function (values) {
+                                $scope.success = false;
+                                $scope.error = {
+                                    errorMsg: values[0],
+                                    data: {
+                                        Message: values[1].replace('%0%', $scope.target.name)
+                                    }
+                                }
+                            });
                         $scope.success = false;
                     }
 
 				}, function (err) {
 					$scope.success = false;
 					$scope.error = err;
+			        $scope.loading = false;
 				});
 			}
 
 		}, function (err) {
 			$scope.success = false;
 			$scope.error = err;
+            $scope.loading = false;
 		});
 
 		$scope.restore = function () {
+		    $scope.loading = true;
 			// this code was copied from `content.move.controller.js`
-			mediaResource.move({ parentId: $scope.target.id, id: node.id })
+            mediaResource.move({ parentId: $scope.target.id, id: $scope.source.id })
 				.then(function (path) {
 
+                    $scope.loading = false;
 					$scope.success = true;
 
 					//first we need to remove the node that launched the dialog
@@ -79,6 +91,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.RestoreController",
 				}, function (err) {
 					$scope.success = false;
 					$scope.error = err;
+                    $scope.loading = false;
 				});
 		};
 

--- a/src/Umbraco.Web.UI.Client/src/views/media/restore.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/restore.html
@@ -2,24 +2,32 @@
 	<div class="umb-dialog-body">
 		<umb-pane>
 
-			<p class="abstract" ng-hide="error != null || success == true">
-				<localize key="actions_restore">Restore</localize> <strong>{{currentNode.name}}</strong> <localize key="general_under">under</localize> <strong>{{target.name}}</strong>?
+		    <umb-load-indicator
+		        ng-show="loading">
+		    </umb-load-indicator>
+
+		    <p class="abstract" ng-hide="loading || error != null || success">
+				<localize key="actions_restore">Restore</localize> <strong>{{source.name}}</strong> <localize key="general_under">under</localize> <strong>{{target.name}}</strong>?
             </p>
 
-            <div class="alert alert-error" ng-show="error != null">
-                <div><strong>{{error.errorMsg}}</strong></div>
-                <div>{{error.data.Message}}</div>
-            </div>
+		    <div ng-show="error">
+		        <div class="alert alert-error">
+		            <div><strong>{{error.errorMsg}}</strong></div>
+		            <div>{{error.data.Message}}</div>
+		        </div>
+		    </div>
 
-			<div class="alert alert-success" ng-show="success == true">
-				<p><strong>{{currentNode.name}}</strong> <localize key="editdatatype_wasMoved">was moved underneath</localize> <strong>{{target.name}}</strong></p>
-				<button class="btn btn-primary" ng-click="nav.hideDialog()"><localize key="general_ok">OK</localize></button>
-			</div>
+		    <div ng-show="success">
+		        <div class="alert alert-success">
+                    <strong>{{source.name}}</strong> <localize key="editdatatype_wasMoved">was moved underneath</localize> <strong>{{target.name}}</strong>
+		        </div>
+		        <button class="btn btn-primary" ng-click="close()"><localize key="general_ok">Ok</localize></button>
+		    </div>
 
 		</umb-pane>
 	</div>
 
-	<div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success == true">
+	<div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="loading || success">
 		<a class="btn btn-link" ng-click="close()"><localize key="general_cancel">Cancel</localize></a>
 		<button class="btn btn-primary" ng-click="restore()" ng-show="error == null"><localize key="actions_restore">Restore</localize></button>
 	</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

(similar to #3770 - just for media and with a few twists)

There are a few issues with the restore media dialog:

1. There is no "loading" state in the dialog, resulting in a fair bit of flickering between states.
2. Restoring a child to a parent that doesn't exist anymore produces a weird error message.
3. Restoring a child to a parent that's also in trash is allowed by the UI (!) and produces a YSOD.
4. The cancel buttons do not work.
5. The name of the target node for the restore operation is missing.
6. The success message is "old-style".
7. If the source node is not selected for editing when invoking the restore operation, the wrong source name occurs in the success message.

Here are a few demos of the issues above:

#### Flickering node name, unresponsive cancel button and "old-style" success

![media-item-restore-before-1](https://user-images.githubusercontent.com/7405322/49079840-0aef0500-f242-11e8-8b60-31f382ecffec.gif)

#### Restore beneath a deleted parent

![media-item-restore-before-2](https://user-images.githubusercontent.com/7405322/49079861-21955c00-f242-11e8-9594-4b100d9128c8.gif)

#### Weird error message when the parent does not exist anymore

![media-item-restore-before-3](https://user-images.githubusercontent.com/7405322/49079903-3d98fd80-f242-11e8-8fde-ffd64bff4785.gif)

#### How it looks with this PR applied

![media-item-restore-after](https://user-images.githubusercontent.com/7405322/49079947-55708180-f242-11e8-80b7-e32cb43b0f1f.gif)

#### Please note

The "Restore" menu icon is a folder. Not the "Undo" icon one would expect. I am waiting for #3773 to be reviewed, then I'll rewrite the media tree actions accordingly, which will fix the "Restore" icon.

