### PR TITLE
Rename PluginManager to TypeLoader in tests

### DIFF
--- a/src/Umbraco.Tests/PublishedContent/PublishedContentLanguageVariantTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentLanguageVariantTests.cs
@@ -16,7 +16,7 @@ using Umbraco.Web;
 namespace Umbraco.Tests.PublishedContent
 {
     [TestFixture]
-    [UmbracoTest(PluginManager = UmbracoTestOptions.PluginManager.PerFixture)]
+    [UmbracoTest(TypeLoader = UmbracoTestOptions.TypeLoader.PerFixture)]
     public class PublishedContentLanguageVariantTests : PublishedContentSnapshotTestBase
     {
         protected override void Compose()

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentMoreTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentMoreTests.cs
@@ -8,7 +8,7 @@ using Umbraco.Tests.Testing;
 namespace Umbraco.Tests.PublishedContent
 {
     [TestFixture]
-    [UmbracoTest(PluginManager = UmbracoTestOptions.PluginManager.PerFixture)]
+    [UmbracoTest(TypeLoader = UmbracoTestOptions.TypeLoader.PerFixture)]
     public class PublishedContentMoreTests : PublishedContentSnapshotTestBase
     {
         internal override void PopulateCache(PublishedContentTypeFactory factory, SolidPublishedContentCache cache)

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentSnapshotTestBase.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentSnapshotTestBase.cs
@@ -40,9 +40,9 @@ namespace Umbraco.Tests.PublishedContent
             Container.RegisterSingleton<IPublishedModelFactory>(f => new PublishedModelFactory(f.GetInstance<TypeLoader>().GetTypes<PublishedContentModel>()));
         }
 
-        protected override TypeLoader CreatePluginManager(IServiceFactory f)
+        protected override TypeLoader CreateTypeLoader(IServiceFactory f)
         {
-            var pluginManager = base.CreatePluginManager(f);
+            var pluginManager = base.CreateTypeLoader(f);
 
             // this is so the model factory looks into the test assembly
             pluginManager.AssembliesToScan = pluginManager.AssembliesToScan

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Tests.PublishedContent
     /// Tests the methods on IPublishedContent using the DefaultPublishedContentStore
     /// </summary>
     [TestFixture]
-    [UmbracoTest(PluginManager = UmbracoTestOptions.PluginManager.PerFixture)]
+    [UmbracoTest(TypeLoader = UmbracoTestOptions.TypeLoader.PerFixture)]
     public class PublishedContentTests : PublishedContentTestBase
     {
         protected override void Compose()
@@ -72,9 +72,9 @@ namespace Umbraco.Tests.PublishedContent
             ContentTypesCache.GetPublishedContentTypeByAlias = alias => type;
         }
 
-        protected override TypeLoader CreatePluginManager(IServiceFactory f)
+        protected override TypeLoader CreateTypeLoader(IServiceFactory f)
         {
-            var pluginManager = base.CreatePluginManager(f);
+            var pluginManager = base.CreateTypeLoader(f);
 
             // this is so the model factory looks into the test assembly
             pluginManager.AssembliesToScan = pluginManager.AssembliesToScan

--- a/src/Umbraco.Tests/Testing/UmbracoTestAttribute.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestAttribute.cs
@@ -48,8 +48,8 @@ namespace Umbraco.Tests.Testing
         /// Gets or sets a value indicating the required plugin manager support.
         /// </summary>
         /// <remarks>Default is to use the global tests plugin manager.</remarks>
-        public UmbracoTestOptions.PluginManager PluginManager { get => _pluginManager.ValueOrDefault(UmbracoTestOptions.PluginManager.Default); set => _pluginManager.Set(value); }
-        private readonly Settable<UmbracoTestOptions.PluginManager> _pluginManager = new Settable<UmbracoTestOptions.PluginManager>();
+        public UmbracoTestOptions.TypeLoader TypeLoader { get => _typeLoader.ValueOrDefault(UmbracoTestOptions.TypeLoader.Default); set => _typeLoader.Set(value); }
+        private readonly Settable<UmbracoTestOptions.TypeLoader> _typeLoader = new Settable<UmbracoTestOptions.TypeLoader>();
 
         protected override TestOptionAttributeBase Merge(TestOptionAttributeBase other)
         {
@@ -62,7 +62,7 @@ namespace Umbraco.Tests.Testing
             _publishedRepositoryEvents.Set(attr._publishedRepositoryEvents);
             _logger.Set(attr._logger);
             _database.Set(attr._database);
-            _pluginManager.Set(attr._pluginManager);
+            _typeLoader.Set(attr._typeLoader);
 
             return this;
         }

--- a/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
@@ -135,7 +135,7 @@ namespace Umbraco.Tests.Testing
             ComposeLogging(Options.Logger);
             ComposeCacheHelper();
             ComposeAutoMapper(Options.AutoMapper);
-            ComposePluginManager(Options.PluginManager);
+            ComposeTypeLoader(Options.TypeLoader);
             ComposeDatabase(Options.Database);
             ComposeApplication(Options.WithApplication);
 
@@ -230,30 +230,30 @@ namespace Umbraco.Tests.Testing
             Container.RegisterFrom<WebMappingProfilesCompositionRoot>();
         }
 
-        protected virtual void ComposePluginManager(UmbracoTestOptions.PluginManager pluginManager)
+        protected virtual void ComposeTypeLoader(UmbracoTestOptions.TypeLoader typeLoader)
         {
             Container.RegisterSingleton(f =>
             {
-                switch (pluginManager)
+                switch (typeLoader)
                 {
-                    case UmbracoTestOptions.PluginManager.Default:
-                        return _commonTypeLoader ?? (_commonTypeLoader = CreateCommonPluginManager(f));
-                    case UmbracoTestOptions.PluginManager.PerFixture:
-                        return _featureTypeLoader ?? (_featureTypeLoader = CreatePluginManager(f));
-                    case UmbracoTestOptions.PluginManager.PerTest:
-                        return CreatePluginManager(f);
+                    case UmbracoTestOptions.TypeLoader.Default:
+                        return _commonTypeLoader ?? (_commonTypeLoader = CreateCommonTypeLoader(f));
+                    case UmbracoTestOptions.TypeLoader.PerFixture:
+                        return _featureTypeLoader ?? (_featureTypeLoader = CreateTypeLoader(f));
+                    case UmbracoTestOptions.TypeLoader.PerTest:
+                        return CreateTypeLoader(f);
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(pluginManager));
+                        throw new ArgumentOutOfRangeException(nameof(typeLoader));
                 }
             });
         }
 
-        protected virtual TypeLoader CreatePluginManager(IServiceFactory f)
+        protected virtual TypeLoader CreateTypeLoader(IServiceFactory f)
         {
-            return CreateCommonPluginManager(f);
+            return CreateCommonTypeLoader(f);
         }
 
-        private static TypeLoader CreateCommonPluginManager(IServiceFactory f)
+        private static TypeLoader CreateCommonTypeLoader(IServiceFactory f)
         {
             return new TypeLoader(f.GetInstance<CacheHelper>().RuntimeCache, f.GetInstance<IGlobalSettings>(), f.GetInstance<ProfilingLogger>(), false)
             {

--- a/src/Umbraco.Tests/Testing/UmbracoTestOptions.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestOptions.cs
@@ -26,7 +26,7 @@
             NewSchemaPerTest
         }
 
-        public enum PluginManager
+        public enum TypeLoader
         {
             // the default, global plugin manager for tests
             Default,


### PR DESCRIPTION
The tests are still referring to PluginManager but that class has gone and been replaced by TypeLoader.

I've updated the tests to reflect this.