### PR TITLE
Fixme - Only allow local KeepAlive Pings requests

### DIFF
--- a/src/Umbraco.Web/Editors/KeepAliveController.cs
+++ b/src/Umbraco.Web/Editors/KeepAliveController.cs
@@ -1,16 +1,13 @@
 ﻿using System.Runtime.Serialization;
 using System.Web.Http;
+using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
 
 namespace Umbraco.Web.Editors
 {
-    // fixme/task - deal with this
-    // this is not authenticated, and therefore public, and therefore reveals we
-    // are running Umbraco - but, all requests should come from localhost really,
-    // so there should be a way to 404 when the request comes from the outside.
-
     public class KeepAliveController : UmbracoApiController
     {
+        [OnlyLocalRequests]
         [HttpGet]
         public KeepAlivePingResult Ping()
         {

--- a/src/Umbraco.Web/Mvc/OnlyLocalRequestsAttribute.cs
+++ b/src/Umbraco.Web/Mvc/OnlyLocalRequestsAttribute.cs
@@ -1,0 +1,20 @@
+
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+
+namespace Umbraco.Web.Mvc
+{
+    public class OnlyLocalRequestsAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(HttpActionContext actionContext)
+        {
+            if (!actionContext.Request.IsLocal())
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Models\ContentEditing\MacroParameterDisplay.cs" />
     <Compile Include="Models\Link.cs" />
     <Compile Include="Models\LinkType.cs" />
+    <Compile Include="Mvc\OnlyLocalRequestsAttribute.cs" />
     <Compile Include="PropertyEditors\MultiUrlPickerConfiguration.cs" />
     <Compile Include="PropertyEditors\MultiUrlPickerConfigurationEditor.cs" />
     <Compile Include="PropertyEditors\MultiUrlPickerPropertyEditor.cs" />


### PR DESCRIPTION
Handled fixme/task

Steps to test:
- Setup machine to allow requests from non-localhost
- Request the endpoint e.g. http://_**hostname**_/umbraco/api/keepalive/ping from localhost.
   - Response should be 200 OK:  
```
<KeepAlivePingResult xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.datacontract.org/2004/07/Umbraco.Web.Editors">
   <Message>I'm alive!</Message>
   <Success>true</Success>
</KeepAlivePingResult>
```

- Request the endpoint from non localhost:
   - Response should be : 404 - Not found