### PR TITLE
Remove hardcoded "Root" when restoring to tree root

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.restore.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.restore.controller.js
@@ -1,5 +1,5 @@
 angular.module("umbraco").controller("Umbraco.Editors.Content.RestoreController",
-    function ($scope, relationResource, contentResource, navigationService, appState, treeService, userService) {
+    function ($scope, relationResource, contentResource, navigationService, appState, treeService, userService, localizationService) {
 		var dialogOptions = $scope.dialogOptions;
 
 		$scope.source = _.clone(dialogOptions.currentNode);
@@ -20,6 +20,10 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.RestoreController"
         }
         userService.getCurrentUser().then(function (userData) {
             $scope.treeModel.hideHeader = userData.startContentIds.length > 0 && userData.startContentIds.indexOf(-1) == -1;
+        });
+        $scope.labels = {};
+        localizationService.localizeMany(["treeHeaders_content"]).then(function (data) {
+            $scope.labels.treeRoot = data[0];
         });
 
         function nodeSelectHandler(ev, args) {
@@ -96,7 +100,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.RestoreController"
 		    $scope.relation = data[0];
 
 			if ($scope.relation.parentId == -1) {
-				$scope.target = { id: -1, name: "Root" };
+                $scope.target = { id: -1, name: $scope.labels.treeRoot };
 
             } else {
                 $scope.loading = true;

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.restore.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.restore.controller.js
@@ -1,5 +1,5 @@
 angular.module("umbraco").controller("Umbraco.Editors.Media.RestoreController",
-    function ($scope, relationResource, mediaResource, navigationService, appState, treeService, userService) {
+    function ($scope, relationResource, mediaResource, navigationService, appState, treeService, userService, localizationService) {
 		var dialogOptions = $scope.dialogOptions;
 
         $scope.source = _.clone(dialogOptions.currentNode);
@@ -20,6 +20,10 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.RestoreController",
         }
         userService.getCurrentUser().then(function (userData) {
             $scope.treeModel.hideHeader = userData.startContentIds.length > 0 && userData.startContentIds.indexOf(-1) == -1;
+        });
+        $scope.labels = {};
+        localizationService.localizeMany(["treeHeaders_media"]).then(function (data) {
+            $scope.labels.treeRoot = data[0];
         });
 
         function nodeSelectHandler(ev, args) {
@@ -96,7 +100,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.RestoreController",
 		    $scope.relation = data[0];
 
 			if ($scope.relation.parentId == -1) {
-				$scope.target = { id: -1, name: "Root" };
+                $scope.target = { id: -1, name: $scope.labels.treeRoot };
 
 			} else {
                 $scope.loading = true;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The tree root names are hardcoded to "Root" when restoring items in content and media:

![localize-restore-to-root-before](https://user-images.githubusercontent.com/7405322/51372407-78f6d080-1afd-11e9-8dfd-e0ecc7b18bf0.gif)

The same root nodes are localized as "Content" or "Media" when moving items. This PR uses the same localization for the restore operation:

![localize-restore-to-root-after](https://user-images.githubusercontent.com/7405322/51372558-f4588200-1afd-11e9-995e-277dd0280b6c.gif)

*Note: I'll submit a separate PR for V8 to avoid the perpetual merge conflicts in the restore controllers.*