### PR TITLE
V8: Allow all content types at root if none are explicitly allowed

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -1822,8 +1822,10 @@ namespace Umbraco.Web.Editors
             }
             if (model.ParentId < 0)
             {
-                //cannot move if the content item is not allowed at the root
-                if (toMove.ContentType.AllowedAsRoot == false)
+                //cannot move if the content item is not allowed at the root unless there are
+                //none allowed at root (in which case all should be allowed at root)
+                var contentTypeService = Services.ContentTypeService;
+                if (toMove.ContentType.AllowedAsRoot == false && contentTypeService.GetAll().Any(ct => ct.AllowedAsRoot))
                 {
                     throw new HttpResponseException(
                             Request.CreateNotificationValidationErrorResponse(

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -393,7 +393,11 @@ namespace Umbraco.Web.Editors
             IEnumerable<IContentType> types;
             if (contentId == Constants.System.Root)
             {
-                types = Services.ContentTypeService.GetAll().Where(x => x.AllowedAsRoot).ToList();
+                var allContentTypes = Services.ContentTypeService.GetAll().ToList();
+                bool AllowedAsRoot(IContentType x) => x.AllowedAsRoot;
+                types = allContentTypes.Any(AllowedAsRoot)
+                    ? allContentTypes.Where(AllowedAsRoot).ToList()
+                    : allContentTypes;
             }
             else
             {

--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -868,8 +868,10 @@ namespace Umbraco.Web.Editors
             }
             if (model.ParentId < 0)
             {
-                //cannot move if the content item is not allowed at the root
-                if (toMove.ContentType.AllowedAsRoot == false)
+                //cannot move if the content item is not allowed at the root unless there are
+                //none allowed at root (in which case all should be allowed at root)
+                var mediaTypeService = Services.MediaTypeService;
+                if (toMove.ContentType.AllowedAsRoot == false && mediaTypeService.GetAll().Any(ct => ct.AllowedAsRoot))
                 {
                     var notificationModel = new SimpleNotificationModel();
                     notificationModel.AddErrorNotification(Services.TextService.Localize("moveOrCopy/notAllowedAtRoot"), "");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4414

### Description

#4414 calls for allowing all content types at the root if none are explicitly marked as "Allow as root". This PR fixes that.

### Testing this PR
This PR affects both content and media and the test steps below should be repeated for both content and media. 

1. Make sure that nothing is broken 😄 in other words test that if any content types are marked as "Allow as root" you can't create, move or copy any other content types to root.
2. Disable "Allow as root" on all content types.
3. Verify that you can create all content types at root.
4. Verify that you can move and copy all content types to root - also from the recycle bin.