### PR TITLE
V8: Don't show all children of a selected node as selected

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -171,8 +171,8 @@ body.touch .umb-tree {
     }
 }
 
-.umb-tree .umb-tree-node-checked i[class^="icon-"],
-.umb-tree .umb-tree-node-checked i[class*=" icon-"] {
+.umb-tree .umb-tree-node-checked > .umb-tree-item__inner > i[class^="icon-"],
+.umb-tree .umb-tree-node-checked > .umb-tree-item__inner > i[class*=" icon-"] {
     font-family: 'icomoon' !important;
     color: @green !important;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Something weird has happened. When you pick a node in a tree picker that supports multiselect (any picker type it seems), all child nodes are marked as selected:

![tree-selection-before](https://user-images.githubusercontent.com/7405322/52376608-cf06c600-2a62-11e9-80de-cd3461fab0d3.gif)

I have made the "checked node" CSS selector quite a bit more explicit and now it looks like this:

![tree-selection-after](https://user-images.githubusercontent.com/7405322/52376695-0d9c8080-2a63-11e9-8671-403036bd2318.gif)

It works for now at least. Perhaps someone a bit more CSS savvy should give it a review.