### PR TITLE
Fix some property editors not marking form dirty when changed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -69,6 +69,8 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
             }
 
             setModelValue();
+            angularHelper.getCurrentForm($scope).$setDirty();
+
 
             if (!$scope.model.config.pickTime) {
                 $element.find("div:first").datetimepicker("hide", 0);
@@ -107,6 +109,7 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
         $scope.hasDatetimePickerValue = false;
         $scope.datetimePickerValue = null;
         $scope.model.value = null;
+        angularHelper.getCurrentForm($scope).$setDirty();
         $scope.datePickerForm.datepicker.$setValidity("pickerError", true);
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -1,7 +1,7 @@
 //this controller simply tells the dialogs service to open a mediaPicker window
 //with a specified callback, this callback will receive an object with a selection on it
 angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerController",
-    function ($rootScope, $scope, dialogService, entityResource, mediaResource, mediaHelper, $timeout, userService, $location, localizationService) {
+    function ($rootScope, $scope, dialogService, entityResource, mediaResource, mediaHelper, angularHelper, $timeout, userService, $location, localizationService) {
 
         //check the pre-values for multi-picker
         var multiPicker = $scope.model.config.multiPicker && $scope.model.config.multiPicker !== '0' ? true : false;
@@ -91,6 +91,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
         $scope.remove = function(index) {
             $scope.mediaItems.splice(index, 1);
             $scope.ids.splice(index, 1);
+            angularHelper.getCurrentForm($scope).$setDirty();
             $scope.sync();
         };
 
@@ -128,6 +129,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                    });
 
                    $scope.sync();
+                   angularHelper.getCurrentForm($scope).$setDirty();
 
                    $scope.mediaPickerOverlay.show = false;
                    $scope.mediaPickerOverlay = null;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -176,6 +176,7 @@
             var value = e.value;
             angularHelper.safeApply($scope, function () {
                 setModelValueFromSlider(value);
+                angularHelper.getCurrentForm($scope).$setDirty();
             });
         }).data('slider');
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: _(no issue)_

### Description
This PR updates the Date Picker, Slider, and Media Picker to ensure they mark the current form 'dirty' when they change, allowing the "You have unsaved changes" prompt to trigger.  Currently they do not trigger the prompt when changed.

#### Current Behavior

![without-pr](https://user-images.githubusercontent.com/1396376/52512428-f9bb6080-2bc1-11e9-9cec-d1115bd85d62.gif)

#### New Behavior

![with-pr](https://user-images.githubusercontent.com/1396376/52512432-fde77e00-2bc1-11e9-86aa-d23f52e81679.gif)


### Testing:

1. **Setup**: On an existing Umbraco doctype, add properties of the following types:  Date Picker, Slider, and Media Picker
2. Visit the Content section and open a page of the above doctype
3. Make one of the following content changes
	1. Change the Slider value
	2. Change the Date Picker value (select new, manual input, or clear)
	3. Change the Media Picker value (select or remove)
4. Click another page in the Umbraco Content Tree
5. Verify:
	1. With this PR applied, you should receive the unsaved changes prompt
	2. Without this PR applied, you will be navigated to the target page without warning 
3. Repeat steps 3-6 for each option in step 3
