### PR TITLE
V8: Use "Email" instead of "Username" on the login screen

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -48,6 +48,7 @@
         vm.externalLoginInfo = externalLoginInfo;
         vm.resetPasswordCodeInfo = resetPasswordCodeInfo;
         vm.backgroundImage = Umbraco.Sys.ServerVariables.umbracoSettings.loginBackgroundImage;
+        vm.usernameIsEmail = Umbraco.Sys.ServerVariables.umbracoSettings.usernameIsEmail;
 
         vm.$onInit = onInit;
         vm.togglePassword = togglePassword;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -62,6 +62,15 @@
         vm.requestPasswordResetSubmit = requestPasswordResetSubmit;
         vm.setPasswordSubmit = setPasswordSubmit;
 
+        vm.labels = {};
+        localizationService.localizeMany([
+            vm.usernameIsEmail ? "general_email" : "general_username", 
+            vm.usernameIsEmail ? "placeholders_email" : "placeholders_usernameHint"]
+        ).then(function (data) {
+            vm.labels.usernameLabel = data[0];
+            vm.labels.usernamePlaceholder = data[1];
+        })                        
+
         function onInit() {
 
             // Check if it is a new user

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -153,11 +153,8 @@
                         </div>
 
                         <div class="control-group" ng-class="{error: vm.loginForm.username.$invalid}">
-                            <label>
-                                <localize ng-hide="vm.usernameIsEmail" key="general_username">Username</localize>
-                                <localize ng-show="vm.usernameIsEmail" key="general_email">Email</localize>
-                            </label>
-                            <input type="text" ng-model="vm.login" name="username" class="-full-width-input" localize="placeholder" placeholder="@placeholders_usernameHint" focus-when="{{vm.view === 'login'}}" />
+                            <label>{{vm.labels.usernameLabel}}</label>
+                            <input type="text" ng-model="vm.login" name="username" class="-full-width-input" placeholder="{{vm.labels.usernamePlaceholder}}" focus-when="{{vm.view === 'login'}}" />
                         </div>
 
                         <div class="control-group" ng-class="{error: vm.loginForm.password.$invalid}">

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -153,7 +153,10 @@
                         </div>
 
                         <div class="control-group" ng-class="{error: vm.loginForm.username.$invalid}">
-                            <label><localize key="general_username">Username</localize></label>
+                            <label>
+                                <localize ng-hide="vm.usernameIsEmail" key="general_username">Username</localize>
+                                <localize ng-show="vm.usernameIsEmail" key="general_email">Email</localize>
+                            </label>
                             <input type="text" ng-model="vm.login" name="username" class="-full-width-input" localize="placeholder" placeholder="@placeholders_usernameHint" focus-when="{{vm.view === 'login'}}" />
                         </div>
 

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -480,7 +480,7 @@
     <key alias="search">Type to search...</key>
     <key alias="filter">Type to filter...</key>
     <key alias="enterTags">Type to add tags (press enter after each tag)...</key>
-    <key alias="email">Enter your email...</key>
+    <key alias="email">Enter your email</key>
     <key alias="enterMessage">Enter a message...</key>
     <key alias="usernameHint">Your username is usually your email</key>
     <key alias="anchor">#value or ?key=value</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -484,7 +484,7 @@
     <key alias="search">Type to search...</key>
     <key alias="filter">Type to filter...</key>
     <key alias="enterTags">Type to add tags (press enter after each tag)...</key>
-    <key alias="email">Enter your email...</key>
+    <key alias="email">Enter your email</key>
     <key alias="enterMessage">Enter a message...</key>
     <key alias="usernameHint">Your username is usually your email</key>
     <key alias="anchor">#value or ?key=value</key>

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -58,7 +58,7 @@ namespace Umbraco.Web.Editors
             var keepOnlyKeys = new Dictionary<string, string[]>
             {
                 {"umbracoUrls", new[] {"authenticationApiBaseUrl", "serverVarsJs", "externalLoginsUrl", "currentUserApiBaseUrl"}},
-                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "canSendRequiredEmail"}},
+                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "canSendRequiredEmail", "usernameIsEmail"}},
                 {"application", new[] {"applicationPath", "cacheBuster"}},
                 {"isDebuggingEnabled", new string[] { }},
                 {"features", new [] {"disabledFeatures"}}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4373

### Description

As discussed on #4373, the login screen should ask for "Email" instead of "Username" when Umbraco is configured to use emails as usernames.

With this PR the login screen looks like this when emails are used as usernames:

![image](https://user-images.githubusercontent.com/7405322/52176716-c9855380-27b6-11e9-9595-5cb28d106c66.png)

#### Testing this PR

1. Set `usernameIsEmail` to `true` in umbracoSettings.config.
2. Verify that the login screen asks for "Email", not "Username".
3. Set `usernameIsEmail` to `false` in umbracoSettings.config.
4. Verify that the login screen asks for "Username", not "Email".
