### PR TITLE
V8: Don't allow creation of element types in the content tree

### DIFF
--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -413,7 +413,7 @@ namespace Umbraco.Web.Editors
                 types = Services.ContentTypeService.GetAll(ids).ToList();
             }
 
-            var basics = types.Select(Mapper.Map<IContentType, ContentTypeBasic>).ToList();
+            var basics = types.Where(type => type.IsElement == false).Select(Mapper.Map<IContentType, ContentTypeBasic>).ToList();
 
             var localizedTextService = Services.TextService;
             foreach (var basic in basics)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4168

### Description

It shouldn't be possible to create new element types in the content tree. Right now there's nothing that prevents it:

![image](https://user-images.githubusercontent.com/7405322/51588049-30675a80-1ee3-11e9-8e9f-ab8d14812a84.png)

This PR all element types from the list of possible children.

#### Testing this PR

1. Create a new content type and allow it as a child to an existing content type.
2. Verify that the new content type can be created underneath content of the existing content type.
3. Turn the new content type into an element type.
4. Verify that you're no longer able to create the new content type underneath content of the existing content type.