### PR TITLE
Multi Url Picker fixes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -73,7 +73,7 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
             currentTarget: target,
             show: true,
             submit: function (model) {
-                if (model.target.url) {
+                if (model.target.url || model.target.anchor) {
                     // if an anchor exists, check that it is appropriately prefixed
                     if (model.target.anchor && model.target.anchor[0] !== '?' && model.target.anchor[0] !== '#') {
                         model.target.anchor = (model.target.anchor.indexOf('=') === -1 ? '#' : '?') + model.target.anchor;
@@ -87,14 +87,14 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
                             link.isMedia = model.target.isMedia;
                         }
 
-                        link.name = model.target.name || model.target.url;
+                        link.name = model.target.name || model.target.url || model.target.anchor;
                         link.queryString = model.target.anchor;
                         link.target = model.target.target;
                         link.url = model.target.url;
                     } else {
                         link = {
                             isMedia: model.target.isMedia,
-                            name: model.target.name || model.target.url,
+                            name: model.target.name || model.target.url || model.target.anchor,
                             queryString: model.target.anchor,
                             target: model.target.target,
                             udi: model.target.udi,

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
@@ -15,7 +15,7 @@ using Umbraco.Web.Routing;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [PropertyEditor(Constants.PropertyEditors.MultiUrlPickerAlias, "Multi Url Picker", PropertyEditorValueTypes.Json, "multiurlpicker", Group = "pickers", Icon = "icon-link", IsParameterEditor = true)]
+    [PropertyEditor(Constants.PropertyEditors.MultiUrlPickerAlias, "Multi Url Picker", PropertyEditorValueTypes.Json, "multiurlpicker", Group = "pickers", Icon = "icon-link")]
     public class MultiUrlPickerPropertyEditor : PropertyEditor
     {
         protected override PreValueEditor CreatePreValueEditor()

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
@@ -112,7 +112,7 @@ namespace Umbraco.Web.PropertyEditors
                             Target = dto.Target,
                             Trashed = false,
                             Udi = dto.Udi,
-                            Url = dto.Url,
+                            Url = dto.Url ?? "",
                         };
 
                         links.Add(link);


### PR DESCRIPTION
Fixes an issue raised over at the Multi Url Picker repo (https://github.com/rasmusjp/umbraco-multi-url-picker/issues/88), where the link wasn't saving if only anchor had been filled out.

Also removes the editor as a Macro Parameter Editor since it isn't supported.