### PR TITLE
v8: Remove IE7 CSS hacks

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/breadcrumbs.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/breadcrumbs.less
@@ -11,7 +11,6 @@
   .border-radius(@baseBorderRadius);
   > li {
     display: inline-block;
-    .ie7-inline-block();
     text-shadow: 0 1px 0 @white;
     > .divider {
       padding: 0 5px;

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/button-groups.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/button-groups.less
@@ -7,11 +7,9 @@
 .btn-group {
   position: relative;
   display: inline-block;
-  .ie7-inline-block();
   font-size: 0; // remove as part 1 of font-size inline-block hack
   vertical-align: middle; // match .btn alignment given font-size hack above
   white-space: nowrap; // prevent buttons from wrapping when in tight spaces (e.g., the table on the tests page)
-  .ie7-restore-left-whitespace();
 }
 
 // Space out series of button groups
@@ -203,7 +201,6 @@
 
 .btn-group-vertical {
   display: inline-block; // makes buttons only take up the width they need
-  .ie7-inline-block();
 }
 .btn-group-vertical > .btn {
   display: block;

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/buttons.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/buttons.less
@@ -9,7 +9,6 @@
 // Core
 .btn {
   display: inline-block;
-  .ie7-inline-block();
   padding: 4px 12px;
   margin-bottom: 0; // For input.btn
   font-size: @baseFontSize;
@@ -19,10 +18,8 @@
   cursor: pointer;
   .buttonBackground(@btnBackground, @btnBackgroundHighlight, @grayDark, 0 1px 1px rgba(255,255,255,.75));
   border: 1px solid @btnBorder;
-  *border: 0; // Remove the border to prevent IE7's black border on input:focus
   border-bottom-color: darken(@btnBorder, 10%);
   .border-radius(@baseBorderRadius);
-  .ie7-restore-left-whitespace(); // Give IE7 some love
   .box-shadow(~"inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05)");
 
   // Hover/focus state
@@ -177,23 +174,6 @@ input[type="submit"].btn {
   &::-moz-focus-inner {
     padding: 0;
     border: 0;
-  }
-
-  // IE7 has some default padding on button controls
-  *padding-top: 3px;
-  *padding-bottom: 3px;
-
-  &.btn-large {
-    *padding-top: 7px;
-    *padding-bottom: 7px;
-  }
-  &.btn-small {
-    *padding-top: 3px;
-    *padding-bottom: 3px;
-  }
-  &.btn-mini {
-    *padding-top: 1px;
-    *padding-bottom: 1px;
   }
 }
 

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/code.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/code.less
@@ -34,7 +34,6 @@ pre.code {
   white-space: pre;
   white-space: pre-wrap;
   background-color: #f5f5f5;
-  border: 1px solid #ccc; // fallback for IE7-8
   border: 1px solid rgba(0,0,0,.15);
   .border-radius(@baseBorderRadius);
 

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/dropdowns.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/dropdowns.less
@@ -47,10 +47,7 @@
   margin: 2px 0 0; // override default ul
   list-style: none;
   background-color: @dropdownBackground;
-  border: 1px solid #ccc; // Fallback for IE7-8
   border: 1px solid @dropdownBorder;
-  *border-right-width: 2px;
-  *border-bottom-width: 2px;
   .border-radius(6px);
   .box-shadow(0 5px 10px rgba(0,0,0,.2));
   -webkit-background-clip: padding-box;

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/dropdowns.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/dropdowns.less
@@ -114,7 +114,6 @@
   text-decoration: none;
   background-color: transparent;
   background-image: none; // Remove CSS gradient
-  .reset-filter();
   cursor: default;
 }
 

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/dropdowns.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/dropdowns.less
@@ -8,10 +8,7 @@
 .dropdown {
   position: relative;
 }
-.dropdown-toggle {
-  // The caret makes the toggle a bit too tall in IE7
-  *margin-bottom: -3px;
-}
+
 .dropdown-toggle:active,
 .open .dropdown-toggle {
   outline: 0;
@@ -127,10 +124,6 @@
 // Open state for the dropdown
 // ---------------------------
 .open {
-  // IE7's z-index only goes to the nearest positioned ancestor, which would
-  // make the menu appear below buttons that appeared later on the page
-  *z-index: @zindexDropdown;
-
   & > .dropdown-menu {
     display: block;
   }

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/forms.less
@@ -135,8 +135,6 @@ input[type="color"],
 input[type="radio"],
 input[type="checkbox"] {
   margin: 4px 0 0;
-  *margin-top: 0; /* IE7 */
-  margin-top: 1px \9; /* IE8-9 */
   line-height: normal;
 }
 
@@ -154,8 +152,7 @@ input[type="checkbox"] {
 // Set the height of select and file controls to match text inputs
 select,
 input[type="file"] {
-  height: @inputHeight; /* In IE7, the height of the select element cannot be changed by height, only font-size */
-  *margin-top: 4px; /* For IE7, add top margin to align select with labels */
+  height: @inputHeight;
   line-height: @inputHeight;
 }
 
@@ -409,7 +406,6 @@ select:focus:invalid {
 
 .help-inline {
   display: inline-block;
-  .ie7-inline-block();
   vertical-align: middle;
   padding-left: 5px;
 }
@@ -542,9 +538,7 @@ select:focus:invalid {
 
 input.search-query {
   padding-right: 14px;
-  padding-right: 4px \9;
   padding-left: 14px;
-  padding-left: 4px \9; /* IE7-8 doesn't have border-radius, so don't indent the padding */
   margin-bottom: 0; // Remove the default margin on all inputs
   .border-radius(15px);
 }
@@ -587,7 +581,6 @@ input.search-query {
   .input-prepend,
   .input-append {
     display: inline-block;
-    .ie7-inline-block();
     margin-bottom: 0;
     vertical-align: middle;
   }
@@ -658,15 +651,7 @@ legend + .control-group {
   }
   // Move over all input controls and content
   .controls {
-    // Super jank IE7 fix to ensure the inputs in .input-append and input-prepend
-    // don't inherit the margin of the parent, in this case .controls
-    *display: inline-block;
-    *padding-left: 20px;
     margin-left: @horizontalComponentOffset;
-    *margin-left: 0;
-    &:first-child {
-      *padding-left: @horizontalComponentOffset;
-    }
   }
   // Remove bottom margin on block level help text since that's accounted for on .control-group
   .help-block {

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/mixins.less
@@ -470,14 +470,8 @@
 // -------------------------
 // Dividers (basically an hr) within dropdowns and nav lists
 .nav-divider(@top: #e5e5e5, @bottom: @white) {
-  // IE7 needs a set width since we gave a height. Restricting just
-  // to IE7 to keep the 1px left/right space in other browsers.
-  // It is unclear where IE is getting the extra space that we need
-  // to negative-margin away, but so it goes.
-  *width: 100%;
   height: 1px;
   margin: ((@baseLineHeight / 2) - 1) 1px; // 8px 1px
-  *margin: -5px 0 5px;
   overflow: hidden;
   background-color: @top;
   border-bottom: 1px solid @bottom;
@@ -488,17 +482,14 @@
 .buttonBackground(@startColor, @endColor, @textColor: #fff, @textShadow: 0 -1px 0 rgba(0,0,0,.25)) {
   // gradientBar will set the background to a pleasing blend of these, to support IE<=9
   .gradientBar(@startColor, @endColor, @textColor, @textShadow);
-  *background-color: @endColor; /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   .reset-filter();
 
   // in these cases the gradient won't cover the background, so we override
   &:hover, &:focus, &:active, &.active, &.disabled, &[disabled] {
     color: @textColor;
     background-color: @endColor;
-    *background-color: darken(@endColor, 5%);
   }
 
-  // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves
   &:active,
   &.active {
     background-color: darken(@endColor, 10%) e("\9");

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/mixins.less
@@ -360,7 +360,6 @@
 // Opacity
 .opacity(@opacity) {
   opacity: @opacity / 100;
-  filter: ~"alpha(opacity=@{opacity})";
 }
 
 
@@ -398,7 +397,6 @@
     background-image: -o-linear-gradient(left, @startColor, @endColor); // Opera 11.10
     background-image: linear-gradient(to right, @startColor, @endColor); // Standard, IE10
     background-repeat: repeat-x;
-    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=1)",argb(@startColor),argb(@endColor))); // IE9 and down
   }
   .vertical(@startColor: #555, @endColor: #333) {
     background-color: mix(@startColor, @endColor, 60%);
@@ -408,7 +406,6 @@
     background-image: -o-linear-gradient(top, @startColor, @endColor); // Opera 11.10
     background-image: linear-gradient(to bottom, @startColor, @endColor); // Standard, IE10
     background-repeat: repeat-x;
-    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",argb(@startColor),argb(@endColor))); // IE9 and down
   }
   .directional(@startColor: #555, @endColor: #333, @deg: 45deg) {
     background-color: @endColor;
@@ -426,7 +423,6 @@
     background-image: -o-linear-gradient(left, @startColor, @midColor @colorStop, @endColor);
     background-image: linear-gradient(to right, @startColor, @midColor @colorStop, @endColor);
     background-repeat: no-repeat;
-    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",argb(@startColor),argb(@endColor))); // IE9 and down, gets no color-stop at all for proper fallback
   }
 
   .vertical-three-colors(@startColor: #00b3ee, @midColor: #7a43b6, @colorStop: 50%, @endColor: #c3325f) {
@@ -437,7 +433,6 @@
     background-image: -o-linear-gradient(@startColor, @midColor @colorStop, @endColor);
     background-image: linear-gradient(@startColor, @midColor @colorStop, @endColor);
     background-repeat: no-repeat;
-    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",argb(@startColor),argb(@endColor))); // IE9 and down, gets no color-stop at all for proper fallback
   }
   .radial(@innerColor: #555, @outerColor: #333) {
     background-color: @outerColor;
@@ -455,10 +450,6 @@
     background-image: -o-linear-gradient(@angle, rgba(255,255,255,.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,.15) 50%, rgba(255,255,255,.15) 75%, transparent 75%, transparent);
     background-image: linear-gradient(@angle, rgba(255,255,255,.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,.15) 50%, rgba(255,255,255,.15) 75%, transparent 75%, transparent);
   }
-}
-// Reset filters for IE
-.reset-filter() {
-  filter: e(%("progid:DXImageTransform.Microsoft.gradient(enabled = false)"));
 }
 
 
@@ -482,7 +473,6 @@
 .buttonBackground(@startColor, @endColor, @textColor: #fff, @textShadow: 0 -1px 0 rgba(0,0,0,.25)) {
   // gradientBar will set the background to a pleasing blend of these, to support IE<=9
   .gradientBar(@startColor, @endColor, @textColor, @textShadow);
-  .reset-filter();
 
   // in these cases the gradient won't cover the background, so we override
   &:hover, &:focus, &:active, &.active, &.disabled, &[disabled] {

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/mixins.less
@@ -42,31 +42,6 @@
   margin-right: auto;
 }
 
-// IE7 inline-block
-// ----------------
-.ie7-inline-block() {
-  *display: inline; /* IE7 inline-block hack */
-  *zoom: 1;
-}
-
-// IE7 likes to collapse whitespace on either side of the inline-block elements.
-// Ems because we're attempting to match the width of a space character. Left
-// version is for form buttons, which typically come after other elements, and
-// right version is for icons, which come before. Applying both is ok, but it will
-// mean that space between those elements will be .6em (~2 space characters) in IE7,
-// instead of the 1 space in other browsers.
-.ie7-restore-left-whitespace() {
-  *margin-left: .3em;
-
-  &:first-child {
-    *margin-left: 0;
-  }
-}
-
-.ie7-restore-right-whitespace() {
-  *margin-right: .3em;
-}
-
 // Sizing shortcuts
 // -------------------------
 .size(@height, @width) {

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/navbar.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/navbar.less
@@ -10,10 +10,6 @@
 .navbar {
   overflow: visible;
   margin-bottom: @baseLineHeight;
-
-  // Fix for IE7's bad z-indexing so dropdowns don't appear below content that follows the navbar
-  *position: relative;
-  *z-index: 2;
 }
 
 // Inner for background effects
@@ -475,9 +471,7 @@ width: (@gridColumnWidth * @gridColumns) + (@gridGutterWidth * (@gridColumns - 1
       .transition(none);
       .placeholder(@navbarInverseSearchPlaceholderColor);
 
-      // Focus states (we use .focused since IE7-8 and down doesn't support :focus)
-      &:focus,
-      &.focused {
+      &:focus{
         padding: 5px 15px;
         color: @grayDark;
         text-shadow: 0 1px 0 @white;

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/pagination.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/pagination.less
@@ -10,7 +10,6 @@
 .pagination ul {
   // Allow for text-based alignment
   display: inline-block;
-  .ie7-inline-block();
   // Reset default ul styles
   margin-left: 0;
   margin-bottom: 0;

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/reset.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/reset.less
@@ -79,7 +79,6 @@ sub {
 img {
   /* Responsive images (ensure images don't scale beyond their parents) */
   max-width: 100%; /* Part 1: Set a maxium relative to the parent */
-  width: auto\9; /* IE7-8 need help adjusting responsive images */
   height: auto; /* Part 2: Scale the height according to the width, otherwise you get stretching */
 
   vertical-align: middle;

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/sprites.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/sprites.less
@@ -19,7 +19,6 @@
   display: inline-block;
   width: 14px;
   height: 14px;
-  .ie7-restore-right-whitespace();
   line-height: 14px;
   vertical-align: text-top;
   background-image: url("@{iconSpritePath}");

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/tables.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/tables.less
@@ -74,7 +74,6 @@ table {
 .table-bordered {
   border: 1px solid @tableBorder;
   border-collapse: separate; // Done so we can round those corners!
-  *border-collapse: collapse; // IE7 can't round corners anyway
   border-left: 0;
   .border-radius(@baseBorderRadius);
   th,

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/tests/css-tests.css
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/tests/css-tests.css
@@ -86,7 +86,6 @@ body {
   background-image: -o-linear-gradient(left, #555555, #333333);
   background-image: linear-gradient(to right, #555555, #333333);
   background-repeat: repeat-x;
-  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ff555555', endColorstr='#ff333333', GradientType=1);
 }
 
 .gradient-vertical {
@@ -97,7 +96,6 @@ body {
   background-image: -o-linear-gradient(top, #555555, #333333);
   background-image: linear-gradient(to bottom, #555555, #333333);
   background-repeat: repeat-x;
-  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ff555555', endColorstr='#ff333333', GradientType=0);
 }
 
 .gradient-directional {
@@ -117,7 +115,6 @@ body {
   background-image: -o-linear-gradient(#00b3ee, #7a43b6 50%, #c3325f);
   background-image: linear-gradient(#00b3ee, #7a43b6 50%, #c3325f);
   background-repeat: no-repeat;
-  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ff00b3ee', endColorstr='#ffc3325f', GradientType=0);
 }
 
 .gradient-radial {
@@ -146,5 +143,4 @@ body {
   background-image: -o-linear-gradient(left, #00b3ee, #7a43b6 50%, #c3325f);
   background-image: linear-gradient(to right, #00b3ee, #7a43b6 50%, #c3325f);
   background-repeat: no-repeat;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00b3ee', endColorstr='#c3325f', GradientType=0);
 }

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/type.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/type.less
@@ -130,7 +130,6 @@ ol.inline {
   list-style: none;
   > li {
     display: inline-block;
-    .ie7-inline-block();
     padding-left: 5px;
     padding-right: 5px;
   }

--- a/src/Umbraco.Web.UI.Client/src/less/button-groups.less
+++ b/src/Umbraco.Web.UI.Client/src/less/button-groups.less
@@ -102,24 +102,14 @@
   padding-left: 8px;
   padding-right: 8px;
   .box-shadow(~"inset 1px 0 0 rgba(255,255,255,.125), inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05)");
-  *padding-top: 5px;
-  *padding-bottom: 5px;
 }
 .btn-group > .btn-mini + .dropdown-toggle {
   padding-left: 5px;
   padding-right: 5px;
-  *padding-top: 2px;
-  *padding-bottom: 2px;
-}
-.btn-group > .btn-small + .dropdown-toggle {
-  *padding-top: 5px;
-  *padding-bottom: 4px;
 }
 .btn-group > .btn-large + .dropdown-toggle {
   padding-left: 12px;
   padding-right: 12px;
-  *padding-top: 7px;
-  *padding-bottom: 7px;
 }
 
 .btn-group.open {
@@ -178,22 +168,6 @@
 .dropup .btn-large .caret {
   border-bottom-width: 5px;
 }
-
-
-/*
-// Account for other colors
-.btn-primary,
-.btn-warning,
-.btn-danger,
-.btn-info,
-.btn-success,
-.btn-inverse {
-  .caret {
-    border-top-color: @white;
-    border-bottom-color: @white;
-  }
-}
-*/
 
 
 // Vertical button groups

--- a/src/Umbraco.Web.UI.Client/src/less/button-groups.less
+++ b/src/Umbraco.Web.UI.Client/src/less/button-groups.less
@@ -7,11 +7,9 @@
 .btn-group {
   position: relative;
   display: inline-block;
-  .ie7-inline-block();
   font-size: 0; // remove as part 1 of font-size inline-block hack
   vertical-align: middle; // match .btn alignment given font-size hack above
   white-space: nowrap; // prevent buttons from wrapping when in tight spaces (e.g., the table on the tests page)
-  .ie7-restore-left-whitespace();
 }
 
 // Space out series of button groups
@@ -203,7 +201,6 @@
 
 .btn-group-vertical {
   display: inline-block; // makes buttons only take up the width they need
-  .ie7-inline-block();
 }
 .btn-group-vertical > .btn {
   display: block;

--- a/src/Umbraco.Web.UI.Client/src/less/buttons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/buttons.less
@@ -274,23 +274,6 @@ input[type="submit"].btn {
     border: 0;
   }
 
-  // IE7 has some default padding on button controls
-  *padding-top: 3px;
-  *padding-bottom: 3px;
-
-  &.btn-large {
-    *padding-top: 7px;
-    *padding-bottom: 7px;
-  }
-  &.btn-small {
-    *padding-top: 3px;
-    *padding-bottom: 3px;
-  }
-  &.btn-mini {
-    *padding-top: 1px;
-    *padding-bottom: 1px;
-  }
-
   // Safari defaults to 1px for input. Ref U4-7721.
   margin: 0px;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
@@ -970,7 +970,6 @@ iframe {
   font-size: 23px;
   cursor: pointer;
   opacity: 0;
-  filter: alpha(opacity=0);
   transform: translate(-300px, 0) scale(4);
   direction: ltr;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -604,7 +604,6 @@
     -webkit-appearance: none;
     background-image: linear-gradient(to bottom,#e6e6e6,#bfbfbf);
     background-repeat: repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffe6e6e6',endColorstr='#ffbfbfbf',GradientType=0);
     zoom: 1;
     border-color: #bfbfbf #bfbfbf #999;
     border-color: rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);

--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -276,7 +276,7 @@ input[type="checkbox"] {
 // Set the height of select and file controls to match text inputs
 select,
 input[type="file"] {
-  height: @inputHeight; /* In IE7, the height of the select element cannot be changed by height, only font-size */
+  height: @inputHeight;
   line-height: @inputHeight;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -258,7 +258,6 @@ input[type="color"],
 input[type="radio"],
 input[type="checkbox"] {
   margin: 4px 0 0;
-  *margin-top: 0; /* IE7 */
   margin-top: 1px \9; /* IE8-9 */
   line-height: normal;
 }
@@ -278,7 +277,6 @@ input[type="checkbox"] {
 select,
 input[type="file"] {
   height: @inputHeight; /* In IE7, the height of the select element cannot be changed by height, only font-size */
-  *margin-top: 4px; /* For IE7, add top margin to align select with labels */
   line-height: @inputHeight;
 }
 
@@ -526,7 +524,6 @@ input[type="checkbox"][readonly] {
 
 .help-inline {
   display: inline-block;
-  .ie7-inline-block();
   vertical-align: middle;
   padding-left: 5px;
 }
@@ -644,7 +641,6 @@ div.help {
 input.search-query {
   padding-right: 4px \9;
   padding-left: 14px;
-  padding-left: 4px \9; /* IE7-8 doesn't have border-radius, so don't indent the padding */
   margin: 0; // Remove the default margin on all inputs
 }
 
@@ -679,7 +675,6 @@ input.search-query {
   .input-prepend,
   .input-append {
     display: inline-block;
-    .ie7-inline-block();
     margin-bottom: 0;
     vertical-align: top;
   }
@@ -755,12 +750,7 @@ legend + .control-group {
   }
   // Move over all input controls and content
   .controls {
-    // Super jank IE7 fix to ensure the inputs in .input-append and input-prepend
-    // don't inherit the margin of the parent, in this case .controls
-    *display: inline-block;
-    *padding-left: 20px;
     margin-left: @horizontalComponentOffset;
-    *margin-left: 0;
     &:first-child {
       *padding-left: @horizontalComponentOffset;
     }

--- a/src/Umbraco.Web.UI.Client/src/less/gridview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/gridview.less
@@ -414,7 +414,6 @@
      background-image: -o-linear-gradient(top,#e6e6e6,#bfbfbf);
      background-image: linear-gradient(to bottom,#e6e6e6,#bfbfbf);
      background-repeat: repeat-x;
-     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffe6e6e6',endColorstr='#ffbfbfbf',GradientType=0);
      zoom: 1;
      border-color: #bfbfbf #bfbfbf #999;
      border-color: rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);

--- a/src/Umbraco.Web.UI.Client/src/less/hacks.less
+++ b/src/Umbraco.Web.UI.Client/src/less/hacks.less
@@ -59,7 +59,6 @@ iframe, .content-column-body {
   right: 0;
   margin: 0;
   opacity: 0;
-  filter: alpha(opacity=0);
   transform: translate(-300px, 0) scale(4);
   font-size: 23px;
   direction: ltr;

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -379,7 +379,6 @@ table thead a {
   height: 100%;
   z-index: 5999;
   opacity: .6;
-  filter: alpha(opacity=6);
   -webkit-box-shadow: inset 0 0 0 40px white,inset 0 0 0 41px rgba(0,0,0,0.2),inset 0 0 20px 41px rgba(0,0,0,0.2);
   box-shadow: inset 0 0 0 40px white,inset 0 0 0 41px rgba(0,0,0,0.2),inset 0 0 20px 41px rgba(0,0,0,0.2);
 }

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -663,7 +663,6 @@ input[type=checkbox]:checked + .input-label--small {
 
 .visuallyhidden{
     position: absolute !important;
-	clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
 	clip: rect(1px, 1px, 1px, 1px);
 	padding:0 !important;
 	border:0 !important;

--- a/src/Umbraco.Web.UI.Client/src/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/src/less/mixins.less
@@ -10,7 +10,6 @@
 // --------
 // For clearing floats like a boss h5bp.com/q
 .clearfix {
-  *zoom: 1;
   &:before,
   &:after {
     display: table;
@@ -165,18 +164,6 @@
     background-color: @backgroundColor;
     border-color: @textColor;
   }
-  //SD: We could do this but need to get the colors right
-  /*input.ng-invalid {
-    &:-moz-placeholder {
-        color: lighten(@textColor, 50%) !important;
-    }
-    &:-ms-input-placeholder {
-        color: lighten(@textColor, 50%) !important;
-    }
-    &::-webkit-input-placeholder {
-        color: lighten(@textColor, 50%) !important;
-    }
-  }*/
 }
 
 // CSS3 PROPERTIES
@@ -490,7 +477,7 @@
   border-color: @startColor @startColor darken(@startColor, 15%);
   border-color: rgba(0,0,0,.1) rgba(0,0,0,.1) fadein(rgba(0,0,0,.1), 15%);
   
-  background-color: @startColor; /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+  background-color: @startColor;
   .reset-filter();
   
   .caret {
@@ -614,17 +601,14 @@
 
     .offset (@columns) {
       margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + (@fluidGridGutterWidth*2);
-  	  *margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + (@fluidGridGutterWidth*2) - (.5 / @gridRowWidth * 100 * 1%);
     }
 
     .offsetFirstChild (@columns) {
       margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + (@fluidGridGutterWidth);
-      *margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
     }
 
     .span (@columns) {
       width: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1));
-      *width: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%);
     }
 
     .row-fluid {
@@ -634,7 +618,6 @@
         .input-block-level();
         float: left;
         margin-left: @fluidGridGutterWidth;
-        *margin-left: @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
       }
       [class*="span"]:first-child {
         margin-left: 0;

--- a/src/Umbraco.Web.UI.Client/src/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/src/less/mixins.less
@@ -42,31 +42,6 @@
   margin-right: auto;
 }
 
-// IE7 inline-block
-// ----------------
-.ie7-inline-block() {
-  *display: inline; /* IE7 inline-block hack */
-  *zoom: 1;
-}
-
-// IE7 likes to collapse whitespace on either side of the inline-block elements.
-// Ems because we're attempting to match the width of a space character. Left
-// version is for form buttons, which typically come after other elements, and
-// right version is for icons, which come before. Applying both is ok, but it will
-// mean that space between those elements will be .6em (~2 space characters) in IE7,
-// instead of the 1 space in other browsers.
-.ie7-restore-left-whitespace() {
-  *margin-left: .3em;
-
-  &:first-child {
-    *margin-left: 0;
-  }
-}
-
-.ie7-restore-right-whitespace() {
-  *margin-right: .3em;
-}
-
 // Sizing shortcuts
 // -------------------------
 .size(@height, @width) {
@@ -500,14 +475,8 @@
 // -------------------------
 // Dividers (basically an hr) within dropdowns and nav lists
 .nav-divider(@top: @gray-8, @bottom: @white) {
-  // IE7 needs a set width since we gave a height. Restricting just
-  // to IE7 to keep the 1px left/right space in other browsers.
-  // It is unclear where IE is getting the extra space that we need
-  // to negative-margin away, but so it goes.
-  *width: 100%;
   height: 1px;
   margin: ((@baseLineHeight / 2) - 1) 1px; // 8px 1px
-  *margin: -5px 0 5px;
   overflow: hidden;
   background-color: @top;
   border-bottom: 1px solid @bottom;
@@ -516,8 +485,6 @@
 // Button backgrounds
 // ------------------
 .buttonBackground(@startColor, @hoverColor: @startColor, @textColor: #fff, @textColorHover: @textColor) {
-  // gradientBar will set the background to a pleasing blend of these, to support IE<=9
-  //.gradientBar(@startColor, @endColor, @textColor);
   
   color: @textColor;
   border-color: @startColor @startColor darken(@startColor, 15%);
@@ -541,13 +508,6 @@
     color: @white;
     background-color: @sand-2;
   }
-  /*
-  // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves
-  &:active,
-  &.active {
-    background-color: darken(@endColor, 10%) e("\9");
-  }
-  */
 }
 
 // Navbar vertical align

--- a/src/Umbraco.Web.UI.Client/src/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/src/less/mixins.less
@@ -353,7 +353,6 @@
 // Opacity
 .opacity(@opacity) {
   opacity: @opacity / 100;
-  filter: ~"alpha(opacity=@{opacity})";
 }
 
 
@@ -390,7 +389,6 @@
     background-image: -o-linear-gradient(left, @startColor, @endColor); // Opera 11.10
     background-image: linear-gradient(to right, @startColor, @endColor); // Standard, IE10
     background-repeat: repeat-x;
-    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=1)",argb(@startColor),argb(@endColor))); // IE9 and down
   }
   .vertical(@startColor: #555, @endColor: #333) {
     background-color: mix(@startColor, @endColor, 60%);
@@ -400,7 +398,6 @@
     background-image: -o-linear-gradient(top, @startColor, @endColor); // Opera 11.10
     background-image: linear-gradient(to bottom, @startColor, @endColor); // Standard, IE10
     background-repeat: repeat-x;
-    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",argb(@startColor),argb(@endColor))); // IE9 and down
   }
   .directional(@startColor: #555, @endColor: #333, @deg: 45deg) {
     background-color: @endColor;
@@ -418,7 +415,6 @@
     background-image: -o-linear-gradient(left, @startColor, @midColor @colorStop, @endColor);
     background-image: linear-gradient(to right, @startColor, @midColor @colorStop, @endColor);
     background-repeat: no-repeat;
-    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",argb(@startColor),argb(@endColor))); // IE9 and down, gets no color-stop at all for proper fallback
   }
 
   .vertical-three-colors(@startColor: #00b3ee, @midColor: #7a43b6, @colorStop: 50%, @endColor: #c3325f) {
@@ -429,7 +425,6 @@
     background-image: -o-linear-gradient(@startColor, @midColor @colorStop, @endColor);
     background-image: linear-gradient(@startColor, @midColor @colorStop, @endColor);
     background-repeat: no-repeat;
-    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",argb(@startColor),argb(@endColor))); // IE9 and down, gets no color-stop at all for proper fallback
   }
   .radial(@innerColor: #555, @outerColor: #333) {
     background-color: @outerColor;
@@ -447,10 +442,6 @@
     background-image: -o-linear-gradient(@angle, rgba(255,255,255,.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,.15) 50%, rgba(255,255,255,.15) 75%, transparent 75%, transparent);
     background-image: linear-gradient(@angle, rgba(255,255,255,.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,.15) 50%, rgba(255,255,255,.15) 75%, transparent 75%, transparent);
   }
-}
-// Reset filters for IE
-.reset-filter() {
-  filter: e(%("progid:DXImageTransform.Microsoft.gradient(enabled = false)"));
 }
 
 
@@ -478,7 +469,6 @@
   border-color: rgba(0,0,0,.1) rgba(0,0,0,.1) fadein(rgba(0,0,0,.1), 15%);
   
   background-color: @startColor;
-  .reset-filter();
   
   .caret {
       border-top-color: @textColor;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -536,7 +536,6 @@
     z-index: @zindexCropperOverlay - 1;
     -moz-opacity: .75;
     opacity: .75;
-    filter: alpha(opacity=7);
     -webkit-box-shadow: inset 0 0 0 20px white,inset 0 0 0 21px rgba(0,0,0,.1),inset 0 0 20px 21px rgba(0,0,0,.2);
     -moz-box-shadow: inset 0 0 0 20px white,inset 0 0 0 21px rgba(0,0,0,.1),inset 0 0 20px 21px rgba(0,0,0,.2);
     box-shadow: inset 0 0 0 20px white,inset 0 0 0 21px rgba(0,0,0,.1),inset 0 0 20px 21px rgba(0,0,0,.2);

--- a/src/Umbraco.Web.UI.Client/src/less/tables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tables.less
@@ -81,7 +81,6 @@ table {
 .table-bordered {
   border: 1px solid @tableBorder;
   border-collapse: separate; // Done so we can round those corners!
-  *border-collapse: collapse; // IE7 can't round corners anyway
   border-left: 0;
   box-shadow: none;
   .border-radius(@baseBorderRadius);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: #4499 

### Description

I have removed the IE7 related hacks in a few .less files created by Umbraco HQ. 

I my third commit I have also removed any IE7 hacks from the boostrap core files - I don't if that makes sense. But I guess it does since some of the core files are referenced directly and it does not seem like Bootstrap is getting an update anyway so we might as well just loose the "dead weight" since the backoffice will not work in IE7 anyway 😃 So we might as well cut it out and save a few bytes on the bundled css.