### PR TITLE
V8: Safeguard against invalid culture in UMB_MCULTURE cookie

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/controllers/navigation.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/navigation.controller.js
@@ -401,9 +401,10 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
     $scope.selectLanguage = function (language) {
 
         $location.search("mculture", language.culture);
-        // add the selected culture to a cookie so the user will log back into the same culture later on (cookie max age is one year = 31536000 seconds)
-        // NOTE: $cookies doesn't support max-age, so we need to go the good ol' JS way about setting the cookie
-        document.cookie = "UMB_MCULTURE=" +language.culture + ";path=/;max-age=31536000;";
+        // add the selected culture to a cookie so the user will log back into the same culture later on (cookie lifetime = one year)
+        var expireDate = new Date();
+        expireDate.setDate(expireDate.getDate() + 365);
+        $cookies.put("UMB_MCULTURE", language.culture, {path: "/", expires: expireDate});
 
         // close the language selector
         $scope.page.languageSelectorIsOpen = false;

--- a/src/Umbraco.Web.UI.Client/src/controllers/navigation.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/navigation.controller.js
@@ -355,7 +355,9 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
                 if (!currCulture) {
                     // no culture in the request, let's look for one in the cookie that's set when changing language
                     var defaultCulture = $cookies.get("UMB_MCULTURE");
-                    if (!defaultCulture) {
+                    if (!defaultCulture || !_.find($scope.languages, function (l) {
+                            return l.culture.toLowerCase() === defaultCulture.toLowerCase();
+                        })) {
                         // no luck either, look for the default language
                         var defaultLang = _.find($scope.languages, function (l) {
                             return l.isDefault;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/pull/4035#issuecomment-453823291

### Description

As @nul800sebastiaan mentions on #4035, the language selector is blank if the UMB_MCULTURE cookie contains a language that does not exist, and this could become a real problem once people start deleting languages.

#### Steps to reproduce

1. Change the main language.
2. Edit the UMB_MCULTURE cookie and set its value to "xx".
3. Close the browser.
4. Log back into Umbraco. Make sure the querystring does *not* contain a main culture when you do.
5. Notice how the main culture in the querystring is updated to "xx" and that the language selector is blank.

![image](https://user-images.githubusercontent.com/7405322/51086632-29a15080-1749-11e9-8935-40da693ca732.png)

This PR fixes the scenario above. At the same time it reintroduces the use of `$cookies` to set the UMB_MCULTURE cookie (instead of using `document.cookie`).