### PR TITLE
V8: Don't allow templates on element types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.controller.js
@@ -19,13 +19,13 @@
         vm.canCreateTemplate = false;
         vm.updateTemplatePlaceholder = false;
         vm.loadingTemplates = false;
+        vm.isElement = $scope.model.isElement;
 
         vm.createTemplate = createTemplate;
 
         /* ---------- INIT ---------- */
 
         function onInit() {
-
             vm.loadingTemplates = true;
             entityResource.getAll("Template").then(function (templates) {
 
@@ -85,6 +85,15 @@
 
             vm.canCreateTemplate = existingTemplate ? false : true;
         }
+
+        var unbindWatcher = $scope.$watch("model.isElement",
+            function(newValue, oldValue) {
+                vm.isElement = newValue;
+            }
+        );
+        $scope.$on("$destroy", function () {
+            unbindWatcher();
+        });
 
         onInit();
 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
@@ -1,5 +1,5 @@
 <div ng-controller="Umbraco.Editors.DocumentType.TemplatesController as vm">
-    <umb-box>
+    <umb-box ng-hide="vm.isElement">
         <umb-box-content>
             <div class="sub-view-columns">
 
@@ -9,29 +9,34 @@
                 </div>
                 
                 <div class="sub-view-column-right">
-        <umb-grid-selector
-            ng-if="vm.availableTemplates"
-            selected-items="model.allowedTemplates"
-            available-items="vm.availableTemplates"
-            default-item="model.defaultTemplate"
-            item-name="template"
-            name="model.name"
-            alias="model.alias"
-            update-placeholder="vm.updateTemplatePlaceholder">
-        </umb-grid-selector>
+                    <umb-grid-selector
+                        ng-if="vm.availableTemplates"
+                        selected-items="model.allowedTemplates"
+                        available-items="vm.availableTemplates"
+                        default-item="model.defaultTemplate"
+                        item-name="template"
+                        name="model.name"
+                        alias="model.alias"
+                        update-placeholder="vm.updateTemplatePlaceholder">
+                    </umb-grid-selector>
 
-        <umb-button
-            ng-if="vm.canCreateTemplate"
-            type="button"
-            button-style="info"
-            action="vm.createTemplate()"
-            state="vm.createTemplateButtonState"
-            label-key="settings_createMatchingTemplate">
-        </umb-button>
+                    <umb-button
+                        ng-if="vm.canCreateTemplate"
+                        type="button"
+                        button-style="info"
+                        action="vm.createTemplate()"
+                        state="vm.createTemplateButtonState"
+                        label-key="settings_createMatchingTemplate">
+                    </umb-button>
 
                 </div>
 
             </div>
         </umb-box-content>
     </umb-box>
+    <umb-empty-state
+        ng-show="vm.isElement"
+        position="center">
+        <localize key="contentTypeEditor_elementHasNoTemplates">An Element type can't have any templates</localize>
+    </umb-empty-state>
 </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1225,6 +1225,9 @@ Mange hilsner fra Umbraco robotten
     <key alias="memberCanEdit">Medlem kan redigere</key>
     <key alias="showOnMemberProfile">Vis på medlemsprofil</key>
     <key alias="tabHasNoSortOrder">fane har ingen sorteringsrækkefølge</key>
+    <key alias="elementHeading">Er en Element-type</key>
+    <key alias="elementDescription">En Element-type er tiltænkt brug i f.eks. Nested Content, ikke i indholdstræet</key>
+    <key alias="elementHasNoTemplates">En Element-type kan ikke have nogen skabeloner</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternativt felt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1520,6 +1520,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="allowVaryByCulture">Allow varying by culture</key>
     <key alias="elementHeading">Is an Element type</key>
     <key alias="elementDescription">An Element type is meant to be used for instance in Nested Content, and not in the tree</key>
+    <key alias="elementHasNoTemplates">An Element type can't have templates assigned</key>
   </area>
   <area alias="modelsBuilder">
     <key alias="buildingModels">Building models</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1561,6 +1561,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="allowVaryByCulture">Allow varying by culture</key>
     <key alias="elementHeading">Is an Element type</key>
     <key alias="elementDescription">An Element type is meant to be used for instance in Nested Content, and not in the tree</key>
+    <key alias="elementHasNoTemplates">An Element type can't have any templates</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -263,6 +263,15 @@ namespace Umbraco.Web.Editors
                 }
             }
 
+            //Before we send this model into this saving/mapping pipeline, we also need to do some cleanup on templates.
+            //If the doc type is an element type, it can't have any templates assigned, so we need to reset the allowed templates here.
+            if (contentTypeSave.IsElement)
+            {
+                contentTypeSave.AllowedTemplates = new string[] { };
+                contentTypeSave.DefaultTemplate = null;
+            }
+
+
             var savedCt = PerformPostSave<DocumentTypeDisplay, DocumentTypeSave, PropertyTypeBasic>(
                 contentTypeSave:    contentTypeSave,
                 getContentType:     i => Services.ContentTypeService.Get(i),


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4038#issuecomment-454375969

### Description

#4076 introduces an explicit ability to define a doctype as an element type. 

As Stephan mentions in the linked issue, element types can't be created in the tree and thus it makes no sense to assign templates to them.

This PR ensures that you can't assign templates to element types:

![element-templates-after](https://user-images.githubusercontent.com/7405322/51317359-aab55c00-1a57-11e9-9455-eda8cd3a18c8.gif)
