### PR TITLE
V8: Fix JS error in contentnodeinfo directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -97,9 +97,9 @@
                 }
 
                 //load in the audit trail if we are currently looking at the INFO tab
-                if (umbVariantContentCtrl) {
+                if (umbVariantContentCtrl && umbVariantContentCtrl.editor) {
                     var activeApp = _.find(umbVariantContentCtrl.editor.content.apps, a => a.active);
-                    if (activeApp.alias === "umbInfo") {
+                    if (activeApp && activeApp.alias === "umbInfo") {
                         isInfoTab = true;
                         loadAuditTrail();
                         loadRedirectUrls();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes:  https://github.com/umbraco/Umbraco-CMS/issues/4044

### Description

There's a JS error in the console whenever you open some content for editing:

![image](https://user-images.githubusercontent.com/7405322/51040593-36db0580-15b8-11e9-9f4c-c04e708d2bf7.png)

I currently don't see the error mentioned in #4044, but I believe it's being hidden by the error above. In any case I have added some defensive coding to ensure that the error in #4044 doesn't occur.

### Testing this PR

Simple! Just open some content. If the console doesn't report any JS errors it works 😁 