### PR TITLE
Fix edit content localization errors

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1079,10 +1079,10 @@ Mange hilsner fra Umbraco robotten
     <key alias="dictionaryItemSaved">Ordbogsnøgle gemt</key>
     <key alias="editContentPublishedHeader">Indhold publiceret</key>
     <key alias="editContentPublishedText">og nu synligt for besøgende</key>
-    <key alias="editContentPublishedWithExpireDateText">og nu synligt for besøgende indtil {0}</key>
+    <key alias="editContentPublishedWithExpireDateText">og nu synligt for besøgende indtil %0%</key>
     <key alias="editContentSavedHeader">Indhold gemt</key>
     <key alias="editContentSavedText">Husk at publicere for at gøre det synligt for besøgende</key>
-    <key alias="editContentSavedWithReleaseDateText">Ændringerne bliver publiceret den {0}</key>
+    <key alias="editContentSavedWithReleaseDateText">Ændringerne bliver publiceret den %0%</key>
     <key alias="editContentSendToPublish">Send til Godkendelse</key>
     <key alias="editContentSendToPublishText">Rettelser er blevet sendt til godkendelse</key>
     <key alias="editMediaSaved">Medie gemt</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1079,10 +1079,10 @@ Mange hilsner fra Umbraco robotten
     <key alias="dictionaryItemSaved">Ordbogsnøgle gemt</key>
     <key alias="editContentPublishedHeader">Indhold publiceret</key>
     <key alias="editContentPublishedText">og nu synligt for besøgende</key>
-    <key alias="editContentPublishedWithExpireDateText">og nu synligt for besøgende indtil %0%</key>
+    <key alias="editContentPublishedWithExpireDateText">og nu synligt for besøgende indtil %0% kl. %1%</key>
     <key alias="editContentSavedHeader">Indhold gemt</key>
     <key alias="editContentSavedText">Husk at publicere for at gøre det synligt for besøgende</key>
-    <key alias="editContentSavedWithReleaseDateText">Ændringerne bliver publiceret den %0%</key>
+    <key alias="editContentSavedWithReleaseDateText">Ændringerne bliver publiceret den %0% kl. %1%</key>
     <key alias="editContentSendToPublish">Send til Godkendelse</key>
     <key alias="editContentSendToPublishText">Rettelser er blevet sendt til godkendelse</key>
     <key alias="editMediaSaved">Medie gemt</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1397,10 +1397,10 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="editContentPublishedFailedByParent">Publishing failed because the parent page isn't published</key>
         <key alias="editContentPublishedHeader">Content published</key>
         <key alias="editContentPublishedText">and visible on the website</key>
-        <key alias="editContentPublishedWithExpireDateText">and visible on the website until {0}</key>
+        <key alias="editContentPublishedWithExpireDateText">and visible on the website until %0%</key>
         <key alias="editContentSavedHeader">Content saved</key>
         <key alias="editContentSavedText">Remember to publish to make changes visible</key>
-        <key alias="editContentSavedWithReleaseDateText">Changes will be published on {0}</key>
+        <key alias="editContentSavedWithReleaseDateText">Changes will be published on %0%</key>
         <key alias="editContentSendToPublish">Sent For Approval</key>
         <key alias="editContentSendToPublishText">Changes have been sent for approval</key>
         <key alias="editMediaSaved">Media saved</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1397,10 +1397,10 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="editContentPublishedFailedByParent">Publishing failed because the parent page isn't published</key>
         <key alias="editContentPublishedHeader">Content published</key>
         <key alias="editContentPublishedText">and visible on the website</key>
-        <key alias="editContentPublishedWithExpireDateText">and visible on the website until %0%</key>
+        <key alias="editContentPublishedWithExpireDateText">and visible on the website until %0% at %1%</key>
         <key alias="editContentSavedHeader">Content saved</key>
         <key alias="editContentSavedText">Remember to publish to make changes visible</key>
-        <key alias="editContentSavedWithReleaseDateText">Changes will be published on %0%</key>
+        <key alias="editContentSavedWithReleaseDateText">Changes will be published on %0% at %1%</key>
         <key alias="editContentSendToPublish">Sent For Approval</key>
         <key alias="editContentSendToPublishText">Changes have been sent for approval</key>
         <key alias="editMediaSaved">Media saved</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1396,10 +1396,10 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="editContentPublishedFailedByParent">Publishing failed because the parent page isn't published</key>
         <key alias="editContentPublishedHeader">Content published</key>
         <key alias="editContentPublishedText">and visible on the website</key>
-        <key alias="editContentPublishedWithExpireDateText">and visible on the website until %0%</key>
+        <key alias="editContentPublishedWithExpireDateText">and visible on the website until %0% at %1%</key>
         <key alias="editContentSavedHeader">Content saved</key>
         <key alias="editContentSavedText">Remember to publish to make changes visible</key>
-        <key alias="editContentSavedWithReleaseDateText">Changes will be published on %0%</key>
+        <key alias="editContentSavedWithReleaseDateText">Changes will be published on %0% at %1%</key>
         <key alias="editContentSendToPublish">Sent For Approval</key>
         <key alias="editContentSendToPublishText">Changes have been sent for approval</key>
         <key alias="editMediaSaved">Media saved</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1396,10 +1396,10 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="editContentPublishedFailedByParent">Publishing failed because the parent page isn't published</key>
         <key alias="editContentPublishedHeader">Content published</key>
         <key alias="editContentPublishedText">and visible on the website</key>
-        <key alias="editContentPublishedWithExpireDateText">and visible on the website until {0}</key>
+        <key alias="editContentPublishedWithExpireDateText">and visible on the website until %0%</key>
         <key alias="editContentSavedHeader">Content saved</key>
         <key alias="editContentSavedText">Remember to publish to make changes visible</key>
-        <key alias="editContentSavedWithReleaseDateText">Changes will be published on {0}</key>
+        <key alias="editContentSavedWithReleaseDateText">Changes will be published on %0%</key>
         <key alias="editContentSendToPublish">Sent For Approval</key>
         <key alias="editContentSendToPublishText">Changes have been sent for approval</key>
         <key alias="editMediaSaved">Media saved</key>

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -697,7 +697,7 @@ namespace Umbraco.Web.Editors
                         display.AddSuccessNotification(
                             Services.TextService.Localize("speechBubbles/editContentSavedHeader"),
                             contentItem.ReleaseDate.HasValue
-                                ? Services.TextService.Localize("speechBubbles/editContentSavedWithReleaseDateText", new [] { $"{contentItem.ReleaseDate.Value.ToLongDateString()} {contentItem.ReleaseDate.Value.ToString("HH:mm")}" })
+                                ? Services.TextService.Localize("speechBubbles/editContentSavedWithReleaseDateText", new [] { $"{contentItem.ReleaseDate.Value.ToLongDateString()} {contentItem.ReleaseDate.Value.ToShortTimeString()}" })
                                 : Services.TextService.Localize("speechBubbles/editContentSavedText")
                         );
                     }
@@ -1052,7 +1052,7 @@ namespace Umbraco.Web.Editors
                     display.AddSuccessNotification(
                             Services.TextService.Localize("speechBubbles/editContentPublishedHeader"),
                             expireDate.HasValue
-                                ? Services.TextService.Localize("speechBubbles/editContentPublishedWithExpireDateText", new [] { $"{expireDate.Value.ToLongDateString()} {expireDate.Value.ToString("HH:mm")}" })
+                                ? Services.TextService.Localize("speechBubbles/editContentPublishedWithExpireDateText", new [] { $"{expireDate.Value.ToLongDateString()} {expireDate.Value.ToShortTimeString()}" })
                                 : Services.TextService.Localize("speechBubbles/editContentPublishedText")
                     );
                     break;

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -697,8 +697,7 @@ namespace Umbraco.Web.Editors
                         display.AddSuccessNotification(
                             Services.TextService.Localize("speechBubbles/editContentSavedHeader"),
                             contentItem.ReleaseDate.HasValue
-                                ? string.Format(Services.TextService.Localize("speechBubbles/editContentSavedWithReleaseDateText"),
-                                    $"{contentItem.ReleaseDate.Value.ToLongDateString()} {contentItem.ReleaseDate.Value.ToString("HH:mm")}")
+                                ? Services.TextService.Localize("speechBubbles/editContentSavedWithReleaseDateText", new [] { $"{contentItem.ReleaseDate.Value.ToLongDateString()} {contentItem.ReleaseDate.Value.ToString("HH:mm")}" })
                                 : Services.TextService.Localize("speechBubbles/editContentSavedText")
                         );
                     }
@@ -1053,8 +1052,7 @@ namespace Umbraco.Web.Editors
                     display.AddSuccessNotification(
                             Services.TextService.Localize("speechBubbles/editContentPublishedHeader"),
                             expireDate.HasValue
-                                ? string.Format(Services.TextService.Localize("speechBubbles/editContentPublishedWithExpireDateText"),
-                                    $"{expireDate.Value.ToLongDateString()} {expireDate.Value.ToString("HH:mm")}")
+                                ? Services.TextService.Localize("speechBubbles/editContentPublishedWithExpireDateText", new [] { $"{expireDate.Value.ToLongDateString()} {expireDate.Value.ToString("HH:mm")}" })
                                 : Services.TextService.Localize("speechBubbles/editContentPublishedText")
                     );
                     break;

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -697,7 +697,7 @@ namespace Umbraco.Web.Editors
                         display.AddSuccessNotification(
                             Services.TextService.Localize("speechBubbles/editContentSavedHeader"),
                             contentItem.ReleaseDate.HasValue
-                                ? Services.TextService.Localize("speechBubbles/editContentSavedWithReleaseDateText", new [] { $"{contentItem.ReleaseDate.Value.ToLongDateString()} {contentItem.ReleaseDate.Value.ToShortTimeString()}" })
+                                ? Services.TextService.Localize("speechBubbles/editContentSavedWithReleaseDateText", new [] { contentItem.ReleaseDate.Value.ToLongDateString(), contentItem.ReleaseDate.Value.ToShortTimeString() })
                                 : Services.TextService.Localize("speechBubbles/editContentSavedText")
                         );
                     }
@@ -1052,7 +1052,7 @@ namespace Umbraco.Web.Editors
                     display.AddSuccessNotification(
                             Services.TextService.Localize("speechBubbles/editContentPublishedHeader"),
                             expireDate.HasValue
-                                ? Services.TextService.Localize("speechBubbles/editContentPublishedWithExpireDateText", new [] { $"{expireDate.Value.ToLongDateString()} {expireDate.Value.ToShortTimeString()}" })
+                                ? Services.TextService.Localize("speechBubbles/editContentPublishedWithExpireDateText", new [] { expireDate.Value.ToLongDateString(), expireDate.Value.ToShortTimeString() })
                                 : Services.TextService.Localize("speechBubbles/editContentPublishedText")
                     );
                     break;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/pull/3507#pullrequestreview-182524106

### Description

As @Shazwazza points out in his review of #3507, the localization string formats are out of place for `editContentPublishedWithExpireDateText` and `editContentSavedWithReleaseDateText` (using `{0}` instead of `%0%`). 

This PR cleans the texts up and uses the correct formatting in `ContentController`. I have also swapped the hardcoded `HH:mm` time format with a localized one.

/cc @nul800sebastiaan 
