### PR TITLE
V8: Add missing dirty checks to content type dirty checking

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -497,13 +497,17 @@
         });
 
         // #3368 - changes on the other "buttons" do not register on the current form, so we manually have to flag the form as dirty 
-        $scope.$watch("vm.contentType.allowedContentTypes.length + vm.contentType.allowAsRoot + vm.contentType.allowedTemplates.length + vm.contentType.isContainer", function (newVal, oldVal) {
-            if (oldVal === undefined) {
-                // still initializing, ignore
-                return;
+        $scope.$watch(
+            "vm.contentType.allowedContentTypes.length + vm.contentType.allowAsRoot + vm.contentType.allowCultureVariant + vm.contentType.isElement + " +
+            "vm.contentType.allowedTemplates.length + vm.contentType.isContainer + vm.contentType.compositeContentTypes.length",
+            function(newVal, oldVal) {
+                if (oldVal === undefined) {
+                    // still initializing, ignore
+                    return;
+                }
+                angularHelper.getCurrentForm($scope).$setDirty();
             }
-            angularHelper.getCurrentForm($scope).$setDirty();
-        });
+        );
     }
 
     angular.module("umbraco").controller("Umbraco.Editors.DocumentTypes.EditController", DocumentTypesEditController);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4516

### Description

As described on #4516, the content type editor isn't flagged as dirty when the compositions are changed.

It turns out that this also applies to "Allow varying by culture" and "Is an Element type":

![image](https://user-images.githubusercontent.com/7405322/52793378-e3a01b00-306d-11e9-80c0-1556ff09e2be.png)

This is essentially the same problem as in #3368, so I have simply added to that fix.
