### PR TITLE
V8: Fix the member group picker

### DIFF
--- a/src/Umbraco.Core/Services/IMemberGroupService.cs
+++ b/src/Umbraco.Core/Services/IMemberGroupService.cs
@@ -7,6 +7,7 @@ namespace Umbraco.Core.Services
     {
         IEnumerable<IMemberGroup> GetAll();
         IMemberGroup GetById(int id);
+        IEnumerable<IMemberGroup> GetByIds(IEnumerable<int> ids);
         IMemberGroup GetByName(string name);
         void Save(IMemberGroup memberGroup, bool raiseEvents = true);
         void Delete(IMemberGroup memberGroup);

--- a/src/Umbraco.Core/Services/Implement/MemberGroupService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberGroupService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Umbraco.Core.Events;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
@@ -57,6 +58,19 @@ namespace Umbraco.Core.Services.Implement
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _memberGroupRepository.GetMany();
+            }
+        }
+
+        public IEnumerable<IMemberGroup> GetByIds(IEnumerable<int> ids)
+        {
+            if (ids == null || ids.Any() == false)
+            {
+                return new IMemberGroup[0];
+            }
+
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _memberGroupRepository.GetMany(ids.ToArray());
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membergroup.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membergroup.resource.js
@@ -29,6 +29,22 @@ function memberGroupResource($q, $http, umbRequestHelper) {
                "Failed to retrieve member group");
         },
 
+        getByIds: function (ids) {
+
+            var idQuery = "";
+            _.each(ids, function (item) {
+                idQuery += "ids=" + item + "&";
+            });
+
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "memberGroupApiBaseUrl",
+                        "GetByIds",
+                        idQuery)),
+                "Failed to retrieve member group");
+        },
+
         deleteById: function (id) {
 
             return umbRequestHelper.resourcePromise(

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/membergrouppicker/membergrouppicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/membergrouppicker/membergrouppicker.html
@@ -2,7 +2,7 @@
 
 	<div ng-model="renderModel">
 		<umb-node-preview
-			ng-repeat="node in renderModel"
+			ng-repeat="node in renderModel | orderBy:'name'"
 			icon="node.icon"
 			name="node.name"
 			allow-remove="allowRemove"

--- a/src/Umbraco.Web/Editors/MemberGroupController.cs
+++ b/src/Umbraco.Web/Editors/MemberGroupController.cs
@@ -36,6 +36,17 @@ namespace Umbraco.Web.Editors
             return dto;
         }
 
+        public IEnumerable<MemberGroupDisplay> GetByIds([FromUri]int[] ids)
+        {
+            if (_provider.IsUmbracoMembershipProvider())
+            {
+                return Services.MemberGroupService.GetByIds(ids)
+                    .Select(Mapper.Map<IMemberGroup, MemberGroupDisplay>);
+            }
+
+            return Enumerable.Empty<MemberGroupDisplay>();
+        }
+
         [HttpDelete]
         [HttpPost]
         public HttpResponseMessage DeleteById(int id)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The member group picker currently shows the IDs of the picked member groups - not their names:

![member-group-picker-before](https://user-images.githubusercontent.com/7405322/49713995-67432300-fc4b-11e8-9a83-a8ea32fb26f4.gif)

This PR fixes it. To test the PR:

1. Create some member groups.
2. Create a doctype with a member group picker property.
3. Create a page using that doctype.
4. Pick some member groups.
5. Verify that the group names are shown in the picker.
6. Save and reload.
7. Verify that the group names are *still* shown in the picker.

It should looks something like this with the PR applied:

![member-group-picker-after](https://user-images.githubusercontent.com/7405322/49714073-cdc84100-fc4b-11e8-9386-9ba9cf1eca57.gif)

🎄 10/24 🎄 