### PR TITLE
V8: Fix listview create button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -701,16 +701,23 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
         }
 
         getContentTypesCallback(id).then(function (listViewAllowedTypes) {
-            $scope.listViewAllowedTypes = listViewAllowedTypes;
+          $scope.listViewAllowedTypes = listViewAllowedTypes;
 
           var blueprints = false;
           _.each(listViewAllowedTypes, function (allowedType) {
               if (_.isEmpty(allowedType.blueprints)) {
-                  // this helps the view understand that there are no blueprints available
-                  allowedType.blueprints = null;
+                // this helps the view understand that there are no blueprints available
+                allowedType.blueprints = null;
               }
               else {
-                    blueprints = true;
+                blueprints = true;
+                // turn the content type blueprints object into an array of sortable objects for the view
+                allowedType.blueprints = _.map(_.pairs(allowedType.blueprints || {}), function (pair) {
+                  return {
+                    id: pair[0],
+                    name: pair[1]
+                  };
+                });
               }
             });
 
@@ -776,17 +783,19 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
         }
     }
 
-
     function createBlank(entityType, docTypeAlias) {
         $location
             .path("/" + entityType + "/" + entityType + "/edit/" + $scope.contentId)
-            .search("doctype=" + docTypeAlias + "&create=true");
+            .search("doctype", docTypeAlias)
+            .search("create", "true");
     }
 
     function createFromBlueprint(entityType, docTypeAlias, blueprintId) {
         $location
             .path("/" + entityType + "/" + entityType + "/edit/" + $scope.contentId)
-            .search("doctype=" + docTypeAlias + "&create=true&blueprintId=" + blueprintId);
+            .search("doctype", docTypeAlias)
+            .search("create", "true")
+            .search("blueprintId", blueprintId);
     }
 
     $scope.createBlank = createBlank;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -27,10 +27,10 @@
                        </a>
 
                        <umb-dropdown ng-if="page.createDropdownOpen" on-close="page.createDropdownOpen = false">
-                           <umb-dropdown-item ng-repeat="(key, value) in listViewAllowedTypes[0].blueprints track by key">
-                               <a ng-click="createFromBlueprint(entityType, listViewAllowedTypes[0].blueprints.alias, key)">
+                           <umb-dropdown-item ng-repeat="blueprint in listViewAllowedTypes[0].blueprints | orderBy:'name':false">
+                               <a ng-click="createFromBlueprint(entityType, listViewAllowedTypes[0].alias, blueprint.id)">
                                    <i class="{{::listViewAllowedTypes[0].icon}}"></i>
-                                   {{::value}}
+                                   {{::blueprint.name}}
                                </a>
                            </umb-dropdown-item>
                        </umb-dropdown>
@@ -48,9 +48,9 @@
                                    <i class="{{::contentType.icon}}"></i>
                                    {{::contentType.name}} <span ng-show="contentType.blueprints" style="text-transform: lowercase;">(<localize key="blueprints_blankBlueprint">blank</localize>)</span>
                                </a>
-                               <a href="" ng-repeat="(key, value) in contentType.blueprints track by key" ng-click="createFromBlueprint(entityType,contentType.alias , key)" prevent-default>
+                               <a href="" ng-repeat="blueprint in contentType.blueprints | orderBy:'name':false" ng-click="createFromBlueprint(entityType, contentType.alias, blueprint.id)" prevent-default>
                                    &nbsp;&nbsp;<i class="{{::contentType.icon}}"></i>
-                                   {{::value}}
+                                   {{::blueprint.name}}
                                </a>
                            </umb-dropdown-item>
                        </umb-dropdown>
@@ -58,11 +58,11 @@
 
                    <ul class="umb-actions umb-actions-child">
 
-                       <li ng-repeat="(key, value) in docType.blueprints | orderBy:'name':false">
-                           <a ng-click="createFromBlueprint(key)">
+                       <li ng-repeat="blueprint in docType.blueprints | orderBy:'name':false">
+                           <a ng-click="createFromBlueprint(blueprint.id)">
                                <i class="large {{docType.icon}}"></i>
                                <span class="menu-label">
-                                   {{value}}
+                                   {{blueprint.name}}
                                </span>
                            </a>
                        </li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The *Create* button in list views currently doesn't work, no matter if your content has content templates or not:

![listview-create-from-content-templates-before](https://user-images.githubusercontent.com/7405322/50596785-9db83a80-0ea5-11e9-85d3-c362628eef58.gif)

This PR fixes the *Create* button for content both with and without content templates:

![listview-create-from-content-templates-after](https://user-images.githubusercontent.com/7405322/50596906-ec65d480-0ea5-11e9-8f05-283e833379bf.gif)

### Testing this PR

Make sure to test:
1. Content with no content templates.
2. Content with multiple content templates.
3. Content with multiple allowed children.