### PR TITLE
Only add TLS 1.2 if explicit protocols are defined

### DIFF
--- a/src/Umbraco.Web/WebBootManager.cs
+++ b/src/Umbraco.Web/WebBootManager.cs
@@ -131,9 +131,9 @@ namespace Umbraco.Web
             InstallHelper insHelper = new InstallHelper(UmbracoContext.Current);
             insHelper.DeleteLegacyInstaller();
 
-            // Tell .net 4.5 that we also want to try connecting over TLS 1.2, not just 1.1
-            if (ServicePointManager.SecurityProtocol.HasFlag(SecurityProtocolType.Tls12) == false)
-                ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12;
+            // Tell .NET 4.5 that we also want to try connecting over TLS 1.2, not just TLS 1.1 (but only if specific protocols are defined)
+            if (ServicePointManager.SecurityProtocol != 0)
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             return this;
         }


### PR DESCRIPTION
As Microsofts best practices regarding TLS (https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls) state:

> the TLS version should **not** be hardcoded

and

> ServicePointManager, using .NET Framework 4.7 and later versions, defaults to the OS choosing the best security protocol and version. To get the default OS best choice, if possible, don't set a value for the SecurityProtocol property.

As Umbraco can be installed to an application targeting a higher .NET version (e.g. 4.7+), changing the `ServicePointManager.SecurityProtocol` from 0 (`SystemDefault`) to 3072 (only `Tls12`) would be a regression, as that would block outbound connections to HTTPS endpoints without TLS 1.2 support!