### PR TITLE
v8 - fix publishing new content when there are validation problems

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -1201,6 +1201,10 @@ namespace Umbraco.Web.Editors
                     variant.Publish = false;
             }
 
+            //At this stage all variants might have failed validation which means there are no cultures flagged for publishing!
+            var culturesToPublish = cultureVariants.Where(x => x.Publish).Select(x => x.Culture).ToArray();
+            canPublish = canPublish && culturesToPublish.Length > 0;
+
             if (canPublish)
             {
                 //try to publish all the values on the model - this will generally only fail if someone is tampering with the request
@@ -1210,8 +1214,6 @@ namespace Umbraco.Web.Editors
 
             if (canPublish)
             {
-                var culturesToPublish = cultureVariants.Where(x => x.Publish).Select(x => x.Culture).ToArray();
-
                 //proceed to publish if all validation still succeeds
                 var publishStatus = Services.ContentService.SaveAndPublish(contentItem.PersistedContent, culturesToPublish, Security.CurrentUser.Id);
                 wasCancelled = publishStatus.Result == PublishResultType.FailedPublishCancelledByEvent;


### PR DESCRIPTION
Solves this issue:

* Create a new variant with a couple langs that has a text property that validates as a number
* Fill in incorrect (non number data)
* Try to save and publish
* You will get a ysod

This is because when validation fails, we can't publish things so we reset the publish flag to false for the variant that failed validation - but if all the variants fail validation, then there are no cultures to be published and this empty array is sent to the publishing service and we get an exception thrown because we aren't expecting a response of `FailedPublishNothingToPublish`

It is really just missing an extra check as you can see in the PR

Testing:

* Do the above and it will work