### PR TITLE
V8: Make the image crop slider move at 66 hertz

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagecrop.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagecrop.directive.js
@@ -232,7 +232,7 @@ angular.module("umbraco.directives")
 					var throttledResizing = _.throttle(function(){
 						resizeImageToScale(scope.dimensions.scale.current);
 						calculateCropBox();
-					}, 100);
+					}, 15);
 
 
 					//happens when we change the scale


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4483 (in part)

### Description

The image cropper slider currently moves at 10 hertz, probably in an effort to go easy on the client browser. However it results in a miserable editor experience, which is in part outlined in #4483. 

Given the low update frequency it's way too easy to drag the slider all the way to either side without getting the desired result - as shown here:

![image-cropper-slider-frequency-before](https://user-images.githubusercontent.com/7405322/52810443-de08fc00-3092-11e9-99ed-492333e2ce1c.gif)

This PR makes the slider move at 66 hertz. It's obviously more strain on the client, but the alternative is much worse. I have experimented with lower frequencies, but even at 50 hertz it's choppy and pretty easy to reproduce the same errors.

Here's the slider moving at 66 hertz:

![image-cropper-slider-frequency-after](https://user-images.githubusercontent.com/7405322/52810535-114b8b00-3093-11e9-9c45-67d5028e5813.gif)
