### PR TITLE
Cloud not clear MNTP

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -183,13 +183,16 @@ namespace Umbraco.Core.PropertyEditors
             if (value is JValue)
                 value = value.ToString();
 
+            var valueStorageType = ValueTypes.ToStorageType(ValueType);
             //this is a custom check to avoid any errors, if it's a string and it's empty just make it null
-            if (value is string s && string.IsNullOrWhiteSpace(s))
+            if (value is string s
+                && string.IsNullOrWhiteSpace(s)
+                && (valueStorageType != ValueStorageType.Ntext && valueStorageType != ValueStorageType.Nvarchar))
                 value = null;
 
             Type valueType;
             //convert the string to a known type
-            switch (ValueTypes.ToStorageType(ValueType))
+            switch (valueStorageType)
             {
                 case ValueStorageType.Ntext:
                 case ValueStorageType.Nvarchar:
@@ -246,7 +249,7 @@ namespace Umbraco.Core.PropertyEditors
         /// <returns></returns>
         ///  <remarks>
         ///  By default this will attempt to automatically convert the string value to the value type supplied by ValueType.
-        /// 
+        ///
         ///  If overridden then the object returned must match the type supplied in the ValueType, otherwise persisting the
         ///  value to the DB will fail when it tries to validate the value type.
         ///  </remarks>

--- a/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueEditorTests.cs
+++ b/src/Umbraco.Tests/PropertyEditors/PropertyEditorValueEditorTests.cs
@@ -62,6 +62,8 @@ namespace Umbraco.Tests.PropertyEditors
         [TestCase("INT", "123", 123)]
         [TestCase("INT", "", null)] //test empty string for int
         [TestCase("DATETIME", "", null)] //test empty string for date
+        [TestCase("STRING", "", "")] //test empty string for string must remain empty string
+        [TestCase("TEXT", "", "")] //test empty string for text must remain empty string
         public void Value_Editor_Can_Convert_To_Clr_Type(string valueType, string val, object expected)
         {
             var valueEditor = new DataValueEditor


### PR DESCRIPTION
Fixes:: #4119

The issue was because `""` was changed to `null` and null was ignored on save. The solution is to allow saving  `""` for types persisted as `Nvarchar `and `Ntext`

Before fix:
![4037-1](https://user-images.githubusercontent.com/1561480/51384932-0d712b00-1b1e-11e9-9fd7-56670993c6bc.gif)


After fix:
![4119-1](https://user-images.githubusercontent.com/1561480/51385036-5628e400-1b1e-11e9-85f6-c590b879b3f7.gif)
