### PR TITLE
Redirect to recycle bin after deletion

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -38,7 +38,9 @@ function ContentDeleteController($scope, contentResource, treeService, navigatio
 
                 //If the deleted item lived at the root then just redirect back to the root, otherwise redirect to the item's parent
                 var location = "/content";
-                if ($scope.currentNode.parentId.toString() !== "-1")
+                if ($scope.currentNode.parentId.toString() === "-20")
+                    location = "/content/content/recyclebin";
+                else if ($scope.currentNode.parentId.toString() !== "-1")
                     location = "/content/content/edit/" + $scope.currentNode.parentId;
 
                 $location.path(location);

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
@@ -37,8 +37,10 @@ function MediaDeleteController($scope, mediaResource, treeService, navigationSer
             if (editorState.current && editorState.current.id == $scope.currentNode.id) {
 
             	//If the deleted item lived at the root then just redirect back to the root, otherwise redirect to the item's parent
-            	var location = "/media";
-            	if ($scope.currentNode.parentId.toString() !== "-1")
+                var location = "/media";
+                if ($scope.currentNode.parentId.toString() === "-21")
+                    location = "/media/media/recyclebin";
+            	else if ($scope.currentNode.parentId.toString() !== "-1")
             		location = "/media/media/edit/" + $scope.currentNode.parentId;
 
                 $location.path(location);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3841

### Description

To clarify @sniffdk's description in #3841, here are the steps to reproduce:

1. Delete an item
2. Open the deleted item from the recycle bin
3. Delete the item
4. The error occurs

It looks like this:

![delete-reload-before](https://user-images.githubusercontent.com/7405322/49684655-f7139080-fad6-11e8-9629-6e4979846c5b.gif)

**NOTE:** This happens both in the content and the media sections. Make sure to test both sections when testing this PR.

Here's how it looks with this PR applied:

![delete-reload-after](https://user-images.githubusercontent.com/7405322/49684657-00046200-fad7-11e8-9b8e-db5c0f6246df.gif)

🎄 8/12 🎄 