### PR TITLE
V7: Make the image crop slider move at 66 hertz 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagecrop.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagecrop.directive.js
@@ -232,7 +232,7 @@ angular.module("umbraco.directives")
 					var throttledResizing = _.throttle(function(){
 						resizeImageToScale(scope.dimensions.scale.current);
 						calculateCropBox();
-					}, 100);
+					}, 16);
 
 
 					//happens when we change the scale


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is the V7 equivalent of #4594. It's not as bad as it was in V8, but still... worth fixing. 

Here's before:

![image-cropper-slider-frequency-before](https://user-images.githubusercontent.com/7405322/52849903-772b2780-3112-11e9-9457-cc07d2fb8b25.gif)

...and here's after:

![image-cropper-slider-frequency-after](https://user-images.githubusercontent.com/7405322/52849908-7abeae80-3112-11e9-8ce6-f9530aff2625.gif)
