### PR TITLE
Safeguard the tags value converter against empty tags

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/TagsValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/TagsValueConverter.cs
@@ -42,16 +42,22 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
 
         public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
         {
+            var sourceAsString = source?.ToString();
+            if(sourceAsString.IsNullOrWhiteSpace())
+            {
+                return new string[0];
+            }
+
             // if Json storage type deserialzie and return as string array
             if (JsonStorageType(propertyType.DataTypeId))
             {
-                var jArray = JsonConvert.DeserializeObject<JArray>(source.ToString());
+                var jArray = JsonConvert.DeserializeObject<JArray>(sourceAsString);
                 return jArray.ToObject<string[]>();
             }
 
             // Otherwise assume CSV storage type and return as string array
             var csvTags =
-                source.ToString()
+                sourceAsString
                     .Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
                     .ToArray();
             return csvTags;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3954

### Description

See #3954 for a very detailed description and steps to reproduce. 

With this PR the Tags property value converter always returns a string array - an empty one if the property hasn't been set in the editor.

Note that the error also occurs with the default ModelsBuilder setup. This template can reproduce the error (provided that the Tags property alias is `tags`):

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoTemplatePage
@{
	Layout = null;
}

<html>
    <body>
        <h1>@Model.Content.Name</h1>
        <ul>
        @foreach(var tag in Model.Content.GetPropertyValue<IEnumerable<string>>("tags")){
            <li>@tag</li>
        }
        </ul>
    </body>
</html>
```


