### PR TITLE
v8: Fix image cropper prevalues

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -65,8 +65,8 @@
                 <p><span>{{item.alias}}</span> <small>({{item.width}}px &times; {{item.height}}px)</small></p>
             </div>
             <div class="umb-prevalues-multivalues__right">
-                <a href="#" prevent-default class="umb-node-preview__action umb-node-preview__action" ng-click="edit(item, $event)"><localize key="general_edit">Edit</localize></a>
-                <a href="#" prevent-default class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></a>
+                <a href="#" prevent-default class="umb-node-preview__action umb-node-preview__action--red" ng-click="edit(item, $event)" class="umb-prevalues-multivalues__action">Edit</a>
+                <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></a>
             </div>
         </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -65,8 +65,8 @@
                 <p><span>{{item.alias}}</span> <small>({{item.width}}px &times; {{item.height}}px)</small></p>
             </div>
             <div class="umb-prevalues-multivalues__right">
-                <a href="#" prevent-default class="umb-node-preview__action umb-node-preview__action--red" ng-click="edit(item, $event)" class="umb-prevalues-multivalues__action">Edit</a>
-                <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></a>
+                <a href="#" prevent-default class="umb-node-preview__action umb-node-preview__action" ng-click="edit(item, $event)"><localize key="general_edit">Edit</localize></a>
+                <a href="#" prevent-default class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR fixes localization of the edit link in image cropper prevalues, remove duplicate class attribute and also ensure only remove link has the red color on hover.

**Before**

![image](https://user-images.githubusercontent.com/2919859/52017514-d587c180-24e7-11e9-9f21-1bd15dcf73e0.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/52017524-dfa9c000-24e7-11e9-90dc-a1b70e2a006d.png)
