### PR TITLE
V8: Style dialog search results

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -125,6 +125,8 @@ body.touch .umb-tree {
     position: inherit;
     display: inherit;
 
+    list-style: none;
+
     h6 {
         padding: 10px 0 10px 20px;
         font-weight: inherit;
@@ -137,7 +139,15 @@ body.touch .umb-tree {
     }
 
     &-item {
-        padding-left: 20px;
+        padding: 4px 0;
+
+        &:hover {
+            background-color: @gray-10;
+        }
+
+        &-link {
+            display: block;
+        }
     }
 
     &-link {

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
@@ -6,9 +6,9 @@
   <ul class="umb-tree">
     <li class="root">
       <ul class="umb-search-group">
-        <li ng-repeat="result in results">
-          <div style="padding-left: 20px" ng-class="{'umb-tree-node-checked' : result.selected}">
-            <a class="umb-search-group-item-link" ng-class="{first:$first}" ng-click="selectResultCallback($event, result)">
+        <li class="umb-search-group-item" ng-repeat="result in results">
+          <div ng-class="{'umb-tree-node-checked' : result.selected}">
+            <a href class="umb-search-group-item-link" ng-class="{first:$first}" ng-click="selectResultCallback($event, result)">
               <div class="umb-search-group-item-name">
                 <i class="icon umb-tree-icon sprTree {{result.icon}}"></i>
                 {{result.name}}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When searching in various dialogs (content picker, linkpicker, member picker, ...), the search result styling is a bit off:

![dialog-search-results-style-before](https://user-images.githubusercontent.com/7405322/51194144-c0594300-18ea-11e9-98e7-9823d7e9120f.gif)

This PR updates the styling so it looks like this:

![dialog-search-results-style-after](https://user-images.githubusercontent.com/7405322/51194167-cbac6e80-18ea-11e9-87cd-3a3f54c7509d.gif)
