### PR TITLE
Obsolete direct hash generation methods, and switch to GenerateHash

### DIFF
--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -731,6 +731,7 @@ namespace Umbraco.Core
         /// </summary>
         /// <param name="stringToConvert">Referrs to itself</param>
         /// <returns>The MD5 hashed string</returns>
+        [Obsolete("Please use the GenerateHash method instead. This may be removed in future versions")]
         public static string ToMd5(this string stringToConvert)
         {
             return stringToConvert.GenerateHash("MD5");
@@ -741,6 +742,7 @@ namespace Umbraco.Core
         /// </summary>
         /// <param name="stringToConvert">referrs to itself</param>
         /// <returns>The SHA1 hashed string</returns>
+        [Obsolete("Please use the GenerateHash method instead. This may be removed in future versions")]
         public static string ToSHA1(this string stringToConvert)
         {
             return stringToConvert.GenerateHash("SHA1");

--- a/src/Umbraco.Web/Models/Mapping/UserModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/UserModelMapper.cs
@@ -323,7 +323,7 @@ namespace Umbraco.Web.Models.Mapping
                 .ForMember(detail => detail.Culture, opt => opt.MapFrom(user => user.GetUserCulture(applicationContext.Services.TextService)))
                 .ForMember(
                     detail => detail.EmailHash,
-                    opt => opt.MapFrom(user => user.Email.ToLowerInvariant().Trim().ToMd5()))
+                    opt => opt.MapFrom(user => user.Email.ToLowerInvariant().Trim().GenerateHash()))
                 .ForMember(detail => detail.ParentId, opt => opt.UseValue(-1))
                 .ForMember(detail => detail.Path, opt => opt.MapFrom(user => "-1," + user.Id))
                 .ForMember(detail => detail.Notifications, opt => opt.Ignore())


### PR DESCRIPTION
As noted in https://github.com/umbraco/Umbraco-CMS/issues/4292, using direct hash methods can break compliance when on restricted systems that require FIPS compliance.  This has been addressed in a few commits.  This commit goes further to obsolete methods not previously obsoleted relating to direct hashing calls, and switches a direct call to one of these methods to use the correct, generic GenerateHash.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: #4292

### Description
These changes make it possible to run Umbraco on a FIPS-enabled Windows server.  To test this:

Follow the steps at https://our.umbraco.com/documentation/Getting-Started/Setup/Install/install-umbraco-manually to install Umbraco 7.13.1.

Browse the front and log in to the back-office to ensure the site is up and running correctly.

Follow the steps at https://our.umbraco.com/documentation/Reference/Security/Setup-Umbraco-for-a-Fips-Server/ to add needed code for enabling FIPS compliance in Lucene.NET, as well as the steps for how to setup a FIPS-enabled machine.  Note that instead of using an assembly attribute on a website project, you can also add a custom class to a new assembly which extends ApplicationEventHandler and sets the FIPS compliance in the OnApplicationInitializing method.  Then compile that into a DLL and add it to the BIN folder of the website.

Browse the front-office and ensure it still works.

Log in to the back-office and browse to the Users section.  If you see a listing of users, the fix is working correctly.  If instead you see an error related to an invalid cryptographic algorithm, the fix is not working correctly.

