### PR TITLE
V8: Respect the name casing when creating a new template

### DIFF
--- a/src/Umbraco.Core/Services/IFileService.cs
+++ b/src/Umbraco.Core/Services/IFileService.cs
@@ -200,7 +200,7 @@ namespace Umbraco.Core.Services
         /// </returns>
         Attempt<OperationResult<OperationResultType, ITemplate>> CreateTemplateForContentType(string contentTypeAlias, string contentTypeName, int userId = 0);
 
-        ITemplate CreateTemplateWithIdentity(string name, string content, ITemplate masterTemplate = null, int userId = 0);
+        ITemplate CreateTemplateWithIdentity(string name, string alias, string content, ITemplate masterTemplate = null, int userId = 0);
 
         /// <summary>
         /// Deletes a template by its alias

--- a/src/Umbraco.Core/Services/Implement/FileService.cs
+++ b/src/Umbraco.Core/Services/Implement/FileService.cs
@@ -390,16 +390,17 @@ namespace Umbraco.Core.Services.Implement
         /// Create a new template, setting the content if a view exists in the filesystem
         /// </summary>
         /// <param name="name"></param>
+        /// <param name="alias"></param>
         /// <param name="content"></param>
         /// <param name="masterTemplate"></param>
         /// <param name="userId"></param>
         /// <returns></returns>
-        public ITemplate CreateTemplateWithIdentity(string name, string content, ITemplate masterTemplate = null, int userId = 0)
+        public ITemplate CreateTemplateWithIdentity(string name, string alias, string content, ITemplate masterTemplate = null, int userId = 0)
         {
             // file might already be on disk, if so grab the content to avoid overwriting
-            var template = new Template(name, name)
+            var template = new Template(name, alias)
             {
-                Content = GetViewContent(name) ?? content
+                Content = GetViewContent(alias) ?? content
             };
             
             if (masterTemplate != null)

--- a/src/Umbraco.Tests/Services/FileServiceTests.cs
+++ b/src/Umbraco.Tests/Services/FileServiceTests.cs
@@ -19,8 +19,8 @@ namespace Umbraco.Tests.Services
         [Test]
         public void Create_Template_Then_Assign_Child()
         {
-            var child = ServiceContext.FileService.CreateTemplateWithIdentity("child", "test");
-            var parent = ServiceContext.FileService.CreateTemplateWithIdentity("parent", "test");
+            var child = ServiceContext.FileService.CreateTemplateWithIdentity("Child", "child", "test");
+            var parent = ServiceContext.FileService.CreateTemplateWithIdentity("Parent", "parent", "test");
 
             child.SetMasterTemplate(parent);
             ServiceContext.FileService.SaveTemplate(child);
@@ -34,8 +34,8 @@ namespace Umbraco.Tests.Services
         [Test]
         public void Create_Template_With_Child_Then_Unassign()
         {
-            var parent = ServiceContext.FileService.CreateTemplateWithIdentity("parent", "test");
-            var child = ServiceContext.FileService.CreateTemplateWithIdentity("child", "test", parent);
+            var parent = ServiceContext.FileService.CreateTemplateWithIdentity("Parent", "parent", "test");
+            var child = ServiceContext.FileService.CreateTemplateWithIdentity("Child", "child", "test", parent);
 
             child.SetMasterTemplate(null);
             ServiceContext.FileService.SaveTemplate(child);
@@ -48,14 +48,27 @@ namespace Umbraco.Tests.Services
         [Test]
         public void Can_Query_Template_Children()
         {
-            var parent = ServiceContext.FileService.CreateTemplateWithIdentity("parent", "test");
-            var child1 = ServiceContext.FileService.CreateTemplateWithIdentity("child1", "test", parent);
-            var child2 = ServiceContext.FileService.CreateTemplateWithIdentity("child2", "test", parent);
+            var parent = ServiceContext.FileService.CreateTemplateWithIdentity("Parent", "parent", "test");
+            var child1 = ServiceContext.FileService.CreateTemplateWithIdentity("Child1", "child1", "test", parent);
+            var child2 = ServiceContext.FileService.CreateTemplateWithIdentity("Child2", "child2", "test", parent);
 
             var children = ServiceContext.FileService.GetTemplates(parent.Id).Select(x => x.Id).ToArray();
 
             Assert.IsTrue(children.Contains(child1.Id));
             Assert.IsTrue(children.Contains(child2.Id));
+        }
+
+        [Test]
+        public void Create_Template_With_Custom_Alias()
+        {
+            var template = ServiceContext.FileService.CreateTemplateWithIdentity("Test template", "customTemplateAlias", "test");
+
+            ServiceContext.FileService.SaveTemplate(template);
+
+            template = ServiceContext.FileService.GetTemplate(template.Id);
+
+            Assert.AreEqual("Test template", template.Name);
+            Assert.AreEqual("customTemplateAlias", template.Alias);
         }
 
     }

--- a/src/Umbraco.Web/Editors/TemplateController.cs
+++ b/src/Umbraco.Web/Editors/TemplateController.cs
@@ -184,7 +184,7 @@ namespace Umbraco.Web.Editors
                         throw new HttpResponseException(HttpStatusCode.NotFound);
                 }
 
-                var template = Services.FileService.CreateTemplateWithIdentity(display.Alias, display.Content, master);
+                var template = Services.FileService.CreateTemplateWithIdentity(display.Name, display.Alias, display.Content, master);
                 Mapper.Map(template, display);
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4289

### Description

When creating a template, the template alias is used as the template name instead of the given template name:

![create-template-respect-name-before](https://user-images.githubusercontent.com/7405322/51905573-dc1c1900-23c1-11e9-936e-cc5370680d61.gif)

This PR ensures that we use the template name:

![create-template-respect-name-after](https://user-images.githubusercontent.com/7405322/51905600-ed652580-23c1-11e9-9bb4-834fbb7ed924.gif)

