### PR TITLE
V8: Fix the editor actions menu

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditormenu.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditormenu.directive.js
@@ -30,8 +30,8 @@
                 }
 
                 //when the options item is selected, we need to set the current menu item in appState (since this is synonymous with a menu)
-                // Niels: No i think we are wrong, we should not set the currentNode, cause it represents the currentNode of interaction.
-                //appState.setMenuState("currentNode", scope.currentNode);
+                //- otherwise we break any tree dialog that works with the current node (and that's pretty much all of them)
+                appState.setMenuState("currentNode", scope.currentNode);
                 
                 if (!scope.actions) {
                     treeService.getMenu({ treeNode: scope.currentNode })

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditormenu.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditormenu.directive.js
@@ -18,6 +18,10 @@
             //adds a handler to the context menu item click, we need to handle this differently
             //depending on what the menu item is supposed to do.
             scope.executeMenuItem = function (action) {
+                //the action is called as it would be by the tree. to ensure that the action targets the correct node, 
+                //we need to set the current node in appState before calling the action. otherwise we break all actions
+                //that use the current node (and that's pretty much all of them)
+                appState.setMenuState("currentNode", scope.currentNode);                
                 navigationService.executeMenuAction(action, scope.currentNode, scope.currentSection);
                 scope.dropdown.isOpen = false;
             };
@@ -29,10 +33,6 @@
                     return;
                 }
 
-                //when the options item is selected, we need to set the current menu item in appState (since this is synonymous with a menu)
-                //- otherwise we break any tree dialog that works with the current node (and that's pretty much all of them)
-                appState.setMenuState("currentNode", scope.currentNode);
-                
                 if (!scope.actions) {
                     treeService.getMenu({ treeNode: scope.currentNode })
                         .then(function (data) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4369 and https://github.com/umbraco/Umbraco-CMS/issues/4358

### Description

[This change](https://github.com/umbraco/Umbraco-CMS/commit/2ab391eb69abc7fc5d243e4930ce21386a81a870#diff-f5d5e4be9411f9b444fa0513234cc6cdR34) broke the editor actions menu as described in the related issues. I have reverted the change with an updated comment to leave it alone (at least for now).

To test this, simply ensure that the "Culture and Hostnames" dialog can be opened from the actions menu:

![editor-actions-menu](https://user-images.githubusercontent.com/7405322/52177074-3bac6700-27bc-11e9-98c2-0a706bdb2773.gif)

**Update:** I have moved things around a bit so we set the menu state as late as possible. This ensures that the action is *always* carried out on the correct node in the tree.

