### PR TITLE
Saving content id against initial SavePublish action

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2575,8 +2575,18 @@ namespace Umbraco.Core.Services
                         _publishingStrategy.PublishingFinalized(uow, descendants, false);
                     }
 
-                    Audit(uow, AuditType.Publish, "Save and Publish performed by user", userId, content.Id);
                     uow.Commit();
+
+                    if (publishStatus.StatusType == PublishStatusType.Success)
+                    {
+                        Audit(uow, AuditType.Publish, "Save and Publish performed by user", userId, content.Id);
+                    }
+                    else
+                    {
+                        Audit(uow, AuditType.Save, "Save performed by user", userId, content.Id);
+                    }
+                    uow.Commit();
+
                     return Attempt.If(publishStatus.StatusType == PublishStatusType.Success, publishStatus);
                 }
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

There isn't an existing issue, but this was raised in the forums here: https://our.umbraco.com/forum/using-umbraco-and-getting-started/94778-why-is-no-history-item-set-one-the-first-publish

### Description
Nikola posts quite a good video explaining the issue on https://our.umbraco.com/forum/using-umbraco-and-getting-started/94778-why-is-no-history-item-set-one-the-first-publish but basically on initial save and publish, node ids are not getting saved to the umbracoLog table so in the node Info tab > History table, initial saves are not showing up.

I think this is because the unitofwork has not made the initial call to save the content to the database when the audit log is updated, so swapping these calls seems to solve the issue. Did briefly approach @warrenbuckley on this to see if this is (in fact) behaviour by design, so if it is feel - free to ignore :)

This can be tested by saving a new doctype and checking the Info tab > History table.
