### PR TITLE
V8: Don't let the image cropper reuse crop states between crops

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
@@ -1,6 +1,6 @@
 angular.module('umbraco')
     .controller("Umbraco.PropertyEditors.ImageCropperController",
-    function ($scope, fileManager) {
+    function ($scope, fileManager, $timeout) {
 
         var config = angular.copy($scope.model.config);
 
@@ -127,15 +127,32 @@ angular.module('umbraco')
 
         /**
          * crop a specific crop
-         * @param {any} crop
+         * @param {any} targetCrop
          */
-        function crop(crop) {
-            // clone the crop so we can discard the changes
-            $scope.currentCrop = angular.copy(crop);
-            $scope.currentPoint = null;
+        function crop(targetCrop) {
+            if (!$scope.currentCrop) {
+                // clone the crop so we can discard the changes
+                $scope.currentCrop = angular.copy(targetCrop);
+                $scope.currentPoint = null;
 
-            //set form to dirty to track changes
-            $scope.imageCropperForm.$setDirty();
+                //set form to dirty to track changes
+                $scope.imageCropperForm.$setDirty();
+            }
+            else {
+                // we have a crop open already - close the crop (this will discard any changes made)
+                close();
+
+                // the crop editor needs a digest cycle to close down properly, otherwise its state 
+                // is reused for the new crop... and that's really bad
+                $timeout(function () {
+                    crop(targetCrop);
+                    $scope.pendingCrop = false;
+                });
+
+                // this is necessary to keep the screen from flickering too badly while we wait for the new crop to open
+                // - check the view for its usage (basically it makes sure we keep the space reserved for the new crop)
+                $scope.pendingCrop = true;
+            }
         };
 
         /** done cropping */

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
@@ -12,10 +12,10 @@
 
             <div class="imagecropper clearfix">
 
-                <div ng-if="currentCrop" style="float:left; max-width: 100%;" class="clearfix">
+                <div ng-if="currentCrop || pendingCrop" style="float:left; max-width: 100%;" class="clearfix">
                     <div class="umb-cropper__container">
 
-                        <div>
+                        <div ng-if="currentCrop">
                             <umb-image-crop height="{{currentCrop.height}}"
                                             width="{{currentCrop.width}}"
                                             crop="currentCrop.coordinates"
@@ -25,7 +25,7 @@
                             </umb-image-crop>
                         </div>
 
-                        <div class="button-drawer">
+                        <div class="button-drawer" ng-if="currentCrop">
                             <button class="btn btn-link" ng-click="reset()"><localize key="imagecropper_reset">Reset this crop</localize></button>
                             <button class="btn" ng-click="close()"><localize key="imagecropper_undoEditCrop">Undo edits</localize></button>
                             <button class="btn btn-success" ng-click="done()"><localize key="imagecropper_updateEditCrop">Done</localize></button>
@@ -34,7 +34,7 @@
                     </div>
                 </div>
 
-                <div ng-if="!currentCrop" class="umb-cropper-imageholder clearfix">
+                <div ng-if="!currentCrop && !pendingCrop" class="umb-cropper-imageholder clearfix">
                     <umb-image-gravity src="imageSrc"
                                        center="model.value.focalPoint"
                                        on-value-changed="focalPointChanged(left, top)"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4582

### Description

When you switch to a new crop without closing down the previous one, the previous crop state is retained in the crop editor. This results in a very undesirable editorial experience where the crops misbehave horribly - as described in #4582:

![image-cropper-state-issue-before](https://user-images.githubusercontent.com/7405322/52810967-368cc900-3094-11e9-8ec6-303b2ab36301.gif)

This PR forces the crop editor to close and then re-open in a new digest cycle to flush the previous crop state. To avoid too much screen flickering when closing and re-opening the crop editor I had to add an additional state property. It's not the prettiest code to look at but it's efficient and I can't really see any way around it at this point.

Here's the image cropper with this PR applied:

![image-cropper-state-issue-after](https://user-images.githubusercontent.com/7405322/52811074-8075af00-3094-11e9-8178-c8c44596760d.gif)
