### PR TITLE
V8: Remove "Return to list" from media items in infinite editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -47,7 +47,7 @@
                     </umb-button>
 
                     <umb-button alias="returnToList"
-                                ng-if="page.listViewPath"
+                                ng-if="page.listViewPath && !model.infiniteMode"
                                 type="link"
                                 href="#{{page.listViewPath}}"
                                 label-key="buttons_returnToList">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When editing media items in infinite editing, you're given the option to "Return to list" in the primary actions. This is quite confusing, because it actually brings you to the parent media item list view. When chosen you're prompted to save changes, but it's by no means clear what's about to happen:

![media-picker-return-to-list-before](https://user-images.githubusercontent.com/7405322/52538269-fb775680-2d70-11e9-908e-bf5807cc8b8d.gif)

This PR removes "Return to list" in infinite editing:

![image](https://user-images.githubusercontent.com/7405322/52538218-3e84fa00-2d70-11e9-80e7-d1708bd0712a.png)

If the editor really wants to go to the media library, the breadcrumb is fully functional and can be used for just that.