### PR TITLE
Web.Config AppSetting key conventions & move to constants class

### DIFF
--- a/build/NuSpecs/tools/install.ps1
+++ b/build/NuSpecs/tools/install.ps1
@@ -54,7 +54,7 @@ if ($project) {
 			[xml]$config = Get-Content $destinationWebConfig
 			
 			$config.configuration.appSettings.ChildNodes | ForEach-Object { 
-				if($_.key -eq "umbracoConfigurationStatus") 
+				if($_.key -eq "Umbraco.Core.ConfigurationStatus") 
 				{
 					# The web.config has an umbraco-specific appSetting in it
 					# don't overwrite it and let config transforms do their thing

--- a/src/Umbraco.Core/Composing/RegisterFactory.cs
+++ b/src/Umbraco.Core/Composing/RegisterFactory.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Core.Composing
         /// Creates a new instance of the configured container.
         /// </summary>
         /// <remarks>
-        /// To override the default LightInjectContainer, add an appSetting named umbracoRegisterType with
+        /// To override the default LightInjectContainer, add an appSetting named 'Umbraco.Core.RegisterType' with
         /// a fully qualified type name to a class with a static method "Create" returning an IRegister.
         /// </remarks>
         public static IRegister Create()

--- a/src/Umbraco.Core/Composing/RegisterFactory.cs
+++ b/src/Umbraco.Core/Composing/RegisterFactory.cs
@@ -18,14 +18,14 @@ namespace Umbraco.Core.Composing
         /// Creates a new instance of the configured container.
         /// </summary>
         /// <remarks>
-        /// To override the default LightInjectContainer, add an appSetting named umbracoContainerType with
+        /// To override the default LightInjectContainer, add an appSetting named umbracoRegisterType with
         /// a fully qualified type name to a class with a static method "Create" returning an IRegister.
         /// </remarks>
         public static IRegister Create()
         {
             Type type;
 
-            var configuredTypeName = ConfigurationManager.AppSettings["umbracoRegisterType"];
+            var configuredTypeName = ConfigurationManager.AppSettings[Constants.AppSettings.RegisterType];
             if (configuredTypeName.IsNullOrWhiteSpace())
             {
                 // try to get the web LightInject container type,

--- a/src/Umbraco.Core/Composing/TypeFinder.cs
+++ b/src/Umbraco.Core/Composing/TypeFinder.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Core.Composing
                 if (_assembliesAcceptingLoadExceptions != null)
                     return _assembliesAcceptingLoadExceptions;
 
-                var s = ConfigurationManager.AppSettings["Umbraco.AssembliesAcceptingLoadExceptions"];
+                var s = ConfigurationManager.AppSettings[Constants.AppSettings.AssembliesAcceptingLoadExceptions];
                 return _assembliesAcceptingLoadExceptions = string.IsNullOrWhiteSpace(s)
                     ? Array.Empty<string>()
                     : s.Split(',').Select(x => x.Trim()).ToArray();

--- a/src/Umbraco.Core/Configuration/CoreDebug.cs
+++ b/src/Umbraco.Core/Configuration/CoreDebug.cs
@@ -7,8 +7,8 @@ namespace Umbraco.Core.Configuration
         public CoreDebug()
         {
             var appSettings = System.Configuration.ConfigurationManager.AppSettings;
-            LogUncompletedScopes = string.Equals("true", appSettings["Umbraco.CoreDebug.LogUncompletedScopes"], StringComparison.OrdinalIgnoreCase);
-            DumpOnTimeoutThreadAbort = string.Equals("true", appSettings["Umbraco.CoreDebug.DumpOnTimeoutThreadAbort"], StringComparison.OrdinalIgnoreCase);
+            LogUncompletedScopes = string.Equals("true", appSettings[Constants.AppSettings.Debug.LogUncompletedScopes], StringComparison.OrdinalIgnoreCase);
+            DumpOnTimeoutThreadAbort = string.Equals("true", appSettings[Constants.AppSettings.Debug.DumpOnTimeoutThreadAbort], StringComparison.OrdinalIgnoreCase);
         }
 
         // when true, Scope logs the stack trace for any scope that gets disposed without being completed.

--- a/src/Umbraco.Core/Configuration/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/GlobalSettings.cs
@@ -161,13 +161,13 @@ namespace Umbraco.Core.Configuration
         {
             get
             {
-                return ConfigurationManager.AppSettings.ContainsKey("umbracoConfigurationStatus")
-                    ? ConfigurationManager.AppSettings["umbracoConfigurationStatus"]
+                return ConfigurationManager.AppSettings.ContainsKey(Constants.AppSettings.ConfigurationStatus)
+                    ? ConfigurationManager.AppSettings[Constants.AppSettings.ConfigurationStatus]
                     : string.Empty;
             }
             set
             {
-                SaveSetting("umbracoConfigurationStatus", value);
+                SaveSetting(Constants.AppSettings.ConfigurationStatus, value);
             }
         }
         

--- a/src/Umbraco.Core/Configuration/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/GlobalSettings.cs
@@ -85,8 +85,8 @@ namespace Umbraco.Core.Configuration
             {
                 if (_reservedUrls != null) return _reservedUrls;
 
-                var urls = ConfigurationManager.AppSettings.ContainsKey("umbracoReservedUrls")
-                    ? ConfigurationManager.AppSettings["umbracoReservedUrls"]
+                var urls = ConfigurationManager.AppSettings.ContainsKey(Constants.AppSettings.ReservedUrls)
+                    ? ConfigurationManager.AppSettings[Constants.AppSettings.ReservedUrls]
                     : string.Empty;
 
                 //ensure the built on (non-changeable) reserved paths are there at all times
@@ -107,14 +107,14 @@ namespace Umbraco.Core.Configuration
                 if (_reservedPaths != null) return _reservedPaths;
 
                 var reservedPaths = StaticReservedPaths;
-                var umbPath = ConfigurationManager.AppSettings.ContainsKey("umbracoPath") && !ConfigurationManager.AppSettings["umbracoPath"].IsNullOrWhiteSpace()
-                    ? ConfigurationManager.AppSettings["umbracoPath"]
+                var umbPath = ConfigurationManager.AppSettings.ContainsKey(Constants.AppSettings.Path) && !ConfigurationManager.AppSettings[Constants.AppSettings.Path].IsNullOrWhiteSpace()
+                    ? ConfigurationManager.AppSettings[Constants.AppSettings.Path]
                     : "~/umbraco";
                 //always add the umbraco path to the list
                 reservedPaths += umbPath.EnsureEndsWith(',');
 
-                var allPaths = ConfigurationManager.AppSettings.ContainsKey("umbracoReservedPaths")
-                    ? ConfigurationManager.AppSettings["umbracoReservedPaths"]
+                var allPaths = ConfigurationManager.AppSettings.ContainsKey(Constants.AppSettings.ReservedPaths)
+                    ? ConfigurationManager.AppSettings[Constants.AppSettings.ReservedPaths]
                     : string.Empty;
 
                 _reservedPaths = reservedPaths + allPaths;
@@ -133,8 +133,8 @@ namespace Umbraco.Core.Configuration
         {
             get
             {
-                return ConfigurationManager.AppSettings.ContainsKey("umbracoContentXML")
-                    ? ConfigurationManager.AppSettings["umbracoContentXML"]
+                return ConfigurationManager.AppSettings.ContainsKey(Constants.AppSettings.ContentXML)
+                    ? ConfigurationManager.AppSettings[Constants.AppSettings.ContentXML]
                     : "~/App_Data/umbraco.config";
             }
         }
@@ -147,8 +147,8 @@ namespace Umbraco.Core.Configuration
         {
             get
             {
-                return ConfigurationManager.AppSettings.ContainsKey("umbracoPath")
-                    ? IOHelper.ResolveUrl(ConfigurationManager.AppSettings["umbracoPath"])
+                return ConfigurationManager.AppSettings.ContainsKey(Constants.AppSettings.Path)
+                    ? IOHelper.ResolveUrl(ConfigurationManager.AppSettings[Constants.AppSettings.Path])
                     : string.Empty;
             }
         }
@@ -249,7 +249,7 @@ namespace Umbraco.Core.Configuration
             {
                 try
                 {
-                    return int.Parse(ConfigurationManager.AppSettings["umbracoTimeOutInMinutes"]);
+                    return int.Parse(ConfigurationManager.AppSettings[Constants.AppSettings.TimeOutInMinutes]);
                 }
                 catch
                 {
@@ -268,7 +268,7 @@ namespace Umbraco.Core.Configuration
             {
                 try
                 {
-                    return int.Parse(ConfigurationManager.AppSettings["umbracoVersionCheckPeriod"]);
+                    return int.Parse(ConfigurationManager.AppSettings[Constants.AppSettings.VersionCheckPeriod]);
                 }
                 catch
                 {
@@ -287,7 +287,7 @@ namespace Umbraco.Core.Configuration
         {
             get
             {
-                var setting = ConfigurationManager.AppSettings["umbracoLocalTempStorage"];
+                var setting = ConfigurationManager.AppSettings[Constants.AppSettings.LocalTempStorage];
                 if (!string.IsNullOrWhiteSpace(setting))
                     return Enum<LocalTempStorage>.Parse(setting);
 
@@ -304,8 +304,8 @@ namespace Umbraco.Core.Configuration
         {
             get
             {
-                return ConfigurationManager.AppSettings.ContainsKey("umbracoDefaultUILanguage")
-                    ? ConfigurationManager.AppSettings["umbracoDefaultUILanguage"]
+                return ConfigurationManager.AppSettings.ContainsKey(Constants.AppSettings.DefaultUILanguage)
+                    ? ConfigurationManager.AppSettings[Constants.AppSettings.DefaultUILanguage]
                     : string.Empty;
             }
         }
@@ -322,7 +322,7 @@ namespace Umbraco.Core.Configuration
             {
                 try
                 {
-                    return bool.Parse(ConfigurationManager.AppSettings["umbracoHideTopLevelNodeFromPath"]);
+                    return bool.Parse(ConfigurationManager.AppSettings[Constants.AppSettings.HideTopLevelNodeFromPath]);
                 }
                 catch
                 {
@@ -340,7 +340,7 @@ namespace Umbraco.Core.Configuration
             {
                 try
                 {
-                    return bool.Parse(ConfigurationManager.AppSettings["umbracoUseHttps"]);
+                    return bool.Parse(ConfigurationManager.AppSettings[Constants.AppSettings.UseHttps]);
                 }
                 catch
                 {

--- a/src/Umbraco.Core/Configuration/UmbracoVersion.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoVersion.cs
@@ -82,7 +82,7 @@ namespace Umbraco.Core.Configuration
                 try
                 {
                     // TODO: https://github.com/umbraco/Umbraco-CMS/issues/4238 - stop having version in web.config appSettings
-                    var value = ConfigurationManager.AppSettings["umbracoConfigurationStatus"];
+                    var value = ConfigurationManager.AppSettings[Constants.AppSettings.ConfigurationStatus];
                     return value.IsNullOrWhiteSpace() ? null : SemVersion.TryParse(value, out var semver) ? semver : null;
                 }
                 catch

--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.ComponentModel;
 
 namespace Umbraco.Core
 {
     public static partial class Constants
     {
         /// <summary>
-        /// Defines the identifiers for Umbraco system nodes.
+        /// Specific web.config AppSetting keys for Umbraco.Core application
         /// </summary>
         public static class AppSettings
         {
@@ -14,43 +13,111 @@ namespace Umbraco.Core
             [Obsolete("We need to kill this appsetting as we do not use XML content cache umbraco.config anymore due to NuCache")]
             public const string ContentXML = "Umbraco.Core.ContentXML"; //umbracoContentXML
 
-
+            /// <summary>
+            /// TODO: FILL ME IN
+            /// </summary>
             public const string RegisterType = "Umbraco.Core.RegisterType";
+
+            /// <summary>
+            /// This is used for a unit test in PublishedMediaCache
+            /// </summary>
+            public const string PublishedMediaCacheSeconds = "Umbraco.Core.PublishedMediaCacheSeconds";
+
+            /// <summary>
+            /// TODO: FILL ME IN
+            /// </summary>
+            public const string AssembliesAcceptingLoadExceptions = "Umbraco.Core.AssembliesAcceptingLoadExceptions";
+
+            /// <summary>
+            /// This will return the version number of the currently installed umbraco instance
+            /// </summary>
+            /// <remarks>
+            /// Umbraco will automatically set & modify this value when installing & upgrading
+            /// </remarks>
+            public const string ConfigurationStatus = "Umbraco.Core.ConfigurationStatus";
+
+            /// <summary>
+            /// Gets the path to umbraco's root directory (/umbraco by default).
+            /// </summary>
+            public const string Path = "Umbraco.Core.Path";
+
+            /// <summary>
+            /// The reserved urls from web.config.
+            /// </summary>
+            public const string ReservedUrls = "Umbraco.Core.ReservedUrls";
+
+            /// <summary>
+            /// The reserved paths from web.config
+            /// </summary>
+            public const string ReservedPaths = "Umbraco.Core.ReservedPaths";
+
+            /// <summary>
+            /// Set the timeout for the Umbraco backoffice in minutes
+            /// </summary>
+            public const string TimeOutInMinutes = "Umbraco.Core.TimeOutInMinutes";
+
+            /// <summary>
+            /// The number of days to check for a new version of Umbraco
+            /// </summary>
+            /// <remarks>
+            /// Default is set to 7. Setting this to 0 will never check
+            /// This is used to help track statistics
+            /// </remarks>
+            public const string VersionCheckPeriod = "Umbraco.Core.VersionCheckPeriod";
+
+            /// <summary>
+            /// This is the location type to store temporary files such as cache files or other localized files for a given machine
+            /// </summary>
+            /// <remarks>
+            /// Currently used for the xml cache file and the plugin cache files
+            /// </remarks>
+            public const string LocalTempStorage = "Umbraco.Core.LocalTempStorage";
+
+            /// <summary>
+            /// The default UI language of the backoffice such as 'en-US'
+            /// </summary>
+            public const string DefaultUILanguage = "Umbraco.Core.DefaultUILanguage";
+
+            /// <summary>
+            /// A true/false value indicating whether umbraco should hide top level nodes from generated urls.
+            /// </summary>
+            public const string HideTopLevelNodeFromPath = "Umbraco.Core.HideTopLevelNodeFromPath";
+
+            /// <summary>
+            /// A true or false indicating whether umbraco should force a secure (https) connection to the backoffice.
+            /// </summary>
+            public const string UseHttps = "Umbraco.Core.UseHttps";
+
+            /// <summary>
+            /// TODO: FILL ME IN
+            /// </summary>
+            public const string DisableElectionForSingleServer = "Umbraco.Core.DisableElectionForSingleServer";
+
             
-            public const string PublishedMediaCacheSeconds = "Umbraco.Core.PublishedMediaCacheSeconds"; //"Umbraco.PublishedMediaCache.Seconds"
-
-            public const string AssembliesAcceptingLoadExceptions = "Umbraco.Core.AssembliesAcceptingLoadExceptions"; //Umbraco.AssembliesAcceptingLoadExceptions
-
-            public const string ConfigurationStatus = "Umbraco.Core.ConfigurationStatus"; //umbracoConfigurationStatus
-
-            public const string Path = "Umbraco.Core.Path"; //umbracoPath
-
-            public const string ReservedUrls = "Umbraco.Core.ReservedUrls"; //umbracoReservedUrls
-
-            public const string ReservedPaths = "Umbraco.Core.ReservedPaths"; //umbracoReservedPaths
-            
-            public const string TimeOutInMinutes = "Umbraco.Core.TimeOutInMinutes"; //umbracoTimeOutInMinutes
-
-            public const string VersionCheckPeriod = "Umbraco.Core.VersionCheckPeriod"; //umbracoVersionCheckPeriod
-
-            public const string LocalTempStorage = "Umbraco.Core.LocalTempStorage"; //umbracoLocalTempStorage
-
-            public const string DefaultUILanguage = "Umbraco.Core.DefaultUILanguage"; //umbracoDefaultUILanguage
-
-            public const string HideTopLevelNodeFromPath = "Umbraco.Core.HideTopLevelNodeFromPath"; //umbracoHideTopLevelNodeFromPath
-
-            public const string UseHttps = "Umbraco.Core.UseHttps"; //umbracoUseHttps
-
-            public const string DisableElectionForSingleServer = "Umbraco.Core.DisableElectionForSingleServer"; //umbracoDisableElectionForSingleServer
-
-            public const string DatabaseFactoryServerVersion = "Umbraco.Core.DatabaseFactoryServerVersion"; //Umbraco.DatabaseFactory.ServerVersion
-            
-
+            /// <summary>
+            /// Debug specific web.config AppSetting keys for Umbraco
+            /// </summary>
+            /// <remarks>
+            /// Do not use these keys in a production environment
+            /// </remarks>
             public static class Debug
             {
-                public const string LogUncompletedScopes = "Umbraco.Core.LogUncompletedScopes"; //"Umbraco.CoreDebug.LogUncompletedScopes"
+                /// <summary>
+                /// When set to true, Scope logs the stack trace for any scope that gets disposed without being completed.
+                /// this helps troubleshooting rogue scopes that we forget to complete
+                /// </summary>
+                public const string LogUncompletedScopes = "Umbraco.Core.Debug.LogUncompletedScopes";
 
-                public const string DumpOnTimeoutThreadAbort = "Umbraco.Core.DumpOnTimeoutThreadAbort"; //Umbraco.CoreDebug.DumpOnTimeoutThreadAbort
+                /// <summary>
+                /// When set to true, the Logger creates a mini dump of w3wp in ~/App_Data/MiniDump whenever it logs
+                /// an error due to a ThreadAbortException that is due to a timeout.
+                /// </summary>
+                public const string DumpOnTimeoutThreadAbort = "Umbraco.Core.Debug.DumpOnTimeoutThreadAbort";
+
+                /// <summary>
+                /// TODO: FILL ME IN
+                /// </summary>
+                public const string DatabaseFactoryServerVersion = "Umbraco.Core.Debug.DatabaseFactoryServerVersion";
             }
         }
     }

--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -10,11 +10,48 @@ namespace Umbraco.Core
         /// </summary>
         public static class AppSettings
         {
+            // TODO: Kill me - still used in Umbraco.Core.IO.SystemFiles:27
+            [Obsolete("We need to kill this appsetting as we do not use XML content cache umbraco.config anymore due to NuCache")]
+            public const string ContentXML = "Umbraco.Core.ContentXML"; //umbracoContentXML
+
+
             public const string RegisterType = "Umbraco.Core.RegisterType";
+            
+            public const string PublishedMediaCacheSeconds = "Umbraco.Core.PublishedMediaCacheSeconds"; //"Umbraco.PublishedMediaCache.Seconds"
+
+            public const string AssembliesAcceptingLoadExceptions = "Umbraco.Core.AssembliesAcceptingLoadExceptions"; //Umbraco.AssembliesAcceptingLoadExceptions
 
             public const string ConfigurationStatus = "Umbraco.Core.ConfigurationStatus"; //umbracoConfigurationStatus
+
+            public const string Path = "Umbraco.Core.Path"; //umbracoPath
+
+            public const string ReservedUrls = "Umbraco.Core.ReservedUrls"; //umbracoReservedUrls
+
+            public const string ReservedPaths = "Umbraco.Core.ReservedPaths"; //umbracoReservedPaths
+            
+            public const string TimeOutInMinutes = "Umbraco.Core.TimeOutInMinutes"; //umbracoTimeOutInMinutes
+
+            public const string VersionCheckPeriod = "Umbraco.Core.VersionCheckPeriod"; //umbracoVersionCheckPeriod
+
+            public const string LocalTempStorage = "Umbraco.Core.LocalTempStorage"; //umbracoLocalTempStorage
+
+            public const string DefaultUILanguage = "Umbraco.Core.DefaultUILanguage"; //umbracoDefaultUILanguage
+
+            public const string HideTopLevelNodeFromPath = "Umbraco.Core.HideTopLevelNodeFromPath"; //umbracoHideTopLevelNodeFromPath
+
+            public const string UseHttps = "Umbraco.Core.UseHttps"; //umbracoUseHttps
+
+            public const string DisableElectionForSingleServer = "Umbraco.Core.DisableElectionForSingleServer"; //umbracoDisableElectionForSingleServer
+
+            public const string DatabaseFactoryServerVersion = "Umbraco.Core.DatabaseFactoryServerVersion"; //Umbraco.DatabaseFactory.ServerVersion
             
 
+            public static class Debug
+            {
+                public const string LogUncompletedScopes = "Umbraco.Core.LogUncompletedScopes"; //"Umbraco.CoreDebug.LogUncompletedScopes"
+
+                public const string DumpOnTimeoutThreadAbort = "Umbraco.Core.DumpOnTimeoutThreadAbort"; //Umbraco.CoreDebug.DumpOnTimeoutThreadAbort
+            }
         }
     }
 }

--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Umbraco.Core
+{
+    public static partial class Constants
+    {
+        /// <summary>
+        /// Defines the identifiers for Umbraco system nodes.
+        /// </summary>
+        public static class AppSettings
+        {
+            public const string RegisterType = "Umbraco.Core.RegisterType";
+
+            public const string ConfigurationStatus = "Umbraco.Core.ConfigurationStatus"; //umbracoConfigurationStatus
+            
+
+        }
+    }
+}

--- a/src/Umbraco.Core/IO/SystemFiles.cs
+++ b/src/Umbraco.Core/IO/SystemFiles.cs
@@ -8,7 +8,8 @@ namespace Umbraco.Core.IO
     public class SystemFiles
     {
         public static string TinyMceConfig => SystemDirectories.Config + "/tinyMceConfig.config";
-        
+
+        // TODO: Kill this off we don't have umbraco.config XML cache we now have NuCache
         public static string GetContentCacheXml(IGlobalSettings globalSettings)
         {
             switch (globalSettings.LocalTempStorageLocation)
@@ -24,7 +25,7 @@ namespace Umbraco.Core.IO
                         appDomainHash);
                     return Path.Combine(cachePath, "umbraco.config");
                 case LocalTempStorage.Default:
-                    return IOHelper.ReturnPath("umbracoContentXML", "~/App_Data/umbraco.config");
+                    return IOHelper.ReturnPath(Constants.AppSettings.ContentXML, "~/App_Data/umbraco.config");
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -36,8 +36,8 @@ namespace Umbraco.Core.Migrations.Upgrade
             get
             {
                 // no state in database yet - assume we have something in web.config that makes some sense
-                if (!SemVersion.TryParse(ConfigurationManager.AppSettings["umbracoConfigurationStatus"], out var currentVersion))
-                    throw new InvalidOperationException("Could not get current version from web.config umbracoConfigurationStatus appSetting.");
+                if (!SemVersion.TryParse(ConfigurationManager.AppSettings[Constants.AppSettings.ConfigurationStatus], out var currentVersion))
+                    throw new InvalidOperationException($"Could not get current version from web.config {Constants.AppSettings.ConfigurationStatus} appSetting.");
 
                 // we currently support upgrading from 7.10.0 and later
                 if (currentVersion < new SemVersion(7, 10))

--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoUpgrader.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoUpgrader.cs
@@ -35,8 +35,8 @@ namespace Umbraco.Core.Migrations.Upgrade
         public override void AfterMigrations(IScope scope, ILogger logger)
         {
             // assume we have something in web.config that makes some sense = the origin version
-            if (!SemVersion.TryParse(ConfigurationManager.AppSettings["umbracoConfigurationStatus"], out var originVersion))
-                throw new InvalidOperationException("Could not get current version from web.config umbracoConfigurationStatus appSetting.");
+            if (!SemVersion.TryParse(ConfigurationManager.AppSettings[Constants.AppSettings.ConfigurationStatus], out var originVersion))
+                throw new InvalidOperationException($"Could not get current version from web.config {Constants.AppSettings.ConfigurationStatus} appSetting.");
 
             // target version is the code version
             var targetVersion = UmbracoVersion.SemanticVersion;

--- a/src/Umbraco.Core/Models/Language.cs
+++ b/src/Umbraco.Core/Models/Language.cs
@@ -67,7 +67,7 @@ namespace Umbraco.Core.Models
             // culture
             //
             // I assume that, on a site, all language names should be in the SAME language, in DB,
-            // and that would be the umbracoDefaultUILanguage (app setting) - BUT if by accident
+            // and that would be the Umbraco.Core.DefaultUILanguage (app setting) - BUT if by accident
             // ANY culture has been retrieved with another current thread culture - it's now corrupt
             //
             // so, the logic below ensures that the name always end up being the correct name

--- a/src/Umbraco.Core/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Core/Persistence/UmbracoDatabaseFactory.cs
@@ -139,7 +139,7 @@ namespace Umbraco.Core.Persistence
         {
             // replace NPoco database type by a more efficient one
 
-            var setting = ConfigurationManager.AppSettings[Constants.AppSettings.DatabaseFactoryServerVersion];
+            var setting = ConfigurationManager.AppSettings[Constants.AppSettings.Debug.DatabaseFactoryServerVersion];
             var fromSettings = false;
 
             if (setting.IsNullOrWhiteSpace() || !setting.StartsWith("SqlServer.")

--- a/src/Umbraco.Core/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Core/Persistence/UmbracoDatabaseFactory.cs
@@ -139,7 +139,7 @@ namespace Umbraco.Core.Persistence
         {
             // replace NPoco database type by a more efficient one
 
-            var setting = ConfigurationManager.AppSettings["Umbraco.DatabaseFactory.ServerVersion"];
+            var setting = ConfigurationManager.AppSettings[Constants.AppSettings.DatabaseFactoryServerVersion];
             var fromSettings = false;
 
             if (setting.IsNullOrWhiteSpace() || !setting.StartsWith("SqlServer.")

--- a/src/Umbraco.Core/Runtime/CoreRuntimeComposer.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntimeComposer.cs
@@ -76,7 +76,7 @@ namespace Umbraco.Core.Runtime
                 // TODO: this is a hack, use proper configuration!
                 // also: we still register the full IServerMessenger because
                 // even on 1 single server we can have 2 concurrent app domains
-                var singleServer = "true".InvariantEquals(ConfigurationManager.AppSettings["umbracoDisableElectionForSingleServer"]);
+                var singleServer = "true".InvariantEquals(ConfigurationManager.AppSettings[Constants.AppSettings.DisableElectionForSingleServer]);
                 return singleServer
                     ? (IServerRegistrar) new SingleServerRegistrar(f.GetInstance<IRuntimeState>())
                     : new DatabaseServerRegistrar(

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -285,6 +285,7 @@
     <Compile Include="Constants-Security.cs" />
     <Compile Include="Constants-System.cs" />
     <Compile Include="Constants-Indexes.cs" />
+    <Compile Include="Constants-AppSettings.cs" />
     <Compile Include="Constants-Web.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Composing\RegisterExtensions.cs" />

--- a/src/Umbraco.Tests/App.config
+++ b/src/Umbraco.Tests/App.config
@@ -4,7 +4,7 @@
   </configSections>
 
   <appSettings>
-    <add key="umbracoConfigurationStatus" value="6.0.0"/>
+    <add key="Umbraco.Core.ConfigurationStatus" value="6.0.0"/>
     <add key="umbracoReservedUrls" value="~/config/splashes/booting.aspx,~/install/default.aspx,~/config/splashes/noNodes.aspx,~/VSEnterpriseHelper.axd,~/.well-known" />
     <add key="umbracoReservedPaths" value="~/install/"/>
     <add key="umbracoPath" value="~/umbraco"/>

--- a/src/Umbraco.Tests/App.config
+++ b/src/Umbraco.Tests/App.config
@@ -5,14 +5,13 @@
 
   <appSettings>
     <add key="Umbraco.Core.ConfigurationStatus" value="6.0.0"/>
-    <add key="umbracoReservedUrls" value="~/config/splashes/booting.aspx,~/install/default.aspx,~/config/splashes/noNodes.aspx,~/VSEnterpriseHelper.axd,~/.well-known" />
-    <add key="umbracoReservedPaths" value="~/install/"/>
-    <add key="umbracoPath" value="~/umbraco"/>
-    <add key="umbracoHideTopLevelNodeFromPath" value="true"/>
-    <add key="umbracoUseDirectoryUrls" value="false"/>
-    <add key="umbracoTimeOutInMinutes" value="20"/>
-    <add key="umbracoDefaultUILanguage" value="en"/>
-    <add key="umbracoUseHttps" value="false"/>
+    <add key="Umbraco.Core.ReservedUrls" value="~/config/splashes/booting.aspx,~/install/default.aspx,~/config/splashes/noNodes.aspx,~/VSEnterpriseHelper.axd,~/.well-known" />
+    <add key="Umbraco.Core.ReservedPaths" value="~/install/"/>
+    <add key="Umbraco.Core.Path" value="~/umbraco"/>
+    <add key="Umbraco.Core.HideTopLevelNodeFromPath" value="true"/>
+    <add key="Umbraco.Core.TimeOutInMinutes" value="20"/>
+    <add key="Umbraco.Core.DefaultUILanguage" value="en"/>
+    <add key="Umbraco.Core.UseHttps" value="false"/>
     <add key="dataAnnotations:dataTypeAttribute:disableRegEx" value="false"/>
   </appSettings>
 

--- a/src/Umbraco.Tests/LegacyXmlPublishedCache/PublishedMediaCache.cs
+++ b/src/Umbraco.Tests/LegacyXmlPublishedCache/PublishedMediaCache.cs
@@ -645,7 +645,7 @@ namespace Umbraco.Tests.LegacyXmlPublishedCache
 
         private static void InitializeCacheConfig()
         {
-            var value = ConfigurationManager.AppSettings["Umbraco.PublishedMediaCache.Seconds"];
+            var value = ConfigurationManager.AppSettings[Constants.AppSettings.PublishedMediaCacheSeconds];
             int seconds;
             if (int.TryParse(value, out seconds) == false)
                 seconds = PublishedMediaCacheTimespanSeconds;

--- a/src/Umbraco.Tests/Runtimes/StandaloneTests.cs
+++ b/src/Umbraco.Tests/Runtimes/StandaloneTests.cs
@@ -52,7 +52,7 @@ namespace Umbraco.Tests.Runtimes
 
             // settings
             // reset the current version to 0.0.0, clear connection strings
-            ConfigurationManager.AppSettings["umbracoConfigurationStatus"] = "";
+            ConfigurationManager.AppSettings[Constants.AppSettings.ConfigurationStatus] = "";
             // FIXME: we need a better management of settings here (and, true config files?)
 
             // create the very basic and essential things we need

--- a/src/Umbraco.Tests/Security/BackOfficeCookieManagerTests.cs
+++ b/src/Umbraco.Tests/Security/BackOfficeCookieManagerTests.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Tests.Security
         public void ShouldAuthenticateRequest_When_Not_Configured()
         {
             //should force app ctx to show not-configured
-            ConfigurationManager.AppSettings.Set("umbracoConfigurationStatus", "");
+            ConfigurationManager.AppSettings.Set(Constants.AppSettings.ConfigurationStatus, "");
 
             var globalSettings = TestObjects.GetGlobalSettings();
             var umbracoContext = new UmbracoContext(

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -31,13 +31,13 @@
 
     <appSettings>
         <add key="Umbraco.Core.ConfigurationStatus" value="" />
-	    <add key="umbracoReservedUrls" value="" />
-        <add key="umbracoReservedPaths" value="" />
-        <add key="umbracoPath" value="~/umbraco" />
-        <add key="umbracoHideTopLevelNodeFromPath" value="true" />
-        <add key="umbracoTimeOutInMinutes" value="20" />
-        <add key="umbracoDefaultUILanguage" value="en-US" />
-        <add key="umbracoUseHttps" value="false" />
+	    <add key="Umbraco.Core.ReservedUrls" value="" />
+        <add key="Umbraco.Core.ReservedPaths" value="" />
+        <add key="Umbraco.Core.Path" value="~/umbraco" />
+        <add key="Umbraco.Core.HideTopLevelNodeFromPath" value="true" />
+        <add key="Umbraco.Core.TimeOutInMinutes" value="20" />
+        <add key="Umbraco.Core.DefaultUILanguage" value="en-US" />
+        <add key="Umbraco.Core.UseHttps" value="false" />
 
         <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
         <add key="webpages:Enabled" value="false" />

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -30,7 +30,7 @@
     <clientDependency configSource="config\ClientDependency.config" />
 
     <appSettings>
-        <add key="umbracoConfigurationStatus" value="" />
+        <add key="Umbraco.Core.ConfigurationStatus" value="" />
 	    <add key="umbracoReservedUrls" value="" />
         <add key="umbracoReservedPaths" value="" />
         <add key="umbracoPath" value="~/umbraco" />

--- a/src/Umbraco.Web/Runtime/WebRuntimeComponent.cs
+++ b/src/Umbraco.Web/Runtime/WebRuntimeComponent.cs
@@ -248,7 +248,7 @@ namespace Umbraco.Web.Runtime
             XmlFileMapper.FileMapDefaultFolder = SystemDirectories.TempData.EnsureEndsWith('/') + "ClientDependency";
             BaseCompositeFileProcessingProvider.UrlTypeDefault = CompositeUrlType.Base64QueryStrings;
 
-            // Now we need to detect if we are running umbracoLocalTempStorage as EnvironmentTemp and in that case we want to change the CDF file
+            // Now we need to detect if we are running 'Umbraco.Core.LocalTempStorage' as EnvironmentTemp and in that case we want to change the CDF file
             // location to be there
             if (globalSettings.LocalTempStorageLocation == LocalTempStorage.EnvironmentTemp)
             {

--- a/src/Umbraco.Web/Security/ActiveDirectoryBackOfficeUserPasswordChecker.cs
+++ b/src/Umbraco.Web/Security/ActiveDirectoryBackOfficeUserPasswordChecker.cs
@@ -13,6 +13,7 @@ namespace Umbraco.Web.Security
         {
             get
             {
+                // TODO: Verify this AppSetting key is used in .NET Framework & canot be changed to Umbraco.Core. prefix
                 return ConfigurationManager.AppSettings["ActiveDirectoryDomain"];
             }
         }


### PR DESCRIPTION
Bye bye `umbracoPath` and hello `Umbraco.Core.Path`

This PR sets a new convention of `Umbraco.Core.` and `Umbraco.Core.Debug.` for our Application Setting Keys so they align better with `Umbraco.ModelsBuilder.` and `Umbraco.Examine.` AppSetting keys

## Code Review

- [ ] Code sanity check
- [ ] Check again that I have made no typos

## Bonus
If you can fill out or describe nicely the AppSetting keys in the `Constants-AppSettings` class that have TODO in the XML docs summary then that would be awesome 