### PR TITLE
Better Validation Options

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -8,7 +8,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/core": {
@@ -17,20 +17,20 @@
       "integrity": "sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "@babel/generator": "7.1.6",
-        "@babel/helpers": "7.1.5",
-        "@babel/parser": "7.1.6",
-        "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.6",
-        "@babel/types": "7.1.6",
-        "convert-source-map": "1.6.0",
-        "debug": "4.1.0",
-        "json5": "2.1.0",
-        "lodash": "4.17.11",
-        "resolve": "1.8.1",
-        "semver": "5.6.0",
-        "source-map": "0.5.7"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.1.6",
+        "@babel/helpers": "^7.1.5",
+        "@babel/parser": "^7.1.6",
+        "@babel/template": "^7.1.2",
+        "@babel/traverse": "^7.1.6",
+        "@babel/types": "^7.1.6",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.10",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
       }
     },
     "@babel/generator": {
@@ -39,11 +39,11 @@
       "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.6",
-        "jsesc": "2.5.2",
-        "lodash": "4.17.11",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "@babel/types": "^7.1.6",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -52,7 +52,7 @@
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.6"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -61,8 +61,8 @@
       "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.1.0",
-        "@babel/types": "7.1.6"
+        "@babel/helper-explode-assignable-expression": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-call-delegate": {
@@ -71,9 +71,9 @@
       "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0",
-        "@babel/traverse": "7.1.6",
-        "@babel/types": "7.1.6"
+        "@babel/helper-hoist-variables": "^7.0.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-define-map": {
@@ -82,9 +82,9 @@
       "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/types": "7.1.6",
-        "lodash": "4.17.11"
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -93,8 +93,8 @@
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.1.6",
-        "@babel/types": "7.1.6"
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-function-name": {
@@ -103,9 +103,9 @@
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0",
-        "@babel/template": "7.1.2",
-        "@babel/types": "7.1.6"
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -114,7 +114,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.6"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -123,7 +123,7 @@
       "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.6"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -132,7 +132,7 @@
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.6"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-module-imports": {
@@ -141,7 +141,7 @@
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.6"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-module-transforms": {
@@ -150,12 +150,12 @@
       "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0",
-        "@babel/helper-simple-access": "7.1.0",
-        "@babel/helper-split-export-declaration": "7.0.0",
-        "@babel/template": "7.1.2",
-        "@babel/types": "7.1.6",
-        "lodash": "4.17.11"
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -164,7 +164,7 @@
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.6"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -179,7 +179,7 @@
       "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -188,11 +188,11 @@
       "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0",
-        "@babel/helper-wrap-function": "7.1.0",
-        "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.6",
-        "@babel/types": "7.1.6"
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-wrap-function": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-replace-supers": {
@@ -201,10 +201,10 @@
       "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "7.0.0",
-        "@babel/helper-optimise-call-expression": "7.0.0",
-        "@babel/traverse": "7.1.6",
-        "@babel/types": "7.1.6"
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-simple-access": {
@@ -213,8 +213,8 @@
       "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.1.2",
-        "@babel/types": "7.1.6"
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -223,7 +223,7 @@
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.6"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-wrap-function": {
@@ -232,10 +232,10 @@
       "integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.6",
-        "@babel/types": "7.1.6"
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helpers": {
@@ -244,9 +244,9 @@
       "integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.6",
-        "@babel/types": "7.1.6"
+        "@babel/template": "^7.1.2",
+        "@babel/traverse": "^7.1.5",
+        "@babel/types": "^7.1.5"
       }
     },
     "@babel/highlight": {
@@ -255,9 +255,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "4.0.0"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
@@ -272,9 +272,9 @@
       "integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-remap-async-to-generator": "7.1.0",
-        "@babel/plugin-syntax-async-generators": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0",
+        "@babel/plugin-syntax-async-generators": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -283,8 +283,8 @@
       "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-json-strings": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-json-strings": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
@@ -293,8 +293,8 @@
       "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -303,8 +303,8 @@
       "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -313,9 +313,9 @@
       "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-regex": "7.0.0",
-        "regexpu-core": "4.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.2.0"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -324,7 +324,7 @@
       "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -333,7 +333,7 @@
       "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -342,7 +342,7 @@
       "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
@@ -351,7 +351,7 @@
       "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -360,7 +360,7 @@
       "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -369,9 +369,9 @@
       "integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-remap-async-to-generator": "7.1.0"
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -380,7 +380,7 @@
       "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -389,8 +389,8 @@
       "integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "lodash": "4.17.11"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -399,14 +399,14 @@
       "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0",
-        "@babel/helper-define-map": "7.1.0",
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/helper-optimise-call-expression": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-replace-supers": "7.1.0",
-        "@babel/helper-split-export-declaration": "7.0.0",
-        "globals": "11.9.0"
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-define-map": "^7.1.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -415,7 +415,7 @@
       "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -424,7 +424,7 @@
       "integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -433,9 +433,9 @@
       "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-regex": "7.0.0",
-        "regexpu-core": "4.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.1.3"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -444,7 +444,7 @@
       "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -453,8 +453,8 @@
       "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -463,7 +463,7 @@
       "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -472,8 +472,8 @@
       "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-literals": {
@@ -482,7 +482,7 @@
       "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-modules-amd": {
@@ -491,8 +491,8 @@
       "integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.1.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
@@ -501,9 +501,9 @@
       "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.1.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-simple-access": "7.1.0"
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
@@ -512,8 +512,8 @@
       "integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-hoist-variables": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -522,8 +522,8 @@
       "integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.1.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -532,7 +532,7 @@
       "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-object-super": {
@@ -541,8 +541,8 @@
       "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-replace-supers": "7.1.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -551,9 +551,9 @@
       "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "7.1.0",
-        "@babel/helper-get-function-arity": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-call-delegate": "^7.1.0",
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -562,7 +562,7 @@
       "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.13.3"
+        "regenerator-transform": "^0.13.3"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -571,7 +571,7 @@
       "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-spread": {
@@ -580,7 +580,7 @@
       "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -589,8 +589,8 @@
       "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-regex": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0"
       }
     },
     "@babel/plugin-transform-template-literals": {
@@ -599,8 +599,8 @@
       "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
@@ -609,7 +609,7 @@
       "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -618,9 +618,9 @@
       "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-regex": "7.0.0",
-        "regexpu-core": "4.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.1.3"
       }
     },
     "@babel/preset-env": {
@@ -629,47 +629,47 @@
       "integrity": "sha512-YIBfpJNQMBkb6MCkjz/A9J76SNCSuGVamOVBgoUkLzpJD/z8ghHi9I42LQ4pulVX68N/MmImz6ZTixt7Azgexw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-proposal-async-generator-functions": "7.1.0",
-        "@babel/plugin-proposal-json-strings": "7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "7.0.0",
-        "@babel/plugin-proposal-optional-catch-binding": "7.0.0",
-        "@babel/plugin-proposal-unicode-property-regex": "7.0.0",
-        "@babel/plugin-syntax-async-generators": "7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0",
-        "@babel/plugin-transform-arrow-functions": "7.0.0",
-        "@babel/plugin-transform-async-to-generator": "7.1.0",
-        "@babel/plugin-transform-block-scoped-functions": "7.0.0",
-        "@babel/plugin-transform-block-scoping": "7.1.5",
-        "@babel/plugin-transform-classes": "7.1.0",
-        "@babel/plugin-transform-computed-properties": "7.0.0",
-        "@babel/plugin-transform-destructuring": "7.1.3",
-        "@babel/plugin-transform-dotall-regex": "7.0.0",
-        "@babel/plugin-transform-duplicate-keys": "7.0.0",
-        "@babel/plugin-transform-exponentiation-operator": "7.1.0",
-        "@babel/plugin-transform-for-of": "7.0.0",
-        "@babel/plugin-transform-function-name": "7.1.0",
-        "@babel/plugin-transform-literals": "7.0.0",
-        "@babel/plugin-transform-modules-amd": "7.1.0",
-        "@babel/plugin-transform-modules-commonjs": "7.1.0",
-        "@babel/plugin-transform-modules-systemjs": "7.1.3",
-        "@babel/plugin-transform-modules-umd": "7.1.0",
-        "@babel/plugin-transform-new-target": "7.0.0",
-        "@babel/plugin-transform-object-super": "7.1.0",
-        "@babel/plugin-transform-parameters": "7.1.0",
-        "@babel/plugin-transform-regenerator": "7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "7.0.0",
-        "@babel/plugin-transform-spread": "7.0.0",
-        "@babel/plugin-transform-sticky-regex": "7.0.0",
-        "@babel/plugin-transform-template-literals": "7.0.0",
-        "@babel/plugin-transform-typeof-symbol": "7.0.0",
-        "@babel/plugin-transform-unicode-regex": "7.0.0",
-        "browserslist": "4.3.5",
-        "invariant": "2.2.4",
-        "js-levenshtein": "1.1.4",
-        "semver": "5.6.0"
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
+        "@babel/plugin-proposal-json-strings": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+        "@babel/plugin-syntax-async-generators": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-to-generator": "^7.1.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.1.5",
+        "@babel/plugin-transform-classes": "^7.1.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-dotall-regex": "^7.0.0",
+        "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.1.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-amd": "^7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.0.0",
+        "@babel/plugin-transform-modules-umd": "^7.1.0",
+        "@babel/plugin-transform-new-target": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.1.0",
+        "@babel/plugin-transform-parameters": "^7.1.0",
+        "@babel/plugin-transform-regenerator": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "browserslist": "^4.1.0",
+        "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
+        "semver": "^5.3.0"
       }
     },
     "@babel/template": {
@@ -678,9 +678,9 @@
       "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "@babel/parser": "7.1.6",
-        "@babel/types": "7.1.6"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.1.2",
+        "@babel/types": "^7.1.2"
       }
     },
     "@babel/traverse": {
@@ -689,15 +689,15 @@
       "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "@babel/generator": "7.1.6",
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/helper-split-export-declaration": "7.0.0",
-        "@babel/parser": "7.1.6",
-        "@babel/types": "7.1.6",
-        "debug": "4.1.0",
-        "globals": "11.9.0",
-        "lodash": "4.17.11"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.1.6",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.1.6",
+        "@babel/types": "^7.1.6",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/types": {
@@ -706,9 +706,9 @@
       "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.11",
-        "to-fast-properties": "2.0.0"
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -717,8 +717,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "glob-to-regexp": "0.3.0"
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -745,7 +745,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.21",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -755,20 +755,20 @@
       "integrity": "sha512-3OOR92FTc2p5/EcOzPcXp+Cbo+3C15nV9RXHlOUBCBpHhcB+0frbSNR9ehED/o7sTcyGVtqGJpguToEdlXhD0w==",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.6.0",
-        "glob": "7.1.3",
-        "indx": "0.2.3",
-        "lodash.clone": "4.5.0",
-        "lodash.defaults": "4.2.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.merge": "4.6.1",
-        "lodash.partialright": "4.2.1",
-        "lodash.pick": "4.4.0",
-        "lodash.uniq": "4.5.0",
-        "resolve": "1.8.1",
-        "semver": "5.6.0",
-        "uglify-js": "2.8.29",
-        "when": "3.7.8"
+        "convert-source-map": "^1.5.0",
+        "glob": "^7.0.5",
+        "indx": "^0.2.3",
+        "lodash.clone": "^4.3.2",
+        "lodash.defaults": "^4.0.1",
+        "lodash.flatten": "^4.2.0",
+        "lodash.merge": "^4.4.0",
+        "lodash.partialright": "^4.1.4",
+        "lodash.pick": "^4.2.1",
+        "lodash.uniq": "^4.3.0",
+        "resolve": "^1.5.0",
+        "semver": "^5.3.0",
+        "uglify-js": "^2.8.22",
+        "when": "^3.7.8"
       },
       "dependencies": {
         "glob": {
@@ -777,12 +777,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -791,7 +791,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -825,10 +825,10 @@
       "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "align-text": {
@@ -837,9 +837,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       },
       "dependencies": {
         "kind-of": {
@@ -848,7 +848,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -885,7 +885,7 @@
       "resolved": "https://registry.npmjs.org/angular-dynamic-locale/-/angular-dynamic-locale-0.1.37.tgz",
       "integrity": "sha512-m5Kyk8W8/mOZSqRxuByOwHBjv8labLBAgvl0Z3iQx2xT/tWCqb94imKUPwumudszdPDjxeopwyucQvm8Sw7ogw==",
       "requires": {
-        "@types/angular": "1.6.51"
+        "@types/angular": "^1.6.25"
       }
     },
     "angular-i18n": {
@@ -928,9 +928,9 @@
       "resolved": "https://registry.npmjs.org/angular-ui-sortable/-/angular-ui-sortable-0.19.0.tgz",
       "integrity": "sha512-u/uc981Nzg4XN1bMU9qKleMTSt7F1XjMWnyGw6gxPLIeQeLZm8jWNy7tj8y2r2HmvzXFbQVq2z6rObznFKAekQ==",
       "requires": {
-        "angular": "1.7.5",
-        "jquery": "3.3.1",
-        "jquery-ui-dist": "1.12.1"
+        "angular": ">=1.2.x",
+        "jquery": ">=3.1.x",
+        "jquery-ui-dist": ">=1.12.x"
       }
     },
     "animejs": {
@@ -944,7 +944,7 @@
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
-        "ansi-wrap": "0.1.0"
+        "ansi-wrap": "^0.1.0"
       }
     },
     "ansi-cyan": {
@@ -992,7 +992,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "ansi-wrap": {
@@ -1007,8 +1007,8 @@
       "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -1017,7 +1017,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "array-unique": {
@@ -1032,9 +1032,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.3"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "expand-brackets": {
@@ -1043,7 +1043,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "extglob": {
@@ -1052,7 +1052,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-extglob": {
@@ -1067,7 +1067,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "kind-of": {
@@ -1076,7 +1076,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "micromatch": {
@@ -1085,19 +1085,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         }
       }
@@ -1116,7 +1116,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "file-type": "4.4.0"
+        "file-type": "^4.2.0"
       },
       "dependencies": {
         "file-type": {
@@ -1140,7 +1140,7 @@
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -1191,7 +1191,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -1231,7 +1231,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
@@ -1282,12 +1282,12 @@
       "integrity": "sha512-DY9gOh8z3tnCbJ13JIWaeQsoYncTGdsrgCceBaQSIL4nvdrLxgbRSBPevg2XbX7u4QCSfLheSJEEIUUSlkbx6Q==",
       "dev": true,
       "requires": {
-        "browserslist": "4.3.5",
-        "caniuse-lite": "1.0.30000913",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "browserslist": "^4.3.3",
+        "caniuse-lite": "^1.0.30000898",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.5",
+        "postcss-value-parser": "^3.3.1"
       }
     },
     "aws-sign2": {
@@ -1320,13 +1320,13 @@
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1335,7 +1335,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1344,7 +1344,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1353,7 +1353,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1362,9 +1362,9 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -1399,7 +1399,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "beeper": {
@@ -1424,11 +1424,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "decompress": "4.2.0",
-        "download": "6.2.5",
-        "execa": "0.7.0",
-        "p-map-series": "1.0.0",
-        "tempfile": "2.0.0"
+        "decompress": "^4.0.0",
+        "download": "^6.2.2",
+        "execa": "^0.7.0",
+        "p-map-series": "^1.0.0",
+        "tempfile": "^2.0.0"
       }
     },
     "bin-check": {
@@ -1438,8 +1438,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "execa": "0.7.0",
-        "executable": "4.1.1"
+        "execa": "^0.7.0",
+        "executable": "^4.1.0"
       }
     },
     "bin-version": {
@@ -1449,8 +1449,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "execa": "1.0.0",
-        "find-versions": "3.0.0"
+        "execa": "^1.0.0",
+        "find-versions": "^3.0.0"
       },
       "dependencies": {
         "execa": {
@@ -1460,13 +1460,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "4.1.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "get-stream": {
@@ -1476,7 +1476,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         }
       }
@@ -1488,9 +1488,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-version": "3.0.0",
-        "semver": "5.6.0",
-        "semver-truncate": "1.1.2"
+        "bin-version": "^3.0.0",
+        "semver": "^5.6.0",
+        "semver-truncate": "^1.1.2"
       }
     },
     "bin-wrapper": {
@@ -1500,12 +1500,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-check": "4.1.0",
-        "bin-version-check": "4.0.0",
-        "download": "7.1.0",
-        "import-lazy": "3.1.0",
-        "os-filter-obj": "2.0.0",
-        "pify": "4.0.1"
+        "bin-check": "^4.1.0",
+        "bin-version-check": "^4.0.0",
+        "download": "^7.1.0",
+        "import-lazy": "^3.1.0",
+        "os-filter-obj": "^2.0.0",
+        "pify": "^4.0.1"
       },
       "dependencies": {
         "download": {
@@ -1515,18 +1515,18 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "archive-type": "4.0.0",
-            "caw": "2.0.1",
-            "content-disposition": "0.5.2",
-            "decompress": "4.2.0",
-            "ext-name": "5.0.0",
-            "file-type": "8.1.0",
-            "filenamify": "2.1.0",
-            "get-stream": "3.0.0",
-            "got": "8.3.2",
-            "make-dir": "1.3.0",
-            "p-event": "2.1.0",
-            "pify": "3.0.0"
+            "archive-type": "^4.0.0",
+            "caw": "^2.0.1",
+            "content-disposition": "^0.5.2",
+            "decompress": "^4.2.0",
+            "ext-name": "^5.0.0",
+            "file-type": "^8.1.0",
+            "filenamify": "^2.0.0",
+            "get-stream": "^3.0.0",
+            "got": "^8.3.1",
+            "make-dir": "^1.2.0",
+            "p-event": "^2.1.0",
+            "pify": "^3.0.0"
           },
           "dependencies": {
             "pify": {
@@ -1545,23 +1545,23 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@sindresorhus/is": "0.7.0",
-            "cacheable-request": "2.1.4",
-            "decompress-response": "3.3.0",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "into-stream": "3.1.0",
-            "is-retry-allowed": "1.1.0",
-            "isurl": "1.0.0",
-            "lowercase-keys": "1.0.1",
-            "mimic-response": "1.0.1",
-            "p-cancelable": "0.4.1",
-            "p-timeout": "2.0.1",
-            "pify": "3.0.0",
-            "safe-buffer": "5.1.2",
-            "timed-out": "4.0.1",
-            "url-parse-lax": "3.0.0",
-            "url-to-options": "1.0.1"
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
           },
           "dependencies": {
             "pify": {
@@ -1587,7 +1587,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "p-timeout": "2.0.1"
+            "p-timeout": "^2.0.1"
           }
         },
         "p-timeout": {
@@ -1596,7 +1596,7 @@
           "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
           "dev": true,
           "requires": {
-            "p-finally": "1.0.0"
+            "p-finally": "^1.0.0"
           }
         },
         "pify": {
@@ -1620,7 +1620,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "prepend-http": "2.0.0"
+            "prepend-http": "^2.0.0"
           }
         }
       }
@@ -1691,10 +1691,10 @@
       "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
       "dev": true,
       "requires": {
-        "continuable-cache": "0.3.1",
-        "error": "7.0.2",
-        "raw-body": "1.1.7",
-        "safe-json-parse": "1.0.1"
+        "continuable-cache": "^0.3.1",
+        "error": "^7.0.0",
+        "raw-body": "~1.1.0",
+        "safe-json-parse": "~1.0.1"
       }
     },
     "body-parser": {
@@ -1704,15 +1704,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.16"
       },
       "dependencies": {
         "bytes": {
@@ -1736,7 +1736,7 @@
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ms": {
@@ -1781,8 +1781,8 @@
       "resolved": "https://registry.npmjs.org/bootstrap-social/-/bootstrap-social-5.1.1.tgz",
       "integrity": "sha1-dTDGeK31bPj60/qCwp1NPl0CdQE=",
       "requires": {
-        "bootstrap": "3.3.7",
-        "font-awesome": "4.7.0"
+        "bootstrap": "~3",
+        "font-awesome": "~4.7"
       }
     },
     "brace-expansion": {
@@ -1791,7 +1791,7 @@
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1801,16 +1801,16 @@
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.3",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1819,7 +1819,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1830,9 +1830,9 @@
       "integrity": "sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000913",
-        "electron-to-chromium": "1.3.87",
-        "node-releases": "1.0.5"
+        "caniuse-lite": "^1.0.30000912",
+        "electron-to-chromium": "^1.3.86",
+        "node-releases": "^1.0.5"
       }
     },
     "buffer": {
@@ -1842,8 +1842,8 @@
       "dev": true,
       "requires": {
         "base64-js": "0.0.8",
-        "ieee754": "1.1.12",
-        "isarray": "1.0.0"
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -1860,8 +1860,8 @@
       "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "1.1.0",
-        "buffer-fill": "1.0.0"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -1894,7 +1894,7 @@
       "integrity": "sha1-z7GtlWjTujz+k1upq92VLeiKqyo=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "^1.0.33"
       }
     },
     "builtin-modules": {
@@ -1915,15 +1915,15 @@
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "cacheable-request": {
@@ -1956,9 +1956,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "prepend-http": "2.0.0",
-            "query-string": "5.1.1",
-            "sort-keys": "2.0.0"
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
           }
         },
         "prepend-http": {
@@ -1975,7 +1975,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           }
         }
       }
@@ -1992,7 +1992,7 @@
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0"
+        "callsites": "^2.0.0"
       }
     },
     "caller-path": {
@@ -2001,7 +2001,7 @@
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
-        "caller-callsite": "2.0.0"
+        "caller-callsite": "^2.0.0"
       }
     },
     "callsite": {
@@ -2028,8 +2028,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "caniuse-api": {
@@ -2038,10 +2038,10 @@
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.3.5",
-        "caniuse-lite": "1.0.30000913",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
       }
     },
     "caniuse-lite": {
@@ -2068,10 +2068,10 @@
       "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
       "dev": true,
       "requires": {
-        "get-proxy": "2.1.0",
-        "isurl": "1.0.0",
-        "tunnel-agent": "0.6.0",
-        "url-to-options": "1.0.1"
+        "get-proxy": "^2.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "tunnel-agent": "^0.6.0",
+        "url-to-options": "^1.0.1"
       }
     },
     "center-align": {
@@ -2080,8 +2080,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -2090,9 +2090,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -2107,19 +2107,19 @@
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "async-each": "1.0.1",
-        "braces": "2.3.2",
-        "fsevents": "1.2.4",
-        "glob-parent": "3.1.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "4.0.0",
-        "lodash.debounce": "4.0.8",
-        "normalize-path": "2.1.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.2.1",
-        "upath": "1.1.0"
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.5"
       },
       "dependencies": {
         "anymatch": {
@@ -2128,8 +2128,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "3.1.10",
-            "normalize-path": "2.1.1"
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
           }
         },
         "is-glob": {
@@ -2138,7 +2138,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         }
       }
@@ -2155,10 +2155,10 @@
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2167,7 +2167,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -2178,7 +2178,7 @@
       "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
       "dev": true,
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "~0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -2195,7 +2195,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -2209,9 +2209,9 @@
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
       "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
       "requires": {
-        "good-listener": "1.2.2",
-        "select": "1.1.2",
-        "tiny-emitter": "2.0.2"
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
       }
     },
     "cliui": {
@@ -2220,8 +2220,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -2252,7 +2252,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "mimic-response": "1.0.1"
+        "mimic-response": "^1.0.0"
       }
     },
     "clone-stats": {
@@ -2267,9 +2267,9 @@
       "integrity": "sha1-1ZHe5Kj4vBXaQ86X3O66E9Q+KmU=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "2.0.0",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -2284,13 +2284,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2299,7 +2299,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2310,7 +2310,7 @@
       "integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.1.2"
       }
     },
     "collection-visit": {
@@ -2319,8 +2319,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color": {
@@ -2329,8 +2329,8 @@
       "integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3",
-        "color-string": "1.5.3"
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
       }
     },
     "color-convert": {
@@ -2354,8 +2354,8 @@
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3",
-        "simple-swizzle": "0.2.2"
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "color-support": {
@@ -2376,7 +2376,7 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "^4.5.0"
       }
     },
     "combined-stream": {
@@ -2385,7 +2385,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -2427,10 +2427,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -2445,13 +2445,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2460,7 +2460,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2471,7 +2471,7 @@
       "integrity": "sha1-1OqT8FriV5CVG5nns7CeOQikCC4=",
       "dev": true,
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "^0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -2488,8 +2488,8 @@
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
       "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "connect": {
@@ -2500,7 +2500,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
@@ -2540,7 +2540,7 @@
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.3"
+        "bluebird": "^3.1.1"
       }
     },
     "content-disposition": {
@@ -2567,7 +2567,7 @@
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.1"
       }
     },
     "cookie": {
@@ -2600,10 +2600,10 @@
       "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
       "dev": true,
       "requires": {
-        "import-fresh": "2.0.0",
-        "is-directory": "0.3.1",
-        "js-yaml": "3.12.0",
-        "parse-json": "4.0.0"
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.9.0",
+        "parse-json": "^4.0.0"
       }
     },
     "cross-spawn": {
@@ -2612,11 +2612,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.5",
-        "path-key": "2.0.1",
-        "semver": "5.6.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "css-color-names": {
@@ -2631,8 +2631,8 @@
       "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.6",
-        "timsort": "0.3.0"
+        "postcss": "^7.0.1",
+        "timsort": "^0.3.0"
       }
     },
     "css-select": {
@@ -2641,10 +2641,10 @@
       "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.2",
-        "domutils": "1.7.0",
-        "nth-check": "1.0.2"
+        "boolbase": "^1.0.0",
+        "css-what": "^2.1.2",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
       }
     },
     "css-select-base-adapter": {
@@ -2659,8 +2659,8 @@
       "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
       "dev": true,
       "requires": {
-        "mdn-data": "1.1.4",
-        "source-map": "0.5.7"
+        "mdn-data": "~1.1.0",
+        "source-map": "^0.5.3"
       }
     },
     "css-unit-converter": {
@@ -2693,10 +2693,10 @@
       "integrity": "sha512-AiXL90l+MDuQmRNyypG2P7ux7K4XklxYzNNUd5HXZCNcH8/N9bHPcpN97v8tXgRVeFL/Ed8iP8mVmAAu0ZpT7A==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "5.0.7",
-        "cssnano-preset-default": "4.0.5",
-        "is-resolvable": "1.1.0",
-        "postcss": "7.0.6"
+        "cosmiconfig": "^5.0.0",
+        "cssnano-preset-default": "^4.0.5",
+        "is-resolvable": "^1.0.0",
+        "postcss": "^7.0.0"
       }
     },
     "cssnano-preset-default": {
@@ -2705,36 +2705,36 @@
       "integrity": "sha512-f1uhya0ZAjPYtDD58QkBB0R+uYdzHPei7cDxJyQQIHt5acdhyGXaSXl2nDLzWHLwGFbZcHxQtkJS8mmNwnxTvw==",
       "dev": true,
       "requires": {
-        "css-declaration-sorter": "4.0.1",
-        "cssnano-util-raw-cache": "4.0.1",
-        "postcss": "7.0.6",
-        "postcss-calc": "7.0.1",
-        "postcss-colormin": "4.0.2",
-        "postcss-convert-values": "4.0.1",
-        "postcss-discard-comments": "4.0.1",
-        "postcss-discard-duplicates": "4.0.2",
-        "postcss-discard-empty": "4.0.1",
-        "postcss-discard-overridden": "4.0.1",
-        "postcss-merge-longhand": "4.0.9",
-        "postcss-merge-rules": "4.0.2",
-        "postcss-minify-font-values": "4.0.2",
-        "postcss-minify-gradients": "4.0.1",
-        "postcss-minify-params": "4.0.1",
-        "postcss-minify-selectors": "4.0.1",
-        "postcss-normalize-charset": "4.0.1",
-        "postcss-normalize-display-values": "4.0.1",
-        "postcss-normalize-positions": "4.0.1",
-        "postcss-normalize-repeat-style": "4.0.1",
-        "postcss-normalize-string": "4.0.1",
-        "postcss-normalize-timing-functions": "4.0.1",
-        "postcss-normalize-unicode": "4.0.1",
-        "postcss-normalize-url": "4.0.1",
-        "postcss-normalize-whitespace": "4.0.1",
-        "postcss-ordered-values": "4.1.1",
-        "postcss-reduce-initial": "4.0.2",
-        "postcss-reduce-transforms": "4.0.1",
-        "postcss-svgo": "4.0.1",
-        "postcss-unique-selectors": "4.0.1"
+        "css-declaration-sorter": "^4.0.1",
+        "cssnano-util-raw-cache": "^4.0.1",
+        "postcss": "^7.0.0",
+        "postcss-calc": "^7.0.0",
+        "postcss-colormin": "^4.0.2",
+        "postcss-convert-values": "^4.0.1",
+        "postcss-discard-comments": "^4.0.1",
+        "postcss-discard-duplicates": "^4.0.2",
+        "postcss-discard-empty": "^4.0.1",
+        "postcss-discard-overridden": "^4.0.1",
+        "postcss-merge-longhand": "^4.0.9",
+        "postcss-merge-rules": "^4.0.2",
+        "postcss-minify-font-values": "^4.0.2",
+        "postcss-minify-gradients": "^4.0.1",
+        "postcss-minify-params": "^4.0.1",
+        "postcss-minify-selectors": "^4.0.1",
+        "postcss-normalize-charset": "^4.0.1",
+        "postcss-normalize-display-values": "^4.0.1",
+        "postcss-normalize-positions": "^4.0.1",
+        "postcss-normalize-repeat-style": "^4.0.1",
+        "postcss-normalize-string": "^4.0.1",
+        "postcss-normalize-timing-functions": "^4.0.1",
+        "postcss-normalize-unicode": "^4.0.1",
+        "postcss-normalize-url": "^4.0.1",
+        "postcss-normalize-whitespace": "^4.0.1",
+        "postcss-ordered-values": "^4.1.1",
+        "postcss-reduce-initial": "^4.0.2",
+        "postcss-reduce-transforms": "^4.0.1",
+        "postcss-svgo": "^4.0.1",
+        "postcss-unique-selectors": "^4.0.1"
       }
     },
     "cssnano-util-get-arguments": {
@@ -2755,7 +2755,7 @@
       "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.6"
+        "postcss": "^7.0.0"
       }
     },
     "cssnano-util-same-parent": {
@@ -2779,8 +2779,8 @@
           "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
           "dev": true,
           "requires": {
-            "mdn-data": "1.1.4",
-            "source-map": "0.5.7"
+            "mdn-data": "~1.1.0",
+            "source-map": "^0.5.3"
           }
         }
       }
@@ -2791,7 +2791,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "custom-event": {
@@ -2806,7 +2806,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-format": {
@@ -2827,7 +2827,7 @@
       "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
       "dev": true,
       "requires": {
-        "ms": "2.1.1"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -2848,14 +2848,14 @@
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "decompress-tarbz2": "4.1.1",
-        "decompress-targz": "4.1.1",
-        "decompress-unzip": "4.0.1",
-        "graceful-fs": "4.1.15",
-        "make-dir": "1.3.0",
-        "pify": "2.3.0",
-        "strip-dirs": "2.1.0"
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -2878,7 +2878,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.1"
+        "mimic-response": "^1.0.0"
       }
     },
     "decompress-tar": {
@@ -2887,9 +2887,9 @@
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
       "requires": {
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0",
-        "tar-stream": "1.6.2"
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
       },
       "dependencies": {
         "file-type": {
@@ -2906,11 +2906,11 @@
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "6.2.0",
-        "is-stream": "1.1.0",
-        "seek-bzip": "1.0.5",
-        "unbzip2-stream": "1.3.1"
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
       },
       "dependencies": {
         "file-type": {
@@ -2927,9 +2927,9 @@
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0"
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
       },
       "dependencies": {
         "file-type": {
@@ -2946,10 +2946,10 @@
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
       "requires": {
-        "file-type": "3.9.0",
-        "get-stream": "2.3.1",
-        "pify": "2.3.0",
-        "yauzl": "2.10.0"
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
       },
       "dependencies": {
         "file-type": {
@@ -2964,8 +2964,8 @@
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "object-assign": {
@@ -2994,7 +2994,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.4"
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -3003,7 +3003,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "1.0.12"
+        "object-keys": "^1.0.12"
       }
     },
     "define-property": {
@@ -3012,8 +3012,8 @@
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3022,7 +3022,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -3031,7 +3031,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -3040,9 +3040,9 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -3099,8 +3099,8 @@
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
       }
     },
     "doctrine": {
@@ -3109,7 +3109,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom-serialize": {
@@ -3118,10 +3118,10 @@
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "1.0.1",
-        "ent": "2.2.0",
-        "extend": "3.0.2",
-        "void-elements": "2.0.1"
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
       }
     },
     "dom-serializer": {
@@ -3130,8 +3130,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.2"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3154,8 +3154,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.2.1"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -3164,7 +3164,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "download": {
@@ -3174,17 +3174,17 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "caw": "2.0.1",
-        "content-disposition": "0.5.2",
-        "decompress": "4.2.0",
-        "ext-name": "5.0.0",
+        "caw": "^2.0.0",
+        "content-disposition": "^0.5.2",
+        "decompress": "^4.0.0",
+        "ext-name": "^5.0.0",
         "file-type": "5.2.0",
-        "filenamify": "2.1.0",
-        "get-stream": "3.0.0",
-        "got": "7.1.0",
-        "make-dir": "1.3.0",
-        "p-event": "1.3.0",
-        "pify": "3.0.0"
+        "filenamify": "^2.0.0",
+        "get-stream": "^3.0.0",
+        "got": "^7.0.0",
+        "make-dir": "^1.0.0",
+        "p-event": "^1.0.0",
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "file-type": {
@@ -3208,7 +3208,7 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       }
     },
     "duplexer3": {
@@ -3223,8 +3223,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -3251,7 +3251,7 @@
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "dev": true,
       "requires": {
-        "once": "1.3.3"
+        "once": "~1.3.0"
       }
     },
     "engine.io": {
@@ -3260,12 +3260,12 @@
       "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.3",
-        "ws": "3.3.3"
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~3.3.1"
       },
       "dependencies": {
         "debug": {
@@ -3293,14 +3293,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "3.3.3",
-        "xmlhttprequest-ssl": "1.5.5",
+        "ws": "~3.3.1",
+        "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -3328,10 +3328,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "0.0.7",
+        "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.5",
-        "has-binary2": "1.0.3"
+        "has-binary2": "~1.0.2"
       }
     },
     "ent": {
@@ -3353,7 +3353,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error": {
@@ -3362,8 +3362,8 @@
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "dev": true,
       "requires": {
-        "string-template": "0.2.1",
-        "xtend": "4.0.1"
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
       }
     },
     "error-ex": {
@@ -3372,7 +3372,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -3381,11 +3381,11 @@
       "integrity": "sha1-nbvdJ8aFbwABQhyhh4LXhr+KYWU=",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.2.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -3394,9 +3394,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.2"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-promise": {
@@ -3423,11 +3423,11 @@
       "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -3451,44 +3451,44 @@
       "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "ajv": "6.6.1",
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "debug": "4.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "4.0.0",
-        "eslint-utils": "1.3.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "4.1.0",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.3",
-        "globals": "11.9.0",
-        "ignore": "4.0.6",
-        "imurmurhash": "0.1.4",
-        "inquirer": "6.2.1",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.12.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.1",
-        "regexpp": "2.0.1",
-        "require-uncached": "1.0.3",
-        "semver": "5.6.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "5.1.1",
-        "text-table": "0.2.0"
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^4.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.1.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.0.2",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3503,12 +3503,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -3517,7 +3517,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "strip-ansi": {
@@ -3526,7 +3526,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -3537,8 +3537,8 @@
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -3559,9 +3559,9 @@
       "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
       "requires": {
-        "acorn": "6.0.4",
-        "acorn-jsx": "5.0.1",
-        "eslint-visitor-keys": "1.0.0"
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "esprima": {
@@ -3576,7 +3576,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -3585,7 +3585,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estemplate": {
@@ -3594,8 +3594,8 @@
       "integrity": "sha1-FxSp1GGQc4rJWLyv1J4CnNpWo54=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "4.2.0"
+        "esprima": "^2.7.2",
+        "estraverse": "^4.1.1"
       },
       "dependencies": {
         "esprima": {
@@ -3630,13 +3630,13 @@
       "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
         "map-stream": "0.0.7",
-        "pause-stream": "0.0.11",
-        "split": "1.0.1",
-        "stream-combiner": "0.2.2",
-        "through": "2.3.8"
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
       }
     },
     "eventemitter3": {
@@ -3652,11 +3652,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "execa": "0.7.0",
-        "p-finally": "1.0.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.2",
-        "tempfile": "2.0.0"
+        "execa": "^0.7.0",
+        "p-finally": "^1.0.0",
+        "pify": "^3.0.0",
+        "rimraf": "^2.5.4",
+        "tempfile": "^2.0.0"
       }
     },
     "execa": {
@@ -3665,13 +3665,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -3680,9 +3680,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.5",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "lru-cache": {
@@ -3691,8 +3691,8 @@
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         }
       }
@@ -3704,7 +3704,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.2.0"
       },
       "dependencies": {
         "pify": {
@@ -3722,9 +3722,9 @@
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
-        "array-slice": "0.2.3",
-        "array-unique": "0.2.1",
-        "braces": "0.1.5"
+        "array-slice": "^0.2.3",
+        "array-unique": "^0.2.1",
+        "braces": "^0.1.2"
       },
       "dependencies": {
         "array-slice": {
@@ -3745,7 +3745,7 @@
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
           "dev": true,
           "requires": {
-            "expand-range": "0.1.1"
+            "expand-range": "^0.1.0"
           }
         },
         "expand-range": {
@@ -3754,8 +3754,8 @@
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
           "dev": true,
           "requires": {
-            "is-number": "0.1.1",
-            "repeat-string": "0.2.2"
+            "is-number": "^0.1.1",
+            "repeat-string": "^0.2.2"
           }
         },
         "is-number": {
@@ -3778,13 +3778,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -3802,7 +3802,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -3811,7 +3811,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "ms": {
@@ -3828,7 +3828,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.4"
+        "fill-range": "^2.1.0"
       },
       "dependencies": {
         "fill-range": {
@@ -3837,11 +3837,11 @@
           "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "3.1.1",
-            "repeat-element": "1.1.3",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "is-number": {
@@ -3850,7 +3850,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isarray": {
@@ -3874,7 +3874,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3885,7 +3885,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "ext-list": {
@@ -3894,7 +3894,7 @@
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
       "requires": {
-        "mime-db": "1.37.0"
+        "mime-db": "^1.28.0"
       }
     },
     "ext-name": {
@@ -3903,8 +3903,8 @@
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "dev": true,
       "requires": {
-        "ext-list": "2.2.2",
-        "sort-keys-length": "1.0.1"
+        "ext-list": "^2.0.0",
+        "sort-keys-length": "^1.0.0"
       }
     },
     "extend": {
@@ -3919,8 +3919,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3929,7 +3929,7 @@
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -3940,9 +3940,9 @@
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "0.7.0",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -3951,14 +3951,14 @@
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -3967,7 +3967,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -3976,7 +3976,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -3985,7 +3985,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -3994,7 +3994,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -4003,9 +4003,9 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -4037,7 +4037,7 @@
           "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
           "dev": true,
           "requires": {
-            "pend": "1.2.0"
+            "pend": "~1.2.0"
           }
         },
         "ms": {
@@ -4052,7 +4052,7 @@
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "dev": true,
           "requires": {
-            "fd-slicer": "1.0.1"
+            "fd-slicer": "~1.0.1"
           }
         }
       }
@@ -4069,10 +4069,10 @@
       "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
       "dev": true,
       "requires": {
-        "ansi-gray": "0.1.1",
-        "color-support": "1.1.3",
-        "parse-node-version": "1.0.0",
-        "time-stamp": "1.1.0"
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "parse-node-version": "^1.0.0",
+        "time-stamp": "^1.0.0"
       }
     },
     "fast-deep-equal": {
@@ -4087,12 +4087,12 @@
       "integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "2.2.1",
-        "@nodelib/fs.stat": "1.1.3",
-        "glob-parent": "3.1.0",
-        "is-glob": "4.0.0",
-        "merge2": "1.2.3",
-        "micromatch": "3.1.10"
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
       },
       "dependencies": {
         "is-glob": {
@@ -4101,7 +4101,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         }
       }
@@ -4124,7 +4124,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fd-slicer": {
@@ -4133,7 +4133,7 @@
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -4142,7 +4142,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4151,8 +4151,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.4",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -4187,9 +4187,9 @@
       "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "dev": true,
       "requires": {
-        "filename-reserved-regex": "2.0.0",
-        "strip-outer": "1.0.1",
-        "trim-repeated": "1.0.0"
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
       }
     },
     "fill-range": {
@@ -4198,10 +4198,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4210,7 +4210,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -4222,12 +4222,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -4259,8 +4259,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "find-versions": {
@@ -4270,8 +4270,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "array-uniq": "2.0.0",
-        "semver-regex": "2.0.0"
+        "array-uniq": "^2.0.0",
+        "semver-regex": "^2.0.0"
       },
       "dependencies": {
         "array-uniq": {
@@ -4289,10 +4289,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "1.0.0",
-        "is-glob": "3.1.0",
-        "micromatch": "3.1.10",
-        "resolve-dir": "1.0.1"
+        "detect-file": "^1.0.0",
+        "is-glob": "^3.1.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
       }
     },
     "fined": {
@@ -4301,11 +4301,11 @@
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "is-plain-object": "2.0.4",
-        "object.defaults": "1.1.0",
-        "object.pick": "1.3.0",
-        "parse-filepath": "1.0.2"
+        "expand-tilde": "^2.0.2",
+        "is-plain-object": "^2.0.3",
+        "object.defaults": "^1.1.0",
+        "object.pick": "^1.2.0",
+        "parse-filepath": "^1.0.1"
       }
     },
     "first-chunk-stream": {
@@ -4326,10 +4326,10 @@
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "graceful-fs": "4.1.15",
-        "rimraf": "2.6.2",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
       },
       "dependencies": {
         "graceful-fs": {
@@ -4351,7 +4351,7 @@
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0"
+        "debug": "=3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -4388,7 +4388,7 @@
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -4403,9 +4403,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.7",
-        "mime-types": "2.1.21"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -4414,7 +4414,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -4436,8 +4436,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -4454,13 +4454,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -4470,7 +4470,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -4487,9 +4487,9 @@
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -4506,7 +4506,7 @@
       "integrity": "sha1-gAI4I5gfn//+AWCei+Zo9prknnA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15"
+        "graceful-fs": "^4.1.2"
       },
       "dependencies": {
         "graceful-fs": {
@@ -4530,8 +4530,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.11.1",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4557,8 +4557,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -4571,7 +4571,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4635,7 +4635,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -4650,14 +4650,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -4666,12 +4666,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -4686,7 +4686,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -4695,7 +4695,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -4704,8 +4704,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -4724,7 +4724,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -4738,7 +4738,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -4751,8 +4751,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -4761,7 +4761,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -4784,9 +4784,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -4795,16 +4795,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -4813,8 +4813,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -4829,8 +4829,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -4839,10 +4839,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -4861,7 +4861,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -4882,8 +4882,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -4904,10 +4904,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -4924,13 +4924,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -4939,7 +4939,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -4982,9 +4982,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -4993,7 +4993,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -5001,7 +5001,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -5016,13 +5016,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -5037,7 +5037,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -5070,7 +5070,7 @@
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "dev": true,
       "requires": {
-        "globule": "0.1.0"
+        "globule": "~0.1.0"
       }
     },
     "get-proxy": {
@@ -5079,7 +5079,7 @@
       "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
       "dev": true,
       "requires": {
-        "npm-conf": "1.1.3"
+        "npm-conf": "^1.1.0"
       }
     },
     "get-stdin": {
@@ -5106,7 +5106,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "gifsicle": {
@@ -5116,10 +5116,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "3.0.0",
-        "bin-wrapper": "4.1.0",
-        "execa": "1.0.0",
-        "logalot": "2.1.0"
+        "bin-build": "^3.0.0",
+        "bin-wrapper": "^4.0.0",
+        "execa": "^1.0.0",
+        "logalot": "^2.0.0"
       },
       "dependencies": {
         "execa": {
@@ -5129,13 +5129,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "4.1.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "get-stream": {
@@ -5145,7 +5145,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         }
       }
@@ -5156,10 +5156,10 @@
       "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
       "dev": true,
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "2.0.10",
-        "once": "1.3.3"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^2.0.1",
+        "once": "^1.3.0"
       }
     },
     "glob-base": {
@@ -5168,8 +5168,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -5178,7 +5178,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -5193,7 +5193,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -5204,8 +5204,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       }
     },
     "glob-stream": {
@@ -5214,12 +5214,12 @@
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
       "requires": {
-        "glob": "4.5.3",
-        "glob2base": "0.0.12",
-        "minimatch": "2.0.10",
-        "ordered-read-streams": "0.1.0",
-        "through2": "0.6.5",
-        "unique-stream": "1.0.0"
+        "glob": "^4.3.1",
+        "glob2base": "^0.0.12",
+        "minimatch": "^2.0.1",
+        "ordered-read-streams": "^0.1.0",
+        "through2": "^0.6.1",
+        "unique-stream": "^1.0.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -5228,10 +5228,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "through2": {
@@ -5240,8 +5240,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -5258,7 +5258,7 @@
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "dev": true,
       "requires": {
-        "gaze": "0.5.2"
+        "gaze": "^0.5.1"
       }
     },
     "glob2base": {
@@ -5267,7 +5267,7 @@
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
-        "find-index": "0.1.1"
+        "find-index": "^0.1.1"
       }
     },
     "global-modules": {
@@ -5276,9 +5276,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "1.0.2",
-        "is-windows": "1.0.2",
-        "resolve-dir": "1.0.1"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
@@ -5287,11 +5287,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "1.0.2",
-        "which": "1.3.1"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -5306,13 +5306,13 @@
       "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "dir-glob": "2.0.0",
-        "fast-glob": "2.2.4",
-        "glob": "7.1.3",
-        "ignore": "3.3.10",
-        "pify": "3.0.0",
-        "slash": "1.0.0"
+        "array-union": "^1.0.1",
+        "dir-glob": "^2.0.0",
+        "fast-glob": "^2.0.2",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -5321,12 +5321,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "ignore": {
@@ -5341,7 +5341,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -5352,9 +5352,9 @@
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "requires": {
-        "glob": "3.1.21",
-        "lodash": "1.0.2",
-        "minimatch": "0.2.14"
+        "glob": "~3.1.21",
+        "lodash": "~1.0.1",
+        "minimatch": "~0.2.11"
       },
       "dependencies": {
         "glob": {
@@ -5363,9 +5363,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
           }
         },
         "graceful-fs": {
@@ -5392,8 +5392,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -5404,7 +5404,7 @@
       "integrity": "sha1-3PdY5EeJzD89MsHzVio2duajSBA=",
       "dev": true,
       "requires": {
-        "sparkles": "1.0.1"
+        "sparkles": "^1.0.0"
       }
     },
     "good-listener": {
@@ -5412,7 +5412,7 @@
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "requires": {
-        "delegate": "3.2.0"
+        "delegate": "^3.1.2"
       }
     },
     "got": {
@@ -5422,20 +5422,20 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-plain-obj": "1.1.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "isurl": "1.0.0",
-        "lowercase-keys": "1.0.1",
-        "p-cancelable": "0.3.0",
-        "p-timeout": "1.2.1",
-        "safe-buffer": "5.1.2",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "1.0.0",
-        "url-to-options": "1.0.1"
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
+        "url-to-options": "^1.0.1"
       }
     },
     "graceful-fs": {
@@ -5444,7 +5444,7 @@
       "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
       "dev": true,
       "requires": {
-        "natives": "1.1.6"
+        "natives": "^1.1.0"
       }
     },
     "graceful-readlink": {
@@ -5459,19 +5459,19 @@
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
-        "archy": "1.0.0",
-        "chalk": "1.1.3",
-        "deprecated": "0.0.1",
-        "gulp-util": "3.0.8",
-        "interpret": "1.1.0",
-        "liftoff": "2.5.0",
-        "minimist": "1.2.0",
-        "orchestrator": "0.3.8",
-        "pretty-hrtime": "1.0.3",
-        "semver": "4.3.6",
-        "tildify": "1.2.0",
-        "v8flags": "2.1.1",
-        "vinyl-fs": "0.3.14"
+        "archy": "^1.0.0",
+        "chalk": "^1.0.0",
+        "deprecated": "^0.0.1",
+        "gulp-util": "^3.0.0",
+        "interpret": "^1.0.0",
+        "liftoff": "^2.1.0",
+        "minimist": "^1.1.0",
+        "orchestrator": "^0.3.0",
+        "pretty-hrtime": "^1.0.0",
+        "semver": "^4.1.0",
+        "tildify": "^1.0.0",
+        "v8flags": "^2.0.2",
+        "vinyl-fs": "^0.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5486,11 +5486,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "semver": {
@@ -5513,10 +5513,10 @@
       "integrity": "sha512-oomaIqDXxFkg7lbpBou/gnUkX51/Y/M2ZfSjL2hdqXTAlSWZcgZtd2o0cOH0r/eE8LWD0+Q/PsLsr2DKOoqToQ==",
       "dev": true,
       "requires": {
-        "plugin-error": "1.0.1",
-        "replace-ext": "1.0.0",
-        "through2": "2.0.5",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "plugin-error": "^1.0.1",
+        "replace-ext": "^1.0.0",
+        "through2": "^2.0.0",
+        "vinyl-sourcemaps-apply": "^0.2.0"
       },
       "dependencies": {
         "replace-ext": {
@@ -5545,9 +5545,9 @@
           "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "string_decoder": "1.2.0",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "string_decoder": {
@@ -5556,7 +5556,7 @@
           "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "through2": {
@@ -5565,8 +5565,8 @@
           "integrity": "sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "3.0.6",
-            "xtend": "4.0.1"
+            "readable-stream": "2 || 3",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -5577,9 +5577,9 @@
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "dev": true,
       "requires": {
-        "concat-with-sourcemaps": "1.1.0",
-        "through2": "2.0.5",
-        "vinyl": "2.2.0"
+        "concat-with-sourcemaps": "^1.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^2.0.0"
       },
       "dependencies": {
         "clone": {
@@ -5606,12 +5606,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "2.1.2",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.1.2",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
           }
         }
       }
@@ -5622,15 +5622,15 @@
       "integrity": "sha512-FknHeA6smZhiRNrK/3UVH8BHLCFHS7WZdE7Y2VbZHtxye1UTIa5ZY0Cnst6O9n3kL8z7y43QI+acx3nUtJoiHw==",
       "dev": true,
       "requires": {
-        "ansi-colors": "2.0.5",
-        "connect": "3.6.6",
-        "connect-livereload": "0.6.0",
-        "event-stream": "3.3.5",
-        "fancy-log": "1.3.3",
-        "send": "0.16.2",
-        "serve-index": "1.9.1",
-        "serve-static": "1.13.2",
-        "tiny-lr": "1.1.1"
+        "ansi-colors": "^2.0.5",
+        "connect": "^3.6.6",
+        "connect-livereload": "^0.6.0",
+        "event-stream": "^3.3.4",
+        "fancy-log": "^1.3.2",
+        "send": "^0.16.2",
+        "serve-index": "^1.9.1",
+        "serve-static": "^1.13.2",
+        "tiny-lr": "^1.1.1"
       },
       "dependencies": {
         "ansi-colors": {
@@ -5647,9 +5647,9 @@
       "integrity": "sha512-9GUqCqh85C7rP9120cpxXuZz2ayq3BZc85pCTuPJS03VQYxne0aWPIXWx6LSvsGPa3uRqtSO537vaugOh+5cXg==",
       "dev": true,
       "requires": {
-        "eslint": "5.9.0",
-        "fancy-log": "1.3.3",
-        "plugin-error": "1.0.1"
+        "eslint": "^5.0.1",
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^1.0.1"
       }
     },
     "gulp-imagemin": {
@@ -5658,17 +5658,17 @@
       "integrity": "sha512-bKJMix4r6EQPVV2u8sUglw6Rn0PSp6i70pSK2ECN7j0dRy0w/Lz5SBbynY3MfGBZ0cTMZlaUq+6LyKlZgP74Ew==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "fancy-log": "1.3.3",
-        "imagemin": "6.0.0",
-        "imagemin-gifsicle": "6.0.1",
-        "imagemin-jpegtran": "6.0.0",
-        "imagemin-optipng": "6.0.0",
-        "imagemin-svgo": "7.0.0",
-        "plugin-error": "1.0.1",
-        "plur": "3.0.1",
-        "pretty-bytes": "5.1.0",
-        "through2-concurrent": "2.0.0"
+        "chalk": "^2.4.1",
+        "fancy-log": "^1.3.2",
+        "imagemin": "^6.0.0",
+        "imagemin-gifsicle": "^6.0.1",
+        "imagemin-jpegtran": "^6.0.0",
+        "imagemin-optipng": "^6.0.0",
+        "imagemin-svgo": "^7.0.0",
+        "plugin-error": "^1.0.1",
+        "plur": "^3.0.1",
+        "pretty-bytes": "^5.1.0",
+        "through2-concurrent": "^2.0.0"
       }
     },
     "gulp-less": {
@@ -5677,13 +5677,13 @@
       "integrity": "sha512-hmM2k0FfQp7Ptm3ZaqO2CkMX3hqpiIOn4OHtuSsCeFym63F7oWlEua5v6u1cIjVUKYsVIs9zPg9vbqTEb/udpA==",
       "dev": true,
       "requires": {
-        "accord": "0.29.0",
-        "less": "3.9.0",
-        "object-assign": "4.1.1",
-        "plugin-error": "0.1.2",
-        "replace-ext": "1.0.0",
-        "through2": "2.0.5",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "accord": "^0.29.0",
+        "less": "2.6.x || ^3.7.1",
+        "object-assign": "^4.0.1",
+        "plugin-error": "^0.1.2",
+        "replace-ext": "^1.0.0",
+        "through2": "^2.0.0",
+        "vinyl-sourcemaps-apply": "^0.2.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -5692,8 +5692,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-slice": "0.2.3"
+            "arr-flatten": "^1.0.1",
+            "array-slice": "^0.2.3"
           }
         },
         "arr-union": {
@@ -5714,7 +5714,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -5735,11 +5735,11 @@
           "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
           "dev": true,
           "requires": {
-            "ansi-cyan": "0.1.1",
-            "ansi-red": "0.1.1",
-            "arr-diff": "1.1.0",
-            "arr-union": "2.1.0",
-            "extend-shallow": "1.1.4"
+            "ansi-cyan": "^0.1.1",
+            "ansi-red": "^0.1.1",
+            "arr-diff": "^1.0.1",
+            "arr-union": "^2.0.1",
+            "extend-shallow": "^1.1.2"
           }
         },
         "replace-ext": {
@@ -5756,8 +5756,8 @@
       "integrity": "sha1-J7Z6Ql6zh1ImNFq4lgTXN/Y1fCE=",
       "dev": true,
       "requires": {
-        "angular": "1.3.20",
-        "angular-animate": "1.3.20",
+        "angular": "~1.3.1",
+        "angular-animate": "~1.3.1",
         "canonical-path": "0.0.2",
         "extend": "1.3.0",
         "gulp-util": "3.0.0",
@@ -5800,11 +5800,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "clone": {
@@ -5819,8 +5819,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "^4.0.1",
+            "meow": "^3.3.0"
           }
         },
         "extend": {
@@ -5835,15 +5835,15 @@
           "integrity": "sha1-b+7cR9aXKCO6zplH/F9GvYo0Zuc=",
           "dev": true,
           "requires": {
-            "chalk": "0.5.1",
-            "dateformat": "1.0.12",
-            "lodash": "2.4.1",
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.template": "2.4.1",
-            "minimist": "0.2.0",
-            "multipipe": "0.1.2",
-            "through2": "0.5.1",
-            "vinyl": "0.2.3"
+            "chalk": "^0.5.0",
+            "dateformat": "^1.0.7-1.2.3",
+            "lodash": "^2.4.1",
+            "lodash._reinterpolate": "^2.4.1",
+            "lodash.template": "^2.4.1",
+            "minimist": "^0.2.0",
+            "multipipe": "^0.1.0",
+            "through2": "^0.5.0",
+            "vinyl": "^0.2.1"
           },
           "dependencies": {
             "through2": {
@@ -5852,8 +5852,8 @@
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "3.0.0"
+                "readable-stream": "~1.0.17",
+                "xtend": "~3.0.0"
               }
             }
           }
@@ -5864,7 +5864,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "lodash": {
@@ -5885,8 +5885,8 @@
           "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
           "dev": true,
           "requires": {
-            "lodash._objecttypes": "2.4.1",
-            "lodash.keys": "2.4.1"
+            "lodash._objecttypes": "~2.4.1",
+            "lodash.keys": "~2.4.1"
           }
         },
         "lodash.escape": {
@@ -5895,9 +5895,9 @@
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
           "dev": true,
           "requires": {
-            "lodash._escapehtmlchar": "2.4.1",
-            "lodash._reunescapedhtml": "2.4.1",
-            "lodash.keys": "2.4.1"
+            "lodash._escapehtmlchar": "~2.4.1",
+            "lodash._reunescapedhtml": "~2.4.1",
+            "lodash.keys": "~2.4.1"
           }
         },
         "lodash.keys": {
@@ -5906,9 +5906,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         },
         "lodash.template": {
@@ -5917,13 +5917,13 @@
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
           "dev": true,
           "requires": {
-            "lodash._escapestringchar": "2.4.1",
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.defaults": "2.4.1",
-            "lodash.escape": "2.4.1",
-            "lodash.keys": "2.4.1",
-            "lodash.templatesettings": "2.4.1",
-            "lodash.values": "2.4.1"
+            "lodash._escapestringchar": "~2.4.1",
+            "lodash._reinterpolate": "~2.4.1",
+            "lodash.defaults": "~2.4.1",
+            "lodash.escape": "~2.4.1",
+            "lodash.keys": "~2.4.1",
+            "lodash.templatesettings": "~2.4.1",
+            "lodash.values": "~2.4.1"
           }
         },
         "lodash.templatesettings": {
@@ -5932,8 +5932,8 @@
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.escape": "2.4.1"
+            "lodash._reinterpolate": "~2.4.1",
+            "lodash.escape": "~2.4.1"
           }
         },
         "marked": {
@@ -5948,7 +5948,7 @@
           "integrity": "sha1-5oIPet267gA/SMpKWMfFolPV4Fw=",
           "dev": true,
           "requires": {
-            "through2": "0.5.1"
+            "through2": "^0.5.1"
           },
           "dependencies": {
             "through2": {
@@ -5957,8 +5957,8 @@
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "3.0.0"
+                "readable-stream": "~1.0.17",
+                "xtend": "~3.0.0"
               }
             }
           }
@@ -5975,10 +5975,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "strip-ansi": {
@@ -5987,7 +5987,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -6002,8 +6002,8 @@
           "integrity": "sha1-90KzKJPovSYUbnieT9LMssB6cX4=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.27-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           },
           "dependencies": {
             "xtend": {
@@ -6020,7 +6020,7 @@
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
           "dev": true,
           "requires": {
-            "clone-stats": "0.0.1"
+            "clone-stats": "~0.0.1"
           }
         },
         "vinyl-fs": {
@@ -6029,14 +6029,14 @@
           "integrity": "sha1-LiXP5t9cgIGPl/9Be/XCGkHkpJs=",
           "dev": true,
           "requires": {
-            "glob-stream": "3.1.18",
-            "glob-watcher": "0.0.6",
-            "graceful-fs": "3.0.11",
-            "lodash": "2.4.1",
-            "mkdirp": "0.5.1",
-            "strip-bom": "1.0.0",
-            "through2": "0.6.1",
-            "vinyl": "0.4.6"
+            "glob-stream": "^3.1.5",
+            "glob-watcher": "^0.0.6",
+            "graceful-fs": "^3.0.0",
+            "lodash": "^2.4.1",
+            "mkdirp": "^0.5.0",
+            "strip-bom": "^1.0.0",
+            "through2": "^0.6.1",
+            "vinyl": "^0.4.0"
           },
           "dependencies": {
             "vinyl": {
@@ -6045,8 +6045,8 @@
               "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
               "dev": true,
               "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
               }
             }
           }
@@ -6065,10 +6065,10 @@
       "integrity": "sha512-dohokw+npnt48AsD0hhvCLEHLnDMqM35F+amvIfJlX1H2nNHYUClR0Oy1rI0TvbL1/pHiHGNLmohhk+kvwIKjA==",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
+        "colors": "^1.1.2",
         "opn": "5.2.0",
-        "plugin-log": "0.1.0",
-        "through2": "2.0.5"
+        "plugin-log": "^0.1.0",
+        "through2": "^2.0.1"
       }
     },
     "gulp-postcss": {
@@ -6077,11 +6077,11 @@
       "integrity": "sha512-Wtl6vH7a+8IS/fU5W9IbOpcaLqKxd5L1DUOzaPmlnCbX1CrG0aWdwVnC3Spn8th0m8D59YbysV5zPUe1n/GJYg==",
       "dev": true,
       "requires": {
-        "fancy-log": "1.3.3",
-        "plugin-error": "1.0.1",
-        "postcss": "7.0.6",
-        "postcss-load-config": "2.0.0",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^1.0.1",
+        "postcss": "^7.0.2",
+        "postcss-load-config": "^2.0.0",
+        "vinyl-sourcemaps-apply": "^0.2.1"
       }
     },
     "gulp-rename": {
@@ -6096,7 +6096,7 @@
       "integrity": "sha1-xnYqLx8N4KP8WVohWZ0/rI26Gso=",
       "dev": true,
       "requires": {
-        "through2": "2.0.5"
+        "through2": "^2.0.1"
       }
     },
     "gulp-util": {
@@ -6105,24 +6105,24 @@
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.1.3",
-        "dateformat": "2.2.0",
-        "fancy-log": "1.3.3",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
+        "array-differ": "^1.0.0",
+        "array-uniq": "^1.0.2",
+        "beeper": "^1.0.0",
+        "chalk": "^1.0.0",
+        "dateformat": "^2.0.0",
+        "fancy-log": "^1.1.0",
+        "gulplog": "^1.0.0",
+        "has-gulplog": "^0.1.0",
+        "lodash._reescape": "^3.0.0",
+        "lodash._reevaluate": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.template": "^3.0.0",
+        "minimist": "^1.1.0",
+        "multipipe": "^0.1.2",
+        "object-assign": "^3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "2.0.5",
-        "vinyl": "0.5.3"
+        "through2": "^2.0.0",
+        "vinyl": "^0.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6137,11 +6137,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -6159,17 +6159,17 @@
       "dev": true,
       "requires": {
         "ansi-colors": "1.1.0",
-        "anymatch": "1.3.2",
-        "chokidar": "2.0.4",
+        "anymatch": "^1.3.0",
+        "chokidar": "^2.0.0",
         "fancy-log": "1.3.2",
-        "glob-parent": "3.1.0",
-        "object-assign": "4.1.1",
-        "path-is-absolute": "1.0.1",
+        "glob-parent": "^3.0.1",
+        "object-assign": "^4.1.0",
+        "path-is-absolute": "^1.0.1",
         "plugin-error": "1.0.1",
-        "readable-stream": "2.3.6",
-        "slash": "1.0.0",
-        "vinyl": "2.2.0",
-        "vinyl-file": "2.0.0"
+        "readable-stream": "^2.2.2",
+        "slash": "^1.0.0",
+        "vinyl": "^2.1.0",
+        "vinyl-file": "^2.0.0"
       },
       "dependencies": {
         "clone": {
@@ -6190,9 +6190,9 @@
           "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
           "dev": true,
           "requires": {
-            "ansi-gray": "0.1.1",
-            "color-support": "1.1.3",
-            "time-stamp": "1.1.0"
+            "ansi-gray": "^0.1.1",
+            "color-support": "^1.1.3",
+            "time-stamp": "^1.0.0"
           }
         },
         "isarray": {
@@ -6213,13 +6213,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "replace-ext": {
@@ -6234,7 +6234,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "vinyl": {
@@ -6243,12 +6243,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "2.1.2",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.1.2",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
           }
         }
       }
@@ -6259,16 +6259,16 @@
       "integrity": "sha1-FaXCBI4nIecFOaYbrxw0oLxfJyk=",
       "dev": true,
       "requires": {
-        "consolidate": "0.14.5",
-        "es6-promise": "3.3.1",
-        "fs-readfile-promise": "2.0.1",
-        "js-yaml": "3.12.0",
-        "lodash": "4.17.11",
-        "node.extend": "1.1.8",
-        "plugin-error": "0.1.2",
-        "through2": "2.0.5",
-        "tryit": "1.0.3",
-        "vinyl-bufferstream": "1.0.1"
+        "consolidate": "^0.14.1",
+        "es6-promise": "^3.1.2",
+        "fs-readfile-promise": "^2.0.1",
+        "js-yaml": "^3.2.6",
+        "lodash": "^4.11.1",
+        "node.extend": "^1.1.2",
+        "plugin-error": "^0.1.2",
+        "through2": "^2.0.1",
+        "tryit": "^1.0.1",
+        "vinyl-bufferstream": "^1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -6277,8 +6277,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-slice": "0.2.3"
+            "arr-flatten": "^1.0.1",
+            "array-slice": "^0.2.3"
           }
         },
         "arr-union": {
@@ -6299,7 +6299,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -6314,11 +6314,11 @@
           "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
           "dev": true,
           "requires": {
-            "ansi-cyan": "0.1.1",
-            "ansi-red": "0.1.1",
-            "arr-diff": "1.1.0",
-            "arr-union": "2.1.0",
-            "extend-shallow": "1.1.4"
+            "ansi-cyan": "^0.1.1",
+            "ansi-red": "^0.1.1",
+            "arr-diff": "^1.0.1",
+            "arr-union": "^2.0.1",
+            "extend-shallow": "^1.1.2"
           }
         }
       }
@@ -6329,12 +6329,12 @@
       "integrity": "sha1-3uYqpISqupVHqT0f9c0MPQvtwDE=",
       "dev": true,
       "requires": {
-        "escodegen": "1.11.0",
-        "esprima": "2.7.3",
-        "estemplate": "0.5.1",
-        "gulp-util": "3.0.8",
-        "through2": "2.0.5",
-        "vinyl-sourcemaps-apply": "0.1.4"
+        "escodegen": "^1.6.1",
+        "esprima": "^2.3.0",
+        "estemplate": "*",
+        "gulp-util": "~3.0.5",
+        "through2": "*",
+        "vinyl-sourcemaps-apply": "^0.1.4"
       },
       "dependencies": {
         "esprima": {
@@ -6349,7 +6349,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "vinyl-sourcemaps-apply": {
@@ -6358,7 +6358,7 @@
           "integrity": "sha1-xfy9Q+LyOEI8LcmL3db3m3K8NFs=",
           "dev": true,
           "requires": {
-            "source-map": "0.1.43"
+            "source-map": "^0.1.39"
           }
         }
       }
@@ -6369,7 +6369,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "1.0.1"
+        "glogg": "^1.0.0"
       }
     },
     "har-schema": {
@@ -6384,8 +6384,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "6.6.1",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -6394,7 +6394,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -6403,7 +6403,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary2": {
@@ -6441,7 +6441,7 @@
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "1.0.1"
+        "sparkles": "^1.0.0"
       }
     },
     "has-symbol-support-x": {
@@ -6462,7 +6462,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "1.4.2"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-value": {
@@ -6471,9 +6471,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -6482,8 +6482,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6492,7 +6492,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6503,8 +6503,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "hex-color-regex": {
@@ -6519,7 +6519,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -6559,10 +6559,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       },
       "dependencies": {
         "statuses": {
@@ -6585,9 +6585,9 @@
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
-        "eventemitter3": "3.1.0",
-        "follow-redirects": "1.5.10",
-        "requires-port": "1.0.0"
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http-signature": {
@@ -6596,9 +6596,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.15.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -6607,7 +6607,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {
@@ -6635,12 +6635,12 @@
       "integrity": "sha512-m4Mxwt2QvCp1F85HXoTungXk0Y6XzuvQGqrK9qEddQfo/7x4aZjRENmyXXfc29ei4Mk55rW002bORG86YM3/aQ==",
       "dev": true,
       "requires": {
-        "file-type": "8.1.0",
-        "globby": "8.0.1",
-        "make-dir": "1.3.0",
-        "p-pipe": "1.2.0",
-        "pify": "3.0.0",
-        "replace-ext": "1.0.0"
+        "file-type": "^8.1.0",
+        "globby": "^8.0.1",
+        "make-dir": "^1.0.0",
+        "p-pipe": "^1.1.0",
+        "pify": "^3.0.0",
+        "replace-ext": "^1.0.0"
       },
       "dependencies": {
         "replace-ext": {
@@ -6658,9 +6658,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "3.2.0",
-        "gifsicle": "4.0.1",
-        "is-gif": "3.0.0"
+        "exec-buffer": "^3.0.0",
+        "gifsicle": "^4.0.0",
+        "is-gif": "^3.0.0"
       }
     },
     "imagemin-jpegtran": {
@@ -6670,9 +6670,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "3.2.0",
-        "is-jpg": "2.0.0",
-        "jpegtran-bin": "4.0.0"
+        "exec-buffer": "^3.0.0",
+        "is-jpg": "^2.0.0",
+        "jpegtran-bin": "^4.0.0"
       }
     },
     "imagemin-optipng": {
@@ -6682,9 +6682,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "3.2.0",
-        "is-png": "1.1.0",
-        "optipng-bin": "5.0.0"
+        "exec-buffer": "^3.0.0",
+        "is-png": "^1.0.0",
+        "optipng-bin": "^5.0.0"
       }
     },
     "imagemin-svgo": {
@@ -6694,8 +6694,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-svg": "3.0.0",
-        "svgo": "1.1.1"
+        "is-svg": "^3.0.0",
+        "svgo": "^1.0.5"
       }
     },
     "import-cwd": {
@@ -6704,7 +6704,7 @@
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
-        "import-from": "2.1.0"
+        "import-from": "^2.1.0"
       }
     },
     "import-fresh": {
@@ -6713,8 +6713,8 @@
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
-        "caller-path": "2.0.0",
-        "resolve-from": "3.0.0"
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
       }
     },
     "import-from": {
@@ -6723,7 +6723,7 @@
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "import-lazy": {
@@ -6745,7 +6745,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexes-of": {
@@ -6772,8 +6772,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.3.3",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -6794,19 +6794,19 @@
       "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "3.0.3",
-        "figures": "2.0.0",
-        "lodash": "4.17.11",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rxjs": "6.3.3",
-        "string-width": "2.1.1",
-        "strip-ansi": "5.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6821,7 +6821,7 @@
           "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.0.0"
+            "ansi-regex": "^4.0.0"
           }
         }
       }
@@ -6839,8 +6839,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "from2": "2.3.0",
-        "p-is-promise": "1.1.0"
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
       }
     },
     "invariant": {
@@ -6849,7 +6849,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "irregular-plurals": {
@@ -6870,8 +6870,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "1.0.0",
-        "is-windows": "1.0.2"
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
       }
     },
     "is-absolute-url": {
@@ -6886,7 +6886,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6895,7 +6895,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6912,7 +6912,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.12.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -6927,7 +6927,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -6942,12 +6942,12 @@
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "dev": true,
       "requires": {
-        "css-color-names": "0.0.4",
-        "hex-color-regex": "1.1.0",
-        "hsl-regex": "1.0.0",
-        "hsla-regex": "1.0.0",
-        "rgb-regex": "1.0.1",
-        "rgba-regex": "1.0.0"
+        "css-color-names": "^0.0.4",
+        "hex-color-regex": "^1.1.0",
+        "hsl-regex": "^1.0.0",
+        "hsla-regex": "^1.0.0",
+        "rgb-regex": "^1.0.1",
+        "rgba-regex": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -6956,7 +6956,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6965,7 +6965,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6982,9 +6982,9 @@
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -7013,7 +7013,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -7034,7 +7034,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -7050,7 +7050,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "file-type": "10.6.0"
+        "file-type": "^10.4.0"
       },
       "dependencies": {
         "file-type": {
@@ -7068,7 +7068,7 @@
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.0"
       }
     },
     "is-jpg": {
@@ -7090,7 +7090,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -7099,7 +7099,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -7128,7 +7128,7 @@
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-png": {
@@ -7162,7 +7162,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-relative": {
@@ -7171,7 +7171,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "1.0.0"
+        "is-unc-path": "^1.0.0"
       }
     },
     "is-resolvable": {
@@ -7198,7 +7198,7 @@
       "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
       "dev": true,
       "requires": {
-        "html-comment-regex": "1.1.2"
+        "html-comment-regex": "^1.1.0"
       }
     },
     "is-symbol": {
@@ -7207,7 +7207,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.0"
+        "has-symbols": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -7222,7 +7222,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "0.1.2"
+        "unc-path-regex": "^0.1.2"
       }
     },
     "is-utf8": {
@@ -7255,7 +7255,7 @@
       "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
       "dev": true,
       "requires": {
-        "buffer-alloc": "1.2.0"
+        "buffer-alloc": "^1.2.0"
       }
     },
     "isexe": {
@@ -7282,8 +7282,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "jasmine-core": {
@@ -7299,9 +7299,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "3.0.0",
-        "bin-wrapper": "4.1.0",
-        "logalot": "2.1.0"
+        "bin-build": "^3.0.0",
+        "bin-wrapper": "^4.0.0",
+        "logalot": "^2.0.0"
       }
     },
     "jquery": {
@@ -7337,8 +7337,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -7396,7 +7396,7 @@
       "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.2.0"
       }
     },
     "jsonfile": {
@@ -7405,7 +7405,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15"
+        "graceful-fs": "^4.1.6"
       },
       "dependencies": {
         "graceful-fs": {
@@ -7435,31 +7435,31 @@
       "integrity": "sha512-NetT3wPCQMNB36uiL9LLyhrOt8SQwrEKt0xD3+KpTCfm0VxVyUJdPL5oTq2Ic5ouemgL/Iz4wqXEbF3zea9kQQ==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.3",
-        "body-parser": "1.18.3",
-        "chokidar": "2.0.4",
-        "colors": "1.1.2",
-        "combine-lists": "1.0.1",
-        "connect": "3.6.6",
-        "core-js": "2.5.7",
-        "di": "0.0.1",
-        "dom-serialize": "2.2.1",
-        "expand-braces": "0.1.2",
-        "glob": "7.1.3",
-        "graceful-fs": "4.1.15",
-        "http-proxy": "1.17.0",
-        "isbinaryfile": "3.0.3",
-        "lodash": "4.17.11",
-        "log4js": "3.0.6",
-        "mime": "2.4.0",
-        "minimatch": "3.0.4",
-        "optimist": "0.6.1",
-        "qjobs": "1.2.0",
-        "range-parser": "1.2.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.2",
+        "bluebird": "^3.3.0",
+        "body-parser": "^1.16.1",
+        "chokidar": "^2.0.3",
+        "colors": "^1.1.0",
+        "combine-lists": "^1.0.0",
+        "connect": "^3.6.0",
+        "core-js": "^2.2.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.0",
+        "expand-braces": "^0.1.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
+        "http-proxy": "^1.13.0",
+        "isbinaryfile": "^3.0.0",
+        "lodash": "^4.17.4",
+        "log4js": "^3.0.0",
+        "mime": "^2.3.1",
+        "minimatch": "^3.0.2",
+        "optimist": "^0.6.1",
+        "qjobs": "^1.1.4",
+        "range-parser": "^1.2.0",
+        "rimraf": "^2.6.0",
+        "safe-buffer": "^5.0.1",
         "socket.io": "2.1.1",
-        "source-map": "0.6.1",
+        "source-map": "^0.6.1",
         "tmp": "0.0.33",
         "useragent": "2.2.1"
       },
@@ -7470,12 +7470,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -7496,7 +7496,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "source-map": {
@@ -7513,7 +7513,7 @@
       "integrity": "sha512-iuC0hmr9b+SNn1DaUD2QEYtUxkS1J+bSJSn7ejdEexs7P8EYvA1CWkEdrDQ+8jVH3AgWlCNwjYsT1chjcNW9lA==",
       "dev": true,
       "requires": {
-        "jasmine-core": "3.3.0"
+        "jasmine-core": "^3.3"
       }
     },
     "karma-phantomjs-launcher": {
@@ -7522,8 +7522,8 @@
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11",
-        "phantomjs-prebuilt": "2.1.16"
+        "lodash": "^4.0.1",
+        "phantomjs-prebuilt": "^2.1.7"
       }
     },
     "kew": {
@@ -7554,7 +7554,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15"
+        "graceful-fs": "^4.1.9"
       },
       "dependencies": {
         "graceful-fs": {
@@ -7583,15 +7583,15 @@
       "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
       "dev": true,
       "requires": {
-        "clone": "2.1.2",
-        "errno": "0.1.7",
-        "graceful-fs": "4.1.15",
-        "image-size": "0.5.5",
-        "mime": "1.4.1",
-        "mkdirp": "0.5.1",
-        "promise": "7.3.1",
-        "request": "2.88.0",
-        "source-map": "0.6.1"
+        "clone": "^2.1.2",
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "mime": "^1.4.1",
+        "mkdirp": "^0.5.0",
+        "promise": "^7.1.1",
+        "request": "^2.83.0",
+        "source-map": "~0.6.0"
       },
       "dependencies": {
         "clone": {
@@ -7622,8 +7622,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "liftoff": {
@@ -7632,14 +7632,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
-        "extend": "3.0.2",
-        "findup-sync": "2.0.0",
-        "fined": "1.1.0",
-        "flagged-respawn": "1.0.0",
-        "is-plain-object": "2.0.4",
-        "object.map": "1.0.1",
-        "rechoir": "0.6.2",
-        "resolve": "1.8.1"
+        "extend": "^3.0.0",
+        "findup-sync": "^2.0.0",
+        "fined": "^1.0.1",
+        "flagged-respawn": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "object.map": "^1.0.0",
+        "rechoir": "^0.6.2",
+        "resolve": "^1.1.7"
       }
     },
     "livereload-js": {
@@ -7654,11 +7654,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -7673,7 +7673,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2"
+            "error-ex": "^1.2.0"
           }
         },
         "pify": {
@@ -7688,7 +7688,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -7723,7 +7723,7 @@
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "2.4.1"
+        "lodash._htmlescapes": "~2.4.1"
       }
     },
     "lodash._escapestringchar": {
@@ -7786,8 +7786,8 @@
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "2.4.1",
-        "lodash.keys": "2.4.1"
+        "lodash._htmlescapes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -7796,9 +7796,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         }
       }
@@ -7815,7 +7815,7 @@
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "lodash.clone": {
@@ -7842,7 +7842,7 @@
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "3.0.1"
+        "lodash._root": "^3.0.0"
       }
     },
     "lodash.flatten": {
@@ -7869,7 +7869,7 @@
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "lodash.keys": {
@@ -7878,9 +7878,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.memoize": {
@@ -7919,15 +7919,15 @@
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash._basetostring": "3.0.1",
-        "lodash._basevalues": "3.0.0",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0",
-        "lodash.keys": "3.1.2",
-        "lodash.restparam": "3.6.1",
-        "lodash.templatesettings": "3.1.1"
+        "lodash._basecopy": "^3.0.0",
+        "lodash._basetostring": "^3.0.0",
+        "lodash._basevalues": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0",
+        "lodash.keys": "^3.0.0",
+        "lodash.restparam": "^3.0.0",
+        "lodash.templatesettings": "^3.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -7936,8 +7936,8 @@
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0"
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0"
       }
     },
     "lodash.uniq": {
@@ -7952,7 +7952,7 @@
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "dev": true,
       "requires": {
-        "lodash.keys": "2.4.1"
+        "lodash.keys": "~2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -7961,9 +7961,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         }
       }
@@ -7974,10 +7974,10 @@
       "integrity": "sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==",
       "dev": true,
       "requires": {
-        "circular-json": "0.5.9",
-        "date-format": "1.2.0",
-        "debug": "3.2.6",
-        "rfdc": "1.1.2",
+        "circular-json": "^0.5.5",
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "rfdc": "^1.1.2",
         "streamroller": "0.7.0"
       },
       "dependencies": {
@@ -7993,7 +7993,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -8005,8 +8005,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "figures": "1.7.0",
-        "squeak": "1.3.0"
+        "figures": "^1.3.5",
+        "squeak": "^1.0.0"
       },
       "dependencies": {
         "figures": {
@@ -8016,8 +8016,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "object-assign": {
@@ -8041,7 +8041,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -8050,8 +8050,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -8067,10 +8067,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "indent-string": "2.1.0",
-        "longest": "1.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "indent-string": "^2.1.0",
+        "longest": "^1.0.0",
+        "meow": "^3.3.0"
       }
     },
     "lru-cache": {
@@ -8085,7 +8085,7 @@
       "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "make-iterator": {
@@ -8094,7 +8094,7 @@
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       }
     },
     "map-cache": {
@@ -8121,7 +8121,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "marked": {
@@ -8154,16 +8154,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -8180,7 +8180,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -8195,13 +8195,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -8210,7 +8210,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -8227,19 +8227,19 @@
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.13",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mime": {
@@ -8260,7 +8260,7 @@
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.37.0"
+        "mime-db": "~1.37.0"
       }
     },
     "mimic-fn": {
@@ -8281,7 +8281,7 @@
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.0.0"
       }
     },
     "minimist": {
@@ -8296,8 +8296,8 @@
       "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -8306,7 +8306,7 @@
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -8367,17 +8367,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "natives": {
@@ -8415,7 +8415,7 @@
       "integrity": "sha512-Ky7q0BO1BBkG/rQz6PkEZ59rwo+aSfhczHP1wwq8IowoVdN/FpiP7qp0XW0P2+BVCWe5fQUBozdbVd54q1RbCQ==",
       "dev": true,
       "requires": {
-        "semver": "5.6.0"
+        "semver": "^5.3.0"
       }
     },
     "node.extend": {
@@ -8424,8 +8424,8 @@
       "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
       "dev": true,
       "requires": {
-        "has": "1.0.3",
-        "is": "3.2.1"
+        "has": "^1.0.3",
+        "is": "^3.2.1"
       }
     },
     "normalize-package-data": {
@@ -8434,10 +8434,10 @@
       "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.6.0",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -8446,7 +8446,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-range": {
@@ -8471,132 +8471,132 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-6.4.1.tgz",
       "integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
       "requires": {
-        "JSONStream": "1.3.4",
-        "abbrev": "1.1.1",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.2.0",
-        "archy": "1.0.0",
-        "bin-links": "1.1.2",
-        "bluebird": "3.5.1",
-        "byte-size": "4.0.3",
-        "cacache": "11.2.0",
-        "call-limit": "1.1.0",
-        "chownr": "1.0.1",
-        "ci-info": "1.4.0",
-        "cli-columns": "3.1.2",
-        "cli-table3": "0.5.0",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.11",
-        "debuglog": "1.0.1",
-        "detect-indent": "5.0.0",
-        "detect-newline": "2.1.0",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "figgy-pudding": "3.4.1",
-        "find-npm-prefix": "1.0.2",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "gentle-fs": "2.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "has-unicode": "2.0.1",
-        "hosted-git-info": "2.7.1",
-        "iferr": "1.0.2",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "init-package-json": "1.10.3",
-        "is-cidr": "2.0.6",
-        "json-parse-better-errors": "1.0.2",
-        "lazy-property": "1.0.0",
-        "libcipm": "2.0.2",
-        "libnpmhook": "4.0.1",
-        "libnpx": "10.2.0",
-        "lock-verify": "2.0.2",
-        "lockfile": "1.0.4",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.6.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "lodash.without": "4.4.0",
-        "lru-cache": "4.1.3",
-        "meant": "1.0.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "node-gyp": "3.8.0",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npm-audit-report": "1.3.1",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.1.0",
-        "npm-package-arg": "6.1.0",
-        "npm-packlist": "1.1.11",
-        "npm-pick-manifest": "2.1.0",
-        "npm-profile": "3.0.2",
-        "npm-registry-client": "8.6.0",
-        "npm-registry-fetch": "1.1.0",
-        "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "opener": "1.5.0",
-        "osenv": "0.1.5",
-        "pacote": "8.1.6",
-        "path-is-inside": "1.0.2",
-        "promise-inflight": "1.0.1",
-        "qrcode-terminal": "0.12.0",
-        "query-string": "6.1.0",
-        "qw": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.13",
-        "read-package-tree": "5.2.1",
-        "readable-stream": "2.3.6",
-        "readdir-scoped-modules": "1.0.2",
-        "request": "2.88.0",
-        "retry": "0.12.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.2",
-        "semver": "5.5.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
-        "ssri": "6.0.0",
-        "stringify-package": "1.0.0",
-        "tar": "4.4.6",
-        "text-table": "0.2.0",
-        "tiny-relative-date": "1.3.0",
+        "JSONStream": "^1.3.4",
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "~1.2.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.2",
+        "bluebird": "~3.5.1",
+        "byte-size": "^4.0.3",
+        "cacache": "^11.2.0",
+        "call-limit": "~1.1.0",
+        "chownr": "~1.0.1",
+        "ci-info": "^1.4.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.5.0",
+        "cmd-shim": "~2.0.2",
+        "columnify": "~1.5.4",
+        "config-chain": "~1.1.11",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "figgy-pudding": "^3.4.1",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.0.1",
+        "glob": "~7.1.2",
+        "graceful-fs": "~4.1.11",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.7.1",
+        "iferr": "^1.0.2",
+        "imurmurhash": "*",
+        "inflight": "~1.0.6",
+        "inherits": "~2.0.3",
+        "ini": "^1.3.5",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "^2.0.6",
+        "json-parse-better-errors": "^1.0.2",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^2.0.2",
+        "libnpmhook": "^4.0.1",
+        "libnpx": "^10.2.0",
+        "lock-verify": "^2.0.2",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^4.1.3",
+        "meant": "~1.0.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "~0.5.1",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^3.8.0",
+        "nopt": "~4.0.1",
+        "normalize-package-data": "~2.4.0",
+        "npm-audit-report": "^1.3.1",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "~3.0.0",
+        "npm-lifecycle": "^2.1.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "^1.1.11",
+        "npm-pick-manifest": "^2.1.0",
+        "npm-profile": "^3.0.2",
+        "npm-registry-client": "^8.6.0",
+        "npm-registry-fetch": "^1.1.0",
+        "npm-user-validate": "~1.0.0",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "^1.5.0",
+        "osenv": "^0.1.5",
+        "pacote": "^8.1.6",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.1.0",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "~1.0.1",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.0.13",
+        "read-package-tree": "^5.2.1",
+        "readable-stream": "^2.3.6",
+        "readdir-scoped-modules": "*",
+        "request": "^2.88.0",
+        "retry": "^0.12.0",
+        "rimraf": "~2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.5.0",
+        "sha": "~2.0.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^6.0.0",
+        "stringify-package": "^1.0.0",
+        "tar": "^4.4.6",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "update-notifier": "2.5.0",
-        "uuid": "3.3.2",
-        "validate-npm-package-license": "3.0.4",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.3.1",
-        "worker-farm": "1.6.0",
-        "write-file-atomic": "2.3.0"
+        "umask": "~1.1.0",
+        "unique-filename": "~1.1.0",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.3.2",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^1.3.1",
+        "worker-farm": "^1.6.0",
+        "write-file-atomic": "^2.3.0"
       },
       "dependencies": {
         "JSONStream": {
           "version": "1.3.4",
           "bundled": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "abbrev": {
@@ -8607,31 +8607,31 @@
           "version": "4.2.0",
           "bundled": true,
           "requires": {
-            "es6-promisify": "5.0.0"
+            "es6-promisify": "^5.0.0"
           }
         },
         "agentkeepalive": {
           "version": "3.4.1",
           "bundled": true,
           "requires": {
-            "humanize-ms": "1.2.1"
+            "humanize-ms": "^1.2.1"
           }
         },
         "ajv": {
           "version": "5.5.2",
           "bundled": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "ansi-align": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "2.1.1"
+            "string-width": "^2.0.0"
           }
         },
         "ansi-regex": {
@@ -8642,7 +8642,7 @@
           "version": "3.2.1",
           "bundled": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "ansicolors": {
@@ -8665,8 +8665,8 @@
           "version": "1.1.4",
           "bundled": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asap": {
@@ -8677,7 +8677,7 @@
           "version": "0.2.4",
           "bundled": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "~2.1.0"
           }
         },
         "assert-plus": {
@@ -8705,25 +8705,25 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "bin-links": {
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cmd-shim": "2.0.2",
-            "gentle-fs": "2.0.1",
-            "graceful-fs": "4.1.11",
-            "write-file-atomic": "2.3.0"
+            "bluebird": "^3.5.0",
+            "cmd-shim": "^2.0.2",
+            "gentle-fs": "^2.0.0",
+            "graceful-fs": "^4.1.11",
+            "write-file-atomic": "^2.3.0"
           }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "bluebird": {
@@ -8734,20 +8734,20 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "ansi-align": "2.0.0",
-            "camelcase": "4.1.0",
-            "chalk": "2.4.1",
-            "cli-boxes": "1.0.0",
-            "string-width": "2.1.1",
-            "term-size": "1.2.0",
-            "widest-line": "2.0.0"
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -8775,20 +8775,20 @@
           "version": "11.2.0",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "chownr": "1.0.1",
-            "figgy-pudding": "3.4.1",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.3",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "6.0.0",
-            "unique-filename": "1.1.0",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.1",
+            "chownr": "^1.0.1",
+            "figgy-pudding": "^3.1.0",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "lru-cache": "^4.1.3",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.0",
+            "unique-filename": "^1.1.0",
+            "y18n": "^4.0.0"
           }
         },
         "call-limit": {
@@ -8811,9 +8811,9 @@
           "version": "2.4.1",
           "bundled": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "chownr": {
@@ -8828,7 +8828,7 @@
           "version": "2.0.9",
           "bundled": true,
           "requires": {
-            "ip-regex": "2.1.0"
+            "ip-regex": "^2.1.0"
           }
         },
         "cli-boxes": {
@@ -8839,26 +8839,26 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "3.0.1"
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.1"
           }
         },
         "cli-table3": {
           "version": "0.5.0",
           "bundled": true,
           "requires": {
-            "colors": "1.1.2",
-            "object-assign": "4.1.1",
-            "string-width": "2.1.1"
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^2.1.1"
           }
         },
         "cliui": {
           "version": "4.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -8869,7 +8869,7 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -8882,8 +8882,8 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1"
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
           }
         },
         "co": {
@@ -8898,7 +8898,7 @@
           "version": "1.9.1",
           "bundled": true,
           "requires": {
-            "color-name": "1.1.3"
+            "color-name": "^1.1.1"
           }
         },
         "color-name": {
@@ -8914,15 +8914,15 @@
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.1"
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
           }
         },
         "combined-stream": {
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -8933,30 +8933,30 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "buffer-from": "1.0.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "1.3.5",
-            "proto-list": "1.2.4"
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
           }
         },
         "configstore": {
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "dot-prop": "4.2.0",
-            "graceful-fs": "4.1.11",
-            "make-dir": "1.3.0",
-            "unique-string": "1.0.0",
-            "write-file-atomic": "2.3.0",
-            "xdg-basedir": "3.0.0"
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           }
         },
         "console-control-strings": {
@@ -8967,12 +8967,12 @@
           "version": "1.0.5",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-write-stream-atomic": "1.0.10",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
           },
           "dependencies": {
             "iferr": {
@@ -8989,16 +8989,16 @@
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "capture-stack-trace": "1.0.0"
+            "capture-stack-trace": "^1.0.0"
           }
         },
         "cross-spawn": {
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "lru-cache": "4.1.3",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "crypto-random-string": {
@@ -9013,7 +9013,7 @@
           "version": "1.14.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "debug": {
@@ -9049,7 +9049,7 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "clone": "1.0.4"
+            "clone": "^1.0.2"
           }
         },
         "delayed-stream": {
@@ -9072,15 +9072,15 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "2.0.6",
-            "wrappy": "1.0.2"
+            "asap": "^2.0.0",
+            "wrappy": "1"
           }
         },
         "dot-prop": {
           "version": "4.2.0",
           "bundled": true,
           "requires": {
-            "is-obj": "1.0.1"
+            "is-obj": "^1.0.0"
           }
         },
         "dotenv": {
@@ -9095,10 +9095,10 @@
           "version": "3.6.0",
           "bundled": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
           }
         },
         "ecc-jsbn": {
@@ -9106,8 +9106,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2"
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
           }
         },
         "editor": {
@@ -9118,14 +9118,14 @@
           "version": "0.1.12",
           "bundled": true,
           "requires": {
-            "iconv-lite": "0.4.23"
+            "iconv-lite": "~0.4.13"
           }
         },
         "end-of-stream": {
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "err-code": {
@@ -9136,7 +9136,7 @@
           "version": "0.1.7",
           "bundled": true,
           "requires": {
-            "prr": "1.0.1"
+            "prr": "~1.0.1"
           }
         },
         "es6-promise": {
@@ -9147,7 +9147,7 @@
           "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "es6-promise": "4.2.4"
+            "es6-promise": "^4.0.3"
           }
         },
         "escape-string-regexp": {
@@ -9158,13 +9158,13 @@
           "version": "0.7.0",
           "bundled": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "extend": {
@@ -9195,15 +9195,15 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "flush-write-stream": {
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
           }
         },
         "forever-agent": {
@@ -9214,43 +9214,43 @@
           "version": "2.3.2",
           "bundled": true,
           "requires": {
-            "asynckit": "0.4.0",
+            "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "2.1.19"
+            "mime-types": "^2.1.12"
           }
         },
         "from2": {
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
           }
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "minipass": "2.3.3"
+            "minipass": "^2.2.1"
           }
         },
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "path-is-inside": "1.0.2",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           },
           "dependencies": {
             "iferr": {
@@ -9267,33 +9267,33 @@
           "version": "1.0.11",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -9306,14 +9306,14 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-vacuum": "1.2.10",
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "path-is-inside": "1.0.2",
-            "read-cmd-shim": "1.0.1",
-            "slide": "1.1.6"
+            "aproba": "^1.1.2",
+            "fs-vacuum": "^1.2.10",
+            "graceful-fs": "^4.1.11",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "path-is-inside": "^1.0.2",
+            "read-cmd-shim": "^1.0.1",
+            "slide": "^1.1.6"
           },
           "dependencies": {
             "iferr": {
@@ -9334,43 +9334,43 @@
           "version": "0.1.7",
           "bundled": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "global-dirs": {
           "version": "0.1.1",
           "bundled": true,
           "requires": {
-            "ini": "1.3.5"
+            "ini": "^1.3.4"
           }
         },
         "got": {
           "version": "6.7.1",
           "bundled": true,
           "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.1",
-            "safe-buffer": "5.1.2",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -9385,8 +9385,8 @@
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
           }
         },
         "has-flag": {
@@ -9409,7 +9409,7 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "agent-base": "4.2.0",
+            "agent-base": "4",
             "debug": "3.1.0"
           }
         },
@@ -9417,31 +9417,31 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.2"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "https-proxy-agent": {
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "agent-base": "4.2.0",
-            "debug": "3.1.0"
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
           }
         },
         "humanize-ms": {
           "version": "1.2.1",
           "bundled": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.0.0"
           }
         },
         "iconv-lite": {
           "version": "0.4.23",
           "bundled": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "iferr": {
@@ -9452,7 +9452,7 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "import-lazy": {
@@ -9467,8 +9467,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -9483,14 +9483,14 @@
           "version": "1.10.3",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2",
-            "npm-package-arg": "6.1.0",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.13",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.4",
-            "validate-npm-package-name": "3.0.0"
+            "glob": "^7.1.1",
+            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "invert-kv": {
@@ -9509,36 +9509,36 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-ci": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "ci-info": "1.4.0"
+            "ci-info": "^1.0.0"
           }
         },
         "is-cidr": {
           "version": "2.0.6",
           "bundled": true,
           "requires": {
-            "cidr-regex": "2.0.9"
+            "cidr-regex": "^2.0.8"
           }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-installed-globally": {
           "version": "0.1.0",
           "bundled": true,
           "requires": {
-            "global-dirs": "0.1.1",
-            "is-path-inside": "1.0.1"
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
           }
         },
         "is-npm": {
@@ -9553,7 +9553,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "path-is-inside": "1.0.2"
+            "path-is-inside": "^1.0.1"
           }
         },
         "is-redirect": {
@@ -9623,7 +9623,7 @@
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "package-json": "4.0.1"
+            "package-json": "^4.0.0"
           }
         },
         "lazy-property": {
@@ -9634,46 +9634,46 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "libcipm": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "bin-links": "1.1.2",
-            "bluebird": "3.5.1",
-            "find-npm-prefix": "1.0.2",
-            "graceful-fs": "4.1.11",
-            "lock-verify": "2.0.2",
-            "mkdirp": "0.5.1",
-            "npm-lifecycle": "2.1.0",
-            "npm-logical-tree": "1.2.1",
-            "npm-package-arg": "6.1.0",
-            "pacote": "8.1.6",
-            "protoduck": "5.0.0",
-            "read-package-json": "2.0.13",
-            "rimraf": "2.6.2",
-            "worker-farm": "1.6.0"
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.1",
+            "find-npm-prefix": "^1.0.2",
+            "graceful-fs": "^4.1.11",
+            "lock-verify": "^2.0.2",
+            "mkdirp": "^0.5.1",
+            "npm-lifecycle": "^2.0.3",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "pacote": "^8.1.6",
+            "protoduck": "^5.0.0",
+            "read-package-json": "^2.0.13",
+            "rimraf": "^2.6.2",
+            "worker-farm": "^1.6.0"
           }
         },
         "libnpmhook": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "3.4.1",
-            "npm-registry-fetch": "3.1.1"
+            "figgy-pudding": "^3.1.0",
+            "npm-registry-fetch": "^3.0.0"
           },
           "dependencies": {
             "npm-registry-fetch": {
               "version": "3.1.1",
               "bundled": true,
               "requires": {
-                "bluebird": "3.5.1",
-                "figgy-pudding": "3.4.1",
-                "lru-cache": "4.1.3",
-                "make-fetch-happen": "4.0.1",
-                "npm-package-arg": "6.1.0"
+                "bluebird": "^3.5.1",
+                "figgy-pudding": "^3.1.0",
+                "lru-cache": "^4.1.2",
+                "make-fetch-happen": "^4.0.0",
+                "npm-package-arg": "^6.0.0"
               }
             }
           }
@@ -9682,37 +9682,37 @@
           "version": "10.2.0",
           "bundled": true,
           "requires": {
-            "dotenv": "5.0.1",
-            "npm-package-arg": "6.1.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.2",
-            "update-notifier": "2.5.0",
-            "which": "1.3.1",
-            "y18n": "4.0.0",
-            "yargs": "11.0.0"
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^11.0.0"
           }
         },
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "lock-verify": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "6.1.0",
-            "semver": "5.5.0"
+            "npm-package-arg": "^5.1.2 || 6",
+            "semver": "^5.4.1"
           }
         },
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "signal-exit": "3.0.2"
+            "signal-exit": "^3.0.2"
           }
         },
         "lodash._baseindexof": {
@@ -9723,8 +9723,8 @@
           "version": "4.6.0",
           "bundled": true,
           "requires": {
-            "lodash._createset": "4.0.3",
-            "lodash._root": "3.0.1"
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
           }
         },
         "lodash._bindcallback": {
@@ -9739,7 +9739,7 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "lodash._getnative": "3.9.1"
+            "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._createset": {
@@ -9782,32 +9782,32 @@
           "version": "4.1.3",
           "bundled": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "make-dir": {
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "make-fetch-happen": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "agentkeepalive": "3.4.1",
-            "cacache": "11.2.0",
-            "http-cache-semantics": "3.8.1",
-            "http-proxy-agent": "2.1.0",
-            "https-proxy-agent": "2.2.1",
-            "lru-cache": "4.1.3",
-            "mississippi": "3.0.0",
-            "node-fetch-npm": "2.0.2",
-            "promise-retry": "1.1.1",
-            "socks-proxy-agent": "4.0.1",
-            "ssri": "6.0.0"
+            "agentkeepalive": "^3.4.1",
+            "cacache": "^11.0.1",
+            "http-cache-semantics": "^3.8.1",
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.1",
+            "lru-cache": "^4.1.2",
+            "mississippi": "^3.0.0",
+            "node-fetch-npm": "^2.0.2",
+            "promise-retry": "^1.1.1",
+            "socks-proxy-agent": "^4.0.0",
+            "ssri": "^6.0.0"
           }
         },
         "meant": {
@@ -9818,7 +9818,7 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "mime-db": {
@@ -9829,7 +9829,7 @@
           "version": "2.1.19",
           "bundled": true,
           "requires": {
-            "mime-db": "1.35.0"
+            "mime-db": "~1.35.0"
           }
         },
         "mimic-fn": {
@@ -9840,7 +9840,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -9851,8 +9851,8 @@
           "version": "2.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
           },
           "dependencies": {
             "yallist": {
@@ -9865,23 +9865,23 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "minipass": "2.3.3"
+            "minipass": "^2.2.1"
           }
         },
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.2",
-            "duplexify": "3.6.0",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.0.3",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.5.1",
-            "stream-each": "1.2.2",
-            "through2": "2.0.3"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           }
         },
         "mkdirp": {
@@ -9895,12 +9895,12 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
           }
         },
         "ms": {
@@ -9915,34 +9915,34 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "encoding": "0.1.12",
-            "json-parse-better-errors": "1.0.2",
-            "safe-buffer": "5.1.2"
+            "encoding": "^0.1.11",
+            "json-parse-better-errors": "^1.0.0",
+            "safe-buffer": "^5.1.1"
           }
         },
         "node-gyp": {
           "version": "3.8.0",
           "bundled": true,
           "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "osenv": "0.1.5",
-            "request": "2.88.0",
-            "rimraf": "2.6.2",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "which": "1.3.1"
+            "fstream": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "^2.87.0",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^2.0.0",
+            "which": "1"
           },
           "dependencies": {
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
               }
             },
             "semver": {
@@ -9953,9 +9953,9 @@
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
               }
             }
           }
@@ -9964,26 +9964,26 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.7.1",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.4"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "npm-audit-report": {
           "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "cli-table3": "0.5.0",
-            "console-control-strings": "1.1.0"
+            "cli-table3": "^0.5.0",
+            "console-control-strings": "^1.1.0"
           }
         },
         "npm-bundled": {
@@ -9998,21 +9998,21 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "byline": "5.0.0",
-            "graceful-fs": "4.1.11",
-            "node-gyp": "3.8.0",
-            "resolve-from": "4.0.0",
-            "slide": "1.1.6",
+            "byline": "^5.0.0",
+            "graceful-fs": "^4.1.11",
+            "node-gyp": "^3.8.0",
+            "resolve-from": "^4.0.0",
+            "slide": "^1.1.6",
             "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "which": "1.3.1"
+            "umask": "^1.1.0",
+            "which": "^1.3.1"
           }
         },
         "npm-logical-tree": {
@@ -10023,52 +10023,52 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.7.1",
-            "osenv": "0.1.5",
-            "semver": "5.5.0",
-            "validate-npm-package-name": "3.0.0"
+            "hosted-git-info": "^2.6.0",
+            "osenv": "^0.1.5",
+            "semver": "^5.5.0",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.5"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "6.1.0",
-            "semver": "5.5.0"
+            "npm-package-arg": "^6.0.0",
+            "semver": "^5.4.1"
           }
         },
         "npm-profile": {
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "make-fetch-happen": "4.0.1"
+            "aproba": "^1.1.2 || 2",
+            "make-fetch-happen": "^2.5.0 || 3 || 4"
           }
         },
         "npm-registry-client": {
           "version": "8.6.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.2",
-            "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.1.0",
-            "npmlog": "4.1.2",
-            "once": "1.4.0",
-            "request": "2.88.0",
-            "retry": "0.10.1",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "ssri": "5.3.0"
+            "concat-stream": "^1.5.2",
+            "graceful-fs": "^4.1.6",
+            "normalize-package-data": "~1.0.1 || ^2.0.0",
+            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+            "npmlog": "2 || ^3.1.0 || ^4.0.0",
+            "once": "^1.3.3",
+            "request": "^2.74.0",
+            "retry": "^0.10.0",
+            "safe-buffer": "^5.1.1",
+            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+            "slide": "^1.1.3",
+            "ssri": "^5.2.4"
           },
           "dependencies": {
             "retry": {
@@ -10079,7 +10079,7 @@
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.1"
               }
             }
           }
@@ -10088,47 +10088,47 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "figgy-pudding": "2.0.1",
-            "lru-cache": "4.1.3",
-            "make-fetch-happen": "3.0.0",
-            "npm-package-arg": "6.1.0",
-            "safe-buffer": "5.1.2"
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^2.0.1",
+            "lru-cache": "^4.1.2",
+            "make-fetch-happen": "^3.0.0",
+            "npm-package-arg": "^6.0.0",
+            "safe-buffer": "^5.1.1"
           },
           "dependencies": {
             "cacache": {
               "version": "10.0.4",
               "bundled": true,
               "requires": {
-                "bluebird": "3.5.1",
-                "chownr": "1.0.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lru-cache": "4.1.3",
-                "mississippi": "2.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "promise-inflight": "1.0.1",
-                "rimraf": "2.6.2",
-                "ssri": "5.3.0",
-                "unique-filename": "1.1.0",
-                "y18n": "4.0.0"
+                "bluebird": "^3.5.1",
+                "chownr": "^1.0.1",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^2.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "ssri": "^5.2.4",
+                "unique-filename": "^1.1.0",
+                "y18n": "^4.0.0"
               },
               "dependencies": {
                 "mississippi": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "1.6.2",
-                    "duplexify": "3.6.0",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.3",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "2.0.1",
-                    "pumpify": "1.5.1",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
+                    "concat-stream": "^1.5.0",
+                    "duplexify": "^3.4.2",
+                    "end-of-stream": "^1.1.0",
+                    "flush-write-stream": "^1.0.0",
+                    "from2": "^2.1.0",
+                    "parallel-transform": "^1.1.0",
+                    "pump": "^2.0.1",
+                    "pumpify": "^1.3.3",
+                    "stream-each": "^1.1.0",
+                    "through2": "^2.0.0"
                   }
                 }
               }
@@ -10141,25 +10141,25 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.4.1",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.3",
-                "mississippi": "3.0.0",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
+                "agentkeepalive": "^3.4.1",
+                "cacache": "^10.0.4",
+                "http-cache-semantics": "^3.8.1",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.0",
+                "lru-cache": "^4.1.2",
+                "mississippi": "^3.0.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.2.4"
               }
             },
             "pump": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             },
             "smart-buffer": {
@@ -10170,23 +10170,23 @@
               "version": "1.1.10",
               "bundled": true,
               "requires": {
-                "ip": "1.1.5",
-                "smart-buffer": "1.1.15"
+                "ip": "^1.1.4",
+                "smart-buffer": "^1.0.13"
               }
             },
             "socks-proxy-agent": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "agent-base": "4.2.0",
-                "socks": "1.1.10"
+                "agent-base": "^4.1.0",
+                "socks": "^1.1.10"
               }
             },
             "ssri": {
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.1"
               }
             }
           }
@@ -10195,7 +10195,7 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "npm-user-validate": {
@@ -10206,10 +10206,10 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -10228,7 +10228,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "opener": {
@@ -10243,9 +10243,9 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "os-tmpdir": {
@@ -10256,8 +10256,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "p-finally": {
@@ -10268,14 +10268,14 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-limit": "1.2.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -10286,50 +10286,50 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "got": "6.7.1",
-            "registry-auth-token": "3.3.2",
-            "registry-url": "3.1.0",
-            "semver": "5.5.0"
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
           }
         },
         "pacote": {
           "version": "8.1.6",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cacache": "11.2.0",
-            "get-stream": "3.0.0",
-            "glob": "7.1.2",
-            "lru-cache": "4.1.3",
-            "make-fetch-happen": "4.0.1",
-            "minimatch": "3.0.4",
-            "minipass": "2.3.3",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.1.0",
-            "npm-packlist": "1.1.11",
-            "npm-pick-manifest": "2.1.0",
-            "osenv": "0.1.5",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "5.0.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "ssri": "6.0.0",
-            "tar": "4.4.6",
-            "unique-filename": "1.1.0",
-            "which": "1.3.1"
+            "bluebird": "^3.5.1",
+            "cacache": "^11.0.2",
+            "get-stream": "^3.0.0",
+            "glob": "^7.1.2",
+            "lru-cache": "^4.1.3",
+            "make-fetch-happen": "^4.0.1",
+            "minimatch": "^3.0.4",
+            "minipass": "^2.3.3",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-packlist": "^1.1.10",
+            "npm-pick-manifest": "^2.1.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.2",
+            "semver": "^5.5.0",
+            "ssri": "^6.0.0",
+            "tar": "^4.4.3",
+            "unique-filename": "^1.1.0",
+            "which": "^1.3.0"
           }
         },
         "parallel-transform": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "cyclist": "0.2.2",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
           }
         },
         "path-exists": {
@@ -10372,8 +10372,8 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "err-code": "1.1.2",
-            "retry": "0.10.1"
+            "err-code": "^1.0.0",
+            "retry": "^0.10.0"
           },
           "dependencies": {
             "retry": {
@@ -10386,7 +10386,7 @@
           "version": "0.3.0",
           "bundled": true,
           "requires": {
-            "read": "1.0.7"
+            "read": "1"
           }
         },
         "proto-list": {
@@ -10397,7 +10397,7 @@
           "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "genfun": "4.0.1"
+            "genfun": "^4.0.1"
           }
         },
         "prr": {
@@ -10416,25 +10416,25 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "pumpify": {
           "version": "1.5.1",
           "bundled": true,
           "requires": {
-            "duplexify": "3.6.0",
-            "inherits": "2.0.3",
-            "pump": "2.0.1"
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
           },
           "dependencies": {
             "pump": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             }
           }
@@ -10455,8 +10455,8 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "strict-uri-encode": "2.0.0"
+            "decode-uri-component": "^0.2.0",
+            "strict-uri-encode": "^2.0.0"
           }
         },
         "qw": {
@@ -10467,10 +10467,10 @@
           "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -10483,113 +10483,113 @@
           "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "0.0.7"
+            "mute-stream": "~0.0.4"
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
           }
         },
         "read-package-json": {
           "version": "2.0.13",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "json-parse-better-errors": "1.0.2",
-            "normalize-package-data": "2.4.0",
-            "slash": "1.0.0"
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "json-parse-better-errors": "^1.0.1",
+            "normalize-package-data": "^2.0.0",
+            "slash": "^1.0.0"
           }
         },
         "read-package-tree": {
           "version": "5.2.1",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.4.0",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "once": "^1.3.0",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.11",
-            "once": "1.4.0"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
           }
         },
         "registry-auth-token": {
           "version": "3.3.2",
           "bundled": true,
           "requires": {
-            "rc": "1.2.7",
-            "safe-buffer": "5.1.2"
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
           }
         },
         "registry-url": {
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "rc": "1.2.7"
+            "rc": "^1.0.1"
           }
         },
         "request": {
           "version": "2.88.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.8.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.1.0",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.19",
-            "oauth-sign": "0.9.0",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "tough-cookie": "2.4.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.3.2"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
           }
         },
         "require-directory": {
@@ -10612,14 +10612,14 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "run-queue": {
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0"
+            "aproba": "^1.1.1"
           }
         },
         "safe-buffer": {
@@ -10638,7 +10638,7 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^5.0.3"
           }
         },
         "set-blocking": {
@@ -10649,15 +10649,15 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "readable-stream": "^2.0.2"
           }
         },
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -10684,16 +10684,16 @@
           "version": "2.2.0",
           "bundled": true,
           "requires": {
-            "ip": "1.1.5",
-            "smart-buffer": "4.0.1"
+            "ip": "^1.1.5",
+            "smart-buffer": "^4.0.1"
           }
         },
         "socks-proxy-agent": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "agent-base": "4.2.0",
-            "socks": "2.2.0"
+            "agent-base": "~4.2.0",
+            "socks": "~2.2.0"
           }
         },
         "sorted-object": {
@@ -10704,16 +10704,16 @@
           "version": "2.1.3",
           "bundled": true,
           "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.2.0"
+            "from2": "^1.3.0",
+            "stream-iterate": "^1.1.0"
           },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "1.1.14"
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
               }
             },
             "isarray": {
@@ -10724,10 +10724,10 @@
               "version": "1.1.14",
               "bundled": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "string_decoder": {
@@ -10740,8 +10740,8 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -10752,8 +10752,8 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -10764,15 +10764,15 @@
           "version": "1.14.2",
           "bundled": true,
           "requires": {
-            "asn1": "0.2.4",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.2",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.2",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
           }
         },
         "ssri": {
@@ -10783,16 +10783,16 @@
           "version": "1.2.2",
           "bundled": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
           }
         },
         "stream-iterate": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "stream-shift": "1.0.0"
+            "readable-stream": "^2.1.5",
+            "stream-shift": "^1.0.0"
           }
         },
         "stream-shift": {
@@ -10807,8 +10807,8 @@
           "version": "2.1.1",
           "bundled": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -10823,7 +10823,7 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -10832,7 +10832,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "stringify-package": {
@@ -10843,7 +10843,7 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-eof": {
@@ -10858,20 +10858,20 @@
           "version": "5.4.0",
           "bundled": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "tar": {
           "version": "4.4.6",
           "bundled": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.3.3",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.3",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           },
           "dependencies": {
             "yallist": {
@@ -10884,7 +10884,7 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "execa": "0.7.0"
+            "execa": "^0.7.0"
           }
         },
         "text-table": {
@@ -10899,8 +10899,8 @@
           "version": "2.0.3",
           "bundled": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         },
         "timed-out": {
@@ -10915,15 +10915,15 @@
           "version": "2.4.3",
           "bundled": true,
           "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -10947,21 +10947,21 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "unique-slug": "2.0.0"
+            "unique-slug": "^2.0.0"
           }
         },
         "unique-slug": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "imurmurhash": "0.1.4"
+            "imurmurhash": "^0.1.4"
           }
         },
         "unique-string": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "crypto-random-string": "1.0.0"
+            "crypto-random-string": "^1.0.0"
           }
         },
         "unpipe": {
@@ -10976,23 +10976,23 @@
           "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "boxen": "1.3.0",
-            "chalk": "2.4.1",
-            "configstore": "3.1.2",
-            "import-lazy": "2.1.0",
-            "is-ci": "1.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           }
         },
         "url-parse-lax": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "prepend-http": "1.0.4"
+            "prepend-http": "^1.0.1"
           }
         },
         "util-deprecate": {
@@ -11011,38 +11011,38 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "1.0.3"
+            "builtins": "^1.0.3"
           }
         },
         "verror": {
           "version": "1.10.0",
           "bundled": true,
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         },
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "defaults": "1.0.3"
+            "defaults": "^1.0.3"
           }
         },
         "which": {
           "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -11053,16 +11053,16 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -11071,31 +11071,31 @@
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "2.1.1"
+            "string-width": "^2.1.1"
           }
         },
         "worker-farm": {
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "0.1.7"
+            "errno": "~0.1.7"
           }
         },
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -11108,9 +11108,9 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
           }
         },
         "xdg-basedir": {
@@ -11133,18 +11133,18 @@
           "version": "11.0.0",
           "bundled": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           },
           "dependencies": {
             "y18n": {
@@ -11157,7 +11157,7 @@
           "version": "9.0.2",
           "bundled": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -11168,8 +11168,8 @@
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "dev": true,
       "requires": {
-        "config-chain": "1.1.12",
-        "pify": "3.0.0"
+        "config-chain": "^1.1.11",
+        "pify": "^3.0.0"
       }
     },
     "npm-run-path": {
@@ -11178,7 +11178,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "nth-check": {
@@ -11187,7 +11187,7 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -11226,9 +11226,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -11237,7 +11237,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -11246,7 +11246,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -11263,7 +11263,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.defaults": {
@@ -11272,10 +11272,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "1.0.1",
-        "array-slice": "1.1.0",
-        "for-own": "1.0.0",
-        "isobject": "3.0.1"
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "object.getownpropertydescriptors": {
@@ -11284,8 +11284,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.12.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.map": {
@@ -11294,8 +11294,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "1.0.0",
-        "make-iterator": "1.0.1"
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
       }
     },
     "object.omit": {
@@ -11304,8 +11304,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-own": {
@@ -11314,7 +11314,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         }
       }
@@ -11325,7 +11325,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "object.values": {
@@ -11334,10 +11334,10 @@
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "on-finished": {
@@ -11355,7 +11355,7 @@
       "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -11364,7 +11364,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "opn": {
@@ -11373,7 +11373,7 @@
       "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
       "dev": true,
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "optimist": {
@@ -11382,8 +11382,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -11406,12 +11406,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "optipng-bin": {
@@ -11421,9 +11421,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "3.0.0",
-        "bin-wrapper": "4.1.0",
-        "logalot": "2.1.0"
+        "bin-build": "^3.0.0",
+        "bin-wrapper": "^4.0.0",
+        "logalot": "^2.0.0"
       }
     },
     "orchestrator": {
@@ -11432,9 +11432,9 @@
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "dev": true,
       "requires": {
-        "end-of-stream": "0.1.5",
-        "sequencify": "0.0.7",
-        "stream-consume": "0.1.1"
+        "end-of-stream": "~0.1.5",
+        "sequencify": "~0.0.7",
+        "stream-consume": "~0.1.0"
       }
     },
     "ordered-read-streams": {
@@ -11450,7 +11450,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "arch": "2.1.1"
+        "arch": "^2.1.0"
       }
     },
     "os-homedir": {
@@ -11479,7 +11479,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "p-timeout": "1.2.1"
+        "p-timeout": "^1.1.1"
       }
     },
     "p-finally": {
@@ -11502,7 +11502,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "p-reduce": "1.0.0"
+        "p-reduce": "^1.0.0"
       }
     },
     "p-pipe": {
@@ -11524,7 +11524,7 @@
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "parse-filepath": {
@@ -11533,9 +11533,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "1.0.0",
-        "map-cache": "0.2.2",
-        "path-root": "0.1.1"
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
       }
     },
     "parse-glob": {
@@ -11544,10 +11544,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -11562,7 +11562,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -11573,8 +11573,8 @@
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2",
-        "json-parse-better-errors": "1.0.2"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse-node-version": {
@@ -11595,7 +11595,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -11604,7 +11604,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -11637,7 +11637,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -11670,7 +11670,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "0.1.2"
+        "path-root-regex": "^0.1.0"
       }
     },
     "path-root-regex": {
@@ -11685,7 +11685,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "pause-stream": {
@@ -11694,7 +11694,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3"
       }
     },
     "pend": {
@@ -11715,15 +11715,15 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.5",
-        "extract-zip": "1.6.7",
-        "fs-extra": "1.0.0",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.88.0",
-        "request-progress": "2.0.1",
-        "which": "1.3.1"
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
       },
       "dependencies": {
         "es6-promise": {
@@ -11758,7 +11758,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "plugin-error": {
@@ -11767,10 +11767,10 @@
       "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
       "dev": true,
       "requires": {
-        "ansi-colors": "1.1.0",
-        "arr-diff": "4.0.0",
-        "arr-union": "3.1.0",
-        "extend-shallow": "3.0.2"
+        "ansi-colors": "^1.0.1",
+        "arr-diff": "^4.0.0",
+        "arr-union": "^3.1.0",
+        "extend-shallow": "^3.0.2"
       }
     },
     "plugin-log": {
@@ -11779,8 +11779,8 @@
       "integrity": "sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "dateformat": "1.0.12"
+        "chalk": "^1.1.1",
+        "dateformat": "^1.0.11"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11795,11 +11795,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "dateformat": {
@@ -11808,8 +11808,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "^4.0.1",
+            "meow": "^3.3.0"
           }
         },
         "supports-color": {
@@ -11826,7 +11826,7 @@
       "integrity": "sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==",
       "dev": true,
       "requires": {
-        "irregular-plurals": "2.0.0"
+        "irregular-plurals": "^2.0.0"
       }
     },
     "pluralize": {
@@ -11847,9 +11847,9 @@
       "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "source-map": "0.6.1",
-        "supports-color": "5.5.0"
+        "chalk": "^2.4.1",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.5.0"
       },
       "dependencies": {
         "source-map": {
@@ -11866,10 +11866,10 @@
       "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
       "dev": true,
       "requires": {
-        "css-unit-converter": "1.1.1",
-        "postcss": "7.0.6",
-        "postcss-selector-parser": "5.0.0-rc.4",
-        "postcss-value-parser": "3.3.1"
+        "css-unit-converter": "^1.1.1",
+        "postcss": "^7.0.5",
+        "postcss-selector-parser": "^5.0.0-rc.4",
+        "postcss-value-parser": "^3.3.1"
       }
     },
     "postcss-colormin": {
@@ -11878,11 +11878,11 @@
       "integrity": "sha512-1QJc2coIehnVFsz0otges8kQLsryi4lo19WD+U5xCWvXd0uw/Z+KKYnbiNDCnO9GP+PvErPHCG0jNvWTngk9Rw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.3.5",
-        "color": "3.1.0",
-        "has": "1.0.3",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "browserslist": "^4.0.0",
+        "color": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-convert-values": {
@@ -11891,8 +11891,8 @@
       "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-discard-comments": {
@@ -11901,7 +11901,7 @@
       "integrity": "sha512-Ay+rZu1Sz6g8IdzRjUgG2NafSNpp2MSMOQUb+9kkzzzP+kh07fP0yNbhtFejURnyVXSX3FYy2nVNW1QTnNjgBQ==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.6"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-duplicates": {
@@ -11910,7 +11910,7 @@
       "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.6"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-empty": {
@@ -11919,7 +11919,7 @@
       "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.6"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-overridden": {
@@ -11928,7 +11928,7 @@
       "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.6"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-load-config": {
@@ -11937,8 +11937,8 @@
       "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "4.0.0",
-        "import-cwd": "2.1.0"
+        "cosmiconfig": "^4.0.0",
+        "import-cwd": "^2.0.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -11947,10 +11947,10 @@
           "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
           "dev": true,
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.12.0",
-            "parse-json": "4.0.0",
-            "require-from-string": "2.0.2"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0",
+            "require-from-string": "^2.0.1"
           }
         }
       }
@@ -11962,9 +11962,9 @@
       "dev": true,
       "requires": {
         "css-color-names": "0.0.4",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1",
-        "stylehacks": "4.0.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "stylehacks": "^4.0.0"
       }
     },
     "postcss-merge-rules": {
@@ -11973,12 +11973,12 @@
       "integrity": "sha512-UiuXwCCJtQy9tAIxsnurfF0mrNHKc4NnNx6NxqmzNNjXpQwLSukUxELHTRF0Rg1pAmcoKLih8PwvZbiordchag==",
       "dev": true,
       "requires": {
-        "browserslist": "4.3.5",
-        "caniuse-api": "3.0.0",
-        "cssnano-util-same-parent": "4.0.1",
-        "postcss": "7.0.6",
-        "postcss-selector-parser": "3.1.1",
-        "vendors": "1.0.2"
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "cssnano-util-same-parent": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0",
+        "vendors": "^1.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -11987,9 +11987,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "4.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -12000,8 +12000,8 @@
       "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-minify-gradients": {
@@ -12010,10 +12010,10 @@
       "integrity": "sha512-pySEW3E6Ly5mHm18rekbWiAjVi/Wj8KKt2vwSfVFAWdW6wOIekgqxKxLU7vJfb107o3FDNPkaYFCxGAJBFyogA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "is-color-stop": "1.1.0",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "is-color-stop": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-minify-params": {
@@ -12022,12 +12022,12 @@
       "integrity": "sha512-h4W0FEMEzBLxpxIVelRtMheskOKKp52ND6rJv+nBS33G1twu2tCyurYj/YtgU76+UDCvWeNs0hs8HFAWE2OUFg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "browserslist": "4.3.5",
-        "cssnano-util-get-arguments": "4.0.0",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.0",
+        "browserslist": "^4.0.0",
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "uniqs": "^2.0.0"
       }
     },
     "postcss-minify-selectors": {
@@ -12036,10 +12036,10 @@
       "integrity": "sha512-8+plQkomve3G+CodLCgbhAKrb5lekAnLYuL1d7Nz+/7RANpBEVdgBkPNwljfSKvZ9xkkZTZITd04KP+zeJTJqg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.3",
-        "postcss": "7.0.6",
-        "postcss-selector-parser": "3.1.1"
+        "alphanum-sort": "^1.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -12048,9 +12048,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "4.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -12061,7 +12061,7 @@
       "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.6"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-normalize-display-values": {
@@ -12070,9 +12070,9 @@
       "integrity": "sha512-R5mC4vaDdvsrku96yXP7zak+O3Mm9Y8IslUobk7IMP+u/g+lXvcN4jngmHY5zeJnrQvE13dfAg5ViU05ZFDwdg==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-positions": {
@@ -12081,10 +12081,10 @@
       "integrity": "sha512-GNoOaLRBM0gvH+ZRb2vKCIujzz4aclli64MBwDuYGU2EY53LwiP7MxOZGE46UGtotrSnmarPPZ69l2S/uxdaWA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-repeat-style": {
@@ -12093,10 +12093,10 @@
       "integrity": "sha512-fFHPGIjBUyUiswY2rd9rsFcC0t3oRta4wxE1h3lpwfQZwFeFjXFSiDtdJ7APCmHQOnUZnqYBADNRPKPwFAONgA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-string": {
@@ -12105,9 +12105,9 @@
       "integrity": "sha512-IJoexFTkAvAq5UZVxWXAGE0yLoNN/012v7TQh5nDo6imZJl2Fwgbhy3J2qnIoaDBrtUP0H7JrXlX1jjn2YcvCQ==",
       "dev": true,
       "requires": {
-        "has": "1.0.3",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-timing-functions": {
@@ -12116,9 +12116,9 @@
       "integrity": "sha512-1nOtk7ze36+63ONWD8RCaRDYsnzorrj+Q6fxkQV+mlY5+471Qx9kspqv0O/qQNMeApg8KNrRf496zHwJ3tBZ7w==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-unicode": {
@@ -12127,9 +12127,9 @@
       "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "dev": true,
       "requires": {
-        "browserslist": "4.3.5",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-url": {
@@ -12138,10 +12138,10 @@
       "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
       "dev": true,
       "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "3.3.0",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-whitespace": {
@@ -12150,8 +12150,8 @@
       "integrity": "sha512-U8MBODMB2L+nStzOk6VvWWjZgi5kQNShCyjRhMT3s+W9Jw93yIjOnrEkKYD3Ul7ChWbEcjDWmXq0qOL9MIAnAw==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-ordered-values": {
@@ -12160,9 +12160,9 @@
       "integrity": "sha512-PeJiLgJWPzkVF8JuKSBcylaU+hDJ/TX3zqAMIjlghgn1JBi6QwQaDZoDIlqWRcCAI8SxKrt3FCPSRmOgKRB97Q==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-reduce-initial": {
@@ -12171,10 +12171,10 @@
       "integrity": "sha512-epUiC39NonKUKG+P3eAOKKZtm5OtAtQJL7Ye0CBN1f+UQTHzqotudp+hki7zxXm7tT0ZAKDMBj1uihpPjP25ug==",
       "dev": true,
       "requires": {
-        "browserslist": "4.3.5",
-        "caniuse-api": "3.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.6"
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0"
       }
     },
     "postcss-reduce-transforms": {
@@ -12183,10 +12183,10 @@
       "integrity": "sha512-sZVr3QlGs0pjh6JAIe6DzWvBaqYw05V1t3d9Tp+VnFRT5j+rsqoWsysh/iSD7YNsULjq9IAylCznIwVd5oU/zA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-selector-parser": {
@@ -12195,9 +12195,9 @@
       "integrity": "sha512-0XvfYuShrKlTk1ooUrVzMCFQRcypsdEIsGqh5IxC5rdtBi4/M/tDAJeSONwC2MTqEFsmPZYAV7Dd4X8rgAfV0A==",
       "dev": true,
       "requires": {
-        "cssesc": "2.0.0",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
+        "cssesc": "^2.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "postcss-svgo": {
@@ -12206,10 +12206,10 @@
       "integrity": "sha512-YD5uIk5NDRySy0hcI+ZJHwqemv2WiqqzDgtvgMzO8EGSkK5aONyX8HMVFRFJSdO8wUWTuisUFn/d7yRRbBr5Qw==",
       "dev": true,
       "requires": {
-        "is-svg": "3.0.0",
-        "postcss": "7.0.6",
-        "postcss-value-parser": "3.3.1",
-        "svgo": "1.1.1"
+        "is-svg": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "svgo": "^1.0.0"
       }
     },
     "postcss-unique-selectors": {
@@ -12218,9 +12218,9 @@
       "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "7.0.6",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.0",
+        "postcss": "^7.0.0",
+        "uniqs": "^2.0.0"
       }
     },
     "postcss-value-parser": {
@@ -12285,7 +12285,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "proto-list": {
@@ -12319,8 +12319,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.3.3"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       },
       "dependencies": {
         "end-of-stream": {
@@ -12329,7 +12329,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           },
           "dependencies": {
             "once": {
@@ -12338,7 +12338,7 @@
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             }
           }
@@ -12376,9 +12376,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -12396,9 +12396,9 @@
       "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -12421,8 +12421,8 @@
       "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
       "dev": true,
       "requires": {
-        "bytes": "1.0.0",
-        "string_decoder": "0.10.31"
+        "bytes": "1",
+        "string_decoder": "0.10"
       }
     },
     "read-pkg": {
@@ -12431,9 +12431,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -12448,9 +12448,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -12467,8 +12467,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -12477,10 +12477,10 @@
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       }
     },
     "readdirp": {
@@ -12489,9 +12489,9 @@
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "micromatch": "3.1.10",
-        "readable-stream": "2.3.6"
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
       },
       "dependencies": {
         "graceful-fs": {
@@ -12512,13 +12512,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -12527,7 +12527,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -12538,7 +12538,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.8.1"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -12547,8 +12547,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regenerate": {
@@ -12563,7 +12563,7 @@
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0"
+        "regenerate": "^1.4.0"
       }
     },
     "regenerator-transform": {
@@ -12572,7 +12572,7 @@
       "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
       "dev": true,
       "requires": {
-        "private": "0.1.8"
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -12581,7 +12581,7 @@
       "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -12590,8 +12590,8 @@
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpp": {
@@ -12606,12 +12606,12 @@
       "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0",
-        "regenerate-unicode-properties": "7.0.0",
-        "regjsgen": "0.4.0",
-        "regjsparser": "0.3.0",
-        "unicode-match-property-ecmascript": "1.0.4",
-        "unicode-match-property-value-ecmascript": "1.0.2"
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^7.0.0",
+        "regjsgen": "^0.4.0",
+        "regjsparser": "^0.3.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.0.2"
       }
     },
     "regjsgen": {
@@ -12626,7 +12626,7 @@
       "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -12661,7 +12661,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -12676,26 +12676,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.7",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.21",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
         "qs": {
@@ -12712,7 +12712,7 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "1.0.0"
+        "throttleit": "^1.0.0"
       }
     },
     "require-from-string": {
@@ -12727,8 +12727,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       },
       "dependencies": {
         "caller-path": {
@@ -12737,7 +12737,7 @@
           "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
           "dev": true,
           "requires": {
-            "callsites": "0.2.0"
+            "callsites": "^0.2.0"
           }
         },
         "callsites": {
@@ -12766,7 +12766,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-dir": {
@@ -12775,8 +12775,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "global-modules": "1.0.0"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -12798,7 +12798,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lowercase-keys": "1.0.1"
+        "lowercase-keys": "^1.0.0"
       }
     },
     "restore-cursor": {
@@ -12807,8 +12807,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -12841,7 +12841,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -12850,7 +12850,7 @@
       "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "glob": {
@@ -12859,12 +12859,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -12873,7 +12873,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -12884,7 +12884,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "run-sequence": {
@@ -12893,9 +12893,9 @@
       "integrity": "sha1-HOZD2jb9jH6n4akynaM/wriJhJU=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "fancy-log": "1.3.3",
-        "plugin-error": "0.1.2"
+        "chalk": "^1.1.3",
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^0.1.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12910,8 +12910,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-slice": "0.2.3"
+            "arr-flatten": "^1.0.1",
+            "array-slice": "^0.2.3"
           }
         },
         "arr-union": {
@@ -12932,11 +12932,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "extend-shallow": {
@@ -12945,7 +12945,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -12960,11 +12960,11 @@
           "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
           "dev": true,
           "requires": {
-            "ansi-cyan": "0.1.1",
-            "ansi-red": "0.1.1",
-            "arr-diff": "1.1.0",
-            "arr-union": "2.1.0",
-            "extend-shallow": "1.1.4"
+            "ansi-cyan": "^0.1.1",
+            "ansi-red": "^0.1.1",
+            "arr-diff": "^1.0.1",
+            "arr-union": "^2.0.1",
+            "extend-shallow": "^1.1.2"
           }
         },
         "supports-color": {
@@ -12981,7 +12981,7 @@
       "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -13002,7 +13002,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -13023,7 +13023,7 @@
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
       "requires": {
-        "commander": "2.8.1"
+        "commander": "~2.8.1"
       }
     },
     "select": {
@@ -13051,7 +13051,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "semver": "5.6.0"
+        "semver": "^5.3.0"
       }
     },
     "send": {
@@ -13061,18 +13061,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -13110,13 +13110,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.3",
-        "mime-types": "2.1.21",
-        "parseurl": "1.3.2"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -13142,9 +13142,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -13154,10 +13154,10 @@
       "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -13166,7 +13166,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -13183,7 +13183,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -13209,7 +13209,7 @@
       "resolved": "https://registry.npmjs.org/signalr/-/signalr-2.4.0.tgz",
       "integrity": "sha512-GPJHb3pcNk3IUui5/WG8lMuarEn+Vpc8wEvJ60w0KQ43W9FHnJcuNcF8dkZePr81eBslzicsRdyEunKNF7KjZQ==",
       "requires": {
-        "jquery": "3.3.1"
+        "jquery": ">=1.6.4"
       }
     },
     "simple-swizzle": {
@@ -13218,7 +13218,7 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.3.2"
+        "is-arrayish": "^0.3.1"
       },
       "dependencies": {
         "is-arrayish": {
@@ -13241,9 +13241,9 @@
       "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "astral-regex": "1.0.0",
-        "is-fullwidth-code-point": "2.0.0"
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "snapdragon": {
@@ -13252,14 +13252,14 @@
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.1"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -13277,7 +13277,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -13286,7 +13286,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "ms": {
@@ -13303,9 +13303,9 @@
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -13314,7 +13314,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -13323,7 +13323,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -13332,7 +13332,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -13341,9 +13341,9 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -13354,7 +13354,7 @@
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -13363,7 +13363,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -13374,12 +13374,12 @@
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "engine.io": "3.2.1",
-        "has-binary2": "1.0.3",
-        "socket.io-adapter": "1.1.1",
+        "debug": "~3.1.0",
+        "engine.io": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "3.2.0"
+        "socket.io-parser": "~3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -13415,15 +13415,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "engine.io-client": "3.2.1",
-        "has-binary2": "1.0.3",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.2.0",
+        "has-binary2": "~1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "3.2.0",
+        "socket.io-parser": "~3.2.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -13451,7 +13451,7 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
+        "debug": "~3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -13484,7 +13484,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "sort-keys-length": {
@@ -13493,7 +13493,7 @@
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
       "requires": {
-        "sort-keys": "1.1.2"
+        "sort-keys": "^1.0.0"
       }
     },
     "source-map": {
@@ -13508,11 +13508,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "2.1.2",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-url": {
@@ -13533,8 +13533,8 @@
       "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.2"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -13549,8 +13549,8 @@
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.2"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -13570,7 +13570,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -13579,7 +13579,7 @@
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -13595,9 +13595,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "chalk": "1.1.3",
-        "console-stream": "0.1.1",
-        "lpad-align": "1.1.2"
+        "chalk": "^1.0.0",
+        "console-stream": "^0.1.1",
+        "lpad-align": "^1.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13614,11 +13614,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -13636,15 +13636,15 @@
       "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stable": {
@@ -13659,8 +13659,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -13669,7 +13669,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -13686,8 +13686,8 @@
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "through": "2.3.8"
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "stream-consume": {
@@ -13702,10 +13702,10 @@
       "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "dev": true,
       "requires": {
-        "date-format": "1.2.0",
-        "debug": "3.2.6",
-        "mkdirp": "0.5.1",
-        "readable-stream": "2.3.6"
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "mkdirp": "^0.5.1",
+        "readable-stream": "^2.3.0"
       },
       "dependencies": {
         "debug": {
@@ -13714,7 +13714,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "isarray": {
@@ -13729,13 +13729,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -13744,7 +13744,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -13768,8 +13768,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -13784,7 +13784,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -13801,7 +13801,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -13810,8 +13810,8 @@
       "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "1.0.0",
-        "is-utf8": "0.2.1"
+        "first-chunk-stream": "^1.0.0",
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-bom-stream": {
@@ -13820,8 +13820,8 @@
       "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "2.0.0",
-        "strip-bom": "2.0.0"
+        "first-chunk-stream": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "first-chunk-stream": {
@@ -13830,7 +13830,7 @@
           "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "^2.0.2"
           }
         },
         "isarray": {
@@ -13845,13 +13845,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -13860,7 +13860,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-bom": {
@@ -13869,7 +13869,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -13880,7 +13880,7 @@
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dev": true,
       "requires": {
-        "is-natural-number": "4.0.1"
+        "is-natural-number": "^4.0.1"
       }
     },
     "strip-eof": {
@@ -13895,7 +13895,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -13910,7 +13910,7 @@
       "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "stylehacks": {
@@ -13919,9 +13919,9 @@
       "integrity": "sha512-TK5zEPeD9NyC1uPIdjikzsgWxdQQN/ry1X3d1iOz1UkYDCmcr928gWD1KHgyC27F50UnE0xCTrBOO1l6KR8M4w==",
       "dev": true,
       "requires": {
-        "browserslist": "4.3.5",
-        "postcss": "7.0.6",
-        "postcss-selector-parser": "3.1.1"
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -13930,9 +13930,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "4.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -13943,7 +13943,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "svgo": {
@@ -13952,20 +13952,20 @@
       "integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
       "dev": true,
       "requires": {
-        "coa": "2.0.1",
-        "colors": "1.1.2",
-        "css-select": "2.0.2",
-        "css-select-base-adapter": "0.1.1",
+        "coa": "~2.0.1",
+        "colors": "~1.1.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "~0.1.0",
         "css-tree": "1.0.0-alpha.28",
-        "css-url-regex": "1.1.0",
-        "csso": "3.5.1",
-        "js-yaml": "3.12.0",
-        "mkdirp": "0.5.1",
-        "object.values": "1.0.4",
-        "sax": "1.2.4",
-        "stable": "0.1.8",
-        "unquote": "1.1.1",
-        "util.promisify": "1.0.0"
+        "css-url-regex": "^1.1.0",
+        "csso": "^3.5.0",
+        "js-yaml": "^3.12.0",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.0.4",
+        "sax": "~1.2.4",
+        "stable": "~0.1.6",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
       }
     },
     "table": {
@@ -13974,10 +13974,10 @@
       "integrity": "sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==",
       "dev": true,
       "requires": {
-        "ajv": "6.6.1",
-        "lodash": "4.17.11",
+        "ajv": "^6.6.1",
+        "lodash": "^4.17.11",
         "slice-ansi": "2.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       }
     },
     "tar-stream": {
@@ -13986,13 +13986,13 @@
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.2.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -14001,7 +14001,7 @@
           "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "isarray": {
@@ -14016,7 +14016,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "readable-stream": {
@@ -14025,13 +14025,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -14040,7 +14040,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -14057,8 +14057,8 @@
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "dev": true,
       "requires": {
-        "temp-dir": "1.0.0",
-        "uuid": "3.3.2"
+        "temp-dir": "^1.0.0",
+        "uuid": "^3.0.1"
       }
     },
     "text-table": {
@@ -14085,8 +14085,8 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -14101,13 +14101,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -14116,7 +14116,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -14127,7 +14127,7 @@
       "integrity": "sha512-R5/jLkfMvdmDD+seLwN7vB+mhbqzWop5fAjx5IX8/yQq7VhBhzDmhXgaHAOnhnWkCpRMM7gToYHycB0CS/pd+A==",
       "dev": true,
       "requires": {
-        "through2": "2.0.5"
+        "through2": "^2.0.0"
       }
     },
     "tildify": {
@@ -14136,7 +14136,7 @@
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "time-stamp": {
@@ -14168,12 +14168,12 @@
       "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
       "dev": true,
       "requires": {
-        "body": "5.1.0",
-        "debug": "3.2.6",
-        "faye-websocket": "0.10.0",
-        "livereload-js": "2.4.0",
-        "object-assign": "4.1.1",
-        "qs": "6.6.0"
+        "body": "^5.1.0",
+        "debug": "^3.1.0",
+        "faye-websocket": "~0.10.0",
+        "livereload-js": "^2.3.0",
+        "object-assign": "^4.1.0",
+        "qs": "^6.4.0"
       },
       "dependencies": {
         "debug": {
@@ -14182,7 +14182,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "object-assign": {
@@ -14204,7 +14204,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-array": {
@@ -14231,7 +14231,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -14240,7 +14240,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -14251,10 +14251,10 @@
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -14263,8 +14263,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -14273,8 +14273,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "1.1.29",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -14297,7 +14297,7 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "trim-right": {
@@ -14324,7 +14324,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -14339,7 +14339,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -14349,7 +14349,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.21"
+        "mime-types": "~2.1.18"
       }
     },
     "typeahead.js": {
@@ -14357,7 +14357,7 @@
       "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.11.1.tgz",
       "integrity": "sha1-TmTmcbIjEKhgb0rsgFkkuoSwFbg=",
       "requires": {
-        "jquery": "3.3.1"
+        "jquery": ">=1.7"
       }
     },
     "typedarray": {
@@ -14372,9 +14372,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -14396,8 +14396,8 @@
       "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
       "dev": true,
       "requires": {
-        "buffer": "3.6.0",
-        "through": "2.3.8"
+        "buffer": "^3.0.1",
+        "through": "^2.3.6"
       }
     },
     "unc-path-regex": {
@@ -14423,8 +14423,8 @@
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "1.0.4",
-        "unicode-property-aliases-ecmascript": "1.0.4"
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -14445,10 +14445,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -14457,7 +14457,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -14466,10 +14466,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -14510,8 +14510,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -14520,9 +14520,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -14562,7 +14562,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -14578,7 +14578,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-to-options": {
@@ -14605,8 +14605,8 @@
       "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.4",
-        "tmp": "0.0.33"
+        "lru-cache": "2.2.x",
+        "tmp": "0.0.x"
       },
       "dependencies": {
         "lru-cache": {
@@ -14629,8 +14629,8 @@
       "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "object.getownpropertydescriptors": "2.0.3"
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "utils-merge": {
@@ -14651,7 +14651,7 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
-        "user-home": "1.1.1"
+        "user-home": "^1.1.1"
       }
     },
     "validate-npm-package-license": {
@@ -14660,8 +14660,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.2",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vendors": {
@@ -14676,9 +14676,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vinyl": {
@@ -14687,8 +14687,8 @@
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "1.0.4",
-        "clone-stats": "0.0.1",
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -14707,12 +14707,12 @@
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0",
-        "strip-bom-stream": "2.0.0",
-        "vinyl": "1.2.0"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.3.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^2.0.0",
+        "vinyl": "^1.1.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -14733,7 +14733,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "vinyl": {
@@ -14742,8 +14742,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "1.0.4",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -14755,14 +14755,14 @@
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
       "requires": {
-        "defaults": "1.0.3",
-        "glob-stream": "3.1.18",
-        "glob-watcher": "0.0.6",
-        "graceful-fs": "3.0.11",
-        "mkdirp": "0.5.1",
-        "strip-bom": "1.0.0",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "defaults": "^1.0.0",
+        "glob-stream": "^3.1.5",
+        "glob-watcher": "^0.0.6",
+        "graceful-fs": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "strip-bom": "^1.0.0",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.0"
       },
       "dependencies": {
         "clone": {
@@ -14777,10 +14777,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "through2": {
@@ -14789,8 +14789,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         },
         "vinyl": {
@@ -14799,8 +14799,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
           }
         }
       }
@@ -14811,7 +14811,7 @@
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.1"
       }
     },
     "void-elements": {
@@ -14826,8 +14826,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.5.0",
-        "websocket-extensions": "0.1.3"
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -14848,7 +14848,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "window-size": {
@@ -14875,7 +14875,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "ws": {
@@ -14884,9 +14884,9 @@
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.2",
-        "ultron": "1.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "xmlhttprequest-ssl": {
@@ -14913,9 +14913,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       },
       "dependencies": {
@@ -14933,8 +14933,8 @@
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.1.0"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "yeast": {

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -8,7 +8,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.0.0"
       }
     },
     "@babel/core": {
@@ -17,20 +17,20 @@
       "integrity": "sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.1.6",
-        "@babel/helpers": "^7.1.5",
-        "@babel/parser": "^7.1.6",
-        "@babel/template": "^7.1.2",
-        "@babel/traverse": "^7.1.6",
-        "@babel/types": "^7.1.6",
-        "convert-source-map": "^1.1.0",
-        "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.10",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.1.6",
+        "@babel/helpers": "7.1.5",
+        "@babel/parser": "7.1.6",
+        "@babel/template": "7.1.2",
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6",
+        "convert-source-map": "1.6.0",
+        "debug": "4.1.0",
+        "json5": "2.1.0",
+        "lodash": "4.17.11",
+        "resolve": "1.8.1",
+        "semver": "5.6.0",
+        "source-map": "0.5.7"
       }
     },
     "@babel/generator": {
@@ -39,11 +39,11 @@
       "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.1.6",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.1.6",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -52,7 +52,7 @@
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -61,8 +61,8 @@
       "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-explode-assignable-expression": "7.1.0",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-call-delegate": {
@@ -71,9 +71,9 @@
       "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.0.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-define-map": {
@@ -82,9 +82,9 @@
       "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.0.0",
-        "lodash": "^4.17.10"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/types": "7.1.6",
+        "lodash": "4.17.11"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -93,8 +93,8 @@
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-function-name": {
@@ -103,9 +103,9 @@
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/template": "7.1.2",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -114,7 +114,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -123,7 +123,7 @@
       "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -132,7 +132,7 @@
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-module-imports": {
@@ -141,7 +141,7 @@
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-module-transforms": {
@@ -150,12 +150,12 @@
       "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0",
-        "lodash": "^4.17.10"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/template": "7.1.2",
+        "@babel/types": "7.1.6",
+        "lodash": "4.17.11"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -164,7 +164,7 @@
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -179,7 +179,7 @@
       "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -188,11 +188,11 @@
       "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-wrap-function": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-wrap-function": "7.1.0",
+        "@babel/template": "7.1.2",
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-replace-supers": {
@@ -201,10 +201,10 @@
       "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-member-expression-to-functions": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-simple-access": {
@@ -213,8 +213,8 @@
       "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/template": "7.1.2",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -223,7 +223,7 @@
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-wrap-function": {
@@ -232,10 +232,10 @@
       "integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/template": "7.1.2",
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helpers": {
@@ -244,9 +244,9 @@
       "integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.1.2",
-        "@babel/traverse": "^7.1.5",
-        "@babel/types": "^7.1.5"
+        "@babel/template": "7.1.2",
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/highlight": {
@@ -255,9 +255,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       }
     },
     "@babel/parser": {
@@ -272,9 +272,9 @@
       "integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0",
-        "@babel/plugin-syntax-async-generators": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0",
+        "@babel/plugin-syntax-async-generators": "7.0.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -283,8 +283,8 @@
       "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-json-strings": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-json-strings": "7.0.0"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
@@ -293,8 +293,8 @@
       "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -303,8 +303,8 @@
       "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -313,9 +313,9 @@
       "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.2.0"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -324,7 +324,7 @@
       "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -333,7 +333,7 @@
       "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -342,7 +342,7 @@
       "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
@@ -351,7 +351,7 @@
       "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -360,7 +360,7 @@
       "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -369,9 +369,9 @@
       "integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -380,7 +380,7 @@
       "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -389,8 +389,8 @@
       "integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.10"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "lodash": "4.17.11"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -399,14 +399,14 @@
       "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.1.0",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "globals": "^11.1.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-define-map": "7.1.0",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "globals": "11.9.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -415,7 +415,7 @@
       "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -424,7 +424,7 @@
       "integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -433,9 +433,9 @@
       "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.2.0"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -444,7 +444,7 @@
       "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -453,8 +453,8 @@
       "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -463,7 +463,7 @@
       "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -472,8 +472,8 @@
       "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-literals": {
@@ -482,7 +482,7 @@
       "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-amd": {
@@ -491,8 +491,8 @@
       "integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-transforms": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
@@ -501,9 +501,9 @@
       "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0"
+        "@babel/helper-module-transforms": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
@@ -512,8 +512,8 @@
       "integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -522,8 +522,8 @@
       "integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-transforms": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -532,7 +532,7 @@
       "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-object-super": {
@@ -541,8 +541,8 @@
       "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.1.0"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -551,9 +551,9 @@
       "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "^7.1.0",
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-call-delegate": "7.1.0",
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -562,7 +562,7 @@
       "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.13.3"
+        "regenerator-transform": "0.13.3"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -571,7 +571,7 @@
       "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-spread": {
@@ -580,7 +580,7 @@
       "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -589,8 +589,8 @@
       "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0"
       }
     },
     "@babel/plugin-transform-template-literals": {
@@ -599,8 +599,8 @@
       "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
@@ -609,7 +609,7 @@
       "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -618,9 +618,9 @@
       "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.2.0"
       }
     },
     "@babel/preset-env": {
@@ -629,47 +629,47 @@
       "integrity": "sha512-YIBfpJNQMBkb6MCkjz/A9J76SNCSuGVamOVBgoUkLzpJD/z8ghHi9I42LQ4pulVX68N/MmImz6ZTixt7Azgexw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
-        "@babel/plugin-proposal-json-strings": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
-        "@babel/plugin-syntax-async-generators": "^7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-async-to-generator": "^7.1.0",
-        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
-        "@babel/plugin-transform-block-scoping": "^7.1.5",
-        "@babel/plugin-transform-classes": "^7.1.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.0.0",
-        "@babel/plugin-transform-dotall-regex": "^7.0.0",
-        "@babel/plugin-transform-duplicate-keys": "^7.0.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
-        "@babel/plugin-transform-for-of": "^7.0.0",
-        "@babel/plugin-transform-function-name": "^7.1.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-amd": "^7.1.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.0.0",
-        "@babel/plugin-transform-modules-umd": "^7.1.0",
-        "@babel/plugin-transform-new-target": "^7.0.0",
-        "@babel/plugin-transform-object-super": "^7.1.0",
-        "@babel/plugin-transform-parameters": "^7.1.0",
-        "@babel/plugin-transform-regenerator": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0",
-        "@babel/plugin-transform-template-literals": "^7.0.0",
-        "@babel/plugin-transform-typeof-symbol": "^7.0.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "browserslist": "^4.1.0",
-        "invariant": "^2.2.2",
-        "js-levenshtein": "^1.1.3",
-        "semver": "^5.3.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "7.1.0",
+        "@babel/plugin-proposal-json-strings": "7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0",
+        "@babel/plugin-syntax-async-generators": "7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0",
+        "@babel/plugin-transform-arrow-functions": "7.0.0",
+        "@babel/plugin-transform-async-to-generator": "7.1.0",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0",
+        "@babel/plugin-transform-block-scoping": "7.1.5",
+        "@babel/plugin-transform-classes": "7.1.0",
+        "@babel/plugin-transform-computed-properties": "7.0.0",
+        "@babel/plugin-transform-destructuring": "7.1.3",
+        "@babel/plugin-transform-dotall-regex": "7.0.0",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0",
+        "@babel/plugin-transform-exponentiation-operator": "7.1.0",
+        "@babel/plugin-transform-for-of": "7.0.0",
+        "@babel/plugin-transform-function-name": "7.1.0",
+        "@babel/plugin-transform-literals": "7.0.0",
+        "@babel/plugin-transform-modules-amd": "7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "7.1.0",
+        "@babel/plugin-transform-modules-systemjs": "7.1.3",
+        "@babel/plugin-transform-modules-umd": "7.1.0",
+        "@babel/plugin-transform-new-target": "7.0.0",
+        "@babel/plugin-transform-object-super": "7.1.0",
+        "@babel/plugin-transform-parameters": "7.1.0",
+        "@babel/plugin-transform-regenerator": "7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0",
+        "@babel/plugin-transform-spread": "7.0.0",
+        "@babel/plugin-transform-sticky-regex": "7.0.0",
+        "@babel/plugin-transform-template-literals": "7.0.0",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0",
+        "@babel/plugin-transform-unicode-regex": "7.0.0",
+        "browserslist": "4.3.5",
+        "invariant": "2.2.4",
+        "js-levenshtein": "1.1.4",
+        "semver": "5.6.0"
       }
     },
     "@babel/template": {
@@ -678,9 +678,9 @@
       "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.1.2",
-        "@babel/types": "^7.1.2"
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/traverse": {
@@ -689,15 +689,15 @@
       "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.1.6",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.1.6",
-        "@babel/types": "^7.1.6",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.10"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.1.6",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/parser": "7.1.6",
+        "@babel/types": "7.1.6",
+        "debug": "4.1.0",
+        "globals": "11.9.0",
+        "lodash": "4.17.11"
       }
     },
     "@babel/types": {
@@ -706,9 +706,9 @@
       "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "2.0.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -717,8 +717,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -745,7 +745,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.21",
         "negotiator": "0.6.1"
       }
     },
@@ -755,20 +755,20 @@
       "integrity": "sha512-3OOR92FTc2p5/EcOzPcXp+Cbo+3C15nV9RXHlOUBCBpHhcB+0frbSNR9ehED/o7sTcyGVtqGJpguToEdlXhD0w==",
       "dev": true,
       "requires": {
-        "convert-source-map": "^1.5.0",
-        "glob": "^7.0.5",
-        "indx": "^0.2.3",
-        "lodash.clone": "^4.3.2",
-        "lodash.defaults": "^4.0.1",
-        "lodash.flatten": "^4.2.0",
-        "lodash.merge": "^4.4.0",
-        "lodash.partialright": "^4.1.4",
-        "lodash.pick": "^4.2.1",
-        "lodash.uniq": "^4.3.0",
-        "resolve": "^1.5.0",
-        "semver": "^5.3.0",
-        "uglify-js": "^2.8.22",
-        "when": "^3.7.8"
+        "convert-source-map": "1.6.0",
+        "glob": "7.1.3",
+        "indx": "0.2.3",
+        "lodash.clone": "4.5.0",
+        "lodash.defaults": "4.2.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.merge": "4.6.1",
+        "lodash.partialright": "4.2.1",
+        "lodash.pick": "4.4.0",
+        "lodash.uniq": "4.5.0",
+        "resolve": "1.8.1",
+        "semver": "5.6.0",
+        "uglify-js": "2.8.29",
+        "when": "3.7.8"
       },
       "dependencies": {
         "glob": {
@@ -777,12 +777,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -791,7 +791,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -825,10 +825,10 @@
       "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "align-text": {
@@ -837,9 +837,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "kind-of": {
@@ -848,7 +848,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -885,7 +885,7 @@
       "resolved": "https://registry.npmjs.org/angular-dynamic-locale/-/angular-dynamic-locale-0.1.37.tgz",
       "integrity": "sha512-m5Kyk8W8/mOZSqRxuByOwHBjv8labLBAgvl0Z3iQx2xT/tWCqb94imKUPwumudszdPDjxeopwyucQvm8Sw7ogw==",
       "requires": {
-        "@types/angular": "^1.6.25"
+        "@types/angular": "1.6.51"
       }
     },
     "angular-i18n": {
@@ -928,9 +928,9 @@
       "resolved": "https://registry.npmjs.org/angular-ui-sortable/-/angular-ui-sortable-0.19.0.tgz",
       "integrity": "sha512-u/uc981Nzg4XN1bMU9qKleMTSt7F1XjMWnyGw6gxPLIeQeLZm8jWNy7tj8y2r2HmvzXFbQVq2z6rObznFKAekQ==",
       "requires": {
-        "angular": ">=1.2.x",
-        "jquery": ">=3.1.x",
-        "jquery-ui-dist": ">=1.12.x"
+        "angular": "1.7.5",
+        "jquery": "3.3.1",
+        "jquery-ui-dist": "1.12.1"
       }
     },
     "animejs": {
@@ -944,7 +944,7 @@
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
-        "ansi-wrap": "^0.1.0"
+        "ansi-wrap": "0.1.0"
       }
     },
     "ansi-cyan": {
@@ -992,7 +992,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "ansi-wrap": {
@@ -1007,8 +1007,8 @@
       "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -1017,7 +1017,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -1032,9 +1032,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.3"
           }
         },
         "expand-brackets": {
@@ -1043,7 +1043,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -1052,7 +1052,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -1067,7 +1067,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "kind-of": {
@@ -1076,7 +1076,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -1085,19 +1085,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         }
       }
@@ -1116,7 +1116,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "file-type": "^4.2.0"
+        "file-type": "4.4.0"
       },
       "dependencies": {
         "file-type": {
@@ -1140,7 +1140,7 @@
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -1191,7 +1191,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -1231,7 +1231,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -1282,12 +1282,12 @@
       "integrity": "sha512-DY9gOh8z3tnCbJ13JIWaeQsoYncTGdsrgCceBaQSIL4nvdrLxgbRSBPevg2XbX7u4QCSfLheSJEEIUUSlkbx6Q==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.3.3",
-        "caniuse-lite": "^1.0.30000898",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^7.0.5",
-        "postcss-value-parser": "^3.3.1"
+        "browserslist": "4.3.5",
+        "caniuse-lite": "1.0.30000913",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "aws-sign2": {
@@ -1320,13 +1320,13 @@
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1335,7 +1335,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1344,7 +1344,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1353,7 +1353,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1362,9 +1362,9 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -1399,7 +1399,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -1424,11 +1424,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "decompress": "^4.0.0",
-        "download": "^6.2.2",
-        "execa": "^0.7.0",
-        "p-map-series": "^1.0.0",
-        "tempfile": "^2.0.0"
+        "decompress": "4.2.0",
+        "download": "6.2.5",
+        "execa": "0.7.0",
+        "p-map-series": "1.0.0",
+        "tempfile": "2.0.0"
       }
     },
     "bin-check": {
@@ -1438,8 +1438,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "execa": "^0.7.0",
-        "executable": "^4.1.0"
+        "execa": "0.7.0",
+        "executable": "4.1.1"
       }
     },
     "bin-version": {
@@ -1449,8 +1449,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "execa": "^1.0.0",
-        "find-versions": "^3.0.0"
+        "execa": "1.0.0",
+        "find-versions": "3.0.0"
       },
       "dependencies": {
         "execa": {
@@ -1460,13 +1460,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "6.0.5",
+            "get-stream": "4.1.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "get-stream": {
@@ -1476,7 +1476,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pump": "^3.0.0"
+            "pump": "3.0.0"
           }
         }
       }
@@ -1488,9 +1488,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-version": "^3.0.0",
-        "semver": "^5.6.0",
-        "semver-truncate": "^1.1.2"
+        "bin-version": "3.0.0",
+        "semver": "5.6.0",
+        "semver-truncate": "1.1.2"
       }
     },
     "bin-wrapper": {
@@ -1500,12 +1500,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-check": "^4.1.0",
-        "bin-version-check": "^4.0.0",
-        "download": "^7.1.0",
-        "import-lazy": "^3.1.0",
-        "os-filter-obj": "^2.0.0",
-        "pify": "^4.0.1"
+        "bin-check": "4.1.0",
+        "bin-version-check": "4.0.0",
+        "download": "7.1.0",
+        "import-lazy": "3.1.0",
+        "os-filter-obj": "2.0.0",
+        "pify": "4.0.1"
       },
       "dependencies": {
         "download": {
@@ -1515,18 +1515,18 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "archive-type": "^4.0.0",
-            "caw": "^2.0.1",
-            "content-disposition": "^0.5.2",
-            "decompress": "^4.2.0",
-            "ext-name": "^5.0.0",
-            "file-type": "^8.1.0",
-            "filenamify": "^2.0.0",
-            "get-stream": "^3.0.0",
-            "got": "^8.3.1",
-            "make-dir": "^1.2.0",
-            "p-event": "^2.1.0",
-            "pify": "^3.0.0"
+            "archive-type": "4.0.0",
+            "caw": "2.0.1",
+            "content-disposition": "0.5.2",
+            "decompress": "4.2.0",
+            "ext-name": "5.0.0",
+            "file-type": "8.1.0",
+            "filenamify": "2.1.0",
+            "get-stream": "3.0.0",
+            "got": "8.3.2",
+            "make-dir": "1.3.0",
+            "p-event": "2.1.0",
+            "pify": "3.0.0"
           },
           "dependencies": {
             "pify": {
@@ -1545,23 +1545,23 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@sindresorhus/is": "^0.7.0",
-            "cacheable-request": "^2.1.1",
-            "decompress-response": "^3.3.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "into-stream": "^3.1.0",
-            "is-retry-allowed": "^1.1.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "mimic-response": "^1.0.0",
-            "p-cancelable": "^0.4.0",
-            "p-timeout": "^2.0.1",
-            "pify": "^3.0.0",
-            "safe-buffer": "^5.1.1",
-            "timed-out": "^4.0.1",
-            "url-parse-lax": "^3.0.0",
-            "url-to-options": "^1.0.1"
+            "@sindresorhus/is": "0.7.0",
+            "cacheable-request": "2.1.4",
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "into-stream": "3.1.0",
+            "is-retry-allowed": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.1",
+            "mimic-response": "1.0.1",
+            "p-cancelable": "0.4.1",
+            "p-timeout": "2.0.1",
+            "pify": "3.0.0",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "3.0.0",
+            "url-to-options": "1.0.1"
           },
           "dependencies": {
             "pify": {
@@ -1587,7 +1587,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "p-timeout": "^2.0.1"
+            "p-timeout": "2.0.1"
           }
         },
         "p-timeout": {
@@ -1596,7 +1596,7 @@
           "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
           "dev": true,
           "requires": {
-            "p-finally": "^1.0.0"
+            "p-finally": "1.0.0"
           }
         },
         "pify": {
@@ -1620,7 +1620,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "prepend-http": "^2.0.0"
+            "prepend-http": "2.0.0"
           }
         }
       }
@@ -1691,10 +1691,10 @@
       "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
       "dev": true,
       "requires": {
-        "continuable-cache": "^0.3.1",
-        "error": "^7.0.0",
-        "raw-body": "~1.1.0",
-        "safe-json-parse": "~1.0.1"
+        "continuable-cache": "0.3.1",
+        "error": "7.0.2",
+        "raw-body": "1.1.7",
+        "safe-json-parse": "1.0.1"
       }
     },
     "body-parser": {
@@ -1704,15 +1704,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "bytes": {
@@ -1736,7 +1736,7 @@
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ms": {
@@ -1781,8 +1781,8 @@
       "resolved": "https://registry.npmjs.org/bootstrap-social/-/bootstrap-social-5.1.1.tgz",
       "integrity": "sha1-dTDGeK31bPj60/qCwp1NPl0CdQE=",
       "requires": {
-        "bootstrap": "~3",
-        "font-awesome": "~4.7"
+        "bootstrap": "3.3.7",
+        "font-awesome": "4.7.0"
       }
     },
     "brace-expansion": {
@@ -1791,7 +1791,7 @@
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1801,16 +1801,16 @@
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.3",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1819,7 +1819,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -1830,9 +1830,9 @@
       "integrity": "sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000912",
-        "electron-to-chromium": "^1.3.86",
-        "node-releases": "^1.0.5"
+        "caniuse-lite": "1.0.30000913",
+        "electron-to-chromium": "1.3.87",
+        "node-releases": "1.0.5"
       }
     },
     "buffer": {
@@ -1842,8 +1842,8 @@
       "dev": true,
       "requires": {
         "base64-js": "0.0.8",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "ieee754": "1.1.12",
+        "isarray": "1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -1860,8 +1860,8 @@
       "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -1894,7 +1894,7 @@
       "integrity": "sha1-z7GtlWjTujz+k1upq92VLeiKqyo=",
       "dev": true,
       "requires": {
-        "readable-stream": "^1.0.33"
+        "readable-stream": "1.1.14"
       }
     },
     "builtin-modules": {
@@ -1915,15 +1915,15 @@
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "cacheable-request": {
@@ -1956,9 +1956,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "prepend-http": "^2.0.0",
-            "query-string": "^5.0.1",
-            "sort-keys": "^2.0.0"
+            "prepend-http": "2.0.0",
+            "query-string": "5.1.1",
+            "sort-keys": "2.0.0"
           }
         },
         "prepend-http": {
@@ -1975,7 +1975,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-plain-obj": "^1.0.0"
+            "is-plain-obj": "1.1.0"
           }
         }
       }
@@ -1992,7 +1992,7 @@
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
-        "callsites": "^2.0.0"
+        "callsites": "2.0.0"
       }
     },
     "caller-path": {
@@ -2001,7 +2001,7 @@
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
-        "caller-callsite": "^2.0.0"
+        "caller-callsite": "2.0.0"
       }
     },
     "callsite": {
@@ -2028,8 +2028,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "caniuse-api": {
@@ -2038,10 +2038,10 @@
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
+        "browserslist": "4.3.5",
+        "caniuse-lite": "1.0.30000913",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-lite": {
@@ -2068,10 +2068,10 @@
       "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
       "dev": true,
       "requires": {
-        "get-proxy": "^2.0.0",
-        "isurl": "^1.0.0-alpha5",
-        "tunnel-agent": "^0.6.0",
-        "url-to-options": "^1.0.1"
+        "get-proxy": "2.1.0",
+        "isurl": "1.0.0",
+        "tunnel-agent": "0.6.0",
+        "url-to-options": "1.0.1"
       }
     },
     "center-align": {
@@ -2080,8 +2080,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chalk": {
@@ -2090,9 +2090,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       }
     },
     "chardet": {
@@ -2107,19 +2107,19 @@
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "anymatch": "2.0.0",
+        "async-each": "1.0.1",
+        "braces": "2.3.2",
+        "fsevents": "1.2.4",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.0",
+        "lodash.debounce": "4.0.8",
+        "normalize-path": "2.1.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.2.1",
+        "upath": "1.1.0"
       },
       "dependencies": {
         "anymatch": {
@@ -2128,8 +2128,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
           }
         },
         "is-glob": {
@@ -2138,7 +2138,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -2155,10 +2155,10 @@
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -2167,7 +2167,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -2178,7 +2178,7 @@
       "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
       "dev": true,
       "requires": {
-        "source-map": "~0.6.0"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -2195,7 +2195,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -2209,9 +2209,9 @@
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
       "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
       "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
       }
     },
     "cliui": {
@@ -2220,8 +2220,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -2252,7 +2252,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "clone-stats": {
@@ -2267,9 +2267,9 @@
       "integrity": "sha1-1ZHe5Kj4vBXaQ86X3O66E9Q+KmU=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -2284,13 +2284,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -2299,7 +2299,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -2310,7 +2310,7 @@
       "integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
       "dev": true,
       "requires": {
-        "q": "^1.1.2"
+        "q": "1.5.1"
       }
     },
     "collection-visit": {
@@ -2319,8 +2319,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color": {
@@ -2329,8 +2329,8 @@
       "integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.2"
+        "color-convert": "1.9.3",
+        "color-string": "1.5.3"
       }
     },
     "color-convert": {
@@ -2354,8 +2354,8 @@
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "dev": true,
       "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
+        "color-name": "1.1.3",
+        "simple-swizzle": "0.2.2"
       }
     },
     "color-support": {
@@ -2376,7 +2376,7 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "^4.5.0"
+        "lodash": "4.17.11"
       }
     },
     "combined-stream": {
@@ -2385,7 +2385,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -2427,10 +2427,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -2445,13 +2445,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -2460,7 +2460,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -2471,7 +2471,7 @@
       "integrity": "sha1-1OqT8FriV5CVG5nns7CeOQikCC4=",
       "dev": true,
       "requires": {
-        "source-map": "^0.6.1"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -2488,8 +2488,8 @@
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
+        "ini": "1.3.5",
+        "proto-list": "1.2.4"
       }
     },
     "connect": {
@@ -2500,7 +2500,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
@@ -2540,7 +2540,7 @@
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
       "dev": true,
       "requires": {
-        "bluebird": "^3.1.1"
+        "bluebird": "3.5.3"
       }
     },
     "content-disposition": {
@@ -2567,7 +2567,7 @@
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "cookie": {
@@ -2600,10 +2600,10 @@
       "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
       "dev": true,
       "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^4.0.0"
+        "import-fresh": "2.0.0",
+        "is-directory": "0.3.1",
+        "js-yaml": "3.12.0",
+        "parse-json": "4.0.0"
       }
     },
     "cross-spawn": {
@@ -2612,11 +2612,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.6.0",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "css-color-names": {
@@ -2631,8 +2631,8 @@
       "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.1",
-        "timsort": "^0.3.0"
+        "postcss": "7.0.6",
+        "timsort": "0.3.0"
       }
     },
     "css-select": {
@@ -2641,10 +2641,10 @@
       "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
       "dev": true,
       "requires": {
-        "boolbase": "^1.0.0",
-        "css-what": "^2.1.2",
-        "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
+        "boolbase": "1.0.0",
+        "css-what": "2.1.2",
+        "domutils": "1.7.0",
+        "nth-check": "1.0.2"
       }
     },
     "css-select-base-adapter": {
@@ -2659,8 +2659,8 @@
       "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
       "dev": true,
       "requires": {
-        "mdn-data": "~1.1.0",
-        "source-map": "^0.5.3"
+        "mdn-data": "1.1.4",
+        "source-map": "0.5.7"
       }
     },
     "css-unit-converter": {
@@ -2693,10 +2693,10 @@
       "integrity": "sha512-AiXL90l+MDuQmRNyypG2P7ux7K4XklxYzNNUd5HXZCNcH8/N9bHPcpN97v8tXgRVeFL/Ed8iP8mVmAAu0ZpT7A==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^5.0.0",
-        "cssnano-preset-default": "^4.0.5",
-        "is-resolvable": "^1.0.0",
-        "postcss": "^7.0.0"
+        "cosmiconfig": "5.0.7",
+        "cssnano-preset-default": "4.0.5",
+        "is-resolvable": "1.1.0",
+        "postcss": "7.0.6"
       }
     },
     "cssnano-preset-default": {
@@ -2705,36 +2705,36 @@
       "integrity": "sha512-f1uhya0ZAjPYtDD58QkBB0R+uYdzHPei7cDxJyQQIHt5acdhyGXaSXl2nDLzWHLwGFbZcHxQtkJS8mmNwnxTvw==",
       "dev": true,
       "requires": {
-        "css-declaration-sorter": "^4.0.1",
-        "cssnano-util-raw-cache": "^4.0.1",
-        "postcss": "^7.0.0",
-        "postcss-calc": "^7.0.0",
-        "postcss-colormin": "^4.0.2",
-        "postcss-convert-values": "^4.0.1",
-        "postcss-discard-comments": "^4.0.1",
-        "postcss-discard-duplicates": "^4.0.2",
-        "postcss-discard-empty": "^4.0.1",
-        "postcss-discard-overridden": "^4.0.1",
-        "postcss-merge-longhand": "^4.0.9",
-        "postcss-merge-rules": "^4.0.2",
-        "postcss-minify-font-values": "^4.0.2",
-        "postcss-minify-gradients": "^4.0.1",
-        "postcss-minify-params": "^4.0.1",
-        "postcss-minify-selectors": "^4.0.1",
-        "postcss-normalize-charset": "^4.0.1",
-        "postcss-normalize-display-values": "^4.0.1",
-        "postcss-normalize-positions": "^4.0.1",
-        "postcss-normalize-repeat-style": "^4.0.1",
-        "postcss-normalize-string": "^4.0.1",
-        "postcss-normalize-timing-functions": "^4.0.1",
-        "postcss-normalize-unicode": "^4.0.1",
-        "postcss-normalize-url": "^4.0.1",
-        "postcss-normalize-whitespace": "^4.0.1",
-        "postcss-ordered-values": "^4.1.1",
-        "postcss-reduce-initial": "^4.0.2",
-        "postcss-reduce-transforms": "^4.0.1",
-        "postcss-svgo": "^4.0.1",
-        "postcss-unique-selectors": "^4.0.1"
+        "css-declaration-sorter": "4.0.1",
+        "cssnano-util-raw-cache": "4.0.1",
+        "postcss": "7.0.6",
+        "postcss-calc": "7.0.1",
+        "postcss-colormin": "4.0.2",
+        "postcss-convert-values": "4.0.1",
+        "postcss-discard-comments": "4.0.1",
+        "postcss-discard-duplicates": "4.0.2",
+        "postcss-discard-empty": "4.0.1",
+        "postcss-discard-overridden": "4.0.1",
+        "postcss-merge-longhand": "4.0.9",
+        "postcss-merge-rules": "4.0.2",
+        "postcss-minify-font-values": "4.0.2",
+        "postcss-minify-gradients": "4.0.1",
+        "postcss-minify-params": "4.0.1",
+        "postcss-minify-selectors": "4.0.1",
+        "postcss-normalize-charset": "4.0.1",
+        "postcss-normalize-display-values": "4.0.1",
+        "postcss-normalize-positions": "4.0.1",
+        "postcss-normalize-repeat-style": "4.0.1",
+        "postcss-normalize-string": "4.0.1",
+        "postcss-normalize-timing-functions": "4.0.1",
+        "postcss-normalize-unicode": "4.0.1",
+        "postcss-normalize-url": "4.0.1",
+        "postcss-normalize-whitespace": "4.0.1",
+        "postcss-ordered-values": "4.1.1",
+        "postcss-reduce-initial": "4.0.2",
+        "postcss-reduce-transforms": "4.0.1",
+        "postcss-svgo": "4.0.1",
+        "postcss-unique-selectors": "4.0.1"
       }
     },
     "cssnano-util-get-arguments": {
@@ -2755,7 +2755,7 @@
       "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.6"
       }
     },
     "cssnano-util-same-parent": {
@@ -2779,8 +2779,8 @@
           "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
           "dev": true,
           "requires": {
-            "mdn-data": "~1.1.0",
-            "source-map": "^0.5.3"
+            "mdn-data": "1.1.4",
+            "source-map": "0.5.7"
           }
         }
       }
@@ -2791,7 +2791,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "custom-event": {
@@ -2806,7 +2806,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "date-format": {
@@ -2827,7 +2827,7 @@
       "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.1"
       }
     },
     "decamelize": {
@@ -2848,14 +2848,14 @@
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "dev": true,
       "requires": {
-        "decompress-tar": "^4.0.0",
-        "decompress-tarbz2": "^4.0.0",
-        "decompress-targz": "^4.0.0",
-        "decompress-unzip": "^4.0.1",
-        "graceful-fs": "^4.1.10",
-        "make-dir": "^1.0.0",
-        "pify": "^2.3.0",
-        "strip-dirs": "^2.0.0"
+        "decompress-tar": "4.1.1",
+        "decompress-tarbz2": "4.1.1",
+        "decompress-targz": "4.1.1",
+        "decompress-unzip": "4.0.1",
+        "graceful-fs": "4.1.15",
+        "make-dir": "1.3.0",
+        "pify": "2.3.0",
+        "strip-dirs": "2.1.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -2878,7 +2878,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "decompress-tar": {
@@ -2887,9 +2887,9 @@
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
       "requires": {
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0",
-        "tar-stream": "^1.5.2"
+        "file-type": "5.2.0",
+        "is-stream": "1.1.0",
+        "tar-stream": "1.6.2"
       },
       "dependencies": {
         "file-type": {
@@ -2906,11 +2906,11 @@
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "dev": true,
       "requires": {
-        "decompress-tar": "^4.1.0",
-        "file-type": "^6.1.0",
-        "is-stream": "^1.1.0",
-        "seek-bzip": "^1.0.5",
-        "unbzip2-stream": "^1.0.9"
+        "decompress-tar": "4.1.1",
+        "file-type": "6.2.0",
+        "is-stream": "1.1.0",
+        "seek-bzip": "1.0.5",
+        "unbzip2-stream": "1.3.1"
       },
       "dependencies": {
         "file-type": {
@@ -2927,9 +2927,9 @@
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "dev": true,
       "requires": {
-        "decompress-tar": "^4.1.1",
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0"
+        "decompress-tar": "4.1.1",
+        "file-type": "5.2.0",
+        "is-stream": "1.1.0"
       },
       "dependencies": {
         "file-type": {
@@ -2946,10 +2946,10 @@
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
       "requires": {
-        "file-type": "^3.8.0",
-        "get-stream": "^2.2.0",
-        "pify": "^2.3.0",
-        "yauzl": "^2.4.2"
+        "file-type": "3.9.0",
+        "get-stream": "2.3.1",
+        "pify": "2.3.0",
+        "yauzl": "2.10.0"
       },
       "dependencies": {
         "file-type": {
@@ -2964,8 +2964,8 @@
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
-            "object-assign": "^4.0.1",
-            "pinkie-promise": "^2.0.0"
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
           }
         },
         "object-assign": {
@@ -2994,7 +2994,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.4"
       }
     },
     "define-properties": {
@@ -3003,7 +3003,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.0.12"
       }
     },
     "define-property": {
@@ -3012,8 +3012,8 @@
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3022,7 +3022,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -3031,7 +3031,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -3040,9 +3040,9 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -3099,8 +3099,8 @@
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
       }
     },
     "doctrine": {
@@ -3109,7 +3109,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "dom-serialize": {
@@ -3118,10 +3118,10 @@
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "~1.0.0",
-        "ent": "~2.2.0",
-        "extend": "^3.0.0",
-        "void-elements": "^2.0.0"
+        "custom-event": "1.0.1",
+        "ent": "2.2.0",
+        "extend": "3.0.2",
+        "void-elements": "2.0.1"
       }
     },
     "dom-serializer": {
@@ -3130,8 +3130,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.2"
       },
       "dependencies": {
         "domelementtype": {
@@ -3154,8 +3154,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.2.1"
       }
     },
     "dot-prop": {
@@ -3164,7 +3164,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "download": {
@@ -3174,17 +3174,17 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "caw": "^2.0.0",
-        "content-disposition": "^0.5.2",
-        "decompress": "^4.0.0",
-        "ext-name": "^5.0.0",
+        "caw": "2.0.1",
+        "content-disposition": "0.5.2",
+        "decompress": "4.2.0",
+        "ext-name": "5.0.0",
         "file-type": "5.2.0",
-        "filenamify": "^2.0.0",
-        "get-stream": "^3.0.0",
-        "got": "^7.0.0",
-        "make-dir": "^1.0.0",
-        "p-event": "^1.0.0",
-        "pify": "^3.0.0"
+        "filenamify": "2.1.0",
+        "get-stream": "3.0.0",
+        "got": "7.1.0",
+        "make-dir": "1.3.0",
+        "p-event": "1.3.0",
+        "pify": "3.0.0"
       },
       "dependencies": {
         "file-type": {
@@ -3208,7 +3208,7 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.9"
+        "readable-stream": "1.1.14"
       }
     },
     "duplexer3": {
@@ -3223,8 +3223,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "ee-first": {
@@ -3251,7 +3251,7 @@
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "dev": true,
       "requires": {
-        "once": "~1.3.0"
+        "once": "1.3.3"
       }
     },
     "engine.io": {
@@ -3260,12 +3260,12 @@
       "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.3",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "debug": {
@@ -3293,14 +3293,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.3",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -3328,10 +3328,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.5",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.3"
       }
     },
     "ent": {
@@ -3353,7 +3353,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error": {
@@ -3362,8 +3362,8 @@
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "dev": true,
       "requires": {
-        "string-template": "~0.2.1",
-        "xtend": "~4.0.0"
+        "string-template": "0.2.1",
+        "xtend": "4.0.1"
       }
     },
     "error-ex": {
@@ -3372,7 +3372,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -3381,11 +3381,11 @@
       "integrity": "sha1-nbvdJ8aFbwABQhyhh4LXhr+KYWU=",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.2.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -3394,9 +3394,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.2"
       }
     },
     "es6-promise": {
@@ -3423,11 +3423,11 @@
       "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -3451,44 +3451,44 @@
       "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^4.0.1",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.6",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.12.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.5",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^5.0.2",
-        "text-table": "^0.2.0"
+        "@babel/code-frame": "7.0.0",
+        "ajv": "6.6.1",
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "debug": "4.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "4.0.0",
+        "eslint-utils": "1.3.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "4.1.0",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.3",
+        "globals": "11.9.0",
+        "ignore": "4.0.6",
+        "imurmurhash": "0.1.4",
+        "inquirer": "6.2.1",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.12.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.1",
+        "regexpp": "2.0.1",
+        "require-uncached": "1.0.3",
+        "semver": "5.6.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "5.1.1",
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3503,12 +3503,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -3517,7 +3517,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "strip-ansi": {
@@ -3526,7 +3526,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -3537,8 +3537,8 @@
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint-utils": {
@@ -3559,9 +3559,9 @@
       "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.2",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "6.0.4",
+        "acorn-jsx": "5.0.1",
+        "eslint-visitor-keys": "1.0.0"
       }
     },
     "esprima": {
@@ -3576,7 +3576,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -3585,7 +3585,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estemplate": {
@@ -3594,8 +3594,8 @@
       "integrity": "sha1-FxSp1GGQc4rJWLyv1J4CnNpWo54=",
       "dev": true,
       "requires": {
-        "esprima": "^2.7.2",
-        "estraverse": "^4.1.1"
+        "esprima": "2.7.3",
+        "estraverse": "4.2.0"
       },
       "dependencies": {
         "esprima": {
@@ -3630,13 +3630,13 @@
       "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
       "dev": true,
       "requires": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
         "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
+        "pause-stream": "0.0.11",
+        "split": "1.0.1",
+        "stream-combiner": "0.2.2",
+        "through": "2.3.8"
       }
     },
     "eventemitter3": {
@@ -3652,11 +3652,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "execa": "^0.7.0",
-        "p-finally": "^1.0.0",
-        "pify": "^3.0.0",
-        "rimraf": "^2.5.4",
-        "tempfile": "^2.0.0"
+        "execa": "0.7.0",
+        "p-finally": "1.0.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2",
+        "tempfile": "2.0.0"
       }
     },
     "execa": {
@@ -3665,13 +3665,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -3680,9 +3680,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.5",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "lru-cache": {
@@ -3691,8 +3691,8 @@
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         }
       }
@@ -3704,7 +3704,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "pify": "^2.2.0"
+        "pify": "2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -3722,9 +3722,9 @@
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
-        "array-slice": "^0.2.3",
-        "array-unique": "^0.2.1",
-        "braces": "^0.1.2"
+        "array-slice": "0.2.3",
+        "array-unique": "0.2.1",
+        "braces": "0.1.5"
       },
       "dependencies": {
         "array-slice": {
@@ -3745,7 +3745,7 @@
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
           "dev": true,
           "requires": {
-            "expand-range": "^0.1.0"
+            "expand-range": "0.1.1"
           }
         },
         "expand-range": {
@@ -3754,8 +3754,8 @@
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
           "dev": true,
           "requires": {
-            "is-number": "^0.1.1",
-            "repeat-string": "^0.2.2"
+            "is-number": "0.1.1",
+            "repeat-string": "0.2.2"
           }
         },
         "is-number": {
@@ -3778,13 +3778,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -3802,7 +3802,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -3811,7 +3811,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "ms": {
@@ -3828,7 +3828,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       },
       "dependencies": {
         "fill-range": {
@@ -3837,11 +3837,11 @@
           "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "dev": true,
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "3.1.1",
+            "repeat-element": "1.1.3",
+            "repeat-string": "1.6.1"
           }
         },
         "is-number": {
@@ -3850,7 +3850,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "isarray": {
@@ -3874,7 +3874,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3885,7 +3885,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "ext-list": {
@@ -3894,7 +3894,7 @@
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
       "requires": {
-        "mime-db": "^1.28.0"
+        "mime-db": "1.37.0"
       }
     },
     "ext-name": {
@@ -3903,8 +3903,8 @@
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "dev": true,
       "requires": {
-        "ext-list": "^2.0.0",
-        "sort-keys-length": "^1.0.0"
+        "ext-list": "2.2.2",
+        "sort-keys-length": "1.0.1"
       }
     },
     "extend": {
@@ -3919,8 +3919,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3929,7 +3929,7 @@
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -3940,9 +3940,9 @@
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
+        "chardet": "0.7.0",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -3951,14 +3951,14 @@
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -3967,7 +3967,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -3976,7 +3976,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -3985,7 +3985,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -3994,7 +3994,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -4003,9 +4003,9 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -4037,7 +4037,7 @@
           "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
           "dev": true,
           "requires": {
-            "pend": "~1.2.0"
+            "pend": "1.2.0"
           }
         },
         "ms": {
@@ -4052,7 +4052,7 @@
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "dev": true,
           "requires": {
-            "fd-slicer": "~1.0.1"
+            "fd-slicer": "1.0.1"
           }
         }
       }
@@ -4069,10 +4069,10 @@
       "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
       "dev": true,
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "parse-node-version": "^1.0.0",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "parse-node-version": "1.0.0",
+        "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -4087,12 +4087,12 @@
       "integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.1.3",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.3",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "is-glob": {
@@ -4101,7 +4101,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -4124,7 +4124,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "fd-slicer": {
@@ -4133,7 +4133,7 @@
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -4142,7 +4142,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4151,8 +4151,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.4",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -4187,9 +4187,9 @@
       "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "dev": true,
       "requires": {
-        "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
+        "filename-reserved-regex": "2.0.0",
+        "strip-outer": "1.0.1",
+        "trim-repeated": "1.0.0"
       }
     },
     "fill-range": {
@@ -4198,10 +4198,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4210,7 +4210,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -4222,12 +4222,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.3.1",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -4259,8 +4259,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "find-versions": {
@@ -4270,8 +4270,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "array-uniq": "^2.0.0",
-        "semver-regex": "^2.0.0"
+        "array-uniq": "2.0.0",
+        "semver-regex": "2.0.0"
       },
       "dependencies": {
         "array-uniq": {
@@ -4289,10 +4289,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       }
     },
     "fined": {
@@ -4301,11 +4301,11 @@
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       }
     },
     "first-chunk-stream": {
@@ -4326,10 +4326,10 @@
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "graceful-fs": "4.1.15",
+        "rimraf": "2.6.2",
+        "write": "0.2.1"
       },
       "dependencies": {
         "graceful-fs": {
@@ -4351,7 +4351,7 @@
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "dev": true,
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -4388,7 +4388,7 @@
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "forever-agent": {
@@ -4403,9 +4403,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.21"
       }
     },
     "fragment-cache": {
@@ -4414,7 +4414,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -4436,8 +4436,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -4454,13 +4454,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -4470,7 +4470,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -4487,9 +4487,9 @@
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0"
+        "graceful-fs": "4.1.15",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1"
       },
       "dependencies": {
         "graceful-fs": {
@@ -4506,7 +4506,7 @@
       "integrity": "sha1-gAI4I5gfn//+AWCei+Zo9prknnA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2"
+        "graceful-fs": "4.1.15"
       },
       "dependencies": {
         "graceful-fs": {
@@ -4530,8 +4530,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.11.1",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4557,8 +4557,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -4571,7 +4571,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4635,7 +4635,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -4650,14 +4650,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -4666,12 +4666,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -4686,7 +4686,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -4695,7 +4695,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -4704,8 +4704,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -4724,7 +4724,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -4738,7 +4738,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -4751,8 +4751,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -4761,7 +4761,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -4784,9 +4784,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -4795,16 +4795,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -4813,8 +4813,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -4829,8 +4829,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -4839,10 +4839,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -4861,7 +4861,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -4882,8 +4882,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -4904,10 +4904,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -4924,13 +4924,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -4939,7 +4939,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -4982,9 +4982,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -4993,7 +4993,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -5001,7 +5001,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -5016,13 +5016,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -5037,7 +5037,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -5070,7 +5070,7 @@
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "dev": true,
       "requires": {
-        "globule": "~0.1.0"
+        "globule": "0.1.0"
       }
     },
     "get-proxy": {
@@ -5079,7 +5079,7 @@
       "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
       "dev": true,
       "requires": {
-        "npm-conf": "^1.1.0"
+        "npm-conf": "1.1.3"
       }
     },
     "get-stdin": {
@@ -5106,7 +5106,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "gifsicle": {
@@ -5116,10 +5116,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "^3.0.0",
-        "bin-wrapper": "^4.0.0",
-        "execa": "^1.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "3.0.0",
+        "bin-wrapper": "4.1.0",
+        "execa": "1.0.0",
+        "logalot": "2.1.0"
       },
       "dependencies": {
         "execa": {
@@ -5129,13 +5129,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "6.0.5",
+            "get-stream": "4.1.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "get-stream": {
@@ -5145,7 +5145,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pump": "^3.0.0"
+            "pump": "3.0.0"
           }
         }
       }
@@ -5156,10 +5156,10 @@
       "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
       "dev": true,
       "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^2.0.1",
-        "once": "^1.3.0"
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "2.0.10",
+        "once": "1.3.3"
       }
     },
     "glob-base": {
@@ -5168,8 +5168,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "glob-parent": {
@@ -5178,7 +5178,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "is-extglob": {
@@ -5193,7 +5193,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -5204,8 +5204,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       }
     },
     "glob-stream": {
@@ -5214,12 +5214,12 @@
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
       "requires": {
-        "glob": "^4.3.1",
-        "glob2base": "^0.0.12",
-        "minimatch": "^2.0.1",
-        "ordered-read-streams": "^0.1.0",
-        "through2": "^0.6.1",
-        "unique-stream": "^1.0.0"
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -5228,10 +5228,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "through2": {
@@ -5240,8 +5240,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -5258,7 +5258,7 @@
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "dev": true,
       "requires": {
-        "gaze": "^0.5.1"
+        "gaze": "0.5.2"
       }
     },
     "glob2base": {
@@ -5267,7 +5267,7 @@
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
-        "find-index": "^0.1.1"
+        "find-index": "0.1.1"
       }
     },
     "global-modules": {
@@ -5276,9 +5276,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -5287,11 +5287,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.1"
       }
     },
     "globals": {
@@ -5306,13 +5306,13 @@
       "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
+        "array-union": "1.0.2",
+        "dir-glob": "2.0.0",
+        "fast-glob": "2.2.4",
+        "glob": "7.1.3",
+        "ignore": "3.3.10",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -5321,12 +5321,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "ignore": {
@@ -5341,7 +5341,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -5352,9 +5352,9 @@
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "requires": {
-        "glob": "~3.1.21",
-        "lodash": "~1.0.1",
-        "minimatch": "~0.2.11"
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
       },
       "dependencies": {
         "glob": {
@@ -5363,9 +5363,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
           }
         },
         "graceful-fs": {
@@ -5392,8 +5392,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         }
       }
@@ -5404,7 +5404,7 @@
       "integrity": "sha1-3PdY5EeJzD89MsHzVio2duajSBA=",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.1"
       }
     },
     "good-listener": {
@@ -5412,7 +5412,7 @@
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "requires": {
-        "delegate": "^3.1.2"
+        "delegate": "3.2.0"
       }
     },
     "got": {
@@ -5422,20 +5422,20 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "decompress-response": "^3.2.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "p-cancelable": "^0.3.0",
-        "p-timeout": "^1.1.1",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "url-parse-lax": "^1.0.0",
-        "url-to-options": "^1.0.1"
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-plain-obj": "1.1.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.1",
+        "p-cancelable": "0.3.0",
+        "p-timeout": "1.2.1",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "1.0.0",
+        "url-to-options": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -5444,7 +5444,7 @@
       "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
       "dev": true,
       "requires": {
-        "natives": "^1.1.0"
+        "natives": "1.1.6"
       }
     },
     "graceful-readlink": {
@@ -5459,19 +5459,19 @@
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "chalk": "^1.0.0",
-        "deprecated": "^0.0.1",
-        "gulp-util": "^3.0.0",
-        "interpret": "^1.0.0",
-        "liftoff": "^2.1.0",
-        "minimist": "^1.1.0",
-        "orchestrator": "^0.3.0",
-        "pretty-hrtime": "^1.0.0",
-        "semver": "^4.1.0",
-        "tildify": "^1.0.0",
-        "v8flags": "^2.0.2",
-        "vinyl-fs": "^0.3.0"
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5486,11 +5486,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "semver": {
@@ -5513,10 +5513,10 @@
       "integrity": "sha512-oomaIqDXxFkg7lbpBou/gnUkX51/Y/M2ZfSjL2hdqXTAlSWZcgZtd2o0cOH0r/eE8LWD0+Q/PsLsr2DKOoqToQ==",
       "dev": true,
       "requires": {
-        "plugin-error": "^1.0.1",
-        "replace-ext": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "plugin-error": "1.0.1",
+        "replace-ext": "1.0.0",
+        "through2": "2.0.5",
+        "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "replace-ext": {
@@ -5545,9 +5545,9 @@
           "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "inherits": "2.0.3",
+            "string_decoder": "1.2.0",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -5556,7 +5556,7 @@
           "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "through2": {
@@ -5565,8 +5565,8 @@
           "integrity": "sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2 || 3",
-            "xtend": "~4.0.1"
+            "readable-stream": "3.0.6",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -5577,9 +5577,9 @@
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "dev": true,
       "requires": {
-        "concat-with-sourcemaps": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^2.0.0"
+        "concat-with-sourcemaps": "1.1.0",
+        "through2": "2.0.5",
+        "vinyl": "2.2.0"
       },
       "dependencies": {
         "clone": {
@@ -5606,12 +5606,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -5622,15 +5622,15 @@
       "integrity": "sha512-FknHeA6smZhiRNrK/3UVH8BHLCFHS7WZdE7Y2VbZHtxye1UTIa5ZY0Cnst6O9n3kL8z7y43QI+acx3nUtJoiHw==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^2.0.5",
-        "connect": "^3.6.6",
-        "connect-livereload": "^0.6.0",
-        "event-stream": "^3.3.4",
-        "fancy-log": "^1.3.2",
-        "send": "^0.16.2",
-        "serve-index": "^1.9.1",
-        "serve-static": "^1.13.2",
-        "tiny-lr": "^1.1.1"
+        "ansi-colors": "2.0.5",
+        "connect": "3.6.6",
+        "connect-livereload": "0.6.0",
+        "event-stream": "3.3.5",
+        "fancy-log": "1.3.3",
+        "send": "0.16.2",
+        "serve-index": "1.9.1",
+        "serve-static": "1.13.2",
+        "tiny-lr": "1.1.1"
       },
       "dependencies": {
         "ansi-colors": {
@@ -5647,9 +5647,9 @@
       "integrity": "sha512-9GUqCqh85C7rP9120cpxXuZz2ayq3BZc85pCTuPJS03VQYxne0aWPIXWx6LSvsGPa3uRqtSO537vaugOh+5cXg==",
       "dev": true,
       "requires": {
-        "eslint": "^5.0.1",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^1.0.1"
+        "eslint": "5.9.0",
+        "fancy-log": "1.3.3",
+        "plugin-error": "1.0.1"
       }
     },
     "gulp-imagemin": {
@@ -5658,17 +5658,17 @@
       "integrity": "sha512-bKJMix4r6EQPVV2u8sUglw6Rn0PSp6i70pSK2ECN7j0dRy0w/Lz5SBbynY3MfGBZ0cTMZlaUq+6LyKlZgP74Ew==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "fancy-log": "^1.3.2",
-        "imagemin": "^6.0.0",
-        "imagemin-gifsicle": "^6.0.1",
-        "imagemin-jpegtran": "^6.0.0",
-        "imagemin-optipng": "^6.0.0",
-        "imagemin-svgo": "^7.0.0",
-        "plugin-error": "^1.0.1",
-        "plur": "^3.0.1",
-        "pretty-bytes": "^5.1.0",
-        "through2-concurrent": "^2.0.0"
+        "chalk": "2.4.1",
+        "fancy-log": "1.3.3",
+        "imagemin": "6.0.0",
+        "imagemin-gifsicle": "6.0.1",
+        "imagemin-jpegtran": "6.0.0",
+        "imagemin-optipng": "6.0.0",
+        "imagemin-svgo": "7.0.0",
+        "plugin-error": "1.0.1",
+        "plur": "3.0.1",
+        "pretty-bytes": "5.1.0",
+        "through2-concurrent": "2.0.0"
       }
     },
     "gulp-less": {
@@ -5677,13 +5677,13 @@
       "integrity": "sha512-hmM2k0FfQp7Ptm3ZaqO2CkMX3hqpiIOn4OHtuSsCeFym63F7oWlEua5v6u1cIjVUKYsVIs9zPg9vbqTEb/udpA==",
       "dev": true,
       "requires": {
-        "accord": "^0.29.0",
-        "less": "2.6.x || ^3.7.1",
-        "object-assign": "^4.0.1",
-        "plugin-error": "^0.1.2",
-        "replace-ext": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "accord": "0.29.0",
+        "less": "3.9.0",
+        "object-assign": "4.1.1",
+        "plugin-error": "0.1.2",
+        "replace-ext": "1.0.0",
+        "through2": "2.0.5",
+        "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -5692,8 +5692,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
           }
         },
         "arr-union": {
@@ -5714,7 +5714,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "^1.1.0"
+            "kind-of": "1.1.0"
           }
         },
         "kind-of": {
@@ -5735,11 +5735,11 @@
           "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
           "dev": true,
           "requires": {
-            "ansi-cyan": "^0.1.1",
-            "ansi-red": "^0.1.1",
-            "arr-diff": "^1.0.1",
-            "arr-union": "^2.0.1",
-            "extend-shallow": "^1.1.2"
+            "ansi-cyan": "0.1.1",
+            "ansi-red": "0.1.1",
+            "arr-diff": "1.1.0",
+            "arr-union": "2.1.0",
+            "extend-shallow": "1.1.4"
           }
         },
         "replace-ext": {
@@ -5756,8 +5756,8 @@
       "integrity": "sha1-J7Z6Ql6zh1ImNFq4lgTXN/Y1fCE=",
       "dev": true,
       "requires": {
-        "angular": "~1.3.1",
-        "angular-animate": "~1.3.1",
+        "angular": "1.3.20",
+        "angular-animate": "1.3.20",
         "canonical-path": "0.0.2",
         "extend": "1.3.0",
         "gulp-util": "3.0.0",
@@ -5800,11 +5800,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
           }
         },
         "clone": {
@@ -5819,8 +5819,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.3.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "extend": {
@@ -5835,15 +5835,15 @@
           "integrity": "sha1-b+7cR9aXKCO6zplH/F9GvYo0Zuc=",
           "dev": true,
           "requires": {
-            "chalk": "^0.5.0",
-            "dateformat": "^1.0.7-1.2.3",
-            "lodash": "^2.4.1",
-            "lodash._reinterpolate": "^2.4.1",
-            "lodash.template": "^2.4.1",
-            "minimist": "^0.2.0",
-            "multipipe": "^0.1.0",
-            "through2": "^0.5.0",
-            "vinyl": "^0.2.1"
+            "chalk": "0.5.1",
+            "dateformat": "1.0.12",
+            "lodash": "2.4.1",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.template": "2.4.1",
+            "minimist": "0.2.0",
+            "multipipe": "0.1.2",
+            "through2": "0.5.1",
+            "vinyl": "0.2.3"
           },
           "dependencies": {
             "through2": {
@@ -5852,8 +5852,8 @@
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "dev": true,
               "requires": {
-                "readable-stream": "~1.0.17",
-                "xtend": "~3.0.0"
+                "readable-stream": "1.0.34",
+                "xtend": "3.0.0"
               }
             }
           }
@@ -5864,7 +5864,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.0"
+            "ansi-regex": "0.2.1"
           }
         },
         "lodash": {
@@ -5885,8 +5885,8 @@
           "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
           "dev": true,
           "requires": {
-            "lodash._objecttypes": "~2.4.1",
-            "lodash.keys": "~2.4.1"
+            "lodash._objecttypes": "2.4.1",
+            "lodash.keys": "2.4.1"
           }
         },
         "lodash.escape": {
@@ -5895,9 +5895,9 @@
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
           "dev": true,
           "requires": {
-            "lodash._escapehtmlchar": "~2.4.1",
-            "lodash._reunescapedhtml": "~2.4.1",
-            "lodash.keys": "~2.4.1"
+            "lodash._escapehtmlchar": "2.4.1",
+            "lodash._reunescapedhtml": "2.4.1",
+            "lodash.keys": "2.4.1"
           }
         },
         "lodash.keys": {
@@ -5906,9 +5906,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         },
         "lodash.template": {
@@ -5917,13 +5917,13 @@
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
           "dev": true,
           "requires": {
-            "lodash._escapestringchar": "~2.4.1",
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.defaults": "~2.4.1",
-            "lodash.escape": "~2.4.1",
-            "lodash.keys": "~2.4.1",
-            "lodash.templatesettings": "~2.4.1",
-            "lodash.values": "~2.4.1"
+            "lodash._escapestringchar": "2.4.1",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.defaults": "2.4.1",
+            "lodash.escape": "2.4.1",
+            "lodash.keys": "2.4.1",
+            "lodash.templatesettings": "2.4.1",
+            "lodash.values": "2.4.1"
           }
         },
         "lodash.templatesettings": {
@@ -5932,8 +5932,8 @@
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.escape": "~2.4.1"
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.escape": "2.4.1"
           }
         },
         "marked": {
@@ -5948,7 +5948,7 @@
           "integrity": "sha1-5oIPet267gA/SMpKWMfFolPV4Fw=",
           "dev": true,
           "requires": {
-            "through2": "^0.5.1"
+            "through2": "0.5.1"
           },
           "dependencies": {
             "through2": {
@@ -5957,8 +5957,8 @@
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "dev": true,
               "requires": {
-                "readable-stream": "~1.0.17",
-                "xtend": "~3.0.0"
+                "readable-stream": "1.0.34",
+                "xtend": "3.0.0"
               }
             }
           }
@@ -5975,10 +5975,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "strip-ansi": {
@@ -5987,7 +5987,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.1"
+            "ansi-regex": "0.2.1"
           }
         },
         "supports-color": {
@@ -6002,8 +6002,8 @@
           "integrity": "sha1-90KzKJPovSYUbnieT9LMssB6cX4=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.27-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           },
           "dependencies": {
             "xtend": {
@@ -6020,7 +6020,7 @@
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
           "dev": true,
           "requires": {
-            "clone-stats": "~0.0.1"
+            "clone-stats": "0.0.1"
           }
         },
         "vinyl-fs": {
@@ -6029,14 +6029,14 @@
           "integrity": "sha1-LiXP5t9cgIGPl/9Be/XCGkHkpJs=",
           "dev": true,
           "requires": {
-            "glob-stream": "^3.1.5",
-            "glob-watcher": "^0.0.6",
-            "graceful-fs": "^3.0.0",
-            "lodash": "^2.4.1",
-            "mkdirp": "^0.5.0",
-            "strip-bom": "^1.0.0",
-            "through2": "^0.6.1",
-            "vinyl": "^0.4.0"
+            "glob-stream": "3.1.18",
+            "glob-watcher": "0.0.6",
+            "graceful-fs": "3.0.11",
+            "lodash": "2.4.1",
+            "mkdirp": "0.5.1",
+            "strip-bom": "1.0.0",
+            "through2": "0.6.1",
+            "vinyl": "0.4.6"
           },
           "dependencies": {
             "vinyl": {
@@ -6045,8 +6045,8 @@
               "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
               "dev": true,
               "requires": {
-                "clone": "^0.2.0",
-                "clone-stats": "^0.0.1"
+                "clone": "0.2.0",
+                "clone-stats": "0.0.1"
               }
             }
           }
@@ -6065,10 +6065,10 @@
       "integrity": "sha512-dohokw+npnt48AsD0hhvCLEHLnDMqM35F+amvIfJlX1H2nNHYUClR0Oy1rI0TvbL1/pHiHGNLmohhk+kvwIKjA==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.1.2",
         "opn": "5.2.0",
-        "plugin-log": "^0.1.0",
-        "through2": "^2.0.1"
+        "plugin-log": "0.1.0",
+        "through2": "2.0.5"
       }
     },
     "gulp-postcss": {
@@ -6077,11 +6077,11 @@
       "integrity": "sha512-Wtl6vH7a+8IS/fU5W9IbOpcaLqKxd5L1DUOzaPmlnCbX1CrG0aWdwVnC3Spn8th0m8D59YbysV5zPUe1n/GJYg==",
       "dev": true,
       "requires": {
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^1.0.1",
-        "postcss": "^7.0.2",
-        "postcss-load-config": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.1"
+        "fancy-log": "1.3.3",
+        "plugin-error": "1.0.1",
+        "postcss": "7.0.6",
+        "postcss-load-config": "2.0.0",
+        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "gulp-rename": {
@@ -6096,7 +6096,7 @@
       "integrity": "sha1-xnYqLx8N4KP8WVohWZ0/rI26Gso=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.1"
+        "through2": "2.0.5"
       }
     },
     "gulp-util": {
@@ -6105,24 +6105,24 @@
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.3",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.5",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6137,11 +6137,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -6159,17 +6159,17 @@
       "dev": true,
       "requires": {
         "ansi-colors": "1.1.0",
-        "anymatch": "^1.3.0",
-        "chokidar": "^2.0.0",
+        "anymatch": "1.3.2",
+        "chokidar": "2.0.4",
         "fancy-log": "1.3.2",
-        "glob-parent": "^3.0.1",
-        "object-assign": "^4.1.0",
-        "path-is-absolute": "^1.0.1",
+        "glob-parent": "3.1.0",
+        "object-assign": "4.1.1",
+        "path-is-absolute": "1.0.1",
         "plugin-error": "1.0.1",
-        "readable-stream": "^2.2.2",
-        "slash": "^1.0.0",
-        "vinyl": "^2.1.0",
-        "vinyl-file": "^2.0.0"
+        "readable-stream": "2.3.6",
+        "slash": "1.0.0",
+        "vinyl": "2.2.0",
+        "vinyl-file": "2.0.0"
       },
       "dependencies": {
         "clone": {
@@ -6190,9 +6190,9 @@
           "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
           "dev": true,
           "requires": {
-            "ansi-gray": "^0.1.1",
-            "color-support": "^1.1.3",
-            "time-stamp": "^1.0.0"
+            "ansi-gray": "0.1.1",
+            "color-support": "1.1.3",
+            "time-stamp": "1.1.0"
           }
         },
         "isarray": {
@@ -6213,13 +6213,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "replace-ext": {
@@ -6234,7 +6234,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "vinyl": {
@@ -6243,12 +6243,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -6259,16 +6259,16 @@
       "integrity": "sha1-FaXCBI4nIecFOaYbrxw0oLxfJyk=",
       "dev": true,
       "requires": {
-        "consolidate": "^0.14.1",
-        "es6-promise": "^3.1.2",
-        "fs-readfile-promise": "^2.0.1",
-        "js-yaml": "^3.2.6",
-        "lodash": "^4.11.1",
-        "node.extend": "^1.1.2",
-        "plugin-error": "^0.1.2",
-        "through2": "^2.0.1",
-        "tryit": "^1.0.1",
-        "vinyl-bufferstream": "^1.0.1"
+        "consolidate": "0.14.5",
+        "es6-promise": "3.3.1",
+        "fs-readfile-promise": "2.0.1",
+        "js-yaml": "3.12.0",
+        "lodash": "4.17.11",
+        "node.extend": "1.1.8",
+        "plugin-error": "0.1.2",
+        "through2": "2.0.5",
+        "tryit": "1.0.3",
+        "vinyl-bufferstream": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -6277,8 +6277,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
           }
         },
         "arr-union": {
@@ -6299,7 +6299,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "^1.1.0"
+            "kind-of": "1.1.0"
           }
         },
         "kind-of": {
@@ -6314,11 +6314,11 @@
           "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
           "dev": true,
           "requires": {
-            "ansi-cyan": "^0.1.1",
-            "ansi-red": "^0.1.1",
-            "arr-diff": "^1.0.1",
-            "arr-union": "^2.0.1",
-            "extend-shallow": "^1.1.2"
+            "ansi-cyan": "0.1.1",
+            "ansi-red": "0.1.1",
+            "arr-diff": "1.1.0",
+            "arr-union": "2.1.0",
+            "extend-shallow": "1.1.4"
           }
         }
       }
@@ -6329,12 +6329,12 @@
       "integrity": "sha1-3uYqpISqupVHqT0f9c0MPQvtwDE=",
       "dev": true,
       "requires": {
-        "escodegen": "^1.6.1",
-        "esprima": "^2.3.0",
-        "estemplate": "*",
-        "gulp-util": "~3.0.5",
-        "through2": "*",
-        "vinyl-sourcemaps-apply": "^0.1.4"
+        "escodegen": "1.11.0",
+        "esprima": "2.7.3",
+        "estemplate": "0.5.1",
+        "gulp-util": "3.0.8",
+        "through2": "2.0.5",
+        "vinyl-sourcemaps-apply": "0.1.4"
       },
       "dependencies": {
         "esprima": {
@@ -6349,7 +6349,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "vinyl-sourcemaps-apply": {
@@ -6358,7 +6358,7 @@
           "integrity": "sha1-xfy9Q+LyOEI8LcmL3db3m3K8NFs=",
           "dev": true,
           "requires": {
-            "source-map": "^0.1.39"
+            "source-map": "0.1.43"
           }
         }
       }
@@ -6369,7 +6369,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "har-schema": {
@@ -6384,8 +6384,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
+        "ajv": "6.6.1",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -6394,7 +6394,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -6403,7 +6403,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -6441,7 +6441,7 @@
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.1"
       }
     },
     "has-symbol-support-x": {
@@ -6462,7 +6462,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-value": {
@@ -6471,9 +6471,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -6482,8 +6482,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6492,7 +6492,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6503,8 +6503,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1",
-        "pinkie-promise": "^2.0.0"
+        "is-stream": "1.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "hex-color-regex": {
@@ -6519,7 +6519,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -6559,10 +6559,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.5.0"
       },
       "dependencies": {
         "statuses": {
@@ -6585,9 +6585,9 @@
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^3.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.5.10",
+        "requires-port": "1.0.0"
       }
     },
     "http-signature": {
@@ -6596,9 +6596,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.15.2"
       }
     },
     "iconv-lite": {
@@ -6607,7 +6607,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ieee754": {
@@ -6635,12 +6635,12 @@
       "integrity": "sha512-m4Mxwt2QvCp1F85HXoTungXk0Y6XzuvQGqrK9qEddQfo/7x4aZjRENmyXXfc29ei4Mk55rW002bORG86YM3/aQ==",
       "dev": true,
       "requires": {
-        "file-type": "^8.1.0",
-        "globby": "^8.0.1",
-        "make-dir": "^1.0.0",
-        "p-pipe": "^1.1.0",
-        "pify": "^3.0.0",
-        "replace-ext": "^1.0.0"
+        "file-type": "8.1.0",
+        "globby": "8.0.1",
+        "make-dir": "1.3.0",
+        "p-pipe": "1.2.0",
+        "pify": "3.0.0",
+        "replace-ext": "1.0.0"
       },
       "dependencies": {
         "replace-ext": {
@@ -6658,9 +6658,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "gifsicle": "^4.0.0",
-        "is-gif": "^3.0.0"
+        "exec-buffer": "3.2.0",
+        "gifsicle": "4.0.1",
+        "is-gif": "3.0.0"
       }
     },
     "imagemin-jpegtran": {
@@ -6670,9 +6670,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "is-jpg": "^2.0.0",
-        "jpegtran-bin": "^4.0.0"
+        "exec-buffer": "3.2.0",
+        "is-jpg": "2.0.0",
+        "jpegtran-bin": "4.0.0"
       }
     },
     "imagemin-optipng": {
@@ -6682,9 +6682,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "is-png": "^1.0.0",
-        "optipng-bin": "^5.0.0"
+        "exec-buffer": "3.2.0",
+        "is-png": "1.1.0",
+        "optipng-bin": "5.0.0"
       }
     },
     "imagemin-svgo": {
@@ -6694,8 +6694,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-svg": "^3.0.0",
-        "svgo": "^1.0.5"
+        "is-svg": "3.0.0",
+        "svgo": "1.1.1"
       }
     },
     "import-cwd": {
@@ -6704,7 +6704,7 @@
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
-        "import-from": "^2.1.0"
+        "import-from": "2.1.0"
       }
     },
     "import-fresh": {
@@ -6713,8 +6713,8 @@
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
+        "caller-path": "2.0.0",
+        "resolve-from": "3.0.0"
       }
     },
     "import-from": {
@@ -6723,7 +6723,7 @@
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "import-lazy": {
@@ -6745,7 +6745,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexes-of": {
@@ -6772,8 +6772,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.3.3",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -6794,19 +6794,19 @@
       "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "3.0.3",
+        "figures": "2.0.0",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.1.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "6.3.3",
+        "string-width": "2.1.1",
+        "strip-ansi": "5.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6821,7 +6821,7 @@
           "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "4.0.0"
           }
         }
       }
@@ -6839,8 +6839,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
+        "from2": "2.3.0",
+        "p-is-promise": "1.1.0"
       }
     },
     "invariant": {
@@ -6849,7 +6849,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "irregular-plurals": {
@@ -6870,8 +6870,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       }
     },
     "is-absolute-url": {
@@ -6886,7 +6886,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6895,7 +6895,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6912,7 +6912,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.12.0"
       }
     },
     "is-buffer": {
@@ -6927,7 +6927,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -6942,12 +6942,12 @@
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "dev": true,
       "requires": {
-        "css-color-names": "^0.0.4",
-        "hex-color-regex": "^1.1.0",
-        "hsl-regex": "^1.0.0",
-        "hsla-regex": "^1.0.0",
-        "rgb-regex": "^1.0.1",
-        "rgba-regex": "^1.0.0"
+        "css-color-names": "0.0.4",
+        "hex-color-regex": "1.1.0",
+        "hsl-regex": "1.0.0",
+        "hsla-regex": "1.0.0",
+        "rgb-regex": "1.0.1",
+        "rgba-regex": "1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -6956,7 +6956,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6965,7 +6965,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6982,9 +6982,9 @@
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -7013,7 +7013,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -7034,7 +7034,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -7050,7 +7050,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "file-type": "^10.4.0"
+        "file-type": "10.6.0"
       },
       "dependencies": {
         "file-type": {
@@ -7068,7 +7068,7 @@
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.0"
+        "is-extglob": "2.1.1"
       }
     },
     "is-jpg": {
@@ -7090,7 +7090,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -7099,7 +7099,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -7128,7 +7128,7 @@
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-png": {
@@ -7162,7 +7162,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-relative": {
@@ -7171,7 +7171,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-resolvable": {
@@ -7198,7 +7198,7 @@
       "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
       "dev": true,
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "html-comment-regex": "1.1.2"
       }
     },
     "is-symbol": {
@@ -7207,7 +7207,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "1.0.0"
       }
     },
     "is-typedarray": {
@@ -7222,7 +7222,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-utf8": {
@@ -7255,7 +7255,7 @@
       "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
       "dev": true,
       "requires": {
-        "buffer-alloc": "^1.2.0"
+        "buffer-alloc": "1.2.0"
       }
     },
     "isexe": {
@@ -7282,8 +7282,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "jasmine-core": {
@@ -7299,9 +7299,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "^3.0.0",
-        "bin-wrapper": "^4.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "3.0.0",
+        "bin-wrapper": "4.1.0",
+        "logalot": "2.1.0"
       }
     },
     "jquery": {
@@ -7337,8 +7337,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -7396,7 +7396,7 @@
       "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "1.2.0"
       }
     },
     "jsonfile": {
@@ -7405,7 +7405,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.15"
       },
       "dependencies": {
         "graceful-fs": {
@@ -7435,31 +7435,31 @@
       "integrity": "sha512-NetT3wPCQMNB36uiL9LLyhrOt8SQwrEKt0xD3+KpTCfm0VxVyUJdPL5oTq2Ic5ouemgL/Iz4wqXEbF3zea9kQQ==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.3.0",
-        "body-parser": "^1.16.1",
-        "chokidar": "^2.0.3",
-        "colors": "^1.1.0",
-        "combine-lists": "^1.0.0",
-        "connect": "^3.6.0",
-        "core-js": "^2.2.0",
-        "di": "^0.0.1",
-        "dom-serialize": "^2.2.0",
-        "expand-braces": "^0.1.1",
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "http-proxy": "^1.13.0",
-        "isbinaryfile": "^3.0.0",
-        "lodash": "^4.17.4",
-        "log4js": "^3.0.0",
-        "mime": "^2.3.1",
-        "minimatch": "^3.0.2",
-        "optimist": "^0.6.1",
-        "qjobs": "^1.1.4",
-        "range-parser": "^1.2.0",
-        "rimraf": "^2.6.0",
-        "safe-buffer": "^5.0.1",
+        "bluebird": "3.5.3",
+        "body-parser": "1.18.3",
+        "chokidar": "2.0.4",
+        "colors": "1.1.2",
+        "combine-lists": "1.0.1",
+        "connect": "3.6.6",
+        "core-js": "2.5.7",
+        "di": "0.0.1",
+        "dom-serialize": "2.2.1",
+        "expand-braces": "0.1.2",
+        "glob": "7.1.3",
+        "graceful-fs": "4.1.15",
+        "http-proxy": "1.17.0",
+        "isbinaryfile": "3.0.3",
+        "lodash": "4.17.11",
+        "log4js": "3.0.6",
+        "mime": "2.4.0",
+        "minimatch": "3.0.4",
+        "optimist": "0.6.1",
+        "qjobs": "1.2.0",
+        "range-parser": "1.2.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
         "socket.io": "2.1.1",
-        "source-map": "^0.6.1",
+        "source-map": "0.6.1",
         "tmp": "0.0.33",
         "useragent": "2.2.1"
       },
@@ -7470,12 +7470,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -7496,7 +7496,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "source-map": {
@@ -7513,7 +7513,7 @@
       "integrity": "sha512-iuC0hmr9b+SNn1DaUD2QEYtUxkS1J+bSJSn7ejdEexs7P8EYvA1CWkEdrDQ+8jVH3AgWlCNwjYsT1chjcNW9lA==",
       "dev": true,
       "requires": {
-        "jasmine-core": "^3.3"
+        "jasmine-core": "3.3.0"
       }
     },
     "karma-phantomjs-launcher": {
@@ -7522,8 +7522,8 @@
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
       "dev": true,
       "requires": {
-        "lodash": "^4.0.1",
-        "phantomjs-prebuilt": "^2.1.7"
+        "lodash": "4.17.11",
+        "phantomjs-prebuilt": "2.1.16"
       }
     },
     "kew": {
@@ -7554,7 +7554,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.15"
       },
       "dependencies": {
         "graceful-fs": {
@@ -7583,15 +7583,15 @@
       "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
       "dev": true,
       "requires": {
-        "clone": "^2.1.2",
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "mime": "^1.4.1",
-        "mkdirp": "^0.5.0",
-        "promise": "^7.1.1",
-        "request": "^2.83.0",
-        "source-map": "~0.6.0"
+        "clone": "2.1.2",
+        "errno": "0.1.7",
+        "graceful-fs": "4.1.15",
+        "image-size": "0.5.5",
+        "mime": "1.4.1",
+        "mkdirp": "0.5.1",
+        "promise": "7.3.1",
+        "request": "2.88.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "clone": {
@@ -7622,8 +7622,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "liftoff": {
@@ -7632,14 +7632,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.2",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.8.1"
       }
     },
     "livereload-js": {
@@ -7654,11 +7654,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.15",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -7673,7 +7673,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.2"
           }
         },
         "pify": {
@@ -7688,7 +7688,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -7723,7 +7723,7 @@
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1"
       }
     },
     "lodash._escapestringchar": {
@@ -7786,8 +7786,8 @@
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1",
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -7796,9 +7796,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -7815,7 +7815,7 @@
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.clone": {
@@ -7842,7 +7842,7 @@
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.flatten": {
@@ -7869,7 +7869,7 @@
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.keys": {
@@ -7878,9 +7878,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.memoize": {
@@ -7919,15 +7919,15 @@
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
       }
     },
     "lodash.templatesettings": {
@@ -7936,8 +7936,8 @@
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
       }
     },
     "lodash.uniq": {
@@ -7952,7 +7952,7 @@
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "dev": true,
       "requires": {
-        "lodash.keys": "~2.4.1"
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -7961,9 +7961,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -7974,10 +7974,10 @@
       "integrity": "sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.5.5",
-        "date-format": "^1.2.0",
-        "debug": "^3.1.0",
-        "rfdc": "^1.1.2",
+        "circular-json": "0.5.9",
+        "date-format": "1.2.0",
+        "debug": "3.2.6",
+        "rfdc": "1.1.2",
         "streamroller": "0.7.0"
       },
       "dependencies": {
@@ -7993,7 +7993,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         }
       }
@@ -8005,8 +8005,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "figures": "^1.3.5",
-        "squeak": "^1.0.0"
+        "figures": "1.7.0",
+        "squeak": "1.3.0"
       },
       "dependencies": {
         "figures": {
@@ -8016,8 +8016,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "object-assign": {
@@ -8041,7 +8041,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "4.0.0"
       }
     },
     "loud-rejection": {
@@ -8050,8 +8050,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowercase-keys": {
@@ -8067,10 +8067,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "get-stdin": "^4.0.1",
-        "indent-string": "^2.1.0",
-        "longest": "^1.0.0",
-        "meow": "^3.3.0"
+        "get-stdin": "4.0.1",
+        "indent-string": "2.1.0",
+        "longest": "1.0.1",
+        "meow": "3.7.0"
       }
     },
     "lru-cache": {
@@ -8085,7 +8085,7 @@
       "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-iterator": {
@@ -8094,7 +8094,7 @@
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       }
     },
     "map-cache": {
@@ -8121,7 +8121,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "marked": {
@@ -8154,16 +8154,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -8180,7 +8180,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -8195,13 +8195,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -8210,7 +8210,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -8227,19 +8227,19 @@
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "mime": {
@@ -8260,7 +8260,7 @@
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.37.0"
       }
     },
     "mimic-fn": {
@@ -8281,7 +8281,7 @@
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.0.0"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -8296,8 +8296,8 @@
       "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -8306,7 +8306,7 @@
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -8367,17 +8367,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "natives": {
@@ -8415,7 +8415,7 @@
       "integrity": "sha512-Ky7q0BO1BBkG/rQz6PkEZ59rwo+aSfhczHP1wwq8IowoVdN/FpiP7qp0XW0P2+BVCWe5fQUBozdbVd54q1RbCQ==",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.6.0"
       }
     },
     "node.extend": {
@@ -8424,8 +8424,8 @@
       "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3",
-        "is": "^3.2.1"
+        "has": "1.0.3",
+        "is": "3.2.1"
       }
     },
     "normalize-package-data": {
@@ -8434,10 +8434,10 @@
       "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.6.0",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
@@ -8446,7 +8446,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -8471,132 +8471,132 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-6.4.1.tgz",
       "integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
       "requires": {
-        "JSONStream": "^1.3.4",
-        "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
-        "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
-        "bluebird": "~3.5.1",
-        "byte-size": "^4.0.3",
-        "cacache": "^11.2.0",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "ci-info": "^1.4.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.5.0",
-        "cmd-shim": "~2.0.2",
-        "columnify": "~1.5.4",
-        "config-chain": "~1.1.11",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "figgy-pudding": "^3.4.1",
-        "find-npm-prefix": "^1.0.2",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
-        "glob": "~7.1.2",
-        "graceful-fs": "~4.1.11",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.7.1",
-        "iferr": "^1.0.2",
-        "imurmurhash": "*",
-        "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
-        "ini": "^1.3.5",
-        "init-package-json": "^1.10.3",
-        "is-cidr": "^2.0.6",
-        "json-parse-better-errors": "^1.0.2",
-        "lazy-property": "~1.0.0",
-        "libcipm": "^2.0.2",
-        "libnpmhook": "^4.0.1",
-        "libnpx": "^10.2.0",
-        "lock-verify": "^2.0.2",
-        "lockfile": "^1.0.4",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "^4.1.3",
-        "meant": "~1.0.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "~0.5.1",
-        "move-concurrently": "^1.0.1",
-        "node-gyp": "^3.8.0",
-        "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-audit-report": "^1.3.1",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^2.1.0",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.1.11",
-        "npm-pick-manifest": "^2.1.0",
-        "npm-profile": "^3.0.2",
-        "npm-registry-client": "^8.6.0",
-        "npm-registry-fetch": "^1.1.0",
-        "npm-user-validate": "~1.0.0",
-        "npmlog": "~4.1.2",
-        "once": "~1.4.0",
-        "opener": "^1.5.0",
-        "osenv": "^0.1.5",
-        "pacote": "^8.1.6",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
-        "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.1.0",
-        "qw": "~1.0.1",
-        "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
-        "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
-        "readable-stream": "^2.3.6",
-        "readdir-scoped-modules": "*",
-        "request": "^2.88.0",
-        "retry": "^0.12.0",
-        "rimraf": "~2.6.2",
-        "safe-buffer": "^5.1.2",
-        "semver": "^5.5.0",
-        "sha": "~2.0.1",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.0",
-        "stringify-package": "^1.0.0",
-        "tar": "^4.4.6",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
+        "JSONStream": "1.3.4",
+        "abbrev": "1.1.1",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.2",
+        "bluebird": "3.5.1",
+        "byte-size": "4.0.3",
+        "cacache": "11.2.0",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "ci-info": "1.4.0",
+        "cli-columns": "3.1.2",
+        "cli-table3": "0.5.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "figgy-pudding": "3.4.1",
+        "find-npm-prefix": "1.0.2",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.7.1",
+        "iferr": "1.0.2",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.3",
+        "is-cidr": "2.0.6",
+        "json-parse-better-errors": "1.0.2",
+        "lazy-property": "1.0.0",
+        "libcipm": "2.0.2",
+        "libnpmhook": "4.0.1",
+        "libnpx": "10.2.0",
+        "lock-verify": "2.0.2",
+        "lockfile": "1.0.4",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.3",
+        "meant": "1.0.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.8.0",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-audit-report": "1.3.1",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.1.0",
+        "npm-package-arg": "6.1.0",
+        "npm-packlist": "1.1.11",
+        "npm-pick-manifest": "2.1.0",
+        "npm-profile": "3.0.2",
+        "npm-registry-client": "8.6.0",
+        "npm-registry-fetch": "1.1.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.5.0",
+        "osenv": "0.1.5",
+        "pacote": "8.1.6",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.12.0",
+        "query-string": "6.1.0",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.13",
+        "read-package-tree": "5.2.1",
+        "readable-stream": "2.3.6",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.88.0",
+        "retry": "0.12.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
+        "semver": "5.5.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "6.0.0",
+        "stringify-package": "1.0.0",
+        "tar": "4.4.6",
+        "text-table": "0.2.0",
+        "tiny-relative-date": "1.3.0",
         "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
-        "unpipe": "~1.0.0",
-        "update-notifier": "^2.5.0",
-        "uuid": "^3.3.2",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "^1.3.1",
-        "worker-farm": "^1.6.0",
-        "write-file-atomic": "^2.3.0"
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.5.0",
+        "uuid": "3.3.2",
+        "validate-npm-package-license": "3.0.4",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.1",
+        "worker-farm": "1.6.0",
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "JSONStream": {
           "version": "1.3.4",
           "bundled": true,
           "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
           }
         },
         "abbrev": {
@@ -8607,31 +8607,31 @@
           "version": "4.2.0",
           "bundled": true,
           "requires": {
-            "es6-promisify": "^5.0.0"
+            "es6-promisify": "5.0.0"
           }
         },
         "agentkeepalive": {
           "version": "3.4.1",
           "bundled": true,
           "requires": {
-            "humanize-ms": "^1.2.1"
+            "humanize-ms": "1.2.1"
           }
         },
         "ajv": {
           "version": "5.5.2",
           "bundled": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ansi-align": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.0.0"
+            "string-width": "2.1.1"
           }
         },
         "ansi-regex": {
@@ -8642,7 +8642,7 @@
           "version": "3.2.1",
           "bundled": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "ansicolors": {
@@ -8665,8 +8665,8 @@
           "version": "1.1.4",
           "bundled": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "asap": {
@@ -8677,7 +8677,7 @@
           "version": "0.2.4",
           "bundled": true,
           "requires": {
-            "safer-buffer": "~2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "assert-plus": {
@@ -8705,25 +8705,25 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "bin-links": {
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
-            "write-file-atomic": "^2.3.0"
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "write-file-atomic": "2.3.0"
           }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "bluebird": {
@@ -8734,20 +8734,20 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.4.1",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "2.0.0"
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -8775,20 +8775,20 @@
           "version": "11.2.0",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "figgy-pudding": "^3.1.0",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.3",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^6.0.0",
-            "unique-filename": "^1.1.0",
-            "y18n": "^4.0.0"
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "figgy-pudding": "3.4.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "6.0.0",
+            "unique-filename": "1.1.0",
+            "y18n": "4.0.0"
           }
         },
         "call-limit": {
@@ -8811,9 +8811,9 @@
           "version": "2.4.1",
           "bundled": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "chownr": {
@@ -8828,7 +8828,7 @@
           "version": "2.0.9",
           "bundled": true,
           "requires": {
-            "ip-regex": "^2.1.0"
+            "ip-regex": "2.1.0"
           }
         },
         "cli-boxes": {
@@ -8839,26 +8839,26 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.1"
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1"
           }
         },
         "cli-table3": {
           "version": "0.5.0",
           "bundled": true,
           "requires": {
-            "colors": "^1.1.2",
-            "object-assign": "^4.1.0",
-            "string-width": "^2.1.1"
+            "colors": "1.1.2",
+            "object-assign": "4.1.1",
+            "string-width": "2.1.1"
           }
         },
         "cliui": {
           "version": "4.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -8869,7 +8869,7 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -8882,8 +8882,8 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
           }
         },
         "co": {
@@ -8898,7 +8898,7 @@
           "version": "1.9.1",
           "bundled": true,
           "requires": {
-            "color-name": "^1.1.1"
+            "color-name": "1.1.3"
           }
         },
         "color-name": {
@@ -8914,15 +8914,15 @@
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "strip-ansi": "^3.0.0",
-            "wcwidth": "^1.0.0"
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
           }
         },
         "combined-stream": {
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
@@ -8933,30 +8933,30 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
           }
         },
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
           }
         },
         "configstore": {
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.3.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
           }
         },
         "console-control-strings": {
@@ -8967,12 +8967,12 @@
           "version": "1.0.5",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "fs-write-stream-atomic": "^1.0.8",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.0"
+            "aproba": "1.2.0",
+            "fs-write-stream-atomic": "1.0.10",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           },
           "dependencies": {
             "iferr": {
@@ -8989,16 +8989,16 @@
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "capture-stack-trace": "^1.0.0"
+            "capture-stack-trace": "1.0.0"
           }
         },
         "cross-spawn": {
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "crypto-random-string": {
@@ -9013,7 +9013,7 @@
           "version": "1.14.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           }
         },
         "debug": {
@@ -9049,7 +9049,7 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "clone": "^1.0.2"
+            "clone": "1.0.4"
           }
         },
         "delayed-stream": {
@@ -9072,15 +9072,15 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "^2.0.0",
-            "wrappy": "1"
+            "asap": "2.0.6",
+            "wrappy": "1.0.2"
           }
         },
         "dot-prop": {
           "version": "4.2.0",
           "bundled": true,
           "requires": {
-            "is-obj": "^1.0.0"
+            "is-obj": "1.0.1"
           }
         },
         "dotenv": {
@@ -9095,10 +9095,10 @@
           "version": "3.6.0",
           "bundled": true,
           "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
+            "end-of-stream": "1.4.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
           }
         },
         "ecc-jsbn": {
@@ -9106,8 +9106,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2"
           }
         },
         "editor": {
@@ -9118,14 +9118,14 @@
           "version": "0.1.12",
           "bundled": true,
           "requires": {
-            "iconv-lite": "~0.4.13"
+            "iconv-lite": "0.4.23"
           }
         },
         "end-of-stream": {
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "err-code": {
@@ -9136,7 +9136,7 @@
           "version": "0.1.7",
           "bundled": true,
           "requires": {
-            "prr": "~1.0.1"
+            "prr": "1.0.1"
           }
         },
         "es6-promise": {
@@ -9147,7 +9147,7 @@
           "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "es6-promise": "^4.0.3"
+            "es6-promise": "4.2.4"
           }
         },
         "escape-string-regexp": {
@@ -9158,13 +9158,13 @@
           "version": "0.7.0",
           "bundled": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "extend": {
@@ -9195,15 +9195,15 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "flush-write-stream": {
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.4"
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "forever-agent": {
@@ -9214,43 +9214,43 @@
           "version": "2.3.2",
           "bundled": true,
           "requires": {
-            "asynckit": "^0.4.0",
+            "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "^2.1.12"
+            "mime-types": "2.1.19"
           }
         },
         "from2": {
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0"
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.6"
           },
           "dependencies": {
             "iferr": {
@@ -9267,33 +9267,33 @@
           "version": "1.0.11",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
           }
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -9306,14 +9306,14 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "fs-vacuum": "^1.2.10",
-            "graceful-fs": "^4.1.11",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "path-is-inside": "^1.0.2",
-            "read-cmd-shim": "^1.0.1",
-            "slide": "^1.1.6"
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
           },
           "dependencies": {
             "iferr": {
@@ -9334,43 +9334,43 @@
           "version": "0.1.7",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "global-dirs": {
           "version": "0.1.1",
           "bundled": true,
           "requires": {
-            "ini": "^1.3.4"
+            "ini": "1.3.5"
           }
         },
         "got": {
           "version": "6.7.1",
           "bundled": true,
           "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         },
         "graceful-fs": {
@@ -9385,8 +9385,8 @@
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "ajv": "^5.3.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "has-flag": {
@@ -9409,7 +9409,7 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "agent-base": "4",
+            "agent-base": "4.2.0",
             "debug": "3.1.0"
           }
         },
@@ -9417,31 +9417,31 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
           }
         },
         "https-proxy-agent": {
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "agent-base": "^4.1.0",
-            "debug": "^3.1.0"
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
           }
         },
         "humanize-ms": {
           "version": "1.2.1",
           "bundled": true,
           "requires": {
-            "ms": "^2.0.0"
+            "ms": "2.1.1"
           }
         },
         "iconv-lite": {
           "version": "0.4.23",
           "bundled": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "iferr": {
@@ -9452,7 +9452,7 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "import-lazy": {
@@ -9467,8 +9467,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -9483,14 +9483,14 @@
           "version": "1.10.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-            "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
-            "validate-npm-package-name": "^3.0.0"
+            "glob": "7.1.2",
+            "npm-package-arg": "6.1.0",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.13",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.4",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "invert-kv": {
@@ -9509,36 +9509,36 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "builtin-modules": "^1.0.0"
+            "builtin-modules": "1.1.1"
           }
         },
         "is-ci": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "ci-info": "^1.0.0"
+            "ci-info": "1.4.0"
           }
         },
         "is-cidr": {
           "version": "2.0.6",
           "bundled": true,
           "requires": {
-            "cidr-regex": "^2.0.8"
+            "cidr-regex": "2.0.9"
           }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-installed-globally": {
           "version": "0.1.0",
           "bundled": true,
           "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
+            "global-dirs": "0.1.1",
+            "is-path-inside": "1.0.1"
           }
         },
         "is-npm": {
@@ -9553,7 +9553,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "path-is-inside": "^1.0.1"
+            "path-is-inside": "1.0.2"
           }
         },
         "is-redirect": {
@@ -9623,7 +9623,7 @@
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "package-json": "^4.0.0"
+            "package-json": "4.0.1"
           }
         },
         "lazy-property": {
@@ -9634,46 +9634,46 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "1.0.0"
           }
         },
         "libcipm": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "bin-links": "^1.1.2",
-            "bluebird": "^3.5.1",
-            "find-npm-prefix": "^1.0.2",
-            "graceful-fs": "^4.1.11",
-            "lock-verify": "^2.0.2",
-            "mkdirp": "^0.5.1",
-            "npm-lifecycle": "^2.0.3",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.1.0",
-            "pacote": "^8.1.6",
-            "protoduck": "^5.0.0",
-            "read-package-json": "^2.0.13",
-            "rimraf": "^2.6.2",
-            "worker-farm": "^1.6.0"
+            "bin-links": "1.1.2",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.2",
+            "mkdirp": "0.5.1",
+            "npm-lifecycle": "2.1.0",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.1.0",
+            "pacote": "8.1.6",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.13",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.6.0"
           }
         },
         "libnpmhook": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "^3.1.0",
-            "npm-registry-fetch": "^3.0.0"
+            "figgy-pudding": "3.4.1",
+            "npm-registry-fetch": "3.1.1"
           },
           "dependencies": {
             "npm-registry-fetch": {
               "version": "3.1.1",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.1.0",
-                "lru-cache": "^4.1.2",
-                "make-fetch-happen": "^4.0.0",
-                "npm-package-arg": "^6.0.0"
+                "bluebird": "3.5.1",
+                "figgy-pudding": "3.4.1",
+                "lru-cache": "4.1.3",
+                "make-fetch-happen": "4.0.1",
+                "npm-package-arg": "6.1.0"
               }
             }
           }
@@ -9682,37 +9682,37 @@
           "version": "10.2.0",
           "bundled": true,
           "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.1.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "update-notifier": "2.5.0",
+            "which": "1.3.1",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
           }
         },
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "lock-verify": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^5.1.2 || 6",
-            "semver": "^5.4.1"
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "signal-exit": "^3.0.2"
+            "signal-exit": "3.0.2"
           }
         },
         "lodash._baseindexof": {
@@ -9723,8 +9723,8 @@
           "version": "4.6.0",
           "bundled": true,
           "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
           }
         },
         "lodash._bindcallback": {
@@ -9739,7 +9739,7 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "lodash._getnative": "^3.0.0"
+            "lodash._getnative": "3.9.1"
           }
         },
         "lodash._createset": {
@@ -9782,32 +9782,32 @@
           "version": "4.1.3",
           "bundled": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "make-dir": {
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "make-fetch-happen": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "agentkeepalive": "^3.4.1",
-            "cacache": "^11.0.1",
-            "http-cache-semantics": "^3.8.1",
-            "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.1",
-            "lru-cache": "^4.1.2",
-            "mississippi": "^3.0.0",
-            "node-fetch-npm": "^2.0.2",
-            "promise-retry": "^1.1.1",
-            "socks-proxy-agent": "^4.0.0",
-            "ssri": "^6.0.0"
+            "agentkeepalive": "3.4.1",
+            "cacache": "11.2.0",
+            "http-cache-semantics": "3.8.1",
+            "http-proxy-agent": "2.1.0",
+            "https-proxy-agent": "2.2.1",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
+            "node-fetch-npm": "2.0.2",
+            "promise-retry": "1.1.1",
+            "socks-proxy-agent": "4.0.1",
+            "ssri": "6.0.0"
           }
         },
         "meant": {
@@ -9818,7 +9818,7 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "mime-db": {
@@ -9829,7 +9829,7 @@
           "version": "2.1.19",
           "bundled": true,
           "requires": {
-            "mime-db": "~1.35.0"
+            "mime-db": "1.35.0"
           }
         },
         "mimic-fn": {
@@ -9840,7 +9840,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -9851,8 +9851,8 @@
           "version": "2.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           },
           "dependencies": {
             "yallist": {
@@ -9865,23 +9865,23 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "concat-stream": "1.6.2",
+            "duplexify": "3.6.0",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.3",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "3.0.0",
+            "pumpify": "1.5.1",
+            "stream-each": "1.2.2",
+            "through2": "2.0.3"
           }
         },
         "mkdirp": {
@@ -9895,12 +9895,12 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           }
         },
         "ms": {
@@ -9915,34 +9915,34 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "encoding": "^0.1.11",
-            "json-parse-better-errors": "^1.0.0",
-            "safe-buffer": "^5.1.1"
+            "encoding": "0.1.12",
+            "json-parse-better-errors": "1.0.2",
+            "safe-buffer": "5.1.2"
           }
         },
         "node-gyp": {
           "version": "3.8.0",
           "bundled": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "^2.87.0",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.5",
+            "request": "2.88.0",
+            "rimraf": "2.6.2",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.1"
           },
           "dependencies": {
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
               }
             },
             "semver": {
@@ -9953,9 +9953,9 @@
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
               }
             }
           }
@@ -9964,26 +9964,26 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.7.1",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.4"
           }
         },
         "npm-audit-report": {
           "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "cli-table3": "^0.5.0",
-            "console-control-strings": "^1.1.0"
+            "cli-table3": "0.5.0",
+            "console-control-strings": "1.1.0"
           }
         },
         "npm-bundled": {
@@ -9998,21 +9998,21 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
+            "semver": "5.5.0"
           }
         },
         "npm-lifecycle": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.8.0",
-            "resolve-from": "^4.0.0",
-            "slide": "^1.1.6",
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.8.0",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
             "uid-number": "0.0.6",
-            "umask": "^1.1.0",
-            "which": "^1.3.1"
+            "umask": "1.1.0",
+            "which": "1.3.1"
           }
         },
         "npm-logical-tree": {
@@ -10023,52 +10023,52 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
-            "osenv": "^0.1.5",
-            "semver": "^5.5.0",
-            "validate-npm-package-name": "^3.0.0"
+            "hosted-git-info": "2.7.1",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "npm-packlist": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.5"
           }
         },
         "npm-pick-manifest": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^6.0.0",
-            "semver": "^5.4.1"
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "npm-profile": {
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2 || 2",
-            "make-fetch-happen": "^2.5.0 || 3 || 4"
+            "aproba": "1.2.0",
+            "make-fetch-happen": "4.0.1"
           }
         },
         "npm-registry-client": {
           "version": "8.6.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^5.2.4"
+            "concat-stream": "1.6.2",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.88.0",
+            "retry": "0.10.1",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "ssri": "5.3.0"
           },
           "dependencies": {
             "retry": {
@@ -10079,7 +10079,7 @@
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -10088,47 +10088,47 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^2.0.1",
-            "lru-cache": "^4.1.2",
-            "make-fetch-happen": "^3.0.0",
-            "npm-package-arg": "^6.0.0",
-            "safe-buffer": "^5.1.1"
+            "bluebird": "3.5.1",
+            "figgy-pudding": "2.0.1",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "3.0.0",
+            "npm-package-arg": "6.1.0",
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "cacache": {
               "version": "10.0.4",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
+                "bluebird": "3.5.1",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.3",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.3.0",
+                "unique-filename": "1.1.0",
+                "y18n": "4.0.0"
               },
               "dependencies": {
                 "mississippi": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^2.0.1",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
+                    "concat-stream": "1.6.2",
+                    "duplexify": "3.6.0",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.3",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "2.0.1",
+                    "pumpify": "1.5.1",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
                   }
                 }
               }
@@ -10141,25 +10141,25 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^10.0.4",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.0",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.2.4"
+                "agentkeepalive": "3.4.1",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
               }
             },
             "pump": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
               }
             },
             "smart-buffer": {
@@ -10170,23 +10170,23 @@
               "version": "1.1.10",
               "bundled": true,
               "requires": {
-                "ip": "^1.1.4",
-                "smart-buffer": "^1.0.13"
+                "ip": "1.1.5",
+                "smart-buffer": "1.1.15"
               }
             },
             "socks-proxy-agent": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "agent-base": "^4.1.0",
-                "socks": "^1.1.10"
+                "agent-base": "4.2.0",
+                "socks": "1.1.10"
               }
             },
             "ssri": {
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -10195,7 +10195,7 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "path-key": "^2.0.0"
+            "path-key": "2.0.1"
           }
         },
         "npm-user-validate": {
@@ -10206,10 +10206,10 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -10228,7 +10228,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "opener": {
@@ -10243,9 +10243,9 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "os-tmpdir": {
@@ -10256,8 +10256,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "p-finally": {
@@ -10268,14 +10268,14 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.2.0"
           }
         },
         "p-try": {
@@ -10286,50 +10286,50 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.2",
+            "registry-url": "3.1.0",
+            "semver": "5.5.0"
           }
         },
         "pacote": {
           "version": "8.1.6",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^11.0.2",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.3",
-            "make-fetch-happen": "^4.0.1",
-            "minimatch": "^3.0.4",
-            "minipass": "^2.3.3",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
-            "osenv": "^0.1.5",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.2",
-            "semver": "^5.5.0",
-            "ssri": "^6.0.0",
-            "tar": "^4.4.3",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "bluebird": "3.5.1",
+            "cacache": "11.2.0",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "4.0.1",
+            "minimatch": "3.0.4",
+            "minipass": "2.3.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npm-packlist": "1.1.11",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "ssri": "6.0.0",
+            "tar": "4.4.6",
+            "unique-filename": "1.1.0",
+            "which": "1.3.1"
           }
         },
         "parallel-transform": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "cyclist": "~0.2.2",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.1.5"
+            "cyclist": "0.2.2",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "path-exists": {
@@ -10372,8 +10372,8 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "err-code": "^1.0.0",
-            "retry": "^0.10.0"
+            "err-code": "1.1.2",
+            "retry": "0.10.1"
           },
           "dependencies": {
             "retry": {
@@ -10386,7 +10386,7 @@
           "version": "0.3.0",
           "bundled": true,
           "requires": {
-            "read": "1"
+            "read": "1.0.7"
           }
         },
         "proto-list": {
@@ -10397,7 +10397,7 @@
           "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "genfun": "^4.0.1"
+            "genfun": "4.0.1"
           }
         },
         "prr": {
@@ -10416,25 +10416,25 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "pumpify": {
           "version": "1.5.1",
           "bundled": true,
           "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
+            "duplexify": "3.6.0",
+            "inherits": "2.0.3",
+            "pump": "2.0.1"
           },
           "dependencies": {
             "pump": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
               }
             }
           }
@@ -10455,8 +10455,8 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "decode-uri-component": "^0.2.0",
-            "strict-uri-encode": "^2.0.0"
+            "decode-uri-component": "0.2.0",
+            "strict-uri-encode": "2.0.0"
           }
         },
         "qw": {
@@ -10467,10 +10467,10 @@
           "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -10483,113 +10483,113 @@
           "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "~0.0.4"
+            "mute-stream": "0.0.7"
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2"
+            "graceful-fs": "4.1.11"
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
           }
         },
         "read-package-json": {
           "version": "2.0.13",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.1",
-            "normalize-package-data": "^2.0.0",
-            "slash": "^1.0.0"
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.2",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
           }
         },
         "read-package-tree": {
           "version": "5.2.1",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "graceful-fs": "^4.1.2",
-            "once": "^1.3.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
           }
         },
         "registry-auth-token": {
           "version": "3.3.2",
           "bundled": true,
           "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
+            "rc": "1.2.7",
+            "safe-buffer": "5.1.2"
           }
         },
         "registry-url": {
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "rc": "^1.0.1"
+            "rc": "1.2.7"
           }
         },
         "request": {
           "version": "2.88.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.8.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.2",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.1.0",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.19",
+            "oauth-sign": "0.9.0",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "tough-cookie": "2.4.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
         },
         "require-directory": {
@@ -10612,14 +10612,14 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "run-queue": {
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1"
+            "aproba": "1.2.0"
           }
         },
         "safe-buffer": {
@@ -10638,7 +10638,7 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "semver": "^5.0.3"
+            "semver": "5.5.0"
           }
         },
         "set-blocking": {
@@ -10649,15 +10649,15 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.6"
           }
         },
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "shebang-regex": "^1.0.0"
+            "shebang-regex": "1.0.0"
           }
         },
         "shebang-regex": {
@@ -10684,16 +10684,16 @@
           "version": "2.2.0",
           "bundled": true,
           "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "^4.0.1"
+            "ip": "1.1.5",
+            "smart-buffer": "4.0.1"
           }
         },
         "socks-proxy-agent": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "agent-base": "~4.2.0",
-            "socks": "~2.2.0"
+            "agent-base": "4.2.0",
+            "socks": "2.2.0"
           }
         },
         "sorted-object": {
@@ -10704,16 +10704,16 @@
           "version": "2.1.3",
           "bundled": true,
           "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
           },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
               }
             },
             "isarray": {
@@ -10724,10 +10724,10 @@
               "version": "1.1.14",
               "bundled": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -10740,8 +10740,8 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -10752,8 +10752,8 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -10764,15 +10764,15 @@
           "version": "1.14.2",
           "bundled": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.4",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.2",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.2",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2",
+            "tweetnacl": "0.14.5"
           }
         },
         "ssri": {
@@ -10783,16 +10783,16 @@
           "version": "1.2.2",
           "bundled": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "stream-shift": "^1.0.0"
+            "end-of-stream": "1.4.1",
+            "stream-shift": "1.0.0"
           }
         },
         "stream-iterate": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "stream-shift": "^1.0.0"
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
           }
         },
         "stream-shift": {
@@ -10807,8 +10807,8 @@
           "version": "2.1.1",
           "bundled": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -10823,7 +10823,7 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -10832,7 +10832,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "stringify-package": {
@@ -10843,7 +10843,7 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-eof": {
@@ -10858,20 +10858,20 @@
           "version": "5.4.0",
           "bundled": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "tar": {
           "version": "4.4.6",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.3",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           },
           "dependencies": {
             "yallist": {
@@ -10884,7 +10884,7 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "execa": "^0.7.0"
+            "execa": "0.7.0"
           }
         },
         "text-table": {
@@ -10899,8 +10899,8 @@
           "version": "2.0.3",
           "bundled": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         },
         "timed-out": {
@@ -10915,15 +10915,15 @@
           "version": "2.4.3",
           "bundled": true,
           "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
+            "psl": "1.1.29",
+            "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.2"
           }
         },
         "tweetnacl": {
@@ -10947,21 +10947,21 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "unique-slug": "^2.0.0"
+            "unique-slug": "2.0.0"
           }
         },
         "unique-slug": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "imurmurhash": "^0.1.4"
+            "imurmurhash": "0.1.4"
           }
         },
         "unique-string": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "crypto-random-string": "^1.0.0"
+            "crypto-random-string": "1.0.0"
           }
         },
         "unpipe": {
@@ -10976,23 +10976,23 @@
           "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "boxen": "1.3.0",
+            "chalk": "2.4.1",
+            "configstore": "3.1.2",
+            "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
           }
         },
         "url-parse-lax": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "prepend-http": "^1.0.1"
+            "prepend-http": "1.0.4"
           }
         },
         "util-deprecate": {
@@ -11011,38 +11011,38 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "^1.0.3"
+            "builtins": "1.0.3"
           }
         },
         "verror": {
           "version": "1.10.0",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0",
+            "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
+            "extsprintf": "1.3.0"
           }
         },
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "defaults": "^1.0.3"
+            "defaults": "1.0.3"
           }
         },
         "which": {
           "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         },
         "which-module": {
@@ -11053,16 +11053,16 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -11071,31 +11071,31 @@
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.1.1"
+            "string-width": "2.1.1"
           }
         },
         "worker-farm": {
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "~0.1.7"
+            "errno": "0.1.7"
           }
         },
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -11108,9 +11108,9 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
           }
         },
         "xdg-basedir": {
@@ -11133,18 +11133,18 @@
           "version": "11.0.0",
           "bundled": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           },
           "dependencies": {
             "y18n": {
@@ -11157,7 +11157,7 @@
           "version": "9.0.2",
           "bundled": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -11168,8 +11168,8 @@
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "dev": true,
       "requires": {
-        "config-chain": "^1.1.11",
-        "pify": "^3.0.0"
+        "config-chain": "1.1.12",
+        "pify": "3.0.0"
       }
     },
     "npm-run-path": {
@@ -11178,7 +11178,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "nth-check": {
@@ -11187,7 +11187,7 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "num2fraction": {
@@ -11226,9 +11226,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -11237,7 +11237,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -11246,7 +11246,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -11263,7 +11263,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.defaults": {
@@ -11272,10 +11272,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -11284,8 +11284,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0"
       }
     },
     "object.map": {
@@ -11294,8 +11294,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       }
     },
     "object.omit": {
@@ -11304,8 +11304,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       },
       "dependencies": {
         "for-own": {
@@ -11314,7 +11314,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -11325,7 +11325,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "object.values": {
@@ -11334,10 +11334,10 @@
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "on-finished": {
@@ -11355,7 +11355,7 @@
       "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -11364,7 +11364,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "opn": {
@@ -11373,7 +11373,7 @@
       "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
       "dev": true,
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "1.1.0"
       }
     },
     "optimist": {
@@ -11382,8 +11382,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -11406,12 +11406,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "optipng-bin": {
@@ -11421,9 +11421,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "^3.0.0",
-        "bin-wrapper": "^4.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "3.0.0",
+        "bin-wrapper": "4.1.0",
+        "logalot": "2.1.0"
       }
     },
     "orchestrator": {
@@ -11432,9 +11432,9 @@
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "dev": true,
       "requires": {
-        "end-of-stream": "~0.1.5",
-        "sequencify": "~0.0.7",
-        "stream-consume": "~0.1.0"
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.1"
       }
     },
     "ordered-read-streams": {
@@ -11450,7 +11450,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "arch": "^2.1.0"
+        "arch": "2.1.1"
       }
     },
     "os-homedir": {
@@ -11479,7 +11479,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "p-timeout": "^1.1.1"
+        "p-timeout": "1.2.1"
       }
     },
     "p-finally": {
@@ -11502,7 +11502,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "p-reduce": "^1.0.0"
+        "p-reduce": "1.0.0"
       }
     },
     "p-pipe": {
@@ -11524,7 +11524,7 @@
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "parse-filepath": {
@@ -11533,9 +11533,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-glob": {
@@ -11544,10 +11544,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -11562,7 +11562,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -11573,8 +11573,8 @@
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "1.3.2",
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "parse-node-version": {
@@ -11595,7 +11595,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -11604,7 +11604,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -11637,7 +11637,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -11670,7 +11670,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -11685,7 +11685,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "pause-stream": {
@@ -11694,7 +11694,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "~2.3"
+        "through": "2.3.8"
       }
     },
     "pend": {
@@ -11715,15 +11715,15 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "^4.0.3",
-        "extract-zip": "^1.6.5",
-        "fs-extra": "^1.0.0",
-        "hasha": "^2.2.0",
-        "kew": "^0.7.0",
-        "progress": "^1.1.8",
-        "request": "^2.81.0",
-        "request-progress": "^2.0.1",
-        "which": "^1.2.10"
+        "es6-promise": "4.2.5",
+        "extract-zip": "1.6.7",
+        "fs-extra": "1.0.0",
+        "hasha": "2.2.0",
+        "kew": "0.7.0",
+        "progress": "1.1.8",
+        "request": "2.88.0",
+        "request-progress": "2.0.1",
+        "which": "1.3.1"
       },
       "dependencies": {
         "es6-promise": {
@@ -11758,7 +11758,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "plugin-error": {
@@ -11767,10 +11767,10 @@
       "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^1.0.1",
-        "arr-diff": "^4.0.0",
-        "arr-union": "^3.1.0",
-        "extend-shallow": "^3.0.2"
+        "ansi-colors": "1.1.0",
+        "arr-diff": "4.0.0",
+        "arr-union": "3.1.0",
+        "extend-shallow": "3.0.2"
       }
     },
     "plugin-log": {
@@ -11779,8 +11779,8 @@
       "integrity": "sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "dateformat": "^1.0.11"
+        "chalk": "1.1.3",
+        "dateformat": "1.0.12"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11795,11 +11795,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "dateformat": {
@@ -11808,8 +11808,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.3.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "supports-color": {
@@ -11826,7 +11826,7 @@
       "integrity": "sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^2.0.0"
+        "irregular-plurals": "2.0.0"
       }
     },
     "pluralize": {
@@ -11847,9 +11847,9 @@
       "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.5.0"
+        "chalk": "2.4.1",
+        "source-map": "0.6.1",
+        "supports-color": "5.5.0"
       },
       "dependencies": {
         "source-map": {
@@ -11866,10 +11866,10 @@
       "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
       "dev": true,
       "requires": {
-        "css-unit-converter": "^1.1.1",
-        "postcss": "^7.0.5",
-        "postcss-selector-parser": "^5.0.0-rc.4",
-        "postcss-value-parser": "^3.3.1"
+        "css-unit-converter": "1.1.1",
+        "postcss": "7.0.6",
+        "postcss-selector-parser": "5.0.0-rc.4",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-colormin": {
@@ -11878,11 +11878,11 @@
       "integrity": "sha512-1QJc2coIehnVFsz0otges8kQLsryi4lo19WD+U5xCWvXd0uw/Z+KKYnbiNDCnO9GP+PvErPHCG0jNvWTngk9Rw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "color": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "browserslist": "4.3.5",
+        "color": "3.1.0",
+        "has": "1.0.3",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-convert-values": {
@@ -11891,8 +11891,8 @@
       "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-discard-comments": {
@@ -11901,7 +11901,7 @@
       "integrity": "sha512-Ay+rZu1Sz6g8IdzRjUgG2NafSNpp2MSMOQUb+9kkzzzP+kh07fP0yNbhtFejURnyVXSX3FYy2nVNW1QTnNjgBQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.6"
       }
     },
     "postcss-discard-duplicates": {
@@ -11910,7 +11910,7 @@
       "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.6"
       }
     },
     "postcss-discard-empty": {
@@ -11919,7 +11919,7 @@
       "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.6"
       }
     },
     "postcss-discard-overridden": {
@@ -11928,7 +11928,7 @@
       "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.6"
       }
     },
     "postcss-load-config": {
@@ -11937,8 +11937,8 @@
       "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^4.0.0",
-        "import-cwd": "^2.0.0"
+        "cosmiconfig": "4.0.0",
+        "import-cwd": "2.1.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -11947,10 +11947,10 @@
           "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
           "dev": true,
           "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^4.0.0",
-            "require-from-string": "^2.0.1"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.12.0",
+            "parse-json": "4.0.0",
+            "require-from-string": "2.0.2"
           }
         }
       }
@@ -11962,9 +11962,9 @@
       "dev": true,
       "requires": {
         "css-color-names": "0.0.4",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "stylehacks": "^4.0.0"
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1",
+        "stylehacks": "4.0.1"
       }
     },
     "postcss-merge-rules": {
@@ -11973,12 +11973,12 @@
       "integrity": "sha512-UiuXwCCJtQy9tAIxsnurfF0mrNHKc4NnNx6NxqmzNNjXpQwLSukUxELHTRF0Rg1pAmcoKLih8PwvZbiordchag==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "cssnano-util-same-parent": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0",
-        "vendors": "^1.0.0"
+        "browserslist": "4.3.5",
+        "caniuse-api": "3.0.0",
+        "cssnano-util-same-parent": "4.0.1",
+        "postcss": "7.0.6",
+        "postcss-selector-parser": "3.1.1",
+        "vendors": "1.0.2"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -11987,9 +11987,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         }
       }
@@ -12000,8 +12000,8 @@
       "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-minify-gradients": {
@@ -12010,10 +12010,10 @@
       "integrity": "sha512-pySEW3E6Ly5mHm18rekbWiAjVi/Wj8KKt2vwSfVFAWdW6wOIekgqxKxLU7vJfb107o3FDNPkaYFCxGAJBFyogA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "is-color-stop": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "is-color-stop": "1.1.0",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-minify-params": {
@@ -12022,12 +12022,12 @@
       "integrity": "sha512-h4W0FEMEzBLxpxIVelRtMheskOKKp52ND6rJv+nBS33G1twu2tCyurYj/YtgU76+UDCvWeNs0hs8HFAWE2OUFg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.0",
-        "browserslist": "^4.0.0",
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "browserslist": "4.3.5",
+        "cssnano-util-get-arguments": "4.0.0",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-minify-selectors": {
@@ -12036,10 +12036,10 @@
       "integrity": "sha512-8+plQkomve3G+CodLCgbhAKrb5lekAnLYuL1d7Nz+/7RANpBEVdgBkPNwljfSKvZ9xkkZTZITd04KP+zeJTJqg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.3",
+        "postcss": "7.0.6",
+        "postcss-selector-parser": "3.1.1"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -12048,9 +12048,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         }
       }
@@ -12061,7 +12061,7 @@
       "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.6"
       }
     },
     "postcss-normalize-display-values": {
@@ -12070,9 +12070,9 @@
       "integrity": "sha512-R5mC4vaDdvsrku96yXP7zak+O3Mm9Y8IslUobk7IMP+u/g+lXvcN4jngmHY5zeJnrQvE13dfAg5ViU05ZFDwdg==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-normalize-positions": {
@@ -12081,10 +12081,10 @@
       "integrity": "sha512-GNoOaLRBM0gvH+ZRb2vKCIujzz4aclli64MBwDuYGU2EY53LwiP7MxOZGE46UGtotrSnmarPPZ69l2S/uxdaWA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "has": "1.0.3",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-normalize-repeat-style": {
@@ -12093,10 +12093,10 @@
       "integrity": "sha512-fFHPGIjBUyUiswY2rd9rsFcC0t3oRta4wxE1h3lpwfQZwFeFjXFSiDtdJ7APCmHQOnUZnqYBADNRPKPwFAONgA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-normalize-string": {
@@ -12105,9 +12105,9 @@
       "integrity": "sha512-IJoexFTkAvAq5UZVxWXAGE0yLoNN/012v7TQh5nDo6imZJl2Fwgbhy3J2qnIoaDBrtUP0H7JrXlX1jjn2YcvCQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "has": "1.0.3",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-normalize-timing-functions": {
@@ -12116,9 +12116,9 @@
       "integrity": "sha512-1nOtk7ze36+63ONWD8RCaRDYsnzorrj+Q6fxkQV+mlY5+471Qx9kspqv0O/qQNMeApg8KNrRf496zHwJ3tBZ7w==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-normalize-unicode": {
@@ -12127,9 +12127,9 @@
       "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "browserslist": "4.3.5",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-normalize-url": {
@@ -12138,10 +12138,10 @@
       "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
       "dev": true,
       "requires": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "3.3.0",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-normalize-whitespace": {
@@ -12150,8 +12150,8 @@
       "integrity": "sha512-U8MBODMB2L+nStzOk6VvWWjZgi5kQNShCyjRhMT3s+W9Jw93yIjOnrEkKYD3Ul7ChWbEcjDWmXq0qOL9MIAnAw==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-ordered-values": {
@@ -12160,9 +12160,9 @@
       "integrity": "sha512-PeJiLgJWPzkVF8JuKSBcylaU+hDJ/TX3zqAMIjlghgn1JBi6QwQaDZoDIlqWRcCAI8SxKrt3FCPSRmOgKRB97Q==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-reduce-initial": {
@@ -12171,10 +12171,10 @@
       "integrity": "sha512-epUiC39NonKUKG+P3eAOKKZtm5OtAtQJL7Ye0CBN1f+UQTHzqotudp+hki7zxXm7tT0ZAKDMBj1uihpPjP25ug==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0"
+        "browserslist": "4.3.5",
+        "caniuse-api": "3.0.0",
+        "has": "1.0.3",
+        "postcss": "7.0.6"
       }
     },
     "postcss-reduce-transforms": {
@@ -12183,10 +12183,10 @@
       "integrity": "sha512-sZVr3QlGs0pjh6JAIe6DzWvBaqYw05V1t3d9Tp+VnFRT5j+rsqoWsysh/iSD7YNsULjq9IAylCznIwVd5oU/zA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-match": "4.0.0",
+        "has": "1.0.3",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1"
       }
     },
     "postcss-selector-parser": {
@@ -12195,9 +12195,9 @@
       "integrity": "sha512-0XvfYuShrKlTk1ooUrVzMCFQRcypsdEIsGqh5IxC5rdtBi4/M/tDAJeSONwC2MTqEFsmPZYAV7Dd4X8rgAfV0A==",
       "dev": true,
       "requires": {
-        "cssesc": "^2.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "cssesc": "2.0.0",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-svgo": {
@@ -12206,10 +12206,10 @@
       "integrity": "sha512-YD5uIk5NDRySy0hcI+ZJHwqemv2WiqqzDgtvgMzO8EGSkK5aONyX8HMVFRFJSdO8wUWTuisUFn/d7yRRbBr5Qw==",
       "dev": true,
       "requires": {
-        "is-svg": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "svgo": "^1.0.0"
+        "is-svg": "3.0.0",
+        "postcss": "7.0.6",
+        "postcss-value-parser": "3.3.1",
+        "svgo": "1.1.1"
       }
     },
     "postcss-unique-selectors": {
@@ -12218,9 +12218,9 @@
       "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.0",
-        "postcss": "^7.0.0",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "7.0.6",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-value-parser": {
@@ -12285,7 +12285,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "proto-list": {
@@ -12319,8 +12319,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.3.3"
       },
       "dependencies": {
         "end-of-stream": {
@@ -12329,7 +12329,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           },
           "dependencies": {
             "once": {
@@ -12338,7 +12338,7 @@
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               }
             }
           }
@@ -12376,9 +12376,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "0.2.0",
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
       },
       "dependencies": {
         "object-assign": {
@@ -12396,9 +12396,9 @@
       "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -12421,8 +12421,8 @@
       "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
       "dev": true,
       "requires": {
-        "bytes": "1",
-        "string_decoder": "0.10"
+        "bytes": "1.0.0",
+        "string_decoder": "0.10.31"
       }
     },
     "read-pkg": {
@@ -12431,9 +12431,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -12448,9 +12448,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.15",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -12467,8 +12467,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -12477,10 +12477,10 @@
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
         "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "string_decoder": "0.10.31"
       }
     },
     "readdirp": {
@@ -12489,9 +12489,9 @@
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "graceful-fs": "4.1.15",
+        "micromatch": "3.1.10",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "graceful-fs": {
@@ -12512,13 +12512,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -12527,7 +12527,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -12538,7 +12538,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.8.1"
       }
     },
     "redent": {
@@ -12547,8 +12547,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "regenerate": {
@@ -12563,7 +12563,7 @@
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0"
+        "regenerate": "1.4.0"
       }
     },
     "regenerator-transform": {
@@ -12572,7 +12572,7 @@
       "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
       "dev": true,
       "requires": {
-        "private": "^0.1.6"
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -12581,7 +12581,7 @@
       "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -12590,8 +12590,8 @@
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpp": {
@@ -12606,12 +12606,12 @@
       "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^7.0.0",
-        "regjsgen": "^0.4.0",
-        "regjsparser": "^0.3.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.0.2"
+        "regenerate": "1.4.0",
+        "regenerate-unicode-properties": "7.0.0",
+        "regjsgen": "0.4.0",
+        "regjsparser": "0.3.0",
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.0.2"
       }
     },
     "regjsgen": {
@@ -12626,7 +12626,7 @@
       "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -12661,7 +12661,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -12676,26 +12676,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.21",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "qs": {
@@ -12712,7 +12712,7 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "^1.0.0"
+        "throttleit": "1.0.0"
       }
     },
     "require-from-string": {
@@ -12727,8 +12727,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       },
       "dependencies": {
         "caller-path": {
@@ -12737,7 +12737,7 @@
           "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
           "dev": true,
           "requires": {
-            "callsites": "^0.2.0"
+            "callsites": "0.2.0"
           }
         },
         "callsites": {
@@ -12766,7 +12766,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-dir": {
@@ -12775,8 +12775,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -12798,7 +12798,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lowercase-keys": "^1.0.0"
+        "lowercase-keys": "1.0.1"
       }
     },
     "restore-cursor": {
@@ -12807,8 +12807,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -12841,7 +12841,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -12850,7 +12850,7 @@
       "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.3"
       },
       "dependencies": {
         "glob": {
@@ -12859,12 +12859,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -12873,7 +12873,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -12884,7 +12884,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "run-sequence": {
@@ -12893,9 +12893,9 @@
       "integrity": "sha1-HOZD2jb9jH6n4akynaM/wriJhJU=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^0.1.2"
+        "chalk": "1.1.3",
+        "fancy-log": "1.3.3",
+        "plugin-error": "0.1.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12910,8 +12910,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
           }
         },
         "arr-union": {
@@ -12932,11 +12932,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "extend-shallow": {
@@ -12945,7 +12945,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "^1.1.0"
+            "kind-of": "1.1.0"
           }
         },
         "kind-of": {
@@ -12960,11 +12960,11 @@
           "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
           "dev": true,
           "requires": {
-            "ansi-cyan": "^0.1.1",
-            "ansi-red": "^0.1.1",
-            "arr-diff": "^1.0.1",
-            "arr-union": "^2.0.1",
-            "extend-shallow": "^1.1.2"
+            "ansi-cyan": "0.1.1",
+            "ansi-red": "0.1.1",
+            "arr-diff": "1.1.0",
+            "arr-union": "2.1.0",
+            "extend-shallow": "1.1.4"
           }
         },
         "supports-color": {
@@ -12981,7 +12981,7 @@
       "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.3"
       }
     },
     "safe-buffer": {
@@ -13002,7 +13002,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -13023,7 +13023,7 @@
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
       "requires": {
-        "commander": "~2.8.1"
+        "commander": "2.8.1"
       }
     },
     "select": {
@@ -13051,7 +13051,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.6.0"
       }
     },
     "send": {
@@ -13061,18 +13061,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -13110,13 +13110,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.21",
+        "parseurl": "1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -13142,9 +13142,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -13154,10 +13154,10 @@
       "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -13166,7 +13166,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -13183,7 +13183,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -13209,7 +13209,7 @@
       "resolved": "https://registry.npmjs.org/signalr/-/signalr-2.4.0.tgz",
       "integrity": "sha512-GPJHb3pcNk3IUui5/WG8lMuarEn+Vpc8wEvJ60w0KQ43W9FHnJcuNcF8dkZePr81eBslzicsRdyEunKNF7KjZQ==",
       "requires": {
-        "jquery": ">=1.6.4"
+        "jquery": "3.3.1"
       }
     },
     "simple-swizzle": {
@@ -13218,7 +13218,7 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.3.1"
+        "is-arrayish": "0.3.2"
       },
       "dependencies": {
         "is-arrayish": {
@@ -13241,9 +13241,9 @@
       "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "3.2.1",
+        "astral-regex": "1.0.0",
+        "is-fullwidth-code-point": "2.0.0"
       }
     },
     "snapdragon": {
@@ -13252,14 +13252,14 @@
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "debug": {
@@ -13277,7 +13277,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -13286,7 +13286,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "ms": {
@@ -13303,9 +13303,9 @@
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -13314,7 +13314,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -13323,7 +13323,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -13332,7 +13332,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -13341,9 +13341,9 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -13354,7 +13354,7 @@
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -13363,7 +13363,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -13374,12 +13374,12 @@
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "dev": true,
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "3.1.0",
+        "engine.io": "3.2.1",
+        "has-binary2": "1.0.3",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "~3.2.0"
+        "socket.io-parser": "3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -13415,15 +13415,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.2.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "engine.io-client": "3.2.1",
+        "has-binary2": "1.0.3",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.2.0",
+        "socket.io-parser": "3.2.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -13451,7 +13451,7 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
+        "debug": "3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -13484,7 +13484,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "sort-keys-length": {
@@ -13493,7 +13493,7 @@
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
       "requires": {
-        "sort-keys": "^1.0.0"
+        "sort-keys": "1.1.2"
       }
     },
     "source-map": {
@@ -13508,11 +13508,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-url": {
@@ -13533,8 +13533,8 @@
       "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.2"
       }
     },
     "spdx-exceptions": {
@@ -13549,8 +13549,8 @@
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.2"
       }
     },
     "spdx-license-ids": {
@@ -13570,7 +13570,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split-string": {
@@ -13579,7 +13579,7 @@
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -13595,9 +13595,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "console-stream": "^0.1.1",
-        "lpad-align": "^1.0.1"
+        "chalk": "1.1.3",
+        "console-stream": "0.1.1",
+        "lpad-align": "1.1.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13614,11 +13614,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -13636,15 +13636,15 @@
       "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stable": {
@@ -13659,8 +13659,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -13669,7 +13669,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -13686,8 +13686,8 @@
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
+        "duplexer": "0.1.1",
+        "through": "2.3.8"
       }
     },
     "stream-consume": {
@@ -13702,10 +13702,10 @@
       "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "dev": true,
       "requires": {
-        "date-format": "^1.2.0",
-        "debug": "^3.1.0",
-        "mkdirp": "^0.5.1",
-        "readable-stream": "^2.3.0"
+        "date-format": "1.2.0",
+        "debug": "3.2.6",
+        "mkdirp": "0.5.1",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "debug": {
@@ -13714,7 +13714,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "isarray": {
@@ -13729,13 +13729,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -13744,7 +13744,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -13768,8 +13768,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -13784,7 +13784,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -13801,7 +13801,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -13810,8 +13810,8 @@
       "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "is-utf8": "^0.2.0"
+        "first-chunk-stream": "1.0.0",
+        "is-utf8": "0.2.1"
       }
     },
     "strip-bom-stream": {
@@ -13820,8 +13820,8 @@
       "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "2.0.0",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "first-chunk-stream": {
@@ -13830,7 +13830,7 @@
           "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.6"
           }
         },
         "isarray": {
@@ -13845,13 +13845,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -13860,7 +13860,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-bom": {
@@ -13869,7 +13869,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -13880,7 +13880,7 @@
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dev": true,
       "requires": {
-        "is-natural-number": "^4.0.1"
+        "is-natural-number": "4.0.1"
       }
     },
     "strip-eof": {
@@ -13895,7 +13895,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -13910,7 +13910,7 @@
       "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "stylehacks": {
@@ -13919,9 +13919,9 @@
       "integrity": "sha512-TK5zEPeD9NyC1uPIdjikzsgWxdQQN/ry1X3d1iOz1UkYDCmcr928gWD1KHgyC27F50UnE0xCTrBOO1l6KR8M4w==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
+        "browserslist": "4.3.5",
+        "postcss": "7.0.6",
+        "postcss-selector-parser": "3.1.1"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -13930,9 +13930,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         }
       }
@@ -13943,7 +13943,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "svgo": {
@@ -13952,20 +13952,20 @@
       "integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
       "dev": true,
       "requires": {
-        "coa": "~2.0.1",
-        "colors": "~1.1.2",
-        "css-select": "^2.0.0",
-        "css-select-base-adapter": "~0.1.0",
+        "coa": "2.0.1",
+        "colors": "1.1.2",
+        "css-select": "2.0.2",
+        "css-select-base-adapter": "0.1.1",
         "css-tree": "1.0.0-alpha.28",
-        "css-url-regex": "^1.1.0",
-        "csso": "^3.5.0",
-        "js-yaml": "^3.12.0",
-        "mkdirp": "~0.5.1",
-        "object.values": "^1.0.4",
-        "sax": "~1.2.4",
-        "stable": "~0.1.6",
-        "unquote": "~1.1.1",
-        "util.promisify": "~1.0.0"
+        "css-url-regex": "1.1.0",
+        "csso": "3.5.1",
+        "js-yaml": "3.12.0",
+        "mkdirp": "0.5.1",
+        "object.values": "1.0.4",
+        "sax": "1.2.4",
+        "stable": "0.1.8",
+        "unquote": "1.1.1",
+        "util.promisify": "1.0.0"
       }
     },
     "table": {
@@ -13974,10 +13974,10 @@
       "integrity": "sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==",
       "dev": true,
       "requires": {
-        "ajv": "^6.6.1",
-        "lodash": "^4.17.11",
+        "ajv": "6.6.1",
+        "lodash": "4.17.11",
         "slice-ansi": "2.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       }
     },
     "tar-stream": {
@@ -13986,13 +13986,13 @@
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "buffer-alloc": "1.2.0",
+        "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
+        "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "end-of-stream": {
@@ -14001,7 +14001,7 @@
           "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "isarray": {
@@ -14016,7 +14016,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "readable-stream": {
@@ -14025,13 +14025,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -14040,7 +14040,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -14057,8 +14057,8 @@
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "dev": true,
       "requires": {
-        "temp-dir": "^1.0.0",
-        "uuid": "^3.0.1"
+        "temp-dir": "1.0.0",
+        "uuid": "3.3.2"
       }
     },
     "text-table": {
@@ -14085,8 +14085,8 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -14101,13 +14101,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -14116,7 +14116,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -14127,7 +14127,7 @@
       "integrity": "sha512-R5/jLkfMvdmDD+seLwN7vB+mhbqzWop5fAjx5IX8/yQq7VhBhzDmhXgaHAOnhnWkCpRMM7gToYHycB0CS/pd+A==",
       "dev": true,
       "requires": {
-        "through2": "^2.0.0"
+        "through2": "2.0.5"
       }
     },
     "tildify": {
@@ -14136,7 +14136,7 @@
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "time-stamp": {
@@ -14168,12 +14168,12 @@
       "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
       "dev": true,
       "requires": {
-        "body": "^5.1.0",
-        "debug": "^3.1.0",
-        "faye-websocket": "~0.10.0",
-        "livereload-js": "^2.3.0",
-        "object-assign": "^4.1.0",
-        "qs": "^6.4.0"
+        "body": "5.1.0",
+        "debug": "3.2.6",
+        "faye-websocket": "0.10.0",
+        "livereload-js": "2.4.0",
+        "object-assign": "4.1.1",
+        "qs": "6.6.0"
       },
       "dependencies": {
         "debug": {
@@ -14182,7 +14182,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "object-assign": {
@@ -14204,7 +14204,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-array": {
@@ -14231,7 +14231,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -14240,7 +14240,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -14251,10 +14251,10 @@
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -14263,8 +14263,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "tough-cookie": {
@@ -14273,8 +14273,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.29",
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -14297,7 +14297,7 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "trim-right": {
@@ -14324,7 +14324,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -14339,7 +14339,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-is": {
@@ -14349,7 +14349,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.21"
       }
     },
     "typeahead.js": {
@@ -14357,7 +14357,7 @@
       "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.11.1.tgz",
       "integrity": "sha1-TmTmcbIjEKhgb0rsgFkkuoSwFbg=",
       "requires": {
-        "jquery": ">=1.7"
+        "jquery": "3.3.1"
       }
     },
     "typedarray": {
@@ -14372,9 +14372,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -14396,8 +14396,8 @@
       "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
       "dev": true,
       "requires": {
-        "buffer": "^3.0.1",
-        "through": "^2.3.6"
+        "buffer": "3.6.0",
+        "through": "2.3.8"
       }
     },
     "unc-path-regex": {
@@ -14423,8 +14423,8 @@
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -14445,10 +14445,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -14457,7 +14457,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -14466,10 +14466,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -14510,8 +14510,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -14520,9 +14520,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -14562,7 +14562,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -14578,7 +14578,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "url-to-options": {
@@ -14605,8 +14605,8 @@
       "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.x",
-        "tmp": "0.0.x"
+        "lru-cache": "2.2.4",
+        "tmp": "0.0.33"
       },
       "dependencies": {
         "lru-cache": {
@@ -14629,8 +14629,8 @@
       "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "1.1.3",
+        "object.getownpropertydescriptors": "2.0.3"
       }
     },
     "utils-merge": {
@@ -14651,7 +14651,7 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
-        "user-home": "^1.1.1"
+        "user-home": "1.1.1"
       }
     },
     "validate-npm-package-license": {
@@ -14660,8 +14660,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.2",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vendors": {
@@ -14676,9 +14676,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vinyl": {
@@ -14687,8 +14687,8 @@
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.4",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -14707,12 +14707,12 @@
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.3.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^2.0.0",
-        "vinyl": "^1.1.0"
+        "graceful-fs": "4.1.15",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "2.0.0",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -14733,7 +14733,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "vinyl": {
@@ -14742,8 +14742,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -14755,14 +14755,14 @@
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
       "requires": {
-        "defaults": "^1.0.0",
-        "glob-stream": "^3.1.5",
-        "glob-watcher": "^0.0.6",
-        "graceful-fs": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "strip-bom": "^1.0.0",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.0"
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -14777,10 +14777,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "through2": {
@@ -14789,8 +14789,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -14799,8 +14799,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -14811,7 +14811,7 @@
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.1"
+        "source-map": "0.5.7"
       }
     },
     "void-elements": {
@@ -14826,8 +14826,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.5.0",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -14848,7 +14848,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "window-size": {
@@ -14875,7 +14875,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "ws": {
@@ -14884,9 +14884,9 @@
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.2",
+        "ultron": "1.1.1"
       }
     },
     "xmlhttprequest-ssl": {
@@ -14913,9 +14913,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
         "window-size": "0.1.0"
       },
       "dependencies": {
@@ -14933,8 +14933,8 @@
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.1.0"
       }
     },
     "yeast": {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
@@ -17,7 +17,7 @@
         vm.showValidationPattern = false;
         vm.focusOnPatternField = false;
         vm.focusOnMandatoryField = false;
-        vm.selectedValidationType = {};
+        vm.selectedValidationType = null;
         vm.validationTypes = [];
         vm.labels = {};
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -89,7 +89,7 @@
                                 <localize key="validation_fieldIsMandatory"></localize>
                             </label>
                     
-                            <select class="umb-dropdown" ng-init="vm.selectedValidationType = options[0]" ng-options="validationType.name for validationType in vm.validationTypes" ng-model="vm.selectedValidationType" ng-change="vm.changeValidationType(vm.selectedValidationType)">
+                            <select class="umb-dropdown" ng-options="validationType.name for validationType in vm.validationTypes" ng-model="vm.selectedValidationType" ng-change="vm.changeValidationType(vm.selectedValidationType)">
                                 <option value=""><localize key="validation_noValidation">No validation</localize></option>
                             </select>
                     

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -89,8 +89,8 @@
                                 <localize key="validation_fieldIsMandatory"></localize>
                             </label>
                     
-                            <select class="umb-dropdown" ng-options="validationType.name for validationType in vm.validationTypes" ng-model="vm.selectedValidationType" ng-change="vm.changeValidationType(vm.selectedValidationType)">
-                                <option value=""><localize key="validation_validation">Validation</localize></option>
+                            <select class="umb-dropdown" ng-init="vm.selectedValidationType = options[0]" ng-options="validationType.name for validationType in vm.validationTypes" ng-model="vm.selectedValidationType" ng-change="vm.changeValidationType(vm.selectedValidationType)">
+                                <option value=""><localize key="validation_noValidation">No validation</localize></option>
                             </select>
                     
                             <textarea class="editor-validation-pattern"

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1815,7 +1815,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="deleteUserConfirmation">Are you sure you wish to delete this user account?</key>
   </area>
   <area alias="validation">
-    <key alias="validation">Validation</key>
+    <key alias="validation">No Validation</key>
     <key alias="validateAsEmail">Validate as an email address</key>
     <key alias="validateAsNumber">Validate as a number</key>
     <key alias="validateAsUrl">Validate as a URL</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1816,7 +1816,7 @@ To manage your website, simply open the Umbraco back office and start adding con
   </area>
   <area alias="validation">
     <key alias="validation">Validation</key>
-    <key alias="noValidation">No Validation</key>
+    <key alias="noValidation">No validation</key>
     <key alias="validateAsEmail">Validate as an email address</key>
     <key alias="validateAsNumber">Validate as a number</key>
     <key alias="validateAsUrl">Validate as a URL</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1815,7 +1815,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="deleteUserConfirmation">Are you sure you wish to delete this user account?</key>
   </area>
   <area alias="validation">
-    <key alias="validation">No Validation</key>
+    <key alias="validation">Validation</key>
+    <key alias="noValidation">No Validation</key>
     <key alias="validateAsEmail">Validate as an email address</key>
     <key alias="validateAsNumber">Validate as a number</key>
     <key alias="validateAsUrl">Validate as a URL</key>


### PR DESCRIPTION
Update name and default value for property settings validation select element

When adding a new property to a doctype i noticed that the validation drop-down had no default value. This PR should make the default "No validation". 

No validation is the same option that "Validation" used to be, but I felt that selecting "Validation" to get no validation didn't make much sense to me.


To test, add a new property to a document type and check the validation drop-down 
