### PR TITLE
Visualize image transparency in upload and image cropper thumbnails

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -1,3 +1,5 @@
+@checkered-background: url(../img/checkered-background.png);
+
 //
 // Container styles
 // --------------------------------------------------
@@ -386,7 +388,7 @@ div.umb-codeeditor .umb-btn-toolbar {
     max-height:100%;
     margin:auto;
     display:block;
-    background-image: url(../img/checkered-background.png);
+    background-image: @checkered-background;
 }
 
 .umb-sortable-thumbnails li .trashed {
@@ -599,12 +601,18 @@ div.umb-codeeditor .umb-btn-toolbar {
         vertical-align: top;
     }
 
-    .gravity-container .viewport {
-        max-width: 600px;
-    }
+    .gravity-container {
+        border: 1px solid @gray-8;
+        line-height: 0;
 
-    .gravity-container .viewport:hover {
-        cursor: pointer;
+        .viewport {
+            max-width: 600px;
+            background: @checkered-background;
+
+            &:hover {
+                cursor: pointer;
+            }
+        }
     }
 
     .imagecropper {
@@ -884,6 +892,10 @@ div.umb-codeeditor .umb-btn-toolbar {
   list-style: none;
   vertical-align: middle;
   margin-bottom: 0;
+
+  img {
+    background: @checkered-background;
+  }
 }
 
 .umb-fileupload label {

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -625,6 +625,10 @@ div.umb-codeeditor .umb-btn-toolbar {
             float: left;
             max-width: 100%;
         }
+
+        .viewport img {
+            background: @checkered-background;
+        }
     }
 
     .imagecropper .umb-cropper__container {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4004

### Description

As discussed in #4004 it's currently hard to tell if an image has transparency in it or not, as soon as you move away from the folder view. The upload and image cropper thumbnails do not display the thumbnails with the same checkered background as the folder view does.

#4004 specifically mentions SVG's, but the issue is the same with PNG's as well.

#### Upload field

This image is the Umbraco logo on a transparent background:

![image](https://user-images.githubusercontent.com/7405322/51077038-0a4ee880-16a1-11e9-8e6f-e81f7416ee33.png)

#### Image cropper field

This image is the Umbraco logo on a transparent background. Ironically the crop thumbnails do display the transparency:

![image](https://user-images.githubusercontent.com/7405322/51077059-5a2daf80-16a1-11e9-8b49-584b6e18fd9e.png)

![image](https://user-images.githubusercontent.com/7405322/51077085-a0830e80-16a1-11e9-8842-e976f145ec98.png)

### WIth this PR applied

This PR adds the checkered background to the thumbnails.

#### Upload field

![image](https://user-images.githubusercontent.com/7405322/51077196-58fd8200-16a3-11e9-88bb-cd23423bcef1.png)

#### Image cropper field

![image](https://user-images.githubusercontent.com/7405322/51077206-72063300-16a3-11e9-9478-f46642c3eda0.png)

![image](https://user-images.githubusercontent.com/7405322/51077211-80544f00-16a3-11e9-8c0d-67184bea46ef.png)

Note that I have also added a gray border around the main thumbnail to match the crop thumbnails. It can be hard to spot on the images above due to the transparency, but it looks like this:

![image](https://user-images.githubusercontent.com/7405322/51077279-81d24700-16a4-11e9-8d8c-e327e471787f.png)
