### PR TITLE
V8: Fix the member picker error when choosing "All members" 

### DIFF
--- a/src/Umbraco.Web/Editors/EntityController.cs
+++ b/src/Umbraco.Web/Editors/EntityController.cs
@@ -479,7 +479,9 @@ namespace Umbraco.Web.Editors
             if (objectType.HasValue)
             {
                 var entities = Services.EntityService.GetPagedChildren(id, objectType.Value, pageNumber - 1, pageSize, out var totalRecords,
-                    SqlContext.Query<IUmbracoEntity>().Where(x => x.Name.Contains(filter)),
+                    filter.IsNullOrWhiteSpace()
+                        ? null
+                        : SqlContext.Query<IUmbracoEntity>().Where(x => x.Name.Contains(filter)),
                     Ordering.By(orderBy, orderDirection));
 
                 if (totalRecords == 0)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3941

### Description

When choosing "All members" in the member picker you'll get a YSOD: 

![member-picker-all-members-before](https://user-images.githubusercontent.com/7405322/50610368-04a01880-0ed3-11e9-9a91-e6a53eb8dde4.gif)

The rest of the member picker functionality seems unaffected by this error. 

The problem is that a null value filter is passed to `EntityController.GetPagedChildren()`. This results in an error when search query is constructed. This PR fixes the problem by omitting the filter if a null value is passed:

![member-picker-all-members-after](https://user-images.githubusercontent.com/7405322/50610475-62ccfb80-0ed3-11e9-9c90-509abef83017.gif)
