### PR TITLE
Improved fix for non-web Umbraco hosts

### DIFF
--- a/src/Umbraco.Web/Runtime/WebRuntimeComponent.cs
+++ b/src/Umbraco.Web/Runtime/WebRuntimeComponent.cs
@@ -73,8 +73,12 @@ namespace Umbraco.Web.Runtime
             // setup mvc and webapi services
             SetupMvcAndWebApi();
 
-            // client dependency
-            ConfigureClientDependency(_globalSettings);
+            // When using a non-web runtime and this component is loaded ClientDependency explodes because it'll
+            // want to access HttpContext.Current, which doesn't exist
+            if (IOHelper.IsHosted)
+            {
+                ConfigureClientDependency(_globalSettings);
+            }
 
             // Disable the X-AspNetMvc-Version HTTP Header
             MvcHandler.DisableMvcResponseHeader = true;
@@ -278,10 +282,7 @@ namespace Umbraco.Web.Runtime
                 { "compositeFileHandlerPath", ClientDependencySettings.Instance.CompositeFileHandlerPath }
             });
 
-            // When using a non-web runtime and this component is loaded ClientDependency explodes because it'll
-            // want to access HttpContext.Current, which doesn't exist
-            if (IOHelper.IsHosted)
-                ClientDependencySettings.Instance.MvcRendererCollection.Add(renderer);
+            ClientDependencySettings.Instance.MvcRendererCollection.Add(renderer);
         }
     }
 }


### PR DESCRIPTION
Realised that my last fix wasn't living the test high enough, so now just preventing all Client Dependency setup for a non-web host.