### PR TITLE
Support image crop data set when overwriting files using the API

### DIFF
--- a/src/Umbraco.Core/IO/MediaFileSystem.cs
+++ b/src/Umbraco.Core/IO/MediaFileSystem.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -293,6 +295,12 @@ namespace Umbraco.Core.IO
         {
             var property = GetProperty(content, propertyTypeAlias);
             var svalue = property.Value as string;
+            if (svalue != null && svalue.DetectIsJson())
+            {
+                // the property value is a JSON serialized image crop data set - grab the "src" property as the file source
+                var jObject = JsonConvert.DeserializeObject<JObject>(svalue);
+                svalue = jObject != null ? jObject.GetValueAsString("src") : svalue;
+            }
             var oldpath = svalue == null ? null : GetRelativePath(svalue);
             var filepath = StoreFile(content, property.PropertyType, filename, filestream, oldpath);
             property.Value = GetUrl(filepath);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3937

### Description

See #3937 for excellent guidance on how to reproduce and test (you can drop the test controller in App_Code when testing, it works like a charm).

The error happens because the `umbracoFile` property isn't necessarily just the relative path to the media file, but a JSON-serialized image crop data set - something like `{"src": "/media/1027/random-image.jpg", "crops": []}`. 

However, [`SetUploadFile`](https://github.com/umbraco/Umbraco-CMS/blob/dd6e764588d22ef2b7bce01fd504ece89834f181/src/Umbraco.Core/IO/MediaFileSystem.cs#L296) in `MediaFileSystem` expects the property to be a relative file path, so it happily passes the JSON string onwards as a file path, which obviously doesn't work and produces the "Illegal characters in path" exception mentioned in the linked issue.

This PR fixes the error by detecting if the `umbracoFile` property value is JSON. If it is, the `src` value from the image crop data set is passed onwards instead of the whole JSON string.

🎆 🎉 🍾  **HAPPY NEW YEAR!** 🍾 🎉 🎆 