### PR TITLE
- tls health check

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
@@ -1331,6 +1331,9 @@
     <key alias="smtpMailSettingsConnectionFail">SMTP伺服器 %0% : %1% 無法連接。請確認在Web.config 檔案中 system.net/mailsettings 設定正確。</key>
     <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[提醒郵件已經設為 <strong>%0%</strong>。]]></key>
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[提醒郵件仍為預設值<strong>%0%</strong>。]]></key>
+
+    <key alias="tlsHealthCheckSuccess">您的網站設置為使用TLS 1.2或更高版本進行傳出連接。</key>
+    <key alias="tlsHealthCheckWarn">來自您網站的傳出連接通過舊協議提供。您應該考慮將其更新為使用TLS 1.2或更高版本。</key>
   </area>
   <area alias="redirectUrls">
     <key alias="disableUrlTracker">停止網址追蹤器</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2206,6 +2206,9 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
         <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: %0%</key>
+
+        <key alias="tlsHealthCheckSuccess">Your website is set up to use TLS 1.2 or greater for outgoing connections.</key>
+        <key alias="tlsHealthCheckWarn">Outgoing connections from your website are being served over an old protocol. You should consider updating it to use TLS 1.2 or higher.</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Disable URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2199,6 +2199,9 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
         <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: %0%</key>
+
+        <key alias="tlsHealthCheckSuccess">Your website is set up to use TLS 1.2 or greater for outgoing connections.</key>
+        <key alias="tlsHealthCheckWarn">Outgoing connections from your website are being served over an old protocol. You should consider updating it to use TLS 1.2 or higher.</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Disable URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -1856,6 +1856,9 @@
         <key alias="notificationEmailsCheckErrorMessage"><![CDATA[El email de notificación está todavía configurado en tuvalor por defecto: <strong>%0%</strong>.]]></key>
         <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Los resultados de los Chequeos de Salud de Umbraco programados para ejecutarse el %0% a las %1% son:</p>%2%</body></html>]]></key>
         <key alias="scheduledHealthCheckEmailSubject">Status de los Chequeos de Salud de Umbraco: %0%</key>
+
+        <key alias="tlsHealthCheckSuccess">Su sitio web está configurado para usar TLS 1.2 o superior para las conexiones salientes.</key>
+        <key alias="tlsHealthCheckWarn">Las conexiones salientes de su sitio web están siendo servidas a través de un protocolo antiguo. Deberías considerar actualizarlo para usar TLS 1.2 o superior.</key>
     </area>
     <area alias="redirectUrls">
         <key alias="disableUrlTracker">Desactivar URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -2170,6 +2170,9 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[L'adresse email de notification est toujours à sa valeur par défaut : <strong>%0%</strong>.]]></key>
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Les résultats de l'exécution du Umbraco Health Checks planifiée le %0% à %1% sont les suivants :</p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Statut du Umbraco Health Check: %0%</key>
+
+    <key alias="tlsHealthCheckSuccess">Votre site Web est configuré pour utiliser TLS version 1.2 ou supérieure pour les connexions sortantes.</key>
+    <key alias="tlsHealthCheckWarn">Les connexions sortantes de votre site Web sont servies via un ancien protocole. Vous devriez envisager de le mettre à jour pour utiliser TLS 1.2 ou supérieur.</key>
   </area>
   <area alias="redirectUrls">
     <key alias="disableUrlTracker">Désactiver URL tracker</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -1623,6 +1623,9 @@ Om een vertalingstaak te sluiten, ga aub naar het detailoverzicht en klik op de 
 
     <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Notificatie email is verzonden naar <strong>%0%</strong>.]]></key>
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notificatie email staat nog steeds op de default waarde van <strong>%0%</strong>.]]></key>
+
+    <key alias="tlsHealthCheckSuccess">Uw website is ingesteld om TLS 1.2 of hoger te gebruiken voor uitgaande verbindingen.</key>
+    <key alias="tlsHealthCheckWarn">Uitgaande verbindingen van uw website worden via een oud protocol bediend. U zou moeten overwegen om het bij te werken om TLS 1.2 of hoger te gebruiken.</key>
   </area>
 	<area alias="redirectUrls">
     <key alias="disableUrlTracker">URL tracker uitzetten</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -1674,6 +1674,9 @@ Naciśnij przycisk <strong>instaluj</strong>, aby zainstalować bazę danych Umb
 
     <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[E-mail z powiadomieniem został wysłany do <strong>%0%</strong>.]]></key>
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[E-mail do powiadomień jest nadal ustawiony na domyślną wartość <strong>%0%</strong>.]]></key>
+
+    <key alias="tlsHealthCheckSuccess">Twoja strona internetowa jest skonfigurowana do używania protokołu TLS 1.2 lub nowszego dla połączeń wychodzących.</key>
+    <key alias="tlsHealthCheckWarn">Połączenia wychodzące z Twojej witryny są obsługiwane przez stary protokół. Należy rozważyć zaktualizowanie go do korzystania z TLS w wersji 1.2 lub nowszej.</key>
   </area>
   <area alias="redirectUrls">
     <key alias="disableUrlTracker">Wyłącz śledzenie URL</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -870,6 +870,9 @@
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Адрес для отправки уведомлений все еще установлен в значение по-умолчанию <strong>%0%</strong>.]]></key>
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Зафиксированы следующие результаты автоматической проверки состояния Umbraco по расписанию, запущенной на %0% в %1%:</p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Результат проверки состояния Umbraco: %0%</key>
+
+    <key alias="tlsHealthCheckSuccess">Ваш веб-сайт настроен на использование TLS 1.2 или выше для исходящих соединений.</key>
+    <key alias="tlsHealthCheckWarn">Исходящие соединения с вашего сайта обслуживаются по старому протоколу. Вы должны рассмотреть возможность его обновления для использования TLS 1.2 или выше.</key>
   </area>
   <area alias="help">
     <key alias="goTo">перейти к</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -1598,6 +1598,9 @@
     <key alias="smtpMailSettingsConnectionFail">The SMTP server configured with host '%0%' and port '%1%' could not be reached. Please check to ensure the SMTP settings in the Web.config file system.net/mailsettings are correct.</key>
     <key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Notification email has been set to <strong>%0%</strong>.]]></key>
     <key alias="notificationEmailsCheckErrorMessage"><![CDATA[Notification email is still set to the default value of <strong>%0%</strong>.]]></key>
+
+    <key alias="tlsHealthCheckSuccess">您的网站设置为使用TLS 1.2或更高版本进行传出连接。</key>
+    <key alias="tlsHealthCheckWarn">来自您网站的传出连接通过旧协议提供。您应该考虑将其更新为使用TLS 1.2或更高版本。</key>
   </area>
   <area alias="redirectUrls">
     <key alias="disableUrlTracker">禁用 url 跟踪程序</key>

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/TlsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/TlsCheck.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Web.HealthCheck.Checks.Security
+{
+    [HealthCheck("6D7D4E11-758E-4697-BA72-7E02A530CBD4",
+        "TLS Check",
+        Description = "Checks that your site is set up to use at least TLS 1.2 for outgoing connections.",
+        Group = "Security")]
+    public class TlsCheck : HealthCheck
+    {
+        private readonly ILocalizedTextService _textService;
+
+        public TlsCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
+        {
+            _textService = healthCheckContext.ApplicationContext.Services.TextService;
+        }
+
+        public override IEnumerable<HealthCheckStatus> GetStatus()
+        {
+            return new[] { CheckTls() };
+        }
+
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            throw new InvalidOperationException("TlsCheck has no executable actions");
+        }
+
+        public HealthCheckStatus CheckTls()
+        {
+            bool success = (int)ServicePointManager.SecurityProtocol >= (int)SecurityProtocolType.Tls12;
+
+            string message = success
+                ? _textService.Localize("healthcheck/tlsHealthCheckSuccess")
+                : _textService.Localize("healthcheck/tlsHealthCheckWarn");
+
+            var actions = new List<HealthCheckAction>();
+
+            return
+                new HealthCheckStatus(message)
+                {
+                    ResultType = success
+                        ? StatusResultType.Success
+                        : StatusResultType.Warning,
+                    Actions = actions
+                };
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -338,6 +338,7 @@
     <Compile Include="Editors\CodeFileController.cs" />
     <Compile Include="Editors\TourController.cs" />
     <Compile Include="Features\EnabledFeatures.cs" />
+    <Compile Include="HealthCheck\Checks\Security\TlsCheck.cs" />
     <Compile Include="HealthCheck\Checks\Security\XssProtectionCheck.cs" />
     <Compile Include="HealthCheck\Checks\Security\HstsCheck.cs" />
     <Compile Include="Models\BackOfficeTourFilter.cs" />


### PR DESCRIPTION
- [x] I have added steps to test this contribution in the description below

Here is the issue #4172 

### Description
This adds a health check for checking if tls 1.2 or greater is set up for outgoing connections as per the check in the community health checks project Our.Umbraco.HealthChecks. Requested by @nul800sebastiaan 

To test, do a build, go to the devleoper section, click on health checks, security tab and scroll down to see it. Click on check group to see that the test works.