### PR TITLE
#3648 - Besides mculture also retain cculture in querystring on navig…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -28,7 +28,7 @@ function navigationService($routeParams, $location, $q, $timeout, $injector, eve
 
     //A list of query strings defined that when changed will not cause a reload of the route
     var nonRoutingQueryStrings = ["mculture", "cculture", "lq"];
-    var retainedQueryStrings = ["mculture"];
+    var retainedQueryStrings = ["mculture", "cculture"];
 
         
     function setMode(mode) {


### PR DESCRIPTION
Fixes #3648 

- Besides `mculture` also retain `cculture` in querystring on navigating

Before:
![3648-1](https://user-images.githubusercontent.com/1561480/52047633-b457bd00-2549-11e9-9341-b3c4f2f44215.gif)

After:
![3648-2](https://user-images.githubusercontent.com/1561480/52047636-b883da80-2549-11e9-9c80-c3f924635497.gif)