### PR TITLE
V8: Allowed types for creation do not update

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -17,6 +17,7 @@ function contentCreateController($scope,
   var mainCulture = $routeParams.mculture ? $routeParams.mculture : null;
 
   function initialize() {
+    $scope.allowedTypes = null;
     contentTypeResource.getAllowedTypes($scope.currentNode.id).then(function (data) {
       $scope.allowedTypes = iconHelper.formatContentTypeIcons(data);
     });
@@ -80,7 +81,13 @@ function contentCreateController($scope,
   $scope.createOrSelectBlueprintIfAny = createOrSelectBlueprintIfAny;
   $scope.createFromBlueprint = createFromBlueprint;
 
-  initialize();
+  // the current node changes behind the scenes when the context menu is clicked without closing 
+  // the default menu first, so we must watch the current node and re-initialize accordingly
+  var unbindModelWatcher = $scope.$watch("currentNode", initialize);
+  $scope.$on('$destroy', function () {
+    unbindModelWatcher();
+  });
+
 }
 
 angular.module("umbraco").controller("Umbraco.Editors.Content.CreateController", contentCreateController);

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.create.controller.js
@@ -7,10 +7,13 @@
  * The controller for the media creation dialog
  */
 function mediaCreateController($scope, $routeParams, $location, mediaTypeResource, iconHelper, navigationService) {
-    
-    mediaTypeResource.getAllowedTypes($scope.currentNode.id).then(function(data) {
-        $scope.allowedTypes = iconHelper.formatContentTypeIcons(data);
-    });
+
+    function initialize() {
+        $scope.allowedTypes = null;
+        mediaTypeResource.getAllowedTypes($scope.currentNode.id).then(function(data) {
+            $scope.allowedTypes = iconHelper.formatContentTypeIcons(data);
+        });
+    }
 
     $scope.createMediaItem = function(docType) {
         $location.path("/media/media/edit/" + $scope.currentNode.id).search("doctype", docType.alias).search("create", "true");
@@ -21,7 +24,13 @@ function mediaCreateController($scope, $routeParams, $location, mediaTypeResourc
         const showMenu = true;
         navigationService.hideDialog(showMenu);
     };
-    
+
+    // the current node changes behind the scenes when the context menu is clicked without closing 
+    // the default menu first, so we must watch the current node and re-initialize accordingly
+    var unbindModelWatcher = $scope.$watch("currentNode", initialize);
+    $scope.$on('$destroy', function () {
+        unbindModelWatcher();
+    });
 }
 
 angular.module('umbraco').controller("Umbraco.Editors.Media.CreateController", mediaCreateController);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you click the tree context menu, the "Create" dialog opens with the allowed children of the clicked node. If you then click another node without closing the "Create" dialog, the allowed children do not change even though the target node clearly does (the name in the title changes):

![allowed-types-before](https://user-images.githubusercontent.com/7405322/52622786-f1597300-2eaa-11e9-9699-e0364d1d7ba7.gif)

This PR ensures that the allowed children updates when the selected node changes:

![allowed-types-after](https://user-images.githubusercontent.com/7405322/52622821-07673380-2eab-11e9-8bc0-47a5a871d394.gif)

#### Implementation note

I tried a lot of things to make this work. Although not ideal, the `$watch` ended up being the best compromise. The alternatives included a lot more chatty client state update (read: degraded client performance) and forcefully closing the menu between each click.