### PR TITLE
V8: Add spacing between properties in Nested Content items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -3,6 +3,13 @@
     position: relative;
 }
 
+.umb-nested-content-property-container {
+    position: relative;
+    &:not(:last-child){
+        margin-bottom: 12px;
+    }
+}
+
 .umb-nested-content--not-supported {
     opacity: 0.3;
     pointer-events: none;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.editor.html
@@ -1,5 +1,5 @@
 ﻿<div class="umb-pane">
-  <div ng-repeat="property in tab.properties" style="position: relative;">
+  <div ng-repeat="property in tab.properties" class="umb-nested-content-property-container">
 
     <umb-property property="property" ng-class="{'umb-nested-content--not-supported': property.notSupported}">
       <umb-property-editor model="property"></umb-property-editor>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The properties in Nested Content items have lost their spacing somewhere from V7 to V8:

![image](https://user-images.githubusercontent.com/7405322/51038275-0a70ba80-15b3-11e9-89a3-83d57b96900b.png)

This PR adds some spacing. It looks like this:

![image](https://user-images.githubusercontent.com/7405322/51038236-e6ad7480-15b2-11e9-8442-c47ae4c1fb97.png)
