### PR TITLE
V8: Remove the tooltip position flickering

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbtooltip.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbtooltip.directive.js
@@ -69,21 +69,13 @@ Use this directive to render a tooltip.
 (function() {
    'use strict';
 
-   function TooltipDirective($timeout) {
+   function TooltipDirective() {
 
       function link(scope, el, attr, ctrl) {
 
          scope.tooltipStyles = {};
          scope.tooltipStyles.left = 0;
          scope.tooltipStyles.top = 0;
-
-         function activate() {
-
-            $timeout(function() {
-               setTooltipPosition(scope.event);
-            });
-
-         }
 
          function setTooltipPosition(event) {
 
@@ -141,7 +133,7 @@ Use this directive to render a tooltip.
 
          }
 
-         activate();
+         setTooltipPosition(scope.event);
 
       }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4307

### Description

This PR fixes the position flickering described in #4307. When applied the tooltip behaves like this:

![tooltip-position](https://user-images.githubusercontent.com/7405322/51939075-e9132980-240e-11e9-8940-42af87e473f7.gif)
