### PR TITLE
V8: Add some missing localization for content info

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -44,7 +44,8 @@
                     "prompt_doctypeChangeWarning",
                     "general_history",
                     "auditTrails_historyIncludingVariants",
-                    "content_itemNotPublished"
+                    "content_itemNotPublished",
+                    "general_choose"
                 ];
 
                 localizationService.localizeMany(keys)
@@ -59,6 +60,7 @@
                         labels.notPublished = data[9];
 
                         scope.historyLabel = scope.node.variants && scope.node.variants.length === 1 ? data[7] : data[8];
+                        scope.chooseLabel = data[10];
 
                         setNodePublishStatus();
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.controller.js
@@ -20,6 +20,7 @@
             vm.diff = null;
             vm.currentVersion = null;
             vm.rollbackButtonDisabled = true;
+            vm.labels = {};
 
             // find the current version for invariant nodes
             if($scope.model.node.variants.length === 1) {
@@ -39,12 +40,13 @@
                 }
             }
 
-            // set default title
-            if(!$scope.model.title) {
-                localizationService.localize("actions_rollback").then(function(value){
-                    $scope.model.title = value;
-                });
-            }
+            localizationService.localizeMany(["actions_rollback", "general_choose"]).then(function (data) {
+                // set default title
+                if (!$scope.model.title) {
+                    $scope.model.title = data[0];
+                }
+                vm.labels.choose = data[1];
+            });
 
             // Load in diff library
             assetsService.loadJs('lib/jsdiff/diff.min.js', $scope).then(function () {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.html
@@ -40,7 +40,7 @@
                             ng-model="vm.selectedVersion"
                             ng-options="version.displayValue for version in vm.previousVersions track by version.versionId"
                             ng-change="vm.changeVersion(vm.selectedVersion)">
-                            <option value=""><localize key="general_choose">Choose</localize>...</option>
+                            <option value="">{{vm.labels.choose}}...</option>
                         </select>
                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -158,7 +158,7 @@
                                 ng-model="node.template"
                                 ng-options="key as value for (key, value) in availableTemplates"
                                 ng-change="updateTemplate(node.template)">
-                            <option value=""><localize key="general_choose">Choose</localize>...</option>
+                            <option value="">{{chooseLabel}}...</option>
                         </select>
                         <a href="" ng-show="allowChangeTemplate && node.template !== null" class="umb-node-preview__action" style="margin-left:15px;" ng-click="openTemplate()">
                             <localize key="general_open">Open</localize>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -243,6 +243,7 @@
     <key alias="type">Type</key>
     <key alias="unpublish">Afpublicér</key>
     <key alias="unpublished">Afpubliceret</key>
+    <key alias="notCreated">Ikke oprettet</key>
     <key alias="updateDate">Sidst redigeret</key>
     <key alias="updateDateDesc" version="7.0">Tidspunkt for seneste redigering</key>
     <key alias="uploadClear">Fjern fil</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Just fixing a few things that aren't localized properly on the content info app:

- The "not created" badge doesn't have a Danish translation.
- The localization for the "Choose..." default option in the template dropdown doesn't work.
- The localization for the "Choose..." default option in rollback version dropdown doesn't work.

![info-localization-before](https://user-images.githubusercontent.com/7405322/52559890-fa890800-2df6-11e9-8d2a-1227e1394e81.gif)

With this PR applied it looks like this:

![info-localization-after](https://user-images.githubusercontent.com/7405322/52559897-01b01600-2df7-11e9-9947-58844dd1a2ba.gif)
