### PR TITLE
- disabled the duplicated community health checks

### DIFF
--- a/src/Umbraco.Web.UI/config/HealthChecks.config
+++ b/src/Umbraco.Web.UI/config/HealthChecks.config
@@ -8,20 +8,19 @@ For details on the format of this configuration file see:
 https://our.umbraco.com/documentation/reference/config/healthchecks
 -->
 <HealthChecks>
-  <disabledChecks>
-      <check id="92AE66E1-209D-4F9E-AAF5-19B19D41CF49" disabledOn="22-Jan-2019" disabledBy="0" />
-      <check id="6437384C-D1D3-46DA-9E21-9E0BC1498E1F" disabledOn="22-Jan-2019" disabledBy="0" />
-  </disabledChecks>
-  <notificationSettings enabled="true" firstRunTime="" periodInHours="24">
-    <notificationMethods>
-      <notificationMethod alias="email" enabled="true" verbosity="Summary">
-        <settings>
-          <add key="recipientEmail" value="" />
-        </settings>
-      </notificationMethod>
-    </notificationMethods>
     <disabledChecks>
-      <!--<check id="EB66BB3B-1BCD-4314-9531-9DA2C1D6D9A7" disabledOn="" disabledBy="0" />-->
-    </disabledChecks>    
-  </notificationSettings>
+        <!--<check id="1B5D221B-CE99-4193-97CB-5F3261EC73DF" disabledOn="" disabledBy="0" />-->
+    </disabledChecks>
+    <notificationSettings enabled="true" firstRunTime="" periodInHours="24">
+        <notificationMethods>
+            <notificationMethod alias="email" enabled="true" verbosity="Summary">
+                <settings>
+                    <add key="recipientEmail" value="" />
+                </settings>
+            </notificationMethod>
+        </notificationMethods>
+        <disabledChecks>
+            <!--<check id="EB66BB3B-1BCD-4314-9531-9DA2C1D6D9A7" disabledOn="" disabledBy="0" />-->
+        </disabledChecks>    
+    </notificationSettings>
 </HealthChecks> 

--- a/src/Umbraco.Web.UI/config/HealthChecks.config
+++ b/src/Umbraco.Web.UI/config/HealthChecks.config
@@ -9,7 +9,8 @@ https://our.umbraco.com/documentation/reference/config/healthchecks
 -->
 <HealthChecks>
   <disabledChecks>
-    <!--<check id="1B5D221B-CE99-4193-97CB-5F3261EC73DF" disabledOn="" disabledBy="0" />-->
+      <check id="92AE66E1-209D-4F9E-AAF5-19B19D41CF49" disabledOn="22-Jan-2019" disabledBy="0" />
+      <check id="6437384C-D1D3-46DA-9E21-9E0BC1498E1F" disabledOn="22-Jan-2019" disabledBy="0" />
   </disabledChecks>
   <notificationSettings enabled="true" firstRunTime="" periodInHours="24">
     <notificationMethods>

--- a/src/Umbraco.Web/HealthCheck/HealthCheckController.cs
+++ b/src/Umbraco.Web/HealthCheck/HealthCheckController.cs
@@ -58,11 +58,6 @@ namespace Umbraco.Web.HealthCheck
         /// <returns>Returns a collection of anonymous objects representing each group.</returns>
         public object GetAllHealthChecks()
         {
-            //We want to disable the duplicate health checks from Our.Umbraco.HealthChecks
-            //as per this issue https://github.com/umbraco/Umbraco-CMS/issues/4174
-            _disabledCheckIds.Add(new Guid("92AE66E1-209D-4F9E-AAF5-19B19D41CF49")); //TlsCheck
-            _disabledCheckIds.Add(new Guid("6437384C-D1D3-46DA-9E21-9E0BC1498E1F")); //HstsCheck
-
             var groups = _healthCheckResolver.HealthChecks
                 .Where(x => _disabledCheckIds.Contains(x.Id) == false)
                 .GroupBy(x => x.Group)
@@ -87,7 +82,7 @@ namespace Umbraco.Web.HealthCheck
         public object GetStatus(Guid id)
         {
             var check = GetCheckById(id);
-            
+
             try
             {
                 //Core.Logging.LogHelper.Debug<HealthCheckController>("Running health check: " + check.Name);

--- a/src/Umbraco.Web/HealthCheck/HealthCheckController.cs
+++ b/src/Umbraco.Web/HealthCheck/HealthCheckController.cs
@@ -58,6 +58,11 @@ namespace Umbraco.Web.HealthCheck
         /// <returns>Returns a collection of anonymous objects representing each group.</returns>
         public object GetAllHealthChecks()
         {
+            //We want to disable the duplicate health checks from Our.Umbraco.HealthChecks
+            //as per this issue https://github.com/umbraco/Umbraco-CMS/issues/4174
+            _disabledCheckIds.Add(new Guid("92AE66E1-209D-4F9E-AAF5-19B19D41CF49")); //TlsCheck
+            _disabledCheckIds.Add(new Guid("6437384C-D1D3-46DA-9E21-9E0BC1498E1F")); //HstsCheck
+
             var groups = _healthCheckResolver.HealthChecks
                 .Where(x => _disabledCheckIds.Contains(x.Id) == false)
                 .GroupBy(x => x.Group)

--- a/src/Umbraco.Web/Scheduling/HealthCheckNotifier.cs
+++ b/src/Umbraco.Web/Scheduling/HealthCheckNotifier.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Configuration;
 using System.Linq;
 using System.Threading;
@@ -17,7 +16,7 @@ namespace Umbraco.Web.Scheduling
         private readonly ApplicationContext _appContext;
         private readonly IHealthCheckResolver _healthCheckResolver;
 
-        public HealthCheckNotifier(IBackgroundTaskRunner<RecurringTaskBase> runner, int delayMilliseconds, int periodMilliseconds, 
+        public HealthCheckNotifier(IBackgroundTaskRunner<RecurringTaskBase> runner, int delayMilliseconds, int periodMilliseconds,
             ApplicationContext appContext)
             : base(runner, delayMilliseconds, periodMilliseconds)
         {
@@ -57,12 +56,7 @@ namespace Umbraco.Web.Scheduling
                     .Union(healthCheckConfig.DisabledChecks
                         .Select(x => x.Id))
                     .Distinct()
-                    .ToList();
-
-                //We want to disable the duplicate health checks from Our.Umbraco.HealthChecks
-                //as per this issue https://github.com/umbraco/Umbraco-CMS/issues/4174
-                disabledCheckIds.Add(new Guid("92AE66E1-209D-4F9E-AAF5-19B19D41CF49")); //TlsCheck
-                disabledCheckIds.Add(new Guid("6437384C-D1D3-46DA-9E21-9E0BC1498E1F")); //HstsCheck
+                    .ToArray();
 
                 var checks = _healthCheckResolver.HealthChecks
                     .Where(x => disabledCheckIds.Contains(x.Id) == false);

--- a/src/Umbraco.Web/Scheduling/HealthCheckNotifier.cs
+++ b/src/Umbraco.Web/Scheduling/HealthCheckNotifier.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Configuration;
 using System.Linq;
 using System.Threading;
@@ -56,7 +57,12 @@ namespace Umbraco.Web.Scheduling
                     .Union(healthCheckConfig.DisabledChecks
                         .Select(x => x.Id))
                     .Distinct()
-                    .ToArray();
+                    .ToList();
+
+                //We want to disable the duplicate health checks from Our.Umbraco.HealthChecks
+                //as per this issue https://github.com/umbraco/Umbraco-CMS/issues/4174
+                disabledCheckIds.Add(new Guid("92AE66E1-209D-4F9E-AAF5-19B19D41CF49")); //TlsCheck
+                disabledCheckIds.Add(new Guid("6437384C-D1D3-46DA-9E21-9E0BC1498E1F")); //HstsCheck
 
                 var checks = _healthCheckResolver.HealthChecks
                     .Where(x => disabledCheckIds.Contains(x.Id) == false);

--- a/src/Umbraco.Web/WebBootManager.cs
+++ b/src/Umbraco.Web/WebBootManager.cs
@@ -544,6 +544,19 @@ namespace Umbraco.Web
                 () => PluginManager.ResolveTypes<HealthCheck.HealthCheck>());
             HealthCheckNotificationMethodResolver.Current = new HealthCheckNotificationMethodResolver(LoggerResolver.Current.Logger,
                 () => PluginManager.ResolveTypes<HealthCheck.NotificationMethods.IHealthCheckNotificatationMethod>());
+
+            // Disable duplicate community health checks which appear in Our.Umbraco.HealtchChecks and Umbraco Core.
+            // See this issue to understand why https://github.com/umbraco/Umbraco-CMS/issues/4174
+            var disabledHealthCheckTypes = new[]
+            {
+                "Our.Umbraco.HealthChecks.Checks.Security.HstsCheck",
+                "Our.Umbraco.HealthChecks.Checks.Security.TlsCheck"
+            }.Select(TypeFinder.GetTypeByName).WhereNotNull();
+
+            foreach (var type in disabledHealthCheckTypes)
+            {
+                HealthCheckResolver.Current.RemoveType(type);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
As per this issue #4174, now that we have our first health check which is being promoted from Our.Umbraco.HealthChecks to Umbraco core see #4173 , it would be good to add the id of the one in the community project to the disabled health checks list in the HealtChecks.config file that ships with core. This will prevent the check being duplicated.

I have disabled 2 community health checks by their id in the HealthCheks.config file.

This means the Core ones will always show and the duplicate disabled community ones will not.

It will be a good practice to do this when checks get promoted to the core. This is the aim of the community project over time.