### PR TITLE
V7: Fix the initial zoom offset for new crops in the image cropper

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-crop.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-crop.html
@@ -6,7 +6,7 @@
 		</div>
 	</div>
 
-	<div class="crop-slider">
+	<div class="crop-slider" ng-if="loaded">
 		<i class="icon-picture"></i>
 			<input
 				type="range" 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is the V7 equivalent of #4593. In V7 the problem primarily seems to happen on smaller crop definitions.


Here's before:

![image-cropper-initial-zoom-before](https://user-images.githubusercontent.com/7405322/52849822-421ed500-3112-11e9-96c6-ca8ab4a0dd34.gif)

...and here's after:

![image-cropper-initial-zoom-after](https://user-images.githubusercontent.com/7405322/52849825-43e89880-3112-11e9-9fda-e1a96405ff74.gif)
