### PR TITLE
V8: Media picker upload button does nothing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -104,7 +104,7 @@ angular.module("umbraco")
             }
 
             $scope.upload = function(v) {
-                angular.element(".umb-file-dropzone-directive .file-select").trigger("click");
+                angular.element(".umb-file-dropzone .file-select").trigger("click");
             };
 
             $scope.dragLeave = function(el, event) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4351

### Description

See #4351 for details and steps to reproduce. 

The problem is caused by an element selector based on V7 class names.