### PR TITLE
V7.13 - fixes audit history on info tab

### DIFF
--- a/src/Umbraco.Web/Editors/LogController.cs
+++ b/src/Umbraco.Web/Editors/LogController.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Web.Editors
             long totalRecords;
             var dateQuery = sinceDate.HasValue ? Query<IAuditItem>.Builder.Where(x => x.CreateDate >= sinceDate) : null;
             var result = Services.AuditService.GetPagedItemsByEntity(id, pageNumber - 1, pageSize, out totalRecords, orderDirection, customFilter: dateQuery);
-            var mapped = Mapper.Map<IEnumerable<AuditLog>>(result);
+            var mapped = result.Select(item => Mapper.Map<AuditLog>(item)); //   Mapper.Map<IEnumerable<AuditLog>>(result);            
             
             var page = new PagedResult<AuditLog>(totalRecords, pageNumber, pageSize)
             {

--- a/src/Umbraco.Web/Editors/LogController.cs
+++ b/src/Umbraco.Web/Editors/LogController.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Web.Editors
             long totalRecords;
             var dateQuery = sinceDate.HasValue ? Query<IAuditItem>.Builder.Where(x => x.CreateDate >= sinceDate) : null;
             var result = Services.AuditService.GetPagedItemsByEntity(id, pageNumber - 1, pageSize, out totalRecords, orderDirection, customFilter: dateQuery);
-            var mapped = result.Select(item => Mapper.Map<AuditLog>(item)); //   Mapper.Map<IEnumerable<AuditLog>>(result);            
+            var mapped = result.Select(item => Mapper.Map<AuditLog>(item));        
             
             var page = new PagedResult<AuditLog>(totalRecords, pageNumber, pageSize)
             {

--- a/src/Umbraco.Web/Editors/LogController.cs
+++ b/src/Umbraco.Web/Editors/LogController.cs
@@ -85,16 +85,17 @@ namespace Umbraco.Web.Editors
 
         private IEnumerable<AuditLog> MapAvatarsAndNames(IEnumerable<AuditLog> items)
         {
-            var userIds = items.Select(x => x.UserId).ToArray();
+            var mappedItems = items.ToList();
+            var userIds = mappedItems.Select(x => x.UserId).ToArray();
             var users = Services.UserService.GetUsersById(userIds)
                 .ToDictionary(x => x.Id, x => x.GetUserAvatarUrls(ApplicationContext.ApplicationCache.RuntimeCache));
             var userNames = Services.UserService.GetUsersById(userIds).ToDictionary(x => x.Id, x => x.Name);
-            foreach (var item in items)
+            foreach (var item in mappedItems)
             {
                 item.UserAvatars = users[item.UserId];
                 item.UserName = userNames[item.UserId];
             }
-            return items;
+            return mappedItems;
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: #3916 

### Description
With out this fix every item in the history box on the info tab will display the same date, audit type, etc... See issue for details

With this fix you see correct information again.

![audit-log-info_correct](https://user-images.githubusercontent.com/1193822/50294133-8b85d780-0475-11e9-8dfb-54c57b3b302a.png)

This issue was caused by a mapping to resulted in IEnumerable where all items where equal. Fixed this by changing the mapping. Could be related to this one : https://stackoverflow.com/questions/17268362/automapper-for-a-list-scenario-only-seems-to-repeat-mapping-the-first-object-in

Dave