### PR TITLE
v8: Update navigation icons in package section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/overview.controller.js
@@ -72,7 +72,7 @@
                     },
                     {
                         "name": vm.page.labels.install,
-                        "icon": "icon-add",
+                        "icon": "icon-cloud-upload",
                         "view": "views/packages/views/install-local.html",
                         "active": packageUri === "local",
                         "alias": "umbInstallLocal",
@@ -82,7 +82,7 @@
                     },
                     {
                         "name": vm.page.labels.created,
-                        "icon": "icon-add",
+                        "icon": "icon-files",
                         "view": "views/packages/views/created.html",
                         "active": packageUri === "created",
                         "alias": "umbCreatedPackages",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4387

### Description
I have updated the navigation icons in package section and chosen `icon-cloud-upload` for install local package and `icon-files` for created packages.

I considered a few other icons mostly for created packages:
`icon-categories`, `icon-inbox-full`, `icon-inbox`, `icon-utilities` and `icon-file-cabinet` (the latter one I find a bit too tall compared to the other icons), but feel free the update this if needed.
https://nicbell.github.io/ucreate/icons.html

**Before**

![image](https://user-images.githubusercontent.com/2919859/52805760-96c93e00-3087-11e9-8287-069576302bf1.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/52805783-a2b50000-3087-11e9-90d8-1873d24dd457.png)
