### PR TITLE
V8: Fix disappearing thumbnails in the media grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
@@ -157,7 +157,8 @@ Use this directive to generate a thumbnail grid of media items.
                     item.isFolder = !mediaHelper.hasFilePropertyType(item);
                 }
 
-                if (!item.isFolder) {
+                // if it's not a folder, get the thumbnail, extension etc. if we haven't already
+                if (!item.isFolder && !item.thumbnail) {
 
                     // handle entity
                     if(item.image) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4306

### Description

The problem described in #4306 happens because the media grid tries to re-initialize the thumbnail (and a lot of other stuff) when the user returns to the grid. Apparently the media resolver doesn't like that, so the thumbnail is reset. 

This PR simply ensures that we don't do a lot of re-initialization in the media grid if the media items have already been initialized.