### PR TITLE
V8: Don't change content app when saving media items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -13,7 +13,8 @@
                                hide-icon="true"
                                hide-description="true"
                                hide-alias="true"
-                               navigation="content.apps">
+                               navigation="content.apps"
+                               on-select-navigation-item="appChanged(app)">
             </umb-editor-header>
 
             <umb-editor-container>

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -95,8 +95,11 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource, 
 
     function init() {
 
-        // set first app to active
-        $scope.content.apps[0].active = true;
+        if (!$scope.app) {
+            // set first app to active
+            $scope.content.apps[0].active = true;
+            $scope.app = $scope.content.apps[0];
+        }
 
         // setup infinite mode
         if(infiniteMode) {
@@ -206,6 +209,10 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource, 
             $scope.model.close($scope.model);
         }
     };
+
+    $scope.appChanged = function (app) {
+        $scope.app = app;
+    }
 
     evts.push(eventsService.on("editors.mediaType.saved", function(name, args) {
         // if this media item uses the updated media type we need to reload the media item


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3959

### Description

When you save a media item from the *Info* app (or any other content app), the active app changes back to the *Content* app. But the previously active app is still displayed as active:

![media-apps-before](https://user-images.githubusercontent.com/7405322/50754919-9acb9a00-1257-11e9-8561-15addd924664.gif)

With this PR applied, the active app doesn't change after you save:

![media-apps-after](https://user-images.githubusercontent.com/7405322/50754948-b9ca2c00-1257-11e9-837b-02c5ec17afa9.gif)

*Note: This is somewhat similar to #3906.*