### PR TITLE
Removing ClientDependency setup for non-web runtimes

### DIFF
--- a/src/Umbraco.Web/Runtime/WebRuntimeComponent.cs
+++ b/src/Umbraco.Web/Runtime/WebRuntimeComponent.cs
@@ -278,7 +278,10 @@ namespace Umbraco.Web.Runtime
                 { "compositeFileHandlerPath", ClientDependencySettings.Instance.CompositeFileHandlerPath }
             });
 
-            ClientDependencySettings.Instance.MvcRendererCollection.Add(renderer);
+            // When using a non-web runtime and this component is loaded ClientDependency explodes because it'll
+            // want to access HttpContext.Current, which doesn't exist
+            if (HttpContext.Current != null)
+                ClientDependencySettings.Instance.MvcRendererCollection.Add(renderer);
         }
     }
 }

--- a/src/Umbraco.Web/Runtime/WebRuntimeComponent.cs
+++ b/src/Umbraco.Web/Runtime/WebRuntimeComponent.cs
@@ -280,7 +280,7 @@ namespace Umbraco.Web.Runtime
 
             // When using a non-web runtime and this component is loaded ClientDependency explodes because it'll
             // want to access HttpContext.Current, which doesn't exist
-            if (HttpContext.Current != null)
+            if (IOHelper.IsHosted)
                 ClientDependencySettings.Instance.MvcRendererCollection.Add(renderer);
         }
     }


### PR DESCRIPTION
This is more work regarding issue #3935, but in general, it's for all non-web runtimes. ClientDependency will explode because it can't access the web runtime, so we can test early for it.