### PR TITLE
V8: Add a minimum height to the query builder dropdowns

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-querybuilder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-querybuilder.less
@@ -40,3 +40,7 @@
     flex: 0 1 auto;
     margin: 5px;
 }
+
+.umb-querybuilder .query-items .btn {
+    min-height: 2rem;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3765

### Description

#3765 describes the problem perfectly. 

To test this PR, simply open the query builder and verify that the height of empty dropdowns equal that of non-empty ones:

![query-builder-dropdown-size](https://user-images.githubusercontent.com/7405322/49108664-0994fb00-f289-11e8-8f61-cdae497b41f6.gif)
