### PR TITLE
Fixing icon picker icon label spellings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/helveticons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/helveticons.less
@@ -17,12 +17,14 @@
   -webkit-font-smoothing: antialiased;
   *margin-right: .3em;
 }
+
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
   text-decoration: inherit;
   display: inline-block;
   speak: none;
 }
+
 /*
 [class^="icon-"]:before, [class*=" icon-"]:before {
 	font-family: 'icomoon';
@@ -38,7 +40,6 @@
 i.large{
 	font-size: 32px;
 }
-
 i.medium{
 	font-size: 24px;
 }
@@ -187,8 +188,6 @@ i.small{
 .icon-umb-translation:before, .traytranslation:before {
 	content: "\e1fd";
 }
-
-
 .icon-tv:before {
 	content: "\e02e";
 }
@@ -213,7 +212,8 @@ i.small{
 .icon-train:before {
 	content: "\e035";
 }
-.icon-trafic:before {
+.icon-trafic:before,
+.icon-traffic:before {
 	content: "\e036";
 }
 .icon-traffic-alt:before {
@@ -255,6 +255,7 @@ i.small{
 .icon-target:before {
 	content: "\e043";
 }
+.icon-temperature-alt:before,
 .icon-temperatrure-alt:before {
 	content: "\e044";
 }
@@ -267,6 +268,7 @@ i.small{
 .icon-theater:before {
 	content: "\e047";
 }
+.icon-thief:before,
 .icon-theif:before {
 	content: "\e048";
 }
@@ -375,6 +377,7 @@ i.small{
 .icon-shuffle:before {
 	content: "\e06b";
 }
+.icon-science:before,
 .icon-sience:before {
 	content: "\e06c";
 }
@@ -747,6 +750,7 @@ i.small{
 .icon-pictures-alt-2:before {
 	content: "\e0e7";
 }
+.icon-panel-close:before,
 .icon-pannel-close:before {
 	content: "\e0e8";
 }
@@ -1627,6 +1631,7 @@ i.small{
 .icon-alarm-clock:before {
 	content: "\e20c";
 }
+.icon-addressbook:before,
 .icon-adressbook:before {
 	content: "\e20d";
 }


### PR DESCRIPTION
As reported by a user on Twitter (https://twitter.com/welshfruit/status/1076177728750137344), when browsing the icon picker the label for the "thief" icon has a spelling mistake "theif" in the CMS.

While fixing this I noted several other icons that were incorrectly named.

The icon picker uses CSS classes from the helveticons.less file to get a list of the icons available - the class names are used as labels in the picker.

I've kept the old class names for backwards compatibility incase someone is using them in sites / packages.