### PR TITLE
V8: Fix image upload styles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -161,6 +161,7 @@
 @import "components/umb-file-dropzone.less";
 @import "components/umb-node-preview.less";
 @import "components/umb-mini-editor.less";
+@import "components/umb-property-file-upload.less";
 
 @import "components/users/umb-user-cards.less";
 @import "components/users/umb-user-details.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-file-dropzone.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-file-dropzone.less
@@ -1,5 +1,5 @@
 
-.umb-file-dropzone-directive{
+.umb-file-dropzone {
 
   // drop zone
   // tall and small version - animate height

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-property-file-upload.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-property-file-upload.less
@@ -1,0 +1,28 @@
+﻿.umb-property-file-upload {
+
+    .umb-upload-button-big {
+        display: block;
+        padding: 20px;
+        opacity: 1;
+        border: 1px dashed @gray-8;
+        background: none;
+        text-align: center;
+        font-size: 14px;
+
+        &, &:hover {
+            color: @gray-8;
+        }
+
+        i.icon {
+            font-size: 55px;
+            line-height: 70px
+        }
+
+        input {
+            left: 0;
+            bottom: 0;
+            height: 100%;
+            width: 100%;
+        }
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -687,7 +687,7 @@
 //
 // folder-browser
 // --------------------------------------------------
-.umb-folderbrowser .add-link{
+.umb-folderbrowser .add-link {
   display: inline-block;
   height: 120px;
   width: 120px;
@@ -695,17 +695,6 @@
   border: 1px @gray-10 dashed;
   line-height: 120px
 }
-
-.umb-upload-button-big:hover{color: @gray-8;}
-
-.umb-upload-button-big {display: block}
-.umb-upload-button-big input {
-  left: 0;
-  bottom: 0;
-  height: 100%;
-  width: 100%;
-}
-
 
 //
 // File upload

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -24,7 +24,7 @@
             <!-- Icon for files -->
             <span class="umb-media-grid__item-file-icon" ng-if="!item.thumbnail && item.extension != 'svg'">
                 <i class="umb-media-grid__item-icon {{item.icon}}"></i>
-                <span>.{{item.extension}}</span>
+                <span ng-if="item.extension">.{{item.extension}}</span>
             </span>
         </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
@@ -1,4 +1,4 @@
-<div data-element="dropzone" class="umb-file-dropzone-directive">
+<div data-element="dropzone" class="umb-file-dropzone">
 
 <ng-form name="uploadForm" umb-isolate-form>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
@@ -1,4 +1,5 @@
-﻿<div>
+﻿<div class="umb-property-file-upload">
+
     <ng-form name="vm.fileUploadForm">
 
         <div class="fileinput-button umb-upload-button-big"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3981 and fixes https://github.com/umbraco/Umbraco-CMS/issues/3983

### Description
In v8 there has been added a new component/directive `umb-property-file-upload` which is used in the property editor "imagecropper" and "fileupload".
However it seems a bit too much of this styling has been cleaned up in v8, since only a part of the following styles in v7 for `umb-upload-button-big` exists in v8:
https://github.com/umbraco/Umbraco-CMS/blob/dd6e764588d22ef2b7bce01fd504ece89834f181/src/Umbraco.Web.UI.Client/src/less/property-editors.less#L722-L750

In the entire `src\Umbraco.Web.UI.Client\src\views` folder I could only find a single reference to `umb-property-file-upload`, so I have removed this from the `property-editors.less` to a separate `umb-property-file-upload.less`.

Furthermore I have renamed the class `umb-file-dropzone-directive` to `umb-file-dropzone` to be more consistent with the other components, which doesn't have `directive` in the class name.

It now looks like this:

![image](https://user-images.githubusercontent.com/2919859/50800297-f8a3c480-12df-11e9-9446-e3c688ee0f18.png)

![image](https://user-images.githubusercontent.com/2919859/50800310-08230d80-12e0-11e9-86c5-7a8329e978bb.png)

and also without file extension, when media item doesn't contain a file.

![image](https://user-images.githubusercontent.com/2919859/50800375-402a5080-12e0-11e9-9dfc-b7ee96b9af59.png)
