### PR TITLE
v8 - removal of "Created" events that shouldn't exist

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -320,8 +320,6 @@ namespace Umbraco.Core.Services.Implement
                 scope.Events.Dispatch(TreeChanged, this, new TreeChange<IContent>(content, TreeChangeTypes.RefreshNode).ToEventArgs());
             }
 
-            scope.Events.Dispatch(Created, this, new NewEventArgs<IContent>(content, false, content.ContentType.Alias, parent));
-
             if (withIdentity == false)
                 return;
 
@@ -2280,15 +2278,6 @@ namespace Umbraco.Core.Services.Implement
         /// Occurs after Save
         /// </summary>
         public static event TypedEventHandler<IContentService, ContentSavedEventArgs> Saved;
-
-        /// <summary>
-        /// Occurs after Create
-        /// </summary>
-        /// <remarks>
-        /// Please note that the Content object has been created, but might not have been saved
-        /// so it does not have an identity yet (meaning no Id has been set).
-        /// </remarks>
-        public static event TypedEventHandler<IContentService, NewEventArgs<IContent>> Created;
 
         /// <summary>
         /// Occurs before Copy

--- a/src/Umbraco.Core/Services/Implement/MediaService.cs
+++ b/src/Umbraco.Core/Services/Implement/MediaService.cs
@@ -289,9 +289,7 @@ namespace Umbraco.Core.Services.Implement
                 scope.Events.Dispatch(Saved, this, saveEventArgs);
                 scope.Events.Dispatch(TreeChanged, this, new TreeChange<IMedia>(media, TreeChangeTypes.RefreshNode).ToEventArgs());
             }
-
-            scope.Events.Dispatch(Created, this, new NewEventArgs<IMedia>(media, false, media.ContentType.Alias, parent));
-
+            
             if (withIdentity == false)
                 return;
 
@@ -1214,15 +1212,6 @@ namespace Umbraco.Core.Services.Implement
         /// Occurs after Save
         /// </summary>
         public static event TypedEventHandler<IMediaService, SaveEventArgs<IMedia>> Saved;
-
-        /// <summary>
-        /// Occurs after Create
-        /// </summary>
-        /// <remarks>
-        /// Please note that the Media object has been created, but might not have been saved
-        /// so it does not have an identity yet (meaning no Id has been set).
-        /// </remarks>
-        public static event TypedEventHandler<IMediaService, NewEventArgs<IMedia>> Created;
 
         /// <summary>
         /// Occurs before Media is moved to Recycle Bin

--- a/src/Umbraco.Core/Services/Implement/MemberService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberService.cs
@@ -331,9 +331,7 @@ namespace Umbraco.Core.Services.Implement
                 saveEventArgs.CanCancel = false;
                 scope.Events.Dispatch(Saved, this, saveEventArgs);
             }
-
-            scope.Events.Dispatch(Created, this, new NewEventArgs<IMember>(member, false, member.ContentType.Alias, -1));
-
+            
             if (withIdentity == false)
                 return;
 
@@ -1109,15 +1107,6 @@ namespace Umbraco.Core.Services.Implement
         /// Occurs before Save
         /// </summary>
         public static event TypedEventHandler<IMemberService, SaveEventArgs<IMember>> Saving;
-
-        /// <summary>
-        /// Occurs after Create
-        /// </summary>
-        /// <remarks>
-        /// Please note that the Member object has been created, but might not have been saved
-        /// so it does not have an identity yet (meaning no Id has been set).
-        /// </remarks>
-        public static event TypedEventHandler<IMemberService, NewEventArgs<IMember>> Created;
 
         /// <summary>
         /// Occurs after Save

--- a/src/Umbraco.Tests/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberServiceTests.cs
@@ -522,22 +522,6 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
-        public void Get_Member_Name_In_Created_Event()
-        {
-            IMemberType memberType = MockedContentTypes.CreateSimpleMemberType();
-            ServiceContext.MemberTypeService.Save(memberType);
-
-            TypedEventHandler<IMemberService, NewEventArgs<IMember>> callback = (sender, args) =>
-            {
-                Assert.AreEqual("Test Real Name", args.Entity.Name);
-            };
-
-            MemberService.Created += callback;
-            var member = ServiceContext.MemberService.CreateMember("testUsername", "test@test.com", "Test Real Name", memberType);
-            MemberService.Created -= callback;
-        }
-
-        [Test]
         public void Get_By_Username()
         {
             IMemberType memberType = MockedContentTypes.CreateSimpleMemberType();

--- a/src/Umbraco.Web/PropertyEditors/PropertyEditorsComponent.cs
+++ b/src/Umbraco.Web/PropertyEditors/PropertyEditorsComponent.cs
@@ -32,7 +32,6 @@ namespace Umbraco.Web.PropertyEditors
         private static void Initialize(FileUploadPropertyEditor fileUpload)
         {
             MediaService.Saving += fileUpload.MediaServiceSaving;
-            MediaService.Created += fileUpload.MediaServiceCreated;
             ContentService.Copied += fileUpload.ContentServiceCopied;
 
             MediaService.Deleted += (sender, args)
@@ -46,7 +45,6 @@ namespace Umbraco.Web.PropertyEditors
         private static void Initialize(ImageCropperPropertyEditor imageCropper)
         {
             MediaService.Saving += imageCropper.MediaServiceSaving;
-            MediaService.Created += imageCropper.MediaServiceCreated;
             ContentService.Copied += imageCropper.ContentServiceCopied;
 
             MediaService.Deleted += (sender, args)


### PR DESCRIPTION
These events have existed from 7.0 but should not exist, nor be used. These are events that fire just based on object construction, not persistence! It was an oversight that they haven't been removed yet, but here is the PR. Any modification to new objects via events on services need to use the `Saving` events and in there you can check if the model is new or not.

The other reason this may have been used was to provide default values in the editor for certain properties. This can be achieved with the `EditorModelEventManager.SendingContentModel` or SendingMediaModel, SendingMemberModel, etc...