### PR TITLE
V8: Bugfix for loading paths Ids into TreeEntityPath

### DIFF
--- a/src/Umbraco.Core/Models/Entities/TreeEntityPath.cs
+++ b/src/Umbraco.Core/Models/Entities/TreeEntityPath.cs
@@ -14,5 +14,14 @@
         /// Gets or sets the path of the entity.
         /// </summary>
         public string Path { get; set; }
+
+        /// <summary>
+        /// Proxy of the Id
+        /// </summary>
+        public int NodeId
+        {
+            get => Id;
+            set => Id = value;
+        }
     }
 }


### PR DESCRIPTION
The overall issue, was about not being able to login, if the startnode of media was not the root.

![media-root](https://user-images.githubusercontent.com/1561480/52400232-da87da80-2abe-11e9-8566-63c89c458159.gif)


The solution was a bit tricky. But turned out to be because the `TreeEntityPath` was not having a `NodeId` property.

![image](https://user-images.githubusercontent.com/1561480/52400195-bb894880-2abe-11e9-8fca-fb7d094c3eef.png)

The solution was to add a proxy property named `NodeId` that actually just uses `Id` as a backing field.
