### PR TITLE
Grid fixes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -617,7 +617,7 @@
             // TODO: Add "..." to save button label if there are more than one variant to publish - currently it just adds the elipses if there's more than 1 variant
             if (isContentCultureVariant()) {
                 //before we launch the dialog we want to execute all client side validations first
-                if (formHelper.submitForm({ scope: $scope, action: "save" })) {
+                if (formHelper.submitForm({ scope: $scope, action: "openSaveDialog" })) {
 
                     var dialog = {
                         parentScope: $scope,

--- a/src/Umbraco.Web.UI.Client/src/common/interceptors/_module.js
+++ b/src/Umbraco.Web.UI.Client/src/common/interceptors/_module.js
@@ -6,4 +6,5 @@ angular.module('umbraco.interceptors', [])
 
         $httpProvider.interceptors.push('securityInterceptor');
         $httpProvider.interceptors.push('debugRequestInterceptor');
+        $httpProvider.interceptors.push('doNotPostDollarVariablesOnPostRequestInterceptor');
     }]);

--- a/src/Umbraco.Web.UI.Client/src/common/interceptors/donotpostdollarvariablesrequest.interceptor.js
+++ b/src/Umbraco.Web.UI.Client/src/common/interceptors/donotpostdollarvariablesrequest.interceptor.js
@@ -26,7 +26,7 @@
             //dealing with requests:
             'request': function(config) {
                 if(config.method === "POST"){
-                    config.transformRequest.push(transform);
+                    transform(config.data);
                 }
                 
                 return config;

--- a/src/Umbraco.Web.UI.Client/src/common/interceptors/donotpostdollarvariablesrequest.interceptor.js
+++ b/src/Umbraco.Web.UI.Client/src/common/interceptors/donotpostdollarvariablesrequest.interceptor.js
@@ -1,0 +1,38 @@
+﻿(function() {
+   'use strict';
+   
+    function removeProperty(obj, propertyPrefix) {
+        for (var property in obj) {
+            if (obj.hasOwnProperty(property)) {
+                
+                if (property.startsWith(propertyPrefix) && obj[property]) {
+                    obj[property] = undefined;
+                }
+                
+                if (typeof obj[property] == "object") {
+                    removeProperty(obj[property], propertyPrefix);
+                }
+            }
+        }
+        
+    }
+    
+    function transform(data){
+        removeProperty(data, "$");
+    }
+    
+    function doNotPostDollarVariablesRequestInterceptor($q, urlHelper) {
+        return {
+            //dealing with requests:
+            'request': function(config) {
+                if(config.method === "POST"){
+                    config.transformRequest.push(transform);
+                }
+                
+                return config;
+            }
+        };
+   }
+
+    angular.module('umbraco.interceptors').factory('doNotPostDollarVariablesOnPostRequestInterceptor', doNotPostDollarVariablesRequestInterceptor);
+})();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -909,9 +909,9 @@ angular.module("umbraco")
         // needs to be merged in at runtime to ensure that the real config values are used
         // if they are ever updated.
 
-        var unsubscribe = $scope.$on("formSubmitting", function () {
-
-            if ($scope.model.value && $scope.model.value.sections) {
+        var unsubscribe = $scope.$on("formSubmitting", function (e, args) {
+            
+            if (args.action === "save" && $scope.model.value && $scope.model.value.sections) {
                 _.each($scope.model.value.sections, function(section) {
                     if (section.rows) {
                         _.each(section.rows, function (row) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -60,8 +60,8 @@ angular.module("umbraco")
             start: function (e, ui) {
 
                 // Fade out row when sorting
-                ui.item.context.style.display = "block";
-                ui.item.context.style.opacity = "0.5";
+                ui.item[0].style.display = "block";
+                ui.item[0].style.opacity = "0.5";
 
                 draggedRteSettings = {};
                 ui.item.find(".mceNoEditor").each(function () {
@@ -75,7 +75,7 @@ angular.module("umbraco")
             stop: function (e, ui) {
 
                 // Fade in row when sorting stops
-                ui.item.context.style.opacity = "1";
+                ui.item[0].style.opacity = "1";
 
                 // reset all RTEs affected by the dragging
                 ui.item.parents(".umb-column").find(".mceNoEditor").each(function () {
@@ -185,12 +185,12 @@ angular.module("umbraco")
                 startingArea = area;
 
                 // fade out control when sorting
-                ui.item.context.style.display = "block";
-                ui.item.context.style.opacity = "0.5";
+                ui.item[0].style.display = "block";
+                ui.item[0].style.opacity = "0.5";
 
                 // reset dragged RTE settings in case a RTE isn't dragged
                 draggedRteSettings = undefined;
-                ui.item.context.style.display = "block";
+                ui.item[0].style.display = "block";
                 ui.item.find(".mceNoEditor").each(function () {
                     notIncludedRte = [];
                     var editors = _.findWhere(tinyMCE.editors, { id: $(this).attr("id") });
@@ -210,7 +210,7 @@ angular.module("umbraco")
             stop: function (e, ui) {
 
                 // Fade in control when sorting stops
-                ui.item.context.style.opacity = "1";
+                ui.item[0].style.opacity = "1";
 
                 ui.item.offsetParent().find(".mceNoEditor").each(function () {
                     if ($.inArray($(this).attr("id"), notIncludedRte) < 0) {
@@ -400,7 +400,7 @@ angular.module("umbraco")
         }
 
         $scope.editGridItemSettings = function (gridItem, itemType) {
-
+            
             placeHolder = "{0}";
 
             var styles, config;
@@ -658,7 +658,7 @@ angular.module("umbraco")
         // *********************************************
         $scope.initContent = function () {
             var clear = true;
-
+            
             //settings indicator shortcut
             if (($scope.model.config.items.config && $scope.model.config.items.config.length > 0) || ($scope.model.config.items.styles && $scope.model.config.items.styles.length > 0)) {
                 $scope.hasSettings = true;
@@ -755,7 +755,7 @@ angular.module("umbraco")
         // Init layout / row
         // *********************************************
         $scope.initRow = function (row) {
-
+            
             //merge the layout data with the original config data
             //if there are no config info on this, splice it out
             var original = _.find($scope.model.config.items.layouts, function (o) { return o.name === row.name; });


### PR DESCRIPTION
Fixes: #4068

Fixes a couple of issues with the grid
- We saved too much information on the server after angular upgrade (`$`-prefixed variables was saved). This is not removed from the post data in a intercepter
- The sorting was broken
- We cleared the editor data when the save button was clicked. But if the content is variant, we are able to close the dialog, and then the grid was missing information.

*Steps to reproduce:*
- Add a variant document type with a grid
- Add grid values. 
- Save and check the reloaded content is correct.
- Test the reordering of the grid controls