### PR TITLE
V8: Make sure to show the "No allowed types" for applicable media items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/create.html
@@ -4,7 +4,7 @@
 
 			<h5><localize key="create_createUnder">Create under</localize> {{currentNode.name}}</h5>
 
-			<p class="abstract" ng-hide="allowedTypes">
+			<p class="abstract" ng-show="allowedTypes && allowedTypes.length === 0">
 				<localize key="create_noMediaTypes" />
 			</p>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There's a distinct flickering going on in the "Create" dialog for media items that do not allow children:

![media-no-allowed-types-before](https://user-images.githubusercontent.com/7405322/52623278-3fbb4180-2eac-11e9-92a2-29aaaf31a437.gif)

This PR ensures that the "no allowed types" message sticks:

![media-no-allowed-types-after](https://user-images.githubusercontent.com/7405322/52623330-51044e00-2eac-11e9-8fd7-6da7e59d70d5.gif)
