### PR TITLE
V8: Styling for the item edit link in the media picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -217,4 +217,6 @@
 
 .umb-media-grid__item:hover .umb-media-grid__edit {
     opacity: 1;
- }
+    text-decoration: none;
+    box-shadow: 0 1px 2px rgba(0,0,0,.2);
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The edit link for the media picker items looks a bit strange; it's underlined on hover and generally it's not very visible:

![image](https://user-images.githubusercontent.com/7405322/52537405-e5649880-2d66-11e9-8486-58fd1393a49f.png)

This PR removes the hover underline and adds a bit of drop shadow to the link to make it stand out a bit more:

![image](https://user-images.githubusercontent.com/7405322/52537390-ad5d5580-2d66-11e9-9874-e58d9cf6fb61.png)
