### PR TITLE
V8: Add missing value types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/valuetype.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/valuetype.html
@@ -2,6 +2,8 @@
     <option value="STRING">String</option>
     <option value="DECIMAL">Decimal</option>
     <option value="DATETIME">Date/time</option>
+    <option value="TIME">Time</option>
     <option value="INT">Integer</option>
+    <option value="BIGINT">Big integer</option>
     <option value="TEXT">Long string</option>
 </select>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4226

### Description

As described in #4226, the new labels "Label (bigint)" and "Label (time)" do not have a corresponding type in the "Value type" selector.

It looks like an oversight in [this commit](https://github.com/umbraco/Umbraco-CMS/commit/632e401d33bc60d03394ee21a5a88f11b9efb93b).

This PR adds value types for BIGINT and TIME:

![image](https://user-images.githubusercontent.com/7405322/51677880-4d7f5480-1fdb-11e9-94e6-dfee5a86132e.png)
