### PR TITLE
Added track by $index for `Repeatable Textstrings`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
@@ -1,7 +1,7 @@
 <div class="umb-property-editor umb-multiple-textbox" ng-controller="Umbraco.PropertyEditors.MultipleTextBoxController">
 
   <div ui-sortable="sortableOptions" ng-model="model.value">
-    <div class="flex flex-wrap textbox-wrapper" ng-repeat="item in model.value">
+    <div class="flex flex-wrap textbox-wrapper" ng-repeat="item in model.value track by $index">
       <input type="text" name="item_{{$index}}" ng-model="item.value" class="umb-property-editor umb-textstring textstring"
              ng-keyup="addRemoveOnKeyDown($event, $index)" focus-when="{{item.hasFocus}}"/>
       <i class="icon icon-navigation handle" localize="title" title="@general_move"></i>


### PR DESCRIPTION
Fixes: #4426 

Steps to reproduce:
- Create a new doctype with a `Repeatable Textstrings` property
- Create a content of that type
- Insert minium 2 items in the  `Repeatable Textstrings` property
- Publish
- Go to rollback, and change the value in the select box. 
  - Before this fix a console error occurred.