### PR TITLE
V8: Remove leftover console.log from #4469

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
@@ -22,7 +22,6 @@
                 
                 angular.forEach(scope.content.apps, (app) => {
                     if (app.alias === "umbContent") {
-                        console.log("app: ", app)
                         app.anchors = scope.content.tabs;
                     }
                 });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There's a `console.log()` leftover from #4469 ... it's been annoying me long enough 😄 so here's a PR that removes it.