### PR TITLE
V8: Add the missing right hand side margin for name fields

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -63,14 +63,14 @@
 // header
 
 .umb-editor-header {
-	background: @white;
-	position: absolute;
-	padding-left: 20px;
-	z-index: @zIndexEditor;
-	border-bottom: 1px solid @gray-9;
-	width: 100%;
-	box-sizing: border-box;
-	height: @editorHeaderHeight;
+    background: @white;
+    position: absolute;
+    padding-left: 20px;
+    z-index: @zIndexEditor;
+    border-bottom: 1px solid @gray-9;
+    width: 100%;
+    box-sizing: border-box;
+    height: @editorHeaderHeight;
 }
 
 .umb-editor-header__back {
@@ -81,6 +81,14 @@
 .umb-editor-header__name-wrapper {
 	position: relative;
 	display: flex;
+}
+
+.umb-editor-header__name-and-description {
+    margin-right: 20px;
+}
+
+.-split-view-active .umb-editor-header__name-and-description {
+    margin-right: 0;
 }
 
 .umb-editor-header__name-wrapper ng-form {

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -1,4 +1,4 @@
-<div data-element="editor-header" class="umb-editor-header">
+<div data-element="editor-header" class="umb-editor-header" ng-class="{'-split-view-active': splitViewOpen === true}">
 
     <div class="flex items-center" style="height: 100%;">
 
@@ -10,7 +10,7 @@
 
         <div class="flex items-center" style="flex: 1;">
 
-            <div id="nameField" style="flex: 1 1 auto;">
+            <div id="nameField" class="umb-editor-header__name-and-description" style="flex: 1 1 auto;">
                 <div class="umb-editor-header__name-wrapper">
                     <ng-form name="headerNameForm">
                         <input
@@ -60,7 +60,7 @@
             </a>
         </div>
 
-        <div ng-if="content.apps && splitViewOpen !== true" style="margin-left: 20px;">
+        <div ng-if="content.apps && splitViewOpen !== true">
             <umb-editor-navigation
                 data-element="editor-sub-views"
                 navigation="content.apps"

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -1,4 +1,4 @@
-﻿<div data-element="editor-header" class="umb-editor-header">
+﻿<div data-element="editor-header" class="umb-editor-header" ng-class="{'-split-view-active': splitViewOpen === true}">
 
     <div class="flex items-center" style="height: 100%;">
 
@@ -20,7 +20,7 @@
                 </div>
             </ng-form>
 
-            <div id="nameField" style="flex: 1 1 auto;">
+            <div id="nameField" class="umb-editor-header__name-and-description" style="flex: 1 1 auto;">
                 <div class="umb-editor-header__name-wrapper">
                     <ng-form name="headerNameForm">
                         <input data-element="editor-name-field"
@@ -69,7 +69,7 @@
 
         </div>
 
-        <div ng-if="navigation && splitViewOpen !== true" style="margin-left: 20px;">
+        <div ng-if="navigation && splitViewOpen !== true">
             <umb-editor-navigation
                 data-element="editor-sub-views"
                 navigation="navigation"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4530

### Description

If an item has no navigation items or content apps, its name field goes all the way to the right hand side of the screen; there's no margin. #4530 mentions packages and dictionary items as affected by this, but really there are a lot more places:

- Data types
- Templates
- Partial views
- Partial view macro files
- Scripts
- Users (only on a large screen, the scrollbar accidentally saves the day on smaller screens)
- Groups

![image](https://user-images.githubusercontent.com/7405322/52734876-9026c200-2fc6-11e9-908a-0c03e15d8c9c.png)

![image](https://user-images.githubusercontent.com/7405322/52734927-ad5b9080-2fc6-11e9-8490-6370b496706a.png)

This PR adds the margin for all name fields. As an added bonus it also removes a few bits of ugly inline styling.

### Testing this PR

1. Make sure that all name fields have an appropriate right hand side margin.
![image](https://user-images.githubusercontent.com/7405322/52735656-6b334e80-2fc8-11e9-855f-0cf9b7b8f86c.png)

2. Make sure that the editable description fields also have the same right hand side margin, so they align with the name fields.
![image](https://user-images.githubusercontent.com/7405322/52735596-4c34bc80-2fc8-11e9-9d31-159b9da27536.png)

3. Verify that the margin is not applied when editing in split view.
![image](https://user-images.githubusercontent.com/7405322/52735767-9a49c000-2fc8-11e9-9001-de9d562829e1.png)

