### PR TITLE
V8: Make the on-click-outside directive work again

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
@@ -136,7 +136,7 @@ angular.module('umbraco.directives')
                     return;
                 }
 
-            angularHelper.safeApply(scope, attrs.onOutsideClick);
+                scope.$apply(attrs.onOutsideClick);
         }
 
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3951

### Description

As explained in #3951, the actions dropdown doesn't close when you click outside it. As it turns out, neither do the language selector, the tree context menu, the search bar or the sections tray (when there's not enough room for all sections).

![click-outside-before](https://user-images.githubusercontent.com/7405322/50727463-81253800-111b-11e9-802d-87453761c1d2.gif)

This PR explicitly applies the action passed to the `on-outside-click` directive (using `scope.$apply(...)`) instead of passing it to `angularHelper.safeApply(...)`, because the latter doesn't see the passed action as a function. This is also how the `on-outside-click` directive [works in V7](https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js#L181).

With this PR applied it looks like this:

![click-outside-after](https://user-images.githubusercontent.com/7405322/50727501-f7c23580-111b-11e9-924d-105a884c10cf.gif)

![click-outside-applications-tray-after](https://user-images.githubusercontent.com/7405322/50727502-fb55bc80-111b-11e9-9f74-2f10785c3fec.gif)
