### PR TITLE
Temp8 fixing spelling in umbraco core issue 4125

### DIFF
--- a/src/Umbraco.Core/Attempt.cs
+++ b/src/Umbraco.Core/Attempt.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Core
     public static class Attempt
     {
         // note:
-        // cannot rely on overloads only to differenciate between with/without status
+        // cannot rely on overloads only to differentiate between with/without status
         // in some cases it will always be ambiguous, so be explicit w/ 'WithStatus' methods
 
         /// <summary>

--- a/src/Umbraco.Core/AttemptOfTResult.cs
+++ b/src/Umbraco.Core/AttemptOfTResult.cs
@@ -121,7 +121,7 @@ namespace Umbraco.Core
         }
 
         /// <summary>
-        /// Implicity operator to check if the attempt was successful without having to access the 'success' property
+        /// Implicitly operator to check if the attempt was successful without having to access the 'success' property
         /// </summary>
         /// <param name="a"></param>
         /// <returns></returns>

--- a/src/Umbraco.Core/AttemptOfTResultTStatus.cs
+++ b/src/Umbraco.Core/AttemptOfTResultTStatus.cs
@@ -130,7 +130,7 @@ namespace Umbraco.Core
         }
 
         /// <summary>
-        /// Implicity operator to check if the attempt was successful without having to access the 'success' property
+        /// Implicitly operator to check if the attempt was successful without having to access the 'success' property
         /// </summary>
         /// <param name="a"></param>
         /// <returns></returns>

--- a/src/Umbraco.Core/Cache/DictionaryCacheProviderBase.cs
+++ b/src/Umbraco.Core/Cache/DictionaryCacheProviderBase.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Core.Cache
         // an object that represent a value that has not been created yet
         protected internal static readonly object ValueNotCreated = new object();
 
-        // manupulate the underlying cache entries
+        // manipulate the underlying cache entries
         // these *must* be called from within the appropriate locks
         // and use the full prefixed cache keys
         protected abstract IEnumerable<DictionaryEntry> GetDictionaryEntries();

--- a/src/Umbraco.Core/Cache/DictionaryCacheProviderBase.cs
+++ b/src/Umbraco.Core/Cache/DictionaryCacheProviderBase.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Core.Cache
         protected internal static object GetSafeLazyValue(Lazy<object> lazy, bool onlyIfValueIsCreated = false)
         {
             // if onlyIfValueIsCreated, do not trigger value creation
-            // must return something, though, to differenciate from null values
+            // must return something, though, to differentiate from null values
             if (onlyIfValueIsCreated && lazy.IsValueCreated == false) return ValueNotCreated;
 
             // if execution has thrown then lazy.IsValueCreated is false

--- a/src/Umbraco.Core/Cache/HttpRequestCacheProvider.cs
+++ b/src/Umbraco.Core/Cache/HttpRequestCacheProvider.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Core.Cache
         // that is initialized with a method that returns the "current" context.
         // NOTE
         //   but then it is initialized with () => new HttpContextWrapper(HttpContent.Current)
-        //   which is higly inefficient because it creates a new wrapper each time we refer to _context()
+        //   which is highly inefficient because it creates a new wrapper each time we refer to _context()
         //   so replace it with _context1 and _context2 below + a way to get context.Items.
         //private readonly Func<HttpContextBase> _context;
 

--- a/src/Umbraco.Core/Cache/ICacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/ICacheRefresher.cs
@@ -4,7 +4,7 @@ using Umbraco.Core.Composing;
 namespace Umbraco.Core.Cache
 {
     /// <summary>
-    /// The IcacheRefresher Interface is used for loadbalancing.
+    /// The IcacheRefresher Interface is used for load balancing.
     ///
     /// </summary>
     public interface ICacheRefresher : IDiscoverable

--- a/src/Umbraco.Core/Cache/IRepositoryCachePolicy.cs
+++ b/src/Umbraco.Core/Cache/IRepositoryCachePolicy.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Core.Cache
         /// Updates an entity.
         /// </summary>
         /// <param name="entity">The entity.</param>
-        /// <param name="persistUpdated">The reopsitory PersistUpdatedItem method.</param>
+        /// <param name="persistUpdated">The repository PersistUpdatedItem method.</param>
         /// <remarks>Updates the entity in the repository, and updates the cache accordingly.</remarks>
         void Update(TEntity entity, Action<TEntity> persistUpdated);
 

--- a/src/Umbraco.Core/Components/CompositionExtensions.cs
+++ b/src/Umbraco.Core/Components/CompositionExtensions.cs
@@ -203,7 +203,7 @@ namespace Umbraco.Core.Components
         /// Sets the server registrar.
         /// </summary>
         /// <param name="composition">The composition.</param>
-        /// <param name="factory">A function creating a server registar.</param>
+        /// <param name="factory">A function creating a server registrar.</param>
         public static void SetServerRegistrar(this Composition composition, Func<IFactory, IServerRegistrar> factory)
         {
             composition.RegisterUnique(factory);

--- a/src/Umbraco.Core/Composing/TypeFinder.cs
+++ b/src/Umbraco.Core/Composing/TypeFinder.cs
@@ -163,8 +163,8 @@ namespace Umbraco.Core.Composing
 
         /// <summary>
         /// Return a list of found local Assemblies excluding the known assemblies we don't want to scan
-        /// and exluding the ones passed in and excluding the exclusion list filter, the results of this are
-        /// cached for perforance reasons.
+        /// and excluding the ones passed in and excluding the exclusion list filter, the results of this are
+        /// cached for performance reasons.
         /// </summary>
         /// <param name="excludeFromResults"></param>
         /// <returns></returns>
@@ -183,7 +183,7 @@ namespace Umbraco.Core.Composing
         }
 
         /// <summary>
-        /// Return a distinct list of found local Assemblies and exluding the ones passed in and excluding the exclusion list filter
+        /// Return a distinct list of found local Assemblies and excluding the ones passed in and excluding the exclusion list filter
         /// </summary>
         /// <param name="excludeFromResults"></param>
         /// <param name="exclusionFilter"></param>
@@ -204,7 +204,7 @@ namespace Umbraco.Core.Composing
         }
 
         /// <summary>
-        /// this is our assembly filter to filter out known types that def dont contain types we'd like to find or plugins
+        /// this is our assembly filter to filter out known types that def don't contain types we'd like to find or plugins
         /// </summary>
         /// <remarks>
         /// NOTE the comma vs period... comma delimits the name in an Assembly FullName property so if it ends with comma then its an exact name match

--- a/src/Umbraco.Core/Composing/TypeHelper.cs
+++ b/src/Umbraco.Core/Composing/TypeHelper.cs
@@ -156,7 +156,7 @@ namespace Umbraco.Core.Composing
             {
                 var others = types.Except(new[] {curr});
 
-                //is the curr type a common denominator for all others ?
+                //is the current type a common denominator for all others ?
                 var isBase = others.All(curr.IsAssignableFrom);
 
                 //if this type is the base for all others

--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -109,7 +109,7 @@ namespace Umbraco.Core.Composing
         /// Gets or sets the set of assemblies to scan.
         /// </summary>
         /// <remarks>
-        /// <para>If not explicitely set, defaults to all assemblies except those that are know to not have any of the
+        /// <para>If not explicitly set, defaults to all assemblies except those that are know to not have any of the
         /// types we might scan. Because we only scan for application types, this means we can safely exclude GAC assemblies
         /// for example.</para>
         /// <para>This is for unit tests.</para>

--- a/src/Umbraco.Core/Configuration/CoreDebug.cs
+++ b/src/Umbraco.Core/Configuration/CoreDebug.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Core.Configuration
         // this helps troubleshooting rogue scopes that we forget to complete
         public bool LogUncompletedScopes { get; }
 
-        // when true, the Logger creates a minidump of w3wp in ~/App_Data/MiniDump whenever it logs
+        // when true, the Logger creates a mini dump of w3wp in ~/App_Data/MiniDump whenever it logs
         // an error due to a ThreadAbortException that is due to a timeout.
         public bool DumpOnTimeoutThreadAbort { get; }
     }

--- a/src/Umbraco.Core/Configuration/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/GlobalSettings.cs
@@ -221,7 +221,7 @@ namespace Umbraco.Core.Configuration
         /// Gets a value indicating whether umbraco is running in [debug mode].
         /// </summary>
         /// <value><c>true</c> if [debug mode]; otherwise, <c>false</c>.</value>
-        //fixme surely thsi doesn't belong here and it's also a web request context thing
+        //fixme surely this doesn't belong here and it's also a web request context thing
         public static bool DebugMode
         {
             get

--- a/src/Umbraco.Core/Configuration/UmbracoVersion.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoVersion.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Core.Configuration
         /// </summary>
         /// <remarks>
         /// <para>The assembly version is the value of the <see cref="AssemblyVersionAttribute"/>.</para>
-        /// <para>Is is the one that the CLR checks for compatibility. Therefore, it changes only on
+        /// <para>Is the one that the CLR checks for compatibility. Therefore, it changes only on
         /// hard-breaking changes (for instance, on new major versions).</para>
         /// </remarks>
         public static Version AssemblyVersion {get; }

--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -195,7 +195,7 @@ namespace Umbraco.Core
                 public const string LastLockoutDateLabel = "Last Lockout Date";
 
                 /// <summary>
-                /// Property alias for the number of failed login attemps
+                /// Property alias for the number of failed login attempts
                 /// </summary>
                 public const string FailedPasswordAttempts = "umbracoMemberFailedPasswordAttempts";
 

--- a/src/Umbraco.Core/ContentExtensions.cs
+++ b/src/Umbraco.Core/ContentExtensions.cs
@@ -85,7 +85,7 @@ namespace Umbraco.Core
         #endregion
 
         /// <summary>
-        /// Removes characters that are not valide XML characters from all entity properties
+        /// Removes characters that are not valid XML characters from all entity properties
         /// of type string. See: http://stackoverflow.com/a/961504/5018
         /// </summary>
         /// <returns></returns>

--- a/src/Umbraco.Core/DecimalExtensions.cs
+++ b/src/Umbraco.Core/DecimalExtensions.cs
@@ -13,7 +13,7 @@
         /// </summary>
         /// <param name="value">The value to normalize.</param>
         /// <returns>The normalized value.</returns>
-        /// <remarks>Normalizing changes the scaling factor and removes trailing zeroes,
+        /// <remarks>Normalizing changes the scaling factor and removes trailing zeros,
         /// so 1.2500m comes out as 1.25m.</remarks>
         public static decimal Normalize(this decimal value)
         {

--- a/src/Umbraco.Core/Deploy/IGridCellValueConnector.cs
+++ b/src/Umbraco.Core/Deploy/IGridCellValueConnector.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Core.Deploy
         /// <param name="dependencies">The dependencies of the property.</param>
         /// <returns>The grid cell value to be deployed.</returns>
         /// <remarks>Note that </remarks>
-        string ToArtifact(GridValue.GridControl gridControl, ICollection<ArtifactDependency> dependencies);
+        string GetValue(GridValue.GridControl gridControl, ICollection<ArtifactDependency> dependencies);
 
         /// <summary>
         /// Allows you to modify the value of a control being deployed.
@@ -33,6 +33,6 @@ namespace Umbraco.Core.Deploy
         /// <param name="gridControl">The control being deployed.</param>
         /// <remarks>Follows the pattern of the property value connectors (<see cref="IValueConnector"/>). The SetValue method is used to modify the value of the <paramref name="gridControl"/>.</remarks>
 
-        void FromArtifact(GridValue.GridControl gridControl);
+        void SetValue(GridValue.GridControl gridControl);
     }
 }

--- a/src/Umbraco.Core/Deploy/IGridCellValueConnector.cs
+++ b/src/Umbraco.Core/Deploy/IGridCellValueConnector.cs
@@ -22,20 +22,17 @@ namespace Umbraco.Core.Deploy
         /// Gets the value to be deployed from the control value as a string.
         /// </summary>
         /// <param name="gridControl">The control containing the value.</param>
-        /// <param name="property">The property where the control is located. Do not modify - only used for context</param>
         /// <param name="dependencies">The dependencies of the property.</param>
         /// <returns>The grid cell value to be deployed.</returns>
         /// <remarks>Note that </remarks>
-        string GetValue(GridValue.GridControl gridControl, Property property, ICollection<ArtifactDependency> dependencies);
+        string ToArtifact(GridValue.GridControl gridControl, ICollection<ArtifactDependency> dependencies);
 
         /// <summary>
         /// Allows you to modify the value of a control being deployed.
         /// </summary>
         /// <param name="gridControl">The control being deployed.</param>
-        /// <param name="property">The property where the <paramref name="gridControl"/> is located. Do not modify - only used for context.</param>
         /// <remarks>Follows the pattern of the property value connectors (<see cref="IValueConnector"/>). The SetValue method is used to modify the value of the <paramref name="gridControl"/>.</remarks>
-        /// <remarks>Note that only the <paramref name="gridControl"/> value should be modified - not the <paramref name="property"/>.</remarks>
-        /// <remarks>The <paramref name="property"/> should only be used to assist with context data relevant when setting the <paramref name="gridControl"/> value.</remarks>
-        void SetValue(GridValue.GridControl gridControl, Property property);
+
+        void FromArtifact(GridValue.GridControl gridControl);
     }
 }

--- a/src/Umbraco.Core/DictionaryExtensions.cs
+++ b/src/Umbraco.Core/DictionaryExtensions.cs
@@ -10,7 +10,7 @@ using System.Web;
 namespace Umbraco.Core
 {
     ///<summary>
-    /// Extension methods for dictionary & concurrentdictionary
+    /// Extension methods for dictionary & concurrent dictionary
     ///</summary>
     internal static class DictionaryExtensions
     {
@@ -72,7 +72,7 @@ namespace Umbraco.Core
         /// <remarks>
         /// Taken from: http://stackoverflow.com/questions/12240219/is-there-a-way-to-use-concurrentdictionary-tryupdate-with-a-lambda-expression
         ///
-        /// WARNING: If the value changes after we've retreived it, then the item will not be updated
+        /// WARNING: If the value changes after we've retrieved it, then the item will not be updated
         /// </remarks>
         public static bool TryUpdateOptimisitic<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> dict, TKey key, Func<TValue, TValue> updateFactory)
         {

--- a/src/Umbraco.Core/EnumerableExtensions.cs
+++ b/src/Umbraco.Core/EnumerableExtensions.cs
@@ -264,7 +264,7 @@ namespace Umbraco.Core
             return -1;
         }
 
-        ///<summary>Finds the index of the first occurence of an item in an enumerable.</summary>
+        ///<summary>Finds the index of the first occurrence of an item in an enumerable.</summary>
         ///<param name="items">The enumerable to search.</param>
         ///<param name="item">The item to find.</param>
         ///<returns>The index of the first matching item, or -1 if the item was not found.</returns>

--- a/src/Umbraco.Core/Events/CancellableEventArgs.cs
+++ b/src/Umbraco.Core/Events/CancellableEventArgs.cs
@@ -61,7 +61,7 @@ namespace Umbraco.Core.Events
             {
                 if (CanCancel == false)
                 {
-                    throw new InvalidOperationException("This event argument class does not support cancelling.");
+                    throw new InvalidOperationException("This event argument class does not support canceling.");
                 }
                 return _cancel;
             }
@@ -69,7 +69,7 @@ namespace Umbraco.Core.Events
             {
                 if (CanCancel == false)
                 {
-                    throw new InvalidOperationException("This event argument class does not support cancelling.");
+                    throw new InvalidOperationException("This event argument class does not support canceling.");
                 }
                 _cancel = value;
             }

--- a/src/Umbraco.Core/Events/MacroErrorEventArgs.cs
+++ b/src/Umbraco.Core/Events/MacroErrorEventArgs.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Core.Events
         public MacroErrorBehaviour Behaviour { get; set; }
 
         /// <summary>
-        /// The html code to display when Behavior is Content.
+        /// The HTML code to display when Behavior is Content.
         /// </summary>
         public string Html { get; set; }
     }

--- a/src/Umbraco.Core/Events/MoveEventArgs.cs
+++ b/src/Umbraco.Core/Events/MoveEventArgs.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Core.Events
         /// <param name="canCancel"></param>
         /// <param name="eventMessages"></param>
         /// <param name="moveInfo">
-        /// A colleciton of MoveEventInfo objects that exposes all entities that have been moved during a single move operation
+        /// A collection of MoveEventInfo objects that exposes all entities that have been moved during a single move operation
         /// </param>
         public MoveEventArgs(bool canCancel, EventMessages eventMessages, params MoveEventInfo<TEntity>[] moveInfo)
             : base(default, canCancel, eventMessages)
@@ -34,7 +34,7 @@ namespace Umbraco.Core.Events
         /// </summary>
         /// <param name="eventMessages"></param>
         /// <param name="moveInfo">
-        /// A colleciton of MoveEventInfo objects that exposes all entities that have been moved during a single move operation
+        /// A collection of MoveEventInfo objects that exposes all entities that have been moved during a single move operation
         /// </param>
         public MoveEventArgs(EventMessages eventMessages, params MoveEventInfo<TEntity>[] moveInfo)
             : base(default, eventMessages)
@@ -54,7 +54,7 @@ namespace Umbraco.Core.Events
         /// </summary>
         /// <param name="canCancel"></param>
         /// <param name="moveInfo">
-        /// A colleciton of MoveEventInfo objects that exposes all entities that have been moved during a single move operation
+        /// A collection of MoveEventInfo objects that exposes all entities that have been moved during a single move operation
         /// </param>
         public MoveEventArgs(bool canCancel, params MoveEventInfo<TEntity>[] moveInfo)
             : base(default, canCancel)
@@ -73,7 +73,7 @@ namespace Umbraco.Core.Events
         /// Constructor accepting a collection of MoveEventInfo objects
         /// </summary>
         /// <param name="moveInfo">
-        /// A colleciton of MoveEventInfo objects that exposes all entities that have been moved during a single move operation
+        /// A collection of MoveEventInfo objects that exposes all entities that have been moved during a single move operation
         /// </param>
         public MoveEventArgs(params MoveEventInfo<TEntity>[] moveInfo)
             : base(default)

--- a/src/Umbraco.Core/Events/QueuingEventDispatcherBase.cs
+++ b/src/Umbraco.Core/Events/QueuingEventDispatcherBase.cs
@@ -110,9 +110,9 @@ namespace Umbraco.Core.Events
         }
 
         // fixme
-        // this is way too convoluted, the superceede attribute is used only on DeleteEventargs to specify
-        // that it superceeds save, publish, move and copy - BUT - publish event args is also used for
-        // unpublishing and should NOT be superceeded - so really it should not be managed at event args
+        // this is way too convoluted, the supersede attribute is used only on DeleteEventargs to specify
+        // that it supersedes save, publish, move and copy - BUT - publish event args is also used for
+        // unpublishing and should NOT be superseded - so really it should not be managed at event args
         // level but at event level
         //
         // what we want is:
@@ -137,7 +137,7 @@ namespace Umbraco.Core.Events
             var result = new List<IEventDefinition>();
             var resultArgs = new List<CancellableObjectEventArgs>();
 
-            // eagerly fetch superceeded arg types for each arg type
+            // eagerly fetch superseded arg types for each arg type
             var argTypeSuperceeding = events.Select(x => x.Args.GetType())
                 .Distinct()
                 .ToDictionary(x => x, x => x.GetCustomAttributes<SupersedeEventAttribute>(false).Select(y => y.SupersededEventArgsType).ToArray());
@@ -179,7 +179,7 @@ namespace Umbraco.Core.Events
                             continue;
                         }
 
-                        // look for this entity in superceding event args
+                        // look for this entity in superseding event args
                         // found = must be removed (ie not added), else track
                         if (IsSuperceeded(eventEntity, infos, entities) == false)
                         {
@@ -204,7 +204,7 @@ namespace Umbraco.Core.Events
                             if (eventEntity == null)
                                 continue;
 
-                            // look for this entity in superceding event args
+                            // look for this entity in superseding event args
                             // found = must be removed, else track
                             if (IsSuperceeded(eventEntity, infos, entities))
                                 toRemove.Add(eventEntity);
@@ -212,7 +212,7 @@ namespace Umbraco.Core.Events
                                 entities.Add(Tuple.Create(eventEntity, infos));
                         }
 
-                        // remove superceded entities
+                        // remove superseded entities
                         foreach (var entity in toRemove)
                             eventObjects.Remove(entity);
 
@@ -287,13 +287,13 @@ namespace Umbraco.Core.Events
 
         // determines if a given entity, appearing in a given event definition, should be filtered out,
         // considering the entities that have already been visited - an entity is filtered out if it
-        // appears in another even definition, which superceedes this event definition.
+        // appears in another even definition, which supersedes this event definition.
         private static bool IsSuperceeded(IEntity entity, EventDefinitionInfos infos, List<Tuple<IEntity, EventDefinitionInfos>> entities)
         {
             //var argType = meta.EventArgsType;
             var argType = infos.EventDefinition.Args.GetType();
 
-            // look for other instances of the same entity, coming from an event args that supercedes other event args,
+            // look for other instances of the same entity, coming from an event args that supersedes other event args,
             // ie is marked with the attribute, and is not this event args (cannot supersede itself)
             var superceeding = entities
                 .Where(x => x.Item2.SupersedeTypes.Length > 0 // has the attribute
@@ -306,20 +306,20 @@ namespace Umbraco.Core.Events
                 return false;
 
             // fixme see notes above
-            // delete event args does NOT superceedes 'unpublished' event
+            // delete event args does NOT supersedes 'unpublished' event
             if (argType.IsGenericType && argType.GetGenericTypeDefinition() == typeof(PublishEventArgs<>) && infos.EventDefinition.EventName == "Unpublished")
                 return false;
 
-            // found occurences, need to determine if this event args is superceded
+            // found occurrences, need to determine if this event args is superseded
             if (argType.IsGenericType)
             {
                 // generic, must compare type arguments
                 var supercededBy = superceeding.FirstOrDefault(x =>
                     x.Item2.SupersedeTypes.Any(y =>
-                        // superceeding a generic type which has the same generic type definition
+                        // superseding a generic type which has the same generic type definition
                         // fixme no matter the generic type parameters? could be different?
                         y.IsGenericTypeDefinition && y == argType.GetGenericTypeDefinition()
-                        // or superceeding a non-generic type which is ... fixme how is this ever possible? argType *is* generic?
+                        // or superseding a non-generic type which is ... fixme how is this ever possible? argType *is* generic?
                         || y.IsGenericTypeDefinition == false && y == argType));
                 return supercededBy != null;
             }

--- a/src/Umbraco.Core/Events/SupersedeEventAttribute.cs
+++ b/src/Umbraco.Core/Events/SupersedeEventAttribute.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Core.Events
 {
     /// <summary>
     /// This is used to know if the event arg attributed should supersede another event arg type when
-    /// tracking events for the same entity. If one event args supercedes another then the event args that have been superseded
+    /// tracking events for the same entity. If one event args supersedes another then the event args that have been superseded
     /// will mean that the event will not be dispatched or the args will be filtered to exclude the entity.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]

--- a/src/Umbraco.Core/ExpressionHelper.cs
+++ b/src/Umbraco.Core/ExpressionHelper.cs
@@ -58,7 +58,7 @@ namespace Umbraco.Core
                                 {
                                     var boxedMember = unary.Operand as MemberExpression;
                                     if (boxedMember == null)
-                                        throw new ArgumentException("The type of property could not be infered, try specifying the type parameters explicitly. This can happen if you have tried to access PropertyInfo where the property's return type is a value type, but the expression is trying to convert it to an object");
+                                        throw new ArgumentException("The type of property could not be inferred, try specifying the type parameters explicitly. This can happen if you have tried to access PropertyInfo where the property's return type is a value type, but the expression is trying to convert it to an object");
                                     else member = boxedMember;
                                 }
                             }
@@ -75,7 +75,7 @@ namespace Umbraco.Core
                         if (type != propInfo.ReflectedType &&
                             !type.IsSubclassOf(propInfo.ReflectedType))
                             throw new ArgumentException(string.Format(
-                                "Expresion '{0}' refers to a property that is not from type {1}.",
+                                "Expression '{0}' refers to a property that is not from type {1}.",
                                 propertyLambda,
                                 type));
 

--- a/src/Umbraco.Core/FileResources/Files.resx
+++ b/src/Umbraco.Core/FileResources/Files.resx
@@ -37,7 +37,7 @@
     mimetype set.
     
     The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+    ResXResourceReader how to stop persisting the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
     
     Note - application/x-microsoft.net.object.binary.base64 is the format 

--- a/src/Umbraco.Core/HashGenerator.cs
+++ b/src/Umbraco.Core/HashGenerator.cs
@@ -54,7 +54,7 @@ namespace Umbraco.Core
         {
             //I've tried to no allocate a new string with this which can be done if we use the CompareInfo.GetSortKey method which will create a new
             //byte array that we can use to write to the output, however this also allocates new objects so i really don't think the performance
-            //would be much different. In any case, i'll leave this here for reference. We could write the bytes out based on the sort key,
+            //would be much different. In any case, I'll leave this here for reference. We could write the bytes out based on the sort key,
             //this is how we could deal with case insensitivity without allocating another string
             //for reference see: https://stackoverflow.com/a/10452967/694494
             //we could go a step further and s.Normalize() but we're not really dealing with crazy unicode with this class so far.
@@ -131,7 +131,7 @@ namespace Umbraco.Core
                 //create a StringBuilder object
                 var stringBuilder = new StringBuilder();
 
-                //loop to each each byte
+                //loop to each byte
                 foreach (var b in hashedByteArray)
                 {
                     //append it to our StringBuilder

--- a/src/Umbraco.Core/HexEncoder.cs
+++ b/src/Umbraco.Core/HexEncoder.cs
@@ -4,11 +4,11 @@ using System.Runtime.CompilerServices;
 namespace Umbraco.Core
 {
     /// <summary>
-    /// Provides methods for encoding byte arrays into hexidecimal strings.
+    /// Provides methods for encoding byte arrays into hexadecimal strings.
     /// </summary>
     internal static class HexEncoder
     {
-        // LUT's that provide the hexidecimal representation of each possible byte value.
+        // LUT's that provide the hexadecimal representation of each possible byte value.
         private static readonly char[] HexLutBase = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 
         // The base LUT arranged in 16x each item order. 0 * 16, 1 * 16, .... F * 16
@@ -18,7 +18,7 @@ namespace Umbraco.Core
         private static readonly char[] HexLutLo = Enumerable.Range(0, 256).Select(x => HexLutBase[x % 0x10]).ToArray();
 
         /// <summary>
-        /// Converts a <see cref="T:byte[]"/> to a hexidecimal formatted <see cref="string"/> padded to 2 digits.
+        /// Converts a <see cref="T:byte[]"/> to a hexadecimal formatted <see cref="string"/> padded to 2 digits.
         /// </summary>
         /// <param name="bytes">The bytes.</param>
         /// <returns>The <see cref="string"/>.</returns>
@@ -40,7 +40,7 @@ namespace Umbraco.Core
         }
 
         /// <summary>
-        /// Converts a <see cref="T:byte[]"/> to a hexidecimal formatted <see cref="string"/> padded to 2 digits
+        /// Converts a <see cref="T:byte[]"/> to a hexadecimal formatted <see cref="string"/> padded to 2 digits
         /// and split into blocks with the given char separator.
         /// </summary>
         /// <param name="bytes">The bytes.</param>

--- a/src/Umbraco.Core/IO/IFileSystem.cs
+++ b/src/Umbraco.Core/IO/IFileSystem.cs
@@ -76,7 +76,7 @@ namespace Umbraco.Core.IO
         IEnumerable<string> GetFiles(string path, string filter);
 
         /// <summary>
-        /// Gets a <see cref="Stream"/> representing the file at the gieven path.
+        /// Gets a <see cref="Stream"/> representing the file at the given path.
         /// </summary>
         /// <param name="path">The path to the file.</param>
         /// <returns>

--- a/src/Umbraco.Core/Logging/IProfiler.cs
+++ b/src/Umbraco.Core/Logging/IProfiler.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Core.Logging
         /// Renders the profiling results.
         /// </summary>
         /// <returns>The profiling results.</returns>
-        /// <remarks>Generally used for Html rendering.</remarks>
+        /// <remarks>Generally used for HTML rendering.</remarks>
         string Render();
 
         /// <summary>

--- a/src/Umbraco.Core/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Core/Logging/Serilog/LoggerConfigExtensions.cs
@@ -92,7 +92,7 @@ namespace Umbraco.Core.Logging.Serilog
 
         /// <summary>
         /// Reads settings from /config/serilog.user.config
-        /// That allows a separate logging pipeline to be configured that wil not affect the main Umbraco log
+        /// That allows a separate logging pipeline to be configured that will not affect the main Umbraco log
         /// </summary>
         /// <param name="logConfig">A Serilog LoggerConfiguration</param>
         public static LoggerConfiguration ReadFromUserConfigFile(this LoggerConfiguration logConfig)

--- a/src/Umbraco.Core/MainDom.cs
+++ b/src/Umbraco.Core/MainDom.cs
@@ -165,7 +165,7 @@ namespace Umbraco.Core
                 // which may timeout, and this is accepted - see comments below
 
                 // signal, then wait for the lock, then make sure the event is
-                // resetted (maybe there was noone listening..)
+                // reset (maybe there was noone listening..)
                 _signal.Set();
 
                 // if more than 1 instance reach that point, one will get the lock
@@ -175,7 +175,7 @@ namespace Umbraco.Core
                 _isMainDom = true;
 
                 // we need to reset the event, because otherwise we would end up
-                // signaling ourselves and commiting suicide immediately.
+                // signaling ourselves and committing suicide immediately.
                 // only 1 instance can reach that point, but other instances may
                 // have started and be trying to get the lock - they will timeout,
                 // which is accepted

--- a/src/Umbraco.Core/Manifest/DataEditorConverter.cs
+++ b/src/Umbraco.Core/Manifest/DataEditorConverter.cs
@@ -71,7 +71,7 @@ namespace Umbraco.Core.Manifest
             if (jobject["editor"] == null)
                 throw new InvalidOperationException("Missing 'editor' value.");
 
-            // explicitely assign a value editor of type ValueEditor
+            // explicitly assign a value editor of type ValueEditor
             // (else the deserializer will try to read it before setting it)
             // (and besides it's an interface)
             target.ExplicitValueEditor = new DataValueEditor();
@@ -88,7 +88,7 @@ namespace Umbraco.Core.Manifest
 
             if (jobject["prevalues"] is JObject config)
             {
-                // explicitely assign a configuration editor of type ConfigurationEditor
+                // explicitly assign a configuration editor of type ConfigurationEditor
                 // (else the deserializer will try to read it before setting it)
                 // (and besides it's an interface)
                 target.ExplicitConfigurationEditor = new ConfigurationEditor();
@@ -134,7 +134,7 @@ namespace Umbraco.Core.Manifest
 
             if (jobject.Property("view") != null)
             {
-                // explicitely assign a value editor of type ParameterValueEditor
+                // explicitly assign a value editor of type ParameterValueEditor
                 target.ExplicitValueEditor = new DataValueEditor();
 
                 // move the 'view' property

--- a/src/Umbraco.Core/Manifest/DataEditorConverter.cs
+++ b/src/Umbraco.Core/Manifest/DataEditorConverter.cs
@@ -129,7 +129,7 @@ namespace Umbraco.Core.Manifest
             //   "config": { "key1": "value1", "key2": "value2" ... }
             // }
             //
-            // the view is at top level, but should be down one level to be propertly
+            // the view is at top level, but should be down one level to be properly
             // deserialized as a ParameterValueEditor property -> need to move it
 
             if (jobject.Property("view") != null)

--- a/src/Umbraco.Core/Migrations/Expressions/Create/ICreateBuilder.cs
+++ b/src/Umbraco.Core/Migrations/Expressions/Create/ICreateBuilder.cs
@@ -14,17 +14,17 @@ namespace Umbraco.Core.Migrations.Expressions.Create
     public interface ICreateBuilder : IFluentBuilder
     {
         /// <summary>
-        /// Builds a Create Table expresion, and executes.
+        /// Builds a Create Table expression, and executes.
         /// </summary>
         IExecutableBuilder Table<TDto>(bool withoutKeysAndIndexes = false);
 
         /// <summary>
-        /// Builds a Create Keys and Indexes expresion, and executes.
+        /// Builds a Create Keys and Indexes expression, and executes.
         /// </summary>
         IExecutableBuilder KeysAndIndexes<TDto>();
 
         /// <summary>
-        /// Builds a Create Keys and Indexes expresion, and executes.
+        /// Builds a Create Keys and Indexes expression, and executes.
         /// </summary>
         IExecutableBuilder KeysAndIndexes(Type typeOfDto);
 

--- a/src/Umbraco.Core/Migrations/Expressions/Create/Table/CreateTableBuilder.cs
+++ b/src/Umbraco.Core/Migrations/Expressions/Create/Table/CreateTableBuilder.cs
@@ -95,8 +95,8 @@ namespace Umbraco.Core.Migrations.Expressions.Create.Table
             CurrentColumn.IsPrimaryKey = true;
 
             //For MySQL, the PK will be created WITH the create table expression, however for
-            // SQL Server, the PK get's created in a different Alter table expression afterwords.
-            // MySQL will choke if the same constraint is again added afterword
+            // SQL Server, the PK get's created in a different Alter table expression afterwards.
+            // MySQL will choke if the same constraint is again added afterward
             // TODO: This is a super hack, I'd rather not add another property like 'CreatesPkInCreateTableDefinition' to check
             // for this, but I don't see another way around. MySQL doesn't support checking for a constraint before creating
             // it... except in a very strange way but it doesn't actually provider error feedback if it doesn't work so we cannot use
@@ -124,8 +124,8 @@ namespace Umbraco.Core.Migrations.Expressions.Create.Table
             CurrentColumn.PrimaryKeyName = primaryKeyName;
 
             //For MySQL, the PK will be created WITH the create table expression, however for
-            // SQL Server, the PK get's created in a different Alter table expression afterwords.
-            // MySQL will choke if the same constraint is again added afterword
+            // SQL Server, the PK get's created in a different Alter table expression afterwards.
+            // MySQL will choke if the same constraint is again added afterward
             // TODO: This is a super hack, I'd rather not add another property like 'CreatesPkInCreateTableDefinition' to check
             // for this, but I don't see another way around. MySQL doesn't support checking for a constraint before creating
             // it... except in a very strange way but it doesn't actually provider error feedback if it doesn't work so we cannot use

--- a/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
@@ -161,7 +161,7 @@ namespace Umbraco.Core.Migrations.Install
         /// </summary>
         /// <param name="result"></param>
         /// <remarks>
-        /// This does not validate any database constraints that are not PKs or FKs because Umbraco does not create a database with non PK/FK contraints.
+        /// This does not validate any database constraints that are not PKs or FKs because Umbraco does not create a database with non PK/FK constraints.
         /// Any unique "constraints" in the database are done with unique indexes.
         /// </remarks>
         private void ValidateDbConstraints(DatabaseSchemaResult result)
@@ -374,9 +374,11 @@ namespace Umbraco.Core.Migrations.Install
         /// attribute will be used for the table name. If the attribute is not present, the name
         /// <typeparamref name="T"/> will be used instead.
         /// </remarks>
-        public bool TableExists<T>()        {
+        public bool TableExists<T>()
+        {
             var table = DefinitionFactory.GetTableDefinition(typeof(T), SqlSyntax);
-            return table != null && TableExists(table.Name);        }
+            return table != null && TableExists(table.Name);
+        }
 
         /// <summary>
         /// Creates a new table in the database based on the type of <typeparamref name="T"/>.
@@ -403,7 +405,7 @@ namespace Umbraco.Core.Migrations.Install
         /// Creates a new table in the database for the specified <paramref name="modelType"/>.
         /// </summary>
         /// <param name="overwrite">Whether the table should be overwritten if it already exists.</param>
-        /// <param name="modelType">The the representing the table.</param>
+        /// <param name="modelType">The representing the table.</param>
         /// <param name="dataCreation"></param>
         /// <remarks>
         /// If <paramref name="modelType"/> has been decorated with an <see cref="TableNameAttribute"/>, the name from

--- a/src/Umbraco.Core/Migrations/MigrationPlan.cs
+++ b/src/Umbraco.Core/Migrations/MigrationPlan.cs
@@ -61,7 +61,7 @@ namespace Umbraco.Core.Migrations
             // register the target state if we don't know it already
             // this is how we keep track of the final state - because
             // transitions could be defined in any order, that might
-            // be overriden afterwards.
+            // be overridden afterwards.
             if (!_transitions.ContainsKey(targetState))
                 _transitions.Add(targetState, null);
 

--- a/src/Umbraco.Core/Migrations/Upgrade/V_7_10_0/RenamePreviewFolder.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_7_10_0/RenamePreviewFolder.cs
@@ -5,7 +5,7 @@ using File = System.IO.File;
 namespace Umbraco.Core.Migrations.Upgrade.V_7_10_0
 {
     /// <summary>
-    /// Renames the preview folder containing static html files to ensure it does not interfere with the MVC route
+    /// Renames the preview folder containing static HTML files to ensure it does not interfere with the MVC route
     /// that is now supposed to render these views dynamically. We don't want to delete as people may have made
     /// customizations to these files that would need to be migrated to the new .cshtml view files.
     /// </summary>
@@ -25,7 +25,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_7_10_0
                 {
                     Directory.Move(previewFolderPath, newPath);
                     var readmeText =
-                        $"Static html files used for preview and canvas editing functionality no longer live in this directory.\r\n" +
+                        $"Static HTML files used for preview and canvas editing functionality no longer live in this directory.\r\n" +
                         $"Instead they have been recreated as MVC views and can now be found in '~/Umbraco/Views/Preview'.\r\n" +
                         $"See issue: http://issues.umbraco.org/issue/U4-11090";
                     File.WriteAllText(Path.Combine(newPath, "readme.txt"), readmeText);

--- a/src/Umbraco.Core/Migrations/Upgrade/V_7_6_0/AddIndexesToUmbracoRelationTables.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_7_6_0/AddIndexesToUmbracoRelationTables.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_7_6_0
             if (dbIndexes.Any(x => x.IndexName.InvariantEquals("IX_umbracoRelation_parentChildType")) == false)
             {
                 //This will remove any corrupt/duplicate data in the relation table before the index is applied
-                //Ensure this executes in a defered block which will be done inside of the migration transaction
+                //Ensure this executes in a deferred block which will be done inside of the migration transaction
                 var database = Database;
 
                 //We need to check if this index has corrupted data and then clear that data

--- a/src/Umbraco.Core/Migrations/Upgrade/V_7_7_0/AddUserGroupTables.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_7_7_0/AddUserGroupTables.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_7_7_0
             var constraints = SqlSyntax.GetConstraintsPerColumn(Context.Database).Distinct().ToArray();
             var columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToArray();
 
-            //In some very rare cases, there might alraedy be user group tables that we'll need to remove first
+            //In some very rare cases, there might already be user group tables that we'll need to remove first
             //but of course we don't want to remove the tables we will be creating below if they already exist so
             //need to do some checks first since these old rare tables have a different schema
             RemoveOldTablesIfExist(tables, columns);
@@ -86,7 +86,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_7_7_0
         }
 
         /// <summary>
-        /// In some very rare cases, there might alraedy be user group tables that we'll need to remove first
+        /// In some very rare cases, there might already be user group tables that we'll need to remove first
         /// but of course we don't want to remove the tables we will be creating below if they already exist so
         /// need to do some checks first since these old rare tables have a different schema
         /// </summary>

--- a/src/Umbraco.Core/Migrations/Upgrade/V_7_7_0/UpdateUserTables.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_7_7_0/UpdateUserTables.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_7_7_0
 
         public override void Migrate()
         {
-            //Don't exeucte if the column is already there
+            //Don't execute if the column is already there
             var columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToArray();
 
             if (columns.Any(x => x.TableName.InvariantEquals("umbracoUser") && x.ColumnName.InvariantEquals("createDate")) == false)

--- a/src/Umbraco.Core/Models/ContentBase.cs
+++ b/src/Umbraco.Core/Models/ContentBase.cs
@@ -391,7 +391,7 @@ namespace Umbraco.Core.Models
         #region Dirty
 
         /// <inheritdoc />
-        /// <remarks>Overriden to include user properties.</remarks>
+        /// <remarks>Overridden to include user properties.</remarks>
         public override void ResetDirtyProperties(bool rememberDirty)
         {
             base.ResetDirtyProperties(rememberDirty);
@@ -408,14 +408,14 @@ namespace Umbraco.Core.Models
         }
 
         /// <inheritdoc />
-        /// <remarks>Overriden to include user properties.</remarks>
+        /// <remarks>Overridden to include user properties.</remarks>
         public override bool IsDirty()
         {
             return IsEntityDirty() || this.IsAnyUserPropertyDirty();
         }
 
         /// <inheritdoc />
-        /// <remarks>Overriden to include user properties.</remarks>
+        /// <remarks>Overridden to include user properties.</remarks>
         public override bool WasDirty()
         {
             return WasEntityDirty() || this.WasAnyUserPropertyDirty();
@@ -438,7 +438,7 @@ namespace Umbraco.Core.Models
         }
 
         /// <inheritdoc />
-        /// <remarks>Overriden to include user properties.</remarks>
+        /// <remarks>Overridden to include user properties.</remarks>
         public override bool IsPropertyDirty(string propertyName)
         {
             if (base.IsPropertyDirty(propertyName))
@@ -448,7 +448,7 @@ namespace Umbraco.Core.Models
         }
 
         /// <inheritdoc />
-        /// <remarks>Overriden to include user properties.</remarks>
+        /// <remarks>Overridden to include user properties.</remarks>
         public override bool WasPropertyDirty(string propertyName)
         {
             if (base.WasPropertyDirty(propertyName))
@@ -458,7 +458,7 @@ namespace Umbraco.Core.Models
         }
 
         /// <inheritdoc />
-        /// <remarks>Overriden to include user properties.</remarks>
+        /// <remarks>Overridden to include user properties.</remarks>
         public override IEnumerable<string> GetDirtyProperties()
         {
             var instanceProperties = base.GetDirtyProperties();
@@ -467,7 +467,7 @@ namespace Umbraco.Core.Models
         }
 
         /// <inheritdoc />
-        /// <remarks>Overriden to include user properties.</remarks>
+        /// <remarks>Overridden to include user properties.</remarks>
         public override IEnumerable<string> GetWereDirtyProperties()
         {
             var instanceProperties = base.GetWereDirtyProperties();
@@ -479,7 +479,7 @@ namespace Umbraco.Core.Models
 
         /// <inheritdoc />
         /// <remarks>
-        /// Overriden to deal with specific object instances
+        /// Overridden to deal with specific object instances
         /// </remarks>
         protected override void PerformDeepClone(object clone)
         {

--- a/src/Umbraco.Core/Models/DeepCloneHelper.cs
+++ b/src/Umbraco.Core/Models/DeepCloneHelper.cs
@@ -91,7 +91,7 @@ namespace Umbraco.Core.Models
                                 || (propertyInfo.PropertyType.IsInterface && propertyInfo.PropertyType.IsGenericType == false))
                             {
                                 //if its an array, we'll create a list to work with first and then convert to array later
-                                //otherwise if its just a regular derivitave of IEnumerable, we can use a list too
+                                //otherwise if its just a regular derivative of IEnumerable, we can use a list too
                                 return new ClonePropertyInfo(propertyInfo) { GenericListType = typeof(List<object>) };
                             }
                             //skip instead of trying to create instance of abstract or interface

--- a/src/Umbraco.Core/Models/Entities/EntityBase.cs
+++ b/src/Umbraco.Core/Models/Entities/EntityBase.cs
@@ -140,7 +140,7 @@ namespace Umbraco.Core.Models.Entities
 
             // same identity if
             // - same object (reference equals)
-            // - or same Clr type, both have identities, and they are identical
+            // - or same common language runtime type, both have identities, and they are identical
 
             if (ReferenceEquals(this, other))
                 return true;

--- a/src/Umbraco.Core/Models/Entities/IHaveAdditionalData.cs
+++ b/src/Umbraco.Core/Models/Entities/IHaveAdditionalData.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Core.Models.Entities
         /// Gets additional data for this entity.
         /// </summary>
         /// <remarks>Can be empty, but never null. To avoid allocating, do not
-        /// test for emptyness, but use <see cref="HasAdditionalData"/> instead.</remarks>
+        /// test for emptiness, but use <see cref="HasAdditionalData"/> instead.</remarks>
         IDictionary<string, object> AdditionalData { get; }
 
         /// <summary>

--- a/src/Umbraco.Core/Models/IContentTypeBase.cs
+++ b/src/Umbraco.Core/Models/IContentTypeBase.cs
@@ -68,7 +68,7 @@ namespace Umbraco.Core.Models
         /// </summary>
         /// <param name="culture">The culture.</param>
         /// <param name="segment">The segment.</param>
-        /// <param name="wildcards">A value indicating whether wilcards are supported.</param>
+        /// <param name="wildcards">A value indicating whether wildcard are supported.</param>
         /// <returns>True if the combination is valid; otherwise false.</returns>
         /// <remarks>
         /// <para>The combination must match the content type variation exactly. For instance, if the content type varies by culture,
@@ -81,7 +81,7 @@ namespace Umbraco.Core.Models
         /// </summary>
         /// <param name="culture">The culture.</param>
         /// <param name="segment">The segment.</param>
-        /// <param name="wildcards">A value indicating whether wilcards are supported.</param>
+        /// <param name="wildcards">A value indicating whether wildcard are supported.</param>
         /// <returns>True if the combination is valid; otherwise false.</returns>
         /// <remarks>
         /// <para>The combination must be valid for properties of the content type. For instance, if the content type varies by culture,

--- a/src/Umbraco.Core/Models/IContentTypeComposition.cs
+++ b/src/Umbraco.Core/Models/IContentTypeComposition.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Core.Models
         bool AddContentType(IContentTypeComposition contentType);
 
         /// <summary>
-        /// Removes a ContentType with the supplied alias from the the list of composite ContentTypes
+        /// Removes a ContentType with the supplied alias from the list of composite ContentTypes
         /// </summary>
         /// <param name="alias">Alias of a <see cref="IContentType"/></param>
         /// <returns>True if ContentType was removed, otherwise returns False</returns>

--- a/src/Umbraco.Core/Models/Identity/BackOfficeIdentityUser.cs
+++ b/src/Umbraco.Core/Models/Identity/BackOfficeIdentityUser.cs
@@ -95,7 +95,7 @@ namespace Umbraco.Core.Models.Identity
         }
 
         /// <summary>
-        /// Returns true if an Id has been set on this object this will be false if the object is new and not peristed to the database
+        /// Returns true if an Id has been set on this object this will be false if the object is new and not persisted to the database
         /// </summary>
         public bool HasIdentity => _hasIdentity;
 

--- a/src/Umbraco.Core/Models/Identity/IIdentityUserLogin.cs
+++ b/src/Umbraco.Core/Models/Identity/IIdentityUserLogin.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Core.Models.Identity
     public interface IIdentityUserLogin : IEntity, IRememberBeingDirty
     {
         /// <summary>
-        /// The login provider for the login (i.e. facebook, google)
+        /// The login provider for the login (i.e. Facebook, Google)
         ///
         /// </summary>
         string LoginProvider { get; set; }

--- a/src/Umbraco.Core/Models/Identity/IdentityUserLogin.cs
+++ b/src/Umbraco.Core/Models/Identity/IdentityUserLogin.cs
@@ -4,7 +4,7 @@ using Umbraco.Core.Models.Entities;
 namespace Umbraco.Core.Models.Identity
 {
     /// <summary>
-    /// Entity type for a user's login (i.e. facebook, google)
+    /// Entity type for a user's login (i.e. Facebook, Google)
     ///
     /// </summary>
     public class IdentityUserLogin : EntityBase, IIdentityUserLogin
@@ -26,7 +26,7 @@ namespace Umbraco.Core.Models.Identity
         }
 
         /// <summary>
-        /// The login provider for the login (i.e. facebook, google)
+        /// The login provider for the login (i.e. Facebook, Google)
         ///
         /// </summary>
         public string LoginProvider { get; set; }

--- a/src/Umbraco.Core/Models/Media.cs
+++ b/src/Umbraco.Core/Models/Media.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Core.Models
         /// <summary>
         /// Constructor for creating a Media object
         /// </summary>
-        /// <param name="name">ame of the Media object</param>
+        /// <param name="name">name of the Media object</param>
         /// <param name="parent">Parent <see cref="IMedia"/> object</param>
         /// <param name="contentType">MediaType for the current Media object</param>
         public Media(string name, IMedia parent, IMediaType contentType)
@@ -25,7 +25,7 @@ namespace Umbraco.Core.Models
         /// <summary>
         /// Constructor for creating a Media object
         /// </summary>
-        /// <param name="name">ame of the Media object</param>
+        /// <param name="name">name of the Media object</param>
         /// <param name="parent">Parent <see cref="IMedia"/> object</param>
         /// <param name="contentType">MediaType for the current Media object</param>
         /// <param name="properties">Collection of properties</param>
@@ -38,7 +38,7 @@ namespace Umbraco.Core.Models
         /// <summary>
         /// Constructor for creating a Media object
         /// </summary>
-        /// <param name="name">ame of the Media object</param>
+        /// <param name="name">name of the Media object</param>
         /// <param name="parentId">Id of the Parent IMedia</param>
         /// <param name="contentType">MediaType for the current Media object</param>
         public Media(string name, int parentId, IMediaType contentType)

--- a/src/Umbraco.Core/Models/MediaExtensions.cs
+++ b/src/Umbraco.Core/Models/MediaExtensions.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Core.Models
             var val = media.Properties[propertyType];
             if (val == null) return string.Empty;
 
-            //fixme doesn't take into account variants
+            // fixme doesn't take into account variants
             var jsonString = val.GetValue() as string;
             if (jsonString == null) return string.Empty;
 
@@ -46,7 +46,7 @@ namespace Umbraco.Core.Models
                 }
             }
 
-            // hrm, without knowing what it is, just adding a string here might not be very nice
+            // Without knowing what it is, just adding a string here might not be very nice
             return string.Empty;
         }
 

--- a/src/Umbraco.Core/Models/Member.cs
+++ b/src/Umbraco.Core/Models/Member.cs
@@ -226,7 +226,7 @@ namespace Umbraco.Core.Models
         /// Gets or sets the raw password answer value
         /// </summary>
         /// <remarks>
-        /// For security reasons this value should be encrypted, the encryption process is handled by the memberhip provider
+        /// For security reasons this value should be encrypted, the encryption process is handled by the membership provider
         /// Alias: umbracoMemberPasswordRetrievalAnswer
         ///
         /// Part of the standard properties collection.

--- a/src/Umbraco.Core/Models/Membership/IProfile.cs
+++ b/src/Umbraco.Core/Models/Membership/IProfile.cs
@@ -1,7 +1,7 @@
 ﻿namespace Umbraco.Core.Models.Membership
 {
     /// <summary>
-    /// Defines the the User Profile interface
+    /// Defines the User Profile interface
     /// </summary>
     public interface IProfile
     {

--- a/src/Umbraco.Core/Models/Membership/UserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/UserGroup.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Core.Models.Membership
 
         private static readonly Lazy<PropertySelectors> Ps = new Lazy<PropertySelectors>();
 
-        // ReSharper disable once ClassNeverInstantiated.Local // lazy-instanciated in Ps
+        // ReSharper disable once ClassNeverInstantiated.Local // lazy-instantiated in Ps
         private class PropertySelectors
         {
             public readonly PropertyInfo NameSelector = ExpressionHelper.GetPropertyInfo<UserGroup, string>(x => x.Name);

--- a/src/Umbraco.Core/Models/ObjectTypes.cs
+++ b/src/Umbraco.Core/Models/ObjectTypes.cs
@@ -76,7 +76,7 @@ namespace Umbraco.Core.Models
         }
 
         /// <summary>
-        /// Gets the Clr type corresponding to an object type Guid.
+        /// Gets the common language runtime type corresponding to an object type Guid.
         /// </summary>
         public static Type GetClrType(Guid objectType)
         {
@@ -145,7 +145,7 @@ namespace Umbraco.Core.Models
         }
 
         /// <summary>
-        /// Gets the Clr type corresponding to this Umbraco object type.
+        /// Gets the common language runtime type corresponding to this Umbraco object type.
         /// </summary>
         public static Type GetClrType(this UmbracoObjectTypes objectType)
         {

--- a/src/Umbraco.Core/Models/PropertyGroupCollection.cs
+++ b/src/Umbraco.Core/Models/PropertyGroupCollection.cs
@@ -74,7 +74,7 @@ namespace Umbraco.Core.Models
             {
                 _addLocker.EnterWriteLock();
 
-                //Note this is done to ensure existig groups can be renamed
+                //Note this is done to ensure existing groups can be renamed
                 if (item.HasIdentity && item.Id > 0)
                 {
                     var exists = Contains(item.Id);

--- a/src/Umbraco.Core/Models/PropertyType.cs
+++ b/src/Umbraco.Core/Models/PropertyType.cs
@@ -287,7 +287,7 @@ namespace Umbraco.Core.Models
         /// Converts a value assigned to a property.
         /// </summary>
         /// <remarks>
-        /// <para>The input value can be pretty much anything, and is converted to the actual Clr type
+        /// <para>The input value can be pretty much anything, and is converted to the actual common language runtime type
         /// expected by the property (eg an integer if the property values are integers).</para>
         /// <para>Throws if the value cannot be converted.</para>
         /// </remarks>
@@ -345,7 +345,7 @@ namespace Umbraco.Core.Models
                     var convDecimal = value.TryConvertTo<decimal>();
                     if (convDecimal)
                     {
-                        // need to normalize the value (change the scaling factor and remove trailing zeroes)
+                        // need to normalize the value (change the scaling factor and remove trailing zeros)
                         // because the underlying database is going to mess with the scaling factor anyways.
                         converted = convDecimal.Result.Normalize();
                         return true;

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedModelFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedModelFactory.cs
@@ -24,10 +24,10 @@ namespace Umbraco.Core.Models.PublishedContent
         IList CreateModelList(string alias);
 
         /// <summary>
-        /// Maps a Clr type that may contain model types, to an actual Clr type.
+        /// Maps a common language runtime type that may contain model types, to an actual common language runtime type.
         /// </summary>
-        /// <param name="type">The Clr type.</param>
-        /// <returns>The actual Clr type.</returns>
+        /// <param name="type">The common language runtime type.</param>
+        /// <returns>The actual common language runtime type.</returns>
         /// <remarks>See <seealso cref="ModelType"/> for more details.</remarks>
         Type MapModelType(Type type);
     }

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedProperty.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedProperty.cs
@@ -29,7 +29,7 @@
         /// Gets the source value of the property.
         /// </summary>
         /// <remarks>
-        /// <para>The source value is whatever was passed to the property when it was instanciated, and it is
+        /// <para>The source value is whatever was passed to the property when it was instantiated, and it is
         /// somewhat implementation-dependent -- depending on how the IPublishedCache is implemented.</para>
         /// <para>The XmlPublishedCache source values are strings exclusively since they come from the Xml cache.</para>
         /// <para>For other caches that get their source value from the database, it would be either a string,

--- a/src/Umbraco.Core/Models/PublishedContent/ModelType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/ModelType.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Core.Models.PublishedContent
 {
     /// <inheritdoc />
     /// <summary>
-    /// Represents the Clr type of a model.
+    /// Represents the common language runtime type of a model.
     /// </summary>
     /// <example>
     /// ModelType.For("alias")
@@ -43,11 +43,11 @@ namespace Umbraco.Core.Models.PublishedContent
             => new ModelType(alias);
 
         /// <summary>
-        /// Gets the actual Clr type by replacing model types, if any.
+        /// Gets the actual common language runtime type by replacing model types, if any.
         /// </summary>
         /// <param name="type">The type.</param>
         /// <param name="modelTypes">The model types map.</param>
-        /// <returns>The actual Clr type.</returns>
+        /// <returns>The actual common language runtime type.</returns>
         public static Type Map(Type type, Dictionary<string, Type> modelTypes)
             => Map(type, modelTypes, false);
 
@@ -82,11 +82,11 @@ namespace Umbraco.Core.Models.PublishedContent
         }
 
         /// <summary>
-        /// Gets the actual Clr type name by replacing model types, if any.
+        /// Gets the actual common language runtime type name by replacing model types, if any.
         /// </summary>
         /// <param name="type">The type.</param>
         /// <param name="map">The model types map.</param>
-        /// <returns>The actual Clr type name.</returns>
+        /// <returns>The actual common language runtime type name.</returns>
         public static string MapToName(Type type, Dictionary<string, string> map)
             => MapToName(type, map, false);
 

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentEnumerable.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentEnumerable.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace Umbraco.Core.Models.PublishedContent
 {
-    // fixme imported from 7.6 needs better explaination of what it is
+    // fixme imported from 7.6 needs better explanation of what it is
 
     /// <summary>
     /// The published content enumerable, this model is to allow ToString to be overridden for value converters to support legacy requests for string values

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentEnumerable.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentEnumerable.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Core.Models.PublishedContent
     // fixme imported from 7.6 needs better explaination of what it is
 
     /// <summary>
-    /// The published content enumerable, this model is to allow ToString to be overriden for value converters to support legacy requests for string values
+    /// The published content enumerable, this model is to allow ToString to be overridden for value converters to support legacy requests for string values
     /// </summary>
     public class PublishedContentEnumerable : IEnumerable<IPublishedContent>
     {

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedDataType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedDataType.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Core.Models.PublishedContent
         public int Id { get; }
 
         /// <summary>
-        /// Gets the dat type editor alias.
+        /// Gets the data type editor alias.
         /// </summary>
         public string EditorAlias { get; }
 

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
@@ -283,11 +283,11 @@ namespace Umbraco.Core.Models.PublishedContent
         }
 
         /// <summary>
-        /// Gets the property model Clr type.
+        /// Gets the property model common language runtime type.
         /// </summary>
         /// <remarks>
-        /// <para>The model Clr type may be a <see cref="ModelType"/> type, or may contain <see cref="ModelType"/> types.</para>
-        /// <para>For the actual Clr type, see <see cref="ClrType"/>.</para>
+        /// <para>The model common language runtime type may be a <see cref="ModelType"/> type, or may contain <see cref="ModelType"/> types.</para>
+        /// <para>For the actual common language runtime type, see <see cref="ClrType"/>.</para>
         /// </remarks>
         public Type ModelClrType
         {
@@ -299,12 +299,12 @@ namespace Umbraco.Core.Models.PublishedContent
         }
 
         /// <summary>
-        /// Gets the property Clr type.
+        /// Gets the property common language runtime type.
         /// </summary>
         /// <remarks>
-        /// <para>Returns the actual Clr type which does not contain <see cref="ModelType"/> types.</para>
+        /// <para>Returns the actual common language runtime type which does not contain <see cref="ModelType"/> types.</para>
         /// <para>Mapping from <see cref="ModelClrType"/> may throw if some <see cref="ModelType"/> instances
-        /// could not be mapped to actual Clr types.</para>
+        /// could not be mapped to actual common language runtime types.</para>
         /// </remarks>
         public Type ClrType
         {

--- a/src/Umbraco.Core/Models/ServerRegistration.cs
+++ b/src/Umbraco.Core/Models/ServerRegistration.cs
@@ -26,13 +26,13 @@ namespace Umbraco.Core.Models
         }
 
         /// <summary>
-        /// Initialiazes a new instance of the <see cref="ServerRegistration"/> class.
+        /// Initializes a new instance of the <see cref="ServerRegistration"/> class.
         /// </summary>
         public ServerRegistration()
         { }
 
         /// <summary>
-        /// Initialiazes a new instance of the <see cref="ServerRegistration"/> class.
+        /// Initializes a new instance of the <see cref="ServerRegistration"/> class.
         /// </summary>
         /// <param name="id">The unique id of the server registration.</param>
         /// <param name="serverAddress">The server url.</param>
@@ -54,7 +54,7 @@ namespace Umbraco.Core.Models
         }
 
         /// <summary>
-        /// Initialiazes a new instance of the <see cref="ServerRegistration"/> class.
+        /// Initializes a new instance of the <see cref="ServerRegistration"/> class.
         /// </summary>
         /// <param name="serverAddress">The server url.</param>
         /// <param name="serverIdentity">The unique server identity.</param>

--- a/src/Umbraco.Core/Models/UmbracoObjectTypes.cs
+++ b/src/Umbraco.Core/Models/UmbracoObjectTypes.cs
@@ -5,7 +5,7 @@ using Umbraco.Core.CodeAnnotations;
 namespace Umbraco.Core.Models
 {
     /// <summary>
-    /// Enum used to represent the Umbraco Object Types and thier associated GUIDs
+    /// Enum used to represent the Umbraco Object Types and their associated GUIDs
     /// </summary>
     public enum UmbracoObjectTypes
     {

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Core.Models
         }
 
         /// <summary>
-        /// Tries to lookup the user's gravatar to see if the endpoint can be reached, if so it returns the valid URL
+        /// Tries to lookup the user's Gravatar to see if the endpoint can be reached, if so it returns the valid URL
         /// </summary>
         /// <param name="user"></param>
         /// <param name="staticCache"></param>
@@ -59,7 +59,7 @@ namespace Umbraco.Core.Models
             // If FIPS is required, never check the Gravatar service as it only supports MD5 hashing.  
             // Unfortunately, if the FIPS setting is enabled on Windows, using MD5 will throw an exception
             // and the website will not run.
-            // Also, check if the user has explicitly removed all avatars including a gravatar, this will be possible and the value will be "none"
+            // Also, check if the user has explicitly removed all avatars including a Gravatar, this will be possible and the value will be "none"
             if (user.Avatar == "none" || CryptoConfig.AllowOnlyFipsAlgorithms)
             {
                 return new string[0];
@@ -70,7 +70,7 @@ namespace Umbraco.Core.Models
                 var gravatarHash = user.Email.ToMd5();
                 var gravatarUrl = "https://www.gravatar.com/avatar/" + gravatarHash + "?d=404";
 
-                //try gravatar
+                //try Gravatar
                 var gravatarAccess = staticCache.GetCacheItem<bool>("UserAvatar" + user.Id, () =>
                 {
                     // Test if we can reach this URL, will fail when there's network or firewall errors

--- a/src/Umbraco.Core/NetworkHelper.cs
+++ b/src/Umbraco.Core/NetworkHelper.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Core
                     catch
                     {
                         //if we get here it means we cannot access the machine name
-                        throw new ApplicationException("Cannot resolve the current machine name eithe by Environment.MachineName or by Dns.GetHostname()");
+                        throw new ApplicationException("Cannot resolve the current machine name either by Environment.MachineName or by Dns.GetHostname()");
                     }
                 }
             }

--- a/src/Umbraco.Core/ObjectExtensions.cs
+++ b/src/Umbraco.Core/ObjectExtensions.cs
@@ -153,7 +153,7 @@ namespace Umbraco.Core
                         // Recursively call into this method with the inner (not-nullable) type and handle the outcome
                         var inner = input.TryConvertTo(underlying);
 
-                        // And if sucessful, fall on through to rewrap in a nullable; if failed, pass on the exception
+                        // And if successful, fall on through to rewrap in a nullable; if failed, pass on the exception
                         if (inner.Success)
                         {
                             input = inner.Result; // Now fall on through...
@@ -216,7 +216,7 @@ namespace Umbraco.Core
                     return Attempt.Succeed(input);
                 }
 
-                // Re-check convertables since we altered the input through recursion
+                // Re-check convertibles since we altered the input through recursion
                 if (input is IConvertible convertible2)
                 {
                     return Attempt.Succeed(Convert.ChangeType(convertible2, target));
@@ -391,7 +391,7 @@ namespace Umbraco.Core
         }
         internal static void CheckThrowObjectDisposed(this IDisposable disposable, bool isDisposed, string objectname)
         {
-            //TODO: Localise this exception
+            //TODO: Localize this exception
             if (isDisposed)
                 throw new ObjectDisposedException(objectname);
         }

--- a/src/Umbraco.Core/Packaging/CompiledPackageXmlParser.cs
+++ b/src/Umbraco.Core/Packaging/CompiledPackageXmlParser.cs
@@ -153,7 +153,7 @@ namespace Umbraco.Core.Packaging
         {
             if (actionsElement == null) return Enumerable.Empty<PackageAction>();
 
-            //invariant check ... because people can realy enter anything :/
+            //invariant check ... because people can really enter anything :/
             if (!string.Equals("actions", actionsElement.Name.LocalName, StringComparison.InvariantCultureIgnoreCase))
                 throw new FormatException("Must be \"<actions>\" as root");
 
@@ -161,7 +161,7 @@ namespace Umbraco.Core.Packaging
 
             var actionElementName = actionsElement.Elements().First().Name.LocalName;
 
-            //invariant check ... because people can realy enter anything :/
+            //invariant check ... because people can really enter anything :/
             if (!string.Equals("action", actionElementName, StringComparison.InvariantCultureIgnoreCase))
                 throw new FormatException("Must be \"<action\" as element");
 
@@ -170,7 +170,7 @@ namespace Umbraco.Core.Packaging
                 {
                     var aliasAttr = e.Attribute("alias") ?? e.Attribute("Alias"); //allow both ... because people can really enter anything :/
                     if (aliasAttr == null)
-                        throw new ArgumentException("missing \"alias\" atribute in alias element", nameof(actionsElement));
+                        throw new ArgumentException("missing \"alias\" attribute in alias element", nameof(actionsElement));
 
                     var packageAction = new PackageAction
                     {

--- a/src/Umbraco.Core/Packaging/IPackageInstallation.cs
+++ b/src/Umbraco.Core/Packaging/IPackageInstallation.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Core.Packaging
     public interface IPackageInstallation
     {
         /// <summary>
-        /// This will run the uninstallation sequence for this <see cref="PackageDefinition"/>
+        /// This will run the uninstall sequence for this <see cref="PackageDefinition"/>
         /// </summary>
         /// <param name="packageDefinition"></param>
         /// <param name="userId"></param>

--- a/src/Umbraco.Core/Packaging/PackageActionRunner.cs
+++ b/src/Umbraco.Core/Packaging/PackageActionRunner.cs
@@ -7,7 +7,7 @@ using Umbraco.Core._Legacy.PackageActions;
 namespace Umbraco.Core.Packaging
 {
     /// <summary>
-    /// Package actions are executed on packge install / uninstall.
+    /// Package actions are executed on package install / uninstall.
     /// </summary>
     internal class PackageActionRunner : IPackageActionRunner
     {

--- a/src/Umbraco.Core/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Core/Packaging/PackageDataInstallation.cs
@@ -182,7 +182,7 @@ namespace Umbraco.Core.Packaging
         /// <param name="parentId">Optional parent Id for the content being imported</param>
         /// <param name="importedDocumentTypes">A dictionary of already imported document types (basically used as a cache)</param>
         /// <param name="userId">Optional Id of the user performing the import</param>
-        /// <returns>An enumrable list of generated content</returns>
+        /// <returns>An enumerable list of generated content</returns>
         public IEnumerable<IContent> ImportContent(CompiledPackageDocument packageDocument, int parentId, IDictionary<string, IContentType> importedDocumentTypes, int userId)
         {
             var element = packageDocument.XmlData;
@@ -343,7 +343,7 @@ namespace Umbraco.Core.Packaging
         /// </summary>
         /// <param name="docTypeElements">Xml to import</param>
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin).</param>
-        /// <returns>An enumrable list of generated ContentTypes</returns>
+        /// <returns>An enumerable list of generated ContentTypes</returns>
         public IEnumerable<IContentType> ImportDocumentTypes(IEnumerable<XElement> docTypeElements, int userId)
         {
             return ImportDocumentTypes(docTypeElements.ToList(), true, userId);
@@ -355,12 +355,12 @@ namespace Umbraco.Core.Packaging
         /// <param name="unsortedDocumentTypes">Xml to import</param>
         /// <param name="importStructure">Boolean indicating whether or not to import the </param>
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin).</param>
-        /// <returns>An enumrable list of generated ContentTypes</returns>
+        /// <returns>An enumerable list of generated ContentTypes</returns>
         public IEnumerable<IContentType> ImportDocumentTypes(IReadOnlyCollection<XElement> unsortedDocumentTypes, bool importStructure, int userId)
         {
             var importedContentTypes = new Dictionary<string, IContentType>();
             
-            //When you are importing a single doc type we have to assume that the depedencies are already there.
+            //When you are importing a single doc type we have to assume that the dependencies are already there.
             //Otherwise something like uSync won't work.
             var graph = new TopoGraph<string, TopoGraph.Node<string, XElement>>(x => x.Key, x => x.Dependencies);
             var isSingleDocTypeImport = unsortedDocumentTypes.Count == 1;
@@ -437,7 +437,7 @@ namespace Umbraco.Core.Packaging
             if (importStructure)
             {
                 var updatedContentTypes = new List<IContentType>();
-                //Update the structure here - we can't do it untill all DocTypes have been created
+                //Update the structure here - we can't do it until all DocTypes have been created
                 foreach (var documentType in documentTypes)
                 {
                     var alias = documentType.Element("Info").Element("Alias").Value;
@@ -796,7 +796,7 @@ namespace Umbraco.Core.Packaging
         /// </summary>
         /// <param name="dataTypeElements">Xml to import</param>
         /// <param name="userId">Optional id of the user</param>
-        /// <returns>An enumrable list of generated DataTypeDefinitions</returns>
+        /// <returns>An enumerable list of generated DataTypeDefinitions</returns>
         public IEnumerable<IDataType> ImportDataTypes(IReadOnlyCollection<XElement> dataTypeElements, int userId)
         {
             var dataTypes = new List<IDataType>();
@@ -815,7 +815,7 @@ namespace Umbraco.Core.Packaging
                     parentId = importedFolders[dataTypeDefinitionName];
 
                 var definition = _dataTypeService.GetDataType(dataTypeDefinitionId);
-                //If the datatypedefinition doesn't already exist we create a new new according to the one in the package xml
+                //If the datatype definition doesn't already exist we create a new according to the one in the package xml
                 if (definition == null)
                 {
                     var databaseType = databaseTypeAttribute?.Value.EnumParse<ValueStorageType>(true) ?? ValueStorageType.Ntext;
@@ -1195,7 +1195,7 @@ namespace Umbraco.Core.Packaging
         /// </summary>
         /// <param name="templateElements">Xml to import</param>
         /// <param name="userId">Optional user id</param>
-        /// <returns>An enumrable list of generated Templates</returns>
+        /// <returns>An enumerable list of generated Templates</returns>
         public IEnumerable<ITemplate> ImportTemplates(IReadOnlyCollection<XElement> templateElements, int userId)
         {
             var templates = new List<ITemplate>();

--- a/src/Umbraco.Core/Packaging/PackageExtraction.cs
+++ b/src/Umbraco.Core/Packaging/PackageExtraction.cs
@@ -56,7 +56,7 @@ namespace Umbraco.Core.Packaging
             // Check if the file is a valid package
             if (alowedExtension.All(ae => ae.InvariantEquals(extension) == false))
             {
-                throw new ArgumentException("Error - file isn't a package. only extentions: \"{string.Join(", ", alowedExtension)}\" is allowed");
+                throw new ArgumentException("Error - file isn't a package. only extensions: \"{string.Join(", ", alowedExtension)}\" is allowed");
             }
         }
 

--- a/src/Umbraco.Core/Packaging/PackagesRepository.cs
+++ b/src/Umbraco.Core/Packaging/PackagesRepository.cs
@@ -505,7 +505,7 @@ namespace Umbraco.Core.Packaging
         /// Converts a umbraco stylesheet to a package xml node
         /// </summary>
         /// <param name="name">The name of the stylesheet.</param>
-        /// <param name="includeProperties">if set to <c>true</c> [incluce properties].</param>
+        /// <param name="includeProperties">if set to <c>true</c> [include properties].</param>
         /// <returns></returns>
         private XElement GetStylesheetXml(string name, bool includeProperties)
         {

--- a/src/Umbraco.Core/Persistence/BulkDataReader.cs
+++ b/src/Umbraco.Core/Persistence/BulkDataReader.cs
@@ -160,7 +160,7 @@ namespace Umbraco.Core.Persistence
         /// A helper method to support <see cref="AddSchemaTableRows"/>.
         /// </summary>
         /// <remarks>
-        /// This methds does extensive argument checks. These errors will cause hard to diagnose exceptions in latter
+        /// This methods does extensive argument checks. These errors will cause hard to diagnose exceptions in latter
         /// processing so it is important to detect them when they can be easily associated with the code defect.
         /// </remarks>
         /// <exception cref="ArgumentException">

--- a/src/Umbraco.Core/Persistence/DatabaseAnnotations/ForeignKeyAttribute.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseAnnotations/ForeignKeyAttribute.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Core.Persistence.DatabaseAnnotations
         internal string OnUpdate { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the foreign key refence
+        /// Gets or sets the name of the foreign key reference
         /// </summary>
         /// <remarks>
         /// Overrides the default naming of a foreign key reference:

--- a/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/DbIndexDefinition.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/DbIndexDefinition.cs
@@ -3,7 +3,7 @@
 namespace Umbraco.Core.Persistence.DatabaseModelDefinitions
 {
     /// <summary>
-    /// Represents a database index definition retreived by querying the database
+    /// Represents a database index definition retrieved by querying the database
     /// </summary>
     internal class DbIndexDefinition
     {

--- a/src/Umbraco.Core/Persistence/Factories/ContentBaseFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/ContentBaseFactory.cs
@@ -187,7 +187,7 @@ namespace Umbraco.Core.Persistence.Factories
         }
 
         /// <summary>
-        /// Buils a dto from an IMedia item.
+        /// Builds a dto from an IMedia item.
         /// </summary>
         public static MediaDto BuildDto(IMedia entity)
         {
@@ -204,7 +204,7 @@ namespace Umbraco.Core.Persistence.Factories
         }
 
         /// <summary>
-        /// Buils a dto from an IMember item.
+        /// Builds a dto from an IMember item.
         /// </summary>
         public static MemberDto BuildDto(IMember entity)
         {

--- a/src/Umbraco.Core/Persistence/Factories/MemberTypeReadOnlyFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/MemberTypeReadOnlyFactory.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Core.Persistence.Factories
 
                 var propertyTypes = GetPropertyTypes(dto, memberType, standardPropertyTypes);
 
-                //By Convention we add 9 stnd PropertyTypes - This is only here to support loading of types that didn't have these conventions before.
+                //By Convention we add 9 standard PropertyTypes - This is only here to support loading of types that didn't have these conventions before.
                 foreach (var standardPropertyType in standardPropertyTypes)
                 {
                     if (dto.PropertyTypes.Any(x => x.Alias.Equals(standardPropertyType.Key))) continue;

--- a/src/Umbraco.Core/Persistence/Factories/PropertyFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/PropertyFactory.cs
@@ -104,7 +104,7 @@ namespace Umbraco.Core.Persistence.Factories
         /// <param name="properties">The properties to map</param>
         /// <param name="languageRepository"></param>
         /// <param name="edited">out parameter indicating that one or more properties have been edited</param>
-        /// <param name="editedCultures">out parameter containing a collection of of edited cultures when the contentVariation varies by culture</param>
+        /// <param name="editedCultures">out parameter containing a collection of edited cultures when the contentVariation varies by culture</param>
         /// <returns></returns>
         public static IEnumerable<PropertyDataDto> BuildDtos(ContentVariation contentVariation, int currentVersionId, int publishedVersionId, IEnumerable<Property> properties,
             ILanguageRepository languageRepository, out bool edited, out HashSet<string> editedCultures)

--- a/src/Umbraco.Core/Persistence/LocalDb.cs
+++ b/src/Umbraco.Core/Persistence/LocalDb.cs
@@ -275,7 +275,7 @@ namespace Umbraco.Core.Persistence
             /// <remarks>
             /// The database should not exist in the LocalDb instance.
             /// It will be attached with its name being its MDF filename (full path), uppercased, when
-            /// the first connection is opened, and remain attached until explicitely detached.
+            /// the first connection is opened, and remain attached until explicitly detached.
             /// </remarks>
             public string GetAttachedConnectionString(string databaseName, string filesPath)
             {

--- a/src/Umbraco.Core/Persistence/Mappers/UserTypeMapper.cs
+++ b/src/Umbraco.Core/Persistence/Mappers/UserTypeMapper.cs
@@ -25,4 +25,4 @@
 //        }
 //    }
 //}
-// fixme remoev this file
+// fixme remove this file

--- a/src/Umbraco.Core/Persistence/NPocoSqlExtensions.cs
+++ b/src/Umbraco.Core/Persistence/NPocoSqlExtensions.cs
@@ -816,7 +816,7 @@ namespace Umbraco.Core.Persistence
         /// </summary>
         /// <typeparam name="TDto">The type of the Dto to select.</typeparam>
         /// <param name="sql">The origin Sql.</param>
-        /// <param name="reference">An expression speficying the reference.</param>
+        /// <param name="reference">An expression specifying the reference.</param>
         /// <param name="sqlexpr">An expression to apply to the Sql statement before adding the reference selection.</param>
         /// <returns>The Sql statement.</returns>
         /// <remarks>The <paramref name="sqlexpr"/> expression applies to the Sql statement before the reference selection

--- a/src/Umbraco.Core/Persistence/PocoDataDataReader.cs
+++ b/src/Umbraco.Core/Persistence/PocoDataDataReader.cs
@@ -90,7 +90,7 @@ namespace Umbraco.Core.Persistence
                 }
                 else
                 {
-                    //get the SqlDbType from the clr type
+                    //get the SqlDbType from the common language runtime type
                     sqlDbType = _sqlSyntaxProvider.GetSqlDbType(col.PropertyType);
                 }
 

--- a/src/Umbraco.Core/Persistence/Repositories/IContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IContentTypeRepositoryBase.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Core.Persistence.Repositories
         /// </summary>
         /// <param name="alias">The original alias.</param>
         /// <returns>The original alias with a number appended to it, so that it is unique.</returns>
-        /// <remarks>Unique accross all content, media and member types.</remarks>
+        /// <remarks>Unique across all content, media and member types.</remarks>
         string GetUniqueAlias(string alias);
 
 

--- a/src/Umbraco.Core/Persistence/Repositories/IPartialViewMacroRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IPartialViewMacroRepository.cs
@@ -1,6 +1,6 @@
 ﻿namespace Umbraco.Core.Persistence.Repositories
 {
-    // this only exists to differenciate with IPartialViewRepository in IoC
+    // this only exists to differentiate with IPartialViewRepository in IoC
     // without resorting to constants, names, whatever - and IPartialViewRepository
     // is implemented by PartialViewRepository and IPartialViewMacroRepository by
     // PartialViewMacroRepository - just to inject the proper filesystem.

--- a/src/Umbraco.Core/Persistence/Repositories/IUserGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IUserGroupRepository.cs
@@ -26,14 +26,14 @@ namespace Umbraco.Core.Persistence.Repositories
         void AddOrUpdateGroupWithUsers(IUserGroup userGroup, int[] userIds);
 
         /// <summary>
-        /// Gets explicilty defined permissions for the group for specified entities
+        /// Gets explicitly defined permissions for the group for specified entities
         /// </summary>
         /// <param name="groupIds"></param>
         /// <param name="entityIds">Array of entity Ids, if empty will return permissions for the group for all entities</param>
         EntityPermissionCollection GetPermissions(int[] groupIds, params int[] entityIds);
 
         /// <summary>
-        /// Gets explicilt and default permissions (if requested) permissions for the group for specified entities
+        /// Gets explicit and default permissions (if requested) permissions for the group for specified entities
         /// </summary>
         /// <param name="groups"></param>
         /// <param name="fallbackToDefaultPermissions">If true will include the group's default permissions if no permissions are explicitly assigned</param>

--- a/src/Umbraco.Core/Persistence/Repositories/IUserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IUserRepository.cs
@@ -51,7 +51,7 @@ namespace Umbraco.Core.Persistence.Repositories
         /// <param name="excludeUserGroups">
         /// A filter to only include users that do not belong to these user groups
         /// </param>
-        /// <param name="userState">Optional parameter to filter by specfied user state</param>
+        /// <param name="userState">Optional parameter to filter by specified user state</param>
         /// <returns></returns>
         IEnumerable<IUser> GetPagedResultsByQuery(IQuery<IUser> query, long pageIndex, int pageSize, out long totalRecords,
             Expression<Func<IUser, object>> orderBy, Direction orderDirection = Direction.Ascending,

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -515,7 +515,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             }
 
             // now we have
-            // - the definitinos
+            // - the definitions
             // - all property data dtos
             // - tag editors
             // and we need to build the proper property collections
@@ -865,7 +865,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             public Guid Version => DocumentDto?.VersionId ?? ContentVersionDto.VersionId;
 
-            // This is used to determien which version is the most recent
+            // This is used to determine which version is the most recent
             public int VersionId => ContentVersionDto.Id;
 
             public DateTime VersionDate => ContentVersionDto.VersionDate;
@@ -924,7 +924,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             }
 
             /// <summary>
-            /// Creates a paged query based on the original query and subtitutes the selectColumns specified
+            /// Creates a paged query based on the original query and substitutes the selectColumns specified
             /// </summary>
             /// <param name="columns"></param>
             /// <returns></returns>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -83,7 +83,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var dtos = Database.Fetch<ContentTypeTemplateDto>(sql);
 
             return
-                //This returns a lookup from the GetAll cached looup
+                //This returns a lookup from the GetAll cached lookup
                 (dtos.Any()
                     ? GetMany(dtos.DistinctBy(x => x.ContentTypeDto.NodeId).Select(x => x.ContentTypeDto.NodeId).ToArray())
                     : Enumerable.Empty<IContentType>())

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -1751,7 +1751,7 @@ ORDER BY contentTypeId, groupId, id";
 
         public string GetUniqueAlias(string alias)
         {
-            // alias is unique accross ALL content types!
+            // alias is unique across ALL content types!
             var aliasColumn = SqlSyntax.GetQuotedColumnName("alias");
             var aliases = Database.Fetch<string>(@"SELECT cmsContentType." + aliasColumn + @" FROM cmsContentType
 INNER JOIN umbracoNode ON cmsContentType.nodeId = umbracoNode.id

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -103,7 +103,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 .On<PropertyTypeDto, DataTypeDto>(left => left.DataTypeId, right => right.NodeId);
 
             var translator = new SqlTranslator<PropertyType>(sqlClause, query);
-            // fixme v8 are we sorting only for 7.6 relators?
+            // fixme v8 are we sorting only for 7.6 relator's?
             var sql = translator.Translate()
                 .OrderBy<PropertyTypeDto>(x => x.PropertyTypeGroupId);
 
@@ -121,7 +121,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         {
             var dto = ContentTypeFactory.BuildContentTypeDto(entity);
 
-            //Cannot add a duplicate content type type
+            //Cannot add a duplicate content type
             var exists = Database.ExecuteScalar<int>(@"SELECT COUNT(*) FROM cmsContentType
 INNER JOIN umbracoNode ON cmsContentType.nodeId = umbracoNode.id
 WHERE cmsContentType." + SqlSyntax.GetQuotedColumnName("alias") + @"= @alias
@@ -1320,7 +1320,7 @@ AND umbracoNode.id <> @id",
                 parentMediaTypeIds = new Dictionary<int, List<int>>();
                 var mappedMediaTypes = new List<IMediaType>();
 
-                //loop through each result and fill in our required values, each row will contain different requried data than the rest.
+                //loop through each result and fill in our required values, each row will contain different required data than the rest.
                 // it is much quicker to iterate each result and populate instead of looking up the values over and over in the result like
                 // we used to do.
                 var queue = new Queue<dynamic>(result);
@@ -1727,7 +1727,7 @@ ORDER BY contentTypeId, groupId, id";
         }
 
         /// <summary>
-        /// Gets all entities of the spefified type
+        /// Gets all entities of the specified type
         /// </summary>
         /// <param name="ids"></param>
         /// <returns></returns>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentBlueprintRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentBlueprintRepository.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
     /// </summary>
     /// <remarks>
     /// It would be nicer if we could separate most of this down into a smaller version of the ContentRepository class, however to do that
-    /// requires quite a lot of work since we'd need to re-organize the interhitance quite a lot or create a helper class to perform a lot of the underlying logic.
+    /// requires quite a lot of work since we'd need to re-organize the inheritance quite a lot or create a helper class to perform a lot of the underlying logic.
     ///
     /// TODO: Create a helper method to contain most of the underlying logic for the ContentRepository
     /// </remarks>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -567,7 +567,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 Database.Execute(deleteDocumentVariations);
 
                 // fixme NPoco InsertBulk issue?
-                // we should use the native NPoco InsertBulk here but it causes problems (not sure exaclty all scenarios)
+                // we should use the native NPoco InsertBulk here but it causes problems (not sure exactly all scenarios)
                 // but by using SQL Server and updating a variants name will cause: Unable to cast object of type
                 // 'Umbraco.Core.Persistence.FaultHandling.RetryDbConnection' to type 'System.Data.SqlClient.SqlConnection'.
                 // (same in PersistNewItem above)
@@ -1338,7 +1338,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             // variant content = update with default culture or anything really
             EnsureInvariantNameExists(content);
 
-            // ensure that that invariant name is unique
+            // ensure that invariant name is unique
             EnsureInvariantNameIsUnique(content);
 
             // and finally,
@@ -1357,7 +1357,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 if (content.CultureInfos.Count == 0)
                     throw new InvalidOperationException("Cannot save content with an empty name.");
 
-                // and then, we need to set the invariant name implicitely,
+                // and then, we need to set the invariant name implicitly,
                 // using the default culture if it has a name, otherwise anything we can
                 var defaultCulture = LanguageRepository.GetDefaultIsoCode();
                 content.Name = defaultCulture != null && content.CultureInfos.TryGetValue(defaultCulture, out var cultureName)

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MediaTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MediaTypeRepository.cs
@@ -85,7 +85,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var dtos = Database.Fetch<ContentTypeDto>(sql);
 
             return
-                //This returns a lookup from the GetAll cached looup
+                //This returns a lookup from the GetAll cached lookup
                 (dtos.Any()
                     ? GetMany(dtos.DistinctBy(x => x.NodeId).Select(x => x.NodeId).ToArray())
                     : Enumerable.Empty<IMediaType>())

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
@@ -70,7 +70,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             // check if the query is based on properties or not
 
             var wheres = query.GetWhereClauses();
-            //this is a pretty rudimentary check but wil work, we just need to know if this query requires property
+            //this is a pretty rudimentary check but will work, we just need to know if this query requires property
             // level queries
             if (wheres.Any(x => x.Item1.Contains("cmsPropertyType")))
             {
@@ -583,7 +583,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             // load all properties for all documents from database in 1 query - indexed by version id
             var properties = GetPropertyCollections(temps);
 
-            // assign properites
+            // assign properties
             foreach (var temp in temps)
             {
                 temp.Content.Properties = properties[temp.VersionId];

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -205,7 +205,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 entity.Icon = "icon-user";
             }
 
-            //By Convention we add 9 stnd PropertyTypes to an Umbraco MemberType
+            //By Convention we add 9 standard PropertyTypes to an Umbraco MemberType
             entity.AddPropertyGroup(Constants.Conventions.Member.StandardPropertiesGroupName);
             var standardPropertyTypes = Constants.Conventions.Member.GetStandardPropertyTypeStubs();
             foreach (var standardPropertyType in standardPropertyTypes)

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -533,7 +533,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         public IEnumerable<ITemplate> GetAll(params string[] aliases)
         {
             //We must call the base (normal) GetAll method
-            // which is cached. This is a specialized method and unfortunatley with the params[] it
+            // which is cached. This is a specialized method and unfortunately with the params[] it
             // overlaps with the normal GetAll method.
             if (aliases.Any() == false) return base.GetMany();
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserGroupRepository.cs
@@ -89,7 +89,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
 
         /// <summary>
-        /// Gets explicilty defined permissions for the group for specified entities
+        /// Gets explicitly defined permissions for the group for specified entities
         /// </summary>
         /// <param name="groupIds"></param>
         /// <param name="entityIds">Array of entity Ids, if empty will return permissions for the group for all entities</param>
@@ -99,7 +99,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         }
 
         /// <summary>
-        /// Gets explicilt and default permissions (if requested) permissions for the group for specified entities
+        /// Gets explicit and default permissions (if requested) permissions for the group for specified entities
         /// </summary>
         /// <param name="groups"></param>
         /// <param name="fallbackToDefaultPermissions">If true will include the group's default permissions if no permissions are explicitly assigned</param>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
@@ -169,7 +169,7 @@ ORDER BY colName";
 
         public Guid CreateLoginSession(int userId, string requestingIpAddress, bool cleanStaleSessions = true)
         {
-            //TODO: I know this doesn't follow the normal repository conventions which would require us to crete a UserSessionRepository
+            //TODO: I know this doesn't follow the normal repository conventions which would require us to create a UserSessionRepository
             //and also business logic models for these objects but that's just so overkill for what we are doing
             //and now that everything is properly in a transaction (Scope) there doesn't seem to be much reason for using that anymore
             var now = DateTime.UtcNow;
@@ -690,7 +690,7 @@ ORDER BY colName";
         /// <param name="excludeUserGroups">
         /// A filter to only include users that do not belong to these user groups
         /// </param>
-        /// <param name="userState">Optional parameter to filter by specfied user state</param>
+        /// <param name="userState">Optional parameter to filter by specified user state</param>
         /// <param name="filter"></param>
         /// <returns></returns>
         /// <remarks>

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -482,7 +482,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
             var dbTypeDefinition = column.Size != default(int)
                 ? $"{definition}({column.Size})"
                 : definition;
-            //NOTE Percision is left out
+            //NOTE Precision is left out
             return dbTypeDefinition;
         }
 

--- a/src/Umbraco.Core/PropertyEditors/ConfigurationEditorOfTConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationEditorOfTConfiguration.cs
@@ -54,7 +54,7 @@ namespace Umbraco.Core.PropertyEditors
                     continue;
                 }
 
-                // if the field has its own type, instanciate it
+                // if the field has its own type, instantiate it
                 try
                 {
                     field = (ConfigurationField) Activator.CreateInstance(attribute.Type);

--- a/src/Umbraco.Core/PropertyEditors/ConfigurationEditorOfTConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationEditorOfTConfiguration.cs
@@ -130,7 +130,7 @@ namespace Umbraco.Core.PropertyEditors
         /// <param name="configuration">The current configuration object.</param>
         public virtual TConfiguration FromConfigurationEditor(IDictionary<string, object> editorValues, TConfiguration configuration)
         {
-            // note - editorValue contains a mix of Clr types (string, int...) and JToken
+            // note - editorValue contains a mix of common language runtime types (string, int...) and JToken
             // turning everything back into a JToken... might not be fastest but is simplest
             // for now
 

--- a/src/Umbraco.Core/PropertyEditors/ConfigurationField.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationField.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Core.PropertyEditors
         public string PropertyName { get; set; }
 
         /// <summary>
-        /// Gets or sets the property clr type of the field.
+        /// Gets or sets the property common language runtime type of the field.
         /// </summary>
         [JsonIgnore]
         public Type PropertyType { get; set; }

--- a/src/Umbraco.Core/PropertyEditors/DataEditorAttribute.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditorAttribute.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Core.PropertyEditors
         /// <param name="name">The friendly name of the editor.</param>
         /// <param name="view">The view to use to render the editor.</param>
         /// <remarks>
-        /// <para>Set <paramref name="view"/> to <see cref="NullView"/> to explicitely set the view to null.</para>
+        /// <para>Set <paramref name="view"/> to <see cref="NullView"/> to explicitly set the view to null.</para>
         /// <para>Otherwise, <paramref name="view"/> cannot be null nor empty.</para>
         /// </remarks>
         public DataEditorAttribute(string alias, EditorType type, string name, string view)

--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -128,7 +128,7 @@ namespace Umbraco.Core.PropertyEditors
 
             // mandatory and regex validators cannot be part of valueEditor.Validators because they
             // depend on values that are not part of the configuration, .Mandatory and .ValidationRegEx,
-            // so they have to be explicitely invoked here.
+            // so they have to be explicitly invoked here.
 
             if (required)
             {

--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -163,7 +163,7 @@ namespace Umbraco.Core.PropertyEditors
         public virtual IValueFormatValidator FormatValidator => new RegexValidator();
 
         /// <summary>
-        /// If this is is true than the editor will be displayed full width without a label
+        /// If this is true than the editor will be displayed full width without a label
         /// </summary>
         [JsonProperty("hideLabel")]
         public bool HideLabel { get; set; }
@@ -238,7 +238,7 @@ namespace Umbraco.Core.PropertyEditors
         ///  </summary>
         ///  <param name="editorValue"></param>
         ///  <param name="currentValue">
-        ///  The current value that has been persisted to the database for this editor. This value may be usesful for
+        ///  The current value that has been persisted to the database for this editor. This value may be useful for
         ///  how the value then get's deserialized again to be re-persisted. In most cases it will probably not be used.
         ///  </param>
         /// <param name="languageId"></param>
@@ -360,7 +360,7 @@ namespace Umbraco.Core.PropertyEditors
         /// </summary>
         /// <remarks>
         /// <para>By default, this returns the value of ConvertDbToString but ensures that if the db value type is
-        /// NVarchar or NText, the value is returned as a CDATA fragment - elxe it's a Text fragment.</para>
+        /// NVarchar or NText, the value is returned as a CDATA fragment - else it's a Text fragment.</para>
         /// <para>Returns an XText or XCData instance which must be wrapped in a element.</para>
         /// <para>If the value is empty we will not return as CDATA since that will just take up more space in the file.</para>
         /// </remarks>

--- a/src/Umbraco.Core/PropertyEditors/IPropertyValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/IPropertyValueConverter.cs
@@ -62,7 +62,7 @@ namespace Umbraco.Core.PropertyEditors
         /// <para>The converter should be prepared to handle both situations.</para>
         /// <para>When source values are strings, the converter must handle empty strings, whitespace
         /// strings, and xml-whitespace strings appropriately, ie it should know whether to preserve
-        /// whitespaces.</para>
+        /// white spaces.</para>
         /// </remarks>
         object ConvertSourceToIntermediate(IPublishedElement owner, PublishedPropertyType propertyType, object source, bool preview);
 
@@ -99,7 +99,7 @@ namespace Umbraco.Core.PropertyEditors
         /// indicating that no value has been assigned to the property. It is up to the converter to determine
         /// what to return in that case: either <c>null</c>, or the default value...</para>
         /// <para>If successful, the result should be either <c>null</c>, a string, or an <c>XPathNavigator</c>
-        /// instance. Whether an xml-whitespace string should be returned as <c>null</c> or litterally, is
+        /// instance. Whether an xml-whitespace string should be returned as <c>null</c> or literally, is
         /// up to the converter.</para>
         /// <para>The converter may want to return an XML fragment that represent a part of the content tree,
         /// but should pay attention not to create infinite loops that would kill XPath and XSLT.</para>

--- a/src/Umbraco.Core/ReadLock.cs
+++ b/src/Umbraco.Core/ReadLock.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Core
     /// </summary>
     /// <remarks>
     /// <para>Intended as an infrastructure class.</para>
-    /// <para>This is a very unefficient way to lock as it allocates one object each time we lock,
+    /// <para>This is a very inefficient way to lock as it allocates one object each time we lock,
     /// so it's OK to use this class for things that happen once, where it is convenient, but not
     /// for performance-critical code!</para>
     /// </remarks>

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -329,7 +329,7 @@ namespace Umbraco.Core.Runtime
         {
             // need the deep clone runtime cache provider to ensure entities are cached properly, ie
             // are cloned in and cloned out - no request-based cache here since no web-based context,
-            // is overriden by the web runtime
+            // is overridden by the web runtime
 
             return new CacheHelper(
                 new DeepCloneRuntimeCacheProvider(new ObjectCacheRuntimeCacheProvider()),

--- a/src/Umbraco.Core/SafeCallContext.cs
+++ b/src/Umbraco.Core/SafeCallContext.cs
@@ -45,8 +45,8 @@ namespace Umbraco.Core
         //
         // note
         // see System.Transactions
-        // pre 4.5.1, the TransactionScope would not flow in async, and then then introduced
-        // an option to store in in the LLC so that it flows
+        // pre 4.5.1, the TransactionScope would not flow in async, and then introduced
+        // an option to store in the LLC so that it flows
         // they are using a conditional weak table to store the data, and what they store in
         // LLC is the key - which is just an empty MarshalByRefObject that is created with
         // the transaction scope - that way, they can "clear current data" provided that

--- a/src/Umbraco.Core/Scoping/IScopeContext.cs
+++ b/src/Umbraco.Core/Scoping/IScopeContext.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Core.Scoping
     /// </summary>
     /// <remarks>A scope context can enlist objects that will be attached to the scope, and available
     /// for the duration of the scope. In addition, it can enlist actions, that will run when the
-    /// scope is exiting, and after the database transaction has been commited.</remarks>
+    /// scope is exiting, and after the database transaction has been committed.</remarks>
     public interface IScopeContext
     {
         /// <summary>

--- a/src/Umbraco.Core/Scoping/ScopeProvider.cs
+++ b/src/Umbraco.Core/Scoping/ScopeProvider.cs
@@ -425,7 +425,7 @@ namespace Umbraco.Core.Scoping
         //        LogHelper.Debug<ScopeProvider>("CallContext: " + Environment.StackTrace);
         //}
 
-        // all scope instances that are currently beeing tracked
+        // all scope instances that are currently being tracked
         private static readonly object StaticScopeInfosLock = new object();
         private static readonly Dictionary<IScope, ScopeInfo> StaticScopeInfos = new Dictionary<IScope, ScopeInfo>();
 

--- a/src/Umbraco.Core/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Core/Security/BackOfficeUserStore.cs
@@ -538,7 +538,7 @@ namespace Umbraco.Core.Security
         /// <param name="user"/>
         /// <returns/>
         /// <remarks>
-        /// Currently we do not suport a timed lock out, when they are locked out, an admin will  have to reset the status
+        /// Currently we do not support a timed lock out, when they are locked out, an admin will  have to reset the status
         /// </remarks>
         public Task<DateTimeOffset> GetLockoutEndDateAsync(BackOfficeIdentityUser user)
         {
@@ -555,7 +555,7 @@ namespace Umbraco.Core.Security
         /// <param name="user"/><param name="lockoutEnd"/>
         /// <returns/>
         /// <remarks>
-        /// Currently we do not suport a timed lock out, when they are locked out, an admin will  have to reset the status
+        /// Currently we do not support a timed lock out, when they are locked out, an admin will  have to reset the status
         /// </remarks>
         public Task SetLockoutEndDateAsync(BackOfficeIdentityUser user, DateTimeOffset lockoutEnd)
         {

--- a/src/Umbraco.Core/Security/MembershipProviderBase.cs
+++ b/src/Umbraco.Core/Security/MembershipProviderBase.cs
@@ -522,7 +522,7 @@ namespace Umbraco.Core.Security
         protected abstract MembershipUser PerformCreateUser(string username, string password, string email, string passwordQuestion, string passwordAnswer, bool isApproved, object providerUserKey, out MembershipCreateStatus status);
 
         /// <summary>
-        /// Gets the members password if password retreival is enabled
+        /// Gets the members password if password retrieval is enabled
         /// </summary>
         /// <param name="username"></param>
         /// <param name="answer"></param>
@@ -539,7 +539,7 @@ namespace Umbraco.Core.Security
         }
 
         /// <summary>
-        /// Gets the members password if password retreival is enabled
+        /// Gets the members password if password retrieval is enabled
         /// </summary>
         /// <param name="username"></param>
         /// <param name="answer"></param>

--- a/src/Umbraco.Core/Security/MembershipProviderPasswordValidator.cs
+++ b/src/Umbraco.Core/Security/MembershipProviderPasswordValidator.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNet.Identity;
 namespace Umbraco.Core.Security
 {
     /// <summary>
-    /// Ensure that both the normal password validator rules are processed along with the underlying memberhsip provider rules
+    /// Ensure that both the normal password validator rules are processed along with the underlying membership provider rules
     /// </summary>
     public class MembershipProviderPasswordValidator : PasswordValidator
     {

--- a/src/Umbraco.Core/Security/UmbracoBackOfficeIdentity.cs
+++ b/src/Umbraco.Core/Security/UmbracoBackOfficeIdentity.cs
@@ -113,7 +113,7 @@ namespace Umbraco.Core.Security
         /// Returns the required claim types for a back office identity
         /// </summary>
         /// <remarks>
-        /// This does not incude the role claim type or allowed apps type since that is a collection and in theory could be empty
+        /// This does not induce the role claim type or allowed apps type since that is a collection and in theory could be empty
         /// </remarks>
         public static IEnumerable<string> RequiredBackOfficeIdentityClaimTypes => new[]
         {

--- a/src/Umbraco.Core/Serialization/NoTypeConverterJsonConverter.cs
+++ b/src/Umbraco.Core/Serialization/NoTypeConverterJsonConverter.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Core.Serialization
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <remarks>
-    /// In some cases thsi is required if your model has an explicit type converter, see: http://stackoverflow.com/a/31328131/694494
+    /// In some cases this is required if your model has an explicit type converter, see: http://stackoverflow.com/a/31328131/694494
     ///
     /// NOTE: I was going to use this for the ImageCropDataSetConverter to convert to String, which would have worked by putting this attribute:
     /// [JsonConverter(typeof(NoTypeConverterJsonConverter{ImageCropDataSet}))] on top of the ImageCropDataSet class, however it turns out we

--- a/src/Umbraco.Core/Services/Changes/ContentTypeChangeTypes.cs
+++ b/src/Umbraco.Core/Services/Changes/ContentTypeChangeTypes.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Core.Services.Changes
     {
         None = 0,
         Create = 1, // item type has been created, no impact
-        RefreshMain = 2, // changed, impacts content (adding ppty or composition does NOT)
+        RefreshMain = 2, // changed, impacts content (adding property or composition does NOT)
         RefreshOther = 4, // changed, other changes
         Remove = 8 // item type has been removed
     }

--- a/src/Umbraco.Core/Services/ContentTypeServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceExtensions.cs
@@ -58,7 +58,7 @@ namespace Umbraco.Core.Services
             }
 
             // if it is not used then composition is possible
-            // hashset guarantees unicity on Id
+            // hashset guarantees unity on Id
             var list = new HashSet<IContentTypeComposition>(new DelegateEqualityComparer<IContentTypeComposition>(
                 (x, y) => x.Id == y.Id,
                 x => x.Id));
@@ -141,7 +141,7 @@ namespace Umbraco.Core.Services
         {
             if (ctype == null) return Enumerable.Empty<IContentTypeComposition>();
 
-            // hashset guarantees unicity on Id
+            // hashset guarantees unity on Id
             var all = new HashSet<IContentTypeComposition>(new DelegateEqualityComparer<IContentTypeComposition>(
                 (x, y) => x.Id == y.Id,
                 x => x.Id));

--- a/src/Umbraco.Core/Services/IApplicationTreeService.cs
+++ b/src/Umbraco.Core/Services/IApplicationTreeService.cs
@@ -44,14 +44,14 @@ namespace Umbraco.Core.Services
         IEnumerable<ApplicationTree> GetAll();
         
         /// <summary>
-        /// Gets the application tree for the applcation with the specified alias
+        /// Gets the application tree for the application with the specified alias
         /// </summary>
         /// <param name="applicationAlias">The application alias.</param>
         /// <returns>Returns a ApplicationTree Array</returns>
         IEnumerable<ApplicationTree> GetApplicationTrees(string applicationAlias);
 
         /// <summary>
-        /// Gets the application tree for the applcation with the specified alias
+        /// Gets the application tree for the application with the specified alias
         /// </summary>
         /// <param name="applicationAlias">The application alias.</param>
         /// <param name="onlyInitialized"></param>
@@ -129,7 +129,7 @@ namespace Umbraco.Core.Services
         }
 
         /// <summary>
-        /// Gets the application tree for the applcation with the specified alias
+        /// Gets the application tree for the application with the specified alias
         /// </summary>
         /// <param name="applicationAlias">The application alias.</param>
         /// <returns>Returns a ApplicationTree Array</returns>
@@ -139,7 +139,7 @@ namespace Umbraco.Core.Services
         }
 
         /// <summary>
-        /// Gets the application tree for the applcation with the specified alias
+        /// Gets the application tree for the application with the specified alias
         /// </summary>
         /// <param name="applicationAlias">The application alias.</param>
         /// <param name="onlyInitialized"></param>

--- a/src/Umbraco.Core/Services/IConsentService.cs
+++ b/src/Umbraco.Core/Services/IConsentService.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Core.Services
         /// <param name="contextStartsWith">Determines whether <paramref name="context"/> is a start pattern.</param>
         /// <param name="actionStartsWith">Determines whether <paramref name="action"/> is a start pattern.</param>
         /// <param name="includeHistory">Determines whether to include the history of consents.</param>
-        /// <returns>Consents matching the paramters.</returns>
+        /// <returns>Consents matching the parameters.</returns>
         IEnumerable<IConsent> LookupConsent(string source = null, string context = null, string action = null,
             bool sourceStartsWith = false, bool contextStartsWith = false, bool actionStartsWith = false,
             bool includeHistory = false);

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -182,7 +182,7 @@ namespace Umbraco.Core.Services
             IQuery<IContent> filter = null, Ordering ordering = null);
 
         /// <summary>
-        /// Gets paged documents of a content content
+        /// Gets paged documents of a content
         /// </summary>
         /// <param name="contentTypeId">The page number.</param>
         /// <param name="pageIndex">The page number.</param>
@@ -303,7 +303,7 @@ namespace Umbraco.Core.Services
         /// Copies a document.
         /// </summary>
         /// <remarks>
-        /// <para>Optionaly recursively copies all children.</para>
+        /// <para>Optionally recursively copies all children.</para>
         /// </remarks>
         IContent Copy(IContent content, int parentId, bool relateToOriginal, bool recursive, int userId = 0);
 

--- a/src/Umbraco.Core/Services/IContentServiceBase.cs
+++ b/src/Umbraco.Core/Services/IContentServiceBase.cs
@@ -1,7 +1,7 @@
 ﻿namespace Umbraco.Core.Services
 {
     /// <summary>
-    /// Placehold for sharing logic between the content, media (and member) services
+    /// Placeholder for sharing logic between the content, media (and member) services
     /// TODO: Start sharing the logic!
     /// </summary>
     public interface IContentServiceBase : IService

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -51,21 +51,21 @@ namespace Umbraco.Core.Services
         /// Saves an <see cref="IDataType"/>
         /// </summary>
         /// <param name="dataType"><see cref="IDataType"/> to save</param>
-        /// <param name="userId">Id of the user issueing the save</param>
+        /// <param name="userId">Id of the user issuing the save</param>
         void Save(IDataType dataType, int userId = 0);
 
         /// <summary>
         /// Saves a collection of <see cref="IDataType"/>
         /// </summary>
         /// <param name="dataTypeDefinitions"><see cref="IDataType"/> to save</param>
-        /// <param name="userId">Id of the user issueing the save</param>
+        /// <param name="userId">Id of the user issuing the save</param>
         void Save(IEnumerable<IDataType> dataTypeDefinitions, int userId = 0);
 
         /// <summary>
         /// Saves a collection of <see cref="IDataType"/>
         /// </summary>
         /// <param name="dataTypeDefinitions"><see cref="IDataType"/> to save</param>
-        /// <param name="userId">Id of the user issueing the save</param>
+        /// <param name="userId">Id of the user issuing the save</param>
         /// <param name="raiseEvents">Boolean indicating whether or not to raise events</param>
         void Save(IEnumerable<IDataType> dataTypeDefinitions, int userId, bool raiseEvents);
 
@@ -77,7 +77,7 @@ namespace Umbraco.Core.Services
         /// all the <see cref="PropertyType"/> data that references this <see cref="IDataType"/>.
         /// </remarks>
         /// <param name="dataType"><see cref="IDataType"/> to delete</param>
-        /// <param name="userId">Id of the user issueing the deletion</param>
+        /// <param name="userId">Id of the user issuing the deletion</param>
         void Delete(IDataType dataType, int userId = 0);
 
         /// <summary>

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -84,7 +84,7 @@ namespace Umbraco.Core.Services
         /// Gets a <see cref="IDataType"/> by its control Id
         /// </summary>
         /// <param name="propertyEditorAlias">Alias of the property editor</param>
-        /// <returns>Collection of <see cref="IDataType"/> objects with a matching contorl id</returns>
+        /// <returns>Collection of <see cref="IDataType"/> objects with a matching control id</returns>
         IEnumerable<IDataType> GetByEditorAlias(string propertyEditorAlias);
 
         Attempt<OperationResult<MoveOperationStatusType>> Move(IDataType toMove, int parentId);

--- a/src/Umbraco.Core/Services/IEntityService.cs
+++ b/src/Umbraco.Core/Services/IEntityService.cs
@@ -264,7 +264,7 @@ namespace Umbraco.Core.Services
         UmbracoObjectTypes GetObjectType(IUmbracoEntity entity);
 
         /// <summary>
-        /// Gets the Clr type of an entity.
+        /// Gets the common language runtime type of an entity.
         /// </summary>
         Type GetEntityType(int id);
 

--- a/src/Umbraco.Core/Services/IExternalLoginService.cs
+++ b/src/Umbraco.Core/Services/IExternalLoginService.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Core.Services
 
         /// <summary>
         /// Returns all logins matching the login info - generally there should only be one but in some cases
-        /// there might be more than one depending on if an adminstrator has been editing/removing members
+        /// there might be more than one depending on if an administrator has been editing/removing members
         /// </summary>
         /// <param name="login"></param>
         /// <returns></returns>

--- a/src/Umbraco.Core/Services/IFileService.cs
+++ b/src/Umbraco.Core/Services/IFileService.cs
@@ -130,7 +130,7 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Gets a <see cref="ITemplate"/> object by its identifier.
         /// </summary>
-        /// <param name="id">The identifer of the template.</param>
+        /// <param name="id">The identifier of the template.</param>
         /// <returns>The <see cref="ITemplate"/> object matching the identifier, or null.</returns>
         ITemplate GetTemplate(int id);
 

--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -109,7 +109,7 @@ namespace Umbraco.Core.Services
             IQuery<IMedia> filter = null, Ordering ordering = null);
 
         /// <summary>
-        /// Gets paged documents of a content content
+        /// Gets paged documents of a content
         /// </summary>
         /// <param name="contentTypeId">The page number.</param>
         /// <param name="pageIndex">The page number.</param>

--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -179,7 +179,7 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <remarks>This needs extra care and attention as its potentially a dangerous and extensive operation</remarks>
         /// <param name="mediaTypeIds">Ids of the <see cref="IMediaType"/>s</param>
-        /// <param name="userId">Optional Id of the user issueing the delete operation</param>
+        /// <param name="userId">Optional Id of the user issuing the delete operation</param>
         void DeleteMediaOfTypes(IEnumerable<int> mediaTypeIds, int userId = 0);
         
         /// <summary>

--- a/src/Umbraco.Core/Services/IMembershipMemberService.cs
+++ b/src/Umbraco.Core/Services/IMembershipMemberService.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Core.Services
     /// Defines part of the MemberService, which is specific to methods used by the membership provider.
     /// </summary>
     /// <remarks>
-    /// Idea is to have this is an isolated interface so that it can be easily 'replaced' in the membership provider impl.
+    /// Idea is to have this as an isolated interface so that it can be easily 'replaced' in the membership provider implementation.
     /// </remarks>
     public interface IMembershipMemberService : IMembershipMemberService<IMember>, IMembershipRoleService<IMember>
     {
@@ -29,7 +29,7 @@ namespace Umbraco.Core.Services
     /// either <see cref="IMember"/> for the MemberService or <see cref="IUser"/> for the UserService.
     /// </summary>
     /// <remarks>
-    /// Idea is to have this is an isolated interface so that it can be easily 'replaced' in the membership provider impl.
+    /// Idea is to have this as an isolated interface so that it can be easily 'replaced' in the membership provider implementation.
     /// </remarks>
     public interface IMembershipMemberService<T> : IService
         where T : class, IMembershipUser

--- a/src/Umbraco.Core/Services/ISectionService.cs
+++ b/src/Umbraco.Core/Services/ISectionService.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Core.Services
         Section GetByAlias(string appAlias);
 
         /// <summary>
-        /// Creates a new applcation if no application with the specified alias is found.
+        /// Creates a new application if no application with the specified alias is found.
         /// </summary>
         /// <param name="name">The application name.</param>
         /// <param name="alias">The application alias.</param>
@@ -81,7 +81,7 @@ namespace Umbraco.Core.Services
         }
 
         /// <summary>
-        /// Creates a new applcation if no application with the specified alias is found.
+        /// Creates a new application if no application with the specified alias is found.
         /// </summary>
         /// <param name="name">The application name.</param>
         /// <param name="alias">The application alias.</param>

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -137,7 +137,7 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <remarks>If no permissions are found for a particular entity then the user's default permissions will be applied</remarks>
         /// <param name="user">User to retrieve permissions for</param>
-        /// <param name="nodeIds">Specifiying nothing will return all user permissions for all nodes that have explicit permissions defined</param>
+        /// <param name="nodeIds">Specifying nothing will return all user permissions for all nodes that have explicit permissions defined</param>
         /// <returns>An enumerable list of <see cref="EntityPermission"/></returns>
         /// <remarks>
         /// This will return the default permissions for the user's groups for node ids that don't have explicitly defined permissions
@@ -151,7 +151,7 @@ namespace Umbraco.Core.Services
         /// <param name="fallbackToDefaultPermissions">
         ///     Flag indicating if we want to include the default group permissions for each result if there are not explicit permissions set
         /// </param>
-        /// <param name="nodeIds">Specifiying nothing will return all permissions for all nodes</param>
+        /// <param name="nodeIds">Specifying nothing will return all permissions for all nodes</param>
         /// <returns>An enumerable list of <see cref="EntityPermission"/></returns>
         EntityPermissionCollection GetPermissions(IUserGroup[] groups, bool fallbackToDefaultPermissions, params int[] nodeIds);
 

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -519,7 +519,7 @@ namespace Umbraco.Core.Services.Implement
         /// <returns>An Enumerable list of <see cref="IContent"/> objects</returns>
         public IEnumerable<IContent> GetAncestors(int id)
         {
-            // intentionnaly not locking
+            // intentionally not locking
             var content = GetById(id);
             return GetAncestors(content);
         }
@@ -628,7 +628,7 @@ namespace Umbraco.Core.Services.Implement
         /// <returns>Parent <see cref="IContent"/> object</returns>
         public IContent GetParent(int id)
         {
-            // intentionnaly not locking
+            // intentionally not locking
             var content = GetById(id);
             return GetParent(content);
         }
@@ -722,9 +722,9 @@ namespace Umbraco.Core.Services.Implement
         }
 
         /// <summary>
-        /// Checks if the passed in <see cref="IContent"/> can be published based on the anscestors publish state.
+        /// Checks if the passed in <see cref="IContent"/> can be published based on the ancestors publish state.
         /// </summary>
-        /// <param name="content"><see cref="IContent"/> to check if anscestors are published</param>
+        /// <param name="content"><see cref="IContent"/> to check if ancestors are published</param>
         /// <returns>True if the Content can be published, otherwise False</returns>
         public bool IsPathPublishable(IContent content)
         {
@@ -877,7 +877,7 @@ namespace Umbraco.Core.Services.Implement
             // if culture is specific, first publish the invariant values, then publish the culture itself.
             // if culture is '*', then publish them all (including variants)
 
-            // explicitely SaveAndPublish a specific culture also publishes invariant values
+            // explicitly SaveAndPublish a specific culture also publishes invariant values
             if (!culture.IsNullOrWhiteSpace() && culture != "*")
             {
                 // publish the invariant values
@@ -1116,7 +1116,7 @@ namespace Umbraco.Core.Services.Implement
                     }
 
                     // if was not published and now is... descendants that were 'published' (but
-                    // had an unpublished ancestor) are 're-published' ie not explicitely published
+                    // had an unpublished ancestor) are 're-published' ie not explicitly published
                     // but back as 'published' nevertheless
                     if (!branchOne && isNew == false && previouslyPublished == false && HasChildren(content.Id))
                     {
@@ -1841,7 +1841,7 @@ namespace Umbraco.Core.Services.Implement
                     return OperationResult.Cancel(evtMsgs);
                 }
 
-                // emptying the recycle bin means deleting whetever is in there - do it properly!
+                // emptying the recycle bin means deleting whatever is in there - do it properly!
                 var query = Query<IContent>().Where(x => x.ParentId == Constants.System.RecycleBinContent);
                 var contents = _documentRepository.Get(query).ToArray();
                 foreach (var content in contents)
@@ -1991,8 +1991,8 @@ namespace Umbraco.Core.Services.Implement
         /// Sends an <see cref="IContent"/> to Publication, which executes handlers and events for the 'Send to Publication' action.
         /// </summary>
         /// <param name="content">The <see cref="IContent"/> to send to publication</param>
-        /// <param name="userId">Optional Id of the User issueing the send to publication</param>
-        /// <returns>True if sending publication was succesfull otherwise false</returns>
+        /// <param name="userId">Optional Id of the User issuing the send to publication</param>
+        /// <returns>True if sending publication was successful otherwise false</returns>
         public bool SendToPublication(IContent content, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
@@ -2561,7 +2561,7 @@ namespace Umbraco.Core.Services.Implement
         /// inheritance and compositions, which need to be managed outside of this method.</para>
         /// </remarks>
         /// <param name="contentTypeId">Id of the <see cref="IContentType"/></param>
-        /// <param name="userId">Optional Id of the user issueing the delete operation</param>
+        /// <param name="userId">Optional Id of the user issuing the delete operation</param>
         public void DeleteOfTypes(IEnumerable<int> contentTypeIds, int userId = 0)
         {
             //TODO: This currently this is called from the ContentTypeService but that needs to change,

--- a/src/Umbraco.Core/Services/Implement/ContentTypeService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentTypeService.cs
@@ -43,47 +43,47 @@ namespace Umbraco.Core.Services.Implement
         }
 
         /// <summary>
-        /// Gets all property type aliases accross content, media and member types.
+        /// Gets all property type aliases across content, media and member types.
         /// </summary>
         /// <returns>All property type aliases.</returns>
-        /// <remarks>Beware! Works accross content, media and member types.</remarks>
+        /// <remarks>Beware! Works across content, media and member types.</remarks>
         public IEnumerable<string> GetAllPropertyTypeAliases()
         {
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
-                // that one is special because it works accross content, media and member types
+                // that one is special because it works across content, media and member types
                 scope.ReadLock(Constants.Locks.ContentTypes, Constants.Locks.MediaTypes, Constants.Locks.MemberTypes);
                 return Repository.GetAllPropertyTypeAliases();
             }
         }
 
         /// <summary>
-        /// Gets all content type aliases accross content, media and member types.
+        /// Gets all content type aliases across content, media and member types.
         /// </summary>
         /// <param name="guids">Optional object types guid to restrict to content, and/or media, and/or member types.</param>
         /// <returns>All content type aliases.</returns>
-        /// <remarks>Beware! Works accross content, media and member types.</remarks>
+        /// <remarks>Beware! Works across content, media and member types.</remarks>
         public IEnumerable<string> GetAllContentTypeAliases(params Guid[] guids)
         {
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
-                // that one is special because it works accross content, media and member types
+                // that one is special because it works across content, media and member types
                 scope.ReadLock(Constants.Locks.ContentTypes, Constants.Locks.MediaTypes, Constants.Locks.MemberTypes);
                 return Repository.GetAllContentTypeAliases(guids);
             }
         }
 
         /// <summary>
-        /// Gets all content type id for aliases accross content, media and member types.
+        /// Gets all content type id for aliases across content, media and member types.
         /// </summary>
         /// <param name="aliases">Aliases to look for.</param>
         /// <returns>All content type ids.</returns>
-        /// <remarks>Beware! Works accross content, media and member types.</remarks>
+        /// <remarks>Beware! Works across content, media and member types.</remarks>
         public IEnumerable<int> GetAllContentTypeIds(string[] aliases)
         {
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
-                // that one is special because it works accross content, media and member types
+                // that one is special because it works across content, media and member types
                 scope.ReadLock(Constants.Locks.ContentTypes, Constants.Locks.MediaTypes, Constants.Locks.MemberTypes);
                 return Repository.GetAllContentTypeIds(aliases);
             }

--- a/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -125,7 +125,7 @@ namespace Umbraco.Core.Services.Implement
 
             // note
             // this is meant to run *after* uow.Commit() so must use WasPropertyDirty() everywhere
-            // instead of IsPropertyDirty() since dirty properties have been resetted already
+            // instead of IsPropertyDirty() since dirty properties have been reset already
 
             var changes = new List<ContentTypeChange<TItem>>();
 

--- a/src/Umbraco.Core/Services/Implement/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/Implement/DataTypeService.cs
@@ -330,7 +330,7 @@ namespace Umbraco.Core.Services.Implement
         /// Saves an <see cref="IDataType"/>
         /// </summary>
         /// <param name="dataType"><see cref="IDataType"/> to save</param>
-        /// <param name="userId">Id of the user issueing the save</param>
+        /// <param name="userId">Id of the user issuing the save</param>
         public void Save(IDataType dataType, int userId = 0)
         {
             dataType.CreatorId = userId;
@@ -362,7 +362,7 @@ namespace Umbraco.Core.Services.Implement
         /// Saves a collection of <see cref="IDataType"/>
         /// </summary>
         /// <param name="dataTypeDefinitions"><see cref="IDataType"/> to save</param>
-        /// <param name="userId">Id of the user issueing the save</param>
+        /// <param name="userId">Id of the user issuing the save</param>
         public void Save(IEnumerable<IDataType> dataTypeDefinitions, int userId = 0)
         {
             Save(dataTypeDefinitions, userId, true);
@@ -372,7 +372,7 @@ namespace Umbraco.Core.Services.Implement
         /// Saves a collection of <see cref="IDataType"/>
         /// </summary>
         /// <param name="dataTypeDefinitions"><see cref="IDataType"/> to save</param>
-        /// <param name="userId">Id of the user issueing the save</param>
+        /// <param name="userId">Id of the user issuing the save</param>
         /// <param name="raiseEvents">Boolean indicating whether or not to raise events</param>
         public void Save(IEnumerable<IDataType> dataTypeDefinitions, int userId, bool raiseEvents)
         {
@@ -412,7 +412,7 @@ namespace Umbraco.Core.Services.Implement
         /// all the <see cref="PropertyType"/> data that references this <see cref="IDataType"/>.
         /// </remarks>
         /// <param name="dataType"><see cref="IDataType"/> to delete</param>
-        /// <param name="userId">Optional Id of the user issueing the deletion</param>
+        /// <param name="userId">Optional Id of the user issuing the deletion</param>
         public void Delete(IDataType dataType, int userId = 0)
         {
             using (var scope = ScopeProvider.CreateScope())
@@ -444,7 +444,7 @@ namespace Umbraco.Core.Services.Implement
                     // so... we are modifying content types here. the service will trigger Deleted event,
                     // which will propagate to DataTypeCacheRefresher which will clear almost every cache
                     // there is to clear... and in addition published snapshot caches will clear themselves too, so
-                    // this is probably safe alghough it looks... weird.
+                    // this is probably safe although it looks... weird.
                     //
                     // what IS weird is that a content type is losing a property and we do NOT raise any
                     // content type event... so ppl better listen on the data type events too.

--- a/src/Umbraco.Core/Services/Implement/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/Implement/DataTypeService.cs
@@ -262,7 +262,7 @@ namespace Umbraco.Core.Services.Implement
         /// Gets a <see cref="IDataType"/> by its control Id
         /// </summary>
         /// <param name="propertyEditorAlias">Alias of the property editor</param>
-        /// <returns>Collection of <see cref="IDataType"/> objects with a matching contorl id</returns>
+        /// <returns>Collection of <see cref="IDataType"/> objects with a matching control id</returns>
         public IEnumerable<IDataType> GetByEditorAlias(string propertyEditorAlias)
         {
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))

--- a/src/Umbraco.Core/Services/Implement/ExternalLoginService.cs
+++ b/src/Umbraco.Core/Services/Implement/ExternalLoginService.cs
@@ -36,7 +36,7 @@ namespace Umbraco.Core.Services.Implement
 
         /// <summary>
         /// Returns all logins matching the login info - generally there should only be one but in some cases
-        /// there might be more than one depending on if an adminstrator has been editing/removing members
+        /// there might be more than one depending on if an administrator has been editing/removing members
         /// </summary>
         /// <param name="login"></param>
         /// <returns></returns>

--- a/src/Umbraco.Core/Services/Implement/FileService.cs
+++ b/src/Umbraco.Core/Services/Implement/FileService.cs
@@ -435,7 +435,7 @@ namespace Umbraco.Core.Services.Implement
         /// <summary>
         /// Gets a <see cref="ITemplate"/> object by its identifier.
         /// </summary>
-        /// <param name="id">The identifer of the template.</param>
+        /// <param name="id">The identifier of the template.</param>
         /// <returns>The <see cref="ITemplate"/> object matching the identifier, or null.</returns>
         public ITemplate GetTemplate(int id)
         {

--- a/src/Umbraco.Core/Services/Implement/LocalizationService.cs
+++ b/src/Umbraco.Core/Services/Implement/LocalizationService.cs
@@ -442,7 +442,7 @@ namespace Umbraco.Core.Services.Implement
         /// <summary>
         /// This is here to take care of a hack - the DictionaryTranslation model contains an ILanguage reference which we don't want but
         /// we cannot remove it because it would be a large breaking change, so we need to make sure it's resolved lazily. This is because
-        /// if developers have a lot of dictionary items and translations, the caching and cloning size gets much much larger because of
+        /// if developers have a lot of dictionary items and translations, the caching and cloning size gets much larger because of
         /// the large object graphs. So now we don't cache or clone the attached ILanguage
         /// </summary>
         private void EnsureDictionaryItemLanguageCallback(IDictionaryItem d)

--- a/src/Umbraco.Core/Services/Implement/LocalizedTextService.cs
+++ b/src/Umbraco.Core/Services/Implement/LocalizedTextService.cs
@@ -111,7 +111,7 @@ namespace Umbraco.Core.Services.Implement
                 //convert all areas + keys to a single key with a '/'
                 result = GetStoredTranslations(xmlSource, culture);
 
-                //merge with the english file in case there's keys in there that don't exist in the local file
+                //merge with the English file in case there's keys in there that don't exist in the local file
                 var englishCulture = new CultureInfo("en-US");
                 if (culture.Equals(englishCulture) == false)
                 {

--- a/src/Umbraco.Core/Services/Implement/LocalizedTextServiceFileSources.cs
+++ b/src/Umbraco.Core/Services/Implement/LocalizedTextServiceFileSources.cs
@@ -186,7 +186,7 @@ namespace Umbraco.Core.Services.Implement
             if (xMasterDoc.Root == null) return;
             if (_supplementFileSources != null)
             {
-                //now load in suplementary
+                //now load in supplementary
                 var found = _supplementFileSources.Where(x =>
                 {
                     var fileName = Path.GetFileName(x.File.FullName);

--- a/src/Umbraco.Core/Services/Implement/MediaService.cs
+++ b/src/Umbraco.Core/Services/Implement/MediaService.cs
@@ -451,7 +451,7 @@ namespace Umbraco.Core.Services.Implement
         /// <returns>An Enumerable list of <see cref="IMedia"/> objects</returns>
         public IEnumerable<IMedia> GetAncestors(int id)
         {
-            // intentionnaly not locking
+            // intentionally not locking
             var media = GetById(id);
             return GetAncestors(media);
         }
@@ -547,7 +547,7 @@ namespace Umbraco.Core.Services.Implement
         /// <returns>Parent <see cref="IMedia"/> object</returns>
         public IMedia GetParent(int id)
         {
-            // intentionnaly not locking
+            // intentionally not locking
             var media = GetById(id);
             return GetParent(media);
         }
@@ -1045,7 +1045,7 @@ namespace Umbraco.Core.Services.Implement
                 // v7 EmptyingRecycleBin and EmptiedRecycleBin events are greatly simplified since
                 // each deleted items will have its own deleting/deleted events. so, files and such
 
-                // emptying the recycle bin means deleting whetever is in there - do it properly!
+                // emptying the recycle bin means deleting whatever is in there - do it properly!
                 // are managed by Delete, and not here.
                 // no idea what those events are for, keep a simplified version
                 var args = new RecycleBinEventArgs(nodeObjectType, evtMsgs);
@@ -1055,7 +1055,7 @@ namespace Umbraco.Core.Services.Implement
                     scope.Complete();
                     return OperationResult.Cancel(evtMsgs);
                 }
-                // emptying the recycle bin means deleting whetever is in there - do it properly!
+                // emptying the recycle bin means deleting whatever is in there - do it properly!
                 var query = Query<IMedia>().Where(x => x.ParentId == Constants.System.RecycleBinMedia);
                 var medias = _mediaRepository.Get(query).ToArray();
                 foreach (var media in medias)

--- a/src/Umbraco.Core/Services/Implement/MemberGroupService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberGroupService.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Core.Services.Implement
             MemberGroupRepository.SavingMemberGroup += MemberGroupRepository_SavingMemberGroup;
         }
 
-        #region Proxied event handlers
+        #region Proxy event handlers
 
         void MemberGroupRepository_SavingMemberGroup(IMemberGroupRepository sender, SaveEventArgs<IMemberGroup> e)
         {

--- a/src/Umbraco.Core/Services/Implement/NotificationService.cs
+++ b/src/Umbraco.Core/Services/Implement/NotificationService.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Core.Services.Implement
             //exit if there are no entities
             if (entitiesL.Count == 0) return;
 
-            //put all entity's paths into a list with the same indicies
+            //put all entity's paths into a list with the same index's
             var paths = entitiesL.Select(x => x.Path.Split(',').Select(int.Parse).ToArray()).ToArray();
 
             // lazily get versions
@@ -301,7 +301,7 @@ namespace Umbraco.Core.Services.Implement
             {
                 if (!_contentSection.DisableHtmlEmail)
                 {
-                    //create the html summary for invariant content
+                    //create the HTML summary for invariant content
 
                     //list all of the property values like we used to
                     summary.Append("<table style=\"width: 100 %; \">");
@@ -318,7 +318,7 @@ namespace Umbraco.Core.Services.Implement
                             var oldProperty = oldDoc.Properties[p.PropertyType.Alias];
                             oldText = oldProperty.GetValue() != null ? oldProperty.GetValue().ToString() : "";
 
-                            // replace html with char equivalent
+                            // replace HTML with char equivalent
                             ReplaceHtmlSymbols(ref oldText);
                             ReplaceHtmlSymbols(ref newText);
                         }
@@ -343,7 +343,7 @@ namespace Umbraco.Core.Services.Implement
 
                 if (!_contentSection.DisableHtmlEmail)
                 {
-                    //Create the html based summary (ul of culture names)
+                    //Create the HTML based summary (ul of culture names)
 
                     var culturesChanged = content.CultureInfos.Where(x => x.Value.WasDirty())
                         .Select(x => x.Key)

--- a/src/Umbraco.Core/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Core/Services/Implement/PackagingService.cs
@@ -69,10 +69,10 @@ namespace Umbraco.Core.Services.Implement
             }
             catch (HttpRequestException ex)
             {
-                throw new ConnectionException("An error occuring downloading the package from " + url, ex);
+                throw new ConnectionException("An error occurring downloading the package from " + url, ex);
             }
 
-            //successfull
+            //successful
             if (bytes.Length > 0)
             {
                 var packagePath = IOHelper.MapPath(SystemDirectories.Packages);

--- a/src/Umbraco.Core/Services/Implement/RelationService.cs
+++ b/src/Umbraco.Core/Services/Implement/RelationService.cs
@@ -381,7 +381,7 @@ namespace Umbraco.Core.Services.Implement
         /// <returns>The created <see cref="Relation"/></returns>
         public IRelation Relate(int parentId, int childId, IRelationType relationType)
         {
-            // Ensure that the RelationType has an indentity before using it to relate two entities
+            // Ensure that the RelationType has an identity before using it to relate two entities
             if (relationType.HasIdentity == false)
                 Save(relationType);
 

--- a/src/Umbraco.Core/Services/Implement/UserService.cs
+++ b/src/Umbraco.Core/Services/Implement/UserService.cs
@@ -929,7 +929,7 @@ namespace Umbraco.Core.Services.Implement
         /// Get explicitly assigned permissions for a user and optional node ids
         /// </summary>
         /// <param name="user">User to retrieve permissions for</param>
-        /// <param name="nodeIds">Specifiying nothing will return all permissions for all nodes</param>
+        /// <param name="nodeIds">Specifying nothing will return all permissions for all nodes</param>
         /// <returns>An enumerable list of <see cref="EntityPermission"/></returns>
         public EntityPermissionCollection GetPermissions(IUser user, params int[] nodeIds)
         {
@@ -946,7 +946,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="fallbackToDefaultPermissions">
         /// Flag indicating if we want to include the default group permissions for each result if there are not explicit permissions set
         /// </param>
-        /// <param name="nodeIds">Specifiying nothing will return all permissions for all nodes</param>
+        /// <param name="nodeIds">Specifying nothing will return all permissions for all nodes</param>
         /// <returns>An enumerable list of <see cref="EntityPermission"/></returns>
         private IEnumerable<EntityPermission> GetPermissions(IReadOnlyUserGroup[] groups, bool fallbackToDefaultPermissions, params int[] nodeIds)
         {
@@ -965,7 +965,7 @@ namespace Umbraco.Core.Services.Implement
         /// <param name="fallbackToDefaultPermissions">
         ///     Flag indicating if we want to include the default group permissions for each result if there are not explicit permissions set
         /// </param>
-        /// <param name="nodeIds">Specifiying nothing will return all permissions for all nodes</param>
+        /// <param name="nodeIds">Specifying nothing will return all permissions for all nodes</param>
         /// <returns>An enumerable list of <see cref="EntityPermission"/></returns>
         public EntityPermissionCollection GetPermissions(IUserGroup[] groups, bool fallbackToDefaultPermissions, params int[] nodeIds)
         {
@@ -1073,7 +1073,7 @@ namespace Umbraco.Core.Services.Implement
                     {
                         if (entityPermission.IsDefaultPermissions == false)
                         {
-                            //explicit permision found so we'll append it and move on, the collection is a hashset anyways
+                            //explicit permission found so we'll append it and move on, the collection is a hashset anyways
                             //so only supports adding one element per groupid/contentid
                             resultPermissions.Add(entityPermission);
                             added = true;

--- a/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
@@ -56,7 +56,7 @@ namespace Umbraco.Core.Services
         }
 
         /// <summary>
-        /// Convert an array of strings to a dictionary of indicies -> values
+        /// Convert an array of strings to a dictionary of indexes -> values
         /// </summary>
         /// <param name="variables"></param>
         /// <returns></returns>

--- a/src/Umbraco.Core/Services/OperationResultType.cs
+++ b/src/Umbraco.Core/Services/OperationResultType.cs
@@ -5,7 +5,7 @@
     /// </summary>
     public enum OperationResultType : byte
     {
-        // all "ResultType" enums must be byte-based, and declare Failed = 128, and declare
+        // all "ResultType" enum's must be byte-based, and declare Failed = 128, and declare
         // every failure codes as >128 - see OperationResult and OperationResultType for details.
 
         /// <summary>

--- a/src/Umbraco.Core/Services/PublishResultType.cs
+++ b/src/Umbraco.Core/Services/PublishResultType.cs
@@ -5,7 +5,7 @@
     /// </summary>
     public enum PublishResultType : byte
     {
-        // all "ResultType" enums must be byte-based, and declare Failed = 128, and declare
+        // all "ResultType" enum's must be byte-based, and declare Failed = 128, and declare
         // every failure codes as >128 - see OperationResult and OperationResultType for details.
 
         #region Success - Publish

--- a/src/Umbraco.Core/Services/UserServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/UserServiceExtensions.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Core.Services
         /// <param name="fallbackToDefaultPermissions">
         ///     Flag indicating if we want to include the default group permissions for each result if there are not explicit permissions set
         /// </param>
-        /// <param name="nodeIds">Specifiying nothing will return all permissions for all nodes</param>
+        /// <param name="nodeIds">Specifying nothing will return all permissions for all nodes</param>
         /// <returns>An enumerable list of <see cref="EntityPermission"/></returns>
         public static EntityPermissionCollection GetPermissions(this IUserService service, IUserGroup group, bool fallbackToDefaultPermissions, params int[] nodeIds)
         {

--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -82,7 +82,7 @@ namespace Umbraco.Core
         }
 
         /// <summary>
-        /// Based on the input string, this will detect if the strnig is a JS path or a JS snippet.
+        /// Based on the input string, this will detect if the string is a JS path or a JS snippet.
         /// If a path cannot be determined, then it is assumed to be a snippet the original text is returned
         /// with an invalid attempt, otherwise a valid attempt is returned with the resolved path
         /// </summary>
@@ -197,7 +197,7 @@ namespace Umbraco.Core
         /// <returns></returns>
         public static string CleanForXss(this string input, params char[] ignoreFromClean)
         {
-            //remove any html
+            //remove any HTML
             input = input.StripHtml();
             //strip out any potential chars involved with XSS
             return input.ExceptChars(new HashSet<char>(CleanForXssChars.Except(ignoreFromClean)));
@@ -314,7 +314,7 @@ namespace Umbraco.Core
             return decryptedValue.ToString();
         }
 
-        //this is from SqlMetal and just makes it a bit of fun to allow pluralisation
+        //this is from SqlMetal and just makes it a bit of fun to allow pluralization
         public static string MakePluralName(this string name)
         {
             if ((name.EndsWith("x", StringComparison.OrdinalIgnoreCase) || name.EndsWith("ch", StringComparison.OrdinalIgnoreCase)) || (name.EndsWith("s", StringComparison.OrdinalIgnoreCase) || name.EndsWith("sh", StringComparison.OrdinalIgnoreCase)))
@@ -532,10 +532,10 @@ namespace Umbraco.Core
         }
 
         /// <summary>
-        /// Strips all html from a string.
+        /// Strips all HTML from a string.
         /// </summary>
         /// <param name="text">The text.</param>
-        /// <returns>Returns the string without any html tags.</returns>
+        /// <returns>Returns the string without any HTML tags.</returns>
         public static string StripHtml(this string text)
         {
             const string pattern = @"<(.|\n)*?>";
@@ -723,7 +723,7 @@ namespace Umbraco.Core
         /// <summary>
         /// Generates a hash of a string based on the FIPS compliance setting.
         /// </summary>
-        /// <param name="str">Referrs to itself</param>
+        /// <param name="str">Refers to itself</param>
         /// <returns>The hashed string</returns>
         public static string GenerateHash(this string str)
         {
@@ -735,7 +735,7 @@ namespace Umbraco.Core
         /// <summary>
         /// Converts the string to MD5
         /// </summary>
-        /// <param name="stringToConvert">Referrs to itself</param>
+        /// <param name="stringToConvert">Refers to itself</param>
         /// <returns>The MD5 hashed string</returns>
         public static string ToMd5(this string stringToConvert)
         {
@@ -745,7 +745,7 @@ namespace Umbraco.Core
         /// <summary>
         /// Converts the string to SHA1
         /// </summary>
-        /// <param name="stringToConvert">referrs to itself</param>
+        /// <param name="stringToConvert">refers to itself</param>
         /// <returns>The SHA1 hashed string</returns>
         public static string ToSHA1(this string stringToConvert)
         {
@@ -754,7 +754,7 @@ namespace Umbraco.Core
 
         /// <summary>Generate a hash of a string based on the hashType passed in
         /// </summary>
-        /// <param name="str">Referrs to itself</param>
+        /// <param name="str">Refers to itself</param>
         /// <param name="hashType">String with the hash type.  See remarks section of the CryptoConfig Class in MSDN docs for a list of possible values.</param>
         /// <returns>The hashed string</returns>
         private static string GenerateHash(this string str, string hashType)
@@ -773,7 +773,7 @@ namespace Umbraco.Core
                 //create a StringBuilder object
                 var stringBuilder = new StringBuilder();
 
-                //loop to each each byte
+                //loop to each byte
                 foreach (var b in hashedByteArray)
                 {
                     //append it to our StringBuilder
@@ -1034,7 +1034,7 @@ namespace Umbraco.Core
         }
 
         /// <summary>
-        /// Returns a new string in which all occurences of specified strings are replaced by other specified strings.
+        /// Returns a new string in which all occurrences of specified strings are replaced by other specified strings.
         /// </summary>
         /// <param name="text">The string to filter.</param>
         /// <param name="replacements">The replacements definition.</param>
@@ -1052,7 +1052,7 @@ namespace Umbraco.Core
         }
 
         /// <summary>
-        /// Returns a new string in which all occurences of specified characters are replaced by a specified character.
+        /// Returns a new string in which all occurrences of specified characters are replaced by a specified character.
         /// </summary>
         /// <param name="text">The string to filter.</param>
         /// <param name="chars">The characters to replace.</param>
@@ -1219,7 +1219,7 @@ namespace Umbraco.Core
         /// Splits a Pascal cased string into a phrase separated by spaces.
         /// </summary>
         /// <param name="phrase">The text to split.</param>
-        /// <returns>The splitted text.</returns>
+        /// <returns>The split text.</returns>
         public static string SplitPascalCasing(this string phrase)
         {
             return Current.ShortStringHelper.SplitPascalCasing(phrase, ' ');
@@ -1270,7 +1270,7 @@ namespace Umbraco.Core
         /// <returns>Updated string</returns>
         public static string Replace(this string source, string oldString, string newString, StringComparison stringComparison)
         {
-            // This initialisation ensures the first check starts at index zero of the source. On successive checks for
+            // This initialization ensures the first check starts at index zero of the source. On successive checks for
             // a match, the source is skipped to immediately after the last replaced occurrence for efficiency
             // and to avoid infinite loops when oldString and newString compare equal.
             int index = -1 * newString.Length;
@@ -1281,7 +1281,7 @@ namespace Umbraco.Core
                 // Remove the old text.
                 source = source.Remove(index, oldString.Length);
 
-                // Add the replacemenet text.
+                // Add the replacement text.
                 source = source.Insert(index, newString);
             }
 
@@ -1357,7 +1357,7 @@ namespace Umbraco.Core
         /// </summary>
         /// <param name="haystack">The string to check</param>
         /// <param name="needles">The collection of strings to check are contained within the first string</param>
-        /// <param name="comparison">The type of comparision to perform - defaults to <see cref="StringComparison.CurrentCulture"/></param>
+        /// <param name="comparison">The type of comparison to perform - defaults to <see cref="StringComparison.CurrentCulture"/></param>
         /// <returns>True if any of the needles are contained with haystack; otherwise returns false</returns>
         /// Added fix to ensure the comparison is used - see http://issues.umbraco.org/issue/U4-11313
         public static bool ContainsAny(this string haystack, IEnumerable<string> needles, StringComparison comparison = StringComparison.CurrentCulture)

--- a/src/Umbraco.Core/Strings/DefaultShortStringHelper.cs
+++ b/src/Umbraco.Core/Strings/DefaultShortStringHelper.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Core.Strings
 
         #region Filters
 
-        // ok to be static here because it's not configureable in any way
+        // ok to be static here because it's not configurable in any way
         private static readonly char[] InvalidFileNameChars =
             Path.GetInvalidFileNameChars()
             .Union("!*'();:@&=+$,/?%#[]-~{}\"<>\\^`| ".ToCharArray())
@@ -574,7 +574,7 @@ namespace Umbraco.Core.Strings
         /// </summary>
         /// <param name="text">The text to split.</param>
         /// <param name="separator">The separator, which defaults to a whitespace.</param>
-        /// <returns>The splitted text.</returns>
+        /// <returns>The split text.</returns>
         /// <remarks>Supports Utf8 and Ascii strings, not Unicode strings.</remarks>
         // NOTE does not support surrogates pairs at the moment
         public virtual string SplitPascalCasing(string text, char separator)

--- a/src/Umbraco.Core/Strings/DefaultShortStringHelperConfig.cs
+++ b/src/Umbraco.Core/Strings/DefaultShortStringHelperConfig.cs
@@ -188,7 +188,7 @@ namespace Umbraco.Core.Strings
             public bool GreedyAcronyms { get; set; }
 
             // the separator char
-            // but then how can we tell we dont want any?
+            // but then how can we tell we don't want any?
             public char Separator { get; set; }
 
             // extends the config

--- a/src/Umbraco.Core/Strings/Diff.cs
+++ b/src/Umbraco.Core/Strings/Diff.cs
@@ -111,7 +111,7 @@ namespace Umbraco.Core.Strings
         /// <param name="textB">B-version of the text (usualy the new one)</param>
         /// <param name="trimSpace">When set to true, all leading and trailing whitespace characters are stripped out before the comparation is done.</param>
         /// <param name="ignoreSpace">When set to true, all whitespace characters are converted to a single space character before the comparation is done.</param>
-        /// <param name="ignoreCase">When set to true, all characters are converted to their lowercase equivivalence before the comparation is done.</param>
+        /// <param name="ignoreCase">When set to true, all characters are converted to their lowercase equivalence before the comparation is done.</param>
         /// <returns>Returns a array of Items that describe the differences.</returns>
         public static Item[] DiffText(string textA, string textB, bool trimSpace, bool ignoreSpace, bool ignoreCase)
         {

--- a/src/Umbraco.Core/Strings/Diff.cs
+++ b/src/Umbraco.Core/Strings/Diff.cs
@@ -76,10 +76,10 @@ namespace Umbraco.Core.Strings
         }
 
         /// <summary>
-        /// Find the difference in 2 texts, comparing by textlines.
+        /// Find the difference in 2 texts, comparing by text lines.
         /// </summary>
-        /// <param name="textA">A-version of the text (usualy the old one)</param>
-        /// <param name="textB">B-version of the text (usualy the new one)</param>
+        /// <param name="textA">A-version of the text (usually the old one)</param>
+        /// <param name="textB">B-version of the text (usually the new one)</param>
         /// <returns>Returns a array of Items that describe the differences.</returns>
         public static Item[] DiffText(string textA, string textB)
         {
@@ -87,12 +87,12 @@ namespace Umbraco.Core.Strings
         } // DiffText
 
         /// <summary>
-        /// Find the difference in 2 texts, comparing by textlines.
+        /// Find the difference in 2 texts, comparing by text lines.
         /// This method uses the DiffInt internally by 1st converting the string into char codes
         /// then uses the diff int method
         /// </summary>
-        /// <param name="textA">A-version of the text (usualy the old one)</param>
-        /// <param name="textB">B-version of the text (usualy the new one)</param>
+        /// <param name="textA">A-version of the text (usually the old one)</param>
+        /// <param name="textB">B-version of the text (usually the new one)</param>
         /// <returns>Returns a array of Items that describe the differences.</returns>
         public static Item[] DiffText1(string textA, string textB)
         {
@@ -101,17 +101,17 @@ namespace Umbraco.Core.Strings
 
 
         /// <summary>
-        /// Find the difference in 2 text documents, comparing by textlines.
+        /// Find the difference in 2 text documents, comparing by text lines.
         /// The algorithm itself is comparing 2 arrays of numbers so when comparing 2 text documents
         /// each line is converted into a (hash) number. This hash-value is computed by storing all
-        /// textlines into a common hashtable so i can find dublicates in there, and generating a
-        /// new number each time a new textline is inserted.
+        /// text lines into a common hash table so i can find duplicates in there, and generating a
+        /// new number each time a new text line is inserted.
         /// </summary>
-        /// <param name="textA">A-version of the text (usualy the old one)</param>
-        /// <param name="textB">B-version of the text (usualy the new one)</param>
-        /// <param name="trimSpace">When set to true, all leading and trailing whitespace characters are stripped out before the comparation is done.</param>
-        /// <param name="ignoreSpace">When set to true, all whitespace characters are converted to a single space character before the comparation is done.</param>
-        /// <param name="ignoreCase">When set to true, all characters are converted to their lowercase equivalence before the comparation is done.</param>
+        /// <param name="textA">A-version of the text (usually the old one)</param>
+        /// <param name="textB">B-version of the text (usually the new one)</param>
+        /// <param name="trimSpace">When set to true, all leading and trailing whitespace characters are stripped out before the comparison is done.</param>
+        /// <param name="ignoreSpace">When set to true, all whitespace characters are converted to a single space character before the comparison is done.</param>
+        /// <param name="ignoreCase">When set to true, all characters are converted to their lowercase equivalence before the comparison is done.</param>
         /// <returns>Returns a array of Items that describe the differences.</returns>
         public static Item[] DiffText(string textA, string textB, bool trimSpace, bool ignoreSpace, bool ignoreCase)
         {
@@ -124,7 +124,7 @@ namespace Umbraco.Core.Strings
             // The B-Version of the data (modified data) to be compared.
             var dataB = new DiffData(DiffCodes(textB, h, trimSpace, ignoreSpace, ignoreCase));
 
-            h = null; // free up hashtable memory (maybe)
+            h = null; // free up hash table memory (maybe)
 
             var max = dataA.Length + dataB.Length + 1;
             // vector for the (0,0) to (x,y) search
@@ -193,8 +193,8 @@ namespace Umbraco.Core.Strings
         /// <summary>
         /// Find the difference in 2 arrays of integers.
         /// </summary>
-        /// <param name="arrayA">A-version of the numbers (usualy the old one)</param>
-        /// <param name="arrayB">B-version of the numbers (usualy the new one)</param>
+        /// <param name="arrayA">A-version of the numbers (usually the old one)</param>
+        /// <param name="arrayB">B-version of the numbers (usually the new one)</param>
         /// <returns>Returns a array of Items that describe the differences.</returns>
         public static Item[] DiffInt(int[] arrayA, int[] arrayB)
         {
@@ -216,11 +216,11 @@ namespace Umbraco.Core.Strings
 
 
         /// <summary>
-        /// This function converts all textlines of the text into unique numbers for every unique textline
+        /// This function converts all text lines of the text into unique numbers for every unique text line
         /// so further work can work only with simple numbers.
         /// </summary>
         /// <param name="aText">the input text</param>
-        /// <param name="h">This extern initialized hashtable is used for storing all ever used textlines.</param>
+        /// <param name="h">This extern initialized hash table is used for storing all ever used text lines.</param>
         /// <param name="trimSpace">ignore leading and trailing space characters</param>
         /// <param name="ignoreSpace"></param>
         /// <param name="ignoreCase"></param>
@@ -230,7 +230,7 @@ namespace Umbraco.Core.Strings
             // get all codes of the text
             var lastUsedCode = h.Count;
 
-            // strip off all cr, only use lf as textline separator.
+            // strip off all cr, only use lf as text line separator.
             aText = aText.Replace("\r", "");
             var lines = aText.Split('\n');
 
@@ -393,7 +393,7 @@ namespace Umbraco.Core.Strings
 
 
         /// <summary>
-        /// This is the divide-and-conquer implementation of the longes common-subsequence (LCS)
+        /// This is the divide-and-conquer implementation of the longest common-subsequence (LCS)
         /// algorithm.
         /// The published algorithm passes recursively parts of the A and B sequences.
         /// To avoid copying these arrays the lower and upper bounds are passed while the sequences stay constant.
@@ -408,15 +408,15 @@ namespace Umbraco.Core.Strings
         /// <param name="upVector">a vector for the (u,v) to (N,M) search. Passed as a parameter for speed reasons.</param>
         private static void Lcs(DiffData dataA, int lowerA, int upperA, DiffData dataB, int lowerB, int upperB, int[] downVector, int[] upVector)
         {
-            // Debug.Write(2, "LCS", String.Format("Analyse the box: A[{0}-{1}] to B[{2}-{3}]", LowerA, UpperA, LowerB, UpperB));
+            // Debug.Write(2, "LCS", String.Format("Analyze the box: A[{0}-{1}] to B[{2}-{3}]", LowerA, UpperA, LowerB, UpperB));
 
-            // Fast walkthrough equal lines at the start
+            // Fast walk through equal lines at the start
             while (lowerA < upperA && lowerB < upperB && dataA.Data[lowerA] == dataB.Data[lowerB])
             {
                 lowerA++; lowerB++;
             }
 
-            // Fast walkthrough equal lines at the end
+            // Fast walk through equal lines at the end
             while (lowerA < upperA && lowerB < upperB && dataA.Data[upperA - 1] == dataB.Data[upperB - 1])
             {
                 --upperA; --upperB;
@@ -438,7 +438,7 @@ namespace Umbraco.Core.Strings
             }
             else
             {
-                // Find the middle snakea and length of an optimal path for A and B
+                // Find the middle snake and length of an optimal path for A and B
                 Smsrd smsrd = Sms(dataA, lowerA, upperA, dataB, lowerB, upperB, downVector, upVector);
                 // Debug.Write(2, "MiddleSnakeData", String.Format("{0},{1}", smsrd.x, smsrd.y));
 

--- a/src/Umbraco.Core/Strings/IShortStringHelper.cs
+++ b/src/Umbraco.Core/Strings/IShortStringHelper.cs
@@ -65,7 +65,7 @@
         /// </summary>
         /// <param name="text">The text to split.</param>
         /// <param name="separator">The separator.</param>
-        /// <returns>The splitted string.</returns>
+        /// <returns>The split string.</returns>
         /// <remarks>Supports Utf8 and Ascii strings, not Unicode strings.</remarks>
         string SplitPascalCasing(string text, char separator);
 

--- a/src/Umbraco.Core/Strings/Utf8ToAsciiConverter.cs
+++ b/src/Umbraco.Core/Strings/Utf8ToAsciiConverter.cs
@@ -3322,7 +3322,7 @@ namespace Umbraco.Core.Strings
 
                     // BEGIN CUSTOM TRANSLITERATION OF CYRILIC CHARS
 
-                    #region Cyrilic chars
+                    #region Cyrillic chars
 
                     // russian uppercase "А Б В Г Д Е Ё Ж З И Й К Л М Н О П Р С Т У Ф Х Ц Ч Ш Щ Ъ Ы Ь Э Ю Я"
                     // russian lowercase "а б в г д е ё ж з и й к л м н о п р с т у ф х ц ч ш щ ъ ы ь э ю я"
@@ -3340,7 +3340,7 @@ namespace Umbraco.Core.Strings
                     // fixme
                     // transliterates Анастасия as Anastasiya, and not Anastasia
                     // Ольга --> Ol'ga, Татьяна --> Tat'yana -- that's bad (?)
-                    // Note: should ä (german umlaut) become a or ae ?
+                    // Note: should ä (German umlaut) become a or ae ?
 
                     case '\u0410': // А
                         output[opos++] = 'A';

--- a/src/Umbraco.Core/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Core/Sync/DatabaseServerMessenger.cs
@@ -153,7 +153,7 @@ namespace Umbraco.Core.Sync
             ReadLastSynced(); // get _lastId
             using (var scope = ScopeProvider.CreateScope())
             {
-                EnsureInstructions(scope.Database); // reset _lastId if instrs are missing
+                EnsureInstructions(scope.Database); // reset _lastId if instructions are missing
                 Initialize(scope.Database); // boot
 
                 scope.Complete();
@@ -326,7 +326,7 @@ namespace Umbraco.Core.Sync
             var processed = new HashSet<RefreshInstruction>();
 
             //It would have been nice to do this in a Query instead of Fetch using a data reader to save
-            // some memory however we cannot do thta because inside of this loop the cache refreshers are also
+            // some memory however we cannot do that because inside of this loop the cache refreshers are also
             // performing some lookups which cannot be done with an active reader open
             foreach (var dto in database.Fetch<CacheInstructionDto>(topSql))
             {
@@ -405,7 +405,7 @@ namespace Umbraco.Core.Sync
             }
             //catch (ThreadAbortException ex)
             //{
-            //    //This will occur if the instructions processing is taking too long since this is occuring on a request thread.
+            //    //This will occur if the instructions processing is taking too long since this is occurring on a request thread.
             //    // Or possibly if IIS terminates the appdomain. In any case, we should deal with this differently perhaps...
             //}
             catch (Exception ex)
@@ -624,7 +624,7 @@ namespace Umbraco.Core.Sync
         /// <param name="instructions"></param>
         /// <param name="processed"></param>
         /// <returns>
-        /// Returns true if all instructions were processed, otherwise false if the processing was interupted (i.e. app shutdown)
+        /// Returns true if all instructions were processed, otherwise false if the processing was interrupted (i.e. app shutdown)
         /// </returns>
         private bool NotifyRefreshers(IEnumerable<RefreshInstruction> instructions, HashSet<RefreshInstruction> processed)
         {

--- a/src/Umbraco.Core/Sync/IServerMessenger.cs
+++ b/src/Umbraco.Core/Sync/IServerMessenger.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Core.Sync
         void PerformRefresh(ICacheRefresher refresher, string jsonPayload);
 
         /// <summary>
-        /// Notifies the distributed cache of specifieds item invalidation, for a specified <see cref="ICacheRefresher"/>.
+        /// Notifies the distributed cache of specified item invalidation, for a specified <see cref="ICacheRefresher"/>.
         /// </summary>
         /// <typeparam name="T">The type of the invalidated items.</typeparam>
         /// <param name="refresher">The ICacheRefresher.</param>
@@ -34,7 +34,7 @@ namespace Umbraco.Core.Sync
         void PerformRefresh<T>(ICacheRefresher refresher, Func<T, int> getNumericId, params T[] instances);
 
         /// <summary>
-        /// Notifies the distributed cache of specifieds item invalidation, for a specified <see cref="ICacheRefresher"/>.
+        /// Notifies the distributed cache of specified item invalidation, for a specified <see cref="ICacheRefresher"/>.
         /// </summary>
         /// <typeparam name="T">The type of the invalidated items.</typeparam>
         /// <param name="refresher">The ICacheRefresher.</param>

--- a/src/Umbraco.Core/Sync/ServerSyncWebServiceClient.cs
+++ b/src/Umbraco.Core/Sync/ServerSyncWebServiceClient.cs
@@ -6,7 +6,7 @@ using Umbraco.Core.IO;
 namespace Umbraco.Core.Sync
 {
     /// <summary>
-    /// The client Soap service for making distrubuted cache calls between servers
+    /// The client Soap service for making distributed cache calls between servers
     /// </summary>
     [WebServiceBinding(Name = "CacheRefresherSoap", Namespace = "http://umbraco.org/webservices/")]
     [Obsolete("Legacy load balancing is obsolete and should be removed")]

--- a/src/Umbraco.Core/TypeExtensions.cs
+++ b/src/Umbraco.Core/TypeExtensions.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Core
         /// <param name="memberName"></param>
         /// <returns></returns>
         /// <remarks>
-        /// Currenty this will only work for ProperCase and camelCase properties, see the TODO below to enable complete case insensitivity
+        /// Currently this will only work for ProperCase and camelCase properties, see the TODO below to enable complete case insensitivity
         /// </remarks>
         internal static Attempt<object> GetMemberIgnoreCase(this Type type, object target, string memberName)
         {
@@ -410,7 +410,7 @@ namespace Umbraco.Core
         /// <param name="type"></param>
         /// <returns></returns>
         /// <remarks>
-        /// This method is like an 'inbetween' of Type.FullName and Type.AssemblyQualifiedName which returns the type and the assembly separated
+        /// This method is like an 'in between' of Type.FullName and Type.AssemblyQualifiedName which returns the type and the assembly separated
         /// by a comma.
         /// </remarks>
         /// <example>

--- a/src/Umbraco.Core/UdiEntityType.cs
+++ b/src/Umbraco.Core/UdiEntityType.cs
@@ -100,7 +100,7 @@ namespace Umbraco.Core
             public const string AnyString = "any-string"; // that one is for tests
 
             public const string Language = "language";
-            public const string MacroScript = "macroscript";
+            public const string MacroScript = "macro script";
             public const string MediaFile = "media-file";
             public const string TemplateFile = "template-file";
             public const string Script = "script";

--- a/src/Umbraco.Core/UriExtensions.cs
+++ b/src/Umbraco.Core/UriExtensions.cs
@@ -66,7 +66,7 @@ namespace Umbraco.Core
             //has an extension, def back office
             if (extension.IsNullOrWhiteSpace() == false) return true;
             //check for special case asp.net calls like:
-            //  /umbraco/webservices/legacyAjaxCalls.asmx/js which will return a null file extension but are still considered extension'd requests
+            //  /umbraco/webservices/legacyAjaxCalls.asmx/js which will return a null file extension but are still considered requests with an extension
             if (urlPath.InvariantContains(".asmx/")
                 || urlPath.InvariantContains(".aspx/")
                 || urlPath.InvariantContains(".ashx/")

--- a/src/Umbraco.Core/WriteLock.cs
+++ b/src/Umbraco.Core/WriteLock.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Core
     /// </summary>
     /// <remarks>
     /// <para>Intended as an infrastructure class.</para>
-    /// <para>This is a very unefficient way to lock as it allocates one object each time we lock,
+    /// <para>This is a very inefficient way to lock as it allocates one object each time we lock,
     /// so it's OK to use this class for things that happen once, where it is convenient, but not
     /// for performance-critical code!</para>
     /// </remarks>

--- a/src/Umbraco.Core/Xml/DynamicContext.cs
+++ b/src/Umbraco.Core/Xml/DynamicContext.cs
@@ -258,7 +258,7 @@ namespace Umbraco.Core.Xml
                             try
                             {
                                 _value = Convert.ToDouble(value);
-                                // We suceeded, so it's a number.
+                                // We succeeded, so it's a number.
                                 _type = XPathResultType.Number;
                             }
                             catch (FormatException)

--- a/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
+++ b/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
@@ -33,7 +33,7 @@ namespace Umbraco.Core.Xml
 
             //TODO: This should probably support some of the old syntax and token replacements, currently
             // it does not, there is a ticket raised here about it: http://issues.umbraco.org/issue/U4-6364
-            // previous tokens were: "$currentPage", "$ancestorOrSelf", "$parentPage" and I beleive they were
+            // previous tokens were: "$currentPage", "$ancestorOrSelf", "$parentPage" and I believe they were
             // allowed 'inline', not just at the beginning... whether or not we want to support that is up
             // for discussion.
 

--- a/src/Umbraco.Core/Xml/XPath/NavigableNavigator.cs
+++ b/src/Umbraco.Core/Xml/XPath/NavigableNavigator.cs
@@ -2,7 +2,7 @@
 
 // We make sure that diagnostics code will not be compiled nor called into Release configuration.
 // In Debug configuration, diagnostics code can be enabled by defining DEBUGNAVIGATOR below,
-// but by default nothing is writted, unless some lines are un-commented in Debug(...) below.
+// but by default nothing is written, unless some lines are un-commented in Debug(...) below.
 //
 // Beware! Diagnostics are extremely verbose and can overflow logging pretty easily.
 

--- a/src/Umbraco.Core/Xml/XPathNavigatorExtensions.cs
+++ b/src/Umbraco.Core/Xml/XPathNavigatorExtensions.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Core.Xml
 
             // Reflector shows that the standard XPathNavigator.Compile method just does
             //   return XPathExpression.Compile(xpath);
-            // only difference is, XPathNavigator.Compile is virtual so it could be overriden
+            // only difference is, XPathNavigator.Compile is virtual so it could be overridden
             // by a class inheriting from XPathNavigator... there does not seem to be any
             // doing it in the Framework, though... so we'll assume it's much cleaner to use
             // the static compile:

--- a/src/Umbraco.Core/Xml/XmlHelper.cs
+++ b/src/Umbraco.Core/Xml/XmlHelper.cs
@@ -206,7 +206,7 @@ namespace Umbraco.Core.Xml
         /// <summary>
         /// Opens a file as a XmlDocument.
         /// </summary>
-        /// <param name="filePath">The relative file path. ei. /config/umbraco.config</param>
+        /// <param name="filePath">The relative file path. ie. /config/umbraco.config</param>
         /// <returns>Returns a XmlDocument class</returns>
         public static XmlDocument OpenAsXmlDocument(string filePath)
         {

--- a/src/Umbraco.Core/Xml/XmlNodeListFactory.cs
+++ b/src/Umbraco.Core/Xml/XmlNodeListFactory.cs
@@ -152,7 +152,7 @@ namespace Umbraco.Core.Xml
                     _iterator.ReadTo(_position);
 
                     // If we reached the end and our index is still
-                    // bigger, there're no more items.
+                    // bigger, there are no more items.
                     if (_iterator.Done && _position >= _iterator.CurrentPosition)
                         return false;
 

--- a/src/Umbraco.Web/Models/Mapping/ActionButtonsResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/ActionButtonsResolver.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Web.Models.Mapping
 
             //TODO: This is certainly not ideal usage here - perhaps the best way to deal with this in the future is
             // with the IUmbracoContextAccessor. In the meantime, if used outside of a web app this will throw a null
-            // refrence exception :(
+            // reference exception :(
             return UserService.GetPermissionsForPath(UmbracoContext.Current.Security.CurrentUser, path).GetAllPermissions();
         }
     }

--- a/src/Umbraco.Web/PropertyEditors/ContentPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/ContentPickerConfiguration.cs
@@ -8,6 +8,6 @@ namespace Umbraco.Web.PropertyEditors
         public bool ShowOpenButton { get; set; }
 
         [ConfigurationField("startNodeId", "Start node", "treepicker")] // + config in configuration editor ctor
-        public int StartNodeId { get; set; } = -1; // default value is -1
+        public string StartNodeId { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ContentPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/ContentPickerConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.PropertyEditors;
+﻿using Umbraco.Core;
+using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -8,6 +9,6 @@ namespace Umbraco.Web.PropertyEditors
         public bool ShowOpenButton { get; set; }
 
         [ConfigurationField("startNodeId", "Start node", "treepicker")] // + config in configuration editor ctor
-        public string StartNodeId { get; set; }
+        public Udi StartNodeId { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MediaPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPickerConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.PropertyEditors;
+﻿using Umbraco.Core;
+using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -17,6 +18,6 @@ namespace Umbraco.Web.PropertyEditors
         public bool DisableFolderSelect { get; set; }
 
         [ConfigurationField("startNodeId", "Start node", "mediapicker")]
-        public string StartNodeId { get; set; }
+        public Udi StartNodeId { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MediaPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPickerConfiguration.cs
@@ -17,6 +17,6 @@ namespace Umbraco.Web.PropertyEditors
         public bool DisableFolderSelect { get; set; }
 
         [ConfigurationField("startNodeId", "Start node", "mediapicker")]
-        public int StartNodeId { get; set; }
+        public string StartNodeId { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfigurationTreeSource.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfigurationTreeSource.cs
@@ -15,6 +15,6 @@ namespace Umbraco.Web.PropertyEditors
         public string StartNodeQuery {get;set;}
 
         [JsonProperty("id")]
-        public int? StartNodeId {get;set;}
+        public string StartNodeId {get;set;}
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfigurationTreeSource.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfigurationTreeSource.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Umbraco.Core;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -15,6 +16,6 @@ namespace Umbraco.Web.PropertyEditors
         public string StartNodeQuery {get;set;}
 
         [JsonProperty("id")]
-        public string StartNodeId {get;set;}
+        public Udi StartNodeId {get;set;}
     }
 }

--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -86,7 +86,7 @@ namespace Umbraco.Web.Trees
                 }
 
                 //Otherwise its a application/section with no trees (aka a full screen app)
-                //For example we do not have a Forms tree definied in C# & can not attribute with [Tree(isSingleNodeTree:true0]
+                //For example we do not have a Forms tree defined in C# & can not attribute with [Tree(isSingleNodeTree:true0]
                 var rootId = Constants.System.Root.ToString(CultureInfo.InvariantCulture);
                 var section = Services.TextService.Localize("sections/" + application);
 

--- a/src/Umbraco.Web/_Legacy/PackageActions/addApplication.cs
+++ b/src/Umbraco.Web/_Legacy/PackageActions/addApplication.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Web._Legacy.PackageActions
         /// <example><code>
         /// <Action runat="install" [undo="false"] alias="addApplication" appName="Application Name"  appAlias="myApplication" appIcon="application.gif"/>
         /// </code></example>
-        /// <returns>true if successfull</returns>
+        /// <returns>true if successful</returns>
         public bool Execute(string packageName, XElement xmlData)
         {
             string name = xmlData.AttributeValue<string>("appName");


### PR DESCRIPTION
### Prerequisites

Issue: #4125 

### Description

This pull request fixes a LOT of spelling and typos in the Umbraco.Core project, almost all of them are code comment issues, a couple are in text strings used in exceptions, so rarely seen by anyone, but definitely better now they are correct.

As discussed on twitter with @nul800sebastiaan I have used a US English spell checker :)

Although there are a lot of changes, hopefully it won't take you very long to merge this in as I don't think there is anything that could cause a breaking change.