### PR TITLE
V8: Element types should not be allowed children to other content types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
@@ -38,13 +38,12 @@
             });
 
             contentTypeResource.getAll().then(function(contentTypes){
-
-                vm.contentTypes = contentTypes;
+                vm.contentTypes = _.where(contentTypes, {isElement: false});
 
                 // convert legacy icons
                 iconHelper.formatContentTypeIcons(vm.contentTypes);
 
-                vm.selectedChildren = contentTypeHelper.makeObjectArrayFromId($scope.model.allowedContentTypes, vm.contentTypes);
+                vm.selectedChildren = contentTypeHelper.makeObjectArrayFromId($scope.model.allowedContentTypes, contentTypes);
 
                 if($scope.model.id === 0) {
                    contentTypeHelper.insertChildNodePlaceholder(vm.contentTypes, $scope.model.name, $scope.model.icon, $scope.model.id);

--- a/src/Umbraco.Web/Models/ContentEditing/ContentTypeBasic.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentTypeBasic.cs
@@ -116,5 +116,13 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "blueprints")]
         [ReadOnly(true)]
         public IDictionary<int, string> Blueprints { get; set; }
+
+        [DataMember(Name = "isContainer")]
+        [ReadOnly(true)]
+        public bool IsContainer { get; set; }
+
+        [DataMember(Name = "isElement")]
+        [ReadOnly(true)]
+        public bool IsElement { get; set; }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4168

### Description

As per #4168 we need to ensure that element types are not allowed as children to other content types. Right now there's no limitation in this regard:

![image](https://user-images.githubusercontent.com/7405322/51557055-24947d80-1e7c-11e9-9956-c707775f21b3.png)

With this PR you can no longer assign element types as children:

![image](https://user-images.githubusercontent.com/7405322/51556888-b2bc3400-1e7b-11e9-8f23-1dddfdb9761b.png)
