### PR TITLE
Removing insert masterpage dialog dictionary keys

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/mocks/services/localization.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/services/localization.mocks.js
@@ -203,7 +203,6 @@ angular.module('umbraco.mocks').
                   "defaultdialogs_siterepublishHelp": "The website cache will be refreshed. All published content will be updated, while unpublished content will stay unpublished.",
                   "defaultdialogs_tableColumns": "Number of columns",
                   "defaultdialogs_tableRows": "Number of rows",
-                  "defaultdialogs_templateContentAreaHelp": "<strong>Set a placeholder id</strong> by setting an ID on your placeholder you can inject content into this template from child templates,      by refering this ID using a <code>&lt;asp:content /&gt;</code> element.",
                   "defaultdialogs_templateContentPlaceHolderHelp": "<strong>Select a placeholder id</strong> from the list below. You can only      choose Id's from the current template's master.",
                   "defaultdialogs_thumbnailimageclickfororiginal": "Click on the image to see full size",
                   "defaultdialogs_treepicker": "Pick item",

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
@@ -243,8 +243,6 @@
     <key alias="siterepublishHelp">Mezipaměť webu bude obnovena. Všechen publikovaný obsah bude aktualizován, zatímco nepublikovaný obsah zůstane nepublikovaný.</key>
     <key alias="tableColumns">Počet sloupců</key>
     <key alias="tableRows">Počet řádků</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Nastavení ID zástupce</strong> Nastavením ID zástupce můžete do této šablony zavést obsah z podřízených šablon tak, že odkážete na toto ID při použití prvku <code>&lt;asp:content /&gt;</code>.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Vyberte id zástupce</strong> ze seznamu níže. Můžete vybírat pouze z ID ze šablony nadřazené tomuto formuláři.]]></key>
     <key alias="thumbnailimageclickfororiginal">Klikněte na obrázek pro zobrazení v plné velikosti</key>
     <key alias="treepicker">Vybrat položku</key>
     <key alias="viewCacheItem">Zobrazit položku mezipaměti</key>
@@ -374,7 +372,6 @@
     <key alias="or">nebo</key>
     <key alias="password">Heslo</key>
     <key alias="path">Cesta</key>
-    <key alias="placeHolderID">ID zástupce</key>
     <key alias="pleasewait">Moment, prosím...</key>
     <key alias="previous">Předchozí</key>
     <key alias="properties">Vlastnosti</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -378,8 +378,6 @@
     <key alias="siterepublishHelp">Websitets cache vil blive genopfrisket. Alt udgivet indhold vil blive opdateret, mens upubliceret indhold vil forblive upubliceret.</key>
     <key alias="tableColumns">Antal kolonner</key>
     <key alias="tableRows">Antal rækker</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Vælg et placeholder id</strong> Ved at sætte et id på en placeholder kan du indskyde indhold fra undertemplates ved at referere til dette ID vha. et <code>&lt;asp:content /&gt;</code> element.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Vælg et placeholder id</strong> fra listen herunder. Du kan kun vælge id'er fra den nuværende masterskabelon.]]></key>
     <key alias="thumbnailimageclickfororiginal">Klik på billedet for at se den fulde størrelse</key>
     <key alias="treepicker">Vælg</key>
     <key alias="viewCacheItem">Se cache element</key>
@@ -577,7 +575,6 @@
     <key alias="orderBy">Sortér efter</key>
     <key alias="password">Kodeord</key>
     <key alias="path">Sti</key>
-    <key alias="placeHolderID">Placeholder ID</key>
     <key alias="pleasewait">Et øjeblik...</key>
     <key alias="previous">Forrige</key>
     <key alias="properties">Egenskaber</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
@@ -255,8 +255,6 @@
     <key alias="siterepublishHelp">Der Zwischenspeicher der Website wird aktualisiert und der veröffentlichte Inhalt auf den neuesten Stand gebracht. Unveröffentlichte Inhalte bleiben dabei weiterhin unveröffentlicht.</key>
     <key alias="tableColumns">Anzahl der Spalten</key>
     <key alias="tableRows">Anzahl der Zeilen</key>
-    <key alias="templateContentAreaHelp">&lt;strong&gt;Legen Sie eine Platzhalter-ID fest.&lt;/strong&gt; Anhand der festgelegten Platzhalter-ID können Sie Inhalte von untergeordneten Vorlagen in diese Vorlage integrieren, indem Sie das &lt;code&gt;&amp;lt;asp:content /&amp;gt;&lt;/code&gt;-Element und die zugehörige Platzhalter-ID verwenden.</key>
-    <key alias="templateContentPlaceHolderHelp">&lt;strong&gt;Wählen Sie eine Platzhalter-ID aus.&lt;/strong&gt; Sie können nur unter den Platzhaltern der übergeordneten Vorlage wählen.</key>
     <key alias="thumbnailimageclickfororiginal">Für Originalgröße auf die Abbildung klicken</key>
     <key alias="treepicker">Element auswählen</key>
     <key alias="viewCacheItem">Zwischenspeicher-Element anzeigen</key>
@@ -389,7 +387,6 @@
     <key alias="or">oder</key>
     <key alias="password">Kennwort</key>
     <key alias="path">Pfad</key>
-    <key alias="placeHolderID">Platzhalter-ID</key>
     <key alias="pleasewait">Einen Moment bitte...</key>
     <key alias="previous">Zurück</key>
     <key alias="properties">Eigenschaften</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -395,10 +395,6 @@
     <key alias="siterepublishHelp">The website cache will be refreshed. All published content will be updated, while unpublished content will stay unpublished.</key>
     <key alias="tableColumns">Number of columns</key>
     <key alias="tableRows">Number of rows</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Set a placeholder id</strong> by setting an ID on your placeholder you can inject content into this template from child templates,
-      by referring this ID using a <code>&lt;asp:content /&gt;</code> element.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Select a placeholder id</strong> from the list below. You can only
-      choose Id's from the current template's master.]]></key>
     <key alias="thumbnailimageclickfororiginal">Click on the image to see full size</key>
     <key alias="treepicker">Pick item</key>
     <key alias="viewCacheItem">View Cache Item</key>
@@ -615,7 +611,6 @@
     <key alias="orderBy">Order by</key>
     <key alias="password">Password</key>
     <key alias="path">Path</key>
-    <key alias="placeHolderID">Placeholder ID</key>
     <key alias="pleasewait">One moment please...</key>
     <key alias="previous">Previous</key>
     <key alias="properties">Properties</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -423,10 +423,6 @@
     <key alias="siterepublishHelp">The website cache will be refreshed. All published content will be updated, while unpublished content will stay unpublished.</key>
     <key alias="tableColumns">Number of columns</key>
     <key alias="tableRows">Number of rows</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Set a placeholder id</strong> by setting an ID on your placeholder you can inject content into this template from child templates,
-      by referring this ID using a <code>&lt;asp:content /&gt;</code> element.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Select a placeholder id</strong> from the list below. You can only
-      choose Id's from the current template's master.]]></key>
     <key alias="thumbnailimageclickfororiginal">Click on the image to see full size</key>
     <key alias="treepicker">Pick item</key>
     <key alias="viewCacheItem">View Cache Item</key>
@@ -644,7 +640,6 @@
     <key alias="orderBy">Order by</key>
     <key alias="password">Password</key>
     <key alias="path">Path</key>
-    <key alias="placeHolderID">Placeholder ID</key>
     <key alias="pleasewait">One moment please...</key>
     <key alias="previous">Previous</key>
     <key alias="properties">Properties</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/es.xml
@@ -332,8 +332,6 @@
     <key alias="siterepublishHelp">La caché del sitio web será actualizada. Todos los contenidos publicados serán actualizados, mientras el contenido no publicado permanecerá no publicado.</key>
     <key alias="tableColumns">Número de columnas</key>
     <key alias="tableRows">Número de filas</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Coloca un 'placeholder' id</strong> al colocar un ID  en tu 'placeholder' puedes insertar contenido en esta plantilla desde una plantilla hija, referenciando este ID usando un elemento<code>&lt;asp:content /&gt;</code>.]]></key>
-        <key alias="templateContentPlaceHolderHelp">Selecciona una tecla de la lista abajo indicada. Sólo puedes elegir a partir de la ID de la plantilla actual del dominio.</key>
         <key alias="thumbnailimageclickfororiginal">Haz clic sobre la imagen para verla a tamaño completo.</key>
         <key alias="treepicker">Seleccionar elemento</key>
         <key alias="viewCacheItem">Ver elemento en la caché</key>
@@ -545,7 +543,6 @@
     <key alias="orderBy">Ordenar por</key>
     <key alias="password">Contraseña</key>
     <key alias="path">Ruta</key>
-    <key alias="placeHolderID">ID de marcador de posición</key>
     <key alias="pleasewait">Un momento por favor...</key>
     <key alias="previous">Anterior</key>
     <key alias="properties">Propiedades</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
@@ -346,10 +346,6 @@
     <key alias="siterepublishHelp">Le cache du site va être mis à jour. Tous les contenus publiés seront mis à jour. Et tous les contenus dépubliés resteront invisibles.</key>
     <key alias="tableColumns">Nombre de colonnes</key>
     <key alias="tableRows">Nombre de lignes</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Définir un placeholder ID</strong>. En mettant un ID sur votre placeholder, vous pouvez injecter du contenu à cet endroit depuis les modèles enfants,
-      en faisant référence à cet ID au sein d'un élément <code>&lt;asp:content /&gt;</code>.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Séléctionnez un placeholder ID</strong> dans la liste ci-dessous. Vous pouvez seulement
-      choisir un ID se trouvant dans le parent du modèle actuel.]]></key>
     <key alias="thumbnailimageclickfororiginal">Cliquez sur l'image pour la voir en taille réelle</key>
     <key alias="treepicker">Sélectionner un élément</key>
     <key alias="viewCacheItem">Voir l'élément de cache</key>
@@ -561,7 +557,6 @@
     <key alias="orderBy">Trier par</key>
     <key alias="password">Mot de passe</key>
     <key alias="path">Chemin</key>
-    <key alias="placeHolderID">Placeholder ID</key>
     <key alias="pleasewait">Un moment s'il vous plaît...</key>
     <key alias="previous">Précédent</key>
     <key alias="properties">Propriétés</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/he.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/he.xml
@@ -192,10 +192,6 @@
     <key alias="siterepublishHelp">זיכרון המטמון של האתר ירוענן. כל התוכן שפורסם ירוענן בהתאם, שאר התוכן המיועד לפירסום ימתין לפירסום</key>
     <key alias="tableColumns">מספר עמודות</key>
     <key alias="tableRows">מספר שורות</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Set a placeholder id</strong> by setting an ID on your placeholder you can inject content into this template from child templates,
-      by refering this ID using a <code>&lt;asp:content /&gt;</code> element.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Select a placeholder id</strong> from the list below. You can only
-      choose Id's from the current template's master.]]></key>
     <key alias="thumbnailimageclickfororiginal">לחץ על התמונה לגודל מלא</key>
     <key alias="treepicker">בחר פריט</key>
     <key alias="viewCacheItem">צפה בפרטי זיכרון מטמון</key>
@@ -316,7 +312,6 @@
     <key alias="or">או</key>
     <key alias="password">סיסמה</key>
     <key alias="path">נתיב</key>
-    <key alias="placeHolderID">Placeholder קוד זיהוי</key>
     <key alias="pleasewait">אנא המתן בבקשה...</key>
     <key alias="previous">הקודם</key>
     <key alias="properties">הגדרות</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/it.xml
@@ -197,8 +197,6 @@
     <key alias="siterepublishHelp"><![CDATA[La cache del sito sarà ricreata. Tutti gli elementi pubblicati saranno aggiornati, tutti quelli non pubblicati rimarranno tali.]]></key>
     <key alias="tableColumns">Numero di colonne</key>
     <key alias="tableRows">Numero di righe</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Imposta identificativo del placeholder</strong>. Settando tale ID puoi inserire il contenuto in questo template dai template figli, facendo riferimento a questo ID usando il codice <code>&lt;asp:content /&gt;</code>.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Seleziona Identificativo del placeholder</strong> dalla lista seguente. Puoi scegliere solo l'ID appartenente al template master corrente.]]></key>
     <key alias="thumbnailimageclickfororiginal"><![CDATA[Clicca sull'immmagine per ingrandirla]]></key>
     <key alias="treepicker">Seleziona elemento</key>
     <key alias="viewCacheItem">Visualizza gli elementi in cache</key>
@@ -318,7 +316,6 @@
     <key alias="or">o</key>
     <key alias="password">Password</key>
     <key alias="path">Percorso</key>
-    <key alias="placeHolderID"><![CDATA[Identificativo "Placeholder"]]></key>
     <key alias="pleasewait"><![CDATA[Attendere prego...]]></key>
     <key alias="previous">Precedente</key>
     <key alias="properties"><![CDATA[Proprietà]]></key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ja.xml
@@ -257,10 +257,6 @@
     <key alias="siterepublishHelp">ウェブサイトのキャッシュがリフレッシュされます。 公開されているコンテンツはリフレッシュされますが、非公開のコンテンツは非公開のままです。</key>
     <key alias="tableColumns">列数</key>
     <key alias="tableRows">行数</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>プレースホルダにidを設定</strong>して、子テンプレートからもこのテンプレートをコンテントに入れられるようにできます。
-      IDは<code>&lt;asp:content /&gt;</code>エレメントとして用います。]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[このリストから<strong>プレースホルダのidを選択</strong>してください。
-      このテンプレートのマスターで使用可能なIdのみ選択可能です。]]></key>
     <key alias="thumbnailimageclickfororiginal">クリックすると画像がフルサイズで表示されます</key>
     <key alias="treepicker">項目の選択</key>
     <key alias="viewCacheItem">キャッシュされている項目の表示</key>
@@ -423,7 +419,6 @@
     <key alias="or">または</key>
     <key alias="password">パスワード</key>
     <key alias="path">パス</key>
-    <key alias="placeHolderID">プレースホルダのID</key>
     <key alias="pleasewait">しばらくお待ちください...</key>
     <key alias="previous">前へ</key>
     <key alias="properties">プロパティ</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ko.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ko.xml
@@ -191,9 +191,6 @@
     <key alias="siterepublishHelp">웹사이트 캐쉬가 재생되었습니다. 모든 발행컨텐츠가 업데이트되었습니다. 그러나 모든 미발행 컨텐츠는 미발행상태로 남아있습니다.</key>
     <key alias="tableColumns">컬럼수</key>
     <key alias="tableRows">줄수</key>
-    <key alias="templateContentAreaHelp"><![CDATA[자식템플릿으로부터 이 템플릿에 컨텐츠를 삽입할 수 있는 Placeholder 아이디를 선택하시거나,
-    <code>&lt;asp:컨텐츠 /&gt;</code> 항목을 사용하는 아이디를 참조하여 <strong>Placeholder 아이디를 설정하세요</strong>.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[아래 리스트에서 <strong>Placeholder 아이디를 선택하세요</strong>. 현재 템플릿의 마스터에 아이디들만 선택할 수 있습니다.]]></key>
     <key alias="thumbnailimageclickfororiginal">이미지를 전체크기로 보시려면 클릭하세요.</key>
     <key alias="treepicker">아이템 선택</key>
     <key alias="viewCacheItem">캐쉬 아이템 보기</key>
@@ -314,7 +311,6 @@
     <key alias="or">또는</key>
     <key alias="password">비밀번호</key>
     <key alias="path">경로</key>
-    <key alias="placeHolderID">Placeholder 아이디</key>
     <key alias="pleasewait">잠시만 기다려주세요...</key>
     <key alias="previous">이전</key>
     <key alias="properties">속성</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -251,8 +251,6 @@
     <key alias="siterepublishHelp">Hurtigbufferen for siden vil bli oppdatert. Alt publisert innhold vil bli oppdatert, mens upublisert innhold vil forbli upublisert.</key>
     <key alias="tableColumns">Antall kolonner</key>
     <key alias="tableRows">Antall rader</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Sett en plassholder-ID</strong><br/>Ved å sette en ID på plassholderen kan du legge inn innhold i denne malen fra underliggende maler, ved å referere denne ID'en ved hjelp av et <code>&lt;asp:content /&gt;</code> element.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Velg en plassholder ID</strong> fra listen under. Du kan bare velge ID'er fra den gjeldende malens overordnede mal.]]></key>
     <key alias="thumbnailimageclickfororiginal">Klikk på bildet for å se det i full størrelse</key>
     <key alias="treepicker">Velg punkt</key>
     <key alias="viewCacheItem">Se buffret node</key>
@@ -384,7 +382,6 @@
     <key alias="or">eller</key>
     <key alias="password">Passord</key>
     <key alias="path">Sti</key>
-    <key alias="placeHolderID">Plassholder ID</key>
     <key alias="pleasewait">Ett øyeblikk...</key>
     <key alias="previous">Forrige</key>
     <key alias="properties">Egenskaper</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -282,10 +282,6 @@
     <key alias="siterepublishHelp">De cache zal worden vernieuwd. Alle gepubliceerde inhoud zal worden ge-update, terwijl ongepubliceerde inhoud ongepubliceerd zal blijven.</key>
     <key alias="tableColumns">Aantal kolommen</key>
     <key alias="tableRows">Aantal regels</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Plaats een placeholder id</strong> door een ID op uw placeholder te zetten kunt u inhoud plaatsen in deze template vanuit onderliggende templates,
-      door te verwijzen naar deze ID door gebruik te maken van een <code>&lt;asp:content /&gt;</code> element.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Selecteer een placeholder id</strong> uit onderstaande lijst. U kunt alleen
-      Id's kiezen van de master van de huidige template..]]></key>
     <key alias="thumbnailimageclickfororiginal">Klik op de afbeelding voor volledige grootte</key>
     <key alias="treepicker">Kies een item</key>
     <key alias="viewCacheItem">Toon cache item</key>
@@ -458,7 +454,6 @@
     <key alias="or">of</key>
     <key alias="password">Wachtwoord</key>
     <key alias="path">Pad</key>
-    <key alias="placeHolderID">Placeholder ID</key>
     <key alias="pleasewait">Een ogenblik geduld aub...</key>
     <key alias="previous">Vorige</key>
     <key alias="properties">Eigenschappen</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/pl.xml
@@ -334,10 +334,6 @@
     <key alias="siterepublishHelp">Cache strony zostanie odświeżone. Cała zawartość opublikowana będzie aktualna, lecz nieopublikowana zawartość pozostanie niewidoczna</key>
     <key alias="tableColumns">Liczba kolumn</key>
     <key alias="tableRows">Liczba wierszy</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Ustaw zastępczy ID</strong> Ustawiając ID na tym elemencie możesz później łączyć treść z podrzędnych szablonów,
-      ustawiając dowiązanie do tego ID na elemencie <code>&lt;asp:treści /&gt;</code>]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Wybierz zastępczy ID</strong> z poniższej listy. Możesz wybierać tylko
-      spośród ID na szablonie nadrzędnym tego formularza.]]></key>
     <key alias="thumbnailimageclickfororiginal">Kliknij na obrazie, aby zobaczyć go w pełnym rozmiarze</key>
     <key alias="treepicker">Wybierz element</key>
     <key alias="viewCacheItem">Podgląd elementów Cache</key>
@@ -531,7 +527,6 @@
     <key alias="or">lub</key>
     <key alias="password">Hasło</key>
     <key alias="path">Ścieżka</key>
-    <key alias="placeHolderID">Zastępczy ID</key>
     <key alias="pleasewait">Proszę czekać...</key>
     <key alias="previous">Poprzedni</key>
     <key alias="properties">Właściwości</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/pt.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/pt.xml
@@ -191,8 +191,6 @@
     <key alias="siterepublishHelp">O cache do website será atualizado. Todo conteúdo publicado será atualizado, enquanto o conteúdo que não foi publicado permanecerá invisível</key>
     <key alias="tableColumns">Número de colunas</key>
     <key alias="tableRows">Número de linhas</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Defina uma id de espaço reservado</strong> definindo uma ID em seu espaço reservado você pode injetar conteúdo dentro deste modelo desde modelos filhos usando esta ID como referência dentro de um elemento <code>&lt;asp:content /&gt;</code>]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Selecione uma id de espaço reservado</strong> da lista abaixo. Você pode escolher somente as IDs em seu modelo mestre atual.]]></key>
     <key alias="thumbnailimageclickfororiginal">Clique para ver a imagem em seu tamanho original</key>
     <key alias="treepicker">Escolha item</key>
     <key alias="viewCacheItem">Ver Item em Cache</key>
@@ -311,7 +309,6 @@
     <key alias="or">ou</key>
     <key alias="password">Senha</key>
     <key alias="path">Caminho</key>
-    <key alias="placeHolderID">ID do Espaço Reservado</key>
     <key alias="pleasewait">Um momento por favor...</key>
     <key alias="previous">Prévio</key>
     <key alias="properties">Propriedades</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
@@ -384,10 +384,6 @@
     <key alias="siterepublishHelp">Кэш сайта будет полностью обновлен. Все опубликованное содержимое будет обновлено, в то время как неопубликованное содержимое по-прежнему останется неопубликованным</key>
     <key alias="tableColumns">Количество столбцов</key>
     <key alias="tableRows">Количество строк</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Идентификация контейнера (placeholder)</strong>
-		путем назначения Вашему элементу-контейнеру уникального идентификатора (ID) позволит Вам автоматически включать в шаблон содержимое из дочерних шаблонов путем указания этого идентификатора (ID) в конструкции <code>&lt;asp:content /&gt;</code>.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Выберите идентификатор элемента-контейнера (placeholder)</strong>
-		из нижеследующего списка. Список ограничивается идентификаторами, определенными в родительском шаблоне данного шаблона.]]></key>
     <key alias="thumbnailimageclickfororiginal">Кликните на изображении, чтобы увидеть полноразмерную версию</key>
     <key alias="treepicker">Выберите элемент</key>
     <key alias="urlLinkPicker">Ссылка</key>
@@ -582,7 +578,6 @@
     <key alias="orderBy">Сортировка по</key>
     <key alias="password">Пароль</key>
     <key alias="path">Путь</key>
-    <key alias="placeHolderID">Идентификатор контейнера</key>
     <key alias="pleasewait">Минуточку...</key>
     <key alias="previous">Пред</key>
     <key alias="properties">Свойства</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
@@ -249,8 +249,6 @@
     <key alias="siterepublishHelp">Webbplatsens cache kommer att uppdateras. Allt innehåll som är publicerat kommer att uppdateras. Innehåll som inte är publicerat kommer att förbli opublicerat.</key>
     <key alias="tableColumns">Antal kolumner</key>
     <key alias="tableRows">Antal rader</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Ge din platshållare ett id</strong> du kan skjuta in innehåll från underordnade sidmallar i platshållaren genom att ge den ett ID. Du refererar sedan till detta ID med hjälp av en <code>&lt;asp:content /&gt;</code> tagg.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Välj ett platshållar-ID</strong> från listan nedan. Du kan bara välja de ID som finns i denna malls huvudmall.]]></key>
     <key alias="thumbnailimageclickfororiginal">Klicka på förhandsgranskningsbilden för att se bilden i full storlek</key>
     <key alias="treepicker">Välj ett objekt</key>
     <key alias="viewCacheItem">Se cachat objekt</key>
@@ -374,7 +372,6 @@
     <key alias="or">eller</key>
     <key alias="password">Lösenord</key>
     <key alias="path">Sökväg</key>
-    <key alias="placeHolderID">Platshållar-ID</key>
     <key alias="pleasewait">Ett ögonblick...</key>
     <key alias="previous">Föregående</key>
     <key alias="properties">Egenskaper</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
@@ -224,10 +224,6 @@
     <key alias="siterepublishHelp">Web sitesi önbelleği yenilenir olacaktır. Yayınlanmamış içerik yayınlanmamış kalacak ise tüm yayınlanan içerik, güncellenecektir.</key>
     <key alias="tableColumns">Sütün sayısı</key>
     <key alias="tableRows">Satır sayısı</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>Yer tutucu kimliği ayarla</strong> senin tutucu bir kimlik ayarlayarak Çocuğunuz şablonları bu şablon içine içerik enjekte edebilir,
-      Bir kullanarak bu kimliği bakarak <code>&lt;asp:content /&gt;</code> element.]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>Yer tutucu kimliği seçin</strong> Aşağıdaki listeden. You can sadece
-       Geçerli şablonun ustadan kimliği sitesinin seçin.]]></key>
     <key alias="thumbnailimageclickfororiginal">Tam boyutta görmek için resmin üzerine tıklayın</key>
     <key alias="treepicker">öğeyi seçin</key>
     <key alias="viewCacheItem">Görünüm Önbellek Öğe</key>
@@ -363,7 +359,6 @@
     <key alias="or">veya</key>
     <key alias="password">Parola</key>
     <key alias="path">Yol</key>
-    <key alias="placeHolderID">Yer tutucu ID</key>
     <key alias="pleasewait">Bir dakika lütfen...</key>
     <key alias="previous">Önceki</key>
     <key alias="properties">Özellikler</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/zh.xml
@@ -270,10 +270,6 @@
     <key alias="siterepublishHelp">网站缓存将会刷新，所有已发布的内容将会更新。</key>
     <key alias="tableColumns">表格列数</key>
     <key alias="tableRows">表格行数</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>设置一个占位符id</strong> 您可以在子模板中通过该ID来插入内容，
-       引用格式： <code>&lt;asp:content /&gt;</code>。]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[从下面的列表中<strong>选择一个
-      占位符id</strong>。]]></key>
     <key alias="thumbnailimageclickfororiginal">点击图片查看完整大小</key>
     <key alias="treepicker">拾取项</key>
     <key alias="viewCacheItem">查看缓存项</key>
@@ -445,7 +441,6 @@
     <key alias="or">或</key>
     <key alias="password">密码</key>
     <key alias="path">路径</key>
-    <key alias="placeHolderID">占位符ID</key>
     <key alias="pleasewait">请稍候…</key>
     <key alias="previous">上一步</key>
     <key alias="properties">属性</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
@@ -267,8 +267,6 @@
     <key alias="siterepublishHelp">網站緩存將會刷新，所有已發佈的內容將會更新。</key>
     <key alias="tableColumns">表格列數</key>
     <key alias="tableRows">表格行數</key>
-    <key alias="templateContentAreaHelp"><![CDATA[<strong>設定預留位置代碼</strong> 以便您要在子範本中插入內容到本範本時，填入此代碼到 <code>&lt;asp:content /&gt;</code> 裡面。]]></key>
-    <key alias="templateContentPlaceHolderHelp"><![CDATA[<strong>選擇預留位置代碼</strong> 於此清單中。您只能選擇目前父範本中的代碼。]]></key>
     <key alias="thumbnailimageclickfororiginal">點擊圖片查看完整大小</key>
     <key alias="treepicker">拾取項</key>
     <key alias="viewCacheItem">查看緩存項</key>
@@ -436,7 +434,6 @@
     <key alias="or">或</key>
     <key alias="password">密碼</key>
     <key alias="path">路徑</key>
-    <key alias="placeHolderID">預留位置代碼</key>
     <key alias="pleasewait">請稍候…</key>
     <key alias="previous">上一步</key>
     <key alias="properties">屬性</key>


### PR DESCRIPTION
More deletions...

As in PR #3971 where I removed masterpages support from Umbraco V8, this removes the now defunct dialogs and related dictionary items as the functionality is no longer needed or used