### PR TITLE
Don't add default content to grids

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -713,9 +713,6 @@ angular.module("umbraco")
                         $scope.model.value.sections.splice(index, 1);
                     }
                 });
-            } else if ($scope.model.config.items.templates && $scope.model.config.items.templates.length === 1) {
-                $scope.addTemplate($scope.model.config.items.templates[0]);
-                clear = false;
             }
 
             if (clear) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4154

### Description

As described in #4154 the grid misbehaves when the grid configuration has only one grid layout and one row configuration - like this:

![image](https://user-images.githubusercontent.com/7405322/51516634-5bd14300-1e18-11e9-9f69-8191dfbba910.png)

Given that configuration, the grid property editor adds a default value to the grid - like this:

![grid-default-before](https://user-images.githubusercontent.com/7405322/51516665-6db2e600-1e18-11e9-9005-a1d43ed5b510.gif)

With this PR applied, the same operation looks like this:

![grid-default-after](https://user-images.githubusercontent.com/7405322/51516697-828f7980-1e18-11e9-9d89-533c53ad8b98.gif)

#### Testing this PR

1. Create a page with grid configured as shown above, and verify that the default value is not added to the grid.
2. Publish the page.
3. Given the template below, verify that `Model.Content.HasValue("[gridPropertyAlias]")` returns false when the page is rendered.

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoTemplatePage
@{
	Layout = null;
}
<html>
    <body>
        <h1>@Model.Content.Name</h1>
        Has value? @Model.Content.HasValue("gridContent")
    </body>
</html>
``` 

![image](https://user-images.githubusercontent.com/7405322/51516831-02b5df00-1e19-11e9-953f-494c1b8b2e2f.png)
