### PR TITLE
v8 - Shows a notification message when client validation fails in the content editor, else it's not clear there are any problems

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -3,8 +3,8 @@
 
     function ContentEditController($rootScope, $scope, $routeParams, $q, $window,
         appState, contentResource, entityResource, navigationService, notificationsService,
-        serverValidationManager, contentEditingHelper, treeService, formHelper, umbRequestHelper,
-        editorState, $http, eventsService, relationResource, overlayService, $location) {
+        serverValidationManager, contentEditingHelper, localizationService, formHelper, umbRequestHelper,
+        editorState, $http, eventsService, overlayService, $location) {
 
         var evts = [];
         var infiniteMode = $scope.infiniteModel && $scope.infiniteModel.infiniteMode;
@@ -410,6 +410,20 @@
             }
         }
 
+        /** Just shows a simple notification that there are client side validation issues to be fixed */
+        function showValidationNotification() {
+            //TODO: We need to make the validation UI much better, there's a lot of inconsistencies in v8 including colors, issues with the property groups and validation errors between variants
+
+            //need to show a notification else it's not clear there was an error.
+            localizationService.localizeMany([
+                    "speechBubbles_validationFailedHeader",
+                    "speechBubbles_validationFailedMessage"
+                ]
+            ).then(function (data) {
+                notificationsService.error(data[0], data[1]);
+            });
+        }
+
         if ($scope.page.isNew) {
 
             $scope.page.loading = true;
@@ -491,7 +505,7 @@
                         variants: $scope.content.variants, //set a model property for the dialog
                         skipFormValidation: true, //when submitting the overlay form, skip any client side validation
                         submitButtonLabelKey: "buttons_saveToPublish",
-                        submit: function (model) {
+                        submit: function(model) {
                             model.submitButtonState = "busy";
                             clearNotifications($scope.content);
                             //we need to return this promise so that the dialog can handle the result and wire up the validation response
@@ -499,27 +513,31 @@
                                 saveMethod: contentResource.sendToPublish,
                                 action: "sendToPublish",
                                 showNotifications: false
-                            }).then(function (data) {
-                                //show all notifications manually here since we disabled showing them automatically in the save method
-                                formHelper.showNotifications(data);
-                                clearNotifications($scope.content);
-                                overlayService.close();
-                                return $q.when(data);
-                            }, function (err) {
-                                clearDirtyState($scope.content.variants);
-                                model.submitButtonState = "error";
-                                //re-map the dialog model since we've re-bound the properties
-                                dialog.variants = $scope.content.variants;
-                                //don't reject, we've handled the error
-                                return $q.when(err);
-                            });
+                            }).then(function(data) {
+                                    //show all notifications manually here since we disabled showing them automatically in the save method
+                                    formHelper.showNotifications(data);
+                                    clearNotifications($scope.content);
+                                    overlayService.close();
+                                    return $q.when(data);
+                                },
+                                function(err) {
+                                    clearDirtyState($scope.content.variants);
+                                    model.submitButtonState = "error";
+                                    //re-map the dialog model since we've re-bound the properties
+                                    dialog.variants = $scope.content.variants;
+                                    //don't reject, we've handled the error
+                                    return $q.when(err);
+                                });
                         },
-                        close: function () {
+                        close: function() {
                             overlayService.close();
                         }
                     };
 
                     overlayService.open(dialog);
+                }
+                else {
+                    showValidationNotification();
                 }
             }
             else {
@@ -547,7 +565,7 @@
                         variants: $scope.content.variants, //set a model property for the dialog
                         skipFormValidation: true, //when submitting the overlay form, skip any client side validation
                         submitButtonLabelKey: "buttons_saveAndPublish",
-                        submit: function (model) {
+                        submit: function(model) {
                             model.submitButtonState = "busy";
                             clearNotifications($scope.content);
                             //we need to return this promise so that the dialog can handle the result and wire up the validation response
@@ -555,14 +573,14 @@
                                 saveMethod: contentResource.publish,
                                 action: "publish",
                                 showNotifications: false
-                            }).then(function (data) {
-                                //show all notifications manually here since we disabled showing them automatically in the save method
-                                formHelper.showNotifications(data);
-                                clearNotifications($scope.content);
-                                overlayService.close();
-                                return $q.when(data);
-                            },
-                                function (err) {
+                            }).then(function(data) {
+                                    //show all notifications manually here since we disabled showing them automatically in the save method
+                                    formHelper.showNotifications(data);
+                                    clearNotifications($scope.content);
+                                    overlayService.close();
+                                    return $q.when(data);
+                                },
+                                function(err) {
                                     clearDirtyState($scope.content.variants);
                                     model.submitButtonState = "error";
                                     //re-map the dialog model since we've re-bound the properties
@@ -571,12 +589,15 @@
                                     return $q.when(err);
                                 });
                         },
-                        close: function () {
+                        close: function() {
                             overlayService.close();
                         }
                     };
 
                     overlayService.open(dialog);
+                }
+                else {
+                    showValidationNotification();
                 }
             }
             else {
@@ -608,7 +629,7 @@
                         variants: $scope.content.variants, //set a model property for the dialog
                         skipFormValidation: true, //when submitting the overlay form, skip any client side validation
                         submitButtonLabelKey: "buttons_save",
-                        submit: function (model) {
+                        submit: function(model) {
                             model.submitButtonState = "busy";
                             clearNotifications($scope.content);
                             //we need to return this promise so that the dialog can handle the result and wire up the validation response
@@ -616,27 +637,31 @@
                                 saveMethod: $scope.saveMethod(),
                                 action: "save",
                                 showNotifications: false
-                            }).then(function (data) {
-                                //show all notifications manually here since we disabled showing them automatically in the save method
-                                formHelper.showNotifications(data);
-                                clearNotifications($scope.content);
-                                overlayService.close();
-                                return $q.when(data);
-                            }, function (err) {
-                                clearDirtyState($scope.content.variants);
-                                model.submitButtonState = "error";
-                                //re-map the dialog model since we've re-bound the properties
-                                dialog.variants = $scope.content.variants;
-                                //don't reject, we've handled the error
-                                return $q.when(err);
-                            });
+                            }).then(function(data) {
+                                    //show all notifications manually here since we disabled showing them automatically in the save method
+                                    formHelper.showNotifications(data);
+                                    clearNotifications($scope.content);
+                                    overlayService.close();
+                                    return $q.when(data);
+                                },
+                                function(err) {
+                                    clearDirtyState($scope.content.variants);
+                                    model.submitButtonState = "error";
+                                    //re-map the dialog model since we've re-bound the properties
+                                    dialog.variants = $scope.content.variants;
+                                    //don't reject, we've handled the error
+                                    return $q.when(err);
+                                });
                         },
-                        close: function (oldModel) {
+                        close: function(oldModel) {
                             overlayService.close();
                         }
                     };
 
                     overlayService.open(dialog);
+                }
+                else {
+                    showValidationNotification();
                 }
             }
             else {
@@ -720,6 +745,9 @@
                 };
                 overlayService.open(dialog);
             }
+            else {
+                showValidationNotification();
+            }
         };
 
         $scope.publishDescendants = function() {
@@ -775,6 +803,9 @@
                     }
                 };
                 overlayService.open(dialog);
+            }
+            else {
+                showValidationNotification();
             }
         };
 

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -7,7 +7,7 @@
  * The controller for the media editor
  */
 function mediaEditController($scope, $routeParams, $q, appState, mediaResource, 
-    entityResource, navigationService, notificationsService, angularHelper, 
+    entityResource, navigationService, notificationsService, localizationService, 
     serverValidationManager, contentEditingHelper, fileManager, formHelper, 
     editorState, umbRequestHelper, $http, eventsService) {
     
@@ -155,12 +155,25 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
                 });
         }
     }
-    
+
+    /** Just shows a simple notification that there are client side validation issues to be fixed */
+    function showValidationNotification() {
+        //TODO: We need to make the validation UI much better, there's a lot of inconsistencies in v8 including colors, issues with the property groups and validation errors between variants
+
+        //need to show a notification else it's not clear there was an error.
+        localizationService.localizeMany([
+                "speechBubbles_validationFailedHeader",
+                "speechBubbles_validationFailedMessage"
+            ]
+        ).then(function (data) {
+            notificationsService.error(data[0], data[1]);
+        });
+    }
+
     $scope.save = function () {
 
-        if (!$scope.busy && formHelper.submitForm({ scope: $scope })) {
-
-            $scope.busy = true;
+        if (formHelper.submitForm({ scope: $scope })) {
+            
             $scope.page.saveButtonState = "busy";
 
             mediaResource.save($scope.content, create, fileManager.getFiles())
@@ -176,7 +189,6 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
                     });
 
                     editorState.set($scope.content);
-                    $scope.busy = false;
                     
                     syncTreeNode($scope.content, data.path);
 
@@ -199,12 +211,12 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
                     });
                     
                     editorState.set($scope.content);
-                    $scope.busy = false;
                     $scope.page.saveButtonState = "error";
 
                 });
-        }else{
-            $scope.busy = false;
+        }
+        else {
+            showValidationNotification();   
         }
         
     };

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the member editor
  */
-function MemberEditController($scope, $routeParams, $location, $q, $window, appState, memberResource, entityResource, navigationService, notificationsService, angularHelper, serverValidationManager, contentEditingHelper, fileManager, formHelper, umbModelMapper, editorState, umbRequestHelper, $http) {
+function MemberEditController($scope, $routeParams, $location, appState, memberResource, entityResource, navigationService, notificationsService, localizationService, serverValidationManager, contentEditingHelper, fileManager, formHelper, editorState, umbRequestHelper, $http) {
 
     //setup scope vars
     $scope.page = {};
@@ -18,7 +18,6 @@ function MemberEditController($scope, $routeParams, $location, $q, $window, appS
     $scope.page.listViewPath = null;
     $scope.page.saveButtonState = "init";
     $scope.page.exportButton = "init";
-    $scope.busy = false;
 
     $scope.page.listViewPath = ($routeParams.page && $routeParams.listName)
         ? "/member/member/list/" + $routeParams.listName + "?page=" + $routeParams.page
@@ -131,14 +130,26 @@ function MemberEditController($scope, $routeParams, $location, $q, $window, appS
       if(content.membershipScenario === 0) {
          $scope.page.nameLocked = true;
       }
+    }
 
+    /** Just shows a simple notification that there are client side validation issues to be fixed */
+    function showValidationNotification() {
+        //TODO: We need to make the validation UI much better, there's a lot of inconsistencies in v8 including colors, issues with the property groups and validation errors between variants
+
+        //need to show a notification else it's not clear there was an error.
+        localizationService.localizeMany([
+                "speechBubbles_validationFailedHeader",
+                "speechBubbles_validationFailedMessage"
+            ]
+        ).then(function (data) {
+            notificationsService.error(data[0], data[1]);
+        });
     }
 
     $scope.save = function() {
 
-        if (!$scope.busy && formHelper.submitForm({ scope: $scope })) {
+        if (formHelper.submitForm({ scope: $scope })) {
 
-            $scope.busy = true;
             $scope.page.saveButtonState = "busy";
 
             memberResource.save($scope.content, $routeParams.create, fileManager.getFiles())
@@ -155,7 +166,6 @@ function MemberEditController($scope, $routeParams, $location, $q, $window, appS
                     });
 
                     editorState.set($scope.content);
-                    $scope.busy = false;
                     $scope.page.saveButtonState = "success";
 
                     var path = buildTreePath(data);
@@ -172,12 +182,12 @@ function MemberEditController($scope, $routeParams, $location, $q, $window, appS
                     });
 
                     editorState.set($scope.content);
-                    $scope.busy = false;
                     $scope.page.saveButtonState = "error";
 
                 });
-        }else{
-            $scope.busy = false;
+        }
+        else {
+            showValidationNotification();
         }
 
     };


### PR DESCRIPTION
When client side validation fails in v8 it doesn't display any notification and the UI to indicate validation failure at the content app level is not sufficient.  For an example, see this video (which is actually explaining a different problem, but shows this one too : https://www.screencast.com/t/z1a5Jl9SHX

This makes it consistent with editors like the doc type editor that show the same validation notification when client side validation fails between any of the sections there. 

This PR updates, content, media and members to show this validation warning. See video: https://www.screencast.com/t/5ZSfy4DtxS0

_The code in this PR that is removed relating to $scope.busy is done on purpose, that is because $scope.busy is a very very old v7 thing (not even in any recent v7 versions), it isn't used anywhere and really needs to be removed throughout the codebase, but for now it's just removed in these editors so the code is more readable._