### PR TITLE
Add null checking for translation details

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/translation/details.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/translation/details.aspx.cs
@@ -84,17 +84,19 @@ namespace umbraco.presentation.umbraco.translation {
             pageRow[ui.Text("name")] = ui.Text("nodeName");
             pageRow[ui.Text("value")] = page.Text;
             pageTable.Rows.Add(pageRow);
-            
-            foreach (PropertyType pt in page.ContentType.PropertyTypes) {
+
+            foreach (PropertyType pt in page.ContentType.PropertyTypes)
+            {
                 pageRow = pageTable.NewRow();
                 pageRow[ui.Text("name")] = pt.Name;
-                if (page.getProperty(pt.Alias) != null && page.getProperty(pt.Alias).Value != null)
+                var property = page.getProperty(pt.Alias);
+                if (property != null && property.Value != null)
                 {
-                    pageRow[ui.Text("value")] = page.getProperty(pt.Alias).Value;
+                    pageRow[ui.Text("value")] = property.Value;
                 }
                 pageTable.Rows.Add(pageRow);
             }
-            
+
             dg_fields.DataSource = pageTable;
             dg_fields.DataBind();
         }

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/translation/details.aspx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/translation/details.aspx.cs
@@ -88,7 +88,10 @@ namespace umbraco.presentation.umbraco.translation {
             foreach (PropertyType pt in page.ContentType.PropertyTypes) {
                 pageRow = pageTable.NewRow();
                 pageRow[ui.Text("name")] = pt.Name;
-                pageRow[ui.Text("value")] = page.getProperty(pt.Alias).Value;
+                if (page.getProperty(pt.Alias) != null && page.getProperty(pt.Alias).Value != null)
+                {
+                    pageRow[ui.Text("value")] = page.getProperty(pt.Alias).Value;
+                }
                 pageTable.Rows.Add(pageRow);
             }
             


### PR DESCRIPTION
### Prerequisites

If there's an existing issue for this PR then this fixes: <!-- link to the issue here! -->
- https://our.umbraco.com/forum/umbraco-7/using-umbraco-7/66911-error-when-viewing-translations

### Description
<!-- A description of the changes proposed in the pull-request and how to test these changes -->
- add null checking in `umbraco.presentation/umbraco/details.cs`


<!-- Thanks for contributing to Umbraco CMS! -->
