### PR TITLE
V8: Don't fail the install if the user opts out of a custom machine key

### DIFF
--- a/src/Umbraco.Web/Install/InstallSteps/ConfigureMachineKey.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/ConfigureMachineKey.cs
@@ -33,7 +33,7 @@ namespace Umbraco.Web.Install.InstallSteps
         /// <returns></returns>
         public override Task<InstallSetupResult> ExecuteAsync(bool? model)
         {
-            if (model.HasValue && model.Value == false) return null;
+            if (model.HasValue && model.Value == false) return Task.FromResult<InstallSetupResult>(null);
 
             //install the machine key
             var fileName = IOHelper.MapPath($"{SystemDirectories.Root}/web.config");
@@ -43,7 +43,7 @@ namespace Umbraco.Web.Install.InstallSteps
 
             // Update appSetting if it exists, or else create a new appSetting for the given key and value
             var machineKey = systemWeb.Descendants("machineKey").FirstOrDefault();
-            if (machineKey != null) return null;
+            if (machineKey != null) return Task.FromResult<InstallSetupResult>(null);
 
             var generator = new MachineKeyGenerator();
             var generatedSection = generator.GenerateConfigurationBlock();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you opt out of a custom machine key during install you're faced with this:

![image](https://user-images.githubusercontent.com/7405322/51857491-b09e1d80-2332-11e9-8f24-42f5ae50da0a.png)

This PR fixes the custom machine key install step for those to choose not to have a custom machine key.

#### Steps to reproduce:

1. On the install screen first select "Customize"
2. Then select "I don't want a custom Machine Key"
3. Finally select "Continue".
4. The error occurs.