### PR TITLE
V8: Set form as dirty when editing tags

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.controller.js
@@ -1,9 +1,12 @@
 angular.module("umbraco")
 .controller("Umbraco.PropertyEditors.TagsController",
-    function ($scope) {
+    function ($scope, angularHelper) {
 
         $scope.valueChanged = function(value) {
             $scope.model.value = value;
+            // the model value seems to be a reference to the same array, so we need
+            // to set the form as dirty explicitly when the content of the array changes
+            angularHelper.getCurrentForm($scope).$setDirty();
         }
 
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4006

### Description
 
See #4006 for steps to recreate.

Here's how it looks with this PR applied - notice that you're prompted to save changes both when removing and adding tags:

![fix-remove-tags-dirty-check](https://user-images.githubusercontent.com/7405322/50897057-49640c00-140b-11e9-9828-3c64b09ffbc9.gif)
