### PR TITLE
V8: Relation type editor crashes for root relations and is using excessive XHR

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
@@ -71,16 +71,38 @@ function RelationTypeEditController($scope, $routeParams, relationTypeResource, 
     }
 
     function getRelationNames(relationType) {
-        if(relationType.relations) {
-            angular.forEach(relationType.relations, function(relation){
-                entityResource.getById(relation.parentId, relationType.parentObjectTypeName).then(function(entity) {
-                    relation.parentName = entity.name;
+        if (relationType.relations) {
+            // can we grab app entity types in one go?
+            if (relationType.parentObjectType === relationType.childObjectType) {
+                // yep, grab the distinct list of parent and child entities
+                var entityIds = _.uniq(_.union(_.pluck(relationType.relations, "parentId"), _.pluck(relationType.relations, "childId")));
+                entityResource.getByIds(entityIds, relationType.parentObjectTypeName).then(function (entities) {
+                    updateRelationNames(relationType, entities);
                 });
-                entityResource.getById(relation.childId, relationType.childObjectTypeName).then(function(entity) {
-                    relation.childName = entity.name;
+            } else {
+                // nope, grab the parent and child entities individually
+                var parentEntityIds = _.uniq(_.pluck(relationType.relations, "parentId"));
+                var childEntityIds = _.uniq(_.pluck(relationType.relations, "childId"));
+                entityResource.getByIds(parentEntityIds, relationType.parentObjectTypeName).then(function (entities) {
+                    updateRelationNames(relationType, entities);
                 });
-            });
+                entityResource.getByIds(childEntityIds, relationType.childObjectTypeName).then(function (entities) {
+                    updateRelationNames(relationType, entities);
+                });
+            }
         }
+    }
+
+    function updateRelationNames(relationType, entities) {
+        var entitiesById = _.indexBy(entities, "id");
+        _.each(relationType.relations, function(relation) {
+            if (entitiesById[relation.parentId]) {
+                relation.parentName = entitiesById[relation.parentId].name;
+            }
+            if (entitiesById[relation.childId]) {
+                relation.childName = entitiesById[relation.childId].name;
+            }
+        });
     }
 
     function saveRelationType() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The relation types "Relate parent document on delete" and "Relate parent media folder on delete" crash once you delete an item on root level:

![relation type editor before](https://user-images.githubusercontent.com/7405322/52108995-3e605e00-25fc-11e9-838a-6366b812ec9c.png)

This PR fixes it. 

I also noticed an excessive number of XHR being initated by the relation type editor (calling `entityResource.getById()` in a `forEach` loop). I have bundled these requests up using `entityResource.getByIds()` instead.

#### Steps to reproduce

1. Create a content node on root level.
2. Move the node to the trash.
3. Open the "Relate parent document on delete" relation type.
4. The editor is stuck in a loading state and the console outputs a JS error.