### PR TITLE
Fix placeholder text when empty alias input after generating alias

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
@@ -86,20 +86,20 @@ angular.module("umbraco.directives")
                 function generateAlias(value) {
 
                   if (generateAliasTimeout) {
-                    $timeout.cancel(generateAliasTimeout);
+                     $timeout.cancel(generateAliasTimeout);
                   }
 
-                  if( value !== undefined && value !== "" && value !== null) {
+                  if (value !== undefined && value !== "" && value !== null) {
 
-                      scope.alias = "";
+                    scope.alias = "";
                     scope.placeholderText = scope.labels.busy;
 
                     generateAliasTimeout = $timeout(function () {
                        updateAlias = true;
                         entityResource.getSafeAlias(value, true).then(function (safeAlias) {
                             if (updateAlias) {
-                              scope.alias = safeAlias.alias;
-                           }
+                                scope.alias = safeAlias.alias;
+                            }
                       });
                     }, 500);
 
@@ -108,7 +108,6 @@ angular.module("umbraco.directives")
                     scope.alias = "";
                     scope.placeholderText = scope.labels.idle;
                   }
-
                 }
 
                 // if alias gets unlocked - stop watching alias
@@ -119,17 +118,21 @@ angular.module("umbraco.directives")
                 }));
 
                 // validate custom entered alias
-                eventBindings.push(scope.$watch('alias', function(newValue, oldValue){
-
-                  if(scope.alias === "" && bindWatcher === true || scope.alias === null && bindWatcher === true) {
-                    // add watcher
-                    eventBindings.push(scope.$watch('aliasFrom', function(newValue, oldValue) {
-                       if(bindWatcher) {
-                          generateAlias(newValue);
-                       }
-                    }));
-                  }
-
+                eventBindings.push(scope.$watch('alias', function (newValue, oldValue) {
+                    if (scope.alias === "" || scope.alias === null || scope.alias === undefined) {
+                        if (bindWatcher === true) {
+                            // add watcher
+                            eventBindings.push(scope.$watch('aliasFrom', function (newValue, oldValue) {
+                                if (bindWatcher) {
+                                    generateAlias(newValue);
+                                }
+                            }));
+                        }
+                        else {
+                            generateAlias(scope.alias);
+                            //scope.placeholderText = scope.labels.idle;
+                        }
+                    }
                }));
 
                // clean up

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
@@ -100,6 +100,7 @@ angular.module("umbraco.directives")
                             if (updateAlias) {
                                 scope.alias = safeAlias.alias;
                             }
+                            scope.placeholderText = scope.labels.idle;
                       });
                     }, 500);
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
@@ -130,7 +130,6 @@ angular.module("umbraco.directives")
                         }
                         else {
                             generateAlias(scope.alias);
-                            //scope.placeholderText = scope.labels.idle;
                         }
                     }
                }));

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
@@ -129,9 +129,6 @@ angular.module("umbraco.directives")
                                 }
                             }));
                         }
-                        else {
-                            generateAlias(scope.alias);
-                        }
                     }
                }));
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4027

### Description
This fixes issue with placeholder text still is "Generating alias..." (which it change to after entering document type name first time), but after clearing alias input, then placeholder text doesn't change back to "Enter alias..".