### PR TITLE
Limit version of Microsoft.AspNet.WebApi.WebHost to be below 5.2.7

### DIFF
--- a/build/NuSpecs/UmbracoCms.Core.nuspec
+++ b/build/NuSpecs/UmbracoCms.Core.nuspec
@@ -19,6 +19,7 @@
       <dependency id="Log4Net.Async" version="[2.0.4,3.0.0)" />
       <dependency id="Microsoft.AspNet.Mvc" version="[5.2.3,6.0.0)" />
       <dependency id="Microsoft.AspNet.WebApi" version="[5.2.3,6.0.0)" />
+      <dependency id="Microsoft.AspNet.WebApi.WebHost" version="[5.2.3,5.2.7)" />
       <dependency id="Microsoft.AspNet.Identity.Owin" version="[2.2.1, 3.0.0)" />
       <dependency id="Microsoft.AspNet.SignalR.Core" version="[2.2.1, 3.0.0)" />
       <dependency id="Microsoft.Owin.Security.Cookies" version="[3.1.0, 4.0.0)" />


### PR DESCRIPTION
### Prerequisites
Temporary workaround for issue: https://github.com/umbraco/Umbraco-CMS/issues/3796

### Description
Updating `Microsoft.AspNet.WebApi.WebHost` to 5.2.7 breaks the Umbraco back-office tree (because of some proxying between controllers according to @Shazwazza in https://github.com/umbraco/Umbraco-CMS/issues/3796#issuecomment-443029066).

As temporary workaround, this version can be limited to be below 5.2.7 untill the controller code is rewritten/updated to work with this new version (and if possible with existing older versions)...