### PR TITLE
Temp8 npm scripts

### DIFF
--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "scripts": {
     "test": "karma start test/config/karma.conf.js --singlerun",
-    "build": "gulp"
+    "build": "gulp build",
+    "dev": "gulp dev"
   },
   "dependencies": {
     "ace-builds": "1.4.2",


### PR DESCRIPTION
Enables you to run a local version of gulp through nodeJS.

Meaning now you can run build, with "npm run build", and run dev with "npm run dev"