### PR TITLE
Explicitly set the form dirty when toggling a boolean

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
@@ -1,4 +1,4 @@
-function booleanEditorController($scope) {
+function booleanEditorController($scope, angularHelper) {
 
     function setupViewModel() {
         $scope.renderModel = {
@@ -28,7 +28,8 @@ function booleanEditorController($scope) {
     };
 
     // Update the value when the toggle is clicked
-    $scope.toggle = function(){
+    $scope.toggle = function () {
+        angularHelper.getCurrentForm($scope).$setDirty();
         if($scope.renderModel.value){
             $scope.model.value = "0";
             setupViewModel();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4301

### Description

This PR fixes #4301 by explicitly setting the form as dirty when a boolean field is toggled. This seems necessary when we're manipulating `model.value` the way it's done in this property editor.

It looks like this:

![boolean-form-invalidate](https://user-images.githubusercontent.com/7405322/51920646-1f887e80-23e6-11e9-8bc9-3ac42d4f62c4.gif)
