### PR TITLE
Ability to add redirects

### DIFF
--- a/src/Umbraco.Core/IO/MediaFileSystem.cs
+++ b/src/Umbraco.Core/IO/MediaFileSystem.cs
@@ -377,21 +377,28 @@ namespace Umbraco.Core.IO
                         return new Size(width, height);
                     }
                 }
+            }
+            catch
+            {
+                //We will just swallow, just means we can't read exif data, we don't want to log an error either
+            }
 
-                //we have no choice but to try to read in via GDI
+            //we have no choice but to try to read in via GDI
+            try
+            {
                 using (var image = Image.FromStream(stream))
                 {
-
                     var fileWidth = image.Width;
                     var fileHeight = image.Height;
                     return new Size(fileWidth, fileHeight);
                 }
             }
-            catch (Exception)
+            catch
             {
-                //We will just swallow, just means we can't read exif data, we don't want to log an error either
-                return new Size(Constants.Conventions.Media.DefaultSize, Constants.Conventions.Media.DefaultSize);
+                //We will just swallow, just means we can't read via GDI, we don't want to log an error either
             }
+
+            return new Size(Constants.Conventions.Media.DefaultSize, Constants.Conventions.Media.DefaultSize);
         }
 
         #endregion

--- a/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
@@ -199,7 +199,7 @@ namespace Umbraco.Core.Persistence.Repositories
                                "DELETE FROM cmsContentXml WHERE nodeId = @Id",
                                "DELETE FROM cmsContent WHERE nodeId = @Id",
                                "DELETE FROM umbracoAccess WHERE nodeId = @Id",
-                               "DELETE FROM umbracoNode WHERE id = @Id"                               
+                               "DELETE FROM umbracoNode WHERE id = @Id"
                            };
             return list;
         }
@@ -468,7 +468,7 @@ namespace Umbraco.Core.Persistence.Repositories
             entity.Id = nodeDto.NodeId; //Set Id on entity to ensure an Id is set
             entity.Path = nodeDto.Path;
             entity.SortOrder = sortOrder;
-            entity.Level = level;            
+            entity.Level = level;
 
             //Create the Content specific data - cmsContent
             var contentDto = dto.ContentVersionDto.ContentDto;
@@ -644,7 +644,7 @@ namespace Umbraco.Core.Persistence.Repositories
                     contentVersionDto.Id = contentVerDto.Id;
                     Database.Update(contentVersionDto);
                 }
-                
+
                 Database.Update(dto);
             }
 
@@ -752,7 +752,7 @@ namespace Umbraco.Core.Persistence.Repositories
         public IEnumerable<IContent> GetBlueprints(IQuery<IContent> query)
         {
             Func<SqlTranslator<IContent>, Sql> translate = t => t.Translate();
-            
+
             var sqlFull = GetBaseQuery(BaseQueryType.FullMultiple);
             var translatorFull = new SqlTranslator<IContent>(sqlFull, query);
             var sqlIds = GetBaseQuery(BaseQueryType.Ids);
@@ -835,6 +835,61 @@ order by umbracoNode.{2}, umbracoNode.parentID, umbracoNode.sortOrder",
 
         }
 
+        public XmlDocument BuildPreviewXmlCache()
+        {
+            var xmlDoc = new XmlDocument();
+            var doctype = xmlDoc.CreateDocumentType("root", null, null,
+                ApplicationContext.Current.Services.ContentTypeService.GetContentTypesDtd());
+            xmlDoc.AppendChild(doctype);
+            var parent = xmlDoc.CreateElement("root");
+            var pIdAtt = xmlDoc.CreateAttribute("id");
+            pIdAtt.Value = "-1";
+            parent.Attributes.Append(pIdAtt);
+            xmlDoc.AppendChild(parent);
+
+            //Ensure that only nodes that have published versions are selected
+            var sql = string.Format(@"select umbracoNode.id, umbracoNode.parentID, umbracoNode.sortOrder, cmsPreviewXml.{0}, umbracoNode.{1} from umbracoNode
+inner join cmsPreviewXml on cmsPreviewXml.nodeId = umbracoNode.id and umbracoNode.nodeObjectType = @type
+inner join cmsDocument on cmsPreviewXml.versionId = cmsDocument.versionId and cmsDocument.newest=1
+order by umbracoNode.{2}, umbracoNode.parentID, umbracoNode.sortOrder",
+                SqlSyntax.GetQuotedColumnName("xml"),
+                SqlSyntax.GetQuotedColumnName("level"),
+                SqlSyntax.GetQuotedColumnName("level"));
+
+            XmlElement last = null;
+
+            //NOTE: Query creates a reader - does not load all into memory
+            foreach (var row in Database.Query<dynamic>(sql, new { type = NodeObjectTypeId }))
+            {
+                string parentId = ((int)row.parentID).ToInvariantString();
+                string xml = row.xml;
+                int sortOrder = row.sortOrder;
+
+                //if the parentid is changing
+                if (last != null && last.GetAttribute("parentID") != parentId)
+                {
+                    parent = xmlDoc.GetElementById(parentId);
+                    if (parent == null)
+                    {
+                        //Need to short circuit here, if the parent is not there it means that the parent is unpublished
+                        // and therefore the child is not published either so cannot be included in the xml cache
+                        continue;
+                    }
+                }
+
+                var xmlDocFragment = xmlDoc.CreateDocumentFragment();
+                xmlDocFragment.InnerXml = xml;
+
+                last = (XmlElement)parent.AppendChild(xmlDocFragment);
+
+                // fix sortOrder - see notes in UpdateSortOrder
+                last.Attributes["sortOrder"].Value = sortOrder.ToInvariantString();
+            }
+
+            return xmlDoc;
+
+        }
+
         public int CountPublished(string contentTypeAlias = null)
         {
             if (contentTypeAlias.IsNullOrWhiteSpace())
@@ -868,9 +923,9 @@ order by umbracoNode.{2}, umbracoNode.parentID, umbracoNode.sortOrder",
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="permission"></param>
-        /// <param name="groupIds"></param>        
+        /// <param name="groupIds"></param>
         public void AssignEntityPermission(IContent entity, char permission, IEnumerable<int> groupIds)
-        {            
+        {
             _permissionRepository.AssignEntityPermission(entity, permission, groupIds);
         }
 
@@ -882,7 +937,7 @@ order by umbracoNode.{2}, umbracoNode.parentID, umbracoNode.sortOrder",
         public EntityPermissionCollection GetPermissionsForEntity(int entityId)
         {
             return _permissionRepository.GetPermissionsForEntity(entityId);
-        }        
+        }
 
         /// <summary>
         /// Adds/updates content/published xml

--- a/src/Umbraco.Core/Persistence/Repositories/Interfaces/IContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Interfaces/IContentRepository.cs
@@ -19,6 +19,8 @@ namespace Umbraco.Core.Persistence.Repositories
         /// <returns></returns>
         XmlDocument BuildXmlCache();
 
+        XmlDocument BuildPreviewXmlCache();
+
         /// <summary>
         /// Get the count of published items
         /// </summary>

--- a/src/Umbraco.Core/Persistence/Repositories/MediaRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/MediaRepository.cs
@@ -95,7 +95,9 @@ namespace Umbraco.Core.Persistence.Repositories
                 .InnerJoin<ContentDto>(SqlSyntax)
                 .On<ContentVersionDto, ContentDto>(SqlSyntax, left => left.NodeId, right => right.NodeId)
                 .InnerJoin<NodeDto>(SqlSyntax)
-                .On<ContentDto, NodeDto>(SqlSyntax, left => left.NodeId, right => right.NodeId);
+                .On<ContentDto, NodeDto>(SqlSyntax, left => left.NodeId, right => right.NodeId)
+                .InnerJoin<ContentTypeDto>(SqlSyntax)
+                .On<ContentTypeDto, ContentDto>(SqlSyntax, left => left.NodeId, right => right.ContentTypeId);
 
             if (includeFilePaths)
             {

--- a/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
@@ -267,8 +267,8 @@ ORDER BY colName";
 
             var fromDate = DateTime.UtcNow - timespan;
 
-            var count = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoUserLogin WHERE lastValidatedUtc=@fromDate", new { fromDate = fromDate });
-            Database.Execute("DELETE FROM umbracoUserLogin WHERE lastValidatedUtc=@fromDate", new { fromDate = fromDate });
+            var count = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoUserLogin WHERE lastValidatedUtc=<@fromDate", new { fromDate = fromDate });
+            Database.Execute("DELETE FROM umbracoUserLogin WHERE lastValidatedUtc=<@fromDate", new { fromDate = fromDate });
             return count;
         }
 

--- a/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
@@ -267,8 +267,8 @@ ORDER BY colName";
 
             var fromDate = DateTime.UtcNow - timespan;
 
-            var count = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoUserLogin WHERE lastValidatedUtc=<@fromDate", new { fromDate = fromDate });
-            Database.Execute("DELETE FROM umbracoUserLogin WHERE lastValidatedUtc=<@fromDate", new { fromDate = fromDate });
+            var count = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoUserLogin WHERE lastValidatedUtc<=@fromDate", new { fromDate = fromDate });
+            Database.Execute("DELETE FROM umbracoUserLogin WHERE lastValidatedUtc<=@fromDate", new { fromDate = fromDate });
             return count;
         }
 

--- a/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
@@ -703,6 +703,8 @@ ORDER BY contentNodeId, versionId, propertytypeid
                 // Members only
                 case "USERNAME":
                     return "cmsMember.LoginName";
+                case "CONTENTTYPEALIAS":
+                    return "cmsContentType.alias";
                 default:
                     //ensure invalid SQL cannot be submitted
                     return Regex.Replace(orderBy, @"[^\w\.,`\[\]@-]", "");

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1741,7 +1741,15 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Empties the Recycle Bin by deleting all <see cref="IContent"/> that resides in the bin
         /// </summary>
-        public void EmptyRecycleBin()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use EmptyRecycleBin with explicit indication of user ID instead")]
+        public void EmptyRecycleBin() => EmptyRecycleBin(0);
+
+        /// <summary>
+        /// Empties the Recycle Bin by deleting all <see cref="IContent"/> that resides in the bin
+        /// </summary>
+        /// <param name="userId">Optional Id of the User emptying the Recycle Bin</param>        
+        public void EmptyRecycleBin(int userId = 0)
         {
             using (new WriteLock(Locker))
             {
@@ -1771,7 +1779,7 @@ namespace Umbraco.Core.Services
                     recycleBinEventArgs.RecycleBinEmptiedSuccessfully = success;
                     uow.Events.Dispatch(EmptiedRecycleBin, this, recycleBinEventArgs);
 
-                    Audit(uow, AuditType.Delete, "Empty Content Recycle Bin performed by user", 0, Constants.System.RecycleBinContent);
+                    Audit(uow, AuditType.Delete, "Empty Content Recycle Bin performed by user", userId, Constants.System.RecycleBinContent);
                     uow.Commit();
                 }
             }

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2192,6 +2192,17 @@ namespace Umbraco.Core.Services
             }
         }
 
+        public XmlDocument BuildPreviewXmlCache()
+        {
+            using (var uow = UowProvider.GetUnitOfWork())
+            {
+                var repository = RepositoryFactory.CreateContentRepository(uow);
+                var result = repository.BuildPreviewXmlCache();
+                uow.Commit();
+                return result;
+            }
+        }
+
         /// <summary>
         /// Rebuilds all xml content in the cmsContentXml table for all documents
         /// </summary>

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -124,6 +124,8 @@ namespace Umbraco.Core.Services
         /// <returns></returns>
         XmlDocument BuildXmlCache();
 
+        XmlDocument BuildPreviewXmlCache();
+
         /// <summary>
         /// Rebuilds all xml content in the cmsContentXml table for all documents
         /// </summary>

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -440,7 +440,15 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Empties the Recycle Bin by deleting all <see cref="IContent"/> that resides in the bin
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use EmptyRecycleBin with explicit indication of user ID instead")]
         void EmptyRecycleBin();
+
+        /// <summary>
+        /// Empties the Recycle Bin by deleting all <see cref="IContent"/> that resides in the bin
+        /// </summary>
+        /// <param name="userId">Optional Id of the User emptying the Recycle Bin</param>        
+        void EmptyRecycleBin(int userId = 0);
 
         /// <summary>
         /// Rollback an <see cref="IContent"/> object to a previous version.

--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -289,7 +289,15 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Empties the Recycle Bin by deleting all <see cref="IMedia"/> that resides in the bin
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use EmptyRecycleBin with explicit indication of user ID instead")]
         void EmptyRecycleBin();
+
+        /// <summary>
+        /// Empties the Recycle Bin by deleting all <see cref="IMedia"/> that resides in the bin
+        /// </summary>
+        /// <param name="userId">Optional Id of the User emptying the Recycle Bin</param>        
+        void EmptyRecycleBin(int userId = 0);
 
         /// <summary>
         /// Deletes all media of specified type. All children of deleted media is moved to Recycle Bin.

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -981,7 +981,15 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Empties the Recycle Bin by deleting all <see cref="IMedia"/> that resides in the bin
         /// </summary>
-        public void EmptyRecycleBin()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use EmptyRecycleBin with explicit indication of user ID instead")]
+        public void EmptyRecycleBin() => EmptyRecycleBin(0);
+
+        /// <summary>
+        /// Empties the Recycle Bin by deleting all <see cref="IMedia"/> that resides in the bin
+        /// </summary>
+        /// <param name="userId">Optional Id of the User emptying the Recycle Bin</param>        
+        public void EmptyRecycleBin(int userId = 0)
         {
             using (new WriteLock(Locker))
             {
@@ -1006,7 +1014,7 @@ namespace Umbraco.Core.Services
                     recycleBinEventArgs.RecycleBinEmptiedSuccessfully = success;
                     uow.Events.Dispatch(EmptiedRecycleBin, this, recycleBinEventArgs);
 
-                    Audit(uow, AuditType.Delete, "Empty Media Recycle Bin performed by user", 0, Constants.System.RecycleBinMedia);
+                    Audit(uow, AuditType.Delete, "Empty Media Recycle Bin performed by user", userId, Constants.System.RecycleBinMedia);
                     uow.Commit();
                 }
             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -48,6 +48,7 @@
 
                 //default setting for redirect url management
                 scope.urlTrackerDisabled = false;
+                scope.editRedirectEnabled = false;
 
                 // Declare a fallback URL for the <umb-node-preview/> directive
                 if (scope.documentType !== null) {
@@ -133,8 +134,9 @@
             function loadRedirectUrls() {
                 scope.loadingRedirectUrls = true;
                 //check if Redirect Url Management is enabled
-                redirectUrlsResource.getEnableState().then(function (response) {
+                redirectUrlsResource.getEnableStateForContentItem(scope.node.id).then(function (response) {
                     scope.urlTrackerDisabled = response.enabled !== true;
+                    scope.editRedirectEnabled = response.userIsAllowed == true;
                     if (scope.urlTrackerDisabled === false) {
 
                         redirectUrlsResource.getRedirectsForContentItem(scope.node.udi)

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -7,8 +7,8 @@
 
             var evts = [];
             var isInfoTab = false;
-            scope.publishStatus = {};
-
+            
+            scope.publishStatus = {};            
             scope.disableTemplates = Umbraco.Sys.ServerVariables.features.disabledFeatures.disableTemplates;
 
             function onInit() {
@@ -163,8 +163,19 @@
                 });
             }
 
-            scope.deleteRedirect = function (redirectUrl) {
-                console.log(redirectUrl);
+            scope.deleteRedirect = function (redirectToDelete) {
+                localizationService.localize("redirectUrls_confirmRemove", [redirectToDelete.originalUrl, scope.node.name]).then(function (value) {
+                    var toggleConfirm = confirm(value);
+
+                    if (toggleConfirm) {
+                        redirectUrlsResource.deleteRedirectUrl(redirectToDelete.redirectId).then(function () {
+                            loadRedirectUrls();
+                            notificationsService.success(localizationService.localize("redirectUrls_redirectRemoved"));
+                        }, function (error) {
+                            notificationsService.error(localizationService.localize("redirectUrls_redirectRemoveError"));
+                        });
+                    }
+                });
             }
 
             scope.redirectUrlPageChange = function (pageNumber) {

--- a/src/Umbraco.Web.UI.Client/src/common/resources/redirecturls.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/redirecturls.resource.js
@@ -129,12 +129,39 @@
                 'Failed to toggle redirect url tracker');
         }
 
+        /**
+         *  @ngdoc function
+         *   * @name umbraco.resources.redirectUrlResource#addRedirect
+         * @methodOf umbraco.resources.redirectUrlResource
+         * @function
+         *
+         * @description
+         * Called to add a redirect to the redirect url tracker
+         * ##usage
+         * <pre>
+         * redirectUrlsResource.addRedirect("/page", 1106)
+         *    .then(function() {
+         *
+         *    });
+         * </pre>
+         * @param {string} url original url to redirect
+         * @param {int} contentId id of the redirect target
+         */
+        function addRedirect(url, contentId) {
+            return umbRequestHelper.resourcePromise(
+                $http.post(umbRequestHelper.getApiUrl(
+                        "redirectUrlManagementApiBaseUrl",
+                    "AddRedirect", { url: url, contentId: contentId })),
+                'Failed to add redirect');
+        }
+
         var resource = {
             searchRedirectUrls: searchRedirectUrls,
             deleteRedirectUrl: deleteRedirectUrl,
             toggleUrlTracker: toggleUrlTracker,
             getEnableState: getEnableState,
-            getRedirectsForContentItem: getRedirectsForContentItem
+            getRedirectsForContentItem: getRedirectsForContentItem,
+            addRedirect: addRedirect
         };
 
         return resource;

--- a/src/Umbraco.Web.UI.Client/src/common/resources/redirecturls.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/redirecturls.resource.js
@@ -76,7 +76,16 @@
                         "GetEnableState")),
                 'Failed to retrieve data to check if the 301 redirect is enabled');
         }
-     
+
+        function getEnableStateForContentItem(id) {
+
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "redirectUrlManagementApiBaseUrl",
+                        "GetEnableStateForContent", { contentId: id })),
+                'Failed to retrieve data to check if the 301 redirect is enabled');
+        }
         /**
          * @ngdoc function
          * @name umbraco.resources.redirectUrlResource#deleteRedirectUrl
@@ -160,6 +169,7 @@
             deleteRedirectUrl: deleteRedirectUrl,
             toggleUrlTracker: toggleUrlTracker,
             getEnableState: getEnableState,
+            getEnableStateForContentItem: getEnableStateForContentItem,
             getRedirectsForContentItem: getRedirectsForContentItem,
             addRedirect: addRedirect
         };

--- a/src/Umbraco.Web.UI.Client/src/common/security/securityinterceptor.js
+++ b/src/Umbraco.Web.UI.Client/src/common/security/securityinterceptor.js
@@ -44,21 +44,28 @@ angular.module('umbraco.security.interceptor')
                         return promise;
                     }
 
-                    //A 401 means that the user is not logged in
-                    if (originalResponse.status === 401 && !originalResponse.config.url.endsWith("umbraco/backoffice/UmbracoApi/Authentication/GetCurrentUser")) {
+                    if (originalResponse.status === 401) {
 
-                      var userService = $injector.get('userService'); // see above
+                        //A 401 means that the user is not logged in
 
-                      //Associate the user name with the retry to ensure we retry for the right user
-                      promise = userService.getCurrentUser()
-                        .then(function (user) {
-                          var userName = user ? user.name : null;
-                          //The request bounced because it was not authorized - add a new request to the retry queue
-                          return queue.pushRetryFn('unauthorized-server', userName, function retryRequest() {
-                            // We must use $injector to get the $http service to prevent circular dependency
-                            return $injector.get('$http')(originalResponse.config);
-                          });
-                        });
+                        //avoid an infinite loop
+                        var umbRequestHelper = $injector.get('umbRequestHelper');
+                        var getCurrentUserPath = umbRequestHelper.getApiUrl("authenticationApiBaseUrl", "GetCurrentUser");
+                        if (!originalResponse.config.url.endsWith(getCurrentUserPath)) {
+
+                            var userService = $injector.get('userService'); // see above
+
+                            //Associate the user name with the retry to ensure we retry for the right user
+                            promise = userService.getCurrentUser()
+                                .then(function (user) {
+                                    var userName = user ? user.name : null;
+                                    //The request bounced because it was not authorized - add a new request to the retry queue
+                                    return queue.pushRetryFn('unauthorized-server', userName, function retryRequest() {
+                                        // We must use $injector to get the $http service to prevent circular dependency
+                                        return $injector.get('$http')(originalResponse.config);
+                                    });
+                                });
+                        }
                     }
                     else if (originalResponse.status === 404) {
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -850,9 +850,10 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
 				return;
 			}
 
-			// Is email and not //user@domain.com
-			if (href.indexOf('@') > 0 && href.indexOf('//') === -1 && href.indexOf('mailto:') === -1) {
-				href = 'mailto:' + href;
+		    // Is email and not //user@domain.com and protocol (e.g. mailto:, sip:) is not specified
+		    if (href.indexOf('@') > 0 && href.indexOf('//') === -1 && href.indexOf(':') === -1) {
+		        // assume it's a mailto link
+		        href = 'mailto:' + href;
 				insertLink();
 				return;
 			}

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.controller.js
@@ -1,0 +1,49 @@
+﻿(function () {
+    "use strict";
+    function RedirectUrlPickerController($scope, entityResource) {
+        /*
+         *TODO: Add regex validation on the Original URL
+         *TODO: Add required validation on "entity"
+         * */
+        var $parentModel = $scope.model;     
+        $scope.model = {
+            multipicker: false,
+            show: true,            
+            submit: function (model) {
+                if (model.selection.length > 0) {
+                    $parentModel.entity = model.selection[0].id
+                    $scope.overlayForm.$setValidity('entity', true);
+                }
+            }
+        };
+        var vm = this;
+        vm.contentItem = null;
+        vm.loaded = false;
+        vm.contentPickerViewPath = "views/common/overlays/contentpicker/contentpicker.html"
+
+        function init() {
+            
+            if ($parentModel.entity) {
+                entityResource.getById($parentModel.entity, $parentModel.entityType).then(function (ent) {
+                    entityResource.getUrl(ent.id, $parentModel.entityType).then(function (data) {
+                        vm.contentItem = ent;
+                        vm.contentItem.url = data;
+                        vm.loaded = true;
+                    });
+                });
+            }
+            else {
+                vm.loaded = true;
+            }
+
+            $scope.$watch("vm.originalUrl", function (newVal, oldVal) {
+                if (newVal !== null && newVal !== undefined && newVal !== oldVal) {
+                    $parentModel.originalUrl = newVal;
+                }
+            });
+        }
+
+        init();
+    }
+    angular.module("umbraco").controller("Umbraco.Overlays.RedirectUrlPickerController", RedirectUrlPickerController);
+})();

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.controller.js
@@ -1,8 +1,40 @@
 ﻿(function () {
     "use strict";
+    function validateUrl() {
+        var pathRegex = new RegExp("^([\/]{1})[^\/].*(?<!\/)$")
+        return {
+            require: 'ngModel',
+            link: function (scope, element, attrs, ctrl) {
+                ctrl.$parsers.unshift(function (viewValue) {
+
+                    viewValue = viewValue.trim();
+
+                    if (viewValue.length == 0) { return viewValue; }
+                    if (viewValue.endsWith("/")) {
+                        viewValue = viewValue.slice(0, -1);
+                    }
+                    if (pathRegex.test(viewValue)) {
+                        ctrl.$setValidity('path', true);
+                    }
+                    else {
+                        ctrl.$setValidity('path', false);
+                        return undefined;
+                    }
+
+                    if (viewValue.indexOf(".") < 0) {
+                        ctrl.$setValidity('dotPath', true);
+                    }
+                    else {
+                        ctrl.$setValidity('dotPath', false);                        
+                        return undefined;
+                    }
+                    return viewValue;
+                });            
+            }
+        };
+    }
     function RedirectUrlPickerController($scope, entityResource, editorState) {
 
-        $scope.urlRegex = new RegExp("([\/]{1})[^\/](.*)");
         $scope.contentItem = null;
         $scope.loaded = false;
         $scope.enablePicker = editorState == null || editorState.current == null;
@@ -54,7 +86,6 @@
                 $scope.loaded = true;
                 return;
             }
-            console.log($scope.model.entityId);
             entityResource.getById($scope.model.entityId, "Document").then(function (ent) {
                 $scope.contentItem = ent;
                 getContentItemUrl().then(function (url) {
@@ -67,4 +98,5 @@
         init();
     }
     angular.module("umbraco").controller("Umbraco.Overlays.RedirectUrlPickerController", RedirectUrlPickerController);
+    angular.module("umbraco").directive('validateUrl', validateUrl);
 })();

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.controller.js
@@ -47,18 +47,21 @@
         }
 
         function init() {
-            if ($scope.model.entityId) {
-                entityResource.getById($scope.model.entityId, "Document").then(function (ent) {
-                    $scope.contentItem = ent;
-                    getContentItemUrl().then(function (url) {
-                        $scope.contentItem.url = url;
-                        $scope.loaded = true;
-                    });
-                });
+            if (!$scope.model.entityId && !$scope.enablePicker) {
+                $scope.model.entityId = editorState.current.id;
             }
             else {
                 $scope.loaded = true;
+                return;
             }
+            console.log($scope.model.entityId);
+            entityResource.getById($scope.model.entityId, "Document").then(function (ent) {
+                $scope.contentItem = ent;
+                getContentItemUrl().then(function (url) {
+                    $scope.contentItem.url = url;
+                    $scope.loaded = true;
+                });
+            });
         }
 
         init();

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.html
@@ -1,30 +1,42 @@
-﻿<div ng-controller="Umbraco.Overlays.RedirectUrlPickerController as vm">
-    <umb-load-indicator ng-hide="vm.loaded"></umb-load-indicator>
-    <div ng-show="vm.loaded">
-        <umb-control-group label="@redirectUrls_originalUrl">
-            <input type="text"
-                   localize="placeholder"
-                   placeholder="@placeholders_enterurl"
-                   class="umb-editor umb-textstring"
-                   ng-model="vm.originalUrl"
-                   required
-                   name="originalUrl"/>
-        </umb-control-group>
-
-        <div class="umb-control-group">
-            <h5>
-                <localize key="redirectUrls_redirectTo">Redirect To</localize>
-            </h5>
-            <umb-node-preview ng-if="vm.contentItem"
-                              icon="vm.contentItem.icon"
-                              name="vm.contentItem.name"
-                              published="vm.contentItem.published"
-                              description="vm.contentItem.url"
-                              sortable="false"
-                              allow-remove="false"
-                              allow-open="false">
-            </umb-node-preview>
-            <div ng-if="!vm.contentItem" ng-include="vm.contentPickerViewPath"></div>
-        </div>
-    </div>
+﻿<div ng-controller="Umbraco.Overlays.RedirectUrlPickerController">
+    <umb-load-indicator ng-hide="loaded"></umb-load-indicator>
+    
+    <umb-control-group label="@redirectUrls_originalUrl" description="@redirectUrls_originalUrlDescription" required="true">
+        <input type="text"
+               localize="placeholder"
+               placeholder="@placeholders_enterurl"
+               class="umb-editor umb-textstring"
+               ng-model="model.originalUrl"
+               required
+               ng-pattern="urlRegex"
+               name="originalUrl" />
+        <span class="help-inline" val-msg-for="originalUrl" val-toggle-msg="required"><localize key="general_required"></localize></span>
+        <span class="help-inline" val-msg-for="originalUrl" val-toggle-msg="pattern"><localize key="redirectUrls_originalUrlPatternValidation"></localize></span>
+    </umb-control-group>
+    <umb-control-group label="@redirectUrls_redirectTo" required="true">
+        <input type="hidden" ng-required="true" ng-model="model.entityId" name="entityId" />
+        <span class="help-inline" val-msg-for="entityId" val-toggle-msg="required"><localize key="general_required"></localize></span>
+        <a ng-show="enablePicker === true && contentItem == null"
+           class="umb-node-preview-add"
+           href=""
+           ng-click="openContentPicker()"
+           prevent-default>
+            <localize key="general_add">Add</localize>
+        </a>
+        <umb-node-preview ng-if="contentItem"
+                          icon="contentItem.icon"
+                          name="contentItem.name"
+                          published="contentItem.published"
+                          description="contentItem.url"
+                          sortable="false"
+                          allow-remove="enablePicker"
+                          on-remove="removeContentItem()">
+        </umb-node-preview>
+    </umb-control-group>
+        <umb-overlay
+        ng-if="contentPickerOverlay.show"
+        model="contentPickerOverlay"
+        position="right"
+        view="contentPickerOverlay.view">
+        </umb-overlay>  
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.html
@@ -8,10 +8,17 @@
                class="umb-editor umb-textstring"
                ng-model="model.originalUrl"
                required
-               ng-pattern="urlRegex"
+               validate-url
                name="originalUrl" />
-        <span class="help-inline" val-msg-for="originalUrl" val-toggle-msg="required"><localize key="general_required"></localize></span>
-        <span class="help-inline" val-msg-for="originalUrl" val-toggle-msg="pattern"><localize key="redirectUrls_originalUrlPatternValidation"></localize></span>
+        <span class="help-inline" val-msg-for="originalUrl" val-toggle-msg="required && !dotPath">
+            <localize key="general_required"></localize>
+        </span>
+        <span class="help-inline" val-msg-for="originalUrl" val-toggle-msg="path">
+            <localize key="redirectUrls_originalUrlPatternValidation"></localize>
+        </span>
+        <span class="help-inline" val-msg-for="originalUrl" val-toggle-msg="dotPath">            
+            <localize key="redirectUrls_originalUrlDotValidation"></localize>
+        </span>
     </umb-control-group>
     <umb-control-group label="@redirectUrls_redirectTo" required="true">
         <input type="hidden" ng-required="true" ng-model="model.entityId" name="entityId" />

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/redirecturlpicker/redirecturlpicker.html
@@ -1,0 +1,30 @@
+﻿<div ng-controller="Umbraco.Overlays.RedirectUrlPickerController as vm">
+    <umb-load-indicator ng-hide="vm.loaded"></umb-load-indicator>
+    <div ng-show="vm.loaded">
+        <umb-control-group label="@redirectUrls_originalUrl">
+            <input type="text"
+                   localize="placeholder"
+                   placeholder="@placeholders_enterurl"
+                   class="umb-editor umb-textstring"
+                   ng-model="vm.originalUrl"
+                   required
+                   name="originalUrl"/>
+        </umb-control-group>
+
+        <div class="umb-control-group">
+            <h5>
+                <localize key="redirectUrls_redirectTo">Redirect To</localize>
+            </h5>
+            <umb-node-preview ng-if="vm.contentItem"
+                              icon="vm.contentItem.icon"
+                              name="vm.contentItem.name"
+                              published="vm.contentItem.published"
+                              description="vm.contentItem.url"
+                              sortable="false"
+                              allow-remove="false"
+                              allow-open="false">
+            </umb-node-preview>
+            <div ng-if="!vm.contentItem" ng-include="vm.contentPickerViewPath"></div>
+        </div>
+    </div>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -19,23 +19,67 @@
                 </ul>
             </umb-box-content>
         </umb-box>
-        <umb-box data-element="node-info-redirects" style="display:none;" ng-cloak ng-show="!urlTrackerDisabled && hasRedirects">
-            <umb-box-header title-key="redirectUrls_redirectUrlManagement"></umb-box-header>
+
+        <umb-box data-element="node-info-redirects" style="display:none;" ng-cloak ng-show="!urlTrackerDisabled">
+            <umb-box-header title-key="redirectUrls_redirectUrlManagement">
+            </umb-box-header>
             <umb-box-content class="block-form">
                 <div style="position: relative;">
                     <div ng-if="loadingRedirectUrls" style="background: rgba(255, 255, 255, 0.8); position: absolute; top: 0; left: 0; right: 0; bottom: 0;"></div>
                     <umb-load-indicator ng-if="loadingRedirectUrls"></umb-load-indicator>
                     <div ng-show="hasRedirects">
                         <p><localize key="redirectUrls_panelInformation" class="ng-isolate-scope ng-scope">The following URLs redirect to this content item:</localize></p>
-                        <ul class="nav nav-stacked" style="margin-bottom: 0;">
-                            <li ng-repeat="redirectUrl in redirectUrls">
-                                <a href="{{redirectUrl.originalUrl}}" target="_blank"><i ng-class="value.icon" class="icon-out"></i> {{redirectUrl.originalUrl}}</a>
-                            </li>
-                        </ul>
+
+                        <div class="umb-table">
+
+                            <div class="umb-table-head">
+                                <div class="umb-table-row">
+                                    <div class="umb-table-cell flx-s1 flx-g1 flx-b8 items-center not-fixed">
+                                    </div>
+                                    <div class="umb-table-cell flx-s1 flx-g1 flx-b2">
+                                        <a class="ng-scope btn btn-info" prevent-default href="#" ng-click="openAddRedirectOverlay()">
+                                            <localize key="redirectUrls_addRedirect" class="ng-isolate-scope ng-scope">Add Redirect</localize>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="umb-table-body">
+                                <div class="umb-table-row -solid ng-scope" ng-repeat="redirectUrl in pagedRedirectUrls" style="margin-bottom: 0;">
+                                    <div class="umb-table-cell flx-s1 flx-g1 flx-b6 items-center not-fixed">
+                                        <div class="flx-s1 flx-g1 flx-b0" style="margin-right: 20px;">
+                                            <a href="{{redirectUrl.originalUrl}}" target="_blank"><i ng-class="value.icon" class="icon-out"></i> {{redirectUrl.originalUrl}}</a>
+                                        </div>
+                                        <button class="umb-era-button umb-button--s -red" prevent-default ng-click="deleteRedirect(redirectUrl)"><localize key="redirectUrls_removeButton">Remove</localize></button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div ng-show="!hasRedirects && !loadingRedirectUrls" style="padding: 15px;">
+                        <umb-empty-state position="center" size="small">
+                            <localize key="redirectUrls_noRedirects"></localize>
+                            <br />
+                            <a class="ng-scope btn btn-info" prevent-default href="#" ng-click="openAddRedirectOverlay()">
+                                <localize key="redirectUrls_addRedirect" class="ng-isolate-scope ng-scope">Add Redirect</localize>
+                            </a>
+                        </umb-empty-state>
+                    </div>
+                    <div class="flex justify-center">
+                        <umb-pagination ng-if="redirectUrlOptions.totalPages > 1"
+                                        page-number="redirectUrlOptions.pageNumber"
+                                        total-pages="redirectUrlOptions.totalPages"
+                                        on-change="redirectUrlPageChange(pageNumber)">
+                        </umb-pagination>
                     </div>
                 </div>
             </umb-box-content>
         </umb-box>
+
+        <umb-overlay ng-if="addRedirectOverlay.show"
+        model="addRedirectOverlay"
+        view="addRedirectOverlay.view"
+        position="right">
+        </umb-overlay>
 
         <umb-box data-element="node-info-history">
             <umb-box-header title-key="general_history"></umb-box-header>
@@ -79,6 +123,8 @@
                                 <umb-badge size="xs"
                                            color="{{item.logTypeColor}}">
 
+
+
                                     <!--{{ item.logType }}-->
                                     <localize key="auditTrails_small{{ item.logType }}">{{ item.logType }}</localize>
                                 </umb-badge>
@@ -103,6 +149,7 @@
                 </div>
 
             </umb-box-content>
+            b-
         </umb-box>
     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -149,7 +149,6 @@
                 </div>
 
             </umb-box-content>
-            b-
         </umb-box>
     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -198,9 +198,10 @@
                         style="max-width: 100%; margin-bottom: 0;"
                         icon="node.icon"
                         name="node.contentTypeName"
+                        alias="documentType.alias"
                         allow-open="allowOpen"
                         on-open="openDocumentType(documentType)"
-						open-url="previewOpenUrl">
+                        open-url="previewOpenUrl">
                     </umb-node-preview>
                 </umb-control-group>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -35,11 +35,12 @@
                             <div class="umb-table-head">
                                 <div class="umb-table-row">
                                     <div class="umb-table-cell flx-s1 flx-g1 flx-b8 items-center not-fixed">
-                                    </div>
-                                    <div class="umb-table-cell flx-s1 flx-g1 flx-b2">
-                                        <a class="ng-scope btn btn-info" prevent-default href="#" ng-click="openAddRedirectOverlay()">
+                                        <a class="bold" style="color: #00aea2; text-decoration: underline;" prevent-default href="#" ng-click="openAddRedirectOverlay()">
                                             <localize key="redirectUrls_addRedirect" class="ng-isolate-scope ng-scope">Add Redirect</localize>
                                         </a>
+                                    </div>
+                                    <div class="umb-table-cell flx-s1 flx-g1 flx-b2">
+                                        
                                     </div>
                                 </div>
                             </div>
@@ -59,7 +60,7 @@
                         <umb-empty-state position="center" size="small">
                             <localize key="redirectUrls_noRedirects"></localize>
                             <br />
-                            <a class="ng-scope btn btn-info" prevent-default href="#" ng-click="openAddRedirectOverlay()">
+                            <a class="bold" style="color: #00aea2; text-decoration: underline;" prevent-default href="#" ng-click="openAddRedirectOverlay()">
                                 <localize key="redirectUrls_addRedirect" class="ng-isolate-scope ng-scope">Add Redirect</localize>
                             </a>
                         </umb-empty-state>

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -33,9 +33,9 @@
                         <div class="umb-table">
 
                             <div class="umb-table-head">
-                                <div class="umb-table-row">
+                                <div ng-show="editRedirectEnabled" class="umb-table-row">
                                     <div class="umb-table-cell flx-s1 flx-g1 flx-b8 items-center not-fixed">
-                                        <a class="bold" style="color: #00aea2; text-decoration: underline;" prevent-default href="#" ng-click="openAddRedirectOverlay()">
+                                        <a  class="bold" style="color: #00aea2; text-decoration: underline;" prevent-default href="#" ng-click="openAddRedirectOverlay()">
                                             <localize key="redirectUrls_addRedirect" class="ng-isolate-scope ng-scope">Add Redirect</localize>
                                         </a>
                                     </div>
@@ -50,7 +50,7 @@
                                         <div class="flx-s1 flx-g1 flx-b0" style="margin-right: 20px;">
                                             <a href="{{redirectUrl.originalUrl}}" target="_blank"><i ng-class="value.icon" class="icon-out"></i> {{redirectUrl.originalUrl}}</a>
                                         </div>
-                                        <button class="umb-era-button umb-button--s -red" prevent-default ng-click="deleteRedirect(redirectUrl)"><localize key="redirectUrls_removeButton">Remove</localize></button>
+                                        <button ng-show="editRedirectEnabled" class="umb-era-button umb-button--s -red" prevent-default ng-click="deleteRedirect(redirectUrl)"><localize key="redirectUrls_removeButton">Remove</localize></button>
                                     </div>
                                 </div>
                             </div>
@@ -60,7 +60,7 @@
                         <umb-empty-state position="center" size="small">
                             <localize key="redirectUrls_noRedirects"></localize>
                             <br />
-                            <a class="bold" style="color: #00aea2; text-decoration: underline;" prevent-default href="#" ng-click="openAddRedirectOverlay()">
+                            <a ng-show="editRedirectEnabled" class="bold" style="color: #00aea2; text-decoration: underline;" prevent-default href="#" ng-click="openAddRedirectOverlay()">
                                 <localize key="redirectUrls_addRedirect" class="ng-isolate-scope ng-scope">Add Redirect</localize>
                             </a>
                         </umb-empty-state>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.controller.js
@@ -27,15 +27,76 @@
 
         vm.goToPage = goToPage;
         vm.search = search;
+        vm.addRedirect = addRedirect;
+        vm.openContentPickerOverlay = openContentPickerOverlay;
         vm.removeRedirect = removeRedirect;
         vm.disableUrlTracker = disableUrlTracker;
         vm.enableUrlTracker = enableUrlTracker;
         vm.filter = filter;
         vm.checkEnabled = checkEnabled;
 
+        vm.status = {
+            adding: false,
+            readyToAdd: false
+        };
+        vm.data = {
+            redirectToSelection: [],
+            redirectFromUrl: ""
+        }
+        vm.removeSelection = removeSelection;
+
+        function removeSelection() {
+            console.log(vm.data.redirectToSelection);
+            vm.data.redirectToSelection = [];
+        }
+        function openContentPickerOverlay() {
+            console.log("hi");
+            vm.contentPickerOverlay = {
+                multiPicker: false,
+                view: "contentpicker",
+                show: true,
+                submit: function (model) {
+                    console.log(model);
+                    angular.forEach(model.selection,
+                        function(entity) {
+                            setEntityUrl(entity);
+                        });
+                    
+                    vm.data.redirectToSelection = model.selection;
+                    vm.status.readyToAdd = vm.data.redirectFromUrl.length > 0 && vm.data.redirectToSelection.length > 0;
+                    vm.contentPickerOverlay.show = false;
+                    vm.contentPickerOverlay = null;
+
+                },
+                close: function (oldModel) {
+                    vm.contentPickerOverlay.show = false;
+                    vm.contentPickerOverlay = null;
+                }
+            }
+
+        };
+
+        function setEntityUrl(entity) {
+
+            // get url for content and media items
+            if (entityType !== "Member") {
+                entityResource.getUrl(entity.id, entityType).then(function(data) {
+                    // update url  
+                    if (entity.trashed) {
+                        item.url = localizationService.dictionary.general_recycleBin;
+                    } else {
+                        item.url = data;
+                    }
+
+                });
+            }
+        }
+
         function activate() {            
             vm.checkEnabled().then(function() {
                 vm.search();
+                vm.data.redirectFromUrl = "";
+                vm.data.redirectToSelection = [];
             });
         }
 
@@ -75,6 +136,34 @@
                 vm.dashboard.loading = false;
 
             });
+        }
+
+        function addRedirect() {
+            vm.addRedirectOverlay = {
+                show: true,
+                view: "treepicker",
+                multiPicker: false,
+                entityType: "document",
+                filterCssClass: "not-allowed not-published",
+                startNodeId: null,
+                callback: function (data) {
+                    console.log(data);
+                },
+                treeAlias: "content",
+                section: "content",
+                idType: "udi"
+            
+            };
+            vm.addRedirectOverlay.submit = function(model) {
+
+                console.log('submitted', model);
+                vm.addRedirectOverlay.close();
+            }
+
+            vm.addRedirectOverlay.close = function() {
+                vm.addRedirectOverlay.show = false;
+                vm.addRedirectOverlay = null;
+            }
         }
 
         function removeRedirect(redirectToDelete) {

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.controller.js
@@ -38,8 +38,7 @@
             vm.addRedirectOverlay = {
                 view: "redirecturlpicker",                
                 show: true,
-                submit: function (model) {
-                    console.log(model);
+                submit: function (model) {                    
                     redirectUrlsResource.addRedirect(model.originalUrl, model.entityId).then(function () {
                         vm.search();
                         vm.addRedirectOverlay.show = false;

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.controller.js
@@ -33,34 +33,23 @@
         vm.enableUrlTracker = enableUrlTracker;
         vm.filter = filter;
         vm.checkEnabled = checkEnabled;
-
-        vm.status = {
-            adding: false,
-            readyToAdd: false
-        };
-        vm.data = {
-            redirectToSelection: [],
-            redirectFromUrl: ""
-        }
-        vm.removeSelection = removeSelection;
-
-        function removeSelection() {
-            console.log(vm.data.redirectToSelection);
-            vm.data.redirectToSelection = [];
-        }
+             
         function openAddRedirectOverlay() {
             vm.addRedirectOverlay = {
-                entity: null,
-                entityType: "Document",
-                view: "redirecturlpicker",
+                view: "redirecturlpicker",                
                 show: true,
                 submit: function (model) {
                     console.log(model);
-                    vm.data.redirectToSelection = model.selection;
-                    vm.status.readyToAdd = vm.data.redirectFromUrl.length > 0 && vm.data.redirectToSelection.length > 0;
-                    vm.addRedirectOverlay.show = false;
-                    vm.addRedirectOverlay = null;
-
+                    redirectUrlsResource.addRedirect(model.originalUrl, model.entityId).then(function () {
+                        vm.search();
+                        vm.addRedirectOverlay.show = false;
+                        vm.addRedirectOverlay = null;
+                        notificationsService.success(localizationService.localize("redirectUrls_redirectAddConfirm"));
+                    }, function (error) {
+                        vm.addRedirectOverlay.show = false;
+                        vm.addRedirectOverlay = null;
+                        notificationsService.error(localizationService.localize("redirectUrls_redirectAddError"));
+                    });
                 },
                 close: function (oldModel) {
                     vm.addRedirectOverlay.show = false;
@@ -73,8 +62,6 @@
         function activate() {
             vm.checkEnabled().then(function() {
                 vm.search();
-                vm.data.redirectFromUrl = "";
-                vm.data.redirectToSelection = [];
             });
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.controller.js
@@ -27,8 +27,7 @@
 
         vm.goToPage = goToPage;
         vm.search = search;
-        vm.addRedirect = addRedirect;
-        vm.openContentPickerOverlay = openContentPickerOverlay;
+        vm.openAddRedirectOverlay = openAddRedirectOverlay;
         vm.removeRedirect = removeRedirect;
         vm.disableUrlTracker = disableUrlTracker;
         vm.enableUrlTracker = enableUrlTracker;
@@ -49,50 +48,29 @@
             console.log(vm.data.redirectToSelection);
             vm.data.redirectToSelection = [];
         }
-        function openContentPickerOverlay() {
-            console.log("hi");
-            vm.contentPickerOverlay = {
-                multiPicker: false,
-                view: "contentpicker",
+        function openAddRedirectOverlay() {
+            vm.addRedirectOverlay = {
+                entity: null,
+                entityType: "Document",
+                view: "redirecturlpicker",
                 show: true,
                 submit: function (model) {
                     console.log(model);
-                    angular.forEach(model.selection,
-                        function(entity) {
-                            setEntityUrl(entity);
-                        });
-                    
                     vm.data.redirectToSelection = model.selection;
                     vm.status.readyToAdd = vm.data.redirectFromUrl.length > 0 && vm.data.redirectToSelection.length > 0;
-                    vm.contentPickerOverlay.show = false;
-                    vm.contentPickerOverlay = null;
+                    vm.addRedirectOverlay.show = false;
+                    vm.addRedirectOverlay = null;
 
                 },
                 close: function (oldModel) {
-                    vm.contentPickerOverlay.show = false;
-                    vm.contentPickerOverlay = null;
+                    vm.addRedirectOverlay.show = false;
+                    vm.addRedirectOverlay = null;
                 }
             }
 
         };
 
-        function setEntityUrl(entity) {
-
-            // get url for content and media items
-            if (entityType !== "Member") {
-                entityResource.getUrl(entity.id, entityType).then(function(data) {
-                    // update url  
-                    if (entity.trashed) {
-                        item.url = localizationService.dictionary.general_recycleBin;
-                    } else {
-                        item.url = data;
-                    }
-
-                });
-            }
-        }
-
-        function activate() {            
+        function activate() {
             vm.checkEnabled().then(function() {
                 vm.search();
                 vm.data.redirectFromUrl = "";
@@ -136,34 +114,6 @@
                 vm.dashboard.loading = false;
 
             });
-        }
-
-        function addRedirect() {
-            vm.addRedirectOverlay = {
-                show: true,
-                view: "treepicker",
-                multiPicker: false,
-                entityType: "document",
-                filterCssClass: "not-allowed not-published",
-                startNodeId: null,
-                callback: function (data) {
-                    console.log(data);
-                },
-                treeAlias: "content",
-                section: "content",
-                idType: "udi"
-            
-            };
-            vm.addRedirectOverlay.submit = function(model) {
-
-                console.log('submitted', model);
-                vm.addRedirectOverlay.close();
-            }
-
-            vm.addRedirectOverlay.close = function() {
-                vm.addRedirectOverlay.show = false;
-                vm.addRedirectOverlay = null;
-            }
         }
 
         function removeRedirect(redirectToDelete) {

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.controller.js
@@ -34,7 +34,7 @@
         vm.filter = filter;
         vm.checkEnabled = checkEnabled;
              
-        function openAddRedirectOverlay() {
+        function openAddRedirectOverlay() {            
             vm.addRedirectOverlay = {
                 view: "redirecturlpicker",                
                 show: true,

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.html
@@ -5,9 +5,14 @@
     <umb-editor-sub-header>
 
         <umb-editor-sub-header-content-right>
-
+            <umb-editor-sub-header-section ng-if="vm.dashboard.userIsAdmin === true && vm.dashboard.urlTrackerDisabled === false">
+                <button type="button"
+                        class="umb-era-button umb-button--s -blue"
+                        ng-click="vm.openAddRedirectOverlay()">
+                    <span><localize key="redirectUrls_addRedirect">Add redirect</localize></span>
+                </button>
+            </umb-editor-sub-header-section>
             <umb-editor-sub-header-section ng-if="vm.dashboard.userIsAdmin === true">
-
                 <button ng-if="vm.dashboard.urlTrackerDisabled === false"
                         type="button"
                         class="umb-era-button umb-button--s"
@@ -77,40 +82,6 @@
                 </div>
 
             </div>
-            <div class="umb-table-row -solid">
-                <div class="umb-table-cell not-fixed flx-s1 flx-g1 flx-b4">
-                    <input type="text" class="form-control" ng-model="vm.data.redirectFromUrl" prevent-enter-submit no-dirty-check />
-                </div>
-
-
-
-                <div class="umb-table-cell flx-s1 flx-g1 flx-b6 items-center">
-                    <umb-node-preview ng-repeat="node in vm.data.redirectToSelection"
-                                      icon="node.icon"
-                                      name="node.name"
-                                      published="node.published"
-                                      description="node.url"
-                                      sortable="false"
-                                      allow-remove="true"
-                                      allow-open="false"
-                                      on-remove="vm.removeSelection($index)" >
-                    </umb-node-preview>
-                    <a ng-show="vm.data.redirectToSelection.length === 0"
-                       class="umb-node-preview-add"
-                       href=""
-                       ng-click="vm.openContentPickerOverlay()"
-                       prevent-default>
-                        
-                    </a>
-
-
-
-                </div>
-                <div class="umb-table-cell flx-s0 flx-g0" style="flex-basis: 60px;">
-                    <button type="button" class="umb-era-button umb-button--s -blue" ng-click="vm.addRedirect()" ng-disabled="!vm.status.readyToAdd">Add</button>
-                </div>
-
-            </div>
         </div>
         
 
@@ -140,9 +111,9 @@
         </umb-pagination>
     </div>
 
-    <umb-overlay ng-if="vm.contentPickerOverlay.show"
-                 model="vm.contentPickerOverlay"
-                 view="vm.contentPickerOverlay.view"
+    <umb-overlay ng-if="vm.addRedirectOverlay.show"
+                 model="vm.addRedirectOverlay"
+                 view="vm.addRedirectOverlay.view"
                  position="right">
     </umb-overlay>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/developer/redirecturls.html
@@ -8,19 +8,17 @@
 
             <umb-editor-sub-header-section ng-if="vm.dashboard.userIsAdmin === true">
 
-                <button
-                    ng-if="vm.dashboard.urlTrackerDisabled === false"
-                    type="button"
-                    class="umb-era-button umb-button--s"
-                    ng-click="vm.disableUrlTracker()">
+                <button ng-if="vm.dashboard.urlTrackerDisabled === false"
+                        type="button"
+                        class="umb-era-button umb-button--s"
+                        ng-click="vm.disableUrlTracker()">
                     <span><localize key="redirectUrls_disableUrlTracker">Disable URL Tracker</localize></span>
                 </button>
 
-                <button
-                    ng-if="vm.dashboard.urlTrackerDisabled === true"
-                    type="button"
-                    class="umb-era-button umb-button--s -green"
-                    ng-click="vm.enableUrlTracker()">
+                <button ng-if="vm.dashboard.urlTrackerDisabled === true"
+                        type="button"
+                        class="umb-era-button umb-button--s -green"
+                        ng-click="vm.enableUrlTracker()">
                     <span><localize key="redirectUrls_enableUrlTracker">Enable URL Tracker</localize></span>
                 </button>
 
@@ -31,20 +29,18 @@
                 <form class="form-search -no-margin-bottom pull-right" novalidate>
                     <div class="inner-addon left-addon">
                         <i class="icon icon-search"></i>
-                        <input
-                            class="form-control search-input"
-                            type="text"
-                            localize="placeholder"
-                            placeholder="@general_typeToSearch"
-                            ng-model="vm.dashboard.searchTerm"
-                            ng-change="vm.filter()"
-                            prevent-enter-submit
-                            no-dirty-check>
+                        <input class="form-control search-input"
+                               type="text"
+                               localize="placeholder"
+                               placeholder="@general_typeToSearch"
+                               ng-model="vm.dashboard.searchTerm"
+                               ng-change="vm.filter()"
+                               prevent-enter-submit
+                               no-dirty-check>
                     </div>
                 </form>
 
             </umb-editor-sub-header-section>
-
         </umb-editor-sub-header-content-right>
 
     </umb-editor-sub-header>
@@ -81,8 +77,42 @@
                 </div>
 
             </div>
+            <div class="umb-table-row -solid">
+                <div class="umb-table-cell not-fixed flx-s1 flx-g1 flx-b4">
+                    <input type="text" class="form-control" ng-model="vm.data.redirectFromUrl" prevent-enter-submit no-dirty-check />
+                </div>
 
+
+
+                <div class="umb-table-cell flx-s1 flx-g1 flx-b6 items-center">
+                    <umb-node-preview ng-repeat="node in vm.data.redirectToSelection"
+                                      icon="node.icon"
+                                      name="node.name"
+                                      published="node.published"
+                                      description="node.url"
+                                      sortable="false"
+                                      allow-remove="true"
+                                      allow-open="false"
+                                      on-remove="vm.removeSelection($index)" >
+                    </umb-node-preview>
+                    <a ng-show="vm.data.redirectToSelection.length === 0"
+                       class="umb-node-preview-add"
+                       href=""
+                       ng-click="vm.openContentPickerOverlay()"
+                       prevent-default>
+                        
+                    </a>
+
+
+
+                </div>
+                <div class="umb-table-cell flx-s0 flx-g0" style="flex-basis: 60px;">
+                    <button type="button" class="umb-era-button umb-button--s -blue" ng-click="vm.addRedirect()" ng-disabled="!vm.status.readyToAdd">Add</button>
+                </div>
+
+            </div>
         </div>
+        
 
     </div>
 
@@ -110,4 +140,9 @@
         </umb-pagination>
     </div>
 
+    <umb-overlay ng-if="vm.contentPickerOverlay.show"
+                 model="vm.contentPickerOverlay"
+                 view="vm.contentPickerOverlay.view"
+                 position="right">
+    </umb-overlay>
 </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2216,7 +2216,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="enableUrlTracker">Enable URL tracker</key>
         <key alias="originalUrl">Original URL</key>
         <key alias="originalUrlDescription"><![CDATA[A valid URL should look like /page or /page/subpage]]></key>
-        <key alias="originalUrlPatternValidation">Does not match pattern /page or /page/subpage</key>
+        <key alias="originalUrlPatternValidation"><![CDATA[Does not match pattern /page or /page/subpage]]></key>
+        <key alias="originalUrlDotValidation"><![CDATA[Url can not contain a .]]></key>
         <key alias="redirectedTo">Redirected To</key>
         <key alias="redirectTo">Redirect To</key>
         <key alias="redirectUrlManagement">Redirect Url Management</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2215,6 +2215,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="disableUrlTracker">Disable URL tracker</key>
         <key alias="enableUrlTracker">Enable URL tracker</key>
         <key alias="originalUrl">Original URL</key>
+        <key alias="originalUrlDescription"><![CDATA[A valid URL should look like /page or /page/subpage]]></key>
+        <key alias="originalUrlPatternValidation">Does not match pattern /page or /page/subpage</key>
         <key alias="redirectedTo">Redirected To</key>
         <key alias="redirectTo">Redirect To</key>
         <key alias="redirectUrlManagement">Redirect Url Management</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2217,7 +2217,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="originalUrl">Original URL</key>
         <key alias="originalUrlDescription"><![CDATA[A valid URL should look like /page or /page/subpage]]></key>
         <key alias="originalUrlPatternValidation"><![CDATA[Does not match pattern /page or /page/subpage]]></key>
-        <key alias="originalUrlDotValidation"><![CDATA[Url can not contain a .]]></key>
+        <key alias="originalUrlDotValidation"><![CDATA[Url cannot contain a .]]></key>
         <key alias="redirectedTo">Redirected To</key>
         <key alias="redirectTo">Redirect To</key>
         <key alias="redirectUrlManagement">Redirect Url Management</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -479,6 +479,7 @@
         <key alias="anchor">#value or ?key=value</key>
         <key alias="enterAlias">Enter alias...</key>
         <key alias="generatingAlias">Generating alias...</key>
+        <key alias="enterurl">Enter URL...</key>
     </area>
     <area alias="editcontenttype">
         <key alias="allowAtRoot" version="7.2">Allow at root</key>
@@ -2215,6 +2216,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="enableUrlTracker">Enable URL tracker</key>
         <key alias="originalUrl">Original URL</key>
         <key alias="redirectedTo">Redirected To</key>
+        <key alias="redirectTo">Redirect To</key>
         <key alias="redirectUrlManagement">Redirect Url Management</key>
         <key alias="panelInformation">The following URLs redirect to this content item:</key>
         <key alias="noRedirects">No redirects have been made</key>
@@ -2228,6 +2230,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="disableError">Error disabling the URL tracker, more information can be found in your log file.</key>
         <key alias="enabledConfirm">URL tracker has now been enabled.</key>
         <key alias="enableError">Error enabling the URL tracker, more information can be found in your log file.</key>
+        <key alias="addRedirect">Add Redirect</key>
     </area>
     <area alias="emptyStates">
         <key alias="emptyDictionaryTree">No Dictionary items to choose from</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2233,6 +2233,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="enabledConfirm">URL tracker has now been enabled.</key>
         <key alias="enableError">Error enabling the URL tracker, more information can be found in your log file.</key>
         <key alias="addRedirect">Add Redirect</key>
+        <key alias="redirectAddConfirm">Redirect successfully added</key>
+        <key alias="redirectAddError">Failed to add redirect</key>
     </area>
     <area alias="emptyStates">
         <key alias="emptyDictionaryTree">No Dictionary items to choose from</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -480,6 +480,7 @@
         <key alias="anchor">#value or ?key=value</key>
         <key alias="enterAlias">Enter alias...</key>
         <key alias="generatingAlias">Generating alias...</key>
+        <key alias="enterurl">Enter URL...</key>
     </area>
     <area alias="editcontenttype">
         <key alias="allowAtRoot" version="7.2">Allow at root</key>
@@ -2208,6 +2209,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="enableUrlTracker">Enable URL tracker</key>
         <key alias="originalUrl">Original URL</key>
         <key alias="redirectedTo">Redirected To</key>
+        <key alias="redirectTo">Redirect To</key>
         <key alias="redirectUrlManagement">Redirect Url Management</key>
         <key alias="panelInformation">The following URLs redirect to this content item:</key>
         <key alias="noRedirects">No redirects have been made</key>
@@ -2221,6 +2223,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="disableError">Error disabling the URL tracker, more information can be found in your log file.</key>
         <key alias="enabledConfirm">URL tracker has now been enabled.</key>
         <key alias="enableError">Error enabling the URL tracker, more information can be found in your log file.</key>
+        <key alias="addRedirect">Add Redirect</key>
     </area>
     <area alias="emptyStates">
         <key alias="emptyDictionaryTree">No Dictionary items to choose from</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2209,7 +2209,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="enableUrlTracker">Enable URL tracker</key>
         <key alias="originalUrl">Original URL</key>
         <key alias="originalUrlDescription"><![CDATA[A valid URL should look like /page or /page/subpage]]></key>
-        <key alias="originalUrlPatternValidation">Does not match pattern /page or /page/subpage</key>        
+        <key alias="originalUrlPatternValidation"><![CDATA[Does not match pattern /page or /page/subpage]]></key>
+        <key alias="originalUrlDotValidation"><![CDATA[Url can not contain a .]]></key>
         <key alias="redirectedTo">Redirected To</key>
         <key alias="redirectTo">Redirect To</key>
         <key alias="redirectUrlManagement">Redirect Url Management</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2226,8 +2226,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="enabledConfirm">URL tracker has now been enabled.</key>
         <key alias="enableError">Error enabling the URL tracker, more information can be found in your log file.</key>
         <key alias="addRedirect">Add Redirect</key>
-        <key alias="redirectAddConfirm"></key>
-        <key alias="redirectAddError"></key>
+        <key alias="redirectAddConfirm">Redirect successfully added</key>
+        <key alias="redirectAddError">Failed to add redirect</key>
     </area>
     <area alias="emptyStates">
         <key alias="emptyDictionaryTree">No Dictionary items to choose from</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2210,7 +2210,7 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="originalUrl">Original URL</key>
         <key alias="originalUrlDescription"><![CDATA[A valid URL should look like /page or /page/subpage]]></key>
         <key alias="originalUrlPatternValidation"><![CDATA[Does not match pattern /page or /page/subpage]]></key>
-        <key alias="originalUrlDotValidation"><![CDATA[Url can not contain a .]]></key>
+        <key alias="originalUrlDotValidation"><![CDATA[Url cannot contain a .]]></key>
         <key alias="redirectedTo">Redirected To</key>
         <key alias="redirectTo">Redirect To</key>
         <key alias="redirectUrlManagement">Redirect Url Management</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2208,6 +2208,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="disableUrlTracker">Disable URL tracker</key>
         <key alias="enableUrlTracker">Enable URL tracker</key>
         <key alias="originalUrl">Original URL</key>
+        <key alias="originalUrlDescription"><![CDATA[A valid URL should look like /page or /page/subpage]]></key>
+        <key alias="originalUrlPatternValidation">Does not match pattern /page or /page/subpage</key>        
         <key alias="redirectedTo">Redirected To</key>
         <key alias="redirectTo">Redirect To</key>
         <key alias="redirectUrlManagement">Redirect Url Management</key>
@@ -2224,6 +2226,8 @@ To manage your website, simply open the Umbraco back office and start adding con
         <key alias="enabledConfirm">URL tracker has now been enabled.</key>
         <key alias="enableError">Error enabling the URL tracker, more information can be found in your log file.</key>
         <key alias="addRedirect">Add Redirect</key>
+        <key alias="redirectAddConfirm"></key>
+        <key alias="redirectAddError"></key>
     </area>
     <area alias="emptyStates">
         <key alias="emptyDictionaryTree">No Dictionary items to choose from</key>

--- a/src/Umbraco.Web/Cache/UnpublishedPageCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/UnpublishedPageCacheRefresher.cs
@@ -6,6 +6,7 @@ using Umbraco.Core.Cache;
 using Umbraco.Core.Models;
 using System.Linq;
 using Newtonsoft.Json;
+using umbraco.cms.businesslogic.web;
 using Umbraco.Core.Persistence.Repositories;
 using Umbraco.Core.Sync;
 
@@ -44,7 +45,7 @@ namespace Umbraco.Web.Cache
             return jsonObject;
         }
 
-      
+
         internal static string SerializeToJsonPayloadForPermanentDeletion(params int[] contentIds)
         {
             var items = contentIds.Select(x => new JsonPayload
@@ -61,12 +62,12 @@ namespace Umbraco.Web.Cache
         #region Sub classes
 
         internal enum OperationType
-        {            
+        {
             Deleted
         }
 
         internal class JsonPayload
-        {            
+        {
             public int Id { get; set; }
             public OperationType Operation { get; set; }
         }
@@ -79,6 +80,7 @@ namespace Umbraco.Web.Cache
             ClearAllIsolatedCacheByEntityType<IContent>();
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();
+            content.Instance.ClearPreviewXmlContent();
             base.RefreshAll();
         }
 
@@ -87,6 +89,9 @@ namespace Umbraco.Web.Cache
             ClearRepositoryCacheItemById(id);
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
             content.Instance.UpdateSortOrder(id);
+            var d = new Document(id);
+            content.Instance.UpdateDocumentCache(d);
+            content.Instance.UpdatePreviewXmlContent(d);
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();
             base.Refresh(id);
         }
@@ -97,6 +102,7 @@ namespace Umbraco.Web.Cache
             ClearRepositoryCacheItemById(id);
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();
+            content.Instance.ClearPreviewXmlContent(id);
             base.Remove(id);
         }
 
@@ -106,6 +112,9 @@ namespace Umbraco.Web.Cache
             ClearRepositoryCacheItemById(instance.Id);
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
             content.Instance.UpdateSortOrder(instance);
+            var d = new Document(instance);
+            content.Instance.UpdateDocumentCache(d);
+            content.Instance.UpdatePreviewXmlContent(d);
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();
             base.Refresh(instance);
         }
@@ -116,6 +125,7 @@ namespace Umbraco.Web.Cache
             ClearRepositoryCacheItemById(instance.Id);
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();
+            content.Instance.ClearPreviewXmlContent(instance.Id);
             base.Remove(instance);
         }
 
@@ -132,6 +142,7 @@ namespace Umbraco.Web.Cache
                 ApplicationContext.Current.Services.IdkMap.ClearCache(payload.Id);
                 ClearRepositoryCacheItemById(payload.Id);
                 content.Instance.UpdateSortOrder(payload.Id);
+                content.Instance.ClearPreviewXmlContent(payload.Id);
             }
 
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -851,7 +851,7 @@ namespace Umbraco.Web.Editors
         [EnsureUserPermissionForContent(Constants.System.RecycleBinContent, 'D')]
         public HttpResponseMessage EmptyRecycleBin()
         {
-            Services.ContentService.EmptyRecycleBin();
+            Services.ContentService.EmptyRecycleBin(Security.CurrentUser.Id);
 
             return Request.CreateNotificationSuccessResponse(Services.TextService.Localize("defaultdialogs/recycleBinIsEmpty"));
         }

--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -88,7 +88,7 @@ namespace Umbraco.Web.Editors
                 throw new HttpResponseException(HttpStatusCode.NotFound);
             }
 
-            var emptyContent = Services.MediaService.CreateMedia("", parentId, contentType.Alias, UmbracoUser.Id);
+            var emptyContent = Services.MediaService.CreateMedia("", parentId, contentType.Alias, Security.CurrentUser.Id);
             var mapped = AutoMapperExtensions.MapWithUmbracoContext<IMedia, MediaItemDisplay>(emptyContent, UmbracoContext);
 
             //remove this tab if it exists: umbContainerView
@@ -422,7 +422,7 @@ namespace Umbraco.Web.Editors
             //if the current item is in the recycle bin
             if (foundMedia.IsInRecycleBin() == false)
             {
-                var moveResult = Services.MediaService.WithResult().MoveToRecycleBin(foundMedia, (int)Security.CurrentUser.Id);
+                var moveResult = Services.MediaService.WithResult().MoveToRecycleBin(foundMedia, Security.CurrentUser.Id);
                 if (moveResult == false)
                 {
                     //returning an object of INotificationModel will ensure that any pending
@@ -432,7 +432,7 @@ namespace Umbraco.Web.Editors
             }
             else
             {
-                var deleteResult = Services.MediaService.WithResult().Delete(foundMedia, (int)Security.CurrentUser.Id);
+                var deleteResult = Services.MediaService.WithResult().Delete(foundMedia, Security.CurrentUser.Id);
                 if (deleteResult == false)
                 {
                     //returning an object of INotificationModel will ensure that any pending
@@ -456,7 +456,7 @@ namespace Umbraco.Web.Editors
             var destinationParentID = move.ParentId;
             var sourceParentID = toMove.ParentId;
             
-            var moveResult = Services.MediaService.WithResult().Move(toMove, move.ParentId);
+            var moveResult = Services.MediaService.WithResult().Move(toMove, move.ParentId, Security.CurrentUser.Id);
 
             if (sourceParentID == destinationParentID)
             {
@@ -525,7 +525,7 @@ namespace Umbraco.Web.Editors
             }
 
             //save the item
-            var saveStatus = Services.MediaService.WithResult().Save(contentItem.PersistedContent, (int)Security.CurrentUser.Id);
+            var saveStatus = Services.MediaService.WithResult().Save(contentItem.PersistedContent, Security.CurrentUser.Id);
 
             //return the updated model
             var display = AutoMapperExtensions.MapWithUmbracoContext<IMedia, MediaItemDisplay>(contentItem.PersistedContent, UmbracoContext);

--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -583,7 +583,7 @@ namespace Umbraco.Web.Editors
         [HttpPost]
         public HttpResponseMessage EmptyRecycleBin()
         {
-            Services.MediaService.EmptyRecycleBin();
+            Services.MediaService.EmptyRecycleBin(Security.CurrentUser.Id);
 
             return Request.CreateNotificationSuccessResponse(Services.TextService.Localize("defaultdialogs/recycleBinIsEmpty"));
         }

--- a/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
+++ b/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
@@ -121,5 +121,22 @@ namespace Umbraco.Web.Editors
 
             return Ok(string.Format("URL tracker is now {0}d", action));
         }
+
+        [HttpPost]
+        public IHttpActionResult AddRedirect(string url, int contentId)
+        {
+            var user = Umbraco.UmbracoContext.Security.CurrentUser;
+            var target = Services.ContentService.GetById(contentId);
+
+            //TODO: Validate user
+            //TODO: Validate url
+
+            //TODO: ensure url does not have a query string
+            //TODO: ensure url does not end in a trailing slash
+            //TODO: ensure url does not point to a file as redirector adds a trailing slash
+
+            Services.RedirectUrlService.Register(url, target.Key);
+            return Ok(string.Format("Url {0} now redirects to {1}", url, target.Name));
+        }
     }
 }

--- a/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
+++ b/src/Umbraco.Web/Editors/RedirectUrlManagementController.cs
@@ -152,13 +152,13 @@ namespace Umbraco.Web.Editors
             //ensure url does not point to a file as redirector adds a trailing slash
             if (url.IndexOf('.') > -1)
             {
-                return BadRequest("Url can not contain a dot.");
+                return BadRequest("Url cannot contain a dot.");
             }
 
             //ensure url does not have a query string            
             if (url.IndexOf("?") > -1)
             {
-                return BadRequest("Url can not contain a querystring.");
+                return BadRequest("Url cannot contain a querystring.");
             }
 
             var target = Services.ContentService.GetById(contentId);

--- a/src/Umbraco.Web/PublishedCache/ContextualPublishedCache.cs
+++ b/src/Umbraco.Web/PublishedCache/ContextualPublishedCache.cs
@@ -106,10 +106,18 @@ namespace Umbraco.Web.PublishedCache
         {
             var guidUdi = contentId as GuidUdi;
             if (guidUdi == null)
-                throw new InvalidOperationException("UDIs for content items must be " + typeof(GuidUdi));
+                throw new ArgumentException($"Udi must be of type {typeof(GuidUdi).Name}.", nameof(contentId));
+
+            if (guidUdi.EntityType != UdiEntityType)
+                throw new ArgumentException($"Udi entity type must be \"{UdiEntityType}\".", nameof(contentId));
 
             return GetById(preview, guidUdi.Guid);
         }
+
+        /// <summary>
+        /// Gets the entity type.
+        /// </summary>
+        protected abstract string UdiEntityType { get; }
 
         /// <summary>
         /// Gets content at root.

--- a/src/Umbraco.Web/PublishedCache/ContextualPublishedContentCache.cs
+++ b/src/Umbraco.Web/PublishedCache/ContextualPublishedContentCache.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Web.PublishedCache.XmlPublishedCache;
 
@@ -20,6 +21,8 @@ namespace Umbraco.Web.PublishedCache
         internal ContextualPublishedContentCache(IPublishedContentCache cache, UmbracoContext umbracoContext)
             : base(umbracoContext, cache)
         { }
+
+        protected override string UdiEntityType => Constants.UdiEntityType.Document;
 
         public override IPublishedContent GetById(bool preview, Guid contentKey)
         {

--- a/src/Umbraco.Web/PublishedCache/ContextualPublishedMediaCache.cs
+++ b/src/Umbraco.Web/PublishedCache/ContextualPublishedMediaCache.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Web.PublishedCache.XmlPublishedCache;
 
@@ -20,6 +21,8 @@ namespace Umbraco.Web.PublishedCache
         internal ContextualPublishedMediaCache(IPublishedMediaCache cache, UmbracoContext umbracoContext)
             : base(umbracoContext, cache)
         { }
+
+        protected override string UdiEntityType => Constants.UdiEntityType.Media;
 
         public override IPublishedContent GetById(bool preview, Guid contentKey)
         {

--- a/src/Umbraco.Web/PublishedCache/XmlPublishedCache/PublishedContentCache.cs
+++ b/src/Umbraco.Web/PublishedCache/XmlPublishedCache/PublishedContentCache.cs
@@ -523,6 +523,8 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
                 {
                     if (preview)
                     {
+                        if (PreviewContent.IsSinglePreview)
+                            return content.Instance.PreviewXmlContent;
                         var previewContent = PreviewContentCache.GetOrCreateValue(context); // will use the ctor with no parameters
                         previewContent.EnsureInitialized(context.UmbracoUser, StateHelper.Cookies.Preview.GetValue(), true, () =>
                         {

--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -96,6 +96,10 @@ namespace Umbraco.Web.Strategies
                     );
                 }
             };
+			
+            //Send notifications for the copy action
+            ContentService.Copied += (sender, args) => applicationContext.Services.NotificationService.SendNotification(
+                args.Original, ActionCopy.Instance, applicationContext);
         }
 
     }

--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -73,6 +73,10 @@ namespace Umbraco.Web.Strategies
                                               applicationContext.Services.NotificationService.SendNotification(
                                                   content, ActionUnPublish.Instance, applicationContext));
 
+            //Send notifications for the rollback action
+            ContentService.RolledBack += (sender, args) => applicationContext.Services.NotificationService.SendNotification(
+                                                               args.Entity, ActionRollback.Instance, applicationContext
+                                                           );
         }
 
     }

--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -59,12 +59,10 @@ namespace Umbraco.Web.Strategies
                     applicationContext.Services.NotificationService.SendNotification(updatedEntities, ActionUpdate.Instance, applicationContext);
                 };
 
-            //Send notifications for the delete action
-            ContentService.Deleted += (sender, args) =>
-                                      args.DeletedEntities.ForEach(
-                                          content =>
-                                          applicationContext.Services.NotificationService.SendNotification(
-                                              content, ActionDelete.Instance, applicationContext));
+            //Send notifications for the delete (send to recycle bin) action
+            ContentService.Trashed += (sender, args) => applicationContext.Services.NotificationService.SendNotification(
+                                                            args.MoveInfoCollection.Select(mi => mi.Entity), ActionDelete.Instance, applicationContext
+                                                        );
            
             //Send notifications for the unpublish action
             ContentService.UnPublished += (sender, args) =>

--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -100,7 +100,19 @@ namespace Umbraco.Web.Strategies
             //Send notifications for the copy action
             ContentService.Copied += (sender, args) => applicationContext.Services.NotificationService.SendNotification(
                 args.Original, ActionCopy.Instance, applicationContext);
-        }
 
+            //Send notifications for the permissions action
+            UserService.UserGroupPermissionsAssigned += (sender, args) =>
+            {
+                var entities = applicationContext.Services.ContentService.GetByIds(args.SavedEntities.Select(e => e.EntityId));
+
+                foreach(var entity in entities)
+                {
+                    applicationContext.Services.NotificationService.SendNotification(
+                        entity, ActionRights.Instance, applicationContext
+                    );
+                }
+            };
+        }
     }
 }

--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -72,11 +72,30 @@ namespace Umbraco.Web.Strategies
                                               content =>
                                               applicationContext.Services.NotificationService.SendNotification(
                                                   content, ActionUnPublish.Instance, applicationContext));
-
+												  
             //Send notifications for the rollback action
             ContentService.RolledBack += (sender, args) => applicationContext.Services.NotificationService.SendNotification(
-                                                               args.Entity, ActionRollback.Instance, applicationContext
-                                                           );
+                                                               args.Entity, ActionRollback.Instance, applicationContext);
+
+            //Send notifications for the move and restore actions
+            ContentService.Moved += (sender, args) =>
+            {
+                // notify about the move for all moved items
+                foreach(var moveInfo in args.MoveInfoCollection)
+                {
+                    applicationContext.Services.NotificationService.SendNotification(
+                        moveInfo.Entity, ActionMove.Instance, applicationContext
+                    );
+                }
+
+                // for any items being moved from the recycle bin (restored), explicitly notify about that too
+                foreach(var moveInfo in args.MoveInfoCollection.Where(m => m.OriginalPath.Contains(Constants.System.RecycleBinContentString)))
+                {
+                    applicationContext.Services.NotificationService.SendNotification(
+                        moveInfo.Entity, ActionRestore.Instance, applicationContext
+                    );
+                }
+            };
         }
 
     }

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/preview/PreviewContent.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/preview/PreviewContent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Globalization;
 using System.IO;
 using System.Xml;
@@ -11,11 +12,57 @@ using Umbraco.Core.Logging;
 
 namespace umbraco.presentation.preview
 {
-    //TODO : Migrate this to a new API!
+    public enum PreviewMode
+    {
+        Unknown = 0, // default value
+        Legacy,
+        Default
+    }
 
     public class PreviewContent
     {
-        // zb-00004 #29956 : refactor cookies names & handling
+        private static PreviewMode _previewMode;
+        private const PreviewMode DefaultPreviewMode = PreviewMode.Default;
+        private static int _singlePreviewCacheDurationSeconds = -1;
+        private const int DefaultSinglePreviewCacheDurationSeconds = 60;
+
+        public static PreviewMode PreviewMode
+        {
+            get
+            {
+                if (_previewMode != PreviewMode.Unknown)
+                    return _previewMode;
+
+                var appSettings = ConfigurationManager.AppSettings;
+                var setting = appSettings["Umbraco.Preview.Mode"];
+                if (setting.IsNullOrWhiteSpace())
+                    return _previewMode = DefaultPreviewMode;
+                if (Enum<PreviewMode>.TryParse(setting, false, out _previewMode))
+                    return _previewMode;
+                throw new ConfigurationErrorsException($"Failed to parse Umbraco.Preview.Mode appSetting, {setting} is not a valid value. "
+                    + "Valid values are: Vintage (default), SinglePreview.");
+            }
+        }
+
+        public static int SinglePreviewCacheDurationSeconds
+        {
+            get
+            {
+                if (_singlePreviewCacheDurationSeconds >= 0)
+                    return _singlePreviewCacheDurationSeconds;
+
+                var appSettings = ConfigurationManager.AppSettings;
+                var setting = appSettings["Umbraco.Preview.SinglePreview.CacheDurationSeconds"];
+                if (setting.IsNullOrWhiteSpace())
+                    return _singlePreviewCacheDurationSeconds = DefaultSinglePreviewCacheDurationSeconds;
+                if (int.TryParse(setting, out _singlePreviewCacheDurationSeconds))
+                    return _singlePreviewCacheDurationSeconds;
+                throw new ConfigurationErrorsException($"Failed to parse Umbraco.Preview.SinglePreview.CacheDurationSeconds appSetting, {setting} is not a valid value. "
+                    + "Valid values are positive integers.");
+            }
+        }
+
+        public static bool IsSinglePreview => PreviewMode == PreviewMode.Default;
 
         public XmlDocument XmlContent { get; set; }
         public Guid PreviewSet { get; set; }
@@ -35,6 +82,8 @@ namespace umbraco.presentation.preview
 
         public void EnsureInitialized(User user, string previewSet, bool validate, Action initialize)
         {
+            if (IsSinglePreview) return;
+
             lock (_initLock)
             {
                 if (_initialized) return;
@@ -53,17 +102,19 @@ namespace umbraco.presentation.preview
 
         public PreviewContent(Guid previewSet)
         {
-            ValidPreviewSet = UpdatePreviewPaths(previewSet, true);
+            ValidPreviewSet = IsSinglePreview || UpdatePreviewPaths(previewSet, true);
         }
         public PreviewContent(User user, Guid previewSet, bool validate)
         {
             _userId = user.Id;
-            ValidPreviewSet = UpdatePreviewPaths(previewSet, validate);
+            ValidPreviewSet = IsSinglePreview || UpdatePreviewPaths(previewSet, validate);
         }
 
 
         public void PrepareDocument(User user, Document documentObject, bool includeSubs)
         {
+            if (IsSinglePreview) return;
+
             _userId = user.Id;
 
             // clone xml
@@ -144,6 +195,8 @@ namespace umbraco.presentation.preview
         /// <returns></returns>
         public bool ValidatePreviewPath()
         {
+            if (IsSinglePreview) return true;
+
             if (!File.Exists(PreviewsetPath))
                 return false;
 
@@ -154,12 +207,21 @@ namespace umbraco.presentation.preview
 
         public void LoadPreviewset()
         {
-            XmlContent = new XmlDocument();
-            XmlContent.Load(PreviewsetPath);
+            if (IsSinglePreview)
+            {
+                XmlContent = content.Instance.PreviewXmlContent;
+            }
+            else
+            {
+                XmlContent = new XmlDocument();
+                XmlContent.Load(PreviewsetPath);
+            }
         }
 
         public void SavePreviewSet()
         {
+            if (IsSinglePreview) return;
+
             //make sure the preview folder exists first
             var dir = new DirectoryInfo(IOHelper.MapPath(SystemDirectories.Preview));
             if (!dir.Exists)
@@ -211,7 +273,7 @@ namespace umbraco.presentation.preview
         public static void ClearPreviewCookie()
         {
             // zb-00004 #29956 : refactor cookies names & handling
-            if (UmbracoContext.Current.UmbracoUser != null)
+            if (!IsSinglePreview && UmbracoContext.Current.UmbracoUser != null)
             {
                 if (StateHelper.Cookies.Preview.HasValue)
                 {


### PR DESCRIPTION
### Prerequisites
Ability to add redirects manually.  I know @marcemarc  started did this with PR 2511.

I have taken on the idea but have hit a couple of points where I need a hand.

Currently I have a add redirect on the dashboard which I can easily add to the info tab. My sticking points currently are:

The best way to validate the add request in the controller. 
 - User should be an admin or have publish rights on the target content item.

- Validation of the URL (either more in JS or controller)
@marcemarc  has a great list of checks  and questions in his code here -https://github.com/marcemarc/tooorangey.RumDo/blob/master/Solution/RumDo/App_Plugins/tooorangey.RumDo/redirecturlcheck.service.js

Whilst we work this all out Ill add a button to the info tab :)

Matt