### PR TITLE
Don't use a hard coded folder type alias to determine folder types in listviews

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -1,4 +1,4 @@
-function listViewController($rootScope, $scope, $routeParams, $injector, $cookieStore, notificationsService, iconHelper, dialogService, editorState, localizationService, $location, appState, $timeout, $q, mediaResource, listViewHelper, userService, navigationService, treeService) {
+function listViewController($rootScope, $scope, $routeParams, $injector, $cookieStore, notificationsService, iconHelper, dialogService, editorState, localizationService, $location, appState, $timeout, $q, mediaResource, listViewHelper, userService, navigationService, treeService, mediaHelper) {
 
    //this is a quick check to see if we're in create mode, if so just exit - we cannot show children for content
    // that isn't created yet, if we continue this will use the parent id in the route params which isn't what
@@ -269,10 +269,12 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
          $scope.listViewResultSet = data;
 
          //update all values for display
+         var section = appState.getSectionState("currentSection");
          if ($scope.listViewResultSet.items) {
             _.each($scope.listViewResultSet.items, function (e, index) {
                setPropertyValues(e);
-               if (e.contentTypeAlias === 'Folder') {
+               // create the folders collection (only for media list views)
+               if (section === "media" && !mediaHelper.hasFilePropertyType(e)) {
                    $scope.folders.push(e);
                }
             });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The list view currently uses a hard coded folder type alias to determine if an item in the list is a folder or not. This is used in the media section, where folders are grouped in the top of the grid layout.

In other words: If you have a custom folder type, folders of this type aren't listed among the folders in the grid layout. And to make matters worse they aren't listed among the items either, because the grid layout uses a [different approach](https://github.com/umbraco/Umbraco-CMS/blob/1bb593d264a085f94a3ce3bd710392b350561430/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/grid/grid.listviewlayout.controller.js#L63) to filter *out* the folders (so they're not listed among the items).

It looks something like this:

![listview-hardcoded-folder-type-before](https://user-images.githubusercontent.com/7405322/50676827-c69c1500-0ff6-11e9-9ec9-13842f1aa9c0.gif)

This PR applies the same filtering approach to the list view as is used in the grid layout. This way the custom folder types work as expected in the media section:

![listview-hardcoded-folder-type-after](https://user-images.githubusercontent.com/7405322/50676892-285c7f00-0ff7-11e9-932f-7d4d9705d508.gif)

**Note for testing:** The filtering approach used deems an item to be a folder type if it *doesn't* have a file property (file upload or image cropper).