### PR TITLE
Allow RTE to set form dirty again after saving content item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -380,6 +380,9 @@ angular.module("umbraco")
                     if (tinyMceEditor !== undefined && tinyMceEditor != null && !$scope.isLoading) {
                         $scope.model.value = tinyMceEditor.getContent();
                     }
+					                    
+                    //Allow RTE to set form dirty again
+                    alreadyDirty = false;
                 });
 
                 //when the element is disposed we need to unsubscribe!


### PR DESCRIPTION
### Prerequisites

This fixes: #4140 

### Description

Allow RTE to set form to dirty again, after saving the _Content_ item.
