### PR TITLE
V8: Nested Content should only allow element types

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
@@ -31,6 +31,8 @@ namespace Umbraco.Core.Models.PublishedContent
 
             _propertyTypes = propertyTypes.ToArray();
 
+            IsElement = contentType.IsElement;
+
             InitializeIndexes();
         }
 
@@ -165,6 +167,11 @@ namespace Umbraco.Core.Models.PublishedContent
         {
             return index >= 0 && index < _propertyTypes.Length ? _propertyTypes[index] : null;
         }
+
+        /// <summary>
+        /// Gets a value indicating whether this content type is for an element.
+        /// </summary>
+        public bool IsElement { get; }
 
         #endregion
     }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -285,27 +285,30 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
         $scope.scaffolds = [];
         _.each($scope.model.config.contentTypes, function (contentType) {
             contentResource.getScaffold(-20, contentType.ncAlias).then(function (scaffold) {
-                // remove all tabs except the specified tab
-                var tabs = scaffold.variants[0].tabs;
-                var tab = _.find(tabs, function (tab) {
-                    return tab.id != 0 && (tab.alias.toLowerCase() == contentType.ncTabAlias.toLowerCase() || contentType.ncTabAlias == "");
-                });
-                scaffold.tabs = [];
-                if (tab) {
-                    scaffold.tabs.push(tab);
+                // make sure it's an element type before allowing the user to create new ones
+                if (scaffold.isElement) {
+                    // remove all tabs except the specified tab
+                    var tabs = scaffold.variants[0].tabs;
+                    var tab = _.find(tabs, function (tab) {
+                        return tab.id != 0 && (tab.alias.toLowerCase() == contentType.ncTabAlias.toLowerCase() || contentType.ncTabAlias == "");
+                    });
+                    scaffold.tabs = [];
+                    if (tab) {
+                        scaffold.tabs.push(tab);
 
-                    angular.forEach(tab.properties,
-                      function (property) {
-                          if (_.find(notSupported, function (x) { return x === property.editor; })) {
-                              property.notSupported = true;
-                              //TODO: Not supported message to be replaced with 'content_nestedContentEditorNotSupported' dictionary key. Currently not possible due to async/timing quirk.
-                              property.notSupportedMessage = "Property " + property.label + " uses editor " + property.editor + " which is not supported by Nested Content.";
-                          }
-                      });
+                        angular.forEach(tab.properties,
+                            function (property) {
+                                if (_.find(notSupported, function (x) { return x === property.editor; })) {
+                                    property.notSupported = true;
+                                    //TODO: Not supported message to be replaced with 'content_nestedContentEditorNotSupported' dictionary key. Currently not possible due to async/timing quirk.
+                                    property.notSupportedMessage = "Property " + property.label + " uses editor " + property.editor + " which is not supported by Nested Content.";
+                                }
+                            });
+                    }
+
+                    // Store the scaffold object
+                    $scope.scaffolds.push(scaffold);
                 }
-
-                // Store the scaffold object
-                $scope.scaffolds.push(scaffold);
 
                 scaffoldsLoaded++;
                 initIfAllScaffoldsHaveLoaded();

--- a/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class NestedContentConfiguration
     {
-        [ConfigurationField("contentTypes", "Document types", "views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html", Description = "Select the documebt types to use as the item blueprints. Only \"element\" types can be used.")]
+        [ConfigurationField("contentTypes", "Document types", "views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html", Description = "Select the document types to use as the item blueprints. Only \"element\" types can be used.")]
         public ContentType[] ContentTypes { get; set; }
 
         [ConfigurationField("minItems", "Min Items", "number", Description = "Set the minimum number of items allowed.")]

--- a/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class NestedContentConfiguration
     {
-        [ConfigurationField("contentTypes", "Doc Types", "views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html", Description = "Select the doc types to use as the data blueprint.")]
+        [ConfigurationField("contentTypes", "Document types", "views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html", Description = "Select the documebt types to use as the item blueprints. Only \"element\" types can be used.")]
         public ContentType[] ContentTypes { get; set; }
 
         [ConfigurationField("minItems", "Min Items", "number", Description = "Set the minimum number of items allowed.")]

--- a/src/Umbraco.Web/PropertyEditors/NestedContentController.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentController.cs
@@ -12,6 +12,7 @@ namespace Umbraco.Web.PropertyEditors
         public IEnumerable<object> GetContentTypes()
         {
             return Services.ContentTypeService.GetAll()
+                .Where(x => x.IsElement)
                 .OrderBy(x => x.SortOrder)
                 .Select(x => new
                 {

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentValueConverterBase.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentValueConverterBase.cs
@@ -45,8 +45,9 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             if (string.IsNullOrEmpty(elementTypeAlias))
                 return null;
 
+            // only convert element types - content types will cause an exception when PublishedModelFactory creates the model
             var publishedContentType = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetContentType(elementTypeAlias);
-            if (publishedContentType == null)
+            if (publishedContentType == null || publishedContentType.IsElement == false)
                 return null;
 
             var propertyValues = sourceObject.ToObject<Dictionary<string, object>>();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4038#issuecomment-454375969

### Description

#4076 introduces an explicit ability to define a doctype as an element type, among other things because Nested Content breaks when it's used with non-element types.

![image](https://user-images.githubusercontent.com/7405322/51248338-1502c980-1990-11e9-9c7f-622a3ae75635.png)

This PR handles different aspects of elements usage within Nested Content.

#### Only allow element types as selectable

You can no longer choose non-element types as item blueprints. The doctypes property description has also been updated to reflect this:

![image](https://user-images.githubusercontent.com/7405322/51248911-e7b71b00-1991-11e9-98ba-2623030fa58c.png)

#### Handle changed types

If an already selected doctype changes from element to non-element type, this PR ensures that:

1. The doctype is removed from the Nested Content editor, similar to if the doctype was removed from the configuration.
2. The Nested Content property value converter skips items of that doctype when rendering in frontend.
