### PR TITLE
V8: Fix the content template selector in the content tree

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -42,14 +42,21 @@ function contentCreateController($scope,
   }
 
   function createOrSelectBlueprintIfAny(docType) {
-    var blueprintIds = _.keys(docType.blueprints || {});
+    // map the blueprints into a collection that's sortable in the view
+    var blueprints = _.map(_.pairs(docType.blueprints || {}), function (pair) {
+      return {
+        id: pair[0],
+        name: pair[1]
+      };
+    });
     $scope.docType = docType;
-    if (blueprintIds.length) {
+    if (blueprints.length) {
       if (blueprintConfig.skipSelect) {
-        createFromBlueprint(blueprintIds[0]);
+        createFromBlueprint(blueprints[0].id);
       } else {
         $scope.selectContentType = false;
         $scope.selectBlueprint = true;
+        $scope.selectableBlueprints = blueprints;
       }
     } else {
       createBlank(docType);

--- a/src/Umbraco.Web.UI.Client/src/views/content/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/create.html
@@ -25,13 +25,13 @@
                 </li>
 
             </ul>
-            <ul class="umb-actions umb-actions-child" ng-if="selectBlueprint && docType.blueprints.length > 0">
+            <ul class="umb-actions umb-actions-child" ng-if="selectBlueprint">
 
-                <li class="umb-action" ng-repeat="(key, value) in docType.blueprints | orderBy:'name':false">
-                    <a class="umb-action-link" ng-click="createFromBlueprint(key)">
+                <li class="umb-action" ng-repeat="blueprint in selectableBlueprints | orderBy:'name':false">
+                    <a class="umb-action-link" ng-click="createFromBlueprint(blueprint.id)">
                         <i class="large icon {{docType.icon}}"></i>
                         <span class="menu-label">
-                            {{value}}
+                            {{blueprint.name}}
                         </span>
                     </a>
                 </li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Right now you can't create content if the content type has one or more content templates. In the following there are two content templates for the content type *Page*:

![create-from-content-templates-before](https://user-images.githubusercontent.com/7405322/50596379-61380f00-0ea4-11e9-8802-e383494d6298.gif)

This PR fixes the problem. The same operation with this PR applied looks like this:

![create-from-content-templates-after](https://user-images.githubusercontent.com/7405322/50596397-76ad3900-0ea4-11e9-83db-735eaae1d3a3.gif)
