### PR TITLE
Image cropper: Prompt for saving when changing focal point and editing crops

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
@@ -14,7 +14,8 @@ angular.module("umbraco.directives")
 				scope: {
 					src: '=',
 					center: "=",
-                    onImageLoaded: "&"
+                    onImageLoaded: "&",
+                    onGravityChanged: "&"
 				},
 				link: function(scope, element, attrs) {
 
@@ -52,7 +53,7 @@ angular.module("umbraco.directives")
 
 					    calculateGravity(offsetX, offsetY);
 
-					    lazyEndEvent();
+					    gravityChanged();
 					};
 
                     var setDimensions = function () {
@@ -77,12 +78,11 @@ angular.module("umbraco.directives")
 						scope.center.top =  (scope.dimensions.top+10) / scope.dimensions.height;
 					};
 
-					var lazyEndEvent = _.debounce(function(){
-						scope.$apply(function(){
-							scope.$emit("imageFocalPointStop");
-						});
-					}, 2000);
-
+                    var gravityChanged = function () {
+                        if (angular.isFunction(scope.onGravityChanged)) {
+                            scope.onGravityChanged();
+                        }
+                    };
 
 					//Drag and drop positioning, using jquery ui draggable
 					//TODO ensure that the point doesnt go outside the box
@@ -100,7 +100,7 @@ angular.module("umbraco.directives")
 								calculateGravity(offsetX, offsetY);
 							});
 
-							lazyEndEvent();
+							gravityChanged();
 						}
 					});
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
@@ -52,6 +52,7 @@ angular.module('umbraco')
             });
             editedCrop.coordinates = $scope.currentCrop.coordinates;
             $scope.close();
+            angularHelper.getCurrentForm($scope).$setDirty();
         };
 
         //reset the current crop
@@ -97,6 +98,10 @@ angular.module('umbraco')
             $scope.isCroppable = isCroppable;
             $scope.hasDimensions = hasDimensions;
         };
+
+        $scope.focalPointChanged = function () {
+            angularHelper.getCurrentForm($scope).$setDirty();
+        }
 
         //on image selected, update the cropper
         $scope.$on("filesSelected", function (ev, args) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
@@ -40,7 +40,8 @@
                 <umb-image-gravity
                     src="imageSrc"
                     center="model.value.focalPoint"
-                    on-image-loaded="imageLoaded(isCroppable, hasDimensions)">
+                    on-image-loaded="imageLoaded(isCroppable, hasDimensions)"
+                    on-gravity-changed="focalPointChanged()">
                 </umb-image-gravity>
                 <a href class="btn btn-link btn-crop-delete" ng-click="clear()"><i class="icon-delete red"></i> <localize key="content_uploadClear">Remove file</localize></a>
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Currently you're not prompted to save changes if change the focal point in the image cropper, or if you edit a crop (unless you change its scale, then sometimes you are):

![image-cropper-set-dirty-before](https://user-images.githubusercontent.com/7405322/51076973-e8089b00-169f-11e9-9cd7-14a38150546c.gif)

This PR fixes it:

![image-cropper-set-dirty-after](https://user-images.githubusercontent.com/7405322/51076975-fbb40180-169f-11e9-8cd4-7bb5b90ecc7d.gif)

Note that I have removed the `imageFocalPointStop` event because it was unused in the codebase, and instead introduced the `onGravityChanged` callback in the `umb-image-gravity` directive.

### Testing this PR

The following actions should not prompt to save changes:

1. Click to set a new focal point.
2. Drag to set a new focal point.
3. Edit a crop.
