### PR TITLE
V8: Add "back to list" button on edit user

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/overview.controller.js
@@ -14,19 +14,17 @@
         vm.page.navigation = [];
 
         function onInit() {
-
             loadNavigation();
-
-            setPageName();
         }
 
         function loadNavigation() {
 
-            var labels = ["sections_users", "general_groups"];
+            var labels = ["sections_users", "general_groups", "user_userManagement"];
 
             localizationService.localizeMany(labels).then(function (data) {
                 vm.page.labels.users = data[0];
                 vm.page.labels.groups = data[1];
+                vm.page.name = data[2];
 
                 vm.page.navigation = [
                     {
@@ -51,12 +49,6 @@
                     }
                 ];
             });
-        }
-
-        function setPageName() {
-            localizationService.localize("user_userManagement").then(function (data) {
-                vm.page.name = data;
-            })
         }
 
         onInit();

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -11,6 +11,7 @@
           changePassword: null
         };
         vm.breadcrumbs = [];
+        vm.showBackButton = true;
         vm.avatarFile = {};
         vm.labels = {};
         vm.maxFileSize = Umbraco.Sys.ServerVariables.umbracoSettings.maxFileSize + "KB";

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.html
@@ -10,7 +10,9 @@
                                hide-icon="true"
                                hide-description="true"
                                hide-alias="true"
-                               navigation="vm.user.navigation">
+                               navigation="vm.user.navigation"
+                               on-back="vm.goToPage(vm.breadcrumbs[0])"
+                               show-back-button="vm.showBackButton">
             </umb-editor-header>
             
             <umb-editor-container>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When you edit a group there's a nice back button in the header that lets you go back to the list of groups: 

![image](https://user-images.githubusercontent.com/7405322/52427760-d9779d00-2b00-11e9-9678-cf1ca674dab6.png)

I would expect the same back button when editing a user, but it's not there. You have to use browser back to get back to the user list, or find the breadcrumb in the bottom of the screen.

![image](https://user-images.githubusercontent.com/7405322/52427636-9f0e0000-2b00-11e9-8735-b6faee43508c.png)

This PR adds the back button to edit user as well. 

![edit-user-back-button-after](https://user-images.githubusercontent.com/7405322/52427548-71c15200-2b00-11e9-88e2-11c14358ba8c.gif)

I also took the liberty of doing a bit if housekeeping to reduce the number of calls to `localizationService`.
