### PR TITLE
Show only the success message upon successful update of notifications

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/notify.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/notify.html
@@ -15,10 +15,11 @@
                     <div class="alert alert-success">
                         <localize key="notify_notificationsSavedFor"></localize><strong> {{currentNode.name}}</strong>
                     </div>
+                    <button class="btn btn-primary" ng-click="vm.cancel()"><localize key="general_ok">Ok</localize></button>
                 </div>
-                <div ng-cloak>
+                <div ng-hide="vm.saveSuccces || vm.saveError" ng-cloak>
                     <div class="block-form" ng-show="!vm.loading">
-                        <h5><localize key="notify_notifySet">Set your notification for</localize> {{ currentNode.name }}</h5>
+                        <localize key="notify_notifySet">Set your notification for</localize> <strong>{{ currentNode.name }}</strong>
                         <umb-control-group>
                             <umb-permission ng-repeat="option in vm.notifyOptions"
                                             name="option.name"
@@ -31,7 +32,7 @@
             </form>
         </div>
     </div>
-    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="vm.saveSuccces || vm.saveError">
         <umb-button label-key="general_cancel"
                     action="vm.cancel()"
                     type="button"
@@ -40,6 +41,7 @@
         <umb-button label-key="buttons_save"
                     type="button"
                     action="vm.save(vm.notifyOptions)"
+                    state="vm.saveState"
                     button-style="success">
         </umb-button>
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you have a small(ish) screen or simply a small(ish) browser window, you won't see the success message when updating your notification settings. And there are no other indications that your settings were saved:

![notify-save-before](https://user-images.githubusercontent.com/7405322/49294145-6a534c00-f4b2-11e8-93a8-917a9a1dfa19.gif)

Also, you have to click "Cancel" to remove the dialog again, which isn't terribly intuitive either.

With this PR the notifications dialog acts like all (most of?) the other ones: It displays *only* the success message along with an OK button to close the dialog:

![notify-save-after](https://user-images.githubusercontent.com/7405322/49294230-ad152400-f4b2-11e8-9d35-3d7db0e8a284.gif)

Oh yes, and I changed the header text to plain text instead of a H5 (this is also in line with the other dialogs).