### PR TITLE
#3642 - also save all languages with content on publish

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
@@ -1,7 +1,7 @@
 <div ng-controller="Umbraco.Overlays.PublishController as vm">
 
     <div style="margin-bottom: 15px;">
-        <p><localize key="content_languagesToPublish"></localize></p>
+        <p>{{vm.headline}}</p>
     </div>
 
     <div ng-if="vm.loading" style="min-height: 50px; position: relative;">
@@ -65,7 +65,7 @@
                 <div ng-repeat="notification in variant.notifications">
                     <div class="umb-permission__description" style="color: #1FB572;">{{notification.message}}</div>
                 </div>
-                
+
             </div>
         </div>
     </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -270,6 +270,7 @@
     <key alias="includeUnpublished">Include drafts: also publish unpublished content items.</key>
     <key alias="isSensitiveValue">This value is hidden. If you need access to view this value please contact your website administrator.</key>
     <key alias="isSensitiveValue_short">This value is hidden.</key>
+    <key alias="languagesToPublishForFirstTime">What languages would you like to publish? All languages with content are saved!</key>
     <key alias="languagesToPublish">What languages would you like to publish?</key>
     <key alias="languagesToSave">What languages would you like to save?</key>
     <key alias="languagesToSaveForFirstTime">All languages with content are saved on creation!</key>


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/3642 
Relates: https://github.com/umbraco/Umbraco-CMS/pull/4021
Also handling save all languages on first request, when published