### PR TITLE
V8: Fix unchangeable language/variant after closing split view 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
@@ -260,6 +260,8 @@
                 vm.editors.splice(editorIndex, 1);
                 //remove variant from open variants
                 vm.openVariants.splice(editorIndex, 1);
+                //update cculture to reflect the last open variant (closing the split view corresponds to selecting the other variant)
+                $location.search("cculture", vm.openVariants[0]);
                 splitViewChanged();
             }, 400);
         }
@@ -270,7 +272,7 @@
          * @param {any} editorIndex The index of the editor being changed
          */
         function selectVariant(variant, editorIndex) {
-            
+
             // prevent variants already open in a split view to be opened
             if(vm.openVariants.indexOf(variant.language.culture) !== -1)  {
                 return;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
@@ -260,7 +260,7 @@
                 vm.editors.splice(editorIndex, 1);
                 //remove variant from open variants
                 vm.openVariants.splice(editorIndex, 1);
-                //update cculture to reflect the last open variant (closing the split view corresponds to selecting the other variant)
+                //update the current culture to reflect the last open variant (closing the split view corresponds to selecting the other variant)
                 $location.search("cculture", vm.openVariants[0]);
                 splitViewChanged();
             }, 400);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3991

### Description

As described in #3991, the split view can easily get you into a state where you can't change the active language/variant.

#### Steps to reproduce

1. Open a page that has two or more language variants. By default it'll open the current main language variant.
2. Open another language variant in split view.
3. Close the left part of the split view (the one that contains the first language variant).
4. Notice that you can't change back to the first language variant using the language selector (but you can probably open it using split view).

With this PR applied, the same operation looks like this:

![fix-unselectable-language-after-closing-split-view](https://user-images.githubusercontent.com/7405322/51142563-a23d0580-184c-11e9-8dd9-0eddd8b46d0f.gif)
