### PR TITLE
V8: Repeatable string hover + move handle styling

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
@@ -37,6 +37,10 @@
     &:extend(.umb-node-preview-add);
 }
 
+.umb-multiple-textbox .add-link:hover {
+    &:extend(.umb-node-preview-add:hover);
+}
+
 .umb-editor-wrapper .umb-multiple-textbox .add-link {
     &:extend(.umb-editor-wrapper .umb-node-preview);
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
@@ -26,6 +26,7 @@
 
 .umb-multiple-textbox .textbox-wrapper i.handle {
     margin-left: 5px;
+    cursor: move;
 }
 
 .umb-multiple-textbox .textbox-wrapper a.remove {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4386

### Description

As #4386 points out, the hover effect for the `umb-multiple-textbox` "Add" link isn't consistent with the "Add" link of the treenode pickers. 

As it turns out, the `umb-multiple-textbox` "Add" link actually inherits its styles from `umb-node-preview-add` (used by the treenode pickers), but the hover effect hasn't been included. This PR fixes it.

I have also added a "move" cursor effect on the move handle for the text strings, as this is also in line with the styling elsewhere.

The whole thing looks something like this:

![repeatable-texts-styling](https://user-images.githubusercontent.com/7405322/52182752-7637f300-2800-11e9-81bb-fc40d7b9e27f.gif)
