### PR TITLE
Rename property editor aliases

### DIFF
--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -219,7 +219,7 @@ namespace Umbraco.Core
                             },
                             {
                                 FailedPasswordAttempts,
-                                new PropertyType(PropertyEditors.Aliases.NoEdit, ValueStorageType.Integer, true, FailedPasswordAttempts)
+                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Integer, true, FailedPasswordAttempts)
                                     {
                                         Name = FailedPasswordAttemptsLabel
                                     }
@@ -240,35 +240,35 @@ namespace Umbraco.Core
                             },
                             {
                                 LastLockoutDate,
-                                new PropertyType(PropertyEditors.Aliases.NoEdit, ValueStorageType.Date, true, LastLockoutDate)
+                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Date, true, LastLockoutDate)
                                     {
                                         Name = LastLockoutDateLabel
                                     }
                             },
                             {
                                 LastLoginDate,
-                                new PropertyType(PropertyEditors.Aliases.NoEdit, ValueStorageType.Date, true, LastLoginDate)
+                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Date, true, LastLoginDate)
                                     {
                                         Name = LastLoginDateLabel
                                     }
                             },
                             {
                                 LastPasswordChangeDate,
-                                new PropertyType(PropertyEditors.Aliases.NoEdit, ValueStorageType.Date, true, LastPasswordChangeDate)
+                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Date, true, LastPasswordChangeDate)
                                     {
                                         Name = LastPasswordChangeDateLabel
                                     }
                             },
                             {
                                 PasswordAnswer,
-                                new PropertyType(PropertyEditors.Aliases.NoEdit, ValueStorageType.Nvarchar, true, PasswordAnswer)
+                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Nvarchar, true, PasswordAnswer)
                                     {
                                         Name = PasswordAnswerLabel
                                     }
                             },
                             {
                                 PasswordQuestion,
-                                new PropertyType(PropertyEditors.Aliases.NoEdit, ValueStorageType.Nvarchar, true, PasswordQuestion)
+                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Nvarchar, true, PasswordQuestion)
                                     {
                                         Name = PasswordQuestionLabel
                                     }

--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Core
                 /// DropDown List.
                 /// </summary>
                 public const string DropDownListFlexible = "Umbraco.DropDown.Flexible";
-                
+
                 /// <summary>
                 /// Grid.
                 /// </summary>
@@ -105,9 +105,9 @@ namespace Umbraco.Core
                 public const string MultipleTextstring = "Umbraco.MultipleTextstring";
 
                 /// <summary>
-                /// NoEdit.
+                /// Label.
                 /// </summary>
-                public const string NoEdit = "Umbraco.NoEdit";
+                public const string Label = "Umbraco.Label";
 
                 /// <summary>
                 /// Picker Relations.
@@ -118,7 +118,7 @@ namespace Umbraco.Core
                 /// RadioButton list.
                 /// </summary>
                 public const string RadioButtonList = "Umbraco.RadioButtonList";
-                
+
                 /// <summary>
                 /// Slider.
                 /// </summary>
@@ -142,7 +142,7 @@ namespace Umbraco.Core
                 /// <summary>
                 /// TinyMCE
                 /// </summary>
-                public const string TinyMce = "Umbraco.TinyMCEv3";
+                public const string TinyMce = "Umbraco.TinyMCE";
 
                 /// <summary>
                 /// Boolean.
@@ -163,7 +163,7 @@ namespace Umbraco.Core
                 /// Upload Field.
                 /// </summary>
                 public const string UploadField = "Umbraco.UploadField";
-                
+
                 /// <summary>
                 /// Email Address.
                 /// </summary>

--- a/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
@@ -271,12 +271,12 @@ namespace Umbraco.Core.Migrations.Install
             _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false, new DataTypeDto { NodeId = -88, EditorAlias = Constants.PropertyEditors.Aliases.TextBox, DbType = "Nvarchar" });
             _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false, new DataTypeDto { NodeId = -89, EditorAlias = Constants.PropertyEditors.Aliases.TextArea, DbType = "Ntext" });
             _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false, new DataTypeDto { NodeId = -90, EditorAlias = Constants.PropertyEditors.Aliases.UploadField, DbType = "Nvarchar" });
-            InsertDataTypeDto(Constants.DataTypes.LabelString, Constants.PropertyEditors.Aliases.NoEdit, "Nvarchar", "{\"umbracoDataValueType\":\"STRING\"}");
-            InsertDataTypeDto(Constants.DataTypes.LabelInt, Constants.PropertyEditors.Aliases.NoEdit, "Integer", "{\"umbracoDataValueType\":\"INT\"}");
-            InsertDataTypeDto(Constants.DataTypes.LabelBigint, Constants.PropertyEditors.Aliases.NoEdit, "Nvarchar", "{\"umbracoDataValueType\":\"BIGINT\"}");
-            InsertDataTypeDto(Constants.DataTypes.LabelDateTime, Constants.PropertyEditors.Aliases.NoEdit, "Date", "{\"umbracoDataValueType\":\"DATETIME\"}");
-            InsertDataTypeDto(Constants.DataTypes.LabelDecimal, Constants.PropertyEditors.Aliases.NoEdit, "Decimal", "{\"umbracoDataValueType\":\"DECIMAL\"}");
-            InsertDataTypeDto(Constants.DataTypes.LabelTime, Constants.PropertyEditors.Aliases.NoEdit, "Date", "{\"umbracoDataValueType\":\"TIME\"}");
+            InsertDataTypeDto(Constants.DataTypes.LabelString, Constants.PropertyEditors.Aliases.Label, "Nvarchar", "{\"umbracoDataValueType\":\"STRING\"}");
+            InsertDataTypeDto(Constants.DataTypes.LabelInt, Constants.PropertyEditors.Aliases.Label, "Integer", "{\"umbracoDataValueType\":\"INT\"}");
+            InsertDataTypeDto(Constants.DataTypes.LabelBigint, Constants.PropertyEditors.Aliases.Label, "Nvarchar", "{\"umbracoDataValueType\":\"BIGINT\"}");
+            InsertDataTypeDto(Constants.DataTypes.LabelDateTime, Constants.PropertyEditors.Aliases.Label, "Date", "{\"umbracoDataValueType\":\"DATETIME\"}");
+            InsertDataTypeDto(Constants.DataTypes.LabelDecimal, Constants.PropertyEditors.Aliases.Label, "Decimal", "{\"umbracoDataValueType\":\"DECIMAL\"}");
+            InsertDataTypeDto(Constants.DataTypes.LabelTime, Constants.PropertyEditors.Aliases.Label, "Date", "{\"umbracoDataValueType\":\"TIME\"}");
             _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false, new DataTypeDto { NodeId = -36, EditorAlias = Constants.PropertyEditors.Aliases.DateTime, DbType = "Date" });
             _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false, new DataTypeDto { NodeId = -37, EditorAlias = Constants.PropertyEditors.Aliases.ColorPicker, DbType = "Nvarchar" });
             InsertDataTypeDto(Constants.DataTypes.DropDownSingle, Constants.PropertyEditors.Aliases.DropDownListFlexible, "Nvarchar", "{\"multiple\":false}");

--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -135,6 +135,8 @@ namespace Umbraco.Core.Migrations.Upgrade
                 .To<RadioAndCheckboxAndDropdownPropertyEditorsMigration>("{940FD19A-00A8-4D5C-B8FF-939143585726}")
             .As("{0576E786-5C30-4000-B969-302B61E90CA3}");
 
+            To<RenameLabelAndRichTextPropertyEditorAliases>("{E0CBE54D-A84F-4A8F-9B13-900945FD7ED9}");
+
             //FINAL
 
 

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/AddTypedLabels.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/AddTypedLabels.cs
@@ -53,7 +53,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
                 var dataTypeDto = new DataTypeDto
                 {
                     NodeId = id,
-                    EditorAlias = Constants.PropertyEditors.Aliases.NoEdit,
+                    EditorAlias = Constants.PropertyEditors.Aliases.Label,
                     DbType = dbType
                 };
 

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/RenameLabelAndRichTextPropertyEditorAliases.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/RenameLabelAndRichTextPropertyEditorAliases.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
+{
+    public class RenameLabelAndRichTextPropertyEditorAliases : MigrationBase
+    {
+        public RenameLabelAndRichTextPropertyEditorAliases(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            MigratePropertyEditorAlias("Umbraco.TinyMCEv3", Constants.PropertyEditors.Aliases.TinyMce);
+            MigratePropertyEditorAlias("Umbraco.NoEdit", Constants.PropertyEditors.Aliases.Label);
+        }
+
+        private void MigratePropertyEditorAlias(string oldAlias, string newAlias)
+        {
+            var dataTypes = GetDataTypes(oldAlias);
+
+            foreach (var dataType in dataTypes)
+            {
+                dataType.EditorAlias = newAlias;
+                Database.Update(dataType);
+            }
+        }
+
+        private List<DataTypeDto> GetDataTypes(string editorAlias)
+        {
+            var dataTypes = Database.Fetch<DataTypeDto>(Sql()
+                .Select<DataTypeDto>()
+                .From<DataTypeDto>()
+                .Where<DataTypeDto>(x => x.EditorAlias == editorAlias));
+            return dataTypes;
+        }
+
+    }
+}

--- a/src/Umbraco.Core/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Core/Packaging/PackageDataInstallation.cs
@@ -735,7 +735,7 @@ namespace Umbraco.Core.Packaging
                         property.Element("Name").Value, dataTypeDefinitionId, property.Element("Type").Value.Trim());
 
                     //convert to a label!
-                    dataTypeDefinition = _dataTypeService.GetByEditorAlias(Constants.PropertyEditors.Aliases.NoEdit).FirstOrDefault();
+                    dataTypeDefinition = _dataTypeService.GetByEditorAlias(Constants.PropertyEditors.Aliases.Label).FirstOrDefault();
                     //if for some odd reason this isn't there then ignore
                     if (dataTypeDefinition == null) continue;
                 }

--- a/src/Umbraco.Core/PropertyEditors/LabelPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/LabelPropertyEditor.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Core.PropertyEditors
     /// <summary>
     /// Represents a property editor for label properties.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.NoEdit, "Label", "readonlyvalue", Icon = "icon-readonly")]
+    [DataEditor(Constants.PropertyEditors.Aliases.Label, "Label", "readonlyvalue", Icon = "icon-readonly")]
     public class LabelPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/LabelValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/LabelValueConverter.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
     public class LabelValueConverter : PropertyValueConverterBase
     {
         public override bool IsConverter(PublishedPropertyType propertyType)
-            => Constants.PropertyEditors.Aliases.NoEdit.Equals(propertyType.EditorAlias);
+            => Constants.PropertyEditors.Aliases.Label.Equals(propertyType.EditorAlias);
 
         public override Type GetPropertyValueType(PublishedPropertyType propertyType)
         {

--- a/src/Umbraco.Core/Services/Implement/MemberService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberService.cs
@@ -1212,21 +1212,21 @@ namespace Umbraco.Core.Services.Implement
                 Id = --identity,
                 Key = identity.ToGuid()
             });
-            propGroup.PropertyTypes.Add(new PropertyType(Constants.PropertyEditors.Aliases.NoEdit, ValueStorageType.Date, Constants.Conventions.Member.LastLockoutDate)
+            propGroup.PropertyTypes.Add(new PropertyType(Constants.PropertyEditors.Aliases.Label, ValueStorageType.Date, Constants.Conventions.Member.LastLockoutDate)
             {
                 Name = Constants.Conventions.Member.LastLockoutDateLabel,
                 SortOrder = 5,
                 Id = --identity,
                 Key = identity.ToGuid()
             });
-            propGroup.PropertyTypes.Add(new PropertyType(Constants.PropertyEditors.Aliases.NoEdit, ValueStorageType.Date, Constants.Conventions.Member.LastLoginDate)
+            propGroup.PropertyTypes.Add(new PropertyType(Constants.PropertyEditors.Aliases.Label, ValueStorageType.Date, Constants.Conventions.Member.LastLoginDate)
             {
                 Name = Constants.Conventions.Member.LastLoginDateLabel,
                 SortOrder = 6,
                 Id = --identity,
                 Key = identity.ToGuid()
             });
-            propGroup.PropertyTypes.Add(new PropertyType(Constants.PropertyEditors.Aliases.NoEdit, ValueStorageType.Date, Constants.Conventions.Member.LastPasswordChangeDate)
+            propGroup.PropertyTypes.Add(new PropertyType(Constants.PropertyEditors.Aliases.Label, ValueStorageType.Date, Constants.Conventions.Member.LastPasswordChangeDate)
             {
                 Name = Constants.Conventions.Member.LastPasswordChangeDateLabel,
                 SortOrder = 7,

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Composing\TypeFinder.cs" />
     <Compile Include="Composing\TypeHelper.cs" />
     <Compile Include="Composing\TypeLoader.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_0_0\RenameLabelAndRichTextPropertyEditorAliases.cs" />
     <Compile Include="TypeLoaderExtensions.cs" />
     <Compile Include="Composing\WeightAttribute.cs" />
     <Compile Include="Composing\WeightedCollectionBuilderBase.cs" />

--- a/src/Umbraco.Tests/Persistence/Repositories/DataTypeDefinitionRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/DataTypeDefinitionRepositoryTest.cs
@@ -344,7 +344,7 @@ namespace Umbraco.Tests.Persistence.Repositories
                 // Assert
                 Assert.That(definitionUpdated, Is.Not.Null);
                 Assert.That(definitionUpdated.Name, Is.EqualTo("AgeDataType Updated"));
-                Assert.That(definitionUpdated.EditorAlias, Is.EqualTo(Constants.PropertyEditors.Aliases.NoEdit));
+                Assert.That(definitionUpdated.EditorAlias, Is.EqualTo(Constants.PropertyEditors.Aliases.Label));
             }
         }
 

--- a/src/Umbraco.Tests/Services/Importing/CompositionsTestPackage-Random.xml
+++ b/src/Umbraco.Tests/Services/Importing/CompositionsTestPackage-Random.xml
@@ -71,7 +71,7 @@
         <GenericProperty>
           <Name>Content</Name>
           <Alias>content</Alias>
-          <Type>Umbraco.TinyMCEv3</Type>
+          <Type>Umbraco.TinyMCE</Type>
           <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
           <Tab>Content</Tab>
           <Mandatory>False</Mandatory>

--- a/src/Umbraco.Tests/Services/Importing/CompositionsTestPackage.xml
+++ b/src/Umbraco.Tests/Services/Importing/CompositionsTestPackage.xml
@@ -324,7 +324,7 @@
         <GenericProperty>
           <Name>AboutText</Name>
           <Alias>aboutText</Alias>
-          <Type>Umbraco.TinyMCEv3</Type>
+          <Type>Umbraco.TinyMCE</Type>
           <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
           <Tab>About</Tab>
           <Mandatory>False</Mandatory>
@@ -472,7 +472,7 @@
         <GenericProperty>
           <Name>Content</Name>
           <Alias>bodyText</Alias>
-          <Type>Umbraco.TinyMCEv3</Type>
+          <Type>Umbraco.TinyMCE</Type>
           <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
           <Tab>Content</Tab>
           <Mandatory>False</Mandatory>
@@ -593,7 +593,7 @@
         <GenericProperty>
           <Name>Content</Name>
           <Alias>bodyText</Alias>
-          <Type>Umbraco.TinyMCEv3</Type>
+          <Type>Umbraco.TinyMCE</Type>
           <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
           <Tab>Content</Tab>
           <Mandatory>False</Mandatory>
@@ -721,8 +721,8 @@
         <![CDATA[@inherits UmbracoTemplatePage
 @{
     Layout = "umbLayout.cshtml";
-    
-    // If the editor has not explicitly provided the "Page title" property page 
+
+    // If the editor has not explicitly provided the "Page title" property page
     // then just show the name of the page otherwise show the provided title
     var pageTitle = string.IsNullOrWhiteSpace(CurrentPage.Title)
         ? CurrentPage.Name
@@ -745,7 +745,7 @@
                             }
 
                             @CurrentPage.BodyText
-                        </section>                           
+                        </section>
                     </article>
                     <!-- /Content -->
                 </div>
@@ -777,7 +777,7 @@
 @{
     Layout = "umbLayout.cshtml";
 
-    // If the editor has not explicitly provided the "Page title" property page 
+    // If the editor has not explicitly provided the "Page title" property page
     // then just show the name of the page otherwise show the provided title
     var pageTitle = string.IsNullOrWhiteSpace(CurrentPage.Title)
         ? CurrentPage.Name
@@ -787,8 +787,8 @@
     // AncestorsOrSelf is all of the ancestors this page has in the tree
     // (1) means: go up to level 1 and stop looking for more ancestors when you get there
     // First() gets the first ancestor found (the home page, on level 1)
-    var homePage = CurrentPage.AncestorsOrSelf(1).First();    
-    
+    var homePage = CurrentPage.AncestorsOrSelf(1).First();
+
     // Find all pages with document type alias umbNewsOverview
     // We do that using the plural, umbNewsOverviews (note the extra "s" in the end)
     // Then take the first one, as we know there will only be on news overview page
@@ -815,18 +815,18 @@
                         @foreach (var item in newsItems)
                         {
 
-                            // If the editor has not explicitly provided the "Page title" property page 
+                            // If the editor has not explicitly provided the "Page title" property page
                             // then just show the name of the page otherwise show the provided title
-                            var title = string.IsNullOrWhiteSpace(item.Title) 
-                                ? item.Name 
+                            var title = string.IsNullOrWhiteSpace(item.Title)
+                                ? item.Name
                                 : item.Title;
 
 
                             // If the editor has not explicitly set the publishDate property then show the create date
-                            var dateTime = item.PublishDate == default(DateTime) 
-                                ? item.CreateDate 
+                            var dateTime = item.PublishDate == default(DateTime)
+                                ? item.CreateDate
                                 : item.PublishDate;
-                            
+
                             <section>
                                 <h3><a href="@item.Url">@title</a></h3>
                                 <span class="byline">@item.SubHeader</span>
@@ -869,11 +869,11 @@
 @{
     Layout = "umbLayout.cshtml";
 
-    // If the editor has not explicitly provided the "Page title" property page 
+    // If the editor has not explicitly provided the "Page title" property page
     // then just show the name of the page otherwise show the provided title
     var pageTitle = string.IsNullOrWhiteSpace(CurrentPage.Title)
         ? CurrentPage.Name
-        : CurrentPage.Title;    
+        : CurrentPage.Title;
 }
 <div id="main-wrapper">
     <div id="main" class="container">
@@ -892,7 +892,7 @@
                             }
 
                             @CurrentPage.BodyText
-                        </section>                           
+                        </section>
                     </article>
                     <!-- /Content -->
                 </div>

--- a/src/Umbraco.Tests/TestHelpers/Entities/MockedContentTypes.cs
+++ b/src/Umbraco.Tests/TestHelpers/Entities/MockedContentTypes.cs
@@ -359,7 +359,7 @@ namespace Umbraco.Tests.TestHelpers.Entities
             contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Nvarchar) { Alias = "singleLineText", Name = "Text String", Mandatory = false, SortOrder = 4, DataTypeId = -88 });
             contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.TextArea, ValueStorageType.Ntext) { Alias = "multilineText", Name = "Multiple Text Strings", Mandatory = false, SortOrder = 5, DataTypeId = -89 });
             contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.UploadField, ValueStorageType.Nvarchar) { Alias = "upload", Name = "Upload Field", Mandatory = false, SortOrder = 6, DataTypeId = -90 });
-            contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.NoEdit, ValueStorageType.Nvarchar) { Alias = "label", Name = "Label", Mandatory = false, SortOrder = 7, DataTypeId = -92 });
+            contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.Label, ValueStorageType.Nvarchar) { Alias = "label", Name = "Label", Mandatory = false, SortOrder = 7, DataTypeId = -92 });
             contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.DateTime, ValueStorageType.Date) { Alias = "dateTime", Name = "Date Time", Mandatory = false, SortOrder = 8, DataTypeId = -36 });
             contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.ColorPicker, ValueStorageType.Nvarchar) { Alias = "colorPicker", Name = "Color Picker", Mandatory = false, SortOrder = 9, DataTypeId = -37 });
             contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.DropDownListFlexible, ValueStorageType.Nvarchar) { Alias = "ddlMultiple", Name = "Dropdown List Multiple", Mandatory = false, SortOrder = 11, DataTypeId = -39 });
@@ -420,10 +420,10 @@ namespace Umbraco.Tests.TestHelpers.Entities
 
             var contentCollection = new PropertyTypeCollection(false);
             contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.UploadField, ValueStorageType.Nvarchar) { Alias = Constants.Conventions.Media.File, Name = "File", Description = "",  Mandatory = false, SortOrder = 1, DataTypeId = -90 });
-            contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.NoEdit, ValueStorageType.Integer) { Alias = Constants.Conventions.Media.Width, Name = "Width", Description = "",  Mandatory = false, SortOrder = 2, DataTypeId = -90 });
-            contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.NoEdit, ValueStorageType.Integer) { Alias = Constants.Conventions.Media.Height, Name = "Height", Description = "",  Mandatory = false, SortOrder = 2, DataTypeId = -90 });
-            contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.NoEdit, ValueStorageType.Integer) { Alias = Constants.Conventions.Media.Bytes, Name = "Bytes", Description = "",  Mandatory = false, SortOrder = 2, DataTypeId = -90 });
-            contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.NoEdit, ValueStorageType.Nvarchar) { Alias = Constants.Conventions.Media.Extension, Name = "File Extension", Description = "",  Mandatory = false, SortOrder = 2, DataTypeId = -90 });
+            contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.Label, ValueStorageType.Integer) { Alias = Constants.Conventions.Media.Width, Name = "Width", Description = "",  Mandatory = false, SortOrder = 2, DataTypeId = -90 });
+            contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.Label, ValueStorageType.Integer) { Alias = Constants.Conventions.Media.Height, Name = "Height", Description = "",  Mandatory = false, SortOrder = 2, DataTypeId = -90 });
+            contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.Label, ValueStorageType.Integer) { Alias = Constants.Conventions.Media.Bytes, Name = "Bytes", Description = "",  Mandatory = false, SortOrder = 2, DataTypeId = -90 });
+            contentCollection.Add(new PropertyType(Constants.PropertyEditors.Aliases.Label, ValueStorageType.Nvarchar) { Alias = Constants.Conventions.Media.Extension, Name = "File Extension", Description = "",  Mandatory = false, SortOrder = 2, DataTypeId = -90 });
 
             mediaType.PropertyGroups.Add(new PropertyGroup(contentCollection) { Name = "Media", SortOrder = 1 });
 

--- a/src/Umbraco.Web/Editors/DataTypeController.cs
+++ b/src/Umbraco.Web/Editors/DataTypeController.cs
@@ -93,7 +93,7 @@ namespace Umbraco.Web.Editors
         public DataTypeDisplay GetEmpty(int parentId)
         {
             // cannot create an "empty" data type, so use something by default.
-            var editor = _propertyEditors[Constants.PropertyEditors.Aliases.NoEdit];
+            var editor = _propertyEditors[Constants.PropertyEditors.Aliases.Label];
             var dt = new DataType(editor, parentId);
             return Mapper.Map<IDataType, DataTypeDisplay>(dt);
         }

--- a/src/Umbraco.Web/Models/Mapping/ContentPropertyBasicConverter.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentPropertyBasicConverter.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Web.Models.Mapping
                     "No property editor '{PropertyEditorAlias}' found, converting to a Label",
                     property.PropertyType.PropertyEditorAlias);
 
-                editor = _propertyEditors[Constants.PropertyEditors.Aliases.NoEdit];
+                editor = _propertyEditors[Constants.PropertyEditors.Aliases.Label];
             }
 
             var result = new TDestination

--- a/src/Umbraco.Web/Models/Mapping/MemberTabsAndPropertiesResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberTabsAndPropertiesResolver.cs
@@ -124,7 +124,7 @@ namespace Umbraco.Web.Models.Mapping
                     Alias = $"{Constants.PropertyEditors.InternalGenericPropertiesPrefix}doctype",
                     Label = _localizedTextService.Localize("content/membertype"),
                     Value = _localizedTextService.UmbracoDictionaryTranslate(member.ContentType.Name),
-                    View = Current.PropertyEditors[Constants.PropertyEditors.Aliases.NoEdit].GetValueEditor().View
+                    View = Current.PropertyEditors[Constants.PropertyEditors.Aliases.Label].GetValueEditor().View
                 },
                 GetLoginProperty(_memberService, member, _localizedTextService),
                 new ContentPropertyDisplay

--- a/src/Umbraco.Web/Models/Mapping/PropertyTypeGroupResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/PropertyTypeGroupResolver.cs
@@ -210,7 +210,7 @@ namespace Umbraco.Web.Models.Mapping
                 {
                     _logger.Error(GetType(),
                         "No property editor could be resolved with the alias: {PropertyEditorAlias}, defaulting to label", p.PropertyEditorAlias);
-                    propertyEditorAlias = Constants.PropertyEditors.Aliases.NoEdit;
+                    propertyEditorAlias = Constants.PropertyEditors.Aliases.Label;
                     propertyEditor = _propertyEditors[propertyEditorAlias];
                 }
 


### PR DESCRIPTION
Fixes: #4569
Connects: #4379 

Test: 
- Everything should work after migration
- Verify the existing labels and RTE's have updated the property editor alias.
- Create a new data type of type Label (Verify alias)
- Create a new data type of type RTE (Verify alias)