### PR TITLE
Make sure the color picker label is stored on first select

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
@@ -128,9 +128,13 @@ function ColorPickerController($scope, angularHelper) {
     // either the value or label was changed on the data type.
     function initActiveColor() {
 
-        // no value
-        if (!$scope.model.value)
-            return;
+        // no value - initialize default value
+        if (!$scope.model.value) {
+            $scope.model.value = {
+                value: "",
+                label: ""
+            };
+        }
 
         // Backwards compatibility, the color used to be stored as a hex value only
         if (typeof $scope.model.value === "string") {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
@@ -77,7 +77,14 @@ function ColorPickerController($scope, angularHelper) {
     $scope.onSelect = function (color) {
         // did the value change?
         if ($scope.model.value.value === color) {
-            // no, skip the rest
+            // User clicked the currently selected color
+            // to remove the selection, they don't want
+            // to select any color after all.
+            // Unselect the color and mark as dirty
+            $scope.model.activeColor = null;
+            $scope.model.value = null;
+            angularHelper.getCurrentForm($scope).$setDirty();
+
             return;
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
@@ -12,31 +12,12 @@ function ColorPickerController($scope, angularHelper) {
     //map back to the model
     $scope.model.config = config;
     
-    function convertArrayToDictionaryArray(model) {
-        //now we need to format the items in the dictionary because we always want to have an array
-        var newItems = [];
-        for (var i = 0; i < model.length; i++) {
-            newItems.push({ id: model[i], sortOrder: 0, value: model[i] });
-        }
-
-        return newItems;
-    }
-
-
-    function convertObjectToDictionaryArray(model) {
-        //now we need to format the items in the dictionary because we always want to have an array
-        var newItems = [];
-        var vals = _.values($scope.model.config.items);
-        var keys = _.keys($scope.model.config.items);
-
-        for (var i = 0; i < vals.length; i++) {
-            var label = vals[i].value ? vals[i].value : vals[i];
-            newItems.push({ id: keys[i], sortOrder: vals[i].sortOrder, value: label });
-        }
-
-        return newItems;
-    }
     $scope.isConfigured = $scope.model.config && $scope.model.config.items && _.keys($scope.model.config.items).length > 0;
+
+    $scope.model.activeColor = {
+        value: "",
+        label: ""
+    };
 
     if ($scope.isConfigured) {
 
@@ -94,33 +75,25 @@ function ColorPickerController($scope, angularHelper) {
     $scope.isConfigured = $scope.model.config && $scope.model.config.items && _.keys($scope.model.config.items).length > 0;
 
     $scope.onSelect = function (color) {
-        // Complex color (value and label)?
-        if (!$scope.model.value.hasOwnProperty("value")) {
-            // did the value change?
-            if ($scope.model.value !== color) {
-                // yes, make sure to set dirty
-                angularHelper.getCurrentForm($scope).$setDirty();
-            }
-            return;
-        }
-
         // did the value change?
         if ($scope.model.value.value === color) {
             // no, skip the rest
             return;
         }
 
-        // yes, make sure to set dirty
-        angularHelper.getCurrentForm($scope).$setDirty();
-
-        // update the label according to the new color
+        // yes, update the model (label + value) according to the new color
         var selectedItem = _.find($scope.model.config.items, function (item) {
             return item.value === color;
         });
         if (!selectedItem) {
             return;
         }
-        $scope.model.value.label = selectedItem.label;
+        $scope.model.value = {
+            label: selectedItem.label,
+            value: selectedItem.value
+        };
+        // make sure to set dirty
+        angularHelper.getCurrentForm($scope).$setDirty();
     }
 
     // Finds the color best matching the model's color,
@@ -129,21 +102,13 @@ function ColorPickerController($scope, angularHelper) {
     function initActiveColor() {
 
         // no value - initialize default value
-        if (!$scope.model.value) {
-            $scope.model.value = {
-                value: "",
-                label: ""
-            };
-        }
+        if (!$scope.model.value)
+            return;
 
         // Backwards compatibility, the color used to be stored as a hex value only
         if (typeof $scope.model.value === "string") {
             $scope.model.value = { value: $scope.model.value, label: $scope.model.value };
         }
-
-        // Complex color (value and label)?
-        if (!$scope.model.value.hasOwnProperty("value"))
-            return;
 
         var modelColor = $scope.model.value.value;
         var modelLabel = $scope.model.value.label;
@@ -184,8 +149,8 @@ function ColorPickerController($scope, angularHelper) {
 
         // If a match was found, set it as the active color.
         if (foundItem) {
-            $scope.model.value.value = foundItem.value;
-            $scope.model.value.label = foundItem.label;
+            $scope.model.activeColor.value = foundItem.value;
+            $scope.model.activeColor.label = foundItem.label;
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
@@ -6,7 +6,7 @@
     </div>
 
     <umb-color-swatches colors="model.config.items"
-                        selected-color="model.value.value"
+                        selected-color="model.activeColor.value"
                         size="m"
                         use-label="model.useLabel"
                         on-select="onSelect(color)">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4319

### Description

When creating new content that contains a color picker property with labels enabled (or editing the same property on existing content for the first time), the color picker value is not stored correctly. The label property is simply not persisted.

This PR fixes that.

#### Steps to reproduce

Create a doctype that contains a color picker property named `color` with labels enabled, and use this template to render it:

```cshtml
@using Umbraco.Core.PropertyEditors.ValueConverters
@inherits UmbracoTemplatePage
@{
    Layout = null;
    var pickedColor = Model.Content.GetPropertyValue<ColorPickerValueConverter.PickedColor>("color");
}

<html>
    <body>
    <h1>@Model.Content.Name</h1>
    @if (pickedColor != null)
    {
        <strong style="color: #@pickedColor.Color">@pickedColor.Label</strong>
    }
    </body>
</html>
```

Create a page using this doctype and pick a color. Do *not* click two colors or the same color twice, just click one color once. Save and publish and view the page - it'll look something like this:

![image](https://user-images.githubusercontent.com/7405322/51975642-0d105280-2483-11e9-932f-c3a1888a87dc.png)

Now go back and pick another color. Save and publish and view the page - now it looks as expected:

![image](https://user-images.githubusercontent.com/7405322/51975678-20232280-2483-11e9-9d94-3c65881f0db8.png)

#### Testing this PR

Obviously it should be tested that the color picker no longer misbehaves as described above.

Since this PR updates the initial value of the color picker if none is set, also verify that the "Discard changes" dialog only shows if you've actually changed a color.