### PR TITLE
Enriched error information

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeFactory.cs
@@ -79,7 +79,7 @@ namespace Umbraco.Core.Models.PublishedContent
             }
 
             if (!publishedDataTypes.TryGetValue(id, out var dataType))
-                throw new ArgumentException("Not a valid datatype identifier.", nameof(id));
+                throw new ArgumentException($"Not a valid datatype identifier. Identifier requested: {id}", nameof(id));
 
             return dataType;
         }


### PR DESCRIPTION
### Investigating issues in deploy
In order to zero in on a bug in deploy we need expanded information regarding which id, that was requested but could not be found.

- Updated error statement to include the necessary information needed
