### PR TITLE
V8: Fix element picker title in Nested Content and use built-in localization

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -81,25 +81,6 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
                 : undefined;
         });
 
-        $scope.editIconTitle = '';
-        $scope.moveIconTitle = '';
-        $scope.deleteIconTitle = '';
-
-        // localize the edit icon title
-        localizationService.localize('general_edit').then(function (value) {
-            $scope.editIconTitle = value;
-        });
-
-        // localize the delete icon title
-        localizationService.localize('general_delete').then(function (value) {
-            $scope.deleteIconTitle = value;
-        });
-
-        // localize the move icon title
-        localizationService.localize('actions_move').then(function (value) {
-            $scope.moveIconTitle = value;
-        });
-
         $scope.nodes = [];
         $scope.currentNode = undefined;
         $scope.realCurrentNode = undefined;
@@ -115,6 +96,11 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
         $scope.singleMode = $scope.minItems == 1 && $scope.maxItems == 1;
         $scope.showIcons = $scope.model.config.showIcons || true;
         $scope.wideMode = $scope.model.config.hideLabel == "1";
+
+        $scope.labels = {};
+        localizationService.localizeMany(["grid_insertControl"]).then(function(data) {
+            $scope.labels.docTypePickerTitle = data[0];
+        });
 
         // helper to force the current form into the dirty state
         $scope.setDirty = function () {
@@ -138,7 +124,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             }
 
             $scope.overlayMenu = {
-                title: localizationService.localize('grid_insertControl'),
+                title: $scope.labels.docTypePickerTitle,
                 show: false,
                 style: {},
                 filter: $scope.scaffolds.length > 15 ? true : false,

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -12,13 +12,13 @@
                     <div class="umb-nested-content__heading" ng-class="{'-with-icon': showIcons}"><i ng-if="showIcons" class="icon" ng-class="$parent.getIcon($index)"></i><span class="umb-nested-content__item-name" ng-bind="$parent.getName($index)"></span></div>
 
                     <div class="umb-nested-content__icons">
-                        <a class="umb-nested-content__icon umb-nested-content__icon--edit" title="{{editIconTitle}}" ng-class="{ 'umb-nested-content__icon--active' : $parent.realCurrentNode.id == node.id }" ng-click="$parent.editNode($index); $event.stopPropagation();" ng-show="$parent.maxItems > 1" prevent-default>
+                        <a class="umb-nested-content__icon umb-nested-content__icon--edit" localize="title" title="general_edit" ng-class="{ 'umb-nested-content__icon--active' : $parent.realCurrentNode.id == node.id }" ng-click="$parent.editNode($index); $event.stopPropagation();" ng-show="$parent.maxItems > 1" prevent-default>
                             <i class="icon icon-edit"></i>
                         </a>
-                        <a class="umb-nested-content__icon umb-nested-content__icon--move" title="{{moveIconTitle}}" ng-click="$event.stopPropagation();" ng-show="$parent.nodes.length > 1" prevent-default>
+                        <a class="umb-nested-content__icon umb-nested-content__icon--move" localize="title" title="actions_move" ng-click="$event.stopPropagation();" ng-show="$parent.nodes.length > 1" prevent-default>
                             <i class="icon icon-navigation"></i>
                         </a>
-                        <a class="umb-nested-content__icon umb-nested-content__icon--delete" title="{{deleteIconTitle}}" ng-class="{ 'umb-nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.deleteNode($index); $event.stopPropagation();" prevent-default>
+                        <a class="umb-nested-content__icon umb-nested-content__icon--delete" localize="title" title="general_delete" ng-class="{ 'umb-nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.deleteNode($index); $event.stopPropagation();" prevent-default>
                             <i class="icon icon-trash"></i>
                         </a>
                     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The element picker title is currently an angular promise, printed out in text as "{}":

![image](https://user-images.githubusercontent.com/7405322/51038430-879c2f80-15b3-11e9-9253-224a32f220a2.png)

This PR fixes the title by resolving the promise beforehand:

![image](https://user-images.githubusercontent.com/7405322/51038497-ac90a280-15b3-11e9-99af-25f6ed905740.png)

Bonus: With some of the more recent updates to the localization directive can now localize attributes in the markup rather than handling the localization by code. So I have updated the Nested Content property editor accordingly. 