### PR TITLE
V8: Don't publish on preview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -815,7 +815,7 @@
 
                     //ensure the save flag is set
                     selectedVariant.save = true;
-                    performSave({ saveMethod: contentResource.publish, action: "save" }).then(function (data) {
+                    performSave({ saveMethod: $scope.saveMethod(), action: "save" }).then(function (data) {
                         previewWindow.location.href = redirect;
                     }, function (err) {
                         //validation issues ....


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3881

### Description

#3881 does a perfect job at describing the problem. 

This PR simply ensures that the assigned "save" action is performed when the preview button is clicked, instead of the current "publish" action.