### PR TITLE
V8: Fix start nodes for media picker in infinite editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/mediapicker.controller.js
@@ -1,6 +1,6 @@
 //this controller simply tells the dialogs service to open a mediaPicker window
 //with a specified callback, this callback will receive an object with a selection on it
-function mediaPickerController($scope, entityResource, iconHelper, editorService) {
+function mediaPickerController($scope, entityResource, iconHelper, editorService, angularHelper) {
 
     function trim(str, chr) {
         var rgxtrim = (!chr) ? new RegExp('^\\s+|\\s+$', 'g') : new RegExp('^' + chr + '+|' + chr + '+$', 'g');
@@ -50,10 +50,12 @@ function mediaPickerController($scope, entityResource, iconHelper, editorService
 
     $scope.remove =function(index){
         $scope.renderModel.splice(index, 1);
+        syncModelValue();
     };
 
     $scope.clear = function() {
         $scope.renderModel = [];
+        syncModelValue();
     };
 
     $scope.add = function (item) {
@@ -76,19 +78,17 @@ function mediaPickerController($scope, entityResource, iconHelper, editorService
             });
 
         }	
+
+        syncModelValue();
     };
 
-    var unsubscribe = $scope.$on("formSubmitting", function (ev, args) {
+    function syncModelValue() {
         var currIds = _.map($scope.renderModel, function (i) {
             return dialogOptions.idType === "udi" ? i.udi : i.id;
         });
         $scope.model.value = trim(currIds.join(), ",");
-    });
-
-    //when the scope is destroyed we need to unsubscribe
-    $scope.$on('$destroy', function () {
-        unsubscribe();
-    });
+        angularHelper.getCurrentForm($scope).$setDirty();
+    }
 
     //load media data
     var modelIds = $scope.model.value ? $scope.model.value.split(',') : [];


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4241

### Description

As #4241 describes, the media picker start node is not saved when editing the data type in infinite editing.

This PR fixes the problem. It looks like this:

![media-picker-prevalues-infinite-editing](https://user-images.githubusercontent.com/7405322/51936470-8cad0b80-2408-11e9-8a25-2dcbef066dfa.gif)

While I was at it I also made sure that changing the start node triggers the "unsaved changes" warning if the data type is not saved. This only works in regular editing, though, as this warning currently isn't triggered in infinite editing.

To test this PR:

1. Verify that you can configure the start node on a media picker property using infinite editing.
2. Verify that you can still configure the start node on a media picker when editing the data type in the Settings section.
3. When editing the data type start node in the Settings section, verify that you are prompted to discard changes if you navigate away without saving.