### PR TITLE
v8: Fix general localization

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/member/umbmembergroupnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/member/umbmembergroupnodeinfo.directive.js
@@ -7,8 +7,6 @@
 
             var evts = [];
 
-            scope.allowChangeMediaType = false;
-
             function onInit() {
 
                 // make sure dates are formatted to the user's locale

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/member/umbmembergroupnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/member/umbmembergroupnodeinfo.directive.js
@@ -1,0 +1,60 @@
+(function () {
+    'use strict';
+
+    function MemberGroupNodeInfoDirective(eventsService, userService, dateHelper) {
+
+        function link(scope, element, attrs, ctrl) {
+
+            var evts = [];
+
+            scope.allowChangeMediaType = false;
+
+            function onInit() {
+
+                // make sure dates are formatted to the user's locale
+                formatDatesToLocal();
+            }
+
+            function formatDatesToLocal() {
+                // get current backoffice user and format dates
+                userService.getCurrentUser().then(function (currentUser) {
+                    scope.node.createDateFormatted = dateHelper.getLocalDate(scope.node.createDate, currentUser.locale, 'LLL');
+                    scope.node.updateDateFormatted = dateHelper.getLocalDate(scope.node.updateDate, currentUser.locale, 'LLL');
+                });
+            }
+
+            // watch for content updates - reload content when node is saved, published etc.
+            scope.$watch('node.updateDate', function(newValue, oldValue){
+                if(!newValue) { return; }
+                if(newValue === oldValue) { return; }
+
+                // Update the create and update dates
+                formatDatesToLocal();
+            });
+
+            //ensure to unregister from all events!
+            scope.$on('$destroy', function () {
+                for (var e in evts) {
+                    eventsService.unsubscribe(evts[e]);
+                }
+            });
+
+            onInit();
+        }
+
+        var directive = {
+            restrict: 'E',
+            replace: true,
+            templateUrl: 'views/components/member/umb-membergroup-node-info.html',
+            scope: {
+                node: "="
+            },
+            link: link
+        };
+
+        return directive;
+    }
+
+    angular.module('umbraco.directives').directive('umbMembergroupNodeInfo', MemberGroupNodeInfoDirective);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
@@ -123,7 +123,7 @@
                     alias="close"
                     type="button"
                     button-style="link"
-                    label="Close"
+                    label-key="general_close"
                     action="vm.closeDrawer()">
                 </umb-button>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
@@ -8,7 +8,7 @@
 
         <umb-drawer-content>
 
-            <!-- Tours -->
+        <!-- Tours -->
         <div class="umb-help-section" ng-if="vm.tours" data-element="help-tours">
 
             <h5 class="umb-help-section__title">Tours</h5>
@@ -47,72 +47,71 @@
                     </div>
                 </div>
 
-            </div>
+        </div>
 
-
-            <!-- Show in custom help dashboard -->
+        <!-- Show in custom help dashboard -->
         <div class="umb-help-section" data-element="help-custom-dashboard" ng-if="vm.customDashboard.length > 0">
-                <div ng-repeat="tab in vm.customDashboard">
-                    <div ng-repeat="property in tab.properties">
-                        <div>
-                            <h5 ng-if="property.caption">{{property.caption}}</h5>
-                            <div ng-include="property.path"></div>
-                        </div>
+            <div ng-repeat="tab in vm.customDashboard">
+                <div ng-repeat="property in tab.properties">
+                    <div>
+                        <h5 ng-if="property.caption">{{property.caption}}</h5>
+                        <div ng-include="property.path"></div>
                     </div>
                 </div>
             </div>
+        </div>
 
-            <!--  Help Content -->
+        <!--  Help Content -->
         <div class="umb-help-section" data-element="help-articles" ng-if="vm.topics.length > 0">
             <h5 class="umb-help-section__title">Articles</h5>
-                <ul class="umb-help-list">
-                    <li class="umb-help-list-item" ng-repeat="topic in vm.topics track by $index">
-                    <a class="umb-help-list-item__content" data-element="help-article-{{topic.name}}" target="_blank" ng-href="{{topic.url}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
-                            <span>
-                                <span class="umb-help-list-item__title">
-                                    <span class="bold">{{topic.name}}</span>
-                                    <span class="umb-help-list-item__open-icon icon-out"></span>
-                                </span>
-                                <span class="umb-help-list-item__description">{{topic.description}}</span>
+            <ul class="umb-help-list">
+                <li class="umb-help-list-item" ng-repeat="topic in vm.topics track by $index">
+                <a class="umb-help-list-item__content" data-element="help-article-{{topic.name}}" target="_blank" ng-href="{{topic.url}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
+                        <span>
+                            <span class="umb-help-list-item__title">
+                                <span class="bold">{{topic.name}}</span>
+                                <span class="umb-help-list-item__open-icon icon-out"></span>
                             </span>
-                        </a>
-                    </li>
-                </ul>
-            </div>
+                            <span class="umb-help-list-item__description">{{topic.description}}</span>
+                        </span>
+                    </a>
+                </li>
+            </ul>
+        </div>
 
-            <!--  Umbraco tv content -->
+        <!--  Umbraco tv content -->
         <div class="umb-help-section" data-element="help-videos" ng-if="vm.hasAccessToSettings">
             <h5 class="umb-help-section__title" ng-if="vm.videos.length > 0">Videos</h5>
-                <ul class="umb-help-list">
-                    <li class="umb-help-list-item" ng-repeat="video in vm.videos track by $index">
-                    <a class="umb-help-list-item__content" data-element="help-article-{{video.title}}" target="_blank" ng-href="{{video.link}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
-                            <i class="umb-help-list-item__icon icon-tv-old"></i>
-                            <span class="umb-help-list-item__title">{{video.title}}</span>
-                            <i class="umb-help-list-item__open-icon icon-out"></i>
-                        </a>
-                    </li>
-                </ul>
-            </div>
+            <ul class="umb-help-list">
+                <li class="umb-help-list-item" ng-repeat="video in vm.videos track by $index">
+                <a class="umb-help-list-item__content" data-element="help-article-{{video.title}}" target="_blank" ng-href="{{video.link}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
+                        <i class="umb-help-list-item__icon icon-tv-old"></i>
+                        <span class="umb-help-list-item__title">{{video.title}}</span>
+                        <i class="umb-help-list-item__open-icon icon-out"></i>
+                    </a>
+                </li>
+            </ul>
+        </div>
 
-            <!--  Links -->
+        <!--  Links -->
         <div class="umb-help-section" data-element="help-links" ng-if="vm.hasAccessToSettings">
             <a data-element="help-link-umbraco-tv" class="umb-help-badge" target="_blank" href="https://umbraco.tv?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
-                    <i class="umb-help-badge__icon icon-tv-old"></i>
-                    <div class="umb-help-badge__title">Visit umbraco.tv</div>
-                    <small>
-                        <localize key="help_theBestUmbracoVideoTutorials">The best Umbraco video tutorials</localize>
-                    </small>
-                </a>
+                <i class="umb-help-badge__icon icon-tv-old"></i>
+                <div class="umb-help-badge__title">Visit umbraco.tv</div>
+                <small>
+                    <localize key="help_theBestUmbracoVideoTutorials">The best Umbraco video tutorials</localize>
+                </small>
+            </a>
 
             <a data-element="help-link-our-umbraco" class="umb-help-badge" target="_blank" href="https://our.umbraco.com?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=our">
-                    <i class="umb-help-badge__icon icon-favorite"></i>
+                <i class="umb-help-badge__icon icon-favorite"></i>
                     
-                    <div class="umb-help-badge__title">Visit our.umbraco.com</div>
-                    <small>
-                        <localize key="defaultdialogs_theFriendliestCommunity">The friendliest community</localize>
-                    </small>
-                </a>
-            </div>
+                <div class="umb-help-badge__title">Visit our.umbraco.com</div>
+                <small>
+                    <localize key="defaultdialogs_theFriendliestCommunity">The friendliest community</localize>
+                </small>
+            </a>
+        </div>
 
         </umb-drawer-content>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/member/umb-membergroup-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/member/umb-membergroup-node-info.html
@@ -1,0 +1,30 @@
+<div class="umb-package-details">
+    <div class="umb-package-details__main-content">
+        <umb-box>
+            <umb-box-header title-key="content_membergroup"></umb-box-header>
+            <umb-box-content class="block-form">
+
+                <umb-empty-state size="small">
+                    <localize key="member_memberGroupNoProperties">Member groups have no additional properties for editing.</localize>
+                </umb-empty-state>
+
+            </umb-box-content>
+        </umb-box>
+
+    </div>
+
+    <div class="umb-package-details__sidebar">
+        <umb-box data-element="node-info-general">
+            <umb-box-header title-key="general_general"></umb-box-header>
+            <umb-box-content class="block-form">
+
+                <umb-control-group ng-if="node.id !== 0" data-element="node-info-id" label="Id">
+                    <div>{{ node.id }}</div>
+                    <small>{{ node.key }}</small>
+                </umb-control-group>
+
+            </umb-box-content>
+        </umb-box>
+    </div>
+
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/macros/macros.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/macros.edit.controller.js
@@ -16,8 +16,7 @@ function MacrosEditController($scope, $q, $routeParams, macroResource, editorSta
     vm.page.loading = false;
     vm.page.saveButtonState = "init";
     vm.page.menu = {}
-
- 
+    vm.labels = {};
 
     function toggleValue(key) {
         vm.macro[key] = !vm.macro[key];
@@ -132,21 +131,32 @@ function MacrosEditController($scope, $q, $routeParams, macroResource, editorSta
             vm.page.loading = false;
         });
 
-        vm.page.navigation = [
-            {
-                "name": "Settings",
-                "alias": "settings",
-                "icon": "icon-settings",
-                "view": "views/macros/views/settings.html",
-                "active": true
-            },
-            {
-                "name": "Parameters",
-                "alias": "parameters",
-                "icon": "icon-list",
-                "view": "views/macros/views/parameters.html"
-            }
+        var labelKeys = [
+            "general_settings",
+            "macro_parameters"
         ];
+
+        localizationService.localizeMany(labelKeys).then(function (values) {
+            // navigation
+            vm.labels.settings = values[0];
+            vm.labels.parameters = values[1];
+
+            vm.page.navigation = [
+                {
+                    "name": vm.labels.settings,
+                    "alias": "settings",
+                    "icon": "icon-settings",
+                    "view": "views/macros/views/settings.html",
+                    "active": true
+                },
+                {
+                    "name": vm.labels.parameters,
+                    "alias": "parameters",
+                    "icon": "icon-list",
+                    "view": "views/macros/views/parameters.html"
+                }
+            ];
+        });
     }
 
     init();      

--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/macro.parameters.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/macro.parameters.controller.js
@@ -47,7 +47,6 @@ function MacrosParametersController($scope, editorService) {
             parameter.key = newParameter.key;
             parameter.label = newParameter.label;
             parameter.editor = newParameter.editor;
-            parameter.editor = newParameter.editor;
             $scope.model.setDirty();
         });
     }

--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/parameters.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/parameters.html
@@ -3,7 +3,7 @@
         <div class="sub-view-columns">
             <div class="sub-view-column-left">
                 <h5>Parameters</h5>
-                <small>Define the parameters hat should be available when using his macro</small>
+                <small>Define the parameters that should be available when using this macro.</small>
             </div>
             <div class="sub-view-column-right">
                 <div class="umb-property-editor umb-stylesheet-rules form-horizontal" ng-controller="Umbraco.Editors.Macros.ParametersController" >

--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/parameters.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/parameters.html
@@ -2,7 +2,7 @@
     <umb-box-content>
         <div class="sub-view-columns">
             <div class="sub-view-column-left">
-                <h5>Parameters</h5>
+                <h5><localize key="macro_parameters">Parameters</localize></h5>
                 <small>Define the parameters that should be available when using this macro.</small>
             </div>
             <div class="sub-view-column-right">

--- a/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.html
@@ -19,10 +19,14 @@
 
             <umb-editor-container class="form-horizontal">
 
-                <p><localize key="member_memberGroupNoProperties">Member groups have no additional properties for editing.</localize></p>
+                <umb-box>
+                    <umb-box-header title-key="general_properties"></umb-box-header>
+                    <umb-box-content>
+                        <p><localize key="member_memberGroupNoProperties">Member groups have no additional properties for editing.</localize></p>
+                    </umb-box-content>
+                </umb-box>
 
             </umb-editor-container>
-            
 
             <umb-editor-footer>
 

--- a/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.html
@@ -19,12 +19,9 @@
 
             <umb-editor-container class="form-horizontal">
 
-                <umb-box>
-                    <umb-box-header title-key="general_properties"></umb-box-header>
-                    <umb-box-content>
-                        <p><localize key="member_memberGroupNoProperties">Member groups have no additional properties for editing.</localize></p>
-                    </umb-box-content>
-                </umb-box>
+                <umb-membergroup-node-info ng-if="content"
+                                           node="content">
+                </umb-membergroup-node-info>
 
             </umb-editor-container>
 

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1020,6 +1020,11 @@ Mange hilsner fra Umbraco robotten
     <key alias="sortPleaseWait"><![CDATA[Vent venligst mens siderne sorteres. Det kan tage et stykke tid.]]></key>
   </area>
   <area alias="speechBubbles">
+    <key alias="validationFailedHeader">Validering</key>
+    <key alias="validationFailedMessage">Valideringsfejl skal rettes før elementet kan gemmes</key>
+    <key alias="operationFailedHeader">Fejlet</key>
+    <key alias="operationSavedHeader">Gemt</key>
+    <key alias="invalidUserPermissionsText">Utilstrækkelige brugerrettigheder, kunne ikke fuldføre handlingen</key>
     <key alias="operationCancelledHeader">Annulleret</key>
     <key alias="operationCancelledText">Handlingen blev annulleret af et 3. part tilføjelsesprogram</key>
     <key alias="contentTypeDublicatePropertyType">Property type eksisterer allerede</key>
@@ -1051,6 +1056,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="editUserError">Der er opstået en fejl under redigering</key>
     <key alias="editUserSaved">Bruger gemt</key>
     <key alias="editUserTypeSaved">Brugertype gemt</key>
+    <key alias="editUserGroupSaved">Brugergruppe gemt</key>
     <key alias="fileErrorHeader">Fil ikke gemt</key>
     <key alias="fileErrorText">Filen kunne ikke gemmes. Tjek filrettighederne</key>
     <key alias="fileSavedHeader">Fil gemt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1223,6 +1223,7 @@ Mange hilsner fra Umbraco robotten
   <area alias="contentTypeEditor">
     <key alias="compositions">Kompositioner</key>
     <key alias="noTabs">Du har ikke tilføjet nogle faner</key>
+    <key alias="addGroup">Tilføj gruppe</key>
     <key alias="inheritedFrom">Nedarvet fra</key>
     <key alias="addProperty">Tilføj egenskab</key>
     <key alias="requiredLabel">Påkrævet label</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1044,6 +1044,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="editMediaSaved">Medie gemt</key>
     <key alias="editMediaSavedText">Medie gemt uden problemer</key>
     <key alias="editMemberSaved">Medlem gemt</key>
+    <key alias="editMemberGroupSaved">Medlemsgruppe gemt</key>
     <key alias="editStylesheetPropertySaved">Stylesheetegenskab gemt</key>
     <key alias="editStylesheetSaved">Stylesheet gemt</key>
     <key alias="editTemplateSaved">Skabelon gemt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1346,7 +1346,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="stylesheets">Stylesheets</key>
     <key alias="templates">Skabeloner</key>
     <key alias="userPermissions">Brugertilladelser</key>
-    <key alias="userTypes">Bruger Typer</key>
+    <key alias="userTypes">Brugertyper</key>
     <key alias="users">Brugere</key>
   </area>
   <area alias="update">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1337,7 +1337,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="packager">Pakker</key>
     <key alias="packages">Pakker</key>
     <key alias="partialViews">Partial Views</key>
-    <key alias="partialViewMacros">Partial View Makro Filer</key>
+    <key alias="partialViewMacros">Partial View makrofiler</key>
     <key alias="repositories">Installer fra "repository"</key>
     <key alias="runway">Installer Runway</key>
     <key alias="runwayModules">Runway-moduler</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1348,6 +1348,9 @@ Mange hilsner fra Umbraco robotten
     <key alias="userPermissions">Brugertilladelser</key>
     <key alias="userTypes">Brugertyper</key>
     <key alias="users">Brugere</key>
+    <key alias="settingsGroup">Indstillinger</key>
+    <key alias="templatingGroup">Templating</key>
+    <key alias="thirdPartyGroup">Tredjepart</key>
   </area>
   <area alias="update">
     <key alias="updateAvailable">Ny opdatering er klar</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1064,6 +1064,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="languageSaved">Sprog gemt</key>
     <key alias="mediaTypeSavedHeader">Medietype gemt</key>
     <key alias="memberTypeSavedHeader">Medlemstype gemt</key>
+    <key alias="memberGroupSavedHeader">Medlemsgruppe gemt</key>
     <key alias="templateErrorHeader">Skabelon ikke gemt</key>
     <key alias="templateErrorText">Undgå venligst at du har 2 templates med samme alias</key>
     <key alias="templateSavedHeader">Skabelon gemt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1349,7 +1349,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="userTypes">Brugertyper</key>
     <key alias="users">Brugere</key>
     <key alias="settingsGroup">Indstillinger</key>
-    <key alias="templatingGroup">Templating</key>
+    <key alias="templatingGroup">Design og layout</key>
     <key alias="thirdPartyGroup">Tredjepart</key>
   </area>
   <area alias="update">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -299,6 +299,7 @@
   <area alias="member">
     <key alias="createNewMember">Opret et nyt medlem</key>
     <key alias="allMembers">Alle medlemmer</key>
+    <key alias="memberGroupNoProperties">Medlemgrupper har ingen yderligere egenskaber til redigering.</key>
   </area>
   <area alias="create">
     <key alias="chooseNode">Hvor ønsker du at oprette den nye %0%</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1264,16 +1264,17 @@ Mange hilsner fra Umbraco robotten
     <key alias="elementDoesNotSupport">Dette benyttes ikke for en Element-type</key>
   </area>
   <area alias="languages">
-      <key alias="addLanguage">Tilføj sprog</key>
-      <key alias="mandatoryLanguage">Påkrævet sprog</key>
-      <key alias="mandatoryLanguageHelp">Egenskaber på dette sprog skal være udfyldt før noden kan blive udgivet.</key>
-      <key alias="defaultLanguage">Standard sprog</key>
-      <key alias="defaultLanguageHelp">Et Umbraco site kan kun have et standard sprog.</key>
-      <key alias="changingDefaultLanguageWarning">Ved at skifte standardsprog kan resultere i standard indhold mangler.</key>
-      <key alias="fallsbackToLabel">Fallsback til</key>
-      <key alias="noFallbackLanguageOption">Ingen fallback sprog</key>
-      <key alias="fallbackLanguageDescription">For at tillade flersproget indhold til at falde tilbage på et andet sprog, hvis det ikke er tilgængelig i det anmodet sprog, vælg det her.</key>
-      <key alias="fallbackLanguage">Fallback sprog</key>
+    <key alias="addLanguage">Tilføj sprog</key>
+    <key alias="mandatoryLanguage">Påkrævet sprog</key>
+    <key alias="mandatoryLanguageHelp">Egenskaber på dette sprog skal være udfyldt før noden kan blive udgivet.</key>
+    <key alias="defaultLanguage">Standard sprog</key>
+    <key alias="defaultLanguageHelp">Et Umbraco site kan kun have et standard sprog.</key>
+    <key alias="changingDefaultLanguageWarning">Ved at skifte standardsprog kan resultere i standard indhold mangler.</key>
+    <key alias="fallsbackToLabel">Fallsback til</key>
+    <key alias="noFallbackLanguageOption">Ingen fallback sprog</key>
+    <key alias="fallbackLanguageDescription">For at tillade flersproget indhold til at falde tilbage på et andet sprog, hvis det ikke er tilgængelig i det anmodet sprog, vælg det her.</key>
+    <key alias="fallbackLanguage">Fallback sprog</key>
+  </area>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternativt felt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -622,6 +622,7 @@
     <key alias="searchNoResult">Beklager, vi kan ikke finde det, du leder efter.</key>
     <key alias="noItemsInList">Ingen elementer er blevet tilføjet</key>
     <key alias="server">Server</key>
+    <key alias="settings">Indstillinger</key>
     <key alias="show">Vis</key>
     <key alias="showPageOnSend">Hvilken side skal vises efter at formularen er sendt</key>
     <key alias="size">Størrelse</key>
@@ -1275,6 +1276,8 @@ Mange hilsner fra Umbraco robotten
     <key alias="fallbackLanguageDescription">For at tillade flersproget indhold til at falde tilbage på et andet sprog, hvis det ikke er tilgængelig i det anmodet sprog, vælg det her.</key>
     <key alias="fallbackLanguage">Fallback sprog</key>
   </area>
+  <area alias="macro">
+    <key alias="parameters">Parametre</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternativt felt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -323,7 +323,7 @@
     <key alias="documentTypeWithoutTemplate">Document Type without a template</key>
     <key alias="newFolder">New folder</key>
     <key alias="newDataType">New data type</key>
-        <key alias="newJavascriptFile">New JavaScript file</key>
+    <key alias="newJavascriptFile">New JavaScript file</key>
     <key alias="newEmptyPartialView">New empty partial view</key>
     <key alias="newPartialViewMacro">New partial view macro</key>
     <key alias="newPartialViewFromSnippet">New partial view from snippet</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1544,6 +1544,18 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="elementDescription">An Element type is meant to be used for instance in Nested Content, and not in the tree</key>
     <key alias="elementDoesNotSupport">This is not applicable for an Element type</key>
   </area>
+  <area alias="languages">
+    <key alias="addLanguage">Add language</key>
+    <key alias="mandatoryLanguage">Mandatory language</key>
+    <key alias="mandatoryLanguageHelp">Properties on this language have to be filled out before the node can be published.</key>
+    <key alias="defaultLanguage">Default language</key>
+    <key alias="defaultLanguageHelp">An Umbraco site can only have one default language set.</key>
+    <key alias="changingDefaultLanguageWarning">Switching default language may result in default content missing.</key>
+    <key alias="fallsbackToLabel">Falls back to</key>
+    <key alias="noFallbackLanguageOption">No fall back language</key>
+    <key alias="fallbackLanguageDescription">To allow multi-lingual content to fall back to another language if not present in the requested language, select it here.</key>
+    <key alias="fallbackLanguage">Fall back language</key>
+  </area>
   <area alias="modelsBuilder">
     <key alias="buildingModels">Building models</key>
     <key alias="waitingMessage">this can take a bit of time, don't worry</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1653,10 +1653,11 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="scripts">Scripts</key>
     <key alias="stylesheets">Stylesheets</key>
     <key alias="templates">Templates</key>
+    <key alias="logViewer">Log Viewer</key>
     <key alias="users">Users</key>
-        <key alias="settingsGroup">Settings</key>
-        <key alias="templatingGroup">Templating</key>
-        <key alias="thirdPartyGroup">Third Party</key>
+    <key alias="settingsGroup">Settings</key>
+    <key alias="templatingGroup">Templating</key>
+    <key alias="thirdPartyGroup">Third Party</key>
   </area>
   <area alias="update">
     <key alias="updateAvailable">New update ready</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1218,11 +1218,11 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="externalLinkPlaceholder">Enter the link</key>
   </area>
   <area alias="imagecropper">
-        <key alias="reset">Reset crop</key>
+    <key alias="reset">Reset crop</key>
     <key alias="saveCrop">Save crop</key>
     <key alias="addCrop">Add new crop</key>
-        <key alias="updateEditCrop">Done</key>
-        <key alias="undoEditCrop">Undo edits</key>
+    <key alias="updateEditCrop">Done</key>
+    <key alias="undoEditCrop">Undo edits</key>
   </area>
   <area alias="rollback">
     <key alias="headline">Select a version to compare with the current version</key>
@@ -1314,7 +1314,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="editContentSendToPublish">Sent For Approval</key>
     <key alias="editContentSendToPublishText">Changes have been sent for approval</key>
     <key alias="editMediaSaved">Media saved</key>
-        <key alias="editMemberGroupSaved">Member group saved</key>
+    <key alias="editMemberGroupSaved">Member group saved</key>
     <key alias="editMediaSavedText">Media saved without any errors</key>
     <key alias="editMemberSaved">Member saved</key>
     <key alias="editStylesheetPropertySaved">Stylesheet Property Saved</key>
@@ -1331,6 +1331,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="languageSaved">Language saved</key>
     <key alias="mediaTypeSavedHeader">Media Type saved</key>
     <key alias="memberTypeSavedHeader">Member Type saved</key>
+    <key alias="memberGroupSavedHeader">Member Group saved</key>
     <key alias="templateErrorHeader">Template not saved</key>
     <key alias="templateErrorText">Please make sure that you do not have 2 templates with the same alias</key>
     <key alias="templateSavedHeader">Template saved</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -652,7 +652,7 @@
     <key alias="rights">Permissions</key>
     <key alias="scheduledPublishing">Scheduled Publishing</key>
     <key alias="search">Search</key>
-        <key alias="searchNoResult">Sorry, we can not find what you are looking for.</key>
+    <key alias="searchNoResult">Sorry, we can not find what you are looking for.</key>
     <key alias="noItemsInList">No items have been added</key>
     <key alias="server">Server</key>
     <key alias="settings">Settings</key>
@@ -1555,6 +1555,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="noFallbackLanguageOption">No fall back language</key>
     <key alias="fallbackLanguageDescription">To allow multi-lingual content to fall back to another language if not present in the requested language, select it here.</key>
     <key alias="fallbackLanguage">Fall back language</key>
+  </area>
+  <area alias="macro">
+    <key alias="parameters">Parameters</key>
   </area>
   <area alias="modelsBuilder">
     <key alias="buildingModels">Building models</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1493,6 +1493,7 @@ To manage your website, simply open the Umbraco back office and start adding con
   <area alias="contentTypeEditor">
     <key alias="compositions">Compositions</key>
     <key alias="noTabs">You have not added any tabs</key>
+    <key alias="addGroup">Add group</key>
     <key alias="inheritedFrom">Inherited from</key>
     <key alias="addProperty">Add property</key>
     <key alias="requiredLabel">Required label</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -302,10 +302,10 @@
     <key alias="disallowedFileType">Cannot upload this file, it does not have an approved file type</key>
     <key alias="maxFileSize">Max file size is</key>
     <key alias="mediaRoot">Media root</key>
-        <key alias="moveFailed">Failed to move media</key>
-        <key alias="copyFailed">Failed to copy media</key>
-        <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>
-        <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>
+    <key alias="moveFailed">Failed to move media</key>
+    <key alias="copyFailed">Failed to copy media</key>
+    <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>
+    <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1684,9 +1684,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="templates">Templates</key>
     <key alias="logViewer">Log Viewer</key>
     <key alias="users">Users</key>
-        <key alias="settingsGroup">Settings</key>
-        <key alias="templatingGroup">Templating</key>
-        <key alias="thirdPartyGroup">Third Party</key>
+    <key alias="settingsGroup">Settings</key>
+    <key alias="templatingGroup">Templating</key>
+    <key alias="thirdPartyGroup">Third Party</key>
   </area>
   <area alias="update">
     <key alias="updateAvailable">New update ready</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1336,6 +1336,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="languageSaved">Language saved</key>
     <key alias="mediaTypeSavedHeader">Media Type saved</key>
     <key alias="memberTypeSavedHeader">Member Type saved</key>
+    <key alias="memberGroupSavedHeader">Member Group saved</key>
     <key alias="templateErrorHeader">Template not saved</key>
     <key alias="templateErrorText">Please make sure that you do not have 2 templates with the same alias</key>
     <key alias="templateSavedHeader">Template saved</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -306,11 +306,11 @@
     <key alias="disallowedFileType">Cannot upload this file, it does not have an approved file type</key>
     <key alias="maxFileSize">Max file size is</key>
     <key alias="mediaRoot">Media root</key>
-        <key alias="moveFailed">Failed to move media</key>
-        <key alias="moveToSameFolderFailed">Parent and destination folders cannot be the same</key>
-        <key alias="copyFailed">Failed to copy media</key>
-        <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>
-        <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>
+    <key alias="moveFailed">Failed to move media</key>
+    <key alias="moveToSameFolderFailed">Parent and destination folders cannot be the same</key>
+    <key alias="copyFailed">Failed to copy media</key>
+    <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>
+    <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1572,6 +1572,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="fallbackLanguageDescription">To allow multi-lingual content to fall back to another language if not present in the requested language, select it here.</key>
     <key alias="fallbackLanguage">Fall back language</key>
   </area>
+  <area alias="macro">
+    <key alias="parameters">Parameters</key>
+  </area>
   <area alias="modelsBuilder">
     <key alias="buildingModels">Building models</key>
     <key alias="waitingMessage">this can take a bit of time, don't worry</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1773,7 +1773,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="userInvitedSuccessHelp">An invitation has been sent to the new user with details about how to log in to Umbraco.</key>
     <key alias="userinviteWelcomeMessage">Hello there and welcome to Umbraco! In just 1 minute you’ll be good to go, we just need you to setup a password and add a picture for your avatar.</key>
     <key alias="userinviteExpiredMessage">Welcome to Umbraco! Unfortunately your invite has expired. Please contact your administrator and ask them to resend it.</key>
-        <key alias="userinviteAvatarMessage">Uploading a photo of yourself will make it easy for other users to recognize you. Click the circle above to upload your photo.</key>
+    <key alias="userinviteAvatarMessage">Uploading a photo of yourself will make it easy for other users to recognize you. Click the circle above to upload your photo.</key>
     <key alias="writer">Writer</key>
     <key alias="change">Change</key>
     <key alias="yourProfile" version="7.0">Your profile</key>

--- a/src/Umbraco.Web/Editors/MemberGroupController.cs
+++ b/src/Umbraco.Web/Editors/MemberGroupController.cs
@@ -93,7 +93,11 @@ namespace Umbraco.Web.Editors
             service.Save(memberGroup);
 
             var display = Mapper.Map<IMemberGroup, MemberGroupDisplay>(memberGroup);
-            display.AddSuccessNotification(Services.TextService.Localize("speechBubbles/memberGroupSaved"), string.Empty);
+
+            display.AddSuccessNotification(
+                            Services.TextService.Localize("speechBubbles/memberGroupSavedHeader"),
+                            string.Empty);
+
             return display;
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have fixed a few localization e.g. the new tree groups in v8 - the word `Templating` is not easy to translate directly to Danish. Some suggestion could be `Design` or `Layout`. Maybe @kjac og @hartvig have some suggestions?

I have also localize the close button in help drawer and the text on member groups which haven't any properties.

![image](https://user-images.githubusercontent.com/2919859/51802890-bc181880-224e-11e9-94d7-75996f4282d1.png)
