### PR TITLE
V8: Fix the disappearing preview/save/publish buttons in listviews

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -24,16 +24,19 @@
         $scope.page.hideActionsMenu = infiniteMode ? true : false;
         $scope.page.hideChangeVariant = infiniteMode ? true : false;
         $scope.allowOpen = true;
+        $scope.app = null;
 
         function init(content) {
-
-            // set first app to active
-            content.apps[0].active = true;
+            if (!$scope.app) {
+                // set first app to active
+                content.apps[0].active = true;
+                $scope.app = content.apps[0];
+            }
 
             if (infiniteMode) {
                 createInfiniteModeButtons(content);
             } else {
-                createButtons(content, content.apps[0]);
+                createButtons(content);
             }
 
             editorState.set($scope.content);
@@ -146,11 +149,11 @@
          * @param {any} content the content node
          * @param {any} app the active content app
          */
-        function createButtons(content, app) {
+        function createButtons(content) {
 
             // only create the save/publish/preview buttons if the
             // content app is "Conent"
-            if (app && app.alias !== "umbContent" && app.alias !== "umbInfo") {
+            if ($scope.app && $scope.app.alias !== "umbContent" && $scope.app.alias !== "umbInfo") {
                 $scope.defaultButton = null;
                 $scope.subButtons = null;
                 $scope.page.showSaveButton = false;
@@ -899,7 +902,8 @@
          * @param {any} app
          */
         $scope.appChanged = function (app) {
-            createButtons($scope.content, app);
+            $scope.app = app;
+            createButtons($scope.content);
         };
 
         // methods for infinite editing


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If your page displays its children in a listview, the preview/save/publish buttons disappear after the first click. To bring them back you have to flip back and forth between content apps:

![listview-buttons-before](https://user-images.githubusercontent.com/7405322/50202903-ffce5700-035f-11e9-81b4-6537aaa9a7d2.gif)

This PR ensures that the buttons stay in place:

![listview-buttons-after](https://user-images.githubusercontent.com/7405322/50202920-0f4da000-0360-11e9-85b6-ab42c4ef3a72.gif)

🎄 19/24 🎄 