### PR TITLE
Don't ship with the cmsContentXml or cmsPreviewXml tables since they are not used

### DIFF
--- a/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
@@ -138,12 +138,17 @@ namespace Umbraco.Core.Migrations.Install
         /// </summary>
         internal DatabaseSchemaResult ValidateSchema()
         {
+            return ValidateSchema(OrderedTables);
+        }
+
+        internal DatabaseSchemaResult ValidateSchema(IEnumerable<Type> orderedTables)
+        {
             var result = new DatabaseSchemaResult(SqlSyntax);
 
             result.IndexDefinitions.AddRange(SqlSyntax.GetDefinedIndexes(_database)
                 .Select(x => new DbIndexDefinition(x)));
 
-            result.TableDefinitions.AddRange(OrderedTables
+            result.TableDefinitions.AddRange(orderedTables
                 .Select(x => DefinitionFactory.GetTableDefinition(x, SqlSyntax)));
 
             ValidateDbTables(result);

--- a/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
@@ -50,8 +50,6 @@ namespace Umbraco.Core.Migrations.Install
             typeof (MemberTypeDto),
             typeof (MemberDto),
             typeof (Member2MemberGroupDto),
-            typeof (ContentXmlDto),
-            typeof (PreviewXmlDto),
             typeof (PropertyTypeGroupDto),
             typeof (PropertyTypeDto),
             typeof (PropertyDataDto),

--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -127,7 +127,8 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<ConvertRelatedLinksToMultiUrlPicker>("{ED28B66A-E248-4D94-8CDB-9BDF574023F0}");
             To<UpdatePickerIntegerValuesToUdi>("{38C809D5-6C34-426B-9BEA-EFD39162595C}");
             To<RenameUmbracoDomainsTable>("{6017F044-8E70-4E10-B2A3-336949692ADD}");
-            To<AddUserLoginDtoDateIndex>("98339BEF-E4B2-48A8-B9D1-D173DC842BBE");
+            To<AddUserLoginDtoDateIndex>("{98339BEF-E4B2-48A8-B9D1-D173DC842BBE}");
+            To<DropXmlTables>("{CDBEDEE4-9496-4903-9CF2-4104E00FF960}");
 
             //FINAL
 

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DropTaskTables.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DropTaskTables.cs
@@ -1,6 +1,5 @@
 ﻿namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
 {
-
     public class DropTaskTables : MigrationBase
     {
         public DropTaskTables(IMigrationContext context)

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DropXmlTables.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DropXmlTables.cs
@@ -1,0 +1,17 @@
+﻿namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
+{
+    public class DropXmlTables : MigrationBase
+    {
+        public DropXmlTables(IMigrationContext context)
+            : base(context)
+        { }
+
+        public override void Migrate()
+        {
+            if (TableExists("cmsContentXml"))
+                Delete.Table("cmsContentXml").Do();
+            if (TableExists("cmsPreviewXml"))
+                Delete.Table("cmsPreviewXml").Do();
+        }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
+++ b/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
@@ -5,17 +5,16 @@ namespace Umbraco.Core
     {
         public static class DatabaseSchema
         {
+            //TODO: Why aren't all table names with the same prefix?
             public const string TableNamePrefix = "umbraco";
 
             public static class Tables
             {
-                public const string Lock = /*TableNamePrefix*/ "umbraco" + "Lock";
-                public const string Log = /*TableNamePrefix*/ "umbraco" + "Log";
+                public const string Lock = TableNamePrefix + "Lock";
+                public const string Log = TableNamePrefix + "Log";
 
-                public const string Node = /*TableNamePrefix*/ "umbraco" + "Node";
+                public const string Node = TableNamePrefix + "Node";
                 public const string NodeData = /*TableNamePrefix*/ "cms" + "ContentNu";
-                public const string NodeXml = /*TableNamePrefix*/ "cms" + "ContentXml"; // TODO: get rid of these with the xml cache
-                public const string NodePreviewXml = /*TableNamePrefix*/ "cms" + "PreviewXml"; // TODO: get rid of these with the xml cache
 
                 public const string ContentType = /*TableNamePrefix*/ "cms" + "ContentType";
                 public const string ContentChildType = /*TableNamePrefix*/ "cms" + "ContentTypeAllowedContentType";
@@ -37,22 +36,22 @@ namespace Umbraco.Core
                 public const string PropertyTypeGroup = /*TableNamePrefix*/ "cms" + "PropertyTypeGroup";
                 public const string PropertyData = TableNamePrefix + "PropertyData";
 
-                public const string RelationType = /*TableNamePrefix*/ "umbraco" + "RelationType";
-                public const string Relation = /*TableNamePrefix*/ "umbraco" + "Relation";
+                public const string RelationType = TableNamePrefix + "RelationType";
+                public const string Relation = TableNamePrefix + "Relation";
 
-                public const string Domain = /*TableNamePrefix*/ "umbraco" + "Domain";
-                public const string Language = /*TableNamePrefix*/ "umbraco" + "Language";
+                public const string Domain = TableNamePrefix + "Domain";
+                public const string Language = TableNamePrefix + "Language";
                 public const string DictionaryEntry = /*TableNamePrefix*/ "cms" + "Dictionary";
                 public const string DictionaryValue = /*TableNamePrefix*/ "cms" + "LanguageText";
 
-                public const string User = /*TableNamePrefix*/ "umbraco" + "User";
-                public const string UserGroup = /*TableNamePrefix*/ "umbraco" + "UserGroup";
-                public const string UserStartNode = /*TableNamePrefix*/ "umbraco" + "UserStartNode";
-                public const string User2UserGroup = /*TableNamePrefix*/ "umbraco" + "User2UserGroup";
-                public const string User2NodeNotify = /*TableNamePrefix*/ "umbraco" + "User2NodeNotify";
-                public const string UserGroup2App = /*TableNamePrefix*/ "umbraco" + "UserGroup2App";
-                public const string UserGroup2NodePermission = /*TableNamePrefix*/ "umbraco" + "UserGroup2NodePermission";
-                public const string ExternalLogin = /*TableNamePrefix*/ "umbraco" + "ExternalLogin";
+                public const string User = TableNamePrefix + "User";
+                public const string UserGroup = TableNamePrefix + "UserGroup";
+                public const string UserStartNode = TableNamePrefix + "UserStartNode";
+                public const string User2UserGroup = TableNamePrefix + "User2UserGroup";
+                public const string User2NodeNotify = TableNamePrefix + "User2NodeNotify";
+                public const string UserGroup2App = TableNamePrefix + "UserGroup2App";
+                public const string UserGroup2NodePermission = TableNamePrefix + "UserGroup2NodePermission";
+                public const string ExternalLogin = TableNamePrefix + "ExternalLogin";
 
                 public const string Macro = /*TableNamePrefix*/ "cms" + "Macro";
                 public const string MacroProperty = /*TableNamePrefix*/ "cms" + "MacroProperty";
@@ -61,21 +60,21 @@ namespace Umbraco.Core
                 public const string MemberType = /*TableNamePrefix*/ "cms" + "MemberType";
                 public const string Member2MemberGroup = /*TableNamePrefix*/ "cms" + "Member2MemberGroup";
 
-                public const string Access = /*TableNamePrefix*/ "umbraco" + "Access";
-                public const string AccessRule = /*TableNamePrefix*/ "umbraco" + "AccessRule";
-                public const string RedirectUrl = /*TableNamePrefix*/ "umbraco" + "RedirectUrl";
+                public const string Access = TableNamePrefix + "Access";
+                public const string AccessRule = TableNamePrefix + "AccessRule";
+                public const string RedirectUrl = TableNamePrefix + "RedirectUrl";
 
-                public const string CacheInstruction = /*TableNamePrefix*/ "umbraco" + "CacheInstruction";
-                public const string Server = /*TableNamePrefix*/ "umbraco" + "Server";
+                public const string CacheInstruction = TableNamePrefix + "CacheInstruction";
+                public const string Server = TableNamePrefix + "Server";
 
                 public const string Tag = /*TableNamePrefix*/ "cms" + "Tags";
                 public const string TagRelationship = /*TableNamePrefix*/ "cms" + "TagRelationship";
                 
                 public const string KeyValue = TableNamePrefix + "KeyValue";
 
-                public const string AuditEntry = /*TableNamePrefix*/ "umbraco" + "Audit";
-                public const string Consent = /*TableNamePrefix*/ "umbraco" + "Consent";
-                public const string UserLogin = /*TableNamePrefix*/ "umbraco" + "UserLogin";
+                public const string AuditEntry = TableNamePrefix + "Audit";
+                public const string Consent = TableNamePrefix + "Consent";
+                public const string UserLogin = TableNamePrefix + "UserLogin";
             }
         }
     }

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -202,10 +202,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.DocumentCultureVariation + " WHERE nodeId = @id",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.DocumentVersion + " WHERE id IN (SELECT id FROM " + Constants.DatabaseSchema.Tables.ContentVersion + " WHERE nodeId = @id)",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.PropertyData + " WHERE versionId IN (SELECT id FROM " + Constants.DatabaseSchema.Tables.ContentVersion + " WHERE nodeId = @id)",
-                "DELETE FROM cmsPreviewXml WHERE nodeId = @id",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.ContentVersionCultureVariation + " WHERE versionId IN (SELECT id FROM " + Constants.DatabaseSchema.Tables.ContentVersion + " WHERE nodeId = @id)",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.ContentVersion + " WHERE nodeId = @id",
-                "DELETE FROM cmsContentXml WHERE nodeId = @id",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.Content + " WHERE nodeId = @id",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.Access + " WHERE nodeId = @id",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.Node + " WHERE id = @id"

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
@@ -188,7 +188,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 "DELETE FROM cmsMember2MemberGroup WHERE Member = @id",
                 "DELETE FROM cmsMember WHERE nodeId = @id",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.ContentVersion + " WHERE nodeId = @id",
-                "DELETE FROM cmsContentXml WHERE nodeId = @id",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.Content + " WHERE nodeId = @id",
                 "DELETE FROM umbracoNode WHERE id = @id"
             };

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -379,6 +379,7 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\DropPreValueTable.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DropTaskTables.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DropTemplateDesignColumn.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_0_0\DropXmlTables.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\FixLockTablePrimaryKey.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\LanguageColumns.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\MakeRedirectUrlVariant.cs" />
@@ -826,7 +827,6 @@
     <Compile Include="Persistence\Dtos\ContentTypeDto.cs" />
     <Compile Include="Persistence\Dtos\ContentTypeTemplateDto.cs" />
     <Compile Include="Persistence\Dtos\ContentVersionDto.cs" />
-    <Compile Include="Persistence\Dtos\ContentXmlDto.cs" />
     <Compile Include="Persistence\Dtos\DataTypeDto.cs" />
     <Compile Include="Persistence\Dtos\DictionaryDto.cs" />
     <Compile Include="Persistence\Dtos\DocumentDto.cs" />
@@ -846,7 +846,6 @@
     <Compile Include="Persistence\Dtos\MemberTypeDto.cs" />
     <Compile Include="Persistence\Dtos\MemberTypeReadOnlyDto.cs" />
     <Compile Include="Persistence\Dtos\NodeDto.cs" />
-    <Compile Include="Persistence\Dtos\PreviewXmlDto.cs" />
     <Compile Include="Persistence\Dtos\PropertyDataDto.cs" />
     <Compile Include="Persistence\Dtos\PropertyTypeDto.cs" />
     <Compile Include="Persistence\Dtos\PropertyTypeGroupDto.cs" />

--- a/src/Umbraco.Tests/LegacyXmlPublishedCache/ContentXmlDto.cs
+++ b/src/Umbraco.Tests/LegacyXmlPublishedCache/ContentXmlDto.cs
@@ -1,12 +1,13 @@
 ﻿using NPoco;
 using Umbraco.Core.Persistence.DatabaseAnnotations;
+using Umbraco.Core.Persistence.Dtos;
 
-namespace Umbraco.Core.Persistence.Dtos
+namespace Umbraco.Tests.LegacyXmlPublishedCache
 {
-    [TableName(Constants.DatabaseSchema.Tables.NodePreviewXml)]
+    [TableName("cmsContentXml")]
     [PrimaryKey("nodeId", AutoIncrement = false)]
     [ExplicitColumns]
-    internal class PreviewXmlDto
+    internal class ContentXmlDto
     {
         [Column("nodeId")]
         [PrimaryKeyColumn(AutoIncrement = false)]

--- a/src/Umbraco.Tests/LegacyXmlPublishedCache/PreviewXmlDto.cs
+++ b/src/Umbraco.Tests/LegacyXmlPublishedCache/PreviewXmlDto.cs
@@ -1,12 +1,13 @@
 ﻿using NPoco;
 using Umbraco.Core.Persistence.DatabaseAnnotations;
+using Umbraco.Core.Persistence.Dtos;
 
-namespace Umbraco.Core.Persistence.Dtos
+namespace Umbraco.Tests.LegacyXmlPublishedCache
 {
-    [TableName(Constants.DatabaseSchema.Tables.NodeXml)]
+    [TableName("cmsPreviewXml")]
     [PrimaryKey("nodeId", AutoIncrement = false)]
     [ExplicitColumns]
-    internal class ContentXmlDto
+    internal class PreviewXmlDto
     {
         [Column("nodeId")]
         [PrimaryKeyColumn(AutoIncrement = false)]

--- a/src/Umbraco.Tests/LegacyXmlPublishedCache/XmlStore.cs
+++ b/src/Umbraco.Tests/LegacyXmlPublishedCache/XmlStore.cs
@@ -12,7 +12,6 @@ using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Persistence;
-using Umbraco.Core.Persistence.Dtos;
 using Umbraco.Core.Persistence.Repositories;
 using Umbraco.Core.Persistence.Repositories.Implement;
 using Umbraco.Core.Scoping;

--- a/src/Umbraco.Tests/Persistence/SchemaValidationTest.cs
+++ b/src/Umbraco.Tests/Persistence/SchemaValidationTest.cs
@@ -1,9 +1,11 @@
-﻿using Moq;
+﻿using System.Linq;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Migrations.Install;
 using Umbraco.Core.Persistence.SqlSyntax;
+using Umbraco.Tests.LegacyXmlPublishedCache;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.Testing;
 
@@ -21,7 +23,9 @@ namespace Umbraco.Tests.Persistence
             using (var scope = ScopeProvider.CreateScope())
             {
                 var schema = new DatabaseSchemaCreator(scope.Database, Logger);
-                result = schema.ValidateSchema();
+                result = schema.ValidateSchema(
+                    //TODO: When we remove the xml cache from tests we can remove this too
+                    DatabaseSchemaCreator.OrderedTables.Concat(new []{typeof(ContentXmlDto), typeof(PreviewXmlDto)}));
             }
 
             // Assert

--- a/src/Umbraco.Tests/Persistence/SqlCeTableByTableTest.cs
+++ b/src/Umbraco.Tests/Persistence/SqlCeTableByTableTest.cs
@@ -5,6 +5,7 @@ using Umbraco.Core.Logging;
 using Umbraco.Core.Migrations.Install;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Dtos;
+using Umbraco.Tests.LegacyXmlPublishedCache;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.Testing;
 

--- a/src/Umbraco.Tests/Persistence/SyntaxProvider/SqlCeSyntaxProviderTests.cs
+++ b/src/Umbraco.Tests/Persistence/SyntaxProvider/SqlCeSyntaxProviderTests.cs
@@ -14,6 +14,7 @@ using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.Dtos;
 using Umbraco.Core.Persistence.SqlSyntax;
 using Umbraco.Core.Scoping;
+using Umbraco.Tests.LegacyXmlPublishedCache;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.Testing;
 

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -18,6 +18,7 @@ using Umbraco.Core.Services.Implement;
 using Umbraco.Tests.Testing;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Cache;
+using Umbraco.Tests.LegacyXmlPublishedCache;
 
 namespace Umbraco.Tests.Services
 {

--- a/src/Umbraco.Tests/Services/ContentTypeServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentTypeServiceTests.cs
@@ -10,6 +10,7 @@ using Umbraco.Core.Models;
 using Umbraco.Core.Persistence.Dtos;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Implement;
+using Umbraco.Tests.LegacyXmlPublishedCache;
 using Umbraco.Tests.TestHelpers.Entities;
 using Umbraco.Tests.Testing;
 using Umbraco.Tests.Scoping;

--- a/src/Umbraco.Tests/Services/MediaServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MediaServiceTests.cs
@@ -14,6 +14,7 @@ using Umbraco.Core.Persistence.Dtos;
 using Umbraco.Core.Persistence.Repositories;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Implement;
+using Umbraco.Tests.LegacyXmlPublishedCache;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.TestHelpers.Entities;
 using Umbraco.Tests.Testing;

--- a/src/Umbraco.Tests/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberServiceTests.cs
@@ -17,6 +17,7 @@ using Umbraco.Core.Persistence.Dtos;
 using Umbraco.Core.Persistence.Querying;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Implement;
+using Umbraco.Tests.LegacyXmlPublishedCache;
 using Umbraco.Tests.TestHelpers.Entities;
 using Umbraco.Tests.Testing;
 using Umbraco.Web.Security.Providers;

--- a/src/Umbraco.Tests/Services/MemberTypeServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberTypeServiceTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.Persistence.Dtos;
+using Umbraco.Tests.LegacyXmlPublishedCache;
 using Umbraco.Tests.TestHelpers.Entities;
 using Umbraco.Tests.Testing;
 

--- a/src/Umbraco.Tests/Services/PerformanceTests.cs
+++ b/src/Umbraco.Tests/Services/PerformanceTests.cs
@@ -13,6 +13,7 @@ using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Dtos;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Implement;
+using Umbraco.Tests.LegacyXmlPublishedCache;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.TestHelpers.Entities;
 using Umbraco.Tests.TestHelpers.Stubs;

--- a/src/Umbraco.Tests/TestHelpers/TestWithDatabaseBase.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestWithDatabaseBase.cs
@@ -307,6 +307,13 @@ namespace Umbraco.Tests.TestHelpers
                     var schemaHelper = new DatabaseSchemaCreator(scope.Database, Logger);
                     //Create the umbraco database and its base data
                     schemaHelper.InitializeDatabaseSchema();
+
+                    //Special case, we need to create the xml cache tables manually since they are not part of the default
+                    //setup.
+                    //TODO: Remove this when we update all tests to use nucache
+                    schemaHelper.CreateTable<ContentXmlDto>();
+                    schemaHelper.CreateTable<PreviewXmlDto>();
+
                     scope.Complete();
                 }
 

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -126,6 +126,8 @@
     <Compile Include="CoreThings\GuidUtilsTests.cs" />
     <Compile Include="CoreThings\HexEncoderTests.cs" />
     <Compile Include="CoreXml\RenamedRootNavigatorTests.cs" />
+    <Compile Include="LegacyXmlPublishedCache\ContentXmlDto.cs" />
+    <Compile Include="LegacyXmlPublishedCache\PreviewXmlDto.cs" />
     <Compile Include="Logging\LogviewerTests.cs" />
     <Compile Include="Manifest\ManifestContentAppTests.cs" />
     <Compile Include="Migrations\MigrationPlanTests.cs" />


### PR DESCRIPTION
These tables are purely for the Xml cache which doesn't exist anymore (only in the unit test project). So this drops those tables and updates the test project accordingly.

Testing: be sure unit tests pass, run the website, make sure the upgrader runs, that the tables are gone and your site is happy.