### PR TITLE
Fix content picker dirty checking

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -35,7 +35,6 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
                 return $scope.model.config.idType === "udi" ? i.udi : i.id;                
             });
             $scope.model.value = trim(currIds.join(), ",");
-            angularHelper.getCurrentForm($scope).$setDirty();
 
             //Validate!
             if ($scope.model.config && $scope.model.config.minNumber && parseInt($scope.model.config.minNumber) > $scope.renderModel.length) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -83,7 +83,10 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         opacity: 0.7,
         tolerance: "pointer",
         scroll: true,
-        zIndex: 6000
+        zIndex: 6000,
+        update: function (e, ui) {
+            angularHelper.getCurrentForm($scope).$setDirty();
+        }
     };
 
     if ($scope.model.config) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3997

### Description

As described in #3997 both the content picker and the MNTP are a bit too eager to set the dirty flag on the current form. If you open a page with a property of either type, and then quickly navigates to another page, you'll be prompted to save changes even though there are none.

This fixes the issue.

While I was at it I also added dirty handling when reordering the nodes in a MNTP (as suggested in the original issue, https://issues.umbraco.org/issue/U4-8143). To test this:

1. Pick some nodes in a MNTP and save the page.
2. Reload the page (to make sure we have no old dirty state interfering with the test).
3. Reorder picked the nodes and navigate to another page without saving.
4. Verify that you're prompted to save changes.

![content-picker-dirty-on-reorder](https://user-images.githubusercontent.com/7405322/50859704-5c87c500-1394-11e9-9dd2-93f9d856f225.gif)
