### PR TITLE
V8: Add missing dirty checks to mediatypes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
@@ -12,7 +12,7 @@
     function MediaTypesEditController($scope, $routeParams, mediaTypeResource, 
         dataTypeResource, editorState, contentEditingHelper, formHelper, 
         navigationService, iconHelper, contentTypeHelper, notificationsService, 
-        $filter, $q, localizationService, overlayHelper, eventsService) {
+        $filter, $q, localizationService, overlayHelper, eventsService, angularHelper) {
 
         var vm = this;
         var evts = [];
@@ -418,6 +418,15 @@
             for (var e in evts) {
                 eventsService.unsubscribe(evts[e]);
             }
+        });
+
+        // changes on the other "buttons" do not register on the current form, so we manually have to flag the form as dirty 
+        $scope.$watch("vm.contentType.allowedContentTypes.length + vm.contentType.allowAsRoot + vm.contentType.isContainer + vm.contentType.compositeContentTypes.length", function (newVal, oldVal) {
+            if (oldVal === undefined) {
+                // still initializing, ignore
+                return;
+            }
+            angularHelper.getCurrentForm($scope).$setDirty();
         });
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is the media type equivalent of #4583 and #3368. The mediatype editor doesn't do a whole lot of dirty checking at the moment - it needs dirty checking on:

- Allowed child node types
- Allow as root
- Enable list view
- Compositions

This PR adds all of the above. It looks like this:

![mediatype-dirty-checks](https://user-images.githubusercontent.com/7405322/52794346-ef8cdc80-306f-11e9-87f5-710654146740.gif)
