### PR TITLE
Fixing default ProfilingLogger

### DIFF
--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -319,7 +319,7 @@ namespace Umbraco.Core.Runtime
         /// Gets a profiler.
         /// </summary>
         protected virtual IProfiler GetProfiler()
-            => new LogProfiler(ProfilingLogger);
+            => new LogProfiler(Logger);
 
         /// <summary>
         /// Gets the application caches.


### PR DESCRIPTION
The current code doesn't set the `ProfilingLogger` until _after_ the `GetProfiler` method is called. This is because the profiler is passed to the `ProfilingLogger`, so it's basically a circular dependency problem.

No matter, just use the `Logger` directly!

Fixes #4033 