### PR TITLE
v8 - fixes rendering content without a template

### DIFF
--- a/src/Umbraco.Web/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Web/Routing/PublishedRouter.cs
@@ -728,7 +728,7 @@ namespace Umbraco.Web.Routing
 
         private ITemplate GetTemplateModel(int? templateId)
         {
-            if (templateId.HasValue == false)
+            if (templateId.HasValue == false || templateId.Value == default)
             {
                 _logger.Debug<PublishedRouter>("GetTemplateModel: No template.");
                 return null;


### PR DESCRIPTION
If a content item has no template (i.e. route hijack), it will fail to render

This happens if you install a package that has no templates assigned to content (i.e. articulate), then you'll get a ysod when trying to view the content item.

I'm sure there's a more low level fix required so that it actually saves NULL instead of 0 into the cache but no time to find that right now.