### PR TITLE
V8: Remove tooltip flicker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tooltip/umb-tooltip.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tooltip/umb-tooltip.less
@@ -10,4 +10,5 @@
    animation-timing-function: ease-in;
    animation: fadeIn;
    margin-top: 15px;
+   pointer-events: none;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In the media grid view a tooltip is shown if you hover over the "info" icon on a file. If the file is near the bottom of the browser, the tooltip flickers horribly:

![tooltip-flicker-2](https://user-images.githubusercontent.com/7405322/51711617-d96d9c80-202c-11e9-9e20-e5f2cb9733b4.gif)

This is because the tooltip triggers the on-leave event, because it is above the "info" icon. The on-leave event closes the tooltip, triggering an on-enter event, which shows the tooltip again... which triggers the on-leave event... you get the point.

This PR fixes it by ensuring that the tooltip doesn't accept pointer events.