### PR TITLE
V8: Make it possible to create folders for stylesheets

### DIFF
--- a/src/Umbraco.Core/Services/IFileService.cs
+++ b/src/Umbraco.Core/Services/IFileService.cs
@@ -109,6 +109,19 @@ namespace Umbraco.Core.Services
         void DeleteScriptFolder(string folderPath);
 
         /// <summary>
+        /// Creates a folder for style sheets
+        /// </summary>
+        /// <param name="folderPath"></param>
+        /// <returns></returns>
+        void CreateStyleSheetFolder(string folderPath);
+
+        /// <summary>
+        /// Deletes a folder for style sheets
+        /// </summary>
+        /// <param name="folderPath"></param>
+        void DeleteStyleSheetFolder(string folderPath);
+
+        /// <summary>
         /// Gets a list of all <see cref="ITemplate"/> objects
         /// </summary>
         /// <returns>An enumerable list of <see cref="ITemplate"/> objects</returns>

--- a/src/Umbraco.Core/Services/Implement/FileService.cs
+++ b/src/Umbraco.Core/Services/Implement/FileService.cs
@@ -140,6 +140,24 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
+        public void CreateStyleSheetFolder(string folderPath)
+        {
+            using (var scope = ScopeProvider.CreateScope())
+            {
+                ((StylesheetRepository) _stylesheetRepository).AddFolder(folderPath);
+                scope.Complete();
+            }
+        }
+
+        public void DeleteStyleSheetFolder(string folderPath)
+        {
+            using (var scope = ScopeProvider.CreateScope())
+            {
+                ((StylesheetRepository) _stylesheetRepository).DeleteFolder(folderPath);
+                scope.Complete();
+            }
+        }
+
         public Stream GetStylesheetFileContentStream(string filepath)
         {
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/create.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function StyleSheetsCreateController($scope, $location, navigationService) {
+    function StyleSheetsCreateController($scope, $location, navigationService, formHelper, codefileResource) {
 
         var vm = this;
         var node = $scope.currentNode;
@@ -9,6 +9,9 @@
         vm.createFile = createFile;
         vm.createRichtextStyle = createRichtextStyle;
         vm.close = close;
+        vm.creatingFolder = false;
+        vm.showCreateFolder = showCreateFolder;
+        vm.createFolder = createFolder;
 
         function createFile() {
             $location.path("/settings/stylesheets/edit/" + node.id).search("create", "true");
@@ -18,6 +21,36 @@
         function createRichtextStyle() {
             $location.path("/settings/stylesheets/edit/" + node.id).search("create", "true").search("rtestyle", "true");
             navigationService.hideMenu();
+        }
+        
+        function showCreateFolder() {
+            vm.creatingFolder = true;
+        }
+
+        function createFolder(form) {
+
+            if (formHelper.submitForm({scope: $scope, formCtrl: form })) {
+
+                codefileResource.createContainer("stylesheets", node.id, vm.folderName).then(function (saved) {
+
+                    navigationService.hideMenu();
+
+                    navigationService.syncTree({
+                        tree: "stylesheets",
+                        path: saved.path,
+                        forceReload: true,
+                        activate: true
+                    });
+
+                    formHelper.resetForm({ scope: $scope });
+
+                }, function(err) {
+
+                  vm.createFolderError = err;
+                    
+                });
+            }
+
         }
 
         function close() {

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/create.html
@@ -2,7 +2,7 @@
 
     <div class="umbracoDialog umb-dialog-body with-footer" ng-cloak>
 
-        <div class="umb-pane">
+        <div class="umb-pane" ng-if="!vm.creatingFolder">
             <h5><localize key="create_createUnder">Create an item under</localize> {{currentNode.name}}</h5>
 
             <ul class="umb-actions umb-actions-child">
@@ -18,8 +18,34 @@
                         <span class="menu-label"><localize key="create_newRteStyleSheetFile">New richtext style sheet file</localize></span>
                     </a>
                 </li>
+                <li class="umb-action">
+                    <a href="" class="umb-action-link" ng-click="vm.showCreateFolder()">
+                        <i class="large icon icon-folder"></i>
+                        <span class="menu-label"><localize key="general_folder"></localize>...</span>
+                    </a>
+                </li>
             </ul>
 
+        </div>
+
+        <div class="umb-pane" ng-if="vm.creatingFolder">
+            <form novalidate name="createFolderForm"
+                  ng-submit="vm.createFolder(createFolderForm)"
+                  val-form-manager>
+
+                <div ng-show="vm.createFolderError">
+                    <div class="alert alert-error">
+                        <div><strong>{{vm.createFolderError.errorMsg}}</strong></div>
+                        <div>{{vm.createFolderError.data.message}}</div>
+                    </div>
+                </div>
+
+                <umb-control-group label="Enter a folder name" hide-label="false">
+                    <input type="text" name="folderName" ng-model="vm.folderName" class="umb-textstring textstring input-block-level" umb-auto-focus required />
+                </umb-control-group>
+
+                <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>
+            </form>
         </div>
 
     </div>

--- a/src/Umbraco.Web/Editors/CodeFileController.cs
+++ b/src/Umbraco.Web/Editors/CodeFileController.cs
@@ -68,7 +68,7 @@ namespace Umbraco.Web.Editors
         }
 
         /// <summary>
-        /// Used to create a container/folder in 'partialViews', 'partialViewMacros' or 'scripts'
+        /// Used to create a container/folder in 'partialViews', 'partialViewMacros', 'scripts' or 'stylesheets'
         /// </summary>
         /// <param name="type">'partialViews', 'partialViewMacros' or 'scripts'</param>
         /// <param name="parentId">The virtual path of the parent.</param>
@@ -110,6 +110,10 @@ namespace Umbraco.Web.Editors
                 case Core.Constants.Trees.Scripts:
                     virtualPath = NormalizeVirtualPath(name, SystemDirectories.Scripts);
                     Services.FileService.CreateScriptFolder(virtualPath);
+                    break;
+                case Core.Constants.Trees.Stylesheets:
+                    virtualPath = NormalizeVirtualPath(name, SystemDirectories.Css);
+                    Services.FileService.CreateStyleSheetFolder(virtualPath);
                     break;
 
             }
@@ -328,6 +332,11 @@ namespace Umbraco.Web.Editors
                     return Request.CreateErrorResponse(HttpStatusCode.NotFound, "No Script or folder found with the specified path");
 
                 case Core.Constants.Trees.Stylesheets:
+                    if (IsDirectory(virtualPath, SystemDirectories.Css))
+                    {
+                        Services.FileService.DeleteStyleSheetFolder(virtualPath);
+                        return Request.CreateResponse(HttpStatusCode.OK);
+                    }
                     if (Services.FileService.GetStylesheetByName(virtualPath) != null)
                     {
                         Services.FileService.DeleteStylesheet(virtualPath, Security.CurrentUser.Id);

--- a/src/Umbraco.Web/Trees/FileSystemTreeController.cs
+++ b/src/Umbraco.Web/Trees/FileSystemTreeController.cs
@@ -28,7 +28,10 @@ namespace Umbraco.Web.Trees
         /// Inheritors can override this method to modify the folder node that is created.
         /// </summary>
         /// <param name="treeNode"></param>
-        protected virtual void OnRenderFolderNode(ref TreeNode treeNode) { }
+        protected virtual void OnRenderFolderNode(ref TreeNode treeNode) {
+            //TODO: This isn't the best way to ensure a noop process for clicking a node but it works for now.
+            treeNode.AdditionalData["jsClickCallback"] = "javascript:void(0);";
+        }
 
         protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
         {

--- a/src/Umbraco.Web/Trees/FilesTreeController.cs
+++ b/src/Umbraco.Web/Trees/FilesTreeController.cs
@@ -15,11 +15,5 @@ namespace Umbraco.Web.Trees
         protected override string[] Extensions => ExtensionsStatic;
 
         protected override string FileIcon => "icon-document";
-
-        protected override void OnRenderFolderNode(ref TreeNode treeNode)
-        {
-            //TODO: This isn't the best way to ensure a noop process for clicking a node but it works for now.
-            treeNode.AdditionalData["jsClickCallback"] = "javascript:void(0);";
-        }
     }
 }

--- a/src/Umbraco.Web/Trees/PartialViewMacrosTreeController.cs
+++ b/src/Umbraco.Web/Trees/PartialViewMacrosTreeController.cs
@@ -23,11 +23,5 @@ namespace Umbraco.Web.Trees
         protected override string[] Extensions => ExtensionsStatic;
 
         protected override string FileIcon => "icon-article";
-
-        protected override void OnRenderFolderNode(ref TreeNode treeNode)
-        {
-            //TODO: This isn't the best way to ensure a noop process for clicking a node but it works for now.
-            treeNode.AdditionalData["jsClickCallback"] = "javascript:void(0);";
-        }
     }
 }

--- a/src/Umbraco.Web/Trees/PartialViewsTreeController.cs
+++ b/src/Umbraco.Web/Trees/PartialViewsTreeController.cs
@@ -23,12 +23,5 @@ namespace Umbraco.Web.Trees
         protected override string[] Extensions => ExtensionsStatic;
 
         protected override string FileIcon => "icon-article";
-
-        protected override void OnRenderFolderNode(ref TreeNode treeNode)
-        {
-            //TODO: This isn't the best way to ensure a noop process for clicking a node but it works for now.
-            treeNode.AdditionalData["jsClickCallback"] = "javascript:void(0);";
-            treeNode.Icon = "icon-folder";
-        }
     }
 }

--- a/src/Umbraco.Web/Trees/ScriptsTreeController.cs
+++ b/src/Umbraco.Web/Trees/ScriptsTreeController.cs
@@ -16,11 +16,5 @@ namespace Umbraco.Web.Trees
         protected override string[] Extensions => ExtensionsStatic;
 
         protected override string FileIcon => "icon-script";
-
-        protected override void OnRenderFolderNode(ref TreeNode treeNode)
-        {
-            //TODO: This isn't the best way to ensure a noop process for clicking a node but it works for now.
-            treeNode.AdditionalData["jsClickCallback"] = "javascript:void(0);";
-        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4150

### Description

As discussed in #4150 it's currently not possible to create folders for stylesheets. 

This PR adds that feature. It looks something like this:

![folders-for-stylesheets](https://user-images.githubusercontent.com/7405322/51491779-b7b3b180-1daf-11e9-9b73-162a791f9a89.gif)

While I was at it I did a bit of clean-up in all the file system tree controllers to remove the duplicate handling of clicking folder nodes.
