### PR TITLE
Add search to "move media" dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/media.move.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.move.controller.js
@@ -6,6 +6,14 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
 	    $scope.dialogTreeEventHandler = $({});
 	    var node = dialogOptions.currentNode;
 
+        $scope.busy = false;
+        $scope.searchInfo = {
+            searchFromId: null,
+            searchFromName: null,
+            showSearch: false,
+            results: [],
+            selectedSearchResults: []
+        }
         $scope.treeModel = {
             hideHeader: false
         }
@@ -44,9 +52,24 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
 			}
 	    }
 
-	    $scope.dialogTreeEventHandler.bind("treeLoaded", treeLoadedHandler);
-	    $scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
-	    $scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
+        $scope.hideSearch = function () {
+            $scope.searchInfo.showSearch = false;
+            $scope.searchInfo.searchFromId = null;
+            $scope.searchInfo.searchFromName = null;
+            $scope.searchInfo.results = [];
+        }
+
+        // method to select a search result 
+        $scope.selectResult = function (evt, result) {
+            result.selected = result.selected === true ? false : true;
+            nodeSelectHandler(evt, { event: evt, node: result });
+        };
+
+        //callback when there are search results 
+        $scope.onSearchResults = function (results) {
+            $scope.searchInfo.results = results;
+            $scope.searchInfo.showSearch = true;
+        };
 
 	    $scope.move = function () {
 	        $scope.busy = true;
@@ -78,6 +101,10 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
                     $scope.error = err;
                 });
 	    };
+
+        $scope.dialogTreeEventHandler.bind("treeLoaded", treeLoadedHandler);
+        $scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
+        $scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
 
 	    $scope.$on('$destroy', function () {
 	        $scope.dialogTreeEventHandler.unbind("treeLoaded", treeLoadedHandler);

--- a/src/Umbraco.Web.UI.Client/src/views/media/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/move.html
@@ -25,15 +25,34 @@
 		    <div ng-hide="success">
             
 			    <div ng-hide="miniListView">
-				    <umb-tree
-					    section="media"
-				        hideheader="{{treeModel.hideHeader}}"
-					    hideoptions="true"
-					    isdialog="true"
-					    eventhandler="dialogTreeEventHandler"
-					    enablelistviewexpand="true"
-					    enablecheckboxes="true">
-				    </umb-tree>
+                    <umb-tree-search-box 
+                        hide-search-callback="hideSearch"
+                        search-callback="onSearchResults"
+                        search-from-id="{{searchInfo.searchFromId}}"
+                        search-from-name="{{searchInfo.searchFromName}}"
+                        show-search="{{searchInfo.showSearch}}"
+                        section="media">
+                    </umb-tree-search-box>
+
+                    <br />
+
+                    <umb-tree-search-results
+                        ng-if="searchInfo.showSearch"
+                        results="searchInfo.results"
+                        select-result-callback="selectResult">
+                    </umb-tree-search-results>
+
+                    <div ng-hide="searchInfo.showSearch">
+                        <umb-tree
+                            section="media"
+                            hideheader="{{treeModel.hideHeader}}"
+                            hideoptions="true"
+                            isdialog="true"
+                            eventhandler="dialogTreeEventHandler"
+                            enablelistviewexpand="true"
+                            enablecheckboxes="true">
+                        </umb-tree>
+                    </div>
 			    </div>
 
 			    <umb-mini-list-view


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

While working on a feature, I realized that the "move media" dialog doesn't have a search option like its content counterpart:

![image](https://user-images.githubusercontent.com/7405322/49233928-572f7600-f3f7-11e8-85c7-62854bb0d62a.png)

This PR adds that search option:

![move-media-search](https://user-images.githubusercontent.com/7405322/49233888-41ba4c00-f3f7-11e8-842a-5d902ab93ff7.gif)

