### PR TITLE
V8: Make Nested Content resilient towards culture variance in elements

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -172,18 +172,16 @@ namespace Umbraco.Web.PropertyEditors
                             try
                             {
                                 // create a temp property with the value
+                                // - force it to be culture invariant as NC can't handle culture variant element properties
+                                propType.Variations = ContentVariation.Nothing;
                                 var tempProp = new Property(propType);
-                                // if the property varies by culture, make sure we save using the current culture
-                                var propCulture = propType.VariesByCulture() || propType.VariesByCultureAndSegment()
-                                    ? culture
-                                    : null;
-                                tempProp.SetValue(propValues[propAlias] == null ? null : propValues[propAlias].ToString(), propCulture);
+                                tempProp.SetValue(propValues[propAlias] == null ? null : propValues[propAlias].ToString());
 
                                 // convert that temp property, and store the converted value
                                 var propEditor = _propertyEditors[propType.PropertyEditorAlias];
                                 var tempConfig = dataTypeService.GetDataType(propType.DataTypeId).Configuration;
                                 var valEditor = propEditor.GetValueEditor(tempConfig);
-                                var convValue = valEditor.ToEditor(tempProp, dataTypeService, propCulture);
+                                var convValue = valEditor.ToEditor(tempProp, dataTypeService);
                                 propValues[propAlias] = convValue == null ? null : JToken.FromObject(convValue);
                             }
                             catch (InvalidOperationException)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

You'll end up with a mapping YSOD if you have Nested Content on culture invariant content using culture variant elements. It's a bit hard to explain, so here's how to reproduce it.

#### Steps to reproduce

1. Create an element type that varies by culture.
2. Add a textbox property to the element type and make it culture variant as well. Name the property "Text".
3. Create a Nested Content datatype that uses the element type as item blueprint.
4. Create a content type that does *not* vary by culture.
5. Add a property to the content type based on the Nested Content datatype. Name the property "List".
6. Create a page based on the content type. 
7. Add an element to "List", enter some text in the element textbox and save.
8. Kaboom!

![nc culture variance error](https://user-images.githubusercontent.com/7405322/52109220-f988f700-25fc-11e9-81ce-5fbce4c1eb87.png)

#### Testing this PR

1. Make sure the steps above do not invoke an error.
2. Assign the template below to the content type.
3. View the page in frontend and verify that the Nested Content element data is rendered in the `<ul/>`
4. Make both the content type and the "List" property culture variant.
5. Add some list elements in another culture.
6. View both cultures in frontend and make sure they render the culture variant Nested Content element data in the `<ul/>`.

#### Test template

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@{
	Layout = null;
}

<html>
    <body>
        <ul>
        @foreach(var element in Model.Value<IEnumerable<IPublishedElement>>("list")) {
            <li>@element.Value("text") (@element.ContentType.Alias)</li>        
        }
        </ul>
    </body>
</html>
```
