### PR TITLE
V8: Fix infinite loop when saving multiple variants using list view 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -305,8 +305,8 @@
                 var fieldControl = item.control;
                 var fieldErrorKeys = item.errorKeys;
 
-                for (var i = 0; i < fieldErrorKeys.length; i++) {
-                    fieldControl.$setValidity(fieldErrorKeys[i], false);
+                for (var j = 0; j < fieldErrorKeys.length; j++) {
+                    fieldControl.$setValidity(fieldErrorKeys[j], false);
                 }
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

OK so here's a weird one. Took me a while to figure out what the heck was going on.

Bottom line: The editor can end up in an infinite JS loop when you save a variant type that uses list view. In Chrome, once the loop is triggered the only way out is to close browser the tab (which in turn forcefully closes the entire browser).

Steps to recreate:

1. Create a variant content type. You don't need to add any properties to it.
2. Enable list view for the content type.
3. Create some content of this type. 
4. Create each variant language one at a time without using split view.
5. Edit the content in split view and hit save.
6. Kaboom 💥 

It looks like this:

![split-view-infinite-loop](https://user-images.githubusercontent.com/7405322/51791041-89621780-219d-11e9-852a-ab1b6525540a.gif)

Apparently it's caused by an inner `for`-loop that uses the same iteration variable name (`i`) as it's parent `for`-loop. Of course one should never do that, but I'm still puzzled why it breaks like this. I would have thought JS was able to scope these variables. Anyway... changing the inner loop iteration variable to `j` fixes the problem.

...guess that's one more reason to use `angular.forEach` or `_.each` to do iterative operations.

