### PR TITLE
Fixed url redirect creation issue

### DIFF
--- a/src/Umbraco.Web/Routing/RedirectTrackingEventHandler.cs
+++ b/src/Umbraco.Web/Routing/RedirectTrackingEventHandler.cs
@@ -190,14 +190,14 @@ namespace Umbraco.Web.Routing
                 // else save routes for all descendants
                 var entityContent = contentCache.GetById(entity.Id);
                 if (entityContent == null) continue;
+
                 foreach (var x in entityContent.DescendantsOrSelf())
                 {
-                    var route = contentCache.GetRouteById(x.Id);
-                    if (IsNotRoute(route)) continue;
+                    if (IsNotRoute(x.Url)) continue;
                     var wk = UnwrapToKey(x);
                     if (wk == null) continue;
 
-                    OldRoutes[x.Id] = Tuple.Create(wk.Key, route);
+                    OldRoutes[x.Id] = Tuple.Create(wk.Key, x.Url);
                 }
             }
 


### PR DESCRIPTION
Issue: https://github.com/umbraco/Umbraco-CMS/issues/3186
Previous PR: https://github.com/umbraco/Umbraco-CMS/pull/3286

This pull requests resolves the issue of the wrong original URL being used for creating redirects when having implemented custom URL providers.

For the creation of redirects, the source of the original url was determined by the route property of the content. Using the url property instead makes the creation of redirects also compatible with custom url providers.

Tested using the custom url provider sebastiaan created when testing the previous pull request. Thanks @nul800sebastiaan 

```
public class CustomUrlProvider : IUrlProvider
    {
        public string GetUrl(UmbracoContext umbracoContext, int id, Uri current, UrlProviderMode mode)
        {
            var content = umbracoContext.ContentCache.GetById(id);

            if (content != null && content.DocumentTypeAlias == "product")
            {
                return   content.Name.ReverseString().ToUrlSegment().EnsureStartsWith("/");
            }

            return null;
        }

        public IEnumerable<string> GetOtherUrls(UmbracoContext umbracoContext, int id, Uri current)
        {
            var content = umbracoContext.ContentCache.GetById(id);

            if (content != null && content.DocumentTypeAlias == "product")
            {
                var urls = new List<string>();

                urls.Add(content.Name.ToUrlSegment().EnsureStartsWith("/"));

                return urls;
            }

            return null;
        }
    }

    public class CustomUrlContentFinder : IContentFinder
    {
        public bool TryFindContent(PublishedContentRequest contentRequest)
        {
            if (contentRequest == null)
                return false;

            var uri = contentRequest.Uri;

            var segments = uri.Segments.Where(x => x != "/").ToList();

            if (segments.Any() && segments.Count == 1)
            {
                var urlPart = segments.First();

                var products = UmbracoContext.Current.ContentCache.GetByXPath("//product[@isDoc]").ToList();

                var matchedProduct = products.FirstOrDefault(x =>
                    x.Name.ReverseString().ToUrlSegment() == urlPart || x.Name.ToUrlSegment() == urlPart);

                if (matchedProduct != null)
                {
                    contentRequest.PublishedContent = matchedProduct;
                    return true;
                }
            }

            return false;
        }
    }

    public class UrlProviderRegistration : ApplicationEventHandler
    {
        protected override void ApplicationStarting(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
        {
            ContentFinderResolver.Current.InsertTypeBefore<ContentFinderByNotFoundHandlers, CustomUrlContentFinder>();
            UrlProviderResolver.Current.InsertTypeBefore<DefaultUrlProvider, CustomUrlProvider>();
        }
    }
```


