### PR TITLE
V8: Allow Content App badges without "count"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation.less
@@ -69,8 +69,8 @@
     background-color: @yellow-d2;
   }
   &:empty {
-    height: 10px;
-    min-width: 10px;
+    height: 12px;
+    min-width: 12px;
   }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation.less
@@ -60,12 +60,17 @@
   font-weight: bold;
   padding: 2px;
   line-height: 16px;
+  display: block;
 
   &.-type-alert {
     background-color: @red-l1;
   }
   &.-type-warning {
     background-color: @yellow-d2;
+  }
+  &:empty {
+    height: 10px;
+    min-width: 10px;
   }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
@@ -12,7 +12,7 @@
                ng-class="{'is-active': item.active, '-has-error': item.hasError}">
                 <i class="icon {{ item.icon }}"></i>
                 <span class="umb-sub-views-nav-item-text">{{ item.name }}</span>
-                <div ng-show="item.badge && item.badge.count" class="badge -type-{{item.badge.type}}">{{item.badge.count}}</div>
+                <div ng-show="item.badge" class="badge -type-{{item.badge.type}}">{{item.badge.count}}</div>
             </a>
         </div>
     </li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As discussed in #3426 there's a use case for Content App badges without numbers in them. This PR allows for just that. It looks like this:

![image](https://user-images.githubusercontent.com/7405322/50899166-a367d000-1411-11e9-9073-929d430e0daa.png)

Note that I made the badge smaller when there's no number in it. It looked slightly comical with the big, empty badge. Here's how a badge with a number looks in comparison:

![image](https://user-images.githubusercontent.com/7405322/50899284-ef1a7980-1411-11e9-9b78-c1b63b16f0c6.png)

To omit the number in the badge, simply don't define the `count` property in `model.badge`:

```js
var count = Math.floor(Math.random() * Math.floor(12));
$scope.model.badge = {
	//count: count,
	type: count > 9 ? "alert" : count > 4 ? "warning" : null
};
```

If this is merged in I'll update [the docs](https://our.umbraco.com/Documentation/Extending/Content-Apps/index-v8) accordingly