### PR TITLE
Changed the default ordering of toolbar in tinymce

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -312,7 +312,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 		 */
         defaultPrevalues: function () {
             var cfg = {};
-            cfg.toolbar = ["code", "bold", "italic", "styleselect", "alignleft", "aligncenter", "alignright", "bullist", "numlist", "outdent", "indent", "link", "image", "umbmediapicker", "umbembeddialog", "umbmacro"];
+            cfg.toolbar = ["ace", "styleselect", "bold", "italic", "alignleft", "aligncenter", "alignright", "bullist", "numlist", "outdent", "indent", "link", "umbmediapicker", "umbmacro", "umbembeddialog"];
             cfg.stylesheets = [];
             cfg.maxImageSize = 500;
             return cfg;


### PR DESCRIPTION
Fixes #4451 

- Changed the default ordering of toolbar in tinymce to be same as ordering in prevalue configuration