### PR TITLE
Added (Doctype) Name and Description to PublishedContentType

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
@@ -25,6 +25,8 @@ namespace Umbraco.Core.Models.PublishedContent
         {
             Id = contentType.Id;
             Alias = contentType.Alias;
+            Name = contentType.Name;
+            Description = contentType.Description;
             _compositionAliases = new HashSet<string>(contentType.CompositionAliases(), StringComparer.InvariantCultureIgnoreCase);
             _propertyTypes = contentType.CompositionPropertyTypes
                 .Select(x => new PublishedPropertyType(this, x))
@@ -33,10 +35,12 @@ namespace Umbraco.Core.Models.PublishedContent
         }
 
         // internal so it can be used for unit tests
-        internal PublishedContentType(int id, string alias, IEnumerable<string> compositionAliases, IEnumerable<PublishedPropertyType> propertyTypes)
+        internal PublishedContentType(int id, string alias, string name, string description, IEnumerable<string> compositionAliases, IEnumerable<PublishedPropertyType> propertyTypes)
         {
             Id = id;
             Alias = alias;
+            Name = name;
+            Description = description;
             _compositionAliases = new HashSet<string>(compositionAliases, StringComparer.InvariantCultureIgnoreCase);
             _propertyTypes = propertyTypes.ToArray();
             foreach (var propertyType in _propertyTypes)
@@ -46,7 +50,7 @@ namespace Umbraco.Core.Models.PublishedContent
 
         // create detached content type - ie does not match anything in the DB
         internal PublishedContentType(string alias, IEnumerable<string> compositionAliases, IEnumerable<PublishedPropertyType> propertyTypes)
-            : this(0, alias, compositionAliases, propertyTypes)
+            : this(0, alias, string.Empty, string.Empty, compositionAliases, propertyTypes)
         { }
 
         private void InitializeIndexes()
@@ -63,6 +67,8 @@ namespace Umbraco.Core.Models.PublishedContent
 
         public int Id { get; private set; }
         public string Alias { get; private set; }
+        public string Name { get; private set; }
+        public string Description { get; private set; }
         public HashSet<string> CompositionAliases { get { return _compositionAliases; } }
 
         #endregion

--- a/src/Umbraco.Tests/CodeFirst/StronglyTypedMapperTest.cs
+++ b/src/Umbraco.Tests/CodeFirst/StronglyTypedMapperTest.cs
@@ -83,7 +83,7 @@ namespace Umbraco.Tests.CodeFirst
                     new PublishedPropertyType("articleDate", 0, "?"), 
                     new PublishedPropertyType("pageTitle", 0, "?"), 
                 };
-            var type = new AutoPublishedContentType(0, "anything", propertyTypes);
+            var type = new AutoPublishedContentType(0, "anything", "anything", "anything", propertyTypes);
             PublishedContentType.GetPublishedContentTypeCallback = (alias) => type;
             Debug.Print("INIT STRONG {0}",
                 PublishedContentType.Get(PublishedItemType.Content, "anything")

--- a/src/Umbraco.Tests/LibraryTests.cs
+++ b/src/Umbraco.Tests/LibraryTests.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Tests
                     // AutoPublishedContentType will auto-generate other properties
                     new PublishedPropertyType("content", 0, "?"), 
                 };
-            var type = new AutoPublishedContentType(0, "anything", propertyTypes);
+            var type = new AutoPublishedContentType(0, "anything", "anything", "anything", propertyTypes);
             PublishedContentType.GetPublishedContentTypeCallback = (alias) => type;
             Debug.Print("INIT LIB {0}",
                 PublishedContentType.Get(PublishedItemType.Content, "anything")

--- a/src/Umbraco.Tests/Membership/DynamicMemberContentTests.cs
+++ b/src/Umbraco.Tests/Membership/DynamicMemberContentTests.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Tests.Membership
                     new PublishedPropertyType("bodyText", 0, "?"), 
                     new PublishedPropertyType("author", 0, "?")
                 };
-            var type = new AutoPublishedContentType(0, "anything", propertyTypes);
+            var type = new AutoPublishedContentType(0, "anything", "anything", "anything", propertyTypes);
             PublishedContentType.GetPublishedContentTypeCallback = (alias) => type;
 
         }

--- a/src/Umbraco.Tests/PublishedContent/DynamicDocumentTestsBase.cs
+++ b/src/Umbraco.Tests/PublishedContent/DynamicDocumentTestsBase.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Tests.PublishedContent
                     new PublishedPropertyType("creatorName", 0, "?"), 
                     new PublishedPropertyType("blah", 0, "?"), // ugly error when that one is missing...
                 };
-            var type = new AutoPublishedContentType(0, "anything", propertyTypes);
+            var type = new AutoPublishedContentType(0, "anything", "anything", "anything", propertyTypes);
             PublishedContentType.GetPublishedContentTypeCallback = (alias) => type;
 
         }

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentDataTableTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentDataTableTests.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Tests.PublishedContent
 
             // need to specify a custom callback for unit tests
             // AutoPublishedContentTypes generates properties automatically
-            var type = new AutoPublishedContentType(0, "anything", new PublishedPropertyType[] {});
+            var type = new AutoPublishedContentType(0, "anything", "anything", "anything", new PublishedPropertyType[] {});
             PublishedContentType.GetPublishedContentTypeCallback = (alias) => type;
 
             // need to specify a different callback for testing

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentMoreTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentMoreTests.cs
@@ -234,9 +234,9 @@ namespace Umbraco.Tests.PublishedContent
                         new PublishedPropertyType("prop1", 1, "?"), 
                     };
 
-            var contentType1 = new PublishedContentType(1, "ContentType1", Enumerable.Empty<string>(), props);
-            var contentType2 = new PublishedContentType(2, "ContentType2", Enumerable.Empty<string>(), props);
-            var contentType2s = new PublishedContentType(3, "ContentType2Sub", Enumerable.Empty<string>(), props);
+            var contentType1 = new PublishedContentType(1, "ContentType1", "ContentType1", "ContentType1", Enumerable.Empty<string>(), props);
+            var contentType2 = new PublishedContentType(2, "ContentType2", "ContentType2", "ContentType2", Enumerable.Empty<string>(), props);
+            var contentType2s = new PublishedContentType(3, "ContentType2Sub", "ContentType2Sub", "ContentType2Sub", Enumerable.Empty<string>(), props);
 
             cache.Add(new SolidPublishedContent(contentType1)
                 {

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTestBase.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTestBase.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Tests.PublishedContent
                     // AutoPublishedContentType will auto-generate other properties
                     new PublishedPropertyType("content", 0, Constants.PropertyEditors.TinyMCEAlias), 
                 };
-            var type = new AutoPublishedContentType(0, "anything", propertyTypes);
+            var type = new AutoPublishedContentType(0, "anything", "anything", "anything", propertyTypes);
             PublishedContentType.GetPublishedContentTypeCallback = (alias) => type;
 
             var rCtx = GetRoutingContext("/test", 1234);

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTestElements.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTestElements.cs
@@ -354,12 +354,12 @@ namespace Umbraco.Tests.PublishedContent
     {
         private static readonly PublishedPropertyType Default = new PublishedPropertyType("*", 0, "?");
 
-        public AutoPublishedContentType(int id, string alias, IEnumerable<PublishedPropertyType> propertyTypes)
-            : base(id, alias, Enumerable.Empty<string>(), propertyTypes)
+        public AutoPublishedContentType(int id, string alias, string name, string description, IEnumerable<PublishedPropertyType> propertyTypes)
+            : base(id, alias, name, description, Enumerable.Empty<string>(), propertyTypes)
         { }
 
-        public AutoPublishedContentType(int id, string alias, IEnumerable<string> compositionAliases, IEnumerable<PublishedPropertyType> propertyTypes)
-            : base(id, alias, compositionAliases, propertyTypes)
+        public AutoPublishedContentType(int id, string alias, string name, string description, IEnumerable<string> compositionAliases, IEnumerable<PublishedPropertyType> propertyTypes)
+            : base(id, alias, name, description, compositionAliases, propertyTypes)
         { }
 
         public override PublishedPropertyType GetPropertyType(string alias)

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -49,7 +49,7 @@ namespace Umbraco.Tests.PublishedContent
                     new PublishedPropertyType("testRecursive", 0, "?"),
                 };
             var compositionAliases = new[] { "MyCompositionAlias" };
-            var type = new AutoPublishedContentType(0, "anything", compositionAliases, propertyTypes);
+            var type = new AutoPublishedContentType(0, "anything", "anything", "anything", compositionAliases, propertyTypes);
             PublishedContentType.GetPublishedContentTypeCallback = (alias) => type;
         }
 

--- a/src/Umbraco.Tests/TestHelpers/BaseWebTest.cs
+++ b/src/Umbraco.Tests/TestHelpers/BaseWebTest.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Tests.TestHelpers
 
             // need to specify a custom callback for unit tests
             // AutoPublishedContentTypes generates properties automatically
-            var type = new AutoPublishedContentType(0, "anything", new PublishedPropertyType[] {});
+            var type = new AutoPublishedContentType(0, "anything", "anything", "anything", new PublishedPropertyType[] {});
             PublishedContentType.GetPublishedContentTypeCallback = (alias) => type;
         }
         

--- a/src/Umbraco.Tests/Views/site1/template2.cshtml
+++ b/src/Umbraco.Tests/Views/site1/template2.cshtml
@@ -1,0 +1,4 @@
+﻿@inherits Umbraco.Web.Mvc.UmbracoTemplatePage
+@{
+	Layout = null;
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Existing Tests have been updated to reflect the changes. All tests succeeded.

### Description

Using PublishedContentType.Get(ItemType, "alias") you can now access Name and Description of the DocType. As PublishedContentType is cached this is better than using ContentTypeService. Also Models Builder exposes the PublishedContentType and thus users of Models Builder will benefit from this.
