### PR TITLE
V8: Remove the hover underline from grid items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-content-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-content-grid.less
@@ -53,7 +53,7 @@
    display: inline-flex;
 }
 
-.umb-content-grid__item-name:hover {
+.umb-content-grid__item-name:hover span {
     text-decoration: underline;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-content-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-content-grid.html
@@ -12,7 +12,7 @@
 
         <div class="umb-content-grid__item-name" ng-click="clickItemName(item, $event, $index)" ng-class="{'-light': !item.published && item.updater != null}">
             <i class="umb-content-grid__icon {{ item.icon }}"></i>
-            {{ item.name }}
+            <span>{{ item.name }}</span>
         </div>
 
         <ul class="umb-content-grid__details-list" ng-class="{'-light': !item.published && item.updater != null}">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4157

### Description

See #4157 for details.

With this PR applied, the grid item hover effect looks like this:

![grid-element-hover](https://user-images.githubusercontent.com/7405322/51712149-24d47a80-202e-11e9-964f-d9645085bae9.gif)
