### PR TITLE
V8: Fix the (almost completely) broken linkpicker tree load

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -37,13 +37,17 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
         var oneTimeTreeSync = {
             executed: false,
             treeReady: false,
-            sync: function() {
+            sync: function () {
+                // don't run this if:
+                // - it was already run once
+                // - the tree isn't ready yet
+                // - the model path hasn't been loaded yet
                 if (this.executed || !this.treeReady || !($scope.model.target && $scope.model.target.path)) {
                     return;
                 }
 
                 this.executed = true;
-                //now sync the tree to this path
+                // sync the tree to the model path
                 $scope.dialogTreeApi.syncTree({
                     path: $scope.model.target.path,
                     tree: "content"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When you edit an internal link (e.g. from the RTE), the linkpicker almost never manages to load the tree. Instead a JS error is logged to the console:

![linkpicker-load-tree-before](https://user-images.githubusercontent.com/7405322/51189223-df9ea300-18df-11e9-896d-0d490ad6c138.gif)

The problem happens because `syncTree` is called before the tree is ready to be synced. 

To sync the tree, two things must be loaded:

1. The tree itself.
2. The path to load.

These two are loaded using two simultaneous promises, so we can't know when both have been loaded. Therefore I have added a "fire once" implementation around the tree sync.

With this PR applied, the same operation looks like this:

![linkpicker-load-tree-after](https://user-images.githubusercontent.com/7405322/51189432-59cf2780-18e0-11e9-836d-5f319ff43a4e.gif)
