### PR TITLE
v8: Modal buttons localization

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -508,7 +508,7 @@
                         view: "views/content/overlays/sendtopublish.html",
                         variants: $scope.content.variants, //set a model property for the dialog
                         skipFormValidation: true, //when submitting the overlay form, skip any client side validation
-                        submitButtonLabel: "Send for approval",
+                        submitButtonLabelKey: "buttons_saveToPublish",
                         submit: function (model) {
                             model.submitButtonState = "busy";
                             clearNotifications($scope.content);
@@ -564,7 +564,7 @@
                         view: "views/content/overlays/publish.html",
                         variants: $scope.content.variants, //set a model property for the dialog
                         skipFormValidation: true, //when submitting the overlay form, skip any client side validation
-                        submitButtonLabel: "Publish",
+                        submitButtonLabelKey: "buttons_saveAndPublish",
                         submit: function (model) {
                             model.submitButtonState = "busy";
                             clearNotifications($scope.content);
@@ -625,7 +625,7 @@
                         view: "views/content/overlays/save.html",
                         variants: $scope.content.variants, //set a model property for the dialog
                         skipFormValidation: true, //when submitting the overlay form, skip any client side validation
-                        submitButtonLabel: "Save",
+                        submitButtonLabelKey: "buttons_save",
                         submit: function (model) {
                             model.submitButtonState = "busy";
                             clearNotifications($scope.content);
@@ -697,7 +697,7 @@
                     view: "views/content/overlays/schedule.html",
                     variants: $scope.content.variants, //set a model property for the dialog
                     skipFormValidation: true, //when submitting the overlay form, skip any client side validation
-                    submitButtonLabel: "Schedule",
+                    submitButtonLabelKey: "buttons_schedulePublish",
                     submit: function (model) {
                         model.submitButtonState = "busy";
                         clearNotifications($scope.content);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4198

### Description
I noticed the buttons in the confirm modals in content section not was localized - they are now.

![image](https://user-images.githubusercontent.com/2919859/51565726-0b4afb80-1e93-11e9-8d1a-49a060ded73b.png)
