### PR TITLE
V8: Add user state and filter localization

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/usershelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/usershelper.service.js
@@ -12,14 +12,15 @@
             { "value": 4, "name": "Inactive", "key": "Inactive", "color": "warning" }
         ];
 
-        angular.forEach(userStates, function (userState) {
-            var key = "user_state" + userState.key;
-            localizationService.localize(key).then(function (value) {
-                var reg = /^\[[\S\s]*]$/g;
-                var result = reg.test(value);
-                if (result === false) {
+        localizationService.localizeMany(_.map(userStates, function (userState) {
+            return "user_state" + userState.key;
+        })).then(function (data) {
+            console.log("Localized", data)
+            var reg = /^\[[\S\s]*]$/g;
+            _.each(data, function (value, index) {
+                if (!reg.test(value)) {
                     // Only translate if key exists
-                    userState.name = value;
+                    userStates[index].name = value;
                 }
             });
         });

--- a/src/Umbraco.Web.UI.Client/src/common/services/usershelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/usershelper.service.js
@@ -15,7 +15,6 @@
         localizationService.localizeMany(_.map(userStates, function (userState) {
             return "user_state" + userState.key;
         })).then(function (data) {
-            console.log("Localized", data)
             var reg = /^\[[\S\s]*]$/g;
             _.each(data, function (value, index) {
                 if (!reg.test(value)) {

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -33,6 +33,11 @@
             });
         });
 
+        vm.labels = {};
+        localizationService.localizeMany(["user_stateAll"]).then(function (data) {
+            vm.labels.all = data[0];
+        });
+
         vm.userStatesFilter = [];
         vm.newUser.userGroups = [];
         vm.usersViewState = 'overview';
@@ -399,7 +404,7 @@
         }
 
         function getFilterName(array) {
-            var name = "All";
+            var name = vm.labels.all;
             var found = false;
             angular.forEach(array, function (item) {
                 if (item.selected) {

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -21,14 +21,14 @@
             { label: "Last login", key: "LastLoginDate", direction: "Descending" }
         ];
 
-        angular.forEach(vm.userSortData, function (userSortData) {
-            var key = "user_sort" + userSortData.key + userSortData.direction;
-            localizationService.localize(key).then(function (value) {
-                var reg = /^\[[\S\s]*]$/g;
-                var result = reg.test(value);
-                if (result === false) {
+        localizationService.localizeMany(_.map(vm.userSortData, function (userSort) {
+            return "user_sort" + userSort.key + userSort.direction;
+        })).then(function (data) {
+            var reg = /^\[[\S\s]*]$/g;
+            _.each(data, function (value, index) {
+                if (!reg.test(value)) {
                     // Only translate if key exists
-                    userSortData.label = value;
+                    vm.userSortData[index].label = value;
                 }
             });
         });

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1473,6 +1473,11 @@ Mange hilsner fra Umbraco robotten
     <key alias="stateLockedOut">Låst ude</key>
     <key alias="stateInvited">Inviteret</key>
     <key alias="stateInactive">Inaktiv</key>
+    <key alias="sortNameAscending">Navn (A-Å)</key>
+    <key alias="sortNameDescending">Navn (Å-A)</key>
+    <key alias="sortCreateDateAscending">Nyeste</key>
+    <key alias="sortCreateDateDescending">Ældste</key>
+    <key alias="sortLastLoginDateDescending">Sidst logget ind</key>
   </area>
   <area alias="validation">
     <key alias="validation">Validering</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1467,6 +1467,11 @@ Mange hilsner fra Umbraco robotten
     <key alias="backToUsers">Tilbage til brugere</key>
     <key alias="inviteEmailCopySubject">Umbraco: Invitation</key>
     <key alias="inviteEmailCopyFormat"><![CDATA[<html><body><p>Hej %0%, du er blevet inviteret af %1% til Umbraco backoffice.</p><p>Besked fra %1%: <em>%2%</em></p><p>Klik på dette <a href="%3%" target="_blank">link</a> for acceptere invitationen</p><p><small>Hvis du ikke kan klikke på linket, så kopier og indsæt denne URL i dit browservindue<br/><br/>%3%</small></p></body></html>]]></key>
+    <key alias="stateActive">Aktiv</key>
+    <key alias="stateDisabled">Deaktiveret</key>
+    <key alias="stateLockedOut">Låst ude</key>
+    <key alias="stateInvited">Inviteret</key>
+    <key alias="stateInactive">Inaktiv</key>
   </area>
   <area alias="validation">
     <key alias="validation">Validering</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1467,6 +1467,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="backToUsers">Tilbage til brugere</key>
     <key alias="inviteEmailCopySubject">Umbraco: Invitation</key>
     <key alias="inviteEmailCopyFormat"><![CDATA[<html><body><p>Hej %0%, du er blevet inviteret af %1% til Umbraco backoffice.</p><p>Besked fra %1%: <em>%2%</em></p><p>Klik på dette <a href="%3%" target="_blank">link</a> for acceptere invitationen</p><p><small>Hvis du ikke kan klikke på linket, så kopier og indsæt denne URL i dit browservindue<br/><br/>%3%</small></p></body></html>]]></key>
+    <key alias="stateAll">Alle</key>
     <key alias="stateActive">Aktiv</key>
     <key alias="stateDisabled">Deaktiveret</key>
     <key alias="stateLockedOut">Låst ude</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1874,6 +1874,11 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="defaultInvitationMessage">Resending invitation...</key>
     <key alias="deleteUser">Delete User</key>
     <key alias="deleteUserConfirmation">Are you sure you wish to delete this user account?</key>
+    <key alias="stateActive">Active</key>
+    <key alias="stateDisabled">Disabled</key>
+    <key alias="stateLockedOut">Locked out</key>
+    <key alias="stateInvited">Invited</key>
+    <key alias="stateInactive">Inactive</key>
   </area>
   <area alias="validation">
     <key alias="validation">Validation</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1880,6 +1880,11 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="stateLockedOut">Locked out</key>
     <key alias="stateInvited">Invited</key>
     <key alias="stateInactive">Inactive</key>
+    <key alias="sortNameAscending">Name (A-Z)</key>
+    <key alias="sortNameDescending">Name (Z-A)</key>
+    <key alias="sortCreateDateAscending">Newest</key>
+    <key alias="sortCreateDateDescending">Oldest</key>
+    <key alias="sortLastLoginDateDescending">Last login</key>
   </area>
   <area alias="validation">
     <key alias="validation">Validation</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1874,6 +1874,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="defaultInvitationMessage">Resending invitation...</key>
     <key alias="deleteUser">Delete User</key>
     <key alias="deleteUserConfirmation">Are you sure you wish to delete this user account?</key>
+    <key alias="stateAll">All</key>
     <key alias="stateActive">Active</key>
     <key alias="stateDisabled">Disabled</key>
     <key alias="stateLockedOut">Locked out</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1886,6 +1886,11 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="defaultInvitationMessage">Resending invitation...</key>
     <key alias="deleteUser">Delete User</key>
     <key alias="deleteUserConfirmation">Are you sure you wish to delete this user account?</key>
+    <key alias="stateActive">Active</key>
+    <key alias="stateDisabled">Disabled</key>
+    <key alias="stateLockedOut">Locked out</key>
+    <key alias="stateInvited">Invited</key>
+    <key alias="stateInactive">Inactive</key>
   </area>
   <area alias="validation">
     <key alias="validation">Validation</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1892,6 +1892,11 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="stateLockedOut">Locked out</key>
     <key alias="stateInvited">Invited</key>
     <key alias="stateInactive">Inactive</key>
+    <key alias="sortNameAscending">Name (A-Z)</key>
+    <key alias="sortNameDescending">Name (Z-A)</key>
+    <key alias="sortCreateDateAscending">Newest</key>
+    <key alias="sortCreateDateDescending">Oldest</key>
+    <key alias="sortLastLoginDateDescending">Last login</key>
   </area>
   <area alias="validation">
     <key alias="validation">Validation</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1886,6 +1886,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="defaultInvitationMessage">Resending invitation...</key>
     <key alias="deleteUser">Delete User</key>
     <key alias="deleteUserConfirmation">Are you sure you wish to delete this user account?</key>
+    <key alias="stateAll">All</key>
     <key alias="stateActive">Active</key>
     <key alias="stateDisabled">Disabled</key>
     <key alias="stateLockedOut">Locked out</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4486

### Description

This PR adds localization to the user states and filters as described in #4486 - it looks like this:

![image](https://user-images.githubusercontent.com/7405322/52548954-ed592280-2dd0-11e9-9161-0ede0925b035.png)

I have added localization for English + Danish.

I have opted not to localize the group names as they're dynamic; it wouldn't be in line with the rest of the code to localize them using the standard localization. Should the need arise we need to look into localizing them server side using the "#name" method used for item localization elsewhere in the UI.