### PR TITLE
Remove/Replace ping.aspx

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -416,9 +416,6 @@
     <Content Include="Umbraco\Js\dualSelectBox.js" />
     <Content Include="Umbraco\Js\guiFunctions.js" />
     <Content Include="Umbraco\Js\umbracoCheckKeys.js" />
-    <Content Include="Umbraco\ping.aspx">
-      <SubType>Form</SubType>
-    </Content>
     <!--<Content Include="Umbraco\users\PermissionEditor.aspx" />-->
     <Content Include="Umbraco\Masterpages\default.Master" />
     <None Include="web.Template.config">

--- a/src/Umbraco.Web.UI/Umbraco/ping.aspx
+++ b/src/Umbraco.Web.UI/Umbraco/ping.aspx
@@ -1,2 +1,0 @@
-<%@ Page language="c#" AutoEventWireup="True"  %>
-I'm alive!

--- a/src/Umbraco.Web/Editors/KeepAliveController.cs
+++ b/src/Umbraco.Web/Editors/KeepAliveController.cs
@@ -1,0 +1,28 @@
+﻿using System.Runtime.Serialization;
+using System.Web.Http;
+using Umbraco.Web.WebApi;
+
+namespace Umbraco.Web.Editors
+{
+    public class KeepAliveController : UmbracoApiController
+    {
+        [HttpGet]
+        public KeepAlivePingResult Ping()
+        {
+            return new KeepAlivePingResult
+            {
+                Success = true,
+                Message = "I'm alive!"
+            };
+        }   
+    }
+
+    public class KeepAlivePingResult
+    {
+        [DataMember(Name = "success")]
+        public bool Success { get; set; }
+
+        [DataMember(Name = "message")]
+        public string Message { get; set; }
+    }
+}

--- a/src/Umbraco.Web/Scheduling/KeepAlive.cs
+++ b/src/Umbraco.Web/Scheduling/KeepAlive.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Web.Scheduling
                         return true; // repeat
                     }
 
-                    var url = umbracoAppUrl + "/ping.aspx";
+                    var url = umbracoAppUrl + "api/keepalive/ping";
 
                     var request = new HttpRequestMessage(HttpMethod.Get, url);
                     var result = await _httpClient.SendAsync(request, token);

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -36,6 +36,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <PropertyGroup />
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
@@ -112,6 +113,7 @@
     <Compile Include="Components\BackOfficeUserAuditEventsComponent.cs" />
     <Compile Include="ContentApps\ListViewContentAppFactory.cs" />
     <Compile Include="Editors\BackOfficePreviewModel.cs" />
+    <Compile Include="Editors\KeepAliveController.cs" />
     <Compile Include="Editors\RelationTypeController.cs" />
     <Compile Include="Logging\WebProfiler.cs" />
     <Compile Include="Logging\WebProfilerComponent.cs" />


### PR DESCRIPTION
### Prerequisites
- [X] I have added steps to test this contribution in the description below

### Description
V8 Hackathon PR - https://trello.com/c/XfqEW7HX/85-rewrite-remove-umbracowebui-umbraco-pingaspx
Removed ping.aspx and replaced it with KeepAliveController.  Also updated the call to ping.aspx to call the new route.  The return object of this is, effectively, hard-coded to return a "success" value and a message.

To test, I put a breakpoint on line 65 of `KeepAlive.cs` and waited for it to call the new route.  Once the breakpoint was hit, I then stepped through and verified that it succeeded, which it did.

*Question* - during peer review - in KeepAliveController I've added a `KeepAlivePingResult` class for the result.  I did this because I saw this done in the `HelpController` in the same folder - is there a better place for me to put this new class?
