### PR TITLE
V8: Style the content links in the info app

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -7,15 +7,11 @@
             <umb-box-content class="block-form">
                 <ul class="nav nav-stacked" style="margin-bottom: 0;">
                     <li ng-repeat="url in currentUrls">
-                        <span ng-if="url.isUrl">
-
+                        <a href="{{url.text}}" target="_blank" ng-if="url.isUrl">
                             <span ng-if="node.variants.length === 1 && url.culture" style="font-size: 13px; color: #cccccc; width: 50px;display: inline-block">{{url.culture}}</span>
-                            <a href="{{url.text}}" target="_blank">
-                                <i class="icon icon-window-popin"></i>
-                                <span>{{url.text}}</span>
-                            </a>
-
-                        </span>
+                            <i class="icon icon-out"></i>
+                            <span>{{url.text}}</span>
+                        </a>
                         <div ng-if="!url.isUrl" style="margin-top: 4px;">
 
                             <span ng-if="node.variants.length === 1 && url.culture" style="font-size: 13px; color: #cccccc; width: 50px;display: inline-block">{{url.culture}}</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

According to the view, the links in the content info app are supposed use the `nav nav-stacked` style, which basically adds a gray hover background to the links in the list. However, due to the CSS being tied to very specific markup structure, the current markup doesn't produce the desired effect:

![content-links-before](https://user-images.githubusercontent.com/7405322/51280482-05ab6c80-19e0-11e9-9c7f-c91f6a6d68ee.gif)

Also... the icon for "opens in a new tab" is really weird. It's a "pop-in" icon, not a "pop-out".

With this PR applied, the content links behave something like this (which is also how the media link behaves, at least once it shows - see #4105):

![content-links-after](https://user-images.githubusercontent.com/7405322/51280581-4efbbc00-19e0-11e9-87f7-5194ce378ca9.gif)
