### PR TITLE
V8: Replace jquery dependencies for partial snippets

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/EditProfile.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/EditProfile.cshtml
@@ -9,9 +9,9 @@
 
     Html.EnableClientValidation();
     Html.EnableUnobtrusiveJavaScript();
-    Html.RequiresJs("/umbraco/lib/jquery/jquery.min.js");
-    Html.RequiresJs("/umbraco/lib/jquery-validate/jquery.validate.min.js");
-    Html.RequiresJs("/umbraco/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js");
+    Html.RequiresJs("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js");
+    Html.RequiresJs("https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.0/jquery.validate.min.js");
+    Html.RequiresJs("https://cdnjs.cloudflare.com/ajax/libs/jquery-validation-unobtrusive/3.2.11/jquery.validate.unobtrusive.min.js");
 
     var success = TempData["ProfileUpdateSuccess"] != null;
 }

--- a/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/Login.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/Login.cshtml
@@ -10,9 +10,9 @@
 
     Html.EnableClientValidation();
     Html.EnableUnobtrusiveJavaScript();
-    Html.RequiresJs("/umbraco/lib/jquery/jquery.min.js");
-    Html.RequiresJs("/umbraco/lib/jquery-validate/jquery.validate.min.js");
-    Html.RequiresJs("/umbraco/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js");
+    Html.RequiresJs("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js");
+    Html.RequiresJs("https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.0/jquery.validate.min.js");
+    Html.RequiresJs("https://cdnjs.cloudflare.com/ajax/libs/jquery-validation-unobtrusive/3.2.11/jquery.validate.unobtrusive.min.js");
 }
 
 @* NOTE: This RenderJsHere code should be put on your main template page where the rest of your script tags are placed *@

--- a/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/LoginStatus.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/LoginStatus.cshtml
@@ -1,5 +1,4 @@
 ﻿@using System.Web.Mvc.Html
-@using ClientDependency.Core.Mvc
 @using Umbraco.Web
 @using Umbraco.Web.Models
 @using Umbraco.Web.Controllers
@@ -7,13 +6,6 @@
 
 @{
     var loginStatusModel = Members.GetCurrentLoginStatus();
-
-    Html.EnableClientValidation();
-    Html.EnableUnobtrusiveJavaScript();
-    Html.RequiresJs("/umbraco/lib/jquery/jquery.min.js");
-    Html.RequiresJs("/umbraco/lib/jquery-validate/jquery.validate.min.js");
-    Html.RequiresJs("/umbraco/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js");
-
     var logoutModel = new PostRedirectModel();
 
     @*
@@ -23,9 +15,6 @@
         logoutModel.RedirectUrl = "/";
     *@
 }
-
-@* NOTE: This RenderJsHere code should be put on your main template page where the rest of your script tags are placed *@
-@Html.RenderJsHere()
 
 @if (loginStatusModel.IsLoggedIn)
 {

--- a/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/RegisterMember.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/RegisterMember.cshtml
@@ -33,9 +33,9 @@
 
     Html.EnableClientValidation();
     Html.EnableUnobtrusiveJavaScript();
-    Html.RequiresJs("/umbraco/lib/jquery/jquery.min.js");
-    Html.RequiresJs("/umbraco/lib/jquery-validate/jquery.validate.min.js");
-    Html.RequiresJs("/umbraco/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js");
+    Html.RequiresJs("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js");
+    Html.RequiresJs("https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.0/jquery.validate.min.js");
+    Html.RequiresJs("https://cdnjs.cloudflare.com/ajax/libs/jquery-validation-unobtrusive/3.2.11/jquery.validate.unobtrusive.min.js");
 
     var success = TempData["FormSuccess"] != null;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3787

### Description

This PR breaks the dependency on the core jQuery libs as outlined in #3787.

Instead of referencing `/umbraco/lib/`, the partial snippets now reference `https://cdnjs.cloudflare.com/ajax/libs/`. Specifically for `LoginStatus.cshtml` the jQuery dependencies have been removed, as they don't seem to be used at all.

At the moment there are some DI errors that makes it really hard to test this properly. Properties decorated with `[Inject]` on `MembershipHelper` seem to be ignored - here's how it looks when trying to execute `LoginStatus.cshtml`:

![image](https://user-images.githubusercontent.com/7405322/49327969-cd9fb580-f568-11e8-9f2f-ea64faf90127.png)
 
The only currently testable snippet is `Login.cshtml` and it works just fine, so there is every reason to believe that the rest of the snippets work as well. But... the rest should be tested when the DI works again.

🎄 1/24 🎄 