### PR TITLE
Change default StorageType for the SetTags extentions method to Json

### DIFF
--- a/src/Umbraco.Core/Models/ContentExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -640,7 +640,7 @@ namespace Umbraco.Core.Models
         /// <returns></returns>
         public static void SetTags(this IContentBase content, string propertyTypeAlias, IEnumerable<string> tags, bool replaceTags, string tagGroup = "default")
         {
-            content.SetTags(TagCacheStorageType.Csv, propertyTypeAlias, tags, replaceTags, tagGroup);
+            content.SetTags(TagCacheStorageType.Json, propertyTypeAlias, tags, replaceTags, tagGroup);
         }
 
         /// <summary>


### PR DESCRIPTION
Now that we've switched the default storage type of the Tags property to Json, should the default StorageType for the SetTags extension method also be set to Json?

Bearing in mind this would be some sort of breaking change if people upgrade and have been using SetTags with a Tag property using the Csv storage type. So any change should certainly need to be mentioned in the Specific Version Upgrade guide.

I'm thinking moving forwards though, new people will increasingly be using Json as the storage format, as it is now the default storage type for the property, and if they use the SetTags extension will fall foul of this difference... what do we think?

Just easier to ask the question in a PR!

Have put a PR into the docs, that outlines the existence of the full signature, so there is some hint that there are different storage types; so that maybe enough if we don't want to introduce the breaking change: https://github.com/umbraco/UmbracoDocs/pull/1519
