### PR TITLE
V8: Make sure the sticky sub header do not clash with the actions menu

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbstickybar.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbstickybar.directive.js
@@ -133,7 +133,9 @@ Use this directive make an element sticky and follow the page when scrolling.
                 clonedBar.addClass('-umb-sticky-bar');
                 clonedBar.css({
                     'position': 'fixed',
-                    'z-index': 500,
+                    // if you change this z-index value, make sure the sticky editor sub headers do not 
+                    // clash with umb-dropdown (e.g. the content actions dropdown in content list view)
+                    'z-index': 99, 
                     'visibility': 'hidden'
                 });
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4495

### Description

This PR fixes the clash between the sticky editor sub header and the actions menu as described in #4495.

With this PR applied it looks like this:

![sticky-header-after](https://user-images.githubusercontent.com/7405322/52537107-117e1a80-2d63-11e9-92f6-603f22ceae5e.gif)
