### PR TITLE
v8 - fixes published content Children method

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -981,7 +981,7 @@ namespace Umbraco.Web
         /// <param name="culture">The specific culture to filter for. If null is used the current culture is used. (Default is null)</param>
         /// <param name="alias">One or more content type alias.</param>
         /// <returns>The children of the content, of any of the specified types.</returns>
-        public static IEnumerable<IPublishedContent> Children(this IPublishedContent content, string culture = null, params string[] alias)
+        public static IEnumerable<IPublishedContent> ChildrenOfType(this IPublishedContent content, string alias, string culture = null)
         {
             return content.Children(x => alias.InvariantContains(x.ContentType.Alias), culture);
         }
@@ -1012,7 +1012,7 @@ namespace Umbraco.Web
         /// </summary>
         public static IPublishedContent FirstChildOfType(this IPublishedContent content, string alias, string culture = null)
         {
-            return content.Children(culture,alias).FirstOrDefault();
+            return content.ChildrenOfType(alias, culture).FirstOrDefault();
         }
 
         public static IPublishedContent FirstChild(this IPublishedContent content, Func<IPublishedContent, bool> predicate, string culture = null)

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -979,11 +979,11 @@ namespace Umbraco.Web
         /// </summary>
         /// <param name="content">The content.</param>
         /// <param name="culture">The specific culture to filter for. If null is used the current culture is used. (Default is null)</param>
-        /// <param name="alias">One or more content type alias.</param>
+        /// <param name="contentTypeAlias">The content type alias.</param>
         /// <returns>The children of the content, of any of the specified types.</returns>
-        public static IEnumerable<IPublishedContent> ChildrenOfType(this IPublishedContent content, string alias, string culture = null)
+        public static IEnumerable<IPublishedContent> ChildrenOfType(this IPublishedContent content, string contentTypeAlias, string culture = null)
         {
-            return content.Children(x => alias.InvariantContains(x.ContentType.Alias), culture);
+            return content.Children(x => contentTypeAlias.InvariantContains(x.ContentType.Alias), culture);
         }
 
         /// <summary>
@@ -1010,9 +1010,9 @@ namespace Umbraco.Web
         /// <summary>
         /// Gets the first child of the content, of a given content type.
         /// </summary>
-        public static IPublishedContent FirstChildOfType(this IPublishedContent content, string alias, string culture = null)
+        public static IPublishedContent FirstChildOfType(this IPublishedContent content, string contentTypeAlias, string culture = null)
         {
-            return content.ChildrenOfType(alias, culture).FirstOrDefault();
+            return content.ChildrenOfType(contentTypeAlias, culture).FirstOrDefault();
         }
 
         public static IPublishedContent FirstChild(this IPublishedContent content, Func<IPublishedContent, bool> predicate, string culture = null)


### PR DESCRIPTION
The original method signature was

```cs
public static IEnumerable<IPublishedContent> Children(this IPublishedContent content, string culture = null, params string[] alias)
```

this causes problems because people are used to using this method like `myContent.Children("myContentType")`, but now if they do that it won't filter anything since that string is being passed in to the culture

to call this correctly you'd have to do `myContent.Children(string.Empty, "myContentType")` which is not very nice.

We also don't allow for multiple content type alias looks in any other method so having the `params string[]` is inconsistent.

So this makes the APIs consistent:

* `ChildrenOfType(string contentTypeAlias, string culture = null)` which is similar to the DescendantsOfType, etc... methods
* `Children(string culture = null)` if you want to get all children or just filter by culture
* have also streamlined the parameter names to be explicit `contentTypeAlias` instead of just `alias`

This still means we need to educate people on the changes and that calling `myContent.Children("myContentType")` will still actually compile it will give you the wrong result, we need to tell people if you are looking to filter by type, use the explicit method `ChildrenOfType`, just like `DescendantOfType`, `DescendantsOfType`, etc.... (there's quite a few `OfType` methods now)