### PR TITLE
V8: Force select the content app for both views when opening split view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
@@ -215,8 +215,14 @@
          * @param {any} selectedVariant
          */
         function openSplitView(selectedVariant) {
-
             var selectedCulture = selectedVariant.language.culture;
+
+            //Find the whole variant model based on the culture that was chosen
+            var variant = _.find(vm.content.variants, function (v) {
+                return v.language.culture === selectedCulture;
+            });
+
+            insertVariantEditor(vm.editors.length, initVariant(variant, vm.editors.length));
 
             //only the content app can be selected since no other apps are shown, and because we copy all of these apps
             //to the "editors" we need to update this across all editors
@@ -232,13 +238,6 @@
                     }
                 }
             }
-
-            //Find the whole variant model based on the culture that was chosen
-            var variant = _.find(vm.content.variants, function (v) {
-                return v.language.culture === selectedCulture;
-            });
-
-            insertVariantEditor(vm.editors.length, initVariant(variant, vm.editors.length));
 
             //TODO: hacking animation states - these should hopefully be easier to do when we upgrade angular
             editor.collapsed = true;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4042

### Description

When opening split view, both views should be forced into the content app no matter which app were active before opening the split view. Currently this only happens for the left side view, which leaves the right side view rather useless if you didn't have the content app open from the beginning.

![split-view-content-app-before](https://user-images.githubusercontent.com/7405322/51169889-540c1e80-18ad-11e9-8d54-675780cc44c0.gif)

As it happens, the code is already attempting to do so. But because of the order of execution it only works on the left side of the split view. 

With this PR both views are forced into the content app:

![split-view-content-app-after](https://user-images.githubusercontent.com/7405322/51169979-86b61700-18ad-11e9-8371-c85eaa34d80e.gif)

