### PR TITLE
v8: Fix validation error label

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbGenerateAlias.directive.js
@@ -44,6 +44,7 @@ the directive will use {@link umbraco.directives.directive:umbLockedField umbLoc
 
 @param {string} alias (<code>binding</code>): The model where the alias is bound.
 @param {string} aliasFrom (<code>binding</code>): The model to generate the alias from.
+@param {string} validationPosition (<code>binding</code>): The position of the validation. Set to <code>'left'</code> or <code>'right'</code>.
 @param {boolean=} enableLock (<code>binding</code>): Set to <code>true</code> to add a lock next to the alias from where it can be unlocked and changed.
 **/
 
@@ -57,6 +58,7 @@ angular.module("umbraco.directives")
                 alias: '=',
                 aliasFrom: '=',
                 enableLock: '=?',
+                validationPosition: '=?',
                 serverValidationField: '@'
             },
             link: function (scope, element, attrs, ctrl) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umblockedfield.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umblockedfield.directive.js
@@ -40,6 +40,7 @@ Use this directive to render a value with a lock next to it. When the lock is cl
 @param {boolean=} locked (<code>binding</code>): <Code>true</code> by default. Set to <code>false</code> to unlock the text.
 @param {string=} placeholderText (<code>binding</code>): If ngModel is empty this text will be shown.
 @param {string=} regexValidation (<code>binding</code>): Set a regex expression for validation of the field.
+@param {string} validationPosition (<code>binding</code>): The position of the validation. Set to <code>'left'</code> or <code>'right'</code>.
 @param {string=} serverValidationField (<code>attribute</code>): Set a server validation field.
 **/
 
@@ -70,7 +71,11 @@ Use this directive to render a value with a lock next to it. When the lock is cl
 				// if locked state is not defined as an attr set default state
 				if (scope.placeholderText === undefined || scope.placeholderText === null) {
 					scope.placeholderText = "Enter value...";
-				}
+                }
+
+                if (scope.validationPosition === undefined || scope.validationPosition === null) {
+                    scope.validationPosition = "left";
+                }
 
 			}
 
@@ -93,9 +98,10 @@ Use this directive to render a value with a lock next to it. When the lock is cl
 			templateUrl: 'views/components/umb-locked-field.html',
 			scope: {
 			    ngModel: "=",
-				locked: "=?",
+                locked: "=?",
 				placeholderText: "=?",
-				regexValidation: "=?",
+                regexValidation: "=?",
+                validationPosition: "=?",
 				serverValidationField: "@"
 			},
 			link: link

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-locked-field.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-locked-field.less
@@ -38,6 +38,7 @@ input.umb-locked-field__input {
   transition: color 0.25s;
   padding: 0;
   height: auto;
+  max-width: 300px;
 }
 
 input.umb-locked-field__input:focus {

--- a/src/Umbraco.Web.UI.Client/src/less/forms/umb-validation-label.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms/umb-validation-label.less
@@ -1,46 +1,67 @@
 .umb-validation-label {
-   position: absolute;
-   top: 27px;
-   width: 200px;
-   padding: 1px 5px;
-   background: @red;
-   color: @white;
-   font-size: 11px;
-   line-height: 1.5em;
+    position: absolute;
+    top: 27px;
+    min-width: 100px;
+    max-width: 200px;
+    padding: 1px 5px;
+    background: @red;
+    color: @white;
+    font-size: 11px;
+    line-height: 1.5em;
 }
 
 .umb-validation-label:after {
-   bottom: 100%;
-   left: 10px;
-   border: solid transparent;
-   content: " ";
-   height: 0;
-   width: 0;
-   position: absolute;
-   pointer-events: none;
-   border-color: rgba(255, 255, 255, 0);
-   border-bottom-color: @red;
-   border-width: 4px;
-   margin-left: -4px;
+    bottom: 100%;
+    left: 10px;
+    border: solid transparent;
+    content: " ";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+    border-color: rgba(255, 255, 255, 0);
+    border-bottom-color: @red;
+    border-width: 4px;
+    margin-left: -4px;
+}
+
+.umb-validation-label.-left {
+    left: 0;
+    right: auto;
+
+    &:after {
+        left: 10px;
+        right: auto;
+    }
+}
+
+.umb-validation-label.-right {
+    right: 0;
+    left: auto;
+    
+    &:after {
+        right: 10px;
+        left: auto;
+    }
 }
 
 .umb-validation-label.-arrow-left {
-   margin-left: 10px;
+    margin-left: 10px;
 }
 
 .umb-validation-label.-arrow-left:after {
-   right: 100%;
-	top: 50%;
-   left: auto;
-   bottom: auto;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
-	border-color: rgba(255, 255, 255, 0);
-	border-right-color: @red;
-	border-width: 4px;
-	margin-top: -4px;
+    right: 100%;
+    top: 50%;
+    left: auto;
+    bottom: auto;
+    border: solid transparent;
+    content: " ";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+    border-color: rgba(255, 255, 255, 0);
+    border-right-color: @red;
+    border-width: 4px;
+    margin-top: -4px;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -373,10 +373,6 @@
    margin-bottom: 0;
 }
 
-.umb-panel-header-alias .umb-validation-label:after {
-   visibility: hidden;
-}
-
 .umb-panel-header-alias .umb-locked-field:after {
    display: none;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -45,6 +45,7 @@
                                         alias="$parent.alias"
                                         alias-from="$parent.name"
                                         enable-lock="true"
+                                        validation-position="'right'"
                                         server-validation-field="Alias">
                     </umb-generate-alias>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-generate-alias.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-generate-alias.html
@@ -5,8 +5,8 @@
       locked="locked"
       ng-model="alias"
       placeholder-text="placeholderText"
+      validation-position="validationPosition"
       server-validation-field="{{serverValidationField}}">
     </umb-locked-field>
     </div>
 </div>
- 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-locked-field.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-locked-field.html
@@ -29,9 +29,22 @@
     </div>
 
     <div ng-messages="lockedFieldForm.lockedField.$error" show-validation-on-submit>
-        <div class="umb-validation-label" ng-message="required"><localize key="general_required">Required</localize> <localize key="content_alias">alias</localize></div>
-        <div ng-if="regexValidation.length > 0" class="umb-validation-label" ng-message="valRegex"><localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize></div>
-        <div ng-if="serverValidationField.length > 0" class="umb-validation-label" ng-message="valServerField">{{lockedFieldForm.lockedField.errorMsg}}</div>
+        <div class="umb-validation-label"
+             ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+             ng-message="required">
+            <localize key="general_required">Required</localize> <localize key="content_alias">alias</localize>
+        </div>
+        <div class="umb-validation-label"
+             ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+             ng-if="regexValidation.length > 0"
+             ng-message="valRegex">
+            <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
+        </div>
+        <div class="umb-validation-label"
+             ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+             ng-if="serverValidationField.length > 0"
+             ng-message="valServerField">{{lockedFieldForm.lockedField.errorMsg}}
+        </div>
     </div>
 
 </ng-form>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4031

### Description
This PR fixes issues with validation error label at e.g. doctype alias. I could change it specific for the header via css, but I think it would be great to have a property to control the position since these are also used at properties on maybe Umbraco Forms re-use this styling too for the validation error label.

![image](https://user-images.githubusercontent.com/2919859/51216700-9113f780-1925-11e9-89e9-5d37ce4b9bf3.png)
