### PR TITLE
Added 2 HtmlHelper extension methods for rendering RelatedLinks, incl…

### DIFF
--- a/src/Umbraco.Tests/Web/Mvc/HtmlHelperExtensionMethodsTests.cs
+++ b/src/Umbraco.Tests/Web/Mvc/HtmlHelperExtensionMethodsTests.cs
@@ -29,5 +29,30 @@ namespace Umbraco.Tests.Web.Mvc
 			var output = _htmlHelper.Wrap("div", "hello world", new {style = "color:red;", onclick = "void();"});
 			Assert.AreEqual("<div style=\"color:red;\" onclick=\"void();\">hello world</div>", output.ToHtmlString());
 		}
-	}
+
+        [Test]
+        public void GetRelatedLinkHtml_Simple()
+        {
+            var relatedLink = new Umbraco.Web.Models.RelatedLink {
+                Caption = "Link Caption",
+                NewWindow = true,
+                Link = "https://www.google.com/"
+            };
+            var output = _htmlHelper.GetRelatedLinkHtml(relatedLink);
+            Assert.AreEqual("<a href=\"https://www.google.com/\" target=\"_blank\">Link Caption</a>", output.ToHtmlString());
+        }
+
+        [Test]
+        public void GetRelatedLinkHtml_HtmlAttributes()
+        {
+            var relatedLink = new Umbraco.Web.Models.RelatedLink
+            {
+                Caption = "Link Caption",
+                NewWindow = true,
+                Link = "https://www.google.com/"
+            };
+            var output = _htmlHelper.GetRelatedLinkHtml(relatedLink, new { @class = "test-class"});
+            Assert.AreEqual("<a class=\"test-class\" href=\"https://www.google.com/\" target=\"_blank\">Link Caption</a>", output.ToHtmlString());
+        }
+    }
 }

--- a/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
@@ -952,5 +952,37 @@ namespace Umbraco.Web
 
         #endregion
 
+        #region RelatedLink
+
+        /// <summary>
+        /// Renders an anchor element for a RelatedLink instance.
+        /// Format: &lt;a href=&quot;relatedLink.Link&quot; target=&quot;_blank/_self&quot;&gt;relatedLink.Caption&lt;/a&gt;
+        /// </summary>
+        /// <param name="htmlHelper">The HTML helper instance that this method extends.</param>
+        /// <param name="relatedLink">The RelatedLink instance</param>
+        /// <returns>An anchor element </returns>
+        public static MvcHtmlString GetRelatedLinkHtml(this HtmlHelper htmlHelper, RelatedLink relatedLink)
+        {
+            return htmlHelper.GetRelatedLinkHtml(relatedLink, null);
+        }
+
+        /// <summary>
+        /// Renders an anchor element for a RelatedLink instance, accepting htmlAttributes.
+        /// Format: &lt;a href=&quot;relatedLink.Link&quot; target=&quot;_blank/_self&quot; htmlAttributes&gt;relatedLink.Caption&lt;/a&gt;
+        /// </summary>
+        /// <param name="htmlHelper">The HTML helper instance that this method extends.</param>
+        /// <param name="relatedLink">The RelatedLink instance</param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.</param>
+        /// <returns></returns>
+        public static MvcHtmlString GetRelatedLinkHtml(this HtmlHelper htmlHelper, RelatedLink relatedLink, object htmlAttributes)
+        {
+            var tagBuilder = new TagBuilder("a");
+            tagBuilder.MergeAttributes(HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
+            tagBuilder.MergeAttribute("href", relatedLink.Link);
+            tagBuilder.MergeAttribute("target", relatedLink.NewWindow ? "_blank" : "_self");
+            tagBuilder.InnerHtml = HttpUtility.HtmlEncode(relatedLink.Caption);
+            return MvcHtmlString.Create(tagBuilder.ToString(TagRenderMode.Normal));
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
…uding Unit tests

### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes feature request: https://github.com/umbraco/Umbraco-CMS/issues/3875

### Description
<!-- A description of the changes proposed in the pull-request and how to test these changes -->
I have added two HtmlHelper extensions for rendering RelatedLink items.
Usage:
`@Html.GetRelatedLinkHtml(item)`
`@Html.GetRelatedLinkHtml(item, new {@class = "button"})`

full example (based on https://our.umbraco.com/Documentation/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Related-Links2):
```
<ul>
    @foreach (var item in Model.Content.GetPropertyValue<RelatedLinks>("footerLinks"))
    {
        <li>@Html.GetRelatedLinkHtml(item)</li>
    }
</ul>
```

I have also added Unit tests in `src/Umbraco.Tests/Web/Mvc/HtmlHelperExtensionMethodsTests.cs`
<!-- Thanks for contributing to Umbraco CMS! -->
