### PR TITLE
V8: Always show folder names in the media picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -4,7 +4,7 @@
             <!--<i ng-show="item.selected" class="icon-check umb-media-grid__checkmark"></i>-->
             <a ng-if="allowOnClickEdit === 'true'" ng-click="clickEdit(item, $event)" ng-href="" class="icon-edit umb-media-grid__edit"></a>
 
-            <div data-element="media-grid-item-edit" class="umb-media-grid__item-overlay" ng-class="{'-locked': item.selected}" ng-click="clickItemName(item, $event, $index)">
+            <div data-element="media-grid-item-edit" class="umb-media-grid__item-overlay" ng-class="{'-locked': item.selected || !item.file}" ng-click="clickItemName(item, $event, $index)">
                 <i ng-if="onDetailsHover" class="icon-info umb-media-grid__info" ng-mouseover="hoverItemDetails(item, $event, true)" ng-mouseleave="hoverItemDetails(item, $event, false)"></i>
                 <div class="umb-media-grid__item-name">{{item.name}}</div>
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4494

### Description

This PR fixes #4494 by always showing the names of the items in the media picker that have no file (i.e. they are folders).

When applied the media picker looks like this:

![image](https://user-images.githubusercontent.com/7405322/52537309-86eaea80-2d65-11e9-86b5-51e236eed139.png)
