### PR TITLE
Fix "allow all row configurations" for grid layouts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.controller.js
@@ -24,16 +24,6 @@ angular.module("umbraco")
     		    return ((spans / $scope.columns) * 100).toFixed(8);
     		};
 
-    		$scope.toggleCollection = function(collection, toggle){
-    		    if(toggle){
-    		        collection = [];
-    		    }else{
-    		        delete collection;
-    		    }
-    		};
-
-
-
     		/****************
     		    Section
     		*****************/
@@ -47,7 +37,17 @@ angular.module("umbraco")
     		    }
     		    
     		    $scope.currentSection = section;
+    		    $scope.currentSection.allowAll = section.allowAll || !section.allowed || !section.allowed.length;
     		};
+
+            $scope.toggleAllowed = function (section) {
+                if (section.allowed) {
+                    delete section.allowed;
+                }
+                else {
+                    section.allowed = [];
+                }
+            }
 
     		$scope.deleteSection = function(section, template) {
     			if ($scope.currentSection === section) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.html
@@ -61,8 +61,7 @@
                           <input type="checkbox"
                                  ng-model="currentSection.allowAll"
                                  style="float: left; margin-right: 10px;"
-                                 ng-checked="currentSection.allowed === undefined"
-                                 ng-change="toggleCollection(currentSection.allowed, currentSection.allowAll)" />
+                                 ng-change="toggleAllowed(currentSection)" />
                                  <localize key="grid_allowAllRowConfigurations"/>
                       </label>
                   </li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is similar to #3889, only for grid layouts.

### Steps to reproduce

1. Create a new Grid datatype
2. Open one of the grid layouts
3. Select one of the layout sections
4. Untick "Allow all configurations"
5. Select one of the row configurations and then submit
6. Open the grid layout again
7. Tick "Allow all configurations" and then submit
8. Open the grid layout again
9. Observe how "Allow all configurations" remains unticked but no row configurations are available for selection

As with the related PR, the grid layout acts somewhat unpredictably until you manage to save some explicitly row configurations again.

It looks like this:

![grid-layout-editing-before](https://user-images.githubusercontent.com/7405322/50058048-427f0c00-0173-11e9-99ca-b5226613940d.gif)

With this PR applied, the same operation becomes more predictable:

![grid-layout-editing-after](https://user-images.githubusercontent.com/7405322/50058078-aacded80-0173-11e9-922b-10971bbf6778.gif)
