### PR TITLE
Fix for RTE never being dirty after initial save (#4140)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -11,20 +11,15 @@ angular.module("umbraco")
         var n = d.getTime();
         $scope.textAreaHtmlId = $scope.model.alias + "_" + n + "_rte";
 
-        var alreadyDirty = false;
         function syncContent(editor){
             editor.save();
             angularHelper.safeApply($scope, function () {
                 $scope.model.value = editor.getContent();
             });
 
-            if (!alreadyDirty) {
-                //make the form dirty manually so that the track changes works, setting our model doesn't trigger
-                // the angular bits because tinymce replaces the textarea.
-                var currForm = angularHelper.getCurrentForm($scope);
-                currForm.$setDirty();
-                alreadyDirty = true;
-            }
+            //make the form dirty manually so that the track changes works, setting our model doesn't trigger
+            // the angular bits because tinymce replaces the textarea.
+            angularHelper.getCurrentForm($scope).$setDirty();
         }
 
         tinyMceService.configuration().then(function (tinyMceConfig) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: #4140 

### Description
As described in #4140, once an RTE change has been saved, the RTE is never marked dirty again on subsequent changes.  This PR removes some checks that were only allowing the dirty flag to be set once.  I wasn't able to locate any obvious case where they were still needed - it looks like the checks were added [a long time ago](https://github.com/umbraco/Umbraco-CMS/commit/173d4c9655b5e48b2831db380a92ea7e69867910), when dirty handling was first being added to the RTE.  Any thoughts on why this might be needed?

#### Current Behavior
![rte-without-pr](https://user-images.githubusercontent.com/1396376/52513072-93384180-2bc5-11e9-8d80-fb7bbce06614.gif)

#### New Behavior
![rte-with-pr](https://user-images.githubusercontent.com/1396376/52513073-96cbc880-2bc5-11e9-87d6-73e8d3175a80.gif)

### Testing

1. Visit a content page that contains a Rich Text Editor
2. Make a change within the Rich Text Editor
3. Attempt to navigate to another page in the content tree
    1. The "unsaved changes" prompt should appear
4. Click *Save* or *Save and publish*
5. Make another change within the Rich Text Editor
6. Attempt to navigate to another page in the content tree
7. Verify:
    1. Without this PR, the "unsaved changes" prompt should not appear
    2. With this PR, the "unsaved changes" prompt should appear

<!-- Thanks for contributing to Umbraco CMS! -->
