### PR TITLE
V8: Redirect tracking for invariant content under variant content

### DIFF
--- a/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs
+++ b/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs
@@ -157,9 +157,14 @@ namespace Umbraco.Web.Routing
             {
                 var entityContent = contentCache.GetById(entity.Id);
                 if (entityContent == null) continue;
+
+                // get the default affected cultures by going up the tree until we find the first culture variant entity (default to no cultures) 
+                var defaultCultures = entityContent.AncestorsOrSelf()?.FirstOrDefault(a => a.Cultures.Any())?.Cultures.Select(c => c.Key).ToArray()
+                    ?? new[] {(string) null};
                 foreach (var x in entityContent.DescendantsOrSelf())
                 {
-                    var cultures = x.Cultures.Any() ? x.Cultures.Select(c => c.Key) : new[] {(string) null};
+                    // if this entity defines specific cultures, use those instead of the default ones
+                    var cultures = x.Cultures.Any() ? x.Cultures.Select(c => c.Key) : defaultCultures;
 
                     foreach (var culture in cultures)
                     {

--- a/src/Umbraco.Web/Routing/RedirectTrackingComposer.cs
+++ b/src/Umbraco.Web/Routing/RedirectTrackingComposer.cs
@@ -12,6 +12,6 @@ namespace Umbraco.Web.Routing
     /// <para>recycle bin = moving to and from does nothing: to = the node is gone, where would we redirect? from = same</para>
     /// </remarks>
     [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
-    public class RedirectTrackingComposer : ComponentComposer<RelateOnCopyComponent>, ICoreComposer
+    public class RedirectTrackingComposer : ComponentComposer<RedirectTrackingComponent>, ICoreComposer
     { }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The redirect tracker doesn't work if you change the name of culture invariant content underneath culture variant content:

![redirect-management-invariant-variant-tree-before](https://user-images.githubusercontent.com/7405322/52234139-3c7af100-28c1-11e9-8d74-57c76857ca19.gif)

It happens because it's trying to resolve a culture invariant URL for the culture variant parents. 

This PR fixes the problem by defaulting the cultures from the first culture variant parent found when resolving the URLs:

![redirect-management-invariant-variant-tree-after](https://user-images.githubusercontent.com/7405322/52234258-85cb4080-28c1-11e9-80b2-f87f5d4fcbce.gif)

### Please note

This PR builds upon #4411, which enables the redirect tracking.
