### PR TITLE
V8: Remove member groups controller TODO's

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/membergroups/membergroups.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/membergroups/membergroups.controller.js
@@ -19,12 +19,7 @@
                     : [model.selectedMemberGroup],
                     function(id) { return parseInt(id) }
                 );
-                // TODO: replace with memberGroupResource.getByIds(selectedGroupIds) if it's merged in (see #3845) - or rewrite it for this
-                memberGroupResource.getGroups().then(function (selectedGroups) {
-                    // TODO: this filter can be removed once we have memberGroupResource.getByIds(selectedGroupIds)
-                    selectedGroups = _.filter(selectedGroups, function(group) {
-                        return selectedGroupIds.indexOf(group.id) >= 0;
-                    });
+                memberGroupResource.getByIds(selectedGroupIds).then(function (selectedGroups) {
                     _.each(selectedGroups, function(group) {
                         $scope.model.value[group.name] = true;
                     });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#3888 introduced a couple of TODO's which can now be removed after the merge of #3845. This PR removes those TODO's 😄 

The performance gain by this change is likely slim to none, but the code is cleaner and easier to read 🎉 

### Testing this PR

Add and remove some member groups to/from some members. If it works and the group assignment changes are persisted on save, this PR works (read: hasn't broken anything).