### PR TITLE
Removed already deleted file from canvasdesiger.loader.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/canvasdesigner.loader.js
+++ b/src/Umbraco.Web.UI.Client/src/canvasdesigner.loader.js
@@ -11,8 +11,7 @@ LazyLoad.js([
       '../js/umbraco.security.js',
       '../ServerVariables',
       '../lib/spectrum/spectrum.js',
-      '../js/umbraco.canvasdesigner.js',
-	  '../js/canvasdesigner.panel.js'
+      '../js/umbraco.canvasdesigner.js'
 ], function () {
     jQuery(document).ready(function () {
         angular.bootstrap(document, ['Umbraco.canvasdesigner']);


### PR DESCRIPTION
### Prerequisites

https://github.com/umbraco/Umbraco-CMS/issues/4018

### Description

Removed already deleted file canvasdesigner.panel.js from canvasdesiger.loader.js

This was causing a 404 when loading the preview view.

To test this fix, load the preview view. You shoukd no longer have a 404 from canvasdesigner.panel.js
