### PR TITLE
V8: Fix the styling of the search box on the Redirect URL Management dashboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
@@ -29,7 +29,7 @@
 
             <umb-editor-sub-header-section ng-if="vm.dashboard.urlTrackerDisabled === false">
 
-                <form class="form-search -no-margin-bottom pull-right" novalidate>
+                <ng-form class="form-search -no-margin-bottom pull-right" novalidate>
                     <div class="inner-addon left-addon">
                         <i class="icon icon-search"></i>
                         <input
@@ -42,7 +42,7 @@
                             prevent-enter-submit
                             no-dirty-check>
                     </div>
-                </form>
+                </ng-form>
 
             </umb-editor-sub-header-section>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3982

### Description

There's a DOM issue that causes the styling of the search box on the Redirect URL Management dashboard to look unlike the other search boxes in the backoffice:

![image](https://user-images.githubusercontent.com/7405322/51143790-a61e5700-184f-11e9-9ef9-eb7c9d727e68.png)

It looks like this with this PR applied:

![image](https://user-images.githubusercontent.com/7405322/51143711-72433180-184f-11e9-8384-0e267660000f.png)
