### PR TITLE
V8: fixed type of dashboards in EditorModelEventManager

### DIFF
--- a/src/Umbraco.Web/Editors/DashboardController.cs
+++ b/src/Umbraco.Web/Editors/DashboardController.cs
@@ -215,7 +215,7 @@ namespace Umbraco.Web.Editors
                     Alias = y.Alias,
                     View = y.View
                 })
-            });
+            }).ToList();
         }
     }
 }

--- a/src/Umbraco.Web/Editors/EditorModelEventManager.cs
+++ b/src/Umbraco.Web/Editors/EditorModelEventManager.cs
@@ -15,9 +15,9 @@ namespace Umbraco.Web.Editors
         public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<MediaItemDisplay>> SendingMediaModel;
         public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<MemberDisplay>> SendingMemberModel;
         public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<UserDisplay>> SendingUserModel;
-        public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<IEnumerable<Tab<IDashboard>>>> SendingDashboardModel;
+        public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<IEnumerable<Tab<IDashboardSlim>>>> SendingDashboardModel;
 
-        private static void OnSendingDashboardModel(HttpActionExecutedContext sender, EditorModelEventArgs<IEnumerable<Tab<IDashboard>>> e)
+        private static void OnSendingDashboardModel(HttpActionExecutedContext sender, EditorModelEventArgs<IEnumerable<Tab<IDashboardSlim>>> e)
         {
             var handler = SendingDashboardModel;
             handler?.Invoke(sender, e);
@@ -67,7 +67,7 @@ namespace Umbraco.Web.Editors
                 OnSendingUserModel(sender, new EditorModelEventArgs<UserDisplay>(e));
 
             if (e.Model is IEnumerable<IDashboard>)
-                OnSendingDashboardModel(sender, new EditorModelEventArgs<IEnumerable<Tab<IDashboard>>>(e));
+                OnSendingDashboardModel(sender, new EditorModelEventArgs<IEnumerable<Tab<IDashboardSlim>>>(e));
         }
     }
 }

--- a/src/Umbraco.Web/Editors/EditorModelEventManager.cs
+++ b/src/Umbraco.Web/Editors/EditorModelEventManager.cs
@@ -66,7 +66,7 @@ namespace Umbraco.Web.Editors
             if (e.Model is UserDisplay)
                 OnSendingUserModel(sender, new EditorModelEventArgs<UserDisplay>(e));
 
-            if (e.Model is IEnumerable<IDashboard>)
+            if (e.Model is IEnumerable<Tab<IDashboardSlim>>)
                 OnSendingDashboardModel(sender, new EditorModelEventArgs<IEnumerable<Tab<IDashboardSlim>>>(e));
         }
     }


### PR DESCRIPTION
It seems that [**GetDashboard** method](https://github.com/umbraco/Umbraco-CMS/blob/temp8/src/Umbraco.Web/Editors/DashboardController.cs#L204) was updated to return `IEnumerable<Tab<IDashboardSlim>>` instead of `IEnumerable<Tab<IDashboard>>`, but the matching logic in `EditorModelEventManager` hasn't been updated as well. As a result, the event is no longer invoked. 💣 

This PR fixes that 😉 