### PR TITLE
v8 - The content service is not returning the invalid properties when publishing fails

### DIFF
--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -193,6 +193,13 @@ namespace Umbraco.Core.Models
 
         public static bool PublishCulture(this IContent content, string culture = "*")
         {
+            return PublishCulture(content, out _, culture);
+        }
+
+        public static bool PublishCulture(this IContent content, out Property[] invalidProperties, string culture = "*")
+        {
+            invalidProperties = null;
+
             culture = culture.NullOrWhiteSpaceAsNull();
 
             // the variation should be supported by the content type properties
@@ -202,7 +209,8 @@ namespace Umbraco.Core.Models
                 throw new NotSupportedException($"Culture \"{culture}\" is not supported by content type \"{content.ContentType.Alias}\" with variation \"{content.ContentType.Variations}\".");
 
             // the values we want to publish should be valid
-            if (content.ValidateProperties(culture).Any())
+            invalidProperties = content.ValidateProperties(culture);
+            if (invalidProperties.Length > 0)
                 return false;
 
             var alsoInvariant = false;

--- a/src/Umbraco.Core/Services/ContentServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/ContentServiceExtensions.cs
@@ -31,16 +31,16 @@ namespace Umbraco.Core.Services
         /// <param name="contentService"></param>
         /// <param name="name"></param>
         /// <param name="parentId"></param>
-        /// <param name="mediaTypeAlias"></param>
+        /// <param name="contentTypeAlias"></param>
         /// <param name="userId"></param>
         /// <returns></returns>
-        public static IContent CreateContent(this IContentService contentService, string name, Udi parentId, string mediaTypeAlias, int userId = Constants.Security.SuperUserId)
+        public static IContent CreateContent(this IContentService contentService, string name, Udi parentId, string contentTypeAlias, int userId = Constants.Security.SuperUserId)
         {
             var guidUdi = parentId as GuidUdi;
             if (guidUdi == null)
                 throw new InvalidOperationException("The UDI provided isn't of type " + typeof(GuidUdi) + " which is required by content");
             var parent = contentService.GetById(guidUdi.Guid);
-            return contentService.Create(name, parent, mediaTypeAlias, userId);
+            return contentService.Create(name, parent, contentTypeAlias, userId);
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -391,30 +391,30 @@ namespace Umbraco.Core.Services
         /// </remarks>
         IEnumerable<PublishResult> SaveAndPublishBranch(IContent content, bool force, string[] cultures, int userId = Constants.Security.SuperUserId);
 
-        /// <summary>
-        /// Saves and publishes a document branch.
-        /// </summary>
-        /// <param name="content">The root document.</param>
-        /// <param name="force">A value indicating whether to force-publish documents that are not already published.</param>
-        /// <param name="shouldPublish">A function determining cultures to publish.</param>
-        /// <param name="publishCultures">A function publishing cultures.</param>
-        /// <param name="userId">The identifier of the user performing the operation.</param>
-        /// <remarks>
-        /// <para>The <paramref name="force"/> parameter determines which documents are published. When <c>false</c>,
-        /// only those documents that are already published, are republished. When <c>true</c>, all documents are
-        /// published. The root of the branch is always published, regardless of <paramref name="force"/>.</para>
-        /// <para>The <paramref name="editing"/> parameter is a function which determines whether a document has
-        /// changes to publish (else there is no need to publish it). If one wants to publish only a selection of
-        /// cultures, one may want to check that only properties for these cultures have changed. Otherwise, other
-        /// cultures may trigger an unwanted republish.</para>
-        /// <para>The <paramref name="publishCultures"/> parameter is a function to execute to publish cultures, on
-        /// each document. It can publish all, one, or a selection of cultures. It returns a boolean indicating
-        /// whether the cultures could be published.</para>
-        /// </remarks>
-        IEnumerable<PublishResult> SaveAndPublishBranch(IContent content, bool force,
-            Func<IContent, HashSet<string>> shouldPublish,
-            Func<IContent, HashSet<string>, bool> publishCultures,
-            int userId = Constants.Security.SuperUserId);
+        ///// <summary>
+        ///// Saves and publishes a document branch.
+        ///// </summary>
+        ///// <param name="content">The root document.</param>
+        ///// <param name="force">A value indicating whether to force-publish documents that are not already published.</param>
+        ///// <param name="shouldPublish">A function determining cultures to publish.</param>
+        ///// <param name="publishCultures">A function publishing cultures.</param>
+        ///// <param name="userId">The identifier of the user performing the operation.</param>
+        ///// <remarks>
+        ///// <para>The <paramref name="force"/> parameter determines which documents are published. When <c>false</c>,
+        ///// only those documents that are already published, are republished. When <c>true</c>, all documents are
+        ///// published. The root of the branch is always published, regardless of <paramref name="force"/>.</para>
+        ///// <para>The <paramref name="editing"/> parameter is a function which determines whether a document has
+        ///// changes to publish (else there is no need to publish it). If one wants to publish only a selection of
+        ///// cultures, one may want to check that only properties for these cultures have changed. Otherwise, other
+        ///// cultures may trigger an unwanted republish.</para>
+        ///// <para>The <paramref name="publishCultures"/> parameter is a function to execute to publish cultures, on
+        ///// each document. It can publish all, one, or a selection of cultures. It returns a boolean indicating
+        ///// whether the cultures could be published.</para>
+        ///// </remarks>
+        //IEnumerable<PublishResult> SaveAndPublishBranch(IContent content, bool force,
+        //    Func<IContent, HashSet<string>> shouldPublish,
+        //    Func<IContent, HashSet<string>, bool> publishCultures,
+        //    int userId = Constants.Security.SuperUserId);
 
         /// <summary>
         /// Unpublishes a document.

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -1449,7 +1449,7 @@ namespace Umbraco.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public IEnumerable<PublishResult> SaveAndPublishBranch(IContent document, bool force,
+        internal IEnumerable<PublishResult> SaveAndPublishBranch(IContent document, bool force,
             Func<IContent, HashSet<string>> shouldPublish,
             Func<IContent, HashSet<string>, bool> publishCultures,
             int userId = Constants.Security.SuperUserId)


### PR DESCRIPTION
When publishing fails because invalid property data is found, the content service doesn't return these results when it is supposed to, this fixes that.

The `PublishResult` contains a collection to expose which properties are invalid when validation fails but they are never populated. 

However, there's one issue, when publishing branches using the callback behavior, we cannot populate these due to the way that the APIs are structured so to fix that the API signatures on `SaveAndPublishBranch` where it specifies callbacks would need to change somehow. This callback parameter is `Func<IContent, HashSet<string>, bool> publishCultures` but this won't support acquiring the invalid properties. This is a public API.