### PR TITLE
V8: Fix the decimal field value converter

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/DecimalValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/DecimalValueConverter.cs
@@ -18,17 +18,31 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
 
         public override object ConvertSourceToIntermediate(IPublishedElement owner, PublishedPropertyType propertyType, object source, bool preview)
         {
-            if (source == null) return 0M;
+            if (source == null)
+            {
+                return 0M;
+            }
 
-            // in XML a decimal is a string
+            // is it already a decimal?
+            if(source is decimal)
+            {
+                return source;
+            }
+
+            // is it a double?
+            if(source is double sourceDouble)
+            {
+                return Convert.ToDecimal(sourceDouble);
+            }
+
+            // is it a string?
             if (source is string sourceString)
             {
                 return decimal.TryParse(sourceString, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out decimal d) ? d : 0M;
             }
 
-            // in the database an a decimal is an a decimal
-            // default value is zero
-            return source is decimal ? source : 0M;
+            // couldn't convert the source value - default to zero
+            return 0M;
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4064

### Description

The decimal field value converter is broken in V8. Apparently it receives `double` values for conversion which it doesn't expect.

This PR fixes the value converter.

#### To test this PR

Create a page with a decimal field named "Price". Verify that the "Price" value is rendered correctly using this fancy template:

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@{
	Layout = null;
}

<html>
    <body>
        <h1>@Model.Name</h1>
	<p>
            Price: @Model.Value("price")
        </p>
    </body>
</html>
```

![image](https://user-images.githubusercontent.com/7405322/51442086-41448000-1cd9-11e9-8dab-191bdd7b0bd1.png)
