### PR TITLE
Add instructions on how to apply a display name in notification emails

### DIFF
--- a/src/Umbraco.Web.UI/config/umbracoSettings.Release.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.Release.config
@@ -32,6 +32,7 @@
     
     <notifications>
       <!-- the email that should be used as from mail when umbraco sends a notification -->
+      <!-- you can add a display name to the email like thist: <email>Your display name here &lt;your@email.here&gt;</email> -->
       <email>your@email.here</email>
     </notifications>
 

--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -48,6 +48,7 @@
     </errors>
     <notifications>
       <!-- the email that should be used as from mail when umbraco sends a notification -->
+      <!-- you can add a display name to the email like this: <email>Your display name here &lt;your@email.here&gt;</email> -->
       <email>your@email.here</email>
     </notifications>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3797

### Description

This adds an extra comment in `umbracoSettings.config` to help people figure out how to apply a display name to notification emails. See #3797.

![image](https://user-images.githubusercontent.com/7405322/49247397-78a05a00-f417-11e8-8c19-66a5bac474ff.png)
