### PR TITLE
V8: Fix long media link

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
@@ -40,6 +40,13 @@
 
             function setMediaLink(){
                 scope.nodeUrl = scope.node.mediaLink;
+                // grab the file name from the URL and use it as the display name in the file link
+                var match = /.*\/(.*)/.exec(scope.nodeUrl);
+                if (match) {
+                    scope.nodeFileName = match[1];
+                } else {
+                    scope.nodeFileName = scope.nodeUrl;
+                }
             }
 
             scope.openMediaType = function (mediaType) {

--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
@@ -14,7 +14,7 @@
                     <li>
                         <a href="{{nodeUrl}}" target="_blank">
                             <i class="icon icon-out"></i>
-                            <span>{{nodeUrl}}</span>
+                            <span>{{nodeFileName}}</span>
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4209

### Description

As #4209 describes, the "GUIDs all things" approach for V8 seems to have made the file links very long - to the point where they just don't make sense to display in their full length on the info tab.

This PR replaces the full file link with the file name. In other words it turns this:

![image](https://user-images.githubusercontent.com/7405322/51673417-49006f00-1fce-11e9-9dc7-016395e5793e.png)

...into this:

![image](https://user-images.githubusercontent.com/7405322/51673382-325a1800-1fce-11e9-91f4-3e5be909d027.png)

I did try outputting an abbreviated file link (`/media/.../dontpanic_1024.jpg`), but it didn't look very nice and also didn't provide the editor anymore relevant information than just displaying the file name.