### PR TITLE
v8 - reverts the list view changes that opened sub items in infinite editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/grid/grid.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/grid/grid.listviewlayout.controller.js
@@ -9,8 +9,7 @@
 (function () {
     "use strict";
 
-    function ListViewGridLayoutController($scope, $routeParams, mediaHelper, mediaResource, 
-        listViewHelper, mediaTypeHelper, editorService) {
+    function ListViewGridLayoutController($scope, $routeParams, mediaHelper, mediaResource, $location, listViewHelper, mediaTypeHelper) {
 
         var vm = this;
         var umbracoSettings = Umbraco.Sys.ServerVariables.umbracoSettings;
@@ -117,29 +116,8 @@
             listViewHelper.selectHandler(folder, $index, $scope.folders, $scope.selection, $event);
         }
 
-        function goToItem(node, $event, $index) {
-            $event.stopPropagation();
-            
-            var contentEditor = {
-                id: node.id,
-                submit: function (model) {
-                    // update the node
-                    node.name = model.contentNode.name;
-                    // TODO: node.description = model.contentNode.description;
-                    node.published = model.contentNode.hasPublishedVersion;
-                    if (entityType !== "Member") {
-                        entityResource.getUrl(model.contentNode.id, entityType).then(function (data) {
-                            node.url = data;
-                        });
-                    }
-                    editorService.close();
-                },
-                close: function () {
-                    editorService.close();
-                }
-            };
-            editorService.contentEditor(contentEditor);
-            
+        function goToItem(item, $event, $index) {
+            $location.path($scope.entityType + '/' + $scope.entityType + '/edit/' + item.id);
         }
 
         activate();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function ListViewListLayoutController($scope, listViewHelper, mediaHelper, mediaTypeHelper, editorService) {
+    function ListViewListLayoutController($scope, listViewHelper, $location, mediaHelper, mediaTypeHelper) {
 
         var vm = this;
         var umbracoSettings = Umbraco.Sys.ServerVariables.umbracoSettings;
@@ -52,30 +52,10 @@
             listViewHelper.selectHandler(selectedItem, $index, $scope.items, $scope.selection, $event);
         }
 
-        function clickItem(node) {
-            
-            var contentEditor = {
-                id: node.id,
-                submit: function (model) {
-                    // update the node
-                    node.name = model.contentNode.name;
-                    // TODO: node.description = model.contentNode.description;
-                    node.published = model.contentNode.hasPublishedVersion;
-                    if (entityType !== "Member") {
-                        entityResource.getUrl(model.contentNode.id, entityType).then(function (data) {
-                            node.url = data;
-                        });
-                    }
-                    editorService.close();
-                },
-                close: function () {
-                    editorService.close();
+        function clickItem(item) {
+            // if item.id is 2147483647 (int.MaxValue) use item.key
+            $location.path($scope.entityType + '/' + $scope.entityType + '/edit/' + (item.id === 2147483647 ? item.key : item.id));
                 }
-            };
-            editorService.contentEditor(contentEditor);
-            
-        }
-
 
         function isSortDirection(col, direction) {
             return listViewHelper.setSortingDirection(col, direction, $scope.options);


### PR DESCRIPTION
The change has broken the ability to edit members and it has other issues like using the Create button inside of list views when opened in infinite editors then exits the infinite editor and asks the user to submit changes, this problem is compounded when there are lists within lists within lists.

To test:

* ensure all list views are working in both the list and thumbnail versions in media, members and content
* ensure that lists within lists are working
* ensure that you can create new items from a list view correctly