### PR TITLE
Color picker: Set form dirty on change and update label

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
@@ -38,7 +38,7 @@ Use this directive to generate color swatches to pick from.
                 scope.selectedColor = color;
 
                 if (scope.onSelect) {
-                    scope.onSelect(color);
+                    scope.onSelect({color: color });
                 }
             };
         }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
@@ -8,7 +8,8 @@
     <umb-color-swatches colors="model.config.items"
                         selected-color="model.value.value"
                         size="m"
-                        use-label="model.useLabel">
+                        use-label="model.useLabel"
+                        on-select="onSelect(color)">
     </umb-color-swatches>
 
     <input type="hidden" name="modelValue" ng-model="model.value" val-property-validator="validateMandatory" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4200

### Description

As described in #4200 the color picker doesn't set the form dirty when its value changes, and when configured to include labels, the labels aren't updated when the color changes. 

This PR fixes that:

![color-picker-dirty-after](https://user-images.githubusercontent.com/7405322/51633257-8a066e00-1f51-11e9-9fa1-9921f02f3995.gif)

I have also done a bit of tidying up as there was a bunch of unused code in the color picker controller.