### PR TITLE
v8: Nicer delete language confirm

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/html/umb-alert.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/html/umb-alert.less
@@ -9,3 +9,13 @@
     background-color: @turquoise-washed;
     border: 1px solid @turquoise;
 }
+
+.umb-alert--warning {
+    background-color: @yellow-washed;
+    border: 1px solid @yellow;
+}
+
+.umb-alert--danger {
+    background-color: @red-washed;
+    border: 1px solid @red;
+}

--- a/src/Umbraco.Web.UI.Client/src/less/utilities/_spacing.less
+++ b/src/Umbraco.Web.UI.Client/src/less/utilities/_spacing.less
@@ -1,7 +1,5 @@
 /*
-
     Spacing
-
 */
 
 @spacing-none: 0;
@@ -37,12 +35,10 @@
    7 = 7th step in spacing scale
 */
 
-
 .m-center {
     margin-left: auto;
     margin-right: auto;
 }
-
 
 .mt0 { margin-top: @spacing-none; }
 .mt1 { margin-top: @spacing-extra-small; }
@@ -52,3 +48,12 @@
 .mt5 { margin-top: @spacing-extra-large; }
 .mt6 { margin-top: @spacing-extra-extra-large; }
 .mt7 { margin-top: @spacing-extra-extra-extra-large; }
+
+.mb0 { margin-bottom: @spacing-none; }
+.mb1 { margin-bottom: @spacing-extra-small; }
+.mb2 { margin-bottom: @spacing-small; }
+.mb3 { margin-bottom: @spacing-medium; }
+.mb4 { margin-bottom: @spacing-large; }
+.mb5 { margin-bottom: @spacing-extra-large; }
+.mb6 { margin-bottom: @spacing-extra-extra-large; }
+.mb7 { margin-bottom: @spacing-extra-extra-extra-large; }

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
@@ -1,6 +1,6 @@
 <div>
 
-    <div ng-if="model.language" class="umb-alert umb-alert--info" style="margin-bottom: 10px;">
+    <div ng-if="model.language" class="umb-alert umb-alert--warning" style="margin-bottom: 10px;">
         This will delete language <strong>{{model.language.name}} [{{model.language.culture}}]</strong>.
     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
@@ -1,7 +1,7 @@
 <div>
 
     <div ng-if="model.language" class="umb-alert umb-alert--warning mb2">
-        This will delete language <strong>{{model.language.name}} [{{model.language.culture}}]</strong>.
+        <localize key="defaultdialogs_languagedeletewarning">This will delete the language</localize> <strong>{{model.language.name}} [{{model.language.culture}}]</strong>.
     </div>
 
     <localize key="defaultdialogs_confirmdelete"></localize>?

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
@@ -1,6 +1,6 @@
 <div>
 
-    <div ng-if="model.language" class="umb-alert umb-alert--warning" style="margin-bottom: 10px;">
+    <div ng-if="model.language" class="umb-alert umb-alert--warning mb2">
         This will delete language <strong>{{model.language.name}} [{{model.language.culture}}]</strong>.
     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
@@ -1,0 +1,9 @@
+<div>
+
+    <div ng-if="model.language" class="umb-alert umb-alert--info" style="margin-bottom: 10px;">
+        This will delete language <strong>{{model.language.name}} [{{model.language.culture}}]</strong>.
+    </div>
+
+    <localize key="defaultdialogs_confirmdelete"></localize>?
+
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
@@ -2,31 +2,29 @@
 
     <umb-editor-view footer="false">
 
-        <umb-editor-header
-            name="vm.page.name"
-            name-locked="true"
-            hide-icon="true"
-            hide-description="true"
-            hide-alias="true">
+        <umb-editor-header name="vm.page.name"
+                           name-locked="true"
+                           hide-icon="true"
+                           hide-description="true"
+                           hide-alias="true">
         </umb-editor-header>
 
         <umb-editor-container>
-            
+
             <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
             <umb-editor-sub-header>
 
                 <umb-editor-sub-header-content-left>
-                    <umb-button
-                        button-style="success"
-                        type="button" 
-                        action="vm.addLanguage()"
-                        label-key="languages_addLanguage">
+                    <umb-button button-style="success"
+                                type="button"
+                                action="vm.addLanguage()"
+                                label-key="languages_addLanguage">
                     </umb-button>
                 </umb-editor-sub-header-content-left>
 
             </umb-editor-sub-header>
-            
+
             <table class="table table-hover" ng-if="!vm.loading">
                 <thead>
                     <tr>
@@ -47,32 +45,29 @@
                             <span>{{ language.culture }}</span>
                         </td>
                         <td>
-                            <umb-checkmark
-                                ng-if="language.isDefault"
-                                checked="language.isDefault"
-                                size="xs">
+                            <umb-checkmark ng-if="language.isDefault"
+                                           checked="language.isDefault"
+                                           size="xs">
                             </umb-checkmark>
                         </td>
                         <td>
-                            <umb-checkmark
-                                ng-if="language.isMandatory"
-                                checked="language.isMandatory"
-                                size="xs">
+                            <umb-checkmark ng-if="language.isMandatory"
+                                           checked="language.isMandatory"
+                                           size="xs">
                             </umb-checkmark>
                         </td>
                         <td>
                             <span ng-if="language.fallbackLanguageId">{{vm.getLanguageById(language.fallbackLanguageId).name}}</span>
                             <span ng-if="!language.fallbackLanguageId">(none)</span>
                         </td>
-                        <td style="text-align: right;">
-                            <umb-button
-                                ng-if="!language.isDefault"
-                                type="button"
-                                size="xxs"
-                                button-style="danger"
-                                state="language.deleteButtonState"
-                                action="vm.deleteLanguage(language, $event)"
-                                label-key="general_delete">
+                        <td class="tr">
+                            <umb-button ng-if="!language.isDefault"
+                                        type="button"
+                                        size="xxs"
+                                        button-style="danger"
+                                        state="language.deleteButtonState"
+                                        action="vm.deleteLanguage(language, $event)"
+                                        label-key="general_delete">
                             </umb-button>
                         </td>
                     </tr>

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
@@ -28,10 +28,10 @@
             <table class="table table-hover" ng-if="!vm.loading">
                 <thead>
                     <tr>
-                        <th>Language</th>
+                        <th><localize key="general_language">Language</localize></th>
                         <th>ISO</th>
-                        <th>Default</th>
-                        <th>Mandatory</th>
+                        <th><localize key="general_default">Default</localize></th>
+                        <th><localize key="general_mandatory">Mandatory</localize></th>
                         <th>Fallback</th>
                     </tr>
                 </thead>

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
@@ -60,7 +60,7 @@
                             <span ng-if="language.fallbackLanguageId">{{vm.getLanguageById(language.fallbackLanguageId).name}}</span>
                             <span ng-if="!language.fallbackLanguageId">(none)</span>
                         </td>
-                        <td class="tr">
+                        <td style="text-align: right;">
                             <umb-button ng-if="!language.isDefault"
                                         type="button"
                                         size="xxs"

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
@@ -36,7 +36,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="language in vm.languages" ng-click="vm.editLanguage(language)" style="cursor: pointer;">
+                    <tr ng-repeat="language in vm.languages track by language.id" ng-click="vm.editLanguage(language)" style="cursor: pointer;">
                         <td>
                             <i class="icon-globe" style="color: #BBBABF; margin-right: 5px;"></i>
                             <span ng-class="{'bold': language.isDefault}">{{ language.name }}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/delete.html
@@ -1,6 +1,6 @@
 <div>
     
-    <div ng-if="model.deletesVariants" class="umb-alert umb-alert--info" style="margin-bottom: 10px;">
+    <div ng-if="model.deletesVariants" class="umb-alert umb-alert--warning mb2">
         <localize key="defaultdialogs_variantdeletewarning">
             This will delete the node and all its languages. If you only want to delete one language go and unpublish it instead.
         </localize>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewpublish.html
@@ -27,7 +27,7 @@
                                 ng-change="vm.changeSelection(language)"
                                 style="margin-right: 8px;" />
                             <div>
-                                <label for="{{language.culture}}" class="mb1">
+                                <label for="{{language.culture}}" style="margin-bottom: 2px;">
                                     <span ng-class="{'bold': language.isDefault}">{{ language.name }}</span>
                                 </label>
     

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewpublish.html
@@ -16,7 +16,7 @@
     
             <div class="umb-list umb-list--condensed" ng-if="!vm.loading">
     
-                <div class="umb-list-item" ng-repeat="language in vm.languages track by language.culture">
+                <div class="umb-list-item" ng-repeat="language in vm.languages track by language.id">
                     <ng-form name="publishLanguageSelectorForm">
                         <div class="flex">
                             <input

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewpublish.html
@@ -6,7 +6,7 @@
     
         <div ng-if="vm.languages.length > 1">
     
-            <div style="margin-bottom: 15px;">
+            <div class="mb3">
                 <p><localize key="content_languagesToPublish"></localize></p>
             </div>
     
@@ -27,7 +27,7 @@
                                 ng-change="vm.changeSelection(language)"
                                 style="margin-right: 8px;" />
                             <div>
-                                <label for="{{language.culture}}" style="margin-bottom: 2px;">
+                                <label for="{{language.culture}}" class="mb1">
                                     <span ng-class="{'bold': language.isDefault}">{{ language.name }}</span>
                                 </label>
     
@@ -45,4 +45,3 @@
         </div>
     
     </div>
-    

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.html
@@ -14,7 +14,7 @@
                 
             <div class="umb-list umb-list--condensed">
         
-                <div class="umb-list-item" ng-repeat="language in vm.languages">
+                <div class="umb-list-item" ng-repeat="language in vm.languages track by language.id">
                     <ng-form name="unpublishLanguageSelectorForm">
                         <div class="flex">
                             <input id="{{language.culture}}"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.html
@@ -8,7 +8,7 @@
         <!-- Multiple languages -->
         <div ng-if="vm.languages.length > 0">
 
-            <div style="margin-bottom: 15px;">
+            <div class="mb3">
                 <p><localize key="content_languagesToUnpublish"></localize></p>
             </div>
                 
@@ -44,4 +44,3 @@
         </div>
         
     </div>
-    

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -354,6 +354,7 @@
     <key alias="insertlink">Indsæt link</key>
     <key alias="insertMacro">Indsæt makro</key>
     <key alias="inserttable">Indsæt tabel</key>
+    <key alias="languagedeletewarning">Dette vil slette sproget</key>
     <key alias="lastEdited">Sidst redigeret</key>
     <key alias="link">Link</key>
     <key alias="linkinternal">Internt link:</key>
@@ -409,6 +410,7 @@
     <key alias="account">konto</key>
     <key alias="selectEditor">Vælg editor</key>
     <key alias="selectSnippet">Vælg snippet</key>
+    <key alias="variantdeletewarning">Dette vil slette noden og alle dets sprog. Hvis du kun vil slette et sprog, så afpublicér det i stedet.</key>
   </area>
   <area alias="dictionaryItem">
     <key alias="description"><![CDATA[
@@ -1225,6 +1227,18 @@ Mange hilsner fra Umbraco robotten
     <key alias="memberCanEdit">Medlem kan redigere</key>
     <key alias="showOnMemberProfile">Vis på medlemsprofil</key>
     <key alias="tabHasNoSortOrder">fane har ingen sorteringsrækkefølge</key>
+  </area>
+  <area alias="languages">
+      <key alias="addLanguage">Tilføj sprog</key>
+      <key alias="mandatoryLanguage">Påkrævet sprog</key>
+      <key alias="mandatoryLanguageHelp">Egenskaber på dette sprog skal være udfyldt før noden kan blive udgivet.</key>
+      <key alias="defaultLanguage">Standard sprog</key>
+      <key alias="defaultLanguageHelp">Et Umbraco site kan kun have et standard sprog.</key>
+      <key alias="changingDefaultLanguageWarning">Ved at skifte standardsprog kan resultere i standard indhold mangler.</key>
+      <key alias="fallsbackToLabel">Fallsback til</key>
+      <key alias="noFallbackLanguageOption">Ingen fallback sprog</key>
+      <key alias="fallbackLanguageDescription">For at tillade flersproget indhold til at falde tilbage på et andet sprog, hvis det ikke er tilgængelig i det anmodet sprog, vælg det her.</key>
+      <key alias="fallbackLanguage">Fallback sprog</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternativt felt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -371,6 +371,7 @@
     <key alias="insertlink">Insert link</key>
     <key alias="insertMacro">Click to add a Macro</key>
     <key alias="inserttable">Insert table</key>
+    <key alias="languagedeletewarning">This will delete the language</key>
     <key alias="lastEdited">Last Edited</key>
     <key alias="link">Link</key>
     <key alias="linkinternal">Internal link:</key>
@@ -433,6 +434,7 @@
     <key alias="account">account</key>
     <key alias="selectEditor">Select editor</key>
     <key alias="selectSnippet">Select snippet</key>
+    <key alias="variantdeletewarning">This will delete the node and all its languages. If you only want to delete one language go and unpublish it instead.</key>
   </area>
   <area alias="dictionaryItem">
     <key alias="description"><![CDATA[
@@ -580,7 +582,7 @@
     <key alias="hide">Hide</key>
     <key alias="history">History</key>
     <key alias="icon">Icon</key>
-        <key alias="id">Id</key>
+    <key alias="id">Id</key>
     <key alias="import">Import</key>
     <key alias="info">Info</key>
     <key alias="innerMargin">Inner margin</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -399,6 +399,7 @@
     <key alias="insertlink">Insert link</key>
     <key alias="insertMacro">Click to add a Macro</key>
     <key alias="inserttable">Insert table</key>
+    <key alias="languagedeletewarning">This will delete the language</key>
     <key alias="lastEdited">Last Edited</key>
     <key alias="link">Link</key>
     <key alias="linkinternal">Internal link:</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/3968

### Description
This PR add a nicer delete confirm dialog instead of the traditional javascript confirm and is therefore more consistent with the rest of the new confirm modal/overlay added in v8, e.g. with listview delete, publish, etc.

![image](https://user-images.githubusercontent.com/2919859/51286927-790ba900-19f5-11e9-8cc1-817512dfa14c.png)
