### PR TITLE
V8: Add a few missing localizations to edit media

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -42,7 +42,7 @@
                     <umb-button ng-if="model.infiniteMode"
                                 action="close()"
                                 button-style="link"
-                                label="Close"
+                                label-key="general_close"
                                 type="button">
                     </umb-button>
 
@@ -50,14 +50,13 @@
                                 ng-if="page.listViewPath"
                                 type="link"
                                 href="#{{page.listViewPath}}"
-                                label="Return to list"
                                 label-key="buttons_returnToList">
                     </umb-button>
 
                     <!-- label-key="buttons_save" -->
                     <umb-button alias="save"
                                 type="submit"
-                                label="{{page.submitButtonLabel}}"
+                                label-key="{{page.submitButtonLabelKey}}"
                                 button-style="success"
                                 shortcut="ctrl+s"
                                 state="page.saveButtonState">

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -40,7 +40,7 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource, 
     $scope.page.menu.currentNode = null; //the editors affiliated node
     $scope.page.listViewPath = null;
     $scope.page.saveButtonState = "init";
-    $scope.page.submitButtonLabel = "Save";
+    $scope.page.submitButtonLabelKey = "buttons_save";
 
     /** Syncs the content item to it's tree node - this occurs on first load and after saving */
     function syncTreeNode(content, path, initialLoad) {
@@ -103,7 +103,7 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource, 
 
         // setup infinite mode
         if(infiniteMode) {
-            $scope.page.submitButtonLabel = "Save and Close";
+            $scope.page.submitButtonLabelKey = "buttons_saveAndClose";
         }
 
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There are a few hardcoded English labels in edit media:

#### In normal mode

![image](https://user-images.githubusercontent.com/7405322/51801311-41460200-223c-11e9-8971-cb27fb889168.png)

#### In infinite editing mode

![image](https://user-images.githubusercontent.com/7405322/51801332-7ce0cc00-223c-11e9-9e31-9e81c90d8cac.png)

This PR replaces those labels with the corresponding localized ones.
