### PR TITLE
V8: Remove the menuDialogTitle tooltip

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbcontextdialog/umbcontextdialog.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbcontextdialog/umbcontextdialog.directive.js
@@ -25,7 +25,7 @@
             transclude: true,
             templateUrl: "views/components/tree/umbcontextdialog/umb-context-dialog.html",
             scope: {
-                title: "<",
+                dialogTitle: "<",
                 currentNode: "<",
                 view: "<"
             },

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -38,7 +38,7 @@
 
             <umb-context-dialog
                 ng-if="showContextMenuDialog"
-                title="menuDialogTitle"
+                dialog-title="menuDialogTitle"
                 current-node="menuNode"
                 view="dialogTemplateUrl">
             </umb-context-dialog>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umbcontextdialog/umb-context-dialog.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umbcontextdialog/umb-context-dialog.html
@@ -1,6 +1,6 @@
 <div id="dialog" class="umb-modalcolumn fill shadow" on-outside-click="outSideClick()">
     <div class="umb-modalcolumn-header">
-        <h1>{{title}}</h1>
+        <h1>{{dialogTitle}}</h1>
     </div>
     <div class="umb-modalcolumn-body" ng-include="view"></div>
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4273

### Description

See description in #4273.

The tooltip is shown because the `umb-context-dialog` directive uses the `title` attribute to pass the dialog title parameter. `title` however is also interpreted by the browser as the tooltip for the `<umb-context-dialog />` element, and thus the tooltip displays the name of the parameter in the container scope (which happens to be `menuDialogTitle`).

Fixed by renaming the dialog title parameter to `dialog-title`.