### PR TITLE
V8 - Default logging set to JSON

### DIFF
--- a/src/Umbraco.Core/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Core/Logging/Serilog/LoggerConfigExtensions.cs
@@ -22,6 +22,7 @@ namespace Umbraco.Core.Logging.Serilog
             //Set this environment variable - so that it can be used in external config file
             //add key="serilog:write-to:RollingFile.pathFormat" value="%BASEDIR%\logs\log.txt" />
             Environment.SetEnvironmentVariable("BASEDIR", AppDomain.CurrentDomain.BaseDirectory, EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("MACHINENAME", Environment.MachineName, EnvironmentVariableTarget.Process);
 
             logConfig.MinimumLevel.Verbose() //Set to highest level of logging (as any sinks may want to restrict it to Errors only)
                 .Enrich.WithProcessId()

--- a/src/Umbraco.Core/Logging/Serilog/SerilogLogger.cs
+++ b/src/Umbraco.Core/Logging/Serilog/SerilogLogger.cs
@@ -41,8 +41,6 @@ namespace Umbraco.Core.Logging.Serilog
             var loggerConfig = new LoggerConfiguration();
             loggerConfig
                 .MinimalConfiguration()
-                .OutputDefaultTextFile(LogEventLevel.Debug)
-                .OutputDefaultJsonFile()
                 .ReadFromConfigFile()
                 .ReadFromUserConfigFile();
 

--- a/src/Umbraco.Web.UI/config/serilog.config
+++ b/src/Umbraco.Web.UI/config/serilog.config
@@ -9,18 +9,17 @@
         <add key="serilog:minimum-level" value="Information" />
 
         <!-- NOTE: Only one logger below can be enabled, you cannot log JSON & TXT files at the same time -->
-        
+
         <!-- Default JSON log file -->
         <!-- This is used by the defualt log viewer in the Umbraco backoffice -->
         <add key="serilog:using:File" value="Serilog.Sinks.File" />
         <add key="serilog:write-to:File.formatter" value="Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact" />
-        <add key="serilog:write-to:File.path" value="%BASEDIR%\App_Data\Logs\UmbracoTraceLog.%MACHINENAME%..json" /> 
+        <add key="serilog:write-to:File.path" value="%BASEDIR%\App_Data\Logs\UmbracoTraceLog.%MACHINENAME%..json" />
         <add key="serilog:write-to:File.shared" value="true" />
         <add key="serilog:write-to:File.restrictedToMinimumLevel" value="Debug" />
         <add key="serilog:write-to:File.retainedFileCountLimit" value="" /> <!-- Number of log files to keep (or remove value to keep all files) -->
         <add key="serilog:write-to:File.rollingInterval" value="Day" /> <!-- Create a new log file every Minute/Hour/Day/Month/Year/infinite -->
- 
-        
+
         <!-- Optional TXT log file -->
         <!--<add key="serilog:using:File" value="Serilog.Sinks.File" /> -->
         <!--<add key="serilog:write-to:File.path" value="%BASEDIR%\App_Data\Logs\UmbracoTraceLog.%MACHINENAME%..txt" /> -->
@@ -29,8 +28,7 @@
         <!--<add key="serilog:write-to:File.retainedFileCountLimit" value="" /> --> <!-- Number of log files to keep (or remove value to keep all files) -->
         <!--<add key="serilog:write-to:File.rollingInterval" value="Day" /> --> <!-- Create a new log file every Minute/Hour/Day/Month/Year/infinite -->
         <!--<add key="serilog:write-to:File.outputTemplate" value="{Timestamp:yyyy-MM-dd HH:mm:ss,fff} [P{ProcessId}/D{AppDomainId}/T{ThreadId}] {Log4NetLevel}  {SourceContext} - {Message:lj}{NewLine}{Exception}" /> -->
-        
-        
+
         <!-- To write to new log locations (aka Sinks) such as your own .txt files with filtering, ELMAH.io, Elastic, SEQ -->
         <!-- Please use the serilog.user.config file to configure your own logging needs -->
 

--- a/src/Umbraco.Web.UI/config/serilog.config
+++ b/src/Umbraco.Web.UI/config/serilog.config
@@ -2,13 +2,36 @@
 <configuration>
     <appSettings>
 
-        <!-- Used to toggle the loge levels for the main Umbraco log files -->
+        <!-- Used to toggle the log levels for the main Umbraco log files -->
         <!-- Found at /app_data/logs/ -->
         <!-- NOTE: Changing this will also flow down into serilog.user.config -->
         <!-- VALID Values: Verbose, Debug, Information, Warning, Error, Fatal -->
         <add key="serilog:minimum-level" value="Information" />
 
-        <!-- To write to new log locations (aka Sinks) such as your own .txt files, ELMAH.io, Elastic, SEQ -->
+        <!-- NOTE: Only one logger below can be enabled, you cannot log JSON & TXT files at the same time -->
+        
+        <!-- Default JSON log file -->
+        <!-- This is used by the defualt log viewer in the Umbraco backoffice -->
+        <add key="serilog:using:File" value="Serilog.Sinks.File" />
+        <add key="serilog:write-to:File.formatter" value="Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact" />
+        <add key="serilog:write-to:File.path" value="%BASEDIR%\App_Data\Logs\UmbracoTraceLog.%MACHINENAME%..json" /> 
+        <add key="serilog:write-to:File.shared" value="true" />
+        <add key="serilog:write-to:File.restrictedToMinimumLevel" value="Debug" />
+        <add key="serilog:write-to:File.retainedFileCountLimit" value="" /> <!-- Number of log files to keep (or remove value to keep all files) -->
+        <add key="serilog:write-to:File.rollingInterval" value="Day" /> <!-- Create a new log file every Minute/Hour/Day/Month/Year/infinite -->
+ 
+        
+        <!-- Optional TXT log file -->
+        <!--<add key="serilog:using:File" value="Serilog.Sinks.File" /> -->
+        <!--<add key="serilog:write-to:File.path" value="%BASEDIR%\App_Data\Logs\UmbracoTraceLog.%MACHINENAME%..txt" /> -->
+        <!--<add key="serilog:write-to:File.shared" value="true" /> -->
+        <!--<add key="serilog:write-to:File.restrictedToMinimumLevel" value="Debug" /> -->
+        <!--<add key="serilog:write-to:File.retainedFileCountLimit" value="" /> --> <!-- Number of log files to keep (or remove value to keep all files) -->
+        <!--<add key="serilog:write-to:File.rollingInterval" value="Day" /> --> <!-- Create a new log file every Minute/Hour/Day/Month/Year/infinite -->
+        <!--<add key="serilog:write-to:File.outputTemplate" value="{Timestamp:yyyy-MM-dd HH:mm:ss,fff} [P{ProcessId}/D{AppDomainId}/T{ThreadId}] {Log4NetLevel}  {SourceContext} - {Message:lj}{NewLine}{Exception}" /> -->
+        
+        
+        <!-- To write to new log locations (aka Sinks) such as your own .txt files with filtering, ELMAH.io, Elastic, SEQ -->
         <!-- Please use the serilog.user.config file to configure your own logging needs -->
 
     </appSettings>


### PR DESCRIPTION
Moves the config of the Umbraco loggers out of C# & into XML appsettings config file

**NOTE:** Only one can be enabled at a time. If both are un-commented then the last one in wins and in this case that would be the TXT logfile.

Please check my spelling & wording in the serilog.config file to ensure the settings & information makes sense at a glance
