### PR TITLE
V8: Adjust install local package styles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-file-dropzone.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-file-dropzone.less
@@ -11,7 +11,7 @@
     background-color: @white;
     text-align: center;
     color: @gray-3;
-    margin: 0 0 20px 0;
+    margin: 0 5px 20px 5px;
     position: relative;
     -webkit-transition: height 0.8s;
     -moz-transition: height 0.8s;
@@ -29,7 +29,6 @@
       border: 1px dashed @gray-1;
     }
   }
-
 
   // center the content of the drop zone
   .content {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-package-local-install.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-package-local-install.less
@@ -1,7 +1,5 @@
 /*
-
     Install local package
-
 */
 
 // Helpers
@@ -22,6 +20,12 @@
     align-items: center;
     margin-bottom: 30px;
     transition: 100ms box-shadow ease, 100ms border ease;
+
+    .content {
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+    }
 
     &:hover,
     &.drag-over {

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
@@ -8,19 +8,17 @@
         ng-model="filesHolder"
         ngf-change="handleFiles($files, $event)"
         class="dropzone"
-        ngf-drag-over-class="drag-over"
+        ngf-drag-over-class="'drag-over'"
         ngf-multiple="true"
         ngf-allow-dir="true"
         ngf-pattern="{{ accept }}"
         ngf-max-size="{{ maxFileSize }}"
         ng-class="{'is-small': compact!=='false' || (done.length+queue.length) > 0 }">
 
-
         <div class="content" >
 
             <!-- Drag and drop illustration -->
             <img class="illustration" src="assets/img/uploader/upload-illustration.svg" alt="" draggable="false" />
-
 
             <!-- Select files -->
             <div 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/install-local.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/install-local.html
@@ -3,7 +3,7 @@
     <div class="umb-packages-view-wrapper" ng-if="vm.state === 'upload'">
 
         <!-- Upload -->
-        <div class="flex items-center justify-center">
+        <div class="flex flex-column items-center justify-center">
             <form novalidate name="localPackageForm" class="flex flex-column justify-center items-center tc">
 
                 <!-- Drag and drop files area -->
@@ -18,7 +18,6 @@
                      ngf-pattern="*.zip"
                      ngf-max-size="{{ maxFileSize }}"
                      ng-class="{'is-small': compact!=='false' || (done.length+queue.length) > 0 }">
-
 
                     <div class="content">
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/install-local.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/install-local.html
@@ -12,7 +12,7 @@
                      ng-model="filesHolder"
                      ngf-change="handleFiles($files, $event)"
                      class="umb-upload-local__dropzone"
-                     ngf-drag-over-class="drag-over"
+                     ngf-drag-over-class="'drag-over'"
                      ngf-multiple="false"
                      ngf-allow-dir="false"
                      ngf-pattern="*.zip"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3961

### Description
This adjust the layout a bit of the local package install package to look a little bit nicer and similar to v7.
Furthermore it seems the dragover class on dropzone doesn't work anymore (it always added "dragover" instead of the "drag-over" class). Funny enough this does work in v7:
https://github.com/umbraco/Umbraco-CMS/blob/dd6e764588d22ef2b7bce01fd504ece89834f181/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html#L11

![image](https://user-images.githubusercontent.com/2919859/50787090-bd8c9b80-12b5-11e9-8347-cc368559dfd0.png)

I think it is because the `ng-file-upload` dependency has been updated in v8, in package.json it says v12.2.13 in temp8 branch.

I think this need to be update a few other places where `ng-file-upload` is used.

There are a few issues about this:
https://github.com/danialfarid/ng-file-upload/issues/1023
https://github.com/danialfarid/ng-file-upload/issues/1105

Furthermore the docs has this:
```
+ngf-drag-over-class="{pattern: 'image/*', accept:'acceptClass', reject:'rejectClass', delay:100}"
                    or "'myDragOverClass'" or "calcDragOverClass($event)"
    <!--  default "dragover". drag over css class behaviour. could be a string, a function
    returning class name or a json object.
    accept/reject class only works in Chrome, validating only the file mime type.
    if pattern is not specified ngf-pattern will be used. See following docs for more info. -->
```

I tried with the format `ngf-drag-over-class="{pattern: 'image/*', accept:'acceptClass', reject:'rejectClass', delay:100}"` but I always got the reject class when I tried with `.zip` and other different file types.

It also seems each value in `ngf-pattern` needs to be wrapped in quotes and the same with the `accept` property. Not sure it the wildcard before `.zip` extension is necessary?