### PR TITLE
v8 - fixing js unit tests + build + CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ build/temp/
 
 
 # eof
+/src/Umbraco.Web.UI.Client/TESTS-*.xml

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/build.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/build.js
@@ -6,5 +6,5 @@ var runSequence = require('run-sequence');
 
 // Build - build the files ready for production
 gulp.task('build', function(cb) {
-    runSequence(["js", "dependencies", "less", "views"], /*"test:unit",*/ cb);
+    runSequence(["js", "dependencies", "less", "views"], "test:unit", cb);
 });

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -8664,6 +8664,16 @@
         "jasmine-core": "^3.3"
       }
     },
+    "karma-junit-reporter": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz",
+      "integrity": "sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=",
+      "dev": true,
+      "requires": {
+        "path-is-absolute": "^1.0.0",
+        "xmlbuilder": "8.2.2"
+      }
+    },
     "karma-phantomjs-launcher": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
@@ -16435,6 +16445,12 @@
         "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
       }
+    },
+    "xmlbuilder": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -48,6 +48,7 @@
     "@babel/preset-env": "7.1.6",
     "autoprefixer": "9.3.1",
     "cssnano": "4.1.7",
+    "fs": "0.0.2",
     "gulp": "^3.9.1",
     "gulp-babel": "8.0.0",
     "gulp-clean-css": "4.0.0",
@@ -58,6 +59,7 @@
     "gulp-imagemin": "^4.1.0",
     "gulp-less": "4.0.1",
     "gulp-ngdocs": "0.3.0",
+    "gulp-notify": "^3.0.0",
     "gulp-open": "3.0.1",
     "gulp-postcss": "8.0.0",
     "gulp-rename": "1.4.0",
@@ -65,16 +67,15 @@
     "gulp-watch": "5.0.1",
     "gulp-wrap": "0.14.0",
     "gulp-wrap-js": "0.4.1",
-    "gulp-notify": "^3.0.0",
     "jasmine-core": "3.3.0",
     "karma": "3.1.1",
     "karma-jasmine": "2.0.1",
+    "karma-junit-reporter": "^1.2.0",
     "karma-phantomjs-launcher": "1.0.4",
     "less": "3.9.0",
     "lodash": "4.17.11",
     "marked": "^0.5.2",
     "merge-stream": "1.0.1",
-    "run-sequence": "2.2.1",
-    "fs": "0.0.2"
+    "run-sequence": "2.2.1"
   }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -191,7 +191,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         //if we have a query for the startnode, we will use that.
         var rootId = $routeParams.id;
         entityResource.getByQuery($scope.model.config.startNode.query, rootId, "Document").then(function (ent) {
-            dialogOptions.startNodeId = $scope.model.config.idType === "udi" ? ent.udi : ent.id;
+            dialogOptions.startNodeId = ($scope.model.config.idType === "udi" ? ent.udi : ent.id).toString();
         });
     }
     else {
@@ -261,7 +261,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     $scope.add = function (item) {
         var currIds = $scope.model.value ? $scope.model.value.split(',') : [];
 
-        var itemId = $scope.model.config.idType === "udi" ? item.udi : item.id;
+        var itemId = ($scope.model.config.idType === "udi" ? item.udi : item.id).toString();
 
         if (currIds.indexOf(itemId) < 0) {
             currIds.push(itemId);

--- a/src/Umbraco.Web.UI.Client/test/config/karma.conf.js
+++ b/src/Umbraco.Web.UI.Client/test/config/karma.conf.js
@@ -113,6 +113,12 @@ module.exports = function (config) {
             nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
             classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
             properties: {} // key value pair of properties to add to the <properties> section of the report
+        },
+
+        client: {
+            jasmine: {
+                random: false
+            }
         }
     });
 };

--- a/src/Umbraco.Web.UI.Client/test/config/karma.conf.js
+++ b/src/Umbraco.Web.UI.Client/test/config/karma.conf.js
@@ -1,7 +1,7 @@
 module.exports = function (config) {
 
     config.set({
-                
+
         // base path, that will be used to resolve files and exclude
         basePath: '../..',
 
@@ -52,7 +52,7 @@ module.exports = function (config) {
         // use dolts reporter, as travis terminal does not support escaping sequences
         // possible values: 'dots', 'progress', 'junit', 'teamcity'
         // CLI --reporters progress
-        reporters: ['progress'],
+        reporters: ['progress', 'junit'],
 
         // web server port
         // CLI --port 9876
@@ -60,7 +60,7 @@ module.exports = function (config) {
 
         // cli runner port
         // CLI --runner-port 9100
-    runnerPort: 9100,
+        runnerPort: 9100,
 
         // enable / disable colors in the output (reporters and logs)
         // CLI --colors --no-colors
@@ -89,7 +89,7 @@ module.exports = function (config) {
         // allow waiting a bit longer, some machines require this
 
         browserNoActivityTimeout: 100000,     // default 10,000ms
-        
+
         // Auto run tests on start (when browsers are captured) and exit
         // CLI --single-run --no-single-run
         singleRun: true,
@@ -100,7 +100,19 @@ module.exports = function (config) {
 
         plugins: [
             require('karma-jasmine'),
-            require('karma-phantomjs-launcher')
-        ]
+            require('karma-phantomjs-launcher'),
+            require('karma-junit-reporter')
+        ],
+
+        // the default configuration
+        junitReporter: {
+            outputDir: '', // results will be saved as $outputDir/$browserName.xml
+            outputFile: undefined, // if included, results will be saved as $outputDir/$browserName/$outputFile
+            suite: '', // suite will become the package name attribute in xml testsuite element
+            useBrowserName: true, // add browser name to report and classes names
+            nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
+            classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
+            properties: {} // key value pair of properties to add to the <properties> section of the report
+        }
     });
 };

--- a/src/Umbraco.Web.UI.Client/test/unit/app/propertyeditors/content-picker-controller.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/app/propertyeditors/content-picker-controller.spec.js
@@ -12,6 +12,7 @@ describe('Content picker controller tests', function () {
 
         httpBackend = $httpBackend;
         scope = $rootScope.$new();
+
         scope.model = {
                         alias: "property",
                         value:"1233,1231,23121",
@@ -86,28 +87,27 @@ describe('Content picker controller tests', function () {
         });
 
         it("Adding an item should update renderModel, ids and model.value", function(){
+            
             scope.add(item);
             scope.$apply();
-            setTimeout(function(){
-                expect(scope.renderModel.length).toBe(4);
-                expect(scope.model.value).toBe("1233,1231,23121,666");
-            }, 1000);
+            httpBackend.flush();
+
+            expect(scope.renderModel.length).toBe(4);
+            expect(scope.model.value).toBe("1233,1231,23121,666");
         });
 
         it("Adding a duplicate item should note update renderModel, ids and model.value", function(){
             scope.add(item);
             scope.$apply();
-            setTimeout(function(){
-                expect(scope.renderModel.length).toBe(4);
-                expect(scope.model.value).toBe("1233,1231,23121,666");
-            }, 1000);
+            httpBackend.flush();
+            expect(scope.renderModel.length).toBe(4);
+            expect(scope.model.value).toBe("1233,1231,23121,666");
 
             scope.add(item);
             scope.$apply();
-            setTimeout(function(){
-                expect(scope.renderModel.length).toBe(4);
-                expect(scope.model.value).toBe("1233,1231,23121,666");
-            }, 1000);
+            
+            expect(scope.renderModel.length).toBe(4);
+            expect(scope.model.value).toBe("1233,1231,23121,666");
 
         });  
     });

--- a/src/Umbraco.Web.UI.Client/test/unit/app/propertyeditors/content-picker-controller.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/app/propertyeditors/content-picker-controller.spec.js
@@ -52,11 +52,15 @@ describe('Content picker controller tests', function () {
 
     describe('content edit controller save and publish', function () {
         
-        var item = {
-            name: "meh",
-            id: 666,
-            icon: "woop"
-        };
+        var item;
+
+        beforeEach(function () {
+            item = {
+                name: "meh",
+                id: 666,
+                icon: "woop"
+            };
+        });
 
         it('should define the default properties on construction', function () {
             expect(scope.model.value).not.toBeUndefined();            

--- a/src/Umbraco.Web.UI.Client/test/unit/app/templates/template-editor-controller.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/app/templates/template-editor-controller.spec.js
@@ -102,43 +102,6 @@
             it("has ace editor", function () {
                 expect(controller.editor).toBe(ace);
             });
-
-            it("sets masterpage on template", function () {
-                controller.setLayout = function() {};
-
-                controller.openMasterTemplateOverlay();
-                setTimeout(function(){
-                    controller.masterTemplateOverlay.submit({
-                        selectedItem: {
-                            alias: "NewMasterPage"
-                        }
-                    });
-                    expect(controller.template.masterTemplateAlias).toBe("NewMasterPage");
-                }, 1000);
-            });
-
-            //// TODO: THIS FAILED
-            //it("changes layout value when masterpage is selected", function() {
-            //    var newTemplate;
-            //    ace.clearSelection = nada;
-            //    ace.navigateFileStart = nada;
-            //    ace.getValue = function () {
-            //        return "@{ Layout = null; }";
-            //    }
-            //    ace.setValue = function (value) {
-            //        newTemplate = value;
-            //    }
-
-            //    controller.openMasterTemplateOverlay();
-            //    setTimeout(function(){
-            //        controller.masterTemplateOverlay.submit({
-            //            selectedItem: {
-            //                alias: "NewMasterPage"
-            //            }
-            //        });
-            //        expect(newTemplate).toBe("@{ Layout = \"NewMasterPage.cshtml\"; }");
-            //    }, 1000);
-            //});
             
         });
 


### PR DESCRIPTION
fixes #4392

These changes are required so that the JS unit tests run as part of the CI build correctly:

* Had to fix up some code for tests that were failing
* Had to fix up some tests since how they were running was incorrect
* Added the compatible test reporter for Azure DevOps (CI) so that successful and completed JS tests are reported by the build server
* I've already updated the CI server to publish these test results and it's working, here's a successful build https://umbraco.visualstudio.com/Umbraco%20Cms/_build/results?buildId=17832&view=ms.vss-test-web.build-test-results-tab  - I've only done this on the Cms 8 Continuous build but we should do that on the other builds as well

![image](https://user-images.githubusercontent.com/1742685/52763431-c409f200-306f-11e9-8389-7c3b437aae19.png)


The reason the tests before were failing intermittently is because some of them were put together poorly and there was strange timing issues. 

This seems to work well and consistent on my machine and the CI server so once merged it should be ok.