### PR TITLE
Image cropper: New crops have a weird offset

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagecrop.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagecrop.directive.js
@@ -103,34 +103,6 @@ angular.module("umbraco.directives")
 						scope.dimensions.cropper.height = _viewPortH; //  scope.dimensions.viewport.height - 2 * scope.dimensions.margin;
 					};
 
-
-					//when loading an image without any crop info, we center and fit it
-					var resizeImageToEditor = function(){
-						//returns size fitting the cropper
-						var size = cropperHelper.calculateAspectRatioFit(
-								scope.dimensions.image.width,
-								scope.dimensions.image.height,
-								scope.dimensions.cropper.width,
-								scope.dimensions.cropper.height,
-								true);
-
-						//sets the image size and updates the scope
-						scope.dimensions.image.width = size.width;
-						scope.dimensions.image.height = size.height;
-
-						//calculate the best suited ratios
-						scope.dimensions.scale.min = size.ratio;
-						scope.dimensions.scale.max = 2;
-						scope.dimensions.scale.current = size.ratio;
-
-						//center the image
-						var position = cropperHelper.centerInsideViewPort(scope.dimensions.image, scope.dimensions.cropper);
-						scope.dimensions.top = position.top;
-						scope.dimensions.left = position.left;
-
-						setConstraints();
-					};
-
 					//resize to a given ratio
 					var resizeImageToScale = function(ratio){
 						//do stuff
@@ -227,12 +199,19 @@ angular.module("umbraco.directives")
 						//set dimensions on image, viewport, cropper etc
 						setDimensions(image);
 
-						//if we have a crop already position the image
-						if(scope.crop){
-							resizeImageToCrop();
-						}else{
-							resizeImageToEditor();
-						}
+						//create a default crop if we haven't got one already
+                        var createDefaultCrop = !scope.crop;
+                        if (createDefaultCrop) {
+                            calculateCropBox();
+                        }
+
+						resizeImageToCrop();
+
+                        //if we're creating a new crop, make sure to zoom out fully
+                        if (createDefaultCrop) {
+                            scope.dimensions.scale.current = scope.dimensions.scale.min;
+    						resizeImageToScale(scope.dimensions.scale.min);
+                        }
 
 						//sets constaints for the cropper
 						setConstraints();

--- a/src/Umbraco.Web.UI.Client/src/common/services/cropperhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/cropperhelper.service.js
@@ -123,13 +123,6 @@ function cropperHelper(umbRequestHelper, $http) {
 			return crop;
 		},
 
-		centerInsideViewPort : function(img, viewport){
-			var left = viewport.width/ 2 - img.width / 2,
-				top = viewport.height / 2 - img.height / 2;
-			
-			return {left: left, top: top};
-		},
-
 		alignToCoordinates : function(image, center, viewport){
 			
 			var min_left = (image.width) - (viewport.width);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There's something weird going on with the image cropper. When you edit a crop for the first time, there's a horizontal offset that can't be undone no matter how much you zoom or drag the image within the crop editor. The only way to fix it is to click "Done" and edit the crop again.

It's a bit hard to explain ... but hopefully this movie makes it a bit clearer:

![image-crop-offset-before](https://user-images.githubusercontent.com/7405322/51800587-9597b480-2231-11e9-829d-bf9b52916345.gif)

It happens on both portrait and landscape and square images. 

To test it:

1. Create an image cropper with crops in various aspect ratios (portrait, landscape and square as minimum)
2. Upload an image and edit the crops.
3. Chances are you're unable to move the image all the way to the left in one or more of your crops.

With this PR applied it looks like this:

![image-crop-offset-after](https://user-images.githubusercontent.com/7405322/51800634-4d2cc680-2232-11e9-9bc3-6536ebebce14.gif)

As an added bonus this PR shaves a bit of complexity off the implementation by reusing the functionality tied to existing crops.