### PR TITLE
Issue 4634 : Fixed colorpicker unselection condition

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
@@ -76,7 +76,7 @@ function ColorPickerController($scope, angularHelper) {
 
     $scope.onSelect = function (color) {
         // did the value change?
-        if ($scope.model.value.value === color) {
+        if ($scope.model.value != null && $scope.model.value.value === color) {
             // User clicked the currently selected color
             // to remove the selection, they don't want
             // to select any color after all.


### PR DESCRIPTION
When the user remove the selection the model is set to null.
When the user tries to select another value after that, the condition is trying to check the "value" property for a null object.

### Prerequisites

- [x ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: 
https://github.com/umbraco/Umbraco-CMS/issues/4634


### Description
<!-- A description of the changes proposed in the pull-request and how to test these changes -->
Just added null check on the condition


<!-- Thanks for contributing to Umbraco CMS! -->
