### PR TITLE
V8: Handle selection from treepicker search result

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -54,6 +54,7 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
         vm.toggleLanguageSelector = toggleLanguageSelector;
         vm.selectLanguage = selectLanguage;
         vm.onSearchResults = onSearchResults;
+        vm.selectResult = selectResult;
         vm.hideSearch = hideSearch;
         vm.closeMiniListView = closeMiniListView;
         vm.selectListViewNode = selectListViewNode;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Nothing happens when you pick a result from a search in any tree picker:

![treepicker-select-from-search-result-before](https://user-images.githubusercontent.com/7405322/51194939-5e99d880-18ec-11e9-8201-ee0a0b7e4153.gif)

Looks like the select handler hasn't been wired up to the view model in the JS controller. This PR fixes that. 

It looks like this:

![treepicker-select-from-search-result-after](https://user-images.githubusercontent.com/7405322/51194970-6e192180-18ec-11e9-971d-b08a1bacde87.gif)
