### PR TITLE
Validate both width and height

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
@@ -35,7 +35,7 @@ angular.module("umbraco.directives")
                     var $overlay = element.find(".overlay");
 
 				    scope.style = function () {
-                        if (scope.dimensions.width <= 0) {
+                        if (scope.dimensions.width <= 0 || scope.dimensions.height <= 0) {
 							setDimensions();
 						}
 


### PR DESCRIPTION
Make sure to validate both width and height before running "setDimensions();". 

The focus point will not work if we have "img { width: 100%; }" in the stylesheet. 

This pull request will fix the bug.