### PR TITLE
V8: Can't localize dynamic items (e.g. content types) using the dictionary

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/LanguageRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/LanguageRepository.cs
@@ -250,6 +250,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             lock (_codeIdMap)
             {
                 if (_codeIdMap.TryGetValue(isoCode, out var id)) return id;
+                if (isoCode.Contains('-') && _codeIdMap.TryGetValue(isoCode.Split('-').First(), out var invariantId)) return invariantId;
             }
             if (throwOnNotFound)
                 throw new ArgumentException($"Code {isoCode} does not correspond to an existing language.", nameof(isoCode));

--- a/src/Umbraco.Tests/Persistence/Repositories/LanguageRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/LanguageRepositoryTest.cs
@@ -79,7 +79,39 @@ namespace Umbraco.Tests.Persistence.Repositories
             }
         }
 
+        [Test]
+        public void Can_Perform_Get_By_Invariant_Code_On_LanguageRepository()
+        {
+            var provider = TestObjects.GetScopeProvider(Logger);
+            using (var scope = provider.CreateScope())
+            {
+                var repository = CreateRepository(provider);
 
+                var es = new CultureInfo("es");
+                var esSpecific = new CultureInfo("es-ES");
+
+                var language = (ILanguage)new Language(es.Name)
+                {
+                    CultureName = es.DisplayName,
+                    FallbackLanguageId = 1
+                };
+                repository.Save(language);
+
+                language = repository.GetByIsoCode(es.Name);
+                var languageSpecific = repository.GetByIsoCode(esSpecific.Name);
+                
+                // Assert
+                Assert.That(language, Is.Not.Null);
+                Assert.That(language.HasIdentity, Is.True);
+                Assert.That(language.IsoCode, Is.EqualTo(es.Name));
+
+                Assert.That(languageSpecific, Is.Not.Null);
+                Assert.That(languageSpecific.HasIdentity, Is.True);
+                Assert.That(languageSpecific.Id, Is.EqualTo(language.Id));
+                Assert.That(language.IsoCode, Is.EqualTo(language.IsoCode));
+            }
+        }
+        
         [Test]
         public void Get_When_Id_Doesnt_Exist_Returns_Null()
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you have a region-less language enabled (e.g. "da" instead of "da-DK"), you can't translate dynamic items (e.g. content types) using the dictionary. This is because `LanguageRepository` can't resolve the reagon-less language from the current thread culture.

This PR lets `LanguageRepository` fall back to the region-less language if it can't find the specific language.

### Steps to reproduce

1. Add "Danish" to the active languages (*not* "Danish (Denmark)"):
![image](https://user-images.githubusercontent.com/7405322/52561559-04f9d080-2dfc-11e9-9173-550c87569b24.png)
2. Create a content type named "#MyPage" and allow it at root. 
3. Add a dictionary item named "MyPage" and enter values for English and Danish.
![image](https://user-images.githubusercontent.com/7405322/52561703-75a0ed00-2dfc-11e9-8940-f8534d819149.png)
4. With `en-US` set as editor language, the translation works as expected:
![image](https://user-images.githubusercontent.com/7405322/52561669-5efa9600-2dfc-11e9-8e6f-c38516067646.png)
5. With `da` set as editor language, the translation doesn't work - the content type simply displays as "MyPage" (without the "#"):
![image](https://user-images.githubusercontent.com/7405322/52561750-99fcc980-2dfc-11e9-852a-f1878f1d7b7d.png)


