### PR TITLE
V8: Update/fix the blur handling for the tags editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
@@ -25,7 +25,7 @@
                    class="typeahead tags-{{vm.htmlId}}"
                    ng-model="vm.tagToAdd"
                    ng-keydown="vm.addTagOnEnter($event)"
-                   on-blur="vm.addTag()"
+                   ng-blur="vm.addTag()"
                    localize="placeholder"
                    placeholder="@placeholders_enterTags" />
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4584

### Description

Looks like the blur handling in the Tags property editor is still using the old custom `on-blur` angular directive instead of `ng-blur`. The redundant custom directives from V7 were written out of the codebase a long time ago (possibly by yours truly).

Anyway - this PR changes `on-blur` to `ng-blur` so the Tags editor adds new tags when it looses focus. 

See the screencast on #4584 if you're in doubt how to test this PR 😄 