### PR TITLE
Introduced properties overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/properties/properties.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/properties/properties.html
@@ -1,0 +1,7 @@
+<div>
+    <form ng-submit="model.submit(model)">
+        <umb-property property="property" ng-repeat="property in model.properties">
+            <umb-property-editor model="property"></umb-property-editor>
+        </umb-property>
+    </form>
+</div>


### PR DESCRIPTION
When developing a package or just an Umbraco site, one may have the need to create an overlay where the user can fill out on or more properties.

This is a fairly simple task, but I usually end up creating a custom view for each scenario/solution where I need this, as there is nothing default in Umbraco to handle this. With this PR, I've added a `properties.html` file so that this will be build in to Umbraco by default.

Usage would be something like (the `properties` array being the key):

```
$scope.overlay = {
    view: "properties",
    title: "My properties dialog",
    show: true,
    properties: [
        {
            alias: "myProperty",
            label: "My property",
            description: "This is a property.",
            view: "textbox",
            validation: {
                mandatory: true
            }
        }
    ],
    submit: function (model) {
        $scope.overlay.show = false;
        $scope.overlay = null;
    }
};
```

When the overlay submits, the properties array can be accessed through `model.properties`.

With the proposed code, `model.properties` is the same array as `$scope.overlay.properties`, so changes are passed back to the array even before the user clicks the submit button of the overlay. So perhaps we should clone the array? Or perhaps this is just something that is up to the developer to handle on their own?

This change makes sense for both V7 and V8, so if merged, it would make sense to merge into `temp8` as well 😄 