### PR TITLE
V8: Fix blank content editor when using infinite editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -27,6 +27,16 @@
         $scope.app = null;
 
         function init(content) {
+
+            if ($scope.app) {
+                var app = _.find(content.apps, function (app) { return app.alias === $scope.app.alias; });
+                if (app) {
+                    app.active = true;
+                } else {
+                    $scope.app = null;
+                }
+            }
+
             if (!$scope.app) {
                 // set first app to active
                 content.apps[0].active = true;

--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -14,7 +14,7 @@
                                hide-description="true"
                                hide-alias="true"
                                navigation="content.apps"
-                               on-select-navigation-item="appChanged(app)">
+                               on-select-navigation-item="appChanged(item)">
             </umb-editor-header>
 
             <umb-editor-container>

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -95,6 +95,15 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource, 
 
     function init() {
 
+        if ($scope.app) {
+            var app = _.find($scope.content.apps, function (app) { return app.alias === $scope.app.alias; });
+            if (app) {
+                app.active = true;
+            } else {
+                $scope.app = null;
+            }
+        }
+
         if (!$scope.app) {
             // set first app to active
             $scope.content.apps[0].active = true;
@@ -210,8 +219,8 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource, 
         }
     };
 
-    $scope.appChanged = function (app) {
-        $scope.app = app;
+    $scope.appChanged = function (item) {
+        $scope.app = item;
     }
 
     evts.push(eventsService.on("editors.mediaType.saved", function(name, args) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4181

### Description

See steps to reproduce in #4181 - it plays out like this:

![content-editor-infinite-editing-before](https://user-images.githubusercontent.com/7405322/51541637-9d361280-1e59-11e9-9759-144e7a424b91.gif)

With this PR applied, the same action looks like this:

![content-editor-infinite-editing-after](https://user-images.githubusercontent.com/7405322/51541667-acb55b80-1e59-11e9-9ab3-1ad8585b82fe.gif)

I took the liberty of preparing the media equivalent for this, even if media doesn't support infinite editing yet.