### PR TITLE
Add "default empty" prevalue to date and datetime

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -145,9 +145,9 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
 
 			    var element = $element.find("div:first");
 
-				// Open the datepicker and add a changeDate eventlistener
+                // Open the datepicker and add a changeDate eventlistener
 			    element
-			        .datetimepicker(angular.extend({ useCurrent: true }, $scope.model.config))
+			        .datetimepicker(angular.extend({ useCurrent: $scope.model.config.defaultEmpty !== "1" }, $scope.model.config))
 			        .on("dp.change", applyDate)
 			        .on("dp.error", function(a, b, c) {
 			            $scope.hasDatetimePickerValue = false;

--- a/src/Umbraco.Web/PropertyEditors/DatePreValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DatePreValueEditor.cs
@@ -6,5 +6,8 @@ namespace Umbraco.Web.PropertyEditors
     {
         [PreValueField("format", "Date format", "textstring", Description = "If left empty then the format is YYYY-MM-DD. (see momentjs.com for supported formats)")]
         public string DefaultValue { get; set; }
+
+        [PreValueField("defaultEmpty", "Default empty", "boolean", Description = "When enabled the date picker will remain empty when opened. Otherwise it will default to \"today\".")]
+        public string DefaultEmpty { get; set; }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3776

### Description

As described in #3776, the date and datetime property editors always default to "today" when opened:

![date-picker-before](https://user-images.githubusercontent.com/7405322/49181555-fc930d00-f357-11e8-875d-808025e4b553.gif)

This PR adds a "Default empty" prevalue to both property editors. If it's enabled, the date picker will stay empty when opened:

![image](https://user-images.githubusercontent.com/7405322/49181623-29472480-f358-11e8-8011-fdec4bcca477.png)

![image](https://user-images.githubusercontent.com/7405322/49181652-3c59f480-f358-11e8-8f78-51edc6f2a36e.png)

It looks like this in action:

![date-picker-after](https://user-images.githubusercontent.com/7405322/49181667-454ac600-f358-11e8-9394-2b7951175fa5.gif)

#### Backwards compatibility

Since this new prevalue is a boolean that defaults to the current behavior, there are no issues with backwards compatibility and thus no need for a migration.

#### V8 concerns

The current date picker component has been replaced with flatpickr in V8. Therefore this PR can't be merged to V8.  I'll put together a separate PR for V8.