### PR TITLE
V8: Fix start node configuration for tree pickers

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ContentPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/ContentPickerConfiguration.cs
@@ -8,6 +8,6 @@ namespace Umbraco.Web.PropertyEditors
         public bool ShowOpenButton { get; set; }
 
         [ConfigurationField("startNodeId", "Start node", "treepicker")] // + config in configuration editor ctor
-        public int StartNodeId { get; set; } = -1; // default value is -1
+        public string StartNodeId { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ContentPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/ContentPickerConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.PropertyEditors;
+﻿using Umbraco.Core;
+using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -8,6 +9,6 @@ namespace Umbraco.Web.PropertyEditors
         public bool ShowOpenButton { get; set; }
 
         [ConfigurationField("startNodeId", "Start node", "treepicker")] // + config in configuration editor ctor
-        public string StartNodeId { get; set; }
+        public Udi StartNodeId { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MediaPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPickerConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.PropertyEditors;
+﻿using Umbraco.Core;
+using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -17,6 +18,6 @@ namespace Umbraco.Web.PropertyEditors
         public bool DisableFolderSelect { get; set; }
 
         [ConfigurationField("startNodeId", "Start node", "mediapicker")]
-        public string StartNodeId { get; set; }
+        public Udi StartNodeId { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MediaPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPickerConfiguration.cs
@@ -17,6 +17,6 @@ namespace Umbraco.Web.PropertyEditors
         public bool DisableFolderSelect { get; set; }
 
         [ConfigurationField("startNodeId", "Start node", "mediapicker")]
-        public int StartNodeId { get; set; }
+        public string StartNodeId { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfigurationTreeSource.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfigurationTreeSource.cs
@@ -15,6 +15,6 @@ namespace Umbraco.Web.PropertyEditors
         public string StartNodeQuery {get;set;}
 
         [JsonProperty("id")]
-        public int? StartNodeId {get;set;}
+        public string StartNodeId {get;set;}
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfigurationTreeSource.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfigurationTreeSource.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Umbraco.Core;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -15,6 +16,6 @@ namespace Umbraco.Web.PropertyEditors
         public string StartNodeQuery {get;set;}
 
         [JsonProperty("id")]
-        public string StartNodeId {get;set;}
+        public Udi StartNodeId {get;set;}
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4066

### Description

You can't set a start node on the tree pickers (content picker, media picker, multinode picker). The server throws a YSOD at you when you try:

![picker-configuration-before](https://user-images.githubusercontent.com/7405322/51236447-761ba480-1972-11e9-8e8d-3dc4e40d5301.gif)

It's a result of "GUIDs everywhere" - the start node is no longer an ID but a UID. This PR updates the picker configurations accordingly:

![picker-configuration-after](https://user-images.githubusercontent.com/7405322/51236524-a5caac80-1972-11e9-8352-5c9a2f92e2a9.gif)

I have also verified that the start node configurations actually work when editing content 😄 