### PR TITLE
fixes cannot insert image element in tinymce.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -145,7 +145,7 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
 					data["data-id"] = img.id;
 				}
 
-				editor.insertContent(editor.dom.createHTML('img', data));
+				editor.selection.setContent(editor.dom.createHTML('img', data));
 
 				$timeout(function () {
 					var imgElm = editor.dom.get('__mcenew');


### PR DESCRIPTION
### Description
Fixes https://github.com/umbraco/Umbraco-CMS/issues/4652

### Test
Insert an image in TinyMce richtext editor and ensure it (still) works.