### PR TITLE
v8: Fix package localization

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/overview.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function PackagesOverviewController($scope, $location, $routeParams, localStorageService) {
+    function PackagesOverviewController($scope, $location, $routeParams, localizationService, localStorageService) {
 
         //Hack!
         // if there is a local storage value for packageInstallData then we need to redirect there,
@@ -22,56 +22,83 @@
         }
         else {
             var vm = this;
+            vm.page = {};
+            vm.page.labels = {};
+            vm.page.name = "";
+            vm.page.navigation = [];
 
             packageUri = packageInstallData ? packageInstallData : packageUri; //use the path stored in storage over the one in the current path
 
-            vm.page = {};
-            vm.page.name = "Packages";
-            vm.page.navigation = [
-                {
-                    "name": "Packages",
-                    "icon": "icon-cloud",
-                    "view": "views/packages/views/repo.html",
-                    "active": !packageUri || packageUri === "repo",
-                    "alias": "umbPackages",
-                    "action": function () {
-                        $location.path("/packages/packages/repo");
-                    }
-                },
-                {
-                    "name": "Installed",
-                    "icon": "icon-box",
-                    "view": "views/packages/views/installed.html",
-                    "active": packageUri === "installed",
-                    "alias": "umbInstalled",
-                    "action": function () {
-                        $location.path("/packages/packages/installed");
-                    }
-                },
-                {
-                    "name": "Install local",
-                    "icon": "icon-add",
-                    "view": "views/packages/views/install-local.html",
-                    "active": packageUri === "local",
-                    "alias": "umbInstallLocal",
-                    "action": function () {
-                        $location.path("/packages/packages/local");
-                    }
-                },
-                {
-                    "name": "Created",
-                    "icon": "icon-add",
-                    "view": "views/packages/views/created.html",
-                    "active": packageUri === "created",
-                    "alias": "umbCreatedPackages",
-                    "action": function () {
-                        $location.path("/packages/packages/created");
-                    }
-                }
-            ];
-
+            onInit();
         }
 
+        function onInit() {
+
+            loadNavigation();
+
+            setPageName();
+        }
+
+        function loadNavigation() {
+
+            var labels = ["sections_packages", "packager_installed", "packager_installLocal", "packager_created"];
+
+            localizationService.localizeMany(labels).then(function (data) {
+                vm.page.labels.packages = data[0];
+                vm.page.labels.installed = data[1];
+                vm.page.labels.install = data[2];
+                vm.page.labels.created = data[3];
+
+                vm.page.navigation = [
+                    {
+                        "name": vm.page.labels.packages,
+                        "icon": "icon-cloud",
+                        "view": "views/packages/views/repo.html",
+                        "active": !packageUri || packageUri === "repo",
+                        "alias": "umbPackages",
+                        "action": function () {
+                            $location.path("/packages/packages/repo");
+                        }
+                    },
+                    {
+                        "name": vm.page.labels.installed,
+                        "icon": "icon-box",
+                        "view": "views/packages/views/installed.html",
+                        "active": packageUri === "installed",
+                        "alias": "umbInstalled",
+                        "action": function () {
+                            $location.path("/packages/packages/installed");
+                        }
+                    },
+                    {
+                        "name": vm.page.labels.install,
+                        "icon": "icon-add",
+                        "view": "views/packages/views/install-local.html",
+                        "active": packageUri === "local",
+                        "alias": "umbInstallLocal",
+                        "action": function () {
+                            $location.path("/packages/packages/local");
+                        }
+                    },
+                    {
+                        "name": vm.page.labels.created,
+                        "icon": "icon-add",
+                        "view": "views/packages/views/created.html",
+                        "active": packageUri === "created",
+                        "alias": "umbCreatedPackages",
+                        "action": function () {
+                            $location.path("/packages/packages/created");
+                        }
+                    }
+                ];
+            });
+        }
+
+        function setPageName() {
+            localizationService.localize("sections_packages").then(function (data) {
+                vm.page.name = data;
+            })
+        }
     }
 
     angular.module("umbraco").controller("Umbraco.Editors.Packages.OverviewController", PackagesOverviewController);

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/created.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/created.html
@@ -46,7 +46,7 @@
     <umb-empty-state
         ng-if="vm.createdPackages.length === 0"
         position="center">
-        No packages have been created yet
+        <localize key="packager_noPackagesCreated">No packages have been created yet</localize>
     </umb-empty-state>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/created.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/created.html
@@ -7,7 +7,8 @@
                 button-style="success"
                 type="button" 
                 action="vm.createPackage()"
-                label="Create package">
+                label="Create package"
+                label-key="packager_createPackage">
             </umb-button>
         </umb-editor-sub-header-content-left>
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/overview.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function UsersOverviewController($scope, $location, $timeout, navigationService, localizationService) {
+    function UsersOverviewController($scope, $location, localizationService) {
 
         var vm = this;
         var usersUri = $location.search().subview;
@@ -24,7 +24,6 @@
             loadNavigation();
 
             setPageName();
-
         }
 
         function loadNavigation() {

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -805,6 +805,8 @@ Mange hilsner fra Umbraco robotten
     <key alias="notifications">Notificeringer</key>
   </area>
   <area alias="packager">
+    <key alias="created">Oprettet</key>
+    <key alias="createPackage">Opret pakke</key>
     <key alias="chooseLocalPackageText">Vælg pakken fra din computer. Umbraco pakker er oftest en ".zip" fil</key>
     <key alias="dropHere">Slip her for at uploade</key>
     <key alias="orClickHereToUpload">eller klik her for at vælge pakkefil</key>
@@ -816,8 +818,10 @@ Mange hilsner fra Umbraco robotten
     <key alias="accept">Jeg accepterer</key>
     <key alias="termsOfUse">betingelser for anvendelse</key>
     <key alias="packageInstall">Installér pakke</key>
-    <key alias="installFinish">Afslut</key>
+    <key alias="installed">Installeret</key>
     <key alias="installedPackages">Installeret pakker</key>
+    <key alias="installLocal">Installér lokal</key>
+    <key alias="installFinish">Afslut</key>
     <key alias="noPackages">Du har ingen pakker installeret</key>
     <key alias="noPackagesDescription"><![CDATA[Du har ikke nogen pakker installeret. Du kan enten installere en lokal pakke ved at vælge den fra din computer eller gennemse de tilgængelige pakker ved hjælp af ikonet <strong>'Pakker'</strong> øverst til højre på din skærm]]></key>
     <key alias="packageSearch">Søg efter pakker</key>
@@ -954,6 +958,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="installer">Umbraco konfigurationsguide</key>
     <key alias="media">Mediearkiv</key>
     <key alias="member">Medlemmer</key>
+    <key alias="packages">Pakker</key>
     <key alias="newsletters">Nyhedsbreve</key>
     <key alias="settings">Indstillinger</key>
     <key alias="statistics">Statistik</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -822,6 +822,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="installedPackages">Installeret pakker</key>
     <key alias="installLocal">Installér lokal</key>
     <key alias="installFinish">Afslut</key>
+    <key alias="noPackagesCreated">Der er ikke blevet oprettet nogle pakker endnu</key>
     <key alias="noPackages">Du har ingen pakker installeret</key>
     <key alias="noPackagesDescription"><![CDATA[Du har ikke nogen pakker installeret. Du kan enten installere en lokal pakke ved at vælge den fra din computer eller gennemse de tilgængelige pakker ved hjælp af ikonet <strong>'Pakker'</strong> øverst til højre på din skærm]]></key>
     <key alias="packageSearch">Søg efter pakker</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1072,6 +1072,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="installedPackages">Installed packages</key>
     <key alias="installLocal">Install local</key>
     <key alias="installFinish">Finish</key>
+    <key alias="noPackagesCreated">No packages have been created yet</key>
     <key alias="noPackages">You don’t have any packages installed</key>
     <key alias="noPackagesDescription"><![CDATA[You don’t have any packages installed. Either install a local package by selecting it from your machine, or browse through available packages using the <strong>'Packages'</strong> icon in the top right of your screen]]></key>
     <key alias="packageSearch">Search for packages</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1052,6 +1052,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="notifications">Notifications</key>
   </area>
   <area alias="packager">
+    <key alias="created">Created</key>
+    <key alias="createPackage">Create package</key>
     <key alias="chooseLocalPackageText"><![CDATA[
       Choose Package from your machine, by clicking the Browse<br />
          button and locating the package. Umbraco packages usually have a ".umb" or ".zip" extension.
@@ -1066,8 +1068,10 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="accept">I accept</key>
     <key alias="termsOfUse">terms of use</key>
     <key alias="packageInstall">Install package</key>
-    <key alias="installFinish">Finish</key>
+    <key alias="installed">Installed</key>
     <key alias="installedPackages">Installed packages</key>
+    <key alias="installLocal">Install local</key>
+    <key alias="installFinish">Finish</key>
     <key alias="noPackages">You don’t have any packages installed</key>
     <key alias="noPackagesDescription"><![CDATA[You don’t have any packages installed. Either install a local package by selecting it from your machine, or browse through available packages using the <strong>'Packages'</strong> icon in the top right of your screen]]></key>
     <key alias="packageSearch">Search for packages</key>
@@ -1215,16 +1219,17 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="content">Content</key>
     <key alias="courier">Courier</key>
     <key alias="developer">Developer</key>
+    <key alias="forms">Forms</key>
+    <key alias="help" version="7.0">Help</key>
     <key alias="installer">Umbraco Configuration Wizard</key>
     <key alias="media">Media</key>
     <key alias="member">Members</key>
     <key alias="newsletters">Newsletters</key>
+    <key alias="packages">Packages</key>
     <key alias="settings">Settings</key>
     <key alias="statistics">Statistics</key>
     <key alias="translation">Translation</key>
     <key alias="users">Users</key>
-    <key alias="help" version="7.0">Help</key>
-    <key alias="forms">Forms</key>
   </area>
   <area alias="help">
     <key alias="theBestUmbracoVideoTutorials">The best Umbraco video tutorials</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1079,6 +1079,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="notifications">Notifications</key>
   </area>
   <area alias="packager">
+    <key alias="created">Created</key>
+    <key alias="createPackage">Create package</key>
     <key alias="chooseLocalPackageText"><![CDATA[
       Choose Package from your machine, by clicking the Browse<br />
          button and locating the package. Umbraco packages usually have a ".umb" or ".zip" extension.
@@ -1093,8 +1095,10 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="accept">I accept</key>
     <key alias="termsOfUse">terms of use</key>
     <key alias="packageInstall">Install package</key>
-    <key alias="installFinish">Finish</key>
+    <key alias="installed">Installed</key>
     <key alias="installedPackages">Installed packages</key>
+    <key alias="installLocal">Install local</key>
+    <key alias="installFinish">Finish</key>
     <key alias="noPackages">You don’t have any packages installed</key>
     <key alias="noPackagesDescription"><![CDATA[You don’t have any packages installed. Either install a local package by selecting it from your machine, or browse through available packages using the <strong>'Packages'</strong> icon in the top right of your screen]]></key>
     <key alias="packageSearch">Search for packages</key>
@@ -1243,13 +1247,13 @@ To manage your website, simply open the Umbraco back office and start adding con
   </area>
   <area alias="sections">
     <key alias="content">Content</key>
-    <key alias="packages">Packages</key>
+    <key alias="forms">Forms</key>
     <key alias="media">Media</key>
     <key alias="member">Members</key>
+    <key alias="packages">Packages</key>
     <key alias="settings">Settings</key>
     <key alias="translation">Translation</key>
     <key alias="users">Users</key>
-    <key alias="forms">Forms</key>
   </area>
   <area alias="help">
     <key alias="theBestUmbracoVideoTutorials">The best Umbraco video tutorials</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1099,6 +1099,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="installedPackages">Installed packages</key>
     <key alias="installLocal">Install local</key>
     <key alias="installFinish">Finish</key>
+    <key alias="noPackagesCreated">No packages have been created yet</key>
     <key alias="noPackages">You don’t have any packages installed</key>
     <key alias="noPackagesDescription"><![CDATA[You don’t have any packages installed. Either install a local package by selecting it from your machine, or browse through available packages using the <strong>'Packages'</strong> icon in the top right of your screen]]></key>
     <key alias="packageSearch">Search for packages</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4158

### Description
This PR fixes some localization in the packages section and localize page name and navigation items similar to how it is done in users section overview.

![image](https://user-images.githubusercontent.com/2919859/51441786-98485600-1cd5-11e9-8311-aa4024de9051.png)
