### PR TITLE
Fix "allow all editors" for grid rows

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.controller.js
@@ -22,16 +22,6 @@ function RowConfigController($scope) {
         return ((spans / $scope.columns) * 100).toFixed(8);
     };
 
-    $scope.toggleCollection = function(collection, toggle) {
-        if (toggle) {
-            collection = [];
-        }
-        else {
-            delete collection;
-        }
-    };
-
-
     /****************
         area
     *****************/
@@ -55,8 +45,18 @@ function RowConfigController($scope) {
                 row.areas.push(cell);
             }
             $scope.currentCell = cell;
+            $scope.currentCell.allowAll = cell.allowAll || !cell.allowed || !cell.allowed.length;
         }
     };
+
+    $scope.toggleAllowed = function (cell) {
+        if (cell.allowed) {
+            delete cell.allowed;
+        }
+        else {
+            cell.allowed = [];
+        }
+    }
 
     $scope.deleteArea = function (cell, row) {
     	if ($scope.currentCell === cell) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
@@ -72,8 +72,7 @@
                       <label>
                           <input type="checkbox"
                               ng-model="currentCell.allowAll"
-                              ng-checked="currentCell.allowed === undefined"
-                              ng-change="toggleCollection(currentCell.allowed, currentCell.allowAll)" />
+                              ng-change="toggleAllowed(currentCell)" />
                               <localize key="grid_allowAllEditors"/>
                       </label>
                   </li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3883

### Description

As described in #3883 there's a glitch in the grid editor configuration for grid rows.

### Steps to reproduce:

1. Create a new Grid datatype
2. Open one of the row configurations
3. Select one of the row cells
4. Untick "Allow all editors"
5. Select one of the editors and then submit
6. Open the row configuration again
7. Tick "Allow all editors" and then submit
8. Open the row configuration again
9. Observe how "Allow all editors" remains unticked but no editors are available for selection

From here on the row configuration acts somewhat unpredictably until you manage to save some explicitly selected editors again. 

It looks something like this:

![grid-row-editing-before](https://user-images.githubusercontent.com/7405322/50058017-d8666700-0172-11e9-855c-c8db534a49b4.gif)

With this PR applied, the same operation becomes more predictable:

![grid-row-editing-after](https://user-images.githubusercontent.com/7405322/50058024-eb793700-0172-11e9-9f07-b4f55a9f7e29.gif)
