### PR TITLE
V8: Handle element type content in the content pickers

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                     if (udi == null)
                         return null;
                     content = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(udi.Guid);
-                    if (content != null)
+                    if (content != null && content.ItemType == PublishedItemType.Content)
                         return content;
                 }
             }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -98,7 +98,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                                     break;
                             }
 
-                            if (multiNodeTreePickerItem != null)
+                            if (multiNodeTreePickerItem != null && multiNodeTreePickerItem.ItemType != PublishedItemType.Element)
                             {
                                 multiNodeTreePicker.Add(multiNodeTreePickerItem);
                             }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                              _publishedSnapshotAccessor.PublishedSnapshot.Media.GetById(preview, dto.Udi.Guid) :
                              _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(preview, dto.Udi.Guid);
 
-                        if (content == null)
+                        if (content == null || content.ItemType == PublishedItemType.Element)
                         {
                             continue;
                         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4168

### Description

If an existing content type is turned into an element type, any picked content of that type should no longer be rendered in the frontend (the element types shouldn't have been in the content tree in the first place).

Right now the content picker and the MNTP doesn't care:

![handle-element-types-in-pickers-before-1](https://user-images.githubusercontent.com/7405322/51610989-742b8580-1f1e-11e9-82e9-5473e5aa651f.gif)

Even though there's no immediate error, soon as I start working with some of the properties I'd expect in an `IPublishedContent` instance (like `.Url`), the view explodes with a `System.NotSupportedException`. This is also exactly what happens if the element type happens to be picked by the multi URL picker:

![handle-element-types-in-pickers-before-2](https://user-images.githubusercontent.com/7405322/51611157-d84e4980-1f1e-11e9-9dc6-41384c517a4c.gif)

This PR filters out element types from these content pickers before passing the model value to the view:

![handle-element-types-in-pickers-after](https://user-images.githubusercontent.com/7405322/51611197-f320be00-1f1e-11e9-9f44-cb31bdb2d844.gif)

#### Test template

You can test this PR using this template (swap the property names to match your own setup):

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@using Umbraco.Web.Models
@{
    Layout = null;
    // the MNTP property
    var contentPickerMultipleValue = Model.Value<IEnumerable<IPublishedContent>>("contentMultiple");
    // the content picker property
    var contentPickerSingleValue = Model.Value<IPublishedContent>("content");
    // the multi URL picker propery
    var links = Model.Value<IEnumerable<Link>>("multiUrlPicker");
}

<html>
    <body>
        <h1>@Model.Name</h1>
        <h2>Content picker multiple</h2>
        @if(contentPickerMultipleValue != null && contentPickerMultipleValue.Any()) {
            <ul>
            @foreach(var content in contentPickerMultipleValue) {
                <li>@content.Name @content.Url</li>
            }
            </ul>
        }
        else {
            <p>Content picker multiple has no value</p>
        }
        
        <h2>Content picker single</h2>
        @if(contentPickerSingleValue != null) {
            @: @contentPickerSingleValue.Name
        }
        else {
            <p>Content picker single has no value</p>
        }
        
        <h2>Multi URL picker</h2>
        @if(links != null && links.Any()) {
            <ul>
            @foreach(var link in links) {
                <li>@link.Name</li>
            }
            </ul>
        }
        else {
            <p>Multi URL picker has no value</p>
        }

    </body>
</html>
``` 