### PR TITLE
V8: Fix missing crops on existing images

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
@@ -97,7 +97,7 @@ angular.module('umbraco')
                 if (angular.isString($scope.model.value)) {
                     setModelValueWithSrc($scope.model.value);
                 }
-                else if ($scope.model.value.crops) {
+                else {
                     //sync any config changes with the editor and drop outdated crops
                     _.each($scope.model.value.crops, function (saved) {
                         var configured = _.find(config.crops, function (item) { return item.alias === saved.alias });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4581

### Description

As described on #4581, if you add crops to an image cropper datatype *after* having created images with that datatype, the created images never get the crops - only newly created images do:

![image-cropper-missing-crops-before](https://user-images.githubusercontent.com/7405322/52811851-6fc63880-3096-11e9-8f47-f7eca3a098a1.gif)

Steps to recreate:

1. Create a new image cropper datatype with no crops.
2. Create a new media type using this new image cropper datatype.
   - You can skip 1 and 2 if you use a blank install without modifying the default image cropper
3. Create a media item using the new media type, upload an image to it and save it.
4. Add some crops to the image cropper datatype.
5. Open the created media item. It has no crops available 😢 
6. Create a new media item using the same media type and upload an image to it. It has crops available!

With this PR applied the crops are added to both new and existing image cropper properties:

![image-cropper-missing-crops-after](https://user-images.githubusercontent.com/7405322/52812187-37732a00-3097-11e9-8602-92f0ec313144.gif)

