### PR TITLE
V8: Remove hardcoded "Root" when restoring to tree root

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.restore.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.restore.controller.js
@@ -1,5 +1,5 @@
 angular.module("umbraco").controller("Umbraco.Editors.Content.RestoreController",
-    function ($scope, relationResource, contentResource, entityResource, navigationService, appState, treeService, userService) {
+    function ($scope, relationResource, contentResource, entityResource, navigationService, appState, treeService, userService, localizationService) {
 
         $scope.source = _.clone($scope.currentNode);
 
@@ -19,6 +19,10 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.RestoreController"
         }
         userService.getCurrentUser().then(function (userData) {
             $scope.treeModel.hideHeader = userData.startContentIds.length > 0 && userData.startContentIds.indexOf(-1) == -1;
+        });
+        $scope.labels = {};
+        localizationService.localizeMany(["treeHeaders_content"]).then(function (data) {
+            $scope.labels.treeRoot = data[0];
         });
 
         function nodeSelectHandler(args) {
@@ -92,7 +96,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Content.RestoreController"
 		    $scope.relation = data[0];
 
 			if ($scope.relation.parentId === -1) {
-				$scope.target = { id: -1, name: "Root" };
+                $scope.target = { id: -1, name: $scope.labels.treeRoot };
 
             } else {
                 $scope.loading = true;

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.restore.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.restore.controller.js
@@ -1,5 +1,5 @@
 angular.module("umbraco").controller("Umbraco.Editors.Media.RestoreController",
-    function ($scope, relationResource, mediaResource, entityResource, navigationService, appState, treeService, userService) {
+    function ($scope, relationResource, mediaResource, entityResource, navigationService, appState, treeService, userService, localizationService) {
 
         $scope.source = _.clone($scope.currentNode);
 
@@ -19,6 +19,10 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.RestoreController",
         }
         userService.getCurrentUser().then(function (userData) {
             $scope.treeModel.hideHeader = userData.startContentIds.length > 0 && userData.startContentIds.indexOf(-1) == -1;
+        });
+        $scope.labels = {};
+        localizationService.localizeMany(["treeHeaders_media"]).then(function (data) {
+            $scope.labels.treeRoot = data[0];
         });
 
         function nodeSelectHandler(args) {
@@ -92,7 +96,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.RestoreController",
 		    $scope.relation = data[0];
 
 			if ($scope.relation.parentId === -1) {
-				$scope.target = { id: -1, name: "Root" };
+                $scope.target = { id: -1, name: $scope.labels.treeRoot };
 
 			} else {
                 $scope.loading = true;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The tree root names are hardcoded to "Root" when restoring items in content and media:

![localize-restore-to-root-before](https://user-images.githubusercontent.com/7405322/51373541-bc067300-1b00-11e9-9b3e-d0ddce2f1885.gif)

The same root nodes are localized as "Content" or "Media" when moving items. This PR uses the same localization for the restore operation:

![localize-restore-to-root-after](https://user-images.githubusercontent.com/7405322/51373553-c32d8100-1b00-11e9-9076-0c29c08c91ee.gif)

*This is the V8 equivalent of #4132.*
