### PR TITLE
Reload the recycle bin when deleting an item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting content
  */
-function ContentDeleteController($scope, contentResource, treeService, navigationService, editorState, $location, dialogService, notificationsService, $timeout) {
+function ContentDeleteController($scope, contentResource, treeService, navigationService, editorState, $location, dialogService, notificationsService) {
 
     $scope.performDelete = function() {
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -26,10 +26,14 @@ function ContentDeleteController($scope, contentResource, treeService, navigatio
             treeService.removeNode($scope.currentNode);
 
             if (rootNode) {
+                //ensure the recycle bin has child nodes now            
                 var recycleBin = treeService.getDescendantNode(rootNode, -20);
                 if (recycleBin) {
-                    // reload the recycle bin
-                    treeService.loadNodeChildren({ node: recycleBin, section: "content" });
+                    recycleBin.hasChildren = true;
+                    //reload the recycle bin if it's already expanded so the deleted item is shown
+                    if (recycleBin.expanded) {
+                        treeService.loadNodeChildren({ node: recycleBin, section: "content" });
+                    }
                 }
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting content
  */
-function ContentDeleteController($scope, contentResource, treeService, navigationService, editorState, $location, dialogService, notificationsService) {
+function ContentDeleteController($scope, contentResource, treeService, navigationService, editorState, $location, dialogService, notificationsService, $timeout) {
 
     $scope.performDelete = function() {
 
@@ -26,13 +26,13 @@ function ContentDeleteController($scope, contentResource, treeService, navigatio
             treeService.removeNode($scope.currentNode);
 
             if (rootNode) {
-                //ensure the recycle bin has child nodes now            
                 var recycleBin = treeService.getDescendantNode(rootNode, -20);
                 if (recycleBin) {
-                    recycleBin.hasChildren = true;
+                    // reload the recycle bin
+                    treeService.loadNodeChildren({ node: recycleBin, section: "content" });
                 }
             }
-            
+
             //if the current edited item is the same one as we're deleting, we need to navigate elsewhere
             if (editorState.current && editorState.current.id == $scope.currentNode.id) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
@@ -26,10 +26,14 @@ function MediaDeleteController($scope, mediaResource, treeService, navigationSer
             treeService.removeNode($scope.currentNode);
 
             if (rootNode) {
+                //ensure the recycle bin has child nodes now            
                 var recycleBin = treeService.getDescendantNode(rootNode, -21);
                 if (recycleBin) {
-                    // reload the recycle bin
-                    treeService.loadNodeChildren({ node: recycleBin, section: "media" });
+                    recycleBin.hasChildren = true;
+                    //reload the recycle bin if it's already expanded so the deleted item is shown
+                    if (recycleBin.expanded) {
+                        treeService.loadNodeChildren({ node: recycleBin, section: "media" });
+                    }
                 }
             }
             

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
@@ -26,10 +26,10 @@ function MediaDeleteController($scope, mediaResource, treeService, navigationSer
             treeService.removeNode($scope.currentNode);
 
             if (rootNode) {
-                //ensure the recycle bin has child nodes now            
                 var recycleBin = treeService.getDescendantNode(rootNode, -21);
                 if (recycleBin) {
-                    recycleBin.hasChildren = true;
+                    // reload the recycle bin
+                    treeService.loadNodeChildren({ node: recycleBin, section: "media" });
                 }
             }
             


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The recycle bin doesn't reload when you delete item things in content or media. If you have the recycle bin open when deleting things, it's a bit worrying that they seem to simply just disappear entirely from the tree (you have to reload manually to see them): 

![reload-recycle-bin-before](https://user-images.githubusercontent.com/7405322/49393901-dd6af580-f732-11e8-92c8-167dfae60cc2.gif)

With this PR, the recycle bin reloads if it's open (can't reload it if it's closed as that would force it to open):

![reload-recycle-bin-after](https://user-images.githubusercontent.com/7405322/49394040-2a4ecc00-f733-11e8-8c03-693a80f380c9.gif)

🎄 3/24 🎄 