### PR TITLE
V8: Fix the redirect tracking composer

### DIFF
--- a/src/Umbraco.Web/Routing/RedirectTrackingComposer.cs
+++ b/src/Umbraco.Web/Routing/RedirectTrackingComposer.cs
@@ -12,6 +12,6 @@ namespace Umbraco.Web.Routing
     /// <para>recycle bin = moving to and from does nothing: to = the node is gone, where would we redirect? from = same</para>
     /// </remarks>
     [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
-    public class RedirectTrackingComposer : ComponentComposer<RelateOnCopyComponent>, ICoreComposer
+    public class RedirectTrackingComposer : ComponentComposer<RedirectTrackingComponent>, ICoreComposer
     { }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4402

### Description

This PR fixes `RedirectTrackingComposer` as described in #4402.

With this PR applied, the redirect tracking starts tracking renames on published content:

![image](https://user-images.githubusercontent.com/7405322/52231052-341eb800-28b9-11e9-9f8b-1d22e5f76673.png)

**Note:** It seems the redirect tracking currently only works with variant content; invariant content is simply ignored. I'll dig into this and submit a new PR or raise an issue.