### PR TITLE
V8: Support localization for doctypes and templates in content editor

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentMapperProfile.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapperProfile.cs
@@ -24,7 +24,8 @@ namespace Umbraco.Web.Models.Mapping
             IContentService contentService,
             IContentTypeService contentTypeService,
             IContentTypeBaseServiceProvider contentTypeBaseServiceProvider,
-            ILocalizationService localizationService)
+            ILocalizationService localizationService,
+            ILocalizedTextService localizedTextService)
         {
             // create, capture, cache
             var contentOwnerResolver = new OwnerResolver<IContent>(userService);
@@ -32,7 +33,7 @@ namespace Umbraco.Web.Models.Mapping
             var actionButtonsResolver = new ActionButtonsResolver(userService, contentService);
             var childOfListViewResolver = new ContentChildOfListViewResolver(contentService, contentTypeService);
             var contentTypeBasicResolver = new ContentTypeBasicResolver<IContent, ContentItemDisplay>(contentTypeBaseServiceProvider);
-            var allowedTemplatesResolver = new AllowedTemplatesResolver(contentTypeService);
+            var allowedTemplatesResolver = new AllowedTemplatesResolver(contentTypeService, localizedTextService);
             var defaultTemplateResolver = new DefaultTemplateResolver();
             var variantResolver = new ContentVariantResolver(localizationService);
             var schedPublishReleaseDateResolver = new ScheduledPublishDateResolver(ContentScheduleAction.Release);
@@ -47,7 +48,7 @@ namespace Umbraco.Web.Models.Mapping
                 .ForMember(dest => dest.ContentApps, opt => opt.MapFrom(contentAppResolver))
                 .ForMember(dest => dest.Icon, opt => opt.MapFrom(src => src.ContentType.Icon))
                 .ForMember(dest => dest.ContentTypeAlias, opt => opt.MapFrom(src => src.ContentType.Alias))
-                .ForMember(dest => dest.ContentTypeName, opt => opt.MapFrom(src => src.ContentType.Name))
+                .ForMember(dest => dest.ContentTypeName, opt => opt.MapFrom(src => localizedTextService.UmbracoDictionaryTranslate(src.ContentType.Name)))
                 .ForMember(dest => dest.IsContainer, opt => opt.MapFrom(src => src.ContentType.IsContainer))
                 .ForMember(dest => dest.IsElement, opt => opt.MapFrom(src => src.ContentType.IsElement))
                 .ForMember(dest => dest.IsBlueprint, opt => opt.MapFrom(src => src.Blueprint))
@@ -146,10 +147,12 @@ namespace Umbraco.Web.Models.Mapping
         private class AllowedTemplatesResolver : IValueResolver<IContent, ContentItemDisplay, IDictionary<string, string>>
         {
             private readonly IContentTypeService _contentTypeService;
+            private readonly ILocalizedTextService _localizedTextService;
 
-            public AllowedTemplatesResolver(IContentTypeService contentTypeService)
+            public AllowedTemplatesResolver(IContentTypeService contentTypeService, ILocalizedTextService localizedTextService)
             {
                 _contentTypeService = contentTypeService;
+                _localizedTextService = localizedTextService;
             }
 
             public IDictionary<string, string> Resolve(IContent source, ContentItemDisplay destination, IDictionary<string, string> destMember, ResolutionContext context)
@@ -158,7 +161,7 @@ namespace Umbraco.Web.Models.Mapping
 
                 return contentType.AllowedTemplates
                     .Where(t => t.Alias.IsNullOrWhiteSpace() == false && t.Name.IsNullOrWhiteSpace() == false)
-                    .ToDictionary(t => t.Alias, t => t.Name);
+                    .ToDictionary(t => t.Alias, t => _localizedTextService.UmbracoDictionaryTranslate(t.Name));
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Dictionary localization of doctypes (the "#name" notation) works in the content tree when creating content:

![image](https://user-images.githubusercontent.com/7405322/52618604-979f7b80-2e9f-11e9-876d-41092e98c56a.png)

...but not in the content info app - and neither does template localization:

![image](https://user-images.githubusercontent.com/7405322/52618816-2a401a80-2ea0-11e9-9e74-2b35a0c551e5.png)

This PR adds support for localizing both the doctypes and the templates in the info app:

![image](https://user-images.githubusercontent.com/7405322/52618586-8d7d7d00-2e9f-11e9-935c-48318d59b1b1.png)

### To test this PR

**Note:** At the time of writing you *must* use region specific cultures to translate anything using the dictionary (e.g. `es-ES`, not `es`). See #4519 for more info. 

1. On a multi-lingual site, create a content type named `#Article` with a similarly named template.
2. Create a dictionary item named `Article` and add translations for all languages.
3. Verify that the content tree (still) displays the content type with the translated name.
4. Verify that the content editor info app displays the content type and its template with the translated name.
