### PR TITLE
check for editorstate.current before attempting to access properties object

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -278,7 +278,7 @@ angular.module("umbraco")
                         $scope.linkPickerOverlay = {
                             view: "linkpicker",
                             currentTarget: currentTarget,
-							anchors: tinyMceService.getAnchorNames(JSON.stringify(editorState.current.properties)),
+							              anchors: editorState.current ? tinyMceService.getAnchorNames(JSON.stringify(editorState.current.properties)) : [],
                             show: true,
                             submit: function(model) {
                                 tinyMceService.insertLinkInEditor(editor, model.target, anchorElement);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: #4262 

### Description
Change simply adds a check for `editorState.current` before attempting to access the `properties` object - if we are in a content node context, `current` will exist, elsewhere it will be null.

If it is null, the `anchors` property for the linkpicker is set to an empty array, otherwise it is populate as normal.

To test, it's more a matter of verifying nothing has changed for the rte link picker (NOT the Grid RTE, just the standalone, since the Grid RTE will only be used in a content item). The issue was raised due to the bug surfacing in a Merchello install, so could be verified there, but not sure that's necessary since it's a trivial change and the logic is sound - was failing due to accessing a non-existent property, now we check and respond accordingly.