### PR TITLE
v8 Fixes umbeditornavigation.directive 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditornavigation.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditornavigation.directive.js
@@ -46,18 +46,15 @@
             };
 
             function onInit() {
-
-                // hide navigation if there is only 1 item
-                if (scope.navigation.length <= 1) {
-                    scope.showNavigation = false;
-                }
-                
-                $timeout(function(){
-                    if($window && $window.innerWidth) {
-                        calculateVisibleItems($window.innerWidth);
-                    }
-                });
-
+                var firstRun = true;
+                scope.$watch("navigation.length",
+                    (newVal, oldVal) => {
+                        if (firstRun || newVal !== undefined && newVal !== oldVal) {
+                            firstRun = false;
+                            scope.showNavigation = newVal > 1;
+                            calculateVisibleItems($window.innerWidth);
+                        }
+                    });
             }
 
             function calculateVisibleItems(windowWidth) {

--- a/src/Umbraco.Web.UI.Client/src/routes.js
+++ b/src/Umbraco.Web.UI.Client/src/routes.js
@@ -157,6 +157,7 @@ app.config(function ($routeProvider) {
                     return;
                 }
 
+                //TODO: Fix this special case by using components, the packager should be a component and then we just have a view for each route like normal rendering the component with the correct parameters
                 //special case for the package section
                 var packagePages = ["edit", "options"];
                 if ($routeParams.section.toLowerCase() === "packages" && $routeParams.tree.toLowerCase() === "packages" && packagePages.indexOf($routeParams.method.toLowerCase()) === -1) {
@@ -164,6 +165,7 @@ app.config(function ($routeProvider) {
                     return;
                 }
 
+                //TODO: Fix this special case by using components, the users section should be a component and then we just have a view for each route like normal rendering the component with the correct parameters
                 //special case for the users section
                 var usersPages = ["user", "group"];
                 if ($routeParams.section.toLowerCase() === "users" && $routeParams.tree.toLowerCase() === "users" && usersPages.indexOf($routeParams.method.toLowerCase()) === -1) {


### PR DESCRIPTION
Fixes #4478

Fixes umbeditornavigation.directive which doesn't listen for any changes to the navigation collection which means it can't dynamically resize or show/hide the items
