### PR TITLE
Add localization to Flatpickr

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
@@ -141,7 +141,8 @@ gulp.task('dependencies', function () {
             "name": "flatpickr",
             "src":  [
                 "./node_modules/flatpickr/dist/flatpickr.js",
-                "./node_modules/flatpickr/dist/flatpickr.css"
+                "./node_modules/flatpickr/dist/flatpickr.css",
+                "./node_modules/flatpickr/dist/l10n/*.js"
             ],
             "base": "./node_modules/flatpickr/dist"
         },

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbflatpickr.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbflatpickr.directive.js
@@ -92,20 +92,25 @@ Use this directive to render a date time picker
 		}
     };
     
-	function umbFlatpickrCtrl($element, $timeout, $scope, assetsService) {
+	function umbFlatpickrCtrl($element, $timeout, $scope, assetsService, userService) {
         var ctrl = this;
         var loaded = false;
+        var userLocale = null;
 
 		ctrl.$onInit = function() {
 
             // load css file for the date picker
-            assetsService.loadCss('lib/flatpickr/flatpickr.css', $scope);
+            assetsService.loadCss('lib/flatpickr/flatpickr.css', $scope).then(function () {
+                userService.getCurrentUser().then(function (user) {
+                    // init date picker
+                    userLocale = user.locale;
+                    if (userLocale.indexOf('-') > -1) {
+                        userLocale = userLocale.split('-')[0];
+                    }
+                    loaded = true;
+                    grabElementAndRunFlatpickr();
 
-            // load the js file for the date picker
-            assetsService.loadJs('lib/flatpickr/flatpickr.js', $scope).then(function () {
-                // init date picker
-                loaded = true;
-                grabElementAndRunFlatpickr();
+                });
             });
 
 		};
@@ -127,6 +132,10 @@ Use this directive to render a date time picker
 			}
 
 			setUpCallbacks();
+
+            if (!ctrl.options.locale) {
+                ctrl.options.locale = userLocale;
+            }
 
             var fpInstance = new fpLib(element, ctrl.options);
             

--- a/src/Umbraco.Web.UI.Client/src/common/resources/javascriptlibrary.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/javascriptlibrary.resource.js
@@ -8,17 +8,17 @@
       **/
     function javascriptLibraryResource($q, $http, umbRequestHelper) {
 
-        var existingLocales = [];
+        var existingLocales = null;
 
-        function getSupportedLocalesForMoment() {
+        function getSupportedLocales() {
             var deferred = $q.defer();
 
-            if (existingLocales.length === 0) {
+            if (existingLocales === null) {
                 umbRequestHelper.resourcePromise(
                     $http.get(
                         umbRequestHelper.getApiUrl(
                             "backOfficeAssetsApiBaseUrl",
-                            "GetSupportedMomentLocales")),
+                            "GetSupportedLocales")),
                     "Failed to get cultures").then(function(locales) {
                     existingLocales = locales;
                     deferred.resolve(existingLocales);
@@ -29,9 +29,9 @@
 
             return deferred.promise;
         }
-
+        
         var service = {
-            getSupportedLocalesForMoment: getSupportedLocalesForMoment
+            getSupportedLocales: getSupportedLocales
         };
 
         return service;

--- a/src/Umbraco.Web.UI.Client/src/common/services/assets.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/assets.service.js
@@ -66,20 +66,26 @@ angular.module('umbraco.services')
         }
 
         function getMomentLocales(locales, supportedLocales) {
+            return getLocales(locales, supportedLocales, 'lib/moment/');
+        }
 
+        function getFlatpickrLocales(locales, supportedLocales) {
+            return getLocales(locales, supportedLocales, 'lib/flatpickr/l10n/');
+        }
+        
+        function getLocales(locales, supportedLocales, path) {
             var localeUrls = [];
             var locales = locales.split(',');
             for (var i = 0; i < locales.length; i++) {
                 var locale = locales[i].toString().toLowerCase();
                 if (locale !== 'en-us') {
-
                     if (supportedLocales.indexOf(locale + '.js') > -1) {
-                        localeUrls.push('lib/moment/' + locale + '.js');
+                        localeUrls.push(path + locale + '.js');
                     }
                     if (locale.indexOf('-') > -1) {
                         var majorLocale = locale.split('-')[0] + '.js';
                         if (supportedLocales.indexOf(majorLocale) > -1) {
-                            localeUrls.push('lib/moment/' + majorLocale);
+                            localeUrls.push(path + majorLocale);
                         }
                     }
                 }
@@ -89,12 +95,13 @@ angular.module('umbraco.services')
         }
 
         /**
-         * Loads specific Moment.js Locales.
+         * Loads specific Moment.js and Flatpickr Locales.
          * @param {any} locales
          * @param {any} supportedLocales
          */
         function loadLocales(locales, supportedLocales) {
-            var localeUrls = getMomentLocales(locales, supportedLocales);
+            var localeUrls = getMomentLocales(locales, supportedLocales.moment);
+            localeUrls = localeUrls.concat(getFlatpickrLocales(locales, supportedLocales.flatpickr));
             if (localeUrls.length >= 1) {
                 return service.load(localeUrls, $rootScope);
             }
@@ -104,12 +111,12 @@ angular.module('umbraco.services')
         }
 
         /**
-         * Loads in moment.js requirements during the _loadInitAssets call
+         * Loads in locale requirements during the _loadInitAssets call
          */
-        function loadMomentLocaleForCurrentUser() {
+        function loadLocaleForCurrentUser() {
 
             userService.getCurrentUser().then(function (currentUser) {
-                return javascriptLibraryResource.getSupportedLocalesForMoment().then(function (supportedLocales) {
+                return javascriptLibraryResource.getSupportedLocales().then(function (supportedLocales) {
                     return loadLocales(currentUser.locale, supportedLocales);
                 });
             });
@@ -141,7 +148,7 @@ angular.module('umbraco.services')
                     var self = this;
                     return self.loadJs(umbRequestHelper.getApiUrl("serverVarsJs", "", ""), $rootScope).then(function () {
                         initAssetsLoaded = true;
-                        return loadMomentLocaleForCurrentUser();
+                        return loadLocaleForCurrentUser();
                     });
                 }
                 else {

--- a/src/Umbraco.Web/Editors/BackOfficeAssetsController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeAssetsController.cs
@@ -11,16 +11,27 @@ namespace Umbraco.Web.Editors
     public class BackOfficeAssetsController : UmbracoAuthorizedJsonController
     {
         private readonly IFileSystem _jsLibFileSystem = new PhysicalFileSystem(SystemDirectories.Umbraco + IOHelper.DirSepChar + "lib");
-
+        
         [HttpGet]
-        public IEnumerable<string> GetSupportedMomentLocales()
+        public object GetSupportedLocales()
         {
             const string momentLocaleFolder = "moment";
-            var cultures = _jsLibFileSystem.GetFiles(momentLocaleFolder, "*.js").ToList();
+            const string flatpickrLocaleFolder = "flatpickr/l10n";
+
+            return new
+            {
+                moment = GetLocales(momentLocaleFolder),
+                flatpickr = GetLocales(flatpickrLocaleFolder)
+            };
+        }
+
+        private IEnumerable<string> GetLocales(string path)
+        {
+            var cultures = _jsLibFileSystem.GetFiles(path, "*.js").ToList();
             for (var i = 0; i < cultures.Count; i++)
             {
                 cultures[i] = cultures[i]
-                    .Substring(cultures[i].IndexOf(momentLocaleFolder, StringComparison.Ordinal) + momentLocaleFolder.Length + 1);
+                    .Substring(cultures[i].IndexOf(path, StringComparison.Ordinal) + path.Length + 1);
             }
             return cultures;
         }

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -302,7 +302,7 @@ namespace Umbraco.Web.Editors
                         },
                         {
                             "backOfficeAssetsApiBaseUrl", _urlHelper.GetUmbracoApiServiceBaseUrl<BackOfficeAssetsController>(
-                                controller => controller.GetSupportedMomentLocales())
+                                controller => controller.GetSupportedLocales())
                         },
                         {
                             "languageApiBaseUrl", _urlHelper.GetUmbracoApiServiceBaseUrl<LanguageController>(

--- a/src/Umbraco.Web/UI/JavaScript/JsInitialize.js
+++ b/src/Umbraco.Web/UI/JavaScript/JsInitialize.js
@@ -7,6 +7,7 @@
     'lib/underscore/underscore-min.js',
 
     'lib/moment/moment.min.js',
+    'lib/flatpickr/flatpickr.js',
 
     'lib/animejs/anime.min.js',
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4201

### Description

This PR adds localization to Flatpickr so it adheres to the current user's editor language.

It works both for system fields like content scheduling dates:

![image](https://user-images.githubusercontent.com/7405322/51639847-3a7c6e00-1f62-11e9-8562-3657ecf0d36b.png)

...and for date properties:

![image](https://user-images.githubusercontent.com/7405322/51639925-6bf53980-1f62-11e9-9911-0d3e8fc58770.png)
