### PR TITLE
v8: Richtext editor is missing icons in settings - updated css file location

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -120,5 +120,5 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
         });
 
         // load TinyMCE skin which contains css for font-icons
-        assetsService.loadCss("lib/tinymce/skins/umbraco/skin.min.css", $scope);
+        assetsService.loadCss("lib/tinymce/skins/lightgray/skin.min.css", $scope);
     });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: #4093 

### Description
Update the path to the skin.min.css file to match the one loaded by the property editor.
