### PR TITLE
PartialView & PartialViewMacros template generation fix

### DIFF
--- a/src/Umbraco.Core/Services/Implement/FileService.cs
+++ b/src/Umbraco.Core/Services/Implement/FileService.cs
@@ -764,6 +764,12 @@ namespace Umbraco.Core.Services.Implement
                     //strip the @inherits if it's there
                     snippetContent = StripPartialViewHeader(snippetContent);
 
+                    //Update Model.Content. to be Model. when used as PartialView
+                    if(partialViewType == PartialViewType.PartialView)
+                    {
+                        snippetContent = snippetContent.Replace("Model.Content.", "Model.");
+                    }
+
                     partialViewContent = $"{partialViewHeader}{Environment.NewLine}{snippetContent}";
                 }
             }
@@ -790,7 +796,7 @@ namespace Umbraco.Core.Services.Implement
             }
 
             return Attempt<IPartialView>.Succeed(partialView);
-        }
+        }        
 
         public bool DeletePartialView(string path, int userId = 0)
         {
@@ -1026,6 +1032,12 @@ namespace Umbraco.Core.Services.Implement
 
                 //strip the @inherits if it's there
                 snippetContent = StripPartialViewHeader(snippetContent);
+
+                //Update Model.Content. to be Model. when used as PartialView
+                if (partialViewType == PartialViewType.PartialView)
+                {
+                    snippetContent = snippetContent.Replace("Model.Content.", "Model.");
+                }
 
                 var content = $"{partialViewHeader}{Environment.NewLine}{snippetContent}";
                 return content;


### PR DESCRIPTION
When creating a PartialView we do a string.replace for `Model.Content` to be `Model.` as MacroPartialViews work with Model.Content and PartialViews like Model.

Connects to #4244 