### PR TITLE
Adds the ability to add tree definitions dynamically on startup

### DIFF
--- a/src/Umbraco.Web/CompositionExtensions.cs
+++ b/src/Umbraco.Web/CompositionExtensions.cs
@@ -109,6 +109,13 @@ namespace Umbraco.Web
         public static EmbedProvidersCollectionBuilder OEmbedProviders(this Composition composition)
             => composition.WithCollectionBuilder<EmbedProvidersCollectionBuilder>();
 
+        /// <summary>
+        /// Gets the back office tree collection builder
+        /// </summary>
+        /// <param name="composition"></param>
+        /// <returns></returns>
+        public static TreeCollectionBuilder Trees(this Composition composition)
+            => composition.WithCollectionBuilder<TreeCollectionBuilder>();
         #endregion
 
         #region Uniques

--- a/src/Umbraco.Web/CompositionExtensions.cs
+++ b/src/Umbraco.Web/CompositionExtensions.cs
@@ -10,6 +10,7 @@ using Umbraco.Web.Media.EmbedProviders;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.PublishedCache;
 using Umbraco.Web.Routing;
+using Umbraco.Web.Search;
 using Umbraco.Web.Tour;
 using Umbraco.Web.Trees;
 using Current = Umbraco.Web.Composing.Current;
@@ -116,6 +117,15 @@ namespace Umbraco.Web
         /// <returns></returns>
         public static TreeCollectionBuilder Trees(this Composition composition)
             => composition.WithCollectionBuilder<TreeCollectionBuilder>();
+
+        /// <summary>
+        /// Gets the back office searchable tree collection builder
+        /// </summary>
+        /// <param name="composition"></param>
+        /// <returns></returns>
+        public static SearchableTreeCollectionBuilder SearchableTrees(this Composition composition)
+            => composition.WithCollectionBuilder<SearchableTreeCollectionBuilder>();
+
         #endregion
 
         #region Uniques

--- a/src/Umbraco.Web/Search/SearchableTreeCollectionBuilder.cs
+++ b/src/Umbraco.Web/Search/SearchableTreeCollectionBuilder.cs
@@ -3,7 +3,7 @@ using Umbraco.Web.Trees;
 
 namespace Umbraco.Web.Search
 {
-    internal class SearchableTreeCollectionBuilder : LazyCollectionBuilderBase<SearchableTreeCollectionBuilder, SearchableTreeCollection, ISearchableTree>
+    public class SearchableTreeCollectionBuilder : LazyCollectionBuilderBase<SearchableTreeCollectionBuilder, SearchableTreeCollection, ISearchableTree>
     {
         protected override SearchableTreeCollectionBuilder This => this;
 

--- a/src/Umbraco.Web/Trees/Tree.cs
+++ b/src/Umbraco.Web/Trees/Tree.cs
@@ -10,12 +10,12 @@ namespace Umbraco.Web.Trees
         public Tree(int sortOrder, string applicationAlias, string group, string alias, string title, TreeUse use, Type treeControllerType, bool isSingleNodeTree)
         {
             SortOrder = sortOrder;
-            SectionAlias = applicationAlias;
+            SectionAlias = applicationAlias ?? throw new ArgumentNullException(nameof(applicationAlias));
             TreeGroup = group;
-            TreeAlias = alias;
-            TreeTitle = title;
+            TreeAlias = alias ?? throw new ArgumentNullException(nameof(alias));
+            TreeTitle = title ?? throw new ArgumentNullException(nameof(title));
             TreeUse = use;
-            TreeControllerType = treeControllerType;
+            TreeControllerType = treeControllerType ?? throw new ArgumentNullException(nameof(treeControllerType));
             IsSingleNodeTree = isSingleNodeTree;
         }
 

--- a/src/Umbraco.Web/Trees/Tree.cs
+++ b/src/Umbraco.Web/Trees/Tree.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Web.Trees
             SectionAlias = applicationAlias ?? throw new ArgumentNullException(nameof(applicationAlias));
             TreeGroup = group;
             TreeAlias = alias ?? throw new ArgumentNullException(nameof(alias));
-            TreeTitle = title ?? throw new ArgumentNullException(nameof(title));
+            TreeTitle = title;
             TreeUse = use;
             TreeControllerType = treeControllerType ?? throw new ArgumentNullException(nameof(treeControllerType));
             IsSingleNodeTree = isSingleNodeTree;

--- a/src/Umbraco.Web/Trees/TreeCollectionBuilder.cs
+++ b/src/Umbraco.Web/Trees/TreeCollectionBuilder.cs
@@ -16,6 +16,20 @@ namespace Umbraco.Web.Trees
 
         public void RegisterWith(IRegister register) => register.Register(CreateCollection, Lifetime.Singleton);
 
+        /// <summary>
+        /// Registers a custom tree definition
+        /// </summary>
+        /// <param name="treeDefinition"></param>
+        /// <remarks>
+        /// This is useful if a developer wishes to have a single tree controller for different tree aliases. In this case the tree controller
+        /// cannot be decorated with the TreeAttribute (since then it will be auto-registered).
+        /// </remarks>
+        public void AddTree(Tree treeDefinition)
+        {
+            if (treeDefinition == null) throw new ArgumentNullException(nameof(treeDefinition));
+            _trees.Add(treeDefinition);
+        }
+
         public void AddTreeController<TController>()
             where TController : TreeControllerBase
             => AddTreeController(typeof(TController));
@@ -25,7 +39,7 @@ namespace Umbraco.Web.Trees
             if (!typeof(TreeControllerBase).IsAssignableFrom(controllerType))
                 throw new ArgumentException($"Type {controllerType} does not inherit from {typeof(TreeControllerBase).FullName}.");
 
-            // no all TreeControllerBase are meant to be used here,
+            // not all TreeControllerBase are meant to be used here,
             // ignore those that don't have the attribute
 
             var attribute = controllerType.GetCustomAttribute<TreeAttribute>(false);


### PR DESCRIPTION
fixes #4408

This is useful if a developer wishes to have a single tree controller for different tree aliases. In this case the tree controller cannot be decorated with the TreeAttribute (since then it will be auto-registered).

see discussion #4408