### PR TITLE
Should be "Add group" to keep the casing consistent

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1496,7 +1496,7 @@ To manage your website, simply open the Umbraco back office and start adding con
   <area alias="contentTypeEditor">
     <key alias="compositions">Compositions</key>
     <key alias="noTabs">You have not added any tabs</key>
-    <key alias="addGroup">Add Group</key>
+    <key alias="addGroup">Add group</key>
     <key alias="inheritedFrom">Inherited from</key>
     <key alias="addProperty">Add property</key>
     <key alias="requiredLabel">Required label</key>


### PR DESCRIPTION
Other labels like this are only capitalizing the first letter of the first word, so this stood a bit out. With this PR, **Add Group** becomes **Add group**.

![image](https://user-images.githubusercontent.com/3634580/50373410-51d0e000-05df-11e9-8741-53e1c678850f.png)
