### PR TITLE
Ensure that media in RTEs are always rendered with up-to-date sources

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
@@ -4,6 +4,7 @@ using Umbraco.Core.Macros;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
+using Umbraco.Web.Templates;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -65,7 +66,8 @@ namespace Umbraco.Web.PropertyEditors
                 if (property.Value == null)
                     return null;
 
-                var parsed = MacroTagParser.FormatRichTextPersistedDataForEditor(property.Value.ToString(), new Dictionary<string, string>());
+                var propertyValueWithMediaResolved = TemplateUtilities.ResolveMediaFromTextString(property.Value.ToString());
+                var parsed = MacroTagParser.FormatRichTextPersistedDataForEditor(propertyValueWithMediaResolved, new Dictionary<string, string>());
                 return parsed;
             }
 

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
@@ -71,9 +71,10 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
             var sourceString = source.ToString();
 
-            // ensures string is parsed for {localLink} and urls are resolved correctly
+            // ensures string is parsed for {localLink} and urls and media are resolved correctly
             sourceString = TemplateUtilities.ParseInternalLinks(sourceString, preview);
             sourceString = TemplateUtilities.ResolveUrlsFromTextString(sourceString);
+            sourceString = TemplateUtilities.ResolveMediaFromTextString(sourceString);
 
             // ensure string is parsed for macros and macros are executed correctly
             sourceString = RenderRteMacros(sourceString, preview);

--- a/src/Umbraco.Web/Templates/TemplateUtilities.cs
+++ b/src/Umbraco.Web/Templates/TemplateUtilities.cs
@@ -102,6 +102,9 @@ namespace Umbraco.Web.Templates
         private static readonly Regex ResolveUrlPattern = new Regex("(=[\"\']?)(\\W?\\~(?:.(?![\"\']?\\s+(?:\\S+)=|[>\"\']))+.)[\"\']?",
             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
+        private static readonly Regex ResolveImgPattern = new Regex(@"(<img[^>]*src="")([^""\?]*)([^""]*""[^>]*data-udi="")([^""]*)(""[^>]*>)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+
         /// <summary>
         /// The RegEx matches any HTML attribute values that start with a tilde (~), those that match are passed to ResolveUrl to replace the tilde with the application path.
         /// </summary>
@@ -144,6 +147,47 @@ namespace Umbraco.Web.Templates
         public static string CleanForXss(string text, params char[] ignoreFromClean)
         {
             return text.CleanForXss(ignoreFromClean);
+        }
+
+        /// <summary>
+        /// Parses the string looking for Umbraco image tags and updates them to their up-to-date image sources.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        /// <remarks>Umbraco image tags are identified by their data-udi attributes</remarks>
+        public static string ResolveMediaFromTextString(string text)
+        {
+            // don't attempt to proceed without a context
+            if (UmbracoContext.Current == null || UmbracoContext.Current.MediaCache == null)
+            {
+                return text;
+            }
+
+            return ResolveImgPattern.Replace(text, match =>
+            {
+                // match groups:
+                // - 1 = from the beginning of the image tag until src attribute value begins
+                // - 2 = the src attribute value excluding the querystring (if present)
+                // - 3 = anything after group 2 and before the data-udi attribute value begins
+                // - 4 = the data-udi attribute value
+                // - 5 = anything after group 4 until the image tag is closed
+                var src = match.Groups[2].Value;
+                var udi = match.Groups[4].Value;
+                if(src.IsNullOrWhiteSpace() || udi.IsNullOrWhiteSpace() || GuidUdi.TryParse(udi, out var guidUdi) == false)
+                {
+                    return match.Value;
+                }
+                var media = UmbracoContext.Current.MediaCache.GetById(guidUdi.Guid);
+                if(media == null)
+                {
+                    // image does not exist - we could choose to remove the image entirely here (return empty string),
+                    // but that would leave the editors completely in the dark as to why the image doesn't show
+                    return match.Value;
+                }
+
+                var url = media.Url;
+                return $"{match.Groups[1].Value}{url}{match.Groups[3].Value}{udi}{match.Groups[5].Value}";
+            });
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3869

### Description

When an image is used in an RTE and subsequently updated in the media library with a new image, both the RTE and the frontend still renders the old image.

**Steps to reproduce**

1. Create an image media item in the media library.
2. Insert the image in an RTE on a page.
3. Save and publish the page and view it in frontend.
4. Upload a new image (with a new name) to the image media item.
5. Reload the page in frontend. Notice that the image doesn't change.
6. Reload the page in backend. Notice that the image isn't updated in the RTE.

This PR ensures that all image tags based on Umbraco images in an RTE are updated with the most recent source URL. It looks like this:

![media-in-rte-after](https://user-images.githubusercontent.com/7405322/50849421-43245000-1377-11e9-9f01-0fcce0420cae.gif)

**Note:** Because of the ImageProcessor cache it doesn't work if you upload a new image with the same name.  