### PR TITLE
V8: Localize content app names

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -77,6 +77,10 @@
     <key alias="update">Tillad adgang til at gemme en node</key>
     <key alias="createblueprint">Tillad adgang til at oprette en indholdsskabelon</key>
   </area>
+  <area alias="apps">
+    <key alias="umbContent">Indhold</key>
+    <key alias="umbInfo">Info</key>
+  </area>
   <area alias="assignDomain">
     <key alias="permissionDenied">Tilladelse nægtet.</key>
     <key alias="addNew">Tilføj nyt domæne</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -78,6 +78,10 @@
     <key alias="update">Allow access to save a node</key>
     <key alias="createblueprint">Allow access to create a Content Template</key>
   </area>
+  <area alias="apps">
+    <key alias="umbContent">Content</key>
+    <key alias="umbInfo">Info</key>
+  </area>
   <area alias="assignDomain">
     <key alias="permissionDenied">Permission denied.</key>
     <key alias="addNew">Add new Domain</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -78,6 +78,10 @@
     <key alias="update">Allow access to save a node</key>
     <key alias="createblueprint">Allow access to create a Content Template</key>
   </area>
+  <area alias="apps">
+    <key alias="umbContent">Content</key>
+    <key alias="umbInfo">Info</key>
+  </area>
   <area alias="assignDomain">
     <key alias="permissionDenied">Permission denied.</key>
     <key alias="addNew">Add new Domain</key>

--- a/src/Umbraco.Web/Models/Mapping/ContentAppResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentAppResolver.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using AutoMapper;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.ContentEditing;
+using Umbraco.Core.Services;
 using Umbraco.Web.ContentApps;
 using Umbraco.Web.Models.ContentEditing;
 
@@ -12,15 +15,29 @@ namespace Umbraco.Web.Models.Mapping
     internal class ContentAppResolver : IValueResolver<IContent, ContentItemDisplay, IEnumerable<ContentApp>>
     {
         private readonly ContentAppFactoryCollection _contentAppDefinitions;
+        private readonly ILocalizedTextService _localizedTextService;
 
-        public ContentAppResolver(ContentAppFactoryCollection contentAppDefinitions)
+        public ContentAppResolver(ContentAppFactoryCollection contentAppDefinitions, ILocalizedTextService localizedTextService)
         {
             _contentAppDefinitions = contentAppDefinitions;
+            _localizedTextService = localizedTextService;
         }
 
         public IEnumerable<ContentApp> Resolve(IContent source, ContentItemDisplay destination, IEnumerable<ContentApp> destMember, ResolutionContext context)
         {
-            return _contentAppDefinitions.GetContentAppsFor(source);
+            var apps = _contentAppDefinitions.GetContentAppsFor(source).ToArray();
+
+            // localize content app names
+            foreach (var app in apps)
+            {
+                var localizedAppName = _localizedTextService.Localize($"apps/{app.Alias}");
+                if (localizedAppName.Equals($"[{app.Alias}]", StringComparison.OrdinalIgnoreCase) == false)
+                {
+                    app.Name = localizedAppName;
+                }
+            }
+
+            return apps;
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4485

### Description

This PR adds localization to content apps as described in #4485.

![image](https://user-images.githubusercontent.com/7405322/52693462-19a6a780-2f67-11e9-8731-c6c028f61a8d.png)

Localization is done using the default backoffice localization files in a new area called `apps`. This also means that:
- The default apps names (Content + Info) can be overridden in the `.user.xml` language files.
- 3rd party content apps can ship localization files that allows localizing their names along with the rest of their UI.