### PR TITLE
Add disabled state to toggle

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
@@ -18,6 +18,7 @@
 
         <umb-toggle
             checked="vm.checked"
+            disabled="vm.disabled"
             on-click="vm.toggle()"
             show-labels="true"
             label-on="Start"
@@ -38,6 +39,7 @@
 
             var vm = this;
             vm.checked = false;
+            vm.disabled = false;
 
             vm.toggle = toggle;
 
@@ -52,6 +54,7 @@
 </pre>
 
 @param {boolean} checked Set to <code>true</code> or <code>false</code> to toggle the switch.
+@param {boolean} disabled Set to <code>true</code> or <code>false</code> to disable the switch.
 @param {callback} onClick The function which should be called when the toggle is clicked.
 @param {string=} showLabels Set to <code>true</code> or <code>false</code> to show a "On" or "Off" label next to the switch.
 @param {string=} labelOn Set a custom label for when the switched is turned on. It will default to "On".
@@ -115,6 +118,7 @@
             templateUrl: 'views/components/buttons/umb-toggle.html',
             scope: {
                 checked: "=",
+                disabled: "=",
                 onClick: "&",
                 labelOn: "@?",
                 labelOff: "@?",

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -41,6 +41,10 @@
     background-color: @green;
 }
 
+.umb-toggle--checked .umb-toggle__toggle {
+    cursor: not-allowed;
+}
+
 .umb-toggle--checked .umb-toggle__handler {
     transform: translate3d(24px, 0, 0) rotate(0);
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -28,7 +28,8 @@
 
 .umb-toggle__toggle {
     cursor: pointer;
-    display: inline-block;
+    align-items: center;
+    display: flex;
     width: 48px;
     height: 24px;
     background: @gray-8;
@@ -67,7 +68,7 @@
 
 .umb-toggle__icon {
     position: absolute;
-    top: 3px;
+    line-height: 1em;
     text-decoration: none;
     transition: all 0.2s ease;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -44,6 +44,7 @@
 
 .umb-toggle--disabled .umb-toggle__toggle {
     cursor: not-allowed;
+    opacity: 0.8;
 }
 
 .umb-toggle--checked .umb-toggle__handler {

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -41,7 +41,7 @@
     background-color: @green;
 }
 
-.umb-toggle--checked .umb-toggle__toggle {
+.umb-toggle--disabled .umb-toggle__toggle {
     cursor: not-allowed;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-permission.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-permission.less
@@ -25,6 +25,11 @@
     cursor: pointer;
 }
 
+.umb-permission--disabled .umb-permission__toggle,
+.umb-permission--disabled .umb-permission__content {
+    cursor: not-allowed;
+}
+
 .umb-permission__description {
     font-size: 13px;
     color: @gray-4;

--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-permission.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-permission.less
@@ -4,10 +4,6 @@
     padding: 7px 0;
 }
 
-.umb-permission--disabled {
-    opacity: 0.8;
-}
-
 .umb-permission:last-of-type {
     border-bottom: none;
 }
@@ -28,6 +24,7 @@
 .umb-permission--disabled .umb-permission__toggle,
 .umb-permission--disabled .umb-permission__content {
     cursor: not-allowed;
+    opacity: 0.8;
 }
 
 .umb-permission__description {

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
@@ -1,4 +1,4 @@
-<button ng-click="click()" type="button" class="umb-toggle" ng-class="{'umb-toggle--checked': checked}">
+<button ng-click="click()" type="button" class="umb-toggle" ng-disabled="disabled" ng-class="{'umb-toggle--checked': checked, 'umb-toggle--disabled': disabled}">
 
     <span ng-if="!labelPosition && showLabels === 'true' || labelPosition === 'left' && showLabels === 'true'">
         <span ng-if="!checked" class="umb-toggle__label umb-toggle__label--left">{{ displayLabelOff }}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/languages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/edit.html
@@ -39,7 +39,8 @@
                             <div class="umb-permission" ng-click="vm.toggleDefault()" ng-class="{'umb-permission--disabled': vm.initIsDefault}">
                                 <umb-toggle
                                     class="umb-permission__toggle"
-                                    checked="vm.language.isDefault">
+                                    checked="vm.language.isDefault"
+                                    disabled="vm.initIsDefault">
                                 </umb-toggle>
                                 <div class="umb-permission__content" >
                                     <div>{{vm.labels.defaultLanguage}}</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3962

### Description
This PR introduce a disabled state to `umb-toggle` and change the cursor style when diabled.

To test this works a expected: 
- Check the disabled toggle at "Default Language" for English (United States) in a clean v8 install in language edit view.
- Ensure other existing toggles in language, content permissions dialog, toggle in user section and a property using Checkbox (toggle) property editor still works.
- Create a simple custom dashboard or property editor using `umb-toggle` component/directive and check `disabled` property with true/false works (also when checked property true/false is set).
E.g. with this dashboard sample: https://our.umbraco.com/documentation/tutorials/Creating-a-Custom-Dashboard/

At the moment I think the toggle in language in v8 is the only place in core with a disabled toggle.

We could eventually adjust the disable style further if needed.

It should also be easy to pull this in v7.13.x 🦄 