### PR TITLE
V8: Don't show the content navigation dropdown if there is only one group

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
@@ -10,7 +10,7 @@
     <div ng-show="item.badge" class="badge -type-{{vm.item.badge.type}}">{{vm.item.badge.count}}</div>
 </a>
 
-<ul class="dropdown-menu umb-sub-views-nav-item__anchor_dropdown" ng-class="{'show': vm.showDropdown}">
+<ul class="dropdown-menu umb-sub-views-nav-item__anchor_dropdown" ng-if="vm.item.anchors && vm.item.anchors.length > 1">
     <li ng-repeat="anchor in vm.item.anchors" ng-class="{'is-active': vm.item.active && anchor.active}">
         <a href="" ng-click="vm.anchorClicked(anchor, $event)">
             {{anchor.label}}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The new content navigation always shows - even if there's only one property group:

![image](https://user-images.githubusercontent.com/7405322/52533591-517ad880-2d36-11e9-8a27-37981b3a731f.png)

I've fixed that so it only shows if there's more than on group available.