### PR TITLE
V8: Don't attempt to resolve URLs for element types

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentUrlResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentUrlResolver.cs
@@ -35,6 +35,11 @@ namespace Umbraco.Web.Models.Mapping
 
         public UrlInfo[] Resolve(IContent source, ContentItemDisplay destination, UrlInfo[] destMember, ResolutionContext context)
         {
+            if (source.ContentType.IsElement)
+            {
+                return new UrlInfo[0];
+            }
+
             var umbracoContext = _umbracoContextAccessor.UmbracoContext;
 
             var urls = umbracoContext == null

--- a/src/Umbraco.Web/Routing/UrlProvider.cs
+++ b/src/Umbraco.Web/Routing/UrlProvider.cs
@@ -185,7 +185,7 @@ namespace Umbraco.Web.Routing
         /// </remarks>
         public string GetUrl(IPublishedContent content, UrlProviderMode mode, string culture = null, Uri current = null)
         {
-            if (content == null)
+            if (content == null || content.ItemType == PublishedItemType.Element)
                 return "#";
 
             // this the ONLY place where we deal with default culture - IUrlProvider always receive a culture


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4168

### Description

Existing element type items in the content tree can cause havoc for the various content pickers, because they'll attempt to resolve the element URLs (and elements are not routable). 

It looks like this:

![element-url-ysods-before-2](https://user-images.githubusercontent.com/7405322/51605534-ad102e00-1f0f-11e9-8b4c-a3b80d2bcb80.gif)

To reproduce:

1. Create content type A with a content picker.
2. Create content type B,
3. Create page A and B of content type A and B respectively and publish both pages (they must be routable and in the cache to provoke this error).
4. From page A pick page B.
5. Turn content type B into an element type.
6. Open page A.
6. YSOD 💥 

The same problem happens if you subsequently attempt to pick page B from other pages of type A.

In general we shouldn't attempt to resolve URLs for element types. This PR ensures just that. 

The scenario above plays out like this with this PR applied:

![element-url-ysods-after-2](https://user-images.githubusercontent.com/7405322/51605540-b1d4e200-1f0f-11e9-83e3-c01577b73faf.gif)

