### PR TITLE
V8: Support explicit sort order for sections

### DIFF
--- a/src/Umbraco.Core/Manifest/ManifestBackOfficeSection.cs
+++ b/src/Umbraco.Core/Manifest/ManifestBackOfficeSection.cs
@@ -11,5 +11,8 @@ namespace Umbraco.Core.Manifest
 
         [DataMember(Name = "name")]
         public string Name { get; set; }
+
+        [DataMember(Name = "sortOrder")]
+        public int SortOrder { get; set; }
     }
 }

--- a/src/Umbraco.Core/Models/Trees/IBackOfficeSection.cs
+++ b/src/Umbraco.Core/Models/Trees/IBackOfficeSection.cs
@@ -14,5 +14,13 @@
         /// Gets the name of the section.
         /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Gets the sort order of the section
+        /// </summary>
+        /// <remarks>
+        /// System section sort orders start at 10 (Content) and increment in steps of 10 (Media has sort order 20, Settings has sort order 30 and so on)
+        /// </remarks>
+        int SortOrder { get; }
     }
 }

--- a/src/Umbraco.Web/Editors/SectionController.cs
+++ b/src/Umbraco.Web/Editors/SectionController.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Web.Editors
 
         public IEnumerable<Section> GetSections()
         {
-            var sections = _sectionService.GetAllowedSections(Security.GetUserId().ResultOr(0));
+            var sections = _sectionService.GetAllowedSections(Security.GetUserId().ResultOr(0)).OrderBy(section => section.SortOrder);
 
             var sectionModels = sections.Select(Mapper.Map<Section>).ToArray();
             

--- a/src/Umbraco.Web/Models/Mapping/UserMapperProfile.cs
+++ b/src/Umbraco.Web/Models/Mapping/UserMapperProfile.cs
@@ -372,7 +372,7 @@ namespace Umbraco.Web.Models.Mapping
         private void MapUserGroupBasic(ISectionService sectionService, IEntityService entityService, ILocalizedTextService textService, dynamic group, UserGroupBasic display)
         {
             var allSections = sectionService.GetSections();
-            display.Sections = allSections.Where(x => Enumerable.Contains(group.AllowedSections, x.Alias)).Select(Mapper.Map<ContentEditing.Section>);
+            display.Sections = allSections.Where(x => Enumerable.Contains(group.AllowedSections, x.Alias)).OrderBy(section => section.SortOrder).Select(Mapper.Map<ContentEditing.Section>);
 
             if (group.StartMediaId > 0)
             {

--- a/src/Umbraco.Web/Trees/ContentBackOfficeSection.cs
+++ b/src/Umbraco.Web/Trees/ContentBackOfficeSection.cs
@@ -13,5 +13,7 @@ namespace Umbraco.Web.Trees
 
         /// <inheritdoc />
         public string Name => "Content";
+
+        public int SortOrder => 10;
     }
 }

--- a/src/Umbraco.Web/Trees/MediaBackOfficeSection.cs
+++ b/src/Umbraco.Web/Trees/MediaBackOfficeSection.cs
@@ -9,6 +9,9 @@ namespace Umbraco.Web.Trees
     public class MediaBackOfficeSection : IBackOfficeSection
     {
         public string Alias => Constants.Applications.Media;
+
         public string Name => "Media";
+
+        public int SortOrder => 20;
     }
 }

--- a/src/Umbraco.Web/Trees/MembersBackOfficeSection.cs
+++ b/src/Umbraco.Web/Trees/MembersBackOfficeSection.cs
@@ -13,5 +13,8 @@ namespace Umbraco.Web.Trees
 
         /// <inheritdoc />
         public string Name => "Members";
+
+        /// <inheritdoc />
+        public int SortOrder => 60;
     }
 }

--- a/src/Umbraco.Web/Trees/PackagesBackOfficeSection.cs
+++ b/src/Umbraco.Web/Trees/PackagesBackOfficeSection.cs
@@ -13,5 +13,8 @@ namespace Umbraco.Web.Trees
 
         /// <inheritdoc />
         public string Name => "Packages";
+
+        /// <inheritdoc />
+        public int SortOrder => 40;
     }
 }

--- a/src/Umbraco.Web/Trees/SettingsBackOfficeSection.cs
+++ b/src/Umbraco.Web/Trees/SettingsBackOfficeSection.cs
@@ -13,5 +13,8 @@ namespace Umbraco.Web.Trees
 
         /// <inheritdoc />
         public string Name => "Settings";
+
+        /// <inheritdoc />
+        public int SortOrder => 30;
     }
 }

--- a/src/Umbraco.Web/Trees/TranslationBackOfficeSection.cs
+++ b/src/Umbraco.Web/Trees/TranslationBackOfficeSection.cs
@@ -13,5 +13,8 @@ namespace Umbraco.Web.Trees
 
         /// <inheritdoc />
         public string Name => "Translation";
+
+        /// <inheritdoc />
+        public int SortOrder => 70;
     }
 }

--- a/src/Umbraco.Web/Trees/UsersBackOfficeSection.cs
+++ b/src/Umbraco.Web/Trees/UsersBackOfficeSection.cs
@@ -13,5 +13,8 @@ namespace Umbraco.Web.Trees
 
         /// <inheritdoc />
         public string Name => "Users";
+
+        /// <inheritdoc />
+        public int SortOrder => 50;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4375

### Description

#4375 calls for the ability to add custom sections in between the system ones. This PR adds `SortOrder` to sections, much along the lines of V7 ([docs](https://our.umbraco.com/documentation/Extending/Section-Trees/sections#create-a-custom-section)).

#### Testing this PR

The easiest way to test this PR is to unzip the following in `App_Plugins`:

[Awesome.zip](https://github.com/umbraco/Umbraco-CMS/files/2827003/Awesome.zip)

It'll install a custom section between Content and Media, which looks like this:

![image](https://user-images.githubusercontent.com/7405322/52196444-2129ca80-285c-11e9-96d3-9a62ed9ff57b.png)

The custom section itself has some errors because it does not implement a section tree, but don't fret about that. It still works for testing.

#### Related issues

There are a couple of issues that should (probably) be addressed in other PRs once this is merged:

1. The given section name ("Awesome section") is not used as fallback text in the UI. It may just be due to `debug=true` but it should be investigated.
2. If the current user has access to Content, this section is used as the default section upon login - no matter what sort order is set by the sections. 
