### PR TITLE
fix for umbracoUserLogin not pruned

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
@@ -267,8 +267,8 @@ ORDER BY colName";
 
             var fromDate = DateTime.UtcNow - timespan;
 
-            var count = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoUserLogin WHERE lastValidatedUtc=@fromDate", new { fromDate = fromDate });
-            Database.Execute("DELETE FROM umbracoUserLogin WHERE lastValidatedUtc=@fromDate", new { fromDate = fromDate });
+            var count = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoUserLogin WHERE lastValidatedUtc=<@fromDate", new { fromDate = fromDate });
+            Database.Execute("DELETE FROM umbracoUserLogin WHERE lastValidatedUtc=<@fromDate", new { fromDate = fromDate });
             return count;
         }
 

--- a/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/UserRepository.cs
@@ -267,8 +267,8 @@ ORDER BY colName";
 
             var fromDate = DateTime.UtcNow - timespan;
 
-            var count = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoUserLogin WHERE lastValidatedUtc=<@fromDate", new { fromDate = fromDate });
-            Database.Execute("DELETE FROM umbracoUserLogin WHERE lastValidatedUtc=<@fromDate", new { fromDate = fromDate });
+            var count = Database.ExecuteScalar<int>("SELECT COUNT(*) FROM umbracoUserLogin WHERE lastValidatedUtc<=@fromDate", new { fromDate = fromDate });
+            Database.Execute("DELETE FROM umbracoUserLogin WHERE lastValidatedUtc<=@fromDate", new { fromDate = fromDate });
             return count;
         }
 

--- a/src/Umbraco.Core/Security/BackOfficeCookieAuthenticationProvider.cs
+++ b/src/Umbraco.Core/Security/BackOfficeCookieAuthenticationProvider.cs
@@ -107,6 +107,11 @@ namespace Umbraco.Core.Security
 
             await EnsureValidSessionId(context);
 
+            if (context?.Identity == null)
+            {
+                context?.OwinContext.Authentication.SignOut(context.Options.AuthenticationType);
+                return;
+            }
             await base.ValidateIdentity(context);
         }        
 


### PR DESCRIPTION
### Prerequisites

Umbraco version 7.13.x.

### Description

Issue #4661. This change fixes the database queries that are supposed to prune the umbracoUserLogin table of rows that are stale by more than 15 days. The current code checks for equality with 15 days prior to the current date. I changed the code to check for less-than-or-equal-to 15 days prior instead.

To test, log into the back office, and then close the browser window without explicitly logging out, and do not log in with the same user account for at least 15 days. Then restart the application pool. The umbracoUserLogin table should be pruned so that no records with lastValidatedUtc > 15 days ago remain.