### PR TITLE
V8: Make sure the style preview text does not overlap for large font sizes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-stylesheet.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-stylesheet.less
@@ -38,10 +38,12 @@
     align-items: center;
 }
 
-.umb-stylesheet-rule-overlay {
-    textarea {
-        width: 300px;
-        height: 120px;
-        resize: none;
-    }
+textarea.umb-stylesheet-rule-styles {
+    width: 300px;
+    height: 100px;
+    resize: none;
+}
+
+.umb-stylesheet-rule-preview {
+    line-height: normal;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/infiniteeditors/richtextrule/richtextrule.html
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/infiniteeditors/richtextrule/richtextrule.html
@@ -27,11 +27,11 @@
                         </umb-control-group>
 
                         <umb-control-group label="@stylesheet_styles" description="@stylesheet_stylesHelp">
-                            <textarea ng-model="model.rule.styles" required></textarea>
+                            <textarea class="umb-stylesheet-rule-styles" ng-model="model.rule.styles" required></textarea>
                         </umb-control-group>
 
                         <umb-control-group label="@stylesheet_preview" description="@stylesheet_previewHelp">
-                            <div style="{{model.rule.styles}}">
+                            <div class="umb-stylesheet-rule-preview" style="{{model.rule.styles}}">
                                 a b c d e f g h i j k l m n o p q r s t u v w x t z
                                 <br>
                                 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4149

### Description

As described in #4149, the stylesheet editor rule preview looks a bit weird for large font sizes:

![image](https://user-images.githubusercontent.com/7405322/51442515-d6497800-1cdd-11e9-936c-8c1964997581.png)

With this PR the preview behaves a bit better While I was at it I also made the "Styles" textarea a little bit bigger:

![image](https://user-images.githubusercontent.com/7405322/51442503-997d8100-1cdd-11e9-8dc6-0384fbe90f81.png)


