### PR TITLE
V8: Allow linkpicker to select items from search/list view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -146,7 +146,7 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
         // method to select a search result
         $scope.selectResult = function (evt, result) {
             result.selected = result.selected === true ? false : true;
-            nodeSelectHandler(evt, {
+            nodeSelectHandler({
                 event: evt,
                 node: result
             });
@@ -166,7 +166,7 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
         // Mini list view
         $scope.selectListViewNode = function (node) {
             node.selected = node.selected === true ? false : true;
-            nodeSelectHandler({}, {
+            nodeSelectHandler({
                 node: node
             });
         };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Right now there's a JS error when you pick a result from search or from list view containers in the linkpicker. That error cascades into another error when you click "submit", and leaves the linkpicker dialog unable to submit the selected node:

![linkpicker-select-from-search-before](https://user-images.githubusercontent.com/7405322/51191849-918c9e00-18e5-11e9-9337-766f6574bbe4.gif)

This PR fixes the initial JS error, and thus allows the linkpicker dialog to submit:

![linkpicker-select-from-search-after](https://user-images.githubusercontent.com/7405322/51191902-af5a0300-18e5-11e9-8c36-d187b9bf760d.gif)

**Note:** The search results aren't terribly pretty in these dialogs. I'm working on a fix for that as well.