### PR TITLE
Delete user start node assignments before deleting the user

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
@@ -382,6 +382,7 @@ ORDER BY colName";
                 "DELETE FROM cmsTask WHERE parentUserId = @Id",
                 "DELETE FROM umbracoUser2UserGroup WHERE userId = @Id",
                 "DELETE FROM umbracoUser2NodeNotify WHERE userId = @Id",
+                "DELETE FROM umbracoUserStartNode WHERE userId = @Id",
                 "DELETE FROM umbracoUser WHERE id = @Id",
                 "DELETE FROM umbracoExternalLogin WHERE id = @Id"
             };


### PR DESCRIPTION

This fixes: https://github.com/umbraco/Umbraco-CMS/issues/3860

### Description
<!-- A description of the changes proposed in the pull-request and how to test these changes -->

In the user deletion process I have included an additional SQL statement to remove all start node information related to this user. This should fix the DB error issue when deleting a user with defined start nodes.

To test this please follow the same steps as in the linked issue:
- Create a new user in the backoffice
- Do not log in as that user to keep the delete option
- Select a content start node or/and a media start node for this user and save the profile changes
- Click on "Delete User"
- Confirm deletion
- Error should not occur anymore

<!-- Thanks for contributing to Umbraco CMS! -->
