### PR TITLE
V8: Show the media link in the info app

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
@@ -5,16 +5,16 @@
             <umb-box-content class="block-form">
 
                 <umb-empty-state
-                    ng-if="!nodeUrl || !nodeUrl.isUrl"
+                    ng-if="!nodeUrl"
                     size="small">
                     <localize key="content_noMediaLink"></localize>
                 </umb-empty-state>
 
-                <ul ng-if="nodeUrl && nodeUrl.isUrl" class="nav nav-stacked" style="margin-bottom: 0;">
+                <ul ng-if="nodeUrl" class="nav nav-stacked" style="margin-bottom: 0;">
                     <li>
-                        <a href="{{nodeUrl.text}}" target="_blank">
-                            <i class="icon icon-window-popin"></i>
-                            <span>{{nodeUrl.text}}</span>
+                        <a href="{{nodeUrl}}" target="_blank">
+                            <i class="icon icon-out"></i>
+                            <span>{{nodeUrl}}</span>
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4072 and https://github.com/umbraco/Umbraco-CMS/issues/4099

### Description

This PR adds the media link to the info app as reported missing in both #4072 and #4099:

![image](https://user-images.githubusercontent.com/7405322/51279845-78b3e380-19de-11e9-81a2-ff6c8331d64c.png)

Given the very long link due to all the GUIDs in the path, it's pretty clear that at some point this will have to be revisited styling wise. But at least now the link shows (and it's not entirely terrible to look at).
