### PR TITLE
V8: Align dialogs in the Settings section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/macros/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/delete.html
@@ -5,6 +5,6 @@
             <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{vm.name}}</strong>?
         </p>
 
-        <umb-confirm on-confirm="vm.performDelete" on-cancel="cancel"></umb-confirm>
+        <umb-confirm on-confirm="vm.performDelete" on-cancel="vm.cancel"></umb-confirm>
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/create.html
@@ -77,7 +77,7 @@
     </div>
 
     <!-- Dialog footer -->
-    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="vm.creatingFolder">
         <button class="btn btn-info" ng-click="vm.close()">
             <localize key="buttons_somethingElse">Do something else</localize>
         </button>

--- a/src/Umbraco.Web.UI.Client/src/views/partialviews/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviews/create.html
@@ -67,7 +67,7 @@
     </div>
 
     <!-- Dialog footer -->
-    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="vm.creatingFolder">
         <button class="btn btn-info" ng-click="vm.close()">
             <localize key="buttons_somethingElse">Do something else</localize>
         </button>

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/create.html
@@ -50,9 +50,3 @@
         </form>
     </div>
 </div>
-
-<div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
-    <button class="btn btn-info">
-        <localize key="buttons_somethingElse">Do something else</localize>
-    </button>
-</div>

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/create.html
@@ -49,7 +49,7 @@
 
     </div>
 
-    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="vm.creatingFolder">
         <button class="btn btn-info" ng-click="vm.close()">
             <localize key="buttons_somethingElse">Do something else</localize>
         </button>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR fixes a few inconsistencies in the Settings section dialogs:

1. The delete macro confirmation dialog is missing its cancel button.
2. "Do something else" is left visible on a few inline create dialogs - it's normally hidden. The affected dialogs are:
   - Create partial view macro folder
   - Create partial view folder
   - Create stylesheets folder
   - Create relation type

![image](https://user-images.githubusercontent.com/7405322/52108646-ee34cc00-25fa-11e9-9d0a-3166d1ca6246.png)

![image](https://user-images.githubusercontent.com/7405322/52108704-1fad9780-25fb-11e9-8b99-517dd1570f38.png)
