### PR TITLE
V8: Clean up trashed content options

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html
@@ -49,7 +49,7 @@
                         ng-if="page.showSaveButton"
                         alias="save"
                         type="button"
-                        button-style="info"
+                        button-style="{{page.saveButtonStyle}}"
                         state="page.saveButtonState"
                         action="save(content)"
                         label-key="buttons_save"
@@ -83,16 +83,6 @@
                         state="publishAndCloseButtonState"
                         label-key="buttons_publishAndClose"
                         type="button">
-                    </umb-button>
-
-                    <umb-button 
-                        alias="restore" 
-                        ng-if="content.trashed" 
-                        type="button" 
-                        button-style="primary" 
-                        action="restore(content)" 
-                        state="page.buttonRestore"
-                        label="Restore">
                     </umb-button>
 
                 </umb-editor-footer-content-right>

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -2037,6 +2037,7 @@ namespace Umbraco.Web.Editors
         private ContentItemDisplay MapToDisplay(IContent content)
         {
             var display = Mapper.Map<ContentItemDisplay>(content);
+            display.AllowPreview = display.AllowPreview && content.Trashed == false;
             return display;
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

You're currently able to preview trashed content. That really doesn't make a lot of sense 😄 

Furthermore the primary action for trashed content is "Restore", which is already represented in the "Actions" menu. This is problematic for a couple of reasons:

1. The same action shouldn't be represented in the editor twice.
2. The primary action for content (and media) editing outside the recycle bin is some variant of saving. But "Restore" is essentially a move operation, which might be less than intuitive.
3. The code to handle the "Restore" button is a custom implementation of content restore, whereas the "Restore" from the "Actions" menu invokes the implementation from the tree.
4. There is no confirmation for the restore action when you use the "Restore" button.

![image](https://user-images.githubusercontent.com/7405322/51384302-37c1e900-1b1c-11e9-86a2-a37221e499f6.png)

This PR removes the "Preview" and "Restore" buttons from trashed content and promotes "Save" to be the primary button.

![image](https://user-images.githubusercontent.com/7405322/51384232-fcbfb580-1b1b-11e9-85e1-7396e6192366.png)

Of course you can still restore trashed content from both the "Actions" menu and the tree node menu.