### PR TITLE
Corrected all the miss spellings of "Separate" - Issue: 4060

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -6,7 +6,7 @@ _Ready to try out Version 8? [See the quick start guide](V8_GETTING_STARTED.md).
 
 When is Umbraco 8 coming?
 =========================
-When it's ready. We're done with the major parts of the architecture work and are focusing on three seperate tracks to prepare Umbraco 8 for release:
+When it's ready. We're done with the major parts of the architecture work and are focusing on three separate tracks to prepare Umbraco 8 for release:
 1) Editor Track (_currently in progress_). Without editors, there's no market for Umbraco. So we want to make sure that Umbraco 8 is full of love for editors.
 2) Partner Track. Without anyone implementing Umbraco, there's nothing for editors to update. So we want to make sure that Umbraco 8 is a joy to implement
 3) Contributor Track. Without our fabulous ecosystem of both individual Umbracians and 3rd party ISVs, Umbraco wouldn't be as rich a platform as it is today. We want to make sure that it's easy, straight forward and as backwards-compatible as possible to create packages for Umbraco

--- a/src/Umbraco.Core/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Core/Logging/Serilog/LoggerConfigExtensions.cs
@@ -92,7 +92,7 @@ namespace Umbraco.Core.Logging.Serilog
 
         /// <summary>
         /// Reads settings from /config/serilog.user.config
-        /// That allows a seperate logging pipeline to be configured that wil not affect the main Umbraco log
+        /// That allows a separate logging pipeline to be configured that wil not affect the main Umbraco log
         /// </summary>
         /// <param name="logConfig">A Serilog LoggerConfiguration</param>
         public static LoggerConfiguration ReadFromUserConfigFile(this LoggerConfiguration logConfig)

--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -892,7 +892,7 @@ namespace Umbraco.Core
         }
 
         /// <summary>
-        /// Ensures that the folder path ends with a DirectorySeperatorChar
+        /// Ensures that the folder path ends with a DirectorySeparatorChar
         /// </summary>
         /// <param name="currentFolder"></param>
         /// <returns></returns>

--- a/src/Umbraco.Tests/Services/Importing/Fanoe-Package.xml
+++ b/src/Umbraco.Tests/Services/Importing/Fanoe-Package.xml
@@ -4163,7 +4163,7 @@ html {
 	text-align: center;
 }
 
-.text--center .seperator {
+.text--center .separator {
 	margin-right: auto;
 	margin-left: auto;
 }

--- a/src/Umbraco.Web.UI.Client/gulpfile.js
+++ b/src/Umbraco.Web.UI.Client/gulpfile.js
@@ -421,7 +421,7 @@ gulp.task('dependencies', function () {
 
 
 /**************************
- * Copies all angular JS files into their seperate umbraco.*.js file
+ * Copies all angular JS files into their separate umbraco.*.js file
  **************************/
 gulp.task('js', function () {
 

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -5204,12 +5204,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5224,17 +5226,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5351,7 +5356,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5363,6 +5369,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5377,6 +5384,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5384,12 +5392,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5408,6 +5418,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5488,7 +5499,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5500,6 +5512,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5621,6 +5634,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/Umbraco.Web.UI.Client/src/common/mocks/resources/tree.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/resources/tree.mocks.js
@@ -11,24 +11,24 @@ angular.module('umbraco.mocks').
           var menu = [
               { name: "Create", cssclass: "plus", alias: "create", metaData: {} },
 
-              { seperator: true, name: "Delete", cssclass: "remove", alias: "delete", metaData: {} },
+              { separator: true, name: "Delete", cssclass: "remove", alias: "delete", metaData: {} },
               { name: "Move", cssclass: "move", alias: "move", metaData: {} },
               { name: "Copy", cssclass: "copy", alias: "copy", metaData: {} },
               { name: "Sort", cssclass: "sort", alias: "sort", metaData: {} },
 
-              { seperator: true, name: "Publish", cssclass: "globe", alias: "publish", metaData: {} },
+              { separator: true, name: "Publish", cssclass: "globe", alias: "publish", metaData: {} },
               { name: "Rollback", cssclass: "undo", alias: "rollback", metaData: {} },
 
-              { seperator: true, name: "Permissions", cssclass: "lock", alias: "permissions", metaData: {} },
+              { separator: true, name: "Permissions", cssclass: "lock", alias: "permissions", metaData: {} },
               { name: "Audit Trail", cssclass: "time", alias: "audittrail", metaData: {} },
               { name: "Notifications", cssclass: "envelope", alias: "notifications", metaData: {} },
 
-              { seperator: true, name: "Hostnames", cssclass: "home", alias: "hostnames", metaData: {} },
+              { separator: true, name: "Hostnames", cssclass: "home", alias: "hostnames", metaData: {} },
               { name: "Public Access", cssclass: "group", alias: "publicaccess", metaData: {} },
 
-              { seperator: true, name: "Reload", cssclass: "refresh", alias: "users", metaData: {} },
+              { separator: true, name: "Reload", cssclass: "refresh", alias: "users", metaData: {} },
           
-                { seperator: true, name: "Empty Recycle Bin", cssclass: "trash", alias: "emptyrecyclebin", metaData: {} }
+                { separator: true, name: "Empty Recycle Bin", cssclass: "trash", alias: "emptyrecyclebin", metaData: {} }
           ];
 
           var result = {
@@ -94,7 +94,7 @@ angular.module('umbraco.mocks').
                        jsAction: "umbracoMenuActions.CreateChildEntity"
                    }
               },              
-              { seperator: true, name: "Reload", cssclass: "refresh", alias: "users", metaData: {} }
+              { separator: true, name: "Reload", cssclass: "refresh", alias: "users", metaData: {} }
           ];
 
           return [200, menu, null];

--- a/src/Umbraco.Web.UI.Client/src/common/mocks/services/localization.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/services/localization.mocks.js
@@ -640,7 +640,7 @@ angular.module('umbraco.mocks').
                   "templateEditor_urlEncodeHelp": "Will format special characters in URLs",
                   "templateEditor_usedIfAllEmpty": "Will only be used when the field values above are empty",
                   "templateEditor_usedIfEmpty": "This field will only be used if the primary field is empty",
-                  "templateEditor_withTime": "Yes, with time. Seperator: ",
+                  "templateEditor_withTime": "Yes, with time. Separator: ",
                   "translation_details": "Translation details",
                   "translation_DownloadXmlDTD": "Download xml DTD",
                   "translation_fields": "Fields",

--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -421,7 +421,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, notifica
          */
         reBindChangedProperties: function (origContent, savedContent) {
 
-            //TODO: We should probably split out this logic to deal with media/members seperately to content
+            //TODO: We should probably split out this logic to deal with media/members separately to content
 
             //a method to ignore built-in prop changes
             var shouldIgnore = function (propName) {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-breadcrumbs.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-breadcrumbs.less
@@ -28,7 +28,7 @@
    color: @black;
 }
 
-.umb-breadcrumbs__seperator {
+.umb-breadcrumbs__separator {
    position: relative;
    top: 1px;
    margin-left: 5px;

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
@@ -55,12 +55,12 @@
                     <ul class="umb-breadcrumbs">
                         <li ng-hide="startNodeId != -1" class="umb-breadcrumbs__ancestor">
                             <a href ng-click="gotoFolder()" prevent-default>Media</a>
-                            <span class="umb-breadcrumbs__seperator">&#47;</span>
+                            <span class="umb-breadcrumbs__separator">&#47;</span>
                         </li>
     
                         <li ng-repeat="item in path" class="umb-breadcrumbs__ancestor">
                             <a href ng-click="gotoFolder(item)" prevent-default>{{item.name}}</a>
-                            <span class="umb-breadcrumbs__seperator">&#47;</span>
+                            <span class="umb-breadcrumbs__separator">&#47;</span>
                         </li>
     
                         <li class="umb-breadcrumbs__ancestor" ng-show="!lockedFolder">

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-contextmenu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-contextmenu.html
@@ -5,7 +5,7 @@
 
     <div class='umb-modalcolumn-body'>
         <ul class="umb-actions">
-            <li data-element="action-{{action.alias}}" ng-click="executeMenuItem(action)" class="umb-action" ng-class="{sep:action.seperator, '-opens-dialog': action.opensDialog}" ng-repeat="action in menuActions">
+            <li data-element="action-{{action.alias}}" ng-click="executeMenuItem(action)" class="umb-action" ng-class="{sep:action.separator, '-opens-dialog': action.opensDialog}" ng-repeat="action in menuActions">
                 <a class="umb-action-link" prevent-default>
                     <i class="icon icon-{{action.cssclass}}"></i>
                     <span class="menu-label">{{action.name}}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-breadcrumbs.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-breadcrumbs.html
@@ -7,7 +7,7 @@
         <!-- use callback to handle click -->
         <a ng-if="!$last && allowOnOpen" href="#" ng-click="open(ancestor)" class="umb-breadcrumbs__ancestor-link" title="{{ancestor.name}}" prevent-default>{{ancestor.name}}</a>
 
-        <span ng-if="!$last" class="umb-breadcrumbs__seperator">&#47;</span>
+        <span ng-if="!$last" class="umb-breadcrumbs__separator">&#47;</span>
 
         <span class="umb-breadcrumbs__ancestor-text" ng-if="$last" title="{{ancestor.name}}">{{ancestor.name}}</span>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
@@ -9,7 +9,7 @@
     </umb-button>
 
     <umb-dropdown ng-if="dropdown.isOpen" class="umb-actions" on-close="dropdown.isOpen = false">
-        <umb-dropdown-item class="umb-action" ng-class="{'sep':action.seperatorm, '-opens-dialog': action.opensDialog}" ng-repeat="action in actions">
+        <umb-dropdown-item class="umb-action" ng-class="{'sep':action.separatorm, '-opens-dialog': action.opensDialog}" ng-repeat="action in actions">
             <a href="" ng-click="executeMenuItem(action)" prevent-default>
                 <i class="icon icon-{{action.cssclass}}"></i>
                 <span class="menu-label">{{action.name}}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -437,7 +437,7 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
             view: "views/propertyeditors/listview/overlays/listviewpublish.html",
             submitButtonLabelKey: "actions_publish",
             submit: function (model) {
-                // create a comma seperated array of selected cultures
+                // create a comma separated array of selected cultures
                 let selectedCultures = [];
                 if (model.languages && model.languages.length > 0) {
                     model.languages.forEach(language => {
@@ -492,7 +492,7 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
             submitButtonLabelKey: "actions_unpublish",
             submit: function (model) {
 
-                // create a comma seperated array of selected cultures
+                // create a comma separated array of selected cultures
                 let selectedCultures = [];
                 if (model.languages && model.languages.length > 0) {
                     model.languages.forEach(language => {

--- a/src/Umbraco.Web/Editors/TemplateController.cs
+++ b/src/Umbraco.Web/Editors/TemplateController.cs
@@ -142,7 +142,7 @@ namespace Umbraco.Web.Editors
                                     continue;
                                 }
 
-                                //Find position in current comma seperate string path (so we get the correct children path)
+                                //Find position in current comma separate string path (so we get the correct children path)
                                 var positionInPath = childTemplate.Path.IndexOf(templateIdInPath) + templateIdInPath.Length;
 
                                 //Get the substring of the child & any children (descendants it may have too)

--- a/src/Umbraco.Web/Models/ContentEditing/CodeFileDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/CodeFileDisplay.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Web.Models.ContentEditing
 
         /// <summary>
         /// Path represents the path used by the backoffice tree
-        /// For files stored on disk, this is a urlencoded, comma seperated
+        /// For files stored on disk, this is a urlencoded, comma separated
         /// path to the file, always starting with -1.
         ///
         /// -1,Partials,Parials%2FFolder,Partials%2FFolder%2FFile.cshtml

--- a/src/Umbraco.Web/Models/Trees/CreateChildEntity.cs
+++ b/src/Umbraco.Web/Models/Trees/CreateChildEntity.cs
@@ -10,18 +10,18 @@ namespace Umbraco.Web.Models.Trees
     {
         public override string AngularServiceName => "umbracoMenuActions";
 
-        public CreateChildEntity(string name, bool seperatorBefore = false)
+        public CreateChildEntity(string name, bool separatorBefore = false)
             : base(ActionNew.ActionAlias, name)
         {
             Icon = "add"; Name = name;
-            SeperatorBefore = seperatorBefore;
+            SeparatorBefore = separatorBefore;
         }
 
-        public CreateChildEntity(ILocalizedTextService textService, bool seperatorBefore = false)
+        public CreateChildEntity(ILocalizedTextService textService, bool separatorBefore = false)
             : base(ActionNew.ActionAlias, textService)
         {
             Icon = "add";
-            SeperatorBefore = seperatorBefore;
+            SeparatorBefore = separatorBefore;
         }
     }
 }

--- a/src/Umbraco.Web/Models/Trees/MenuItem.cs
+++ b/src/Umbraco.Web/Models/Trees/MenuItem.cs
@@ -49,7 +49,7 @@ namespace Umbraco.Web.Models.Trees
         {
             Name = name.IsNullOrWhiteSpace() ? action.Alias : name;
             Alias = action.Alias;
-            SeperatorBefore = false;
+            SeparatorBefore = false;
             Icon = action.Icon;
             Action = action;
         }
@@ -80,8 +80,8 @@ namespace Umbraco.Web.Models.Trees
         /// <summary>
         /// Ensures a menu separator will exist before this menu item
         /// </summary>
-        [DataMember(Name = "seperator")]
-        public bool SeperatorBefore { get; set; }
+        [DataMember(Name = "separator")]
+        public bool SeparatorBefore { get; set; }
 
         [DataMember(Name = "cssclass")]
         public string Icon { get; set; }

--- a/src/Umbraco.Web/Models/Trees/MenuItemList.cs
+++ b/src/Umbraco.Web/Models/Trees/MenuItemList.cs
@@ -83,7 +83,7 @@ namespace Umbraco.Web.Models.Trees
             if (item == null) return null;
             var menuItem = new MenuItem(item, name)
             {
-                SeperatorBefore = hasSeparator,
+                SeparatorBefore = hasSeparator,
                 OpensDialog = opensDialog
             };
 
@@ -98,7 +98,7 @@ namespace Umbraco.Web.Models.Trees
 
             var menuItem = new MenuItem(item, textService.Localize($"actions/{item.Alias}"))
             {
-                SeperatorBefore = hasSeparator,
+                SeparatorBefore = hasSeparator,
                 OpensDialog = opensDialog
             };
 

--- a/src/Umbraco.Web/Models/Trees/RefreshNode.cs
+++ b/src/Umbraco.Web/Models/Trees/RefreshNode.cs
@@ -10,18 +10,18 @@ namespace Umbraco.Web.Models.Trees
     {
         public override string AngularServiceName => "umbracoMenuActions";
 
-        public RefreshNode(string name, bool seperatorBefore = false)
+        public RefreshNode(string name, bool separatorBefore = false)
             : base("refreshNode", name)
         {
             Icon = "refresh";
-            SeperatorBefore = seperatorBefore;
+            SeparatorBefore = separatorBefore;
         }
 
-        public RefreshNode(ILocalizedTextService textService, bool seperatorBefore = false)
+        public RefreshNode(ILocalizedTextService textService, bool separatorBefore = false)
             : base("refreshNode", textService)
         {
             Icon = "refresh";
-            SeperatorBefore = seperatorBefore;
+            SeparatorBefore = separatorBefore;
         }
     }
 }

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -137,7 +137,7 @@ namespace Umbraco.Web.Trees
 
                 if (menu.Items.Any())
                 {
-                    menu.Items.Last().SeperatorBefore = true;
+                    menu.Items.Last().SeparatorBefore = true;
                 }
 
                 // add default actions for *all* users
@@ -242,7 +242,7 @@ namespace Umbraco.Web.Trees
 	            menu.Items.Add(new MenuItem("notify", Services.TextService)
 	            {
 	                Icon = "megaphone",
-	                SeperatorBefore = true,
+	                SeparatorBefore = true,
 	                OpensDialog = true
 	            });
             }

--- a/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
@@ -84,7 +84,7 @@ namespace Umbraco.Web.Trees
                 menu.Items.Add(new MenuItem("importDocumentType", Services.TextService)
                 {
                     Icon = "page-up",
-                    SeperatorBefore = true,
+                    SeparatorBefore = true,
                     OpensDialog = true
                 });
                 menu.Items.Add(new RefreshNode(Services.TextService, true));
@@ -130,7 +130,7 @@ namespace Umbraco.Web.Trees
                 menu.Items.Add(new MenuItem("export", Services.TextService)
                 {
                     Icon = "download-alt",
-                    SeperatorBefore = true,
+                    SeparatorBefore = true,
                     OpensDialog = true
                 });
                 menu.Items.Add<ActionDelete>(Services.TextService, true, opensDialog: true);

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -832,7 +832,7 @@ namespace Umbraco.Web
         }
 
         /// <summary>
-        /// Joins any number of int/string/objects into one string and seperates them with the string seperator parameter.
+        /// Joins any number of int/string/objects into one string and separates them with the string separator parameter.
         /// </summary>
         public string Join(string separator, params object[] args)
         {


### PR DESCRIPTION
### Prerequisites

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/4060

### Description

These spelling mistakes have existed in the code base for years, I think it's a good time to fix them before the next major version is released!

Seperator -> Separator
Seperate -> Separate