### PR TITLE
V8: Rename umbracoDomains table to umbracoDomain (singular)

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -126,6 +126,7 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<UpdateMemberGroupPickerData>("{8A027815-D5CD-4872-8B88-9A51AB5986A6}"); // from 7.14.0
             To<ConvertRelatedLinksToMultiUrlPicker>("{ED28B66A-E248-4D94-8CDB-9BDF574023F0}");
             To<UpdatePickerIntegerValuesToUdi>("{38C809D5-6C34-426B-9BEA-EFD39162595C}");
+            To<RenameUmbracoDomainsTable>("{6017F044-8E70-4E10-B2A3-336949692ADD}");
 
 
             //FINAL

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/RenameUmbracoDomainsTable.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/RenameUmbracoDomainsTable.cs
@@ -1,0 +1,12 @@
+﻿namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
+{
+    public class RenameUmbracoDomainsTable : MigrationBase
+    {
+        public RenameUmbracoDomainsTable(IMigrationContext context) : base(context) { }
+
+        public override void Migrate()
+        {
+            Rename.Table("umbracoDomains").To(Constants.DatabaseSchema.Tables.Domain).Do();
+        }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
+++ b/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Core
                 public const string RelationType = /*TableNamePrefix*/ "umbraco" + "RelationType";
                 public const string Relation = /*TableNamePrefix*/ "umbraco" + "Relation";
 
-                public const string Domain = /*TableNamePrefix*/ "umbraco" + "Domains";
+                public const string Domain = /*TableNamePrefix*/ "umbraco" + "Domain";
                 public const string Language = /*TableNamePrefix*/ "umbraco" + "Language";
                 public const string DictionaryEntry = /*TableNamePrefix*/ "cms" + "Dictionary";
                 public const string DictionaryValue = /*TableNamePrefix*/ "cms" + "LanguageText";

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DomainRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DomainRepository.cs
@@ -33,10 +33,10 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override IEnumerable<IDomain> PerformGetAll(params int[] ids)
         {
-            var sql = GetBaseQuery(false).Where("umbracoDomains.id > 0");
+            var sql = GetBaseQuery(false).Where("umbracoDomain.id > 0");
             if (ids.Any())
             {
-                sql.Where("umbracoDomains.id in (@ids)", new { ids = ids });
+                sql.Where("umbracoDomain.id in (@ids)", new { ids = ids });
             }
 
             return Database.Fetch<DomainDto>(sql).Select(ConvertFromDto);
@@ -56,7 +56,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             }
             else
             {
-                sql.Select("umbracoDomains.*, umbracoLanguage.languageISOCode")
+                sql.Select("umbracoDomain.*, umbracoLanguage.languageISOCode")
                     .From<DomainDto>()
                     .LeftJoin<LanguageDto>()
                     .On<DomainDto, LanguageDto>(dto => dto.DefaultLanguage, dto => dto.Id);
@@ -67,14 +67,14 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoDomains.id = @id";
+            return "umbracoDomain.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()
         {
             var list = new List<string>
                 {
-                    "DELETE FROM umbracoDomains WHERE id = @id"
+                    "DELETE FROM umbracoDomain WHERE id = @id"
                 };
             return list;
         }
@@ -86,7 +86,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override void PersistNewItem(IDomain entity)
         {
-            var exists = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoDomains WHERE domainName = @domainName", new { domainName = entity.DomainName });
+            var exists = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoDomain WHERE domainName = @domainName", new { domainName = entity.DomainName });
             if (exists > 0) throw new DuplicateNameException(string.Format("The domain name {0} is already assigned", entity.DomainName));
 
             if (entity.RootContentId.HasValue)
@@ -122,7 +122,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         {
             ((UmbracoDomain)entity).UpdatingEntity();
 
-            var exists = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoDomains WHERE domainName = @domainName AND umbracoDomains.id <> @id",
+            var exists = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoDomain WHERE domainName = @domainName AND umbracoDomain.id <> @id",
                 new { domainName = entity.DomainName, id = entity.Id });
             //ensure there is no other domain with the same name on another entity
             if (exists > 0) throw new DuplicateNameException(string.Format("The domain name {0} is already assigned", entity.DomainName));

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -379,6 +379,7 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\PropertyEditorsMigration.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\RefactorMacroColumns.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\RefactorVariantsModel.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_0_0\RenameUmbracoDomainsTable.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\SuperZero.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\TablesForScheduledPublishing.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\TagsMigration.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4348

### Description

This PR renames the `umbracoDomains` table to `umbracoDomain` (singular) as decided in #4348.

I have tested the following:

1. Upgraded an existing V8 with multiple domains assigned to multiple root nodes and verified that:
   - The table name changed to singular form.
   - The table data remained intact.
2. Edited, deleted and added domains after the upgrade.
3. Created a blank install and verified the table name after the installation.
4. Added, edited and deleted domains to root nodes after the install.

Can't think of anything else to test 🤔 