### PR TITLE
Added null check for context.Identity

### DIFF
--- a/src/Umbraco.Core/Security/BackOfficeCookieAuthenticationProvider.cs
+++ b/src/Umbraco.Core/Security/BackOfficeCookieAuthenticationProvider.cs
@@ -107,6 +107,11 @@ namespace Umbraco.Core.Security
 
             await EnsureValidSessionId(context);
 
+            if (context?.Identity == null)
+            {
+                context?.OwinContext.Authentication.SignOut(context.Options.AuthenticationType);
+                return;
+            }
             await base.ValidateIdentity(context);
         }        
 


### PR DESCRIPTION
### Prerequisites

Fixes [Issue 4365](https://github.com/umbraco/Umbraco-CMS/issues/4365)

### Description

Since the null argument is actually the `context.Identity`, I suggest adding a null check for `context.Identity` before calling `base.ValidateIdentity(context)`