### PR TITLE
V8: Fix buttons when opening split view editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
@@ -232,6 +232,10 @@
                     var app = editor.content.apps[i];
                     if (app.alias === "umbContent") {
                         app.active = true;
+                        // tell the world that the app has changed (but do it only once)
+                        if (e === 0) {
+                            selectApp(app);
+                        }
                     }
                     else {
                         app.active = false;


### PR DESCRIPTION
…ew is opened

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4214

### Description

If a variant content type uses list view and you open split view editing from the list view, the content app is made active in both sides of the split view. This is by design. However, as described in #4214, the preview/save/publish buttons aren't made visible at the same time, which leaves the editor rather unable to do much.

With this PR applied it behaves like this:

![editor-buttons-in-split-view](https://user-images.githubusercontent.com/7405322/51786914-340d1280-216b-11e9-8c9c-a5db55ada059.gif)
