### PR TITLE
v7: User history showing even if it's empty

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -1,5 +1,4 @@
 <div ng-controller="Umbraco.Overlays.UserController">
-
     <div class="umb-control-group" ng-if="!showPasswordFields">
 
        <h5><localize key="user_yourProfile" /></h5>
@@ -78,8 +77,8 @@
     </div>
 
 
-    <div class="umb-control-group" ng-if="!showPasswordFields">
-        <h5><localize key="user_yourHistory" /></h5>
+    <div class="umb-control-group" ng-if="!showPasswordFields && history.length">
+        <h5><localize key="user_yourHistory" /></h5
         <ul class="umb-tree">
             <li ng-repeat="item in history | orderBy:'time':true">
                 <a ng-href="{{item.link}}" ng-click="gotoHistory(item.link)" prevent-default>
@@ -126,7 +125,7 @@
 
     </div>
 
-    <div class="umb-control-group">
+    <div class="umb-control-group" ng-if="tab.length">
         <div ng-repeat="tab in dashboard">
             <div ng-repeat="property in tab.properties">
                 <div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -78,7 +78,7 @@
 
 
     <div class="umb-control-group" ng-if="!showPasswordFields && history.length">
-        <h5><localize key="user_yourHistory" /></h5
+        <h5><localize key="user_yourHistory" /></h5>
         <ul class="umb-tree">
             <li ng-repeat="item in history | orderBy:'time':true">
                 <a ng-href="{{item.link}}" ng-click="gotoHistory(item.link)" prevent-default>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: #4523 

### Description

I have added two checks for "history.length" and "tab.length" to avoid the rendering of some empty umb-control-group div's, which have some border-bottom's showing otherwise.

Before:
![user-before](https://user-images.githubusercontent.com/1932158/52588618-2e871c00-2e3d-11e9-9e46-ed2343860dcc.png)


After:
![user-after](https://user-images.githubusercontent.com/1932158/52588632-33e46680-2e3d-11e9-8562-42bb06c9b4a4.png)


In the situation with the "history" section another option could be to add a text saying "You have not made any changes yet".

These two changes should probably also be merged into the V8 branch since it's the same scenario in V8.