### PR TITLE
V8: Fix the initial zoom offset for new crops in the image cropper

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-crop.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-crop.html
@@ -6,7 +6,7 @@
 		</div>
 	</div>
 
-	<div class="crop-slider">
+	<div class="crop-slider" ng-if="loaded">
 		<i class="icon-picture"></i>
 			<input
 				type="range" 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4483 (in part)

### Description

The image cropper has a weird zoom offset for new crops and for crops that use minimum zoom level. It simply keeps offsetting itself a little bit:

![image-cropper-initial-zoom-before](https://user-images.githubusercontent.com/7405322/52809828-756d4f80-3091-11e9-8216-099d46c2f628.gif)

Apparenly it's an issue with the range input, or rather somewhere between the range input and the watch attached to its model value. If we simply don't add the range input until the crop has finished initializing itself, the problem disappears. So that's just what this PR does. It looks like this:

![image-cropper-initial-zoom-after](https://user-images.githubusercontent.com/7405322/52809928-b4030a00-3091-11e9-8627-82859fa47fec.gif)
