### PR TITLE
Fixes for broken views..

### DIFF
--- a/src/Umbraco.Tests/Cache/PublishedCache/PublishedMediaCacheTests.cs
+++ b/src/Umbraco.Tests/Cache/PublishedCache/PublishedMediaCacheTests.cs
@@ -207,7 +207,7 @@ namespace Umbraco.Tests.Cache.PublishedCache
             var store = new PublishedMediaCache(new XmlStore((XmlDocument)null, null, null, null), ServiceContext.MediaService, ServiceContext.UserService, new DictionaryAppCache(), ContentTypesCache, Factory.GetInstance<IEntityXmlSerializer>());
             var doc = store.CreateFromCacheValues(store.ConvertFromSearchResult(result));
 
-            DoAssert(doc, 1234, key, templateIdVal: null, 0, "/media/test.jpg", "Image", 23, "Shannon", "Shannon", 0, 0, "-1,1234", DateTime.Parse("2012-07-17T10:34:09"), DateTime.Parse("2012-07-16T10:34:09"), 2);
+            DoAssert(doc, 1234, key, null, 0, "/media/test.jpg", "Image", 23, "Shannon", "Shannon", 0, 0, "-1,1234", DateTime.Parse("2012-07-17T10:34:09"), DateTime.Parse("2012-07-16T10:34:09"), 2);
             Assert.AreEqual(null, doc.Parent);
         }
 
@@ -223,7 +223,7 @@ namespace Umbraco.Tests.Cache.PublishedCache
             var cache = new PublishedMediaCache(new XmlStore((XmlDocument)null, null, null, null), ServiceContext.MediaService, ServiceContext.UserService, new DictionaryAppCache(), ContentTypesCache, Factory.GetInstance<IEntityXmlSerializer>());
             var doc = cache.CreateFromCacheValues(cache.ConvertFromXPathNavigator(navigator, true));
 
-            DoAssert(doc, 2000, key, templateIdVal: null, 2, "image1", "Image", 23, "Shannon", "Shannon", 33, 33, "-1,2000", DateTime.Parse("2012-06-12T14:13:17"), DateTime.Parse("2012-07-20T18:50:43"), 1);
+            DoAssert(doc, 2000, key, null, 2, "image1", "Image", 23, "Shannon", "Shannon", 33, 33, "-1,2000", DateTime.Parse("2012-06-12T14:13:17"), DateTime.Parse("2012-07-20T18:50:43"), 1);
             Assert.AreEqual(null, doc.Parent);
             Assert.AreEqual(2, doc.Children.Count());
             Assert.AreEqual(2001, doc.Children.ElementAt(0).Id);

--- a/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/ListChildPagesOrderedByProperty.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/ListChildPagesOrderedByProperty.cshtml
@@ -17,7 +17,7 @@
 
 @if (propertyAlias != null)
 {
-    var selection = Model.Content.Children.Where(x => x.IsVisible()).OrderBy(x => x.GetPropertyValue(propertyAlias.ToString())).ToArray();
+    var selection = Model.Content.Children.Where(x => x.IsVisible()).OrderBy(x => x.Value(propertyAlias.ToString())).ToArray();
 
     if (selection.Length > 0)
     {

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/TextString.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/TextString.cshtml
@@ -1,12 +1,13 @@
 ﻿@model dynamic
+@using Umbraco.Web.Composing
 @using Umbraco.Web.Templates
 
 @if (Model.editor.config.markup != null)
 {
     string markup = Model.editor.config.markup.ToString();
-    var umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
-    markup = markup.Replace("#value#", umbracoHelper.ReplaceLineBreaksForHtml(HttpUtility.HtmlEncode(Model.value.ToString())));
-    
+    var umbracoHelper = new UmbracoHelper(UmbracoContext.Current, Current.Services);
+    markup = markup.Replace("#value#", umbracoHelper.ReplaceLineBreaksForHtml(HttpUtility.HtmlEncode(Model.value.ToString())).ToString());
+
     if (Model.editor.config.style != null)
     {
         markup = markup.Replace("#style#", Model.editor.config.style.ToString());


### PR DESCRIPTION

Errors before:
- UmbracoHelper could not be created using only one parameter
- String.Replace cound not handle IHtmlString
- GetPropertyValue change to Value
- Named arguments cannot precede positional

Test: 
- To test create a grid with Quote or RTE
   - The display on the website will have compile errors in the view
