### PR TITLE
V8: Approved color styling and beyond

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
@@ -36,10 +36,14 @@ Use this directive to generate color swatches to pick from.
             scope.setColor = function (color, $index, $event) {
                 scope.selectedColor = color;
                 if (scope.onSelect) {
-                    scope.onSelect(color, $index, $event);
+                    scope.onSelect(color.color, $index, $event);
                     $event.stopPropagation();
                 }
             };
+
+            scope.isSelectedColor = function (color) {
+                return scope.selectedColor && color.value === scope.selectedColor.value;
+            }
         }
 
         var directive = {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
@@ -57,10 +57,6 @@
                 .umb-color-box__label {
                     background: @white;
                     font-size: 14px;
-                    display: flex;
-                    flex-flow: column wrap;
-                    flex: 1 0 100%;
-                    justify-content: flex-end;
                     padding: 1px 5px;
                     min-height: 45px;
                     max-width: 100%;

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -1,9 +1,9 @@
 ﻿<div class="umb-color-swatches" ng-class="{ 'with-labels': useLabel }">
 
-    <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{useLabel || useColorClass ? (color.label || color.value) : ('#' + color.value)}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': color.value === selectedColor }" ng-click="setColor(color.value, $index, $event)">
+    <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{useLabel || useColorClass ? (color.label || color.value) : ('#' + color.value)}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': isSelectedColor(color) }" ng-click="setColor(color, $index, $event)">
         <div class="umb-color-box-inner">
             <div class="check_circle">
-                <i class="icon icon-check small" ng-show="selectedColor && color.value === selectedColor.value"></i>
+                <i class="icon icon-check small" ng-show="isSelectedColor(color)"></i>
             </div>
             <div class="umb-color-box__label" ng-if="useLabel">
                 <div class="umb-color-box__name truncate">{{ color.label || color.value }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -2,8 +2,8 @@
 
     <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{useLabel || useColorClass ? (color.label || color.value) : ('#' + color.value)}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': color.value === selectedColor }" ng-click="setColor(color.value, $index, $event)">
         <div class="umb-color-box-inner">
-            <div class="check_circle" ng-if="color.value === selectedColor">
-                <i class="icon icon-check small"></i>
+            <div class="check_circle">
+                <i class="icon icon-check small" ng-show="color.value === selectedColor"></i>
             </div>
             <div class="umb-color-box__label" ng-if="useLabel">
                 <div class="umb-color-box__name truncate">{{ color.label || color.value }}</div>
@@ -13,4 +13,3 @@
     </button>
 
 </div>
- 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -3,7 +3,7 @@
     <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{useLabel || useColorClass ? (color.label || color.value) : ('#' + color.value)}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': color.value === selectedColor }" ng-click="setColor(color.value, $index, $event)">
         <div class="umb-color-box-inner">
             <div class="check_circle">
-                <i class="icon icon-check small" ng-show="color.value === selectedColor"></i>
+                <i class="icon icon-check small" ng-show="selectedColor && color.value === selectedColor.value"></i>
             </div>
             <div class="umb-color-box__label" ng-if="useLabel">
                 <div class="umb-color-box__name truncate">{{ color.label || color.value }}</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4294

### Description

As it turns out, the styling is not the only thing wrong with the approved color property editor in V8. It doesn't actually show the selected color upon reload either:

![approved-color-styling-before](https://user-images.githubusercontent.com/7405322/51913243-5fe00080-23d6-11e9-9c98-66fafe645e20.gif)

This PR fixes both styling and functionality:

![approved-color-styling](https://user-images.githubusercontent.com/7405322/51913272-70907680-23d6-11e9-8fa0-4e54ada5664e.gif)

**Note:** The functionality fix is based on the non-legacy data format. I figured that was OK since the rest of the `umb-color-swatches` also expects this format.