### PR TITLE
V8: Add dirty tracking for slider and datetime

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -131,6 +131,7 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
         else {
             $scope.model.value = null;
         }
+        angularHelper.getCurrentForm($scope).$setDirty();
     }
 
     /** Sets the value of the date picker control adn associated viewModel objects based on the model value */

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -1,4 +1,4 @@
-﻿function sliderController($scope) {
+﻿function sliderController($scope, angularHelper) {
 
     let sliderRef = null;
 
@@ -14,13 +14,14 @@
 
     function setModelValue(values) {
         $scope.model.value = values ? values.toString() : null;
+        angularHelper.getCurrentForm($scope).$setDirty();
     }
 
     $scope.setup = function(slider) {
         sliderRef = slider;
     };
 
-    $scope.end = function(values) {
+    $scope.change = function (values) {
         setModelValue(values);
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.html
@@ -5,7 +5,7 @@
             ng-model="sliderValue"
             options="sliderOptions"
             on-setup="setup(slider)"
-            on-end="end(values)">
+            on-change="change(values)">
         </umb-range-slider>
     </div>
     


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3779

### Description

#3779 contains steps to reproduce/test.

Incidentally this PR also fixes another issue with the slider: As-is the slider value is only persisted if you actually slide the handle - not if you just click somewhere on the slider to change the value.

Here's how it looks with this PR applied:

![slider-datepicker-set-dirty-v2](https://user-images.githubusercontent.com/7405322/49149548-a8157080-f30a-11e8-9409-67752bd6f752.gif)

