### PR TITLE
Makes the Forms Promo App/Section become fullscreen & removes the empty tree

### DIFF
--- a/src/Umbraco.Web.UI/config/trees.config
+++ b/src/Umbraco.Web.UI/config/trees.config
@@ -30,9 +30,5 @@
     <add initialize="true" sortOrder="1" alias="memberGroups" application="member" title="Member Groups" iconClosed="icon-folder" iconOpen="icon-folder-open" type="Umbraco.Web.Trees.MemberGroupTreeController, Umbraco.Web" />
     <!--Translation-->
     <add initialize="true" application="translation" alias="dictionary" title="Dictionary" type="Umbraco.Web.Trees.DictionaryTreeController, Umbraco.Web" iconClosed="icon-folder" iconOpen="icon-folder" sortOrder="0" />   
-    <!-- Custom -->
-    <add initialize="true" sortOrder="2" alias="datasource" application="forms" title="Datasources" iconClosed="icon-folder" iconOpen="icon-folder-open" type="Umbraco.Forms.Web.Trees.DataSourceTreeController, Umbraco.Forms.Web" />
-    <add initialize="true" sortOrder="0" alias="form" application="forms" title="Forms" iconClosed="icon-folder" iconOpen="icon-folder-open" type="Umbraco.Forms.Web.Trees.FormTreeController, Umbraco.Forms.Web" />
-    <add initialize="true" sortOrder="3" alias="prevaluesource" application="forms" title="Prevalue sources" iconClosed="icon-folder" iconOpen="icon-folder-open" type="Umbraco.Forms.Web.Trees.PreValueSourceTreeController, Umbraco.Forms.Web" />
-    <add initialize="true" sortOrder="3" alias="formsecurity" application="users" title="Forms Security" iconClosed="icon-folder" iconOpen="icon-folder-open" type="Umbraco.Forms.Web.Trees.FormSecurityTreeController, Umbraco.Forms.Web" />
+    
 </trees>

--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -78,10 +78,20 @@ namespace Umbraco.Web.Trees
                     }
                 }
 
-                var multiTree = TreeRootNode.CreateMultiTreeRoot(collection);
-                multiTree.Name = Services.TextService.Localize("sections/" + application);
+                if(collection.Count > 0)
+                {
+                    var multiTree = TreeRootNode.CreateMultiTreeRoot(collection);
+                    multiTree.Name = Services.TextService.Localize("sections/" + application);
 
-                return multiTree;
+                    return multiTree;
+                }
+
+                //Otherwise its a application/section with no trees (aka a full screen app)
+                //For example we do not have a Forms tree definied in C# & can not attribute with [Tree(isSingleNodeTree:true0]
+                var rootId = Constants.System.Root.ToString(CultureInfo.InvariantCulture);
+                var section = Services.TextService.Localize("sections/" + application);
+
+                return TreeRootNode.CreateSingleTreeRoot(rootId, null, null, section, TreeNodeCollection.Empty, true);
             }
 
             var rootNodeGroups = new List<TreeRootNode>();


### PR DESCRIPTION
This PR allows the Forms section to be a full screen app. For any sections/applications then do not have any trees then we will create a fullscreen app instead.

As the Forms section has no C# tree classes defined we could not mark it with the `Tree` attribute to indicate that its a single node tree aka fullscreen app `[Tree(isSingleNodeTree:true]`

It did not make logical sense for this to be set in the trees.config XML nor create a C# class to register a tree against the section, this seems a bit odd to do otherwise.