### PR TITLE
V8: Don't open the RTE code editor in "small" sized overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1222,7 +1222,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 var aceEditor = {
                     content: args.editor.getContent(),
                     view: 'views/propertyeditors/rte/codeeditor.html',
-                    size: 'small',
                     submit: function (model) {
                         args.editor.setContent(model.content);
                         editorService.close();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4451

### Description

This PR ensures that the RTE code editor opens in the "large" (default) sized overlay instead of the "small" one.

It looks like this:

![image](https://user-images.githubusercontent.com/7405322/52373895-235a7780-2a5c-11e9-9603-407ac1b9a0e5.png)
