### PR TITLE
Make grid view the default listview layout

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
@@ -33,8 +33,8 @@ namespace Umbraco.Web.PropertyEditors
                     {
                         "layouts", new[]
                         {
-                            new {name = "List", path = "views/propertyeditors/listview/layouts/list/list.html", icon = "icon-list", isSystem = 1, selected = true},
-                            new {name = "Grid", path = "views/propertyeditors/listview/layouts/grid/grid.html", icon = "icon-thumbnails-small", isSystem = 1, selected = true}
+                            new {name = "Grid", path = "views/propertyeditors/listview/layouts/grid/grid.html", icon = "icon-thumbnails-small", isSystem = 1, selected = true},
+                            new {name = "List", path = "views/propertyeditors/listview/layouts/list/list.html", icon = "icon-list", isSystem = 1, selected = true}
                         }
                     },
                     {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3865

### Description

This PR changes the default custom listview layout from "list view" to "grid view" as discussed in #3865. 

It looks like this:

![grid-as-default-listview-layout](https://user-images.githubusercontent.com/7405322/50642860-cc4d1880-0f6c-11e9-9d48-27c344da1e09.gif)
