### PR TITLE
v8 - Fixes ContentService so Saving events are raised when they need to be

### DIFF
--- a/src/Umbraco.Core/Models/Property.cs
+++ b/src/Umbraco.Core/Models/Property.cs
@@ -332,56 +332,6 @@ namespace Umbraco.Core.Models
             return (pvalue, change);
         }
 
-        /// <summary>
-        /// Gets a value indicating whether the property has valid values.
-        /// </summary>
-        internal bool IsValid(string culture = "*", string segment = "*")
-        {
-            // TODO: validating values shouldn't be done here, this calls in to IsValidValue
-
-            culture = culture.NullOrWhiteSpaceAsNull();
-            segment = segment.NullOrWhiteSpaceAsNull();
-
-            // if validating invariant/neutral, and it is supported, validate
-            // (including ensuring that the value exists, if mandatory)
-            if ((culture == null || culture == "*") && (segment == null || segment == "*") && PropertyType.SupportsVariation(null, null))
-                if (!IsValidValue(_pvalue?.EditedValue))
-                    return false;
-
-            // if validating only invariant/neutral, we are good
-            if (culture == null && segment == null)
-                return true;
-
-            // if nothing else to validate, we are good
-            if ((culture == null || culture == "*") && (segment == null || segment == "*") && !PropertyType.VariesByCulture())
-                return true;
-
-            // for anything else, validate the existing values (including mandatory),
-            // but we cannot validate mandatory globally (we don't know the possible cultures and segments)
-
-            if (_vvalues == null) return culture == "*" || IsValidValue(null);
-
-            var pvalues = _vvalues.Where(x =>
-                    PropertyType.SupportsVariation(x.Value.Culture, x.Value.Segment, true) && // the value variation is ok
-                    (culture == "*" || x.Value.Culture.InvariantEquals(culture)) && // the culture matches
-                    (segment == "*" || x.Value.Segment.InvariantEquals(segment))) // the segment matches
-                .Select(x => x.Value)
-                .ToList();
-
-            return pvalues.Count == 0 || pvalues.All(x => IsValidValue(x.EditedValue));
-        }
-
-        /// <summary>
-        /// Boolean indicating whether the passed in value is valid
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns>True is property value is valid, otherwise false</returns>
-        private bool IsValidValue(object value)
-        {
-            // TODO: this shouldn't exist here, the model itself shouldn't be responsible for it's own validation and this requires singleton access
-            return PropertyType.IsPropertyValueValid(value);
-        }
-
         protected override void PerformDeepClone(object clone)
         {
             base.PerformDeepClone(clone);

--- a/src/Umbraco.Core/Models/PropertyType.cs
+++ b/src/Umbraco.Core/Models/PropertyType.cs
@@ -82,8 +82,16 @@ namespace Umbraco.Core.Models
         }
 
         /// <summary>
-        /// Gets a value indicating whether the content type, owning this property type, is publishing.
+        /// Gets a value indicating whether the content type owning this property type is publishing.
         /// </summary>
+        /// <remarks>
+        /// When set to true the Property of this Property Type will return it's published value if it has one.
+        /// This also affects the validation behavior of the Property when assigning values since Members and Media don't support publishing.
+        /// For those entity types, this will be false which means if a value is attempted to be published on a property when it's not supported
+        /// by the PropertyType, an exception will be thrown.
+        ///
+        /// TODO: Should we rename this and other instances of "IsPublishing" (including parameters) to be more clear? Like SupportsPublishing ?
+        /// </remarks>
         public bool IsPublishing { get; internal set; }
 
         /// <summary>

--- a/src/Umbraco.Core/Models/PropertyType.cs
+++ b/src/Umbraco.Core/Models/PropertyType.cs
@@ -363,18 +363,6 @@ namespace Umbraco.Core.Models
         }
 
 
-        // TODO: this and other value validation methods should be a service level (not a model) thing. Changing this to internal for now
-        /// <summary>
-        /// Determines whether a value is valid for this property type.
-        /// </summary>
-        internal bool IsPropertyValueValid(object value)
-        {
-            var editor = Current.PropertyEditors[_propertyEditorAlias]; // TODO: inject
-            var configuration = Current.Services.DataTypeService.GetDataType(_dataTypeId).Configuration; // TODO: inject
-            var valueEditor = editor.GetValueEditor(configuration);
-            return !valueEditor.Validate(value, Mandatory, ValidationRegExp).Any();
-        }
-
         /// <summary>
         /// Sanitizes a property type alias.
         /// </summary>

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -10,6 +10,7 @@ using Umbraco.Core.Models.Membership;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.Querying;
 using Umbraco.Core.Persistence.Repositories;
+using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Scoping;
 using Umbraco.Core.Services.Changes;
 
@@ -27,6 +28,8 @@ namespace Umbraco.Core.Services.Implement
         private readonly IDocumentBlueprintRepository _documentBlueprintRepository;
         private readonly ILanguageRepository _languageRepository;
         private IQuery<IContent> _queryNotTrashed;
+        //TODO: The non-lazy object should be injected
+        private readonly Lazy<PropertyValidationService> _propertyValidationService = new Lazy<PropertyValidationService>(() => new PropertyValidationService());
 
         #region Constructors
 
@@ -193,7 +196,7 @@ namespace Umbraco.Core.Services.Implement
             var content = new Content(name, parentId, contentType);
             using (var scope = ScopeProvider.CreateScope())
             {
-                CreateContent(scope, content, parent, userId, false);
+                CreateContent(scope, content, userId, false);
                 scope.Complete();
             }
 
@@ -227,7 +230,7 @@ namespace Umbraco.Core.Services.Implement
                     throw new ArgumentException("No content type with that alias.", nameof(contentTypeAlias)); // causes rollback
 
                 var content = new Content(name, parent, contentType);
-                CreateContent(scope, content, parent, userId, false);
+                CreateContent(scope, content, userId, false);
 
                 scope.Complete();
                 return content;
@@ -261,7 +264,7 @@ namespace Umbraco.Core.Services.Implement
                     throw new ArgumentException("No content with that id.", nameof(parentId)); // causes rollback
 
                 var content = parentId > 0 ? new Content(name, parent, contentType) : new Content(name, parentId, contentType);
-                CreateContent(scope, content, parent, userId, true);
+                CreateContent(scope, content, userId, true);
 
                 scope.Complete();
                 return content;
@@ -293,14 +296,14 @@ namespace Umbraco.Core.Services.Implement
                     throw new ArgumentException("No content type with that alias.", nameof(contentTypeAlias)); // causes rollback
 
                 var content = new Content(name, parent, contentType);
-                CreateContent(scope, content, parent, userId, true);
+                CreateContent(scope, content, userId, true);
 
                 scope.Complete();
                 return content;
             }
         }
 
-        private void CreateContent(IScope scope, Content content, IContent parent, int userId, bool withIdentity)
+        private void CreateContent(IScope scope, IContent content, int userId, bool withIdentity)
         {
             content.CreatorId = userId;
             content.WriterId = userId;
@@ -311,12 +314,12 @@ namespace Umbraco.Core.Services.Implement
 
                 // if saving is cancelled, content remains without an identity
                 var saveEventArgs = new ContentSavingEventArgs(content, evtMsgs);
-                if (scope.Events.DispatchCancelable(Saving, this, saveEventArgs, "Saving"))
+                if (scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
                     return;
 
                 _documentRepository.Save(content);
 
-                scope.Events.Dispatch(Saved, this, saveEventArgs.ToContentSavedEventArgs(), "Saved");
+                scope.Events.Dispatch(Saved, this, saveEventArgs.ToContentSavedEventArgs(), nameof(Saved));
                 scope.Events.Dispatch(TreeChanged, this, new TreeChange<IContent>(content, TreeChangeTypes.RefreshNode).ToEventArgs());
             }
 
@@ -758,7 +761,7 @@ namespace Umbraco.Core.Services.Implement
             using (var scope = ScopeProvider.CreateScope())
             {
                 var saveEventArgs = new ContentSavingEventArgs(content, evtMsgs);
-                if (raiseEvents && scope.Events.DispatchCancelable(Saving, this, saveEventArgs, "Saving"))
+                if (raiseEvents && scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
                 {
                     scope.Complete();
                     return OperationResult.Cancel(evtMsgs);
@@ -783,7 +786,7 @@ namespace Umbraco.Core.Services.Implement
 
                 if (raiseEvents)
                 {
-                    scope.Events.Dispatch(Saved, this, saveEventArgs.ToContentSavedEventArgs(), "Saved");
+                    scope.Events.Dispatch(Saved, this, saveEventArgs.ToContentSavedEventArgs(), nameof(Saved));
                 }
                 var changeType = TreeChangeTypes.RefreshNode;
                 scope.Events.Dispatch(TreeChanged, this, new TreeChange<IContent>(content, changeType).ToEventArgs());
@@ -813,7 +816,7 @@ namespace Umbraco.Core.Services.Implement
             using (var scope = ScopeProvider.CreateScope())
             {
                 var saveEventArgs = new ContentSavingEventArgs(contentsA, evtMsgs);
-                if (raiseEvents && scope.Events.DispatchCancelable(Saving, this, saveEventArgs, "Saving"))
+                if (raiseEvents && scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
                 {
                     scope.Complete();
                     return OperationResult.Cancel(evtMsgs);
@@ -833,7 +836,7 @@ namespace Umbraco.Core.Services.Implement
 
                 if (raiseEvents)
                 {
-                    scope.Events.Dispatch(Saved, this, saveEventArgs.ToContentSavedEventArgs(), "Saved");
+                    scope.Events.Dispatch(Saved, this, saveEventArgs.ToContentSavedEventArgs(), nameof(Saved));
                 }
                 scope.Events.Dispatch(TreeChanged, this, treeChanges.ToEventArgs());
                 Audit(AuditType.Save, userId == -1 ? 0 : userId, Constants.System.Root, "Saved multiple content");
@@ -866,35 +869,51 @@ namespace Umbraco.Core.Services.Implement
                     throw new NotSupportedException($"Culture \"{culture}\" is not supported by invariant content types.");
             }
 
-            // if culture is specific, first publish the invariant values, then publish the culture itself.
-            // if culture is '*', then publish them all (including variants)
-
-            Property[] invalidProperties;
-
-            // explicitly SaveAndPublish a specific culture also publishes invariant values
-            if (!culture.IsNullOrWhiteSpace() && culture != "*")
+            using (var scope = ScopeProvider.CreateScope())
             {
-                // publish the invariant values
-                var publishInvariant = content.PublishCulture(out invalidProperties, null);
-                if (!publishInvariant)
+                scope.WriteLock(Constants.Locks.ContentTree);
+
+                var saveEventArgs = new ContentSavingEventArgs(content, evtMsgs);
+                if (raiseEvents && scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
+                    return new PublishResult(PublishResultType.FailedPublishCancelledByEvent, evtMsgs, content);
+
+                Property[] invalidProperties;
+
+                // if culture is specific, first publish the invariant values, then publish the culture itself.
+                // if culture is '*', then publish them all (including variants)
+
+                // explicitly SaveAndPublish a specific culture also publishes invariant values
+                if (!culture.IsNullOrWhiteSpace() && culture != "*")
+                {
+                    // publish the invariant values
+                    var publishInvariant = content.PublishCulture(null);
+                    if (!publishInvariant)
+                        return new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, content);
+
+                    //validate the property values
+                    if (!_propertyValidationService.Value.IsPropertyDataValid(content, out invalidProperties))
+                        return new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, content)
+                        {
+                            InvalidProperties = invalidProperties
+                        };
+                }
+
+                // publish the culture(s)
+                var publishCulture = content.PublishCulture(culture);
+                if (!publishCulture)
+                    return new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, content);
+
+                //validate the property values
+                if (!_propertyValidationService.Value.IsPropertyDataValid(content, out invalidProperties))
                     return new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, content)
                     {
-                        InvalidProperties = invalidProperties ?? Enumerable.Empty<Property>()
+                        InvalidProperties = invalidProperties
                     };
 
+                var result = CommitDocumentChangesInternal(scope, content, saveEventArgs, userId, raiseEvents);
+                scope.Complete();
+                return result;
             }
-
-            // publish the culture(s)
-            var publishCulture = content.PublishCulture(out invalidProperties, culture);
-            if (!publishCulture)
-                return new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, content)
-                {
-                    InvalidProperties = invalidProperties ?? Enumerable.Empty<Property>()
-                };
-
-            // finally, "save publishing"
-            // what happens next depends on whether the content can be published or not
-            return CommitDocumentChanges(content, userId, raiseEvents);
         }
 
         /// <inheritdoc />
@@ -903,23 +922,40 @@ namespace Umbraco.Core.Services.Implement
             if (content == null) throw new ArgumentNullException(nameof(content));
             if (cultures == null) throw new ArgumentNullException(nameof(cultures));
 
-            var evtMsgs = EventMessagesFactory.Get();
-
-            var varies = content.ContentType.VariesByCulture();
-            
-            if (cultures.Length == 0)
+            using (var scope = ScopeProvider.CreateScope())
             {
-                //no cultures specified and doesn't vary, so publish it, else nothing to publish
-                return !varies
-                    ? SaveAndPublish(content, userId: userId, raiseEvents: raiseEvents)
-                    : new PublishResult(PublishResultType.FailedPublishNothingToPublish, evtMsgs, content);
+                scope.WriteLock(Constants.Locks.ContentTree);
+
+                var evtMsgs = EventMessagesFactory.Get();
+                var saveEventArgs = new ContentSavingEventArgs(content, evtMsgs);
+                if (raiseEvents && scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
+                    return new PublishResult(PublishResultType.FailedPublishCancelledByEvent, evtMsgs, content);
+
+                var varies = content.ContentType.VariesByCulture();
+
+                if (cultures.Length == 0)
+                {
+                    //no cultures specified and doesn't vary, so publish it, else nothing to publish
+                    return !varies
+                        ? SaveAndPublish(content, userId: userId, raiseEvents: raiseEvents)
+                        : new PublishResult(PublishResultType.FailedPublishNothingToPublish, evtMsgs, content);
+                }
+
+
+                if (cultures.Select(content.PublishCulture).Any(isValid => !isValid))
+                    return new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, content);
+
+                //validate the property values
+                if (!_propertyValidationService.Value.IsPropertyDataValid(content, out var invalidProperties))
+                    return new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, content)
+                    {
+                        InvalidProperties = invalidProperties
+                    };
+
+                var result = CommitDocumentChangesInternal(scope, content, saveEventArgs, userId, raiseEvents);
+                scope.Complete();
+                return result;
             }
-
-            // TODO: currently, no way to know which one failed
-            if (cultures.Select(content.PublishCulture).Any(isValid => !isValid))
-                return new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, content);
-
-            return CommitDocumentChanges(content, userId, raiseEvents);
         }
 
         /// <inheritdoc />
@@ -952,56 +988,87 @@ namespace Umbraco.Core.Services.Implement
             if (!content.Published)
                 return new PublishResult(PublishResultType.SuccessUnpublishAlready, evtMsgs, content);
 
-            // all cultures = unpublish whole
-            if (culture == "*" || (!content.ContentType.VariesByCulture() && culture == null))
+            using (var scope = ScopeProvider.CreateScope())
             {
-                content.PublishedState = PublishedState.Unpublishing;
+                scope.WriteLock(Constants.Locks.ContentTree);
+
+                var saveEventArgs = new ContentSavingEventArgs(content, evtMsgs);
+                if (scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
+                    return new PublishResult(PublishResultType.FailedPublishCancelledByEvent, evtMsgs, content);
+
+                // all cultures = unpublish whole
+                if (culture == "*" || (!content.ContentType.VariesByCulture() && culture == null))
+                {
+                    content.PublishedState = PublishedState.Unpublishing;
+                }
+                else
+                {
+                    // If the culture we want to unpublish was already unpublished, nothing to do.
+                    // To check for that we need to lookup the persisted content item
+                    var persisted = content.HasIdentity ? GetById(content.Id) : null;
+
+                    if (persisted != null && !persisted.IsCulturePublished(culture))
+                        return new PublishResult(PublishResultType.SuccessUnpublishAlready, evtMsgs, content);
+
+                    // unpublish the culture
+                    content.UnpublishCulture(culture);
+                }
+
+                var result = CommitDocumentChangesInternal(scope, content, saveEventArgs, userId);
+                scope.Complete();
+                return result;
             }
-            else
-            {
-                // If the culture we want to unpublish was already unpublished, nothing to do.
-                // To check for that we need to lookup the persisted content item
-                var persisted = content.HasIdentity ? GetById(content.Id) : null;
 
-                if (persisted != null && !persisted.IsCulturePublished(culture))
-                    return new PublishResult(PublishResultType.SuccessUnpublishAlready, evtMsgs, content);
-
-                // unpublish the culture
-                content.UnpublishCulture(culture);
-            }
-
-            // finally, "save publishing"
-            return CommitDocumentChanges(content, userId);
         }
 
         /// <summary>
         /// Saves a document and publishes/unpublishes any pending publishing changes made to the document.
         /// </summary>
         /// <remarks>
+        /// <para>
+        /// This MUST NOT be called from within this service, this used to be a public API and must only be used outside of this service.
+        /// Internally in this service, calls must be made to CommitDocumentChangesInternal
+        /// </para>
+        /// 
         /// <para>This is the underlying logic for both publishing and unpublishing any document</para>
-        /// <para>Pending publishing/unpublishing changes on a document are made with calls to <see cref="IContent.PublishCulture"/> and
-        /// <see cref="IContent.UnpublishCulture"/>.</para>
+        /// <para>Pending publishing/unpublishing changes on a document are made with calls to <see cref="ContentRepositoryExtensions.PublishCulture"/> and
+        /// <see cref="ContentRepositoryExtensions.UnpublishCulture"/>.</para>
         /// <para>When publishing or unpublishing a single culture, or all cultures, use <see cref="SaveAndPublish"/>
         /// and <see cref="Unpublish"/>. But if the flexibility to both publish and unpublish in a single operation is required
-        /// then this method needs to be used in combination with <see cref="IContent.PublishCulture"/> and <see cref="IContent.UnpublishCulture"/>
+        /// then this method needs to be used in combination with <see cref="ContentRepositoryExtensions.PublishCulture"/> and <see cref="ContentRepositoryExtensions.UnpublishCulture"/>
         /// on the content itself - this prepares the content, but does not commit anything - and then, invoke
         /// <see cref="CommitDocumentChanges"/> to actually commit the changes to the database.</para>
         /// <para>The document is *always* saved, even when publishing fails.</para>
         /// </remarks>
-        internal PublishResult CommitDocumentChanges(IContent content, int userId = Constants.Security.SuperUserId, bool raiseEvents = true)
+        internal PublishResult CommitDocumentChanges(IContent content,
+            int userId = Constants.Security.SuperUserId, bool raiseEvents = true)
         {
             using (var scope = ScopeProvider.CreateScope())
             {
+                var evtMsgs = EventMessagesFactory.Get();
+
                 scope.WriteLock(Constants.Locks.ContentTree);
-                var result = CommitDocumentChangesInternal(scope, content, userId, raiseEvents);
+
+                var saveEventArgs = new ContentSavingEventArgs(content, evtMsgs);
+                if (raiseEvents && scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
+                    return new PublishResult(PublishResultType.FailedPublishCancelledByEvent, evtMsgs, content);
+
+                var result = CommitDocumentChangesInternal(scope, content, saveEventArgs, userId, raiseEvents);
                 scope.Complete();
                 return result;
             }
         }
 
-        private PublishResult CommitDocumentChangesInternal(IScope scope, IContent content, int userId = Constants.Security.SuperUserId, bool raiseEvents = true, bool branchOne = false, bool branchRoot = false)
+        private PublishResult CommitDocumentChangesInternal(IScope scope, IContent content,
+            ContentSavingEventArgs saveEventArgs,
+            int userId = Constants.Security.SuperUserId, bool raiseEvents = true, bool branchOne = false, bool branchRoot = false)
         {
-            var evtMsgs = EventMessagesFactory.Get();
+            if (scope == null) throw new ArgumentNullException(nameof(scope));
+            if (content == null) throw new ArgumentNullException(nameof(content));
+            if (saveEventArgs == null) throw new ArgumentNullException(nameof(saveEventArgs));
+
+            var evtMsgs = saveEventArgs.Messages;
+            
             PublishResult publishResult = null;
             PublishResult unpublishResult = null;
 
@@ -1027,10 +1094,6 @@ namespace Umbraco.Core.Services.Implement
             var changeType = isNew ? TreeChangeTypes.RefreshNode : TreeChangeTypes.RefreshBranch;
             var previouslyPublished = content.HasIdentity && content.Published;
 
-            // always save
-            var saveEventArgs = new ContentSavingEventArgs(content, evtMsgs);
-            if (raiseEvents && scope.Events.DispatchCancelable(Saving, this, saveEventArgs, "Saving"))
-                return new PublishResult(PublishResultType.FailedPublishCancelledByEvent, evtMsgs, content);
 
             if (publishing)
             {
@@ -1116,7 +1179,7 @@ namespace Umbraco.Core.Services.Implement
             // raise the Saved event, always
             if (raiseEvents)
             {
-                scope.Events.Dispatch(Saved, this, saveEventArgs.ToContentSavedEventArgs(), "Saved");
+                scope.Events.Dispatch(Saved, this, saveEventArgs.ToContentSavedEventArgs(), nameof(Saved));
             }
 
             if (unpublishing) // we have tried to unpublish - won't happen in a branch
@@ -1251,7 +1314,13 @@ namespace Umbraco.Core.Services.Implement
                             .Distinct()
                             .ToList();
 
-                        Property[] invalidProperties = null;
+                        if (pendingCultures.Count == 0)
+                            break; //shouldn't happen but no point in continuing if there's nothing there
+
+                        var saveEventArgs = new ContentSavingEventArgs(d, evtMsgs);
+                        if (scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
+                            yield return new PublishResult(PublishResultType.FailedPublishCancelledByEvent, evtMsgs, d);
+
                         var publishing = true;
                         foreach (var culture in pendingCultures)
                         {
@@ -1260,19 +1329,24 @@ namespace Umbraco.Core.Services.Implement
 
                             if (d.Trashed) continue; // won't publish
 
-                            publishing &= d.PublishCulture(out invalidProperties, culture); //set the culture to be published
+                            //publish the culture values and validate the property values, if validation fails, log the invalid properties so the develeper has an idea of what has failed
+                            Property[] invalidProperties = null;
+                            var tryPublish = d.PublishCulture(culture) && _propertyValidationService.Value.IsPropertyDataValid(d, out invalidProperties);
+                            if (invalidProperties != null && invalidProperties.Length > 0)
+                                Logger.Warn<ContentService>("Scheduled publishing will fail for document {DocumentId} and culture {Culture} because of invalid properties {InvalidProperties}",
+                                    d.Id, culture, string.Join(",", invalidProperties.Select(x => x.Alias)));
+
+                            publishing &= tryPublish; //set the culture to be published
                             if (!publishing) break; // no point continuing
                         }
 
                         if (d.Trashed)
                             result = new PublishResult(PublishResultType.FailedPublishIsTrashed, evtMsgs, d);
                         else if (!publishing)
-                            result = new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, d)
-                            {
-                                InvalidProperties = invalidProperties ?? Enumerable.Empty<Property>()
-                            };
+                            result = new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, d);
                         else
-                            result = CommitDocumentChanges(d, d.WriterId);
+                            result = CommitDocumentChangesInternal(scope, d, saveEventArgs, d.WriterId);
+
 
                         if (result.Success == false)
                             Logger.Error<ContentService>(null, "Failed to publish document id={DocumentId}, reason={Reason}.", d.Id, result.Result);
@@ -1306,6 +1380,13 @@ namespace Umbraco.Core.Services.Implement
                             .Distinct()
                             .ToList();
 
+                        if (pendingCultures.Count == 0)
+                            break; //shouldn't happen but no point in continuing if there's nothing there
+
+                        var saveEventArgs = new ContentSavingEventArgs(d, evtMsgs);
+                        if (scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
+                            yield return new PublishResult(PublishResultType.FailedPublishCancelledByEvent, evtMsgs, d);
+
                         foreach (var c in pendingCultures)
                         {
                             //Clear this schedule for this culture
@@ -1314,13 +1395,11 @@ namespace Umbraco.Core.Services.Implement
                             d.UnpublishCulture(c);
                         }
 
-                        if (pendingCultures.Count > 0)
-                        {
-                            result = CommitDocumentChanges(d, d.WriterId);
-                            if (result.Success == false)
-                                Logger.Error<ContentService>(null, "Failed to publish document id={DocumentId}, reason={Reason}.", d.Id, result.Result);
-                            yield return result;
-                        }
+                        result = CommitDocumentChangesInternal(scope, d, saveEventArgs, d.WriterId);
+                        if (result.Success == false)
+                            Logger.Error<ContentService>(null, "Failed to publish document id={DocumentId}, reason={Reason}.", d.Id, result.Result);
+                        yield return result;
+
                     }
                     else
                     {
@@ -1341,13 +1420,15 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        private bool SaveAndPublishBranch_PublishCultures(IContent c, HashSet<string> culturesToPublish)
+        private bool SaveAndPublishBranch_PublishCultures(IContent content, HashSet<string> culturesToPublish)
         {
+            //TODO: This does not support being able to return invalid property details to bubble up to the UI
+
             // variant content type - publish specified cultures
             // invariant content type - publish only the invariant culture
-            return c.ContentType.VariesByCulture()
-                ? culturesToPublish.All(c.PublishCulture)
-                : c.PublishCulture();
+            return content.ContentType.VariesByCulture()
+                ? culturesToPublish.All(culture => content.PublishCulture(culture) && _propertyValidationService.Value.IsPropertyDataValid(content, out _))
+                : content.PublishCulture() && _propertyValidationService.Value.IsPropertyDataValid(content, out _);
         }
 
         private HashSet<string> SaveAndPublishBranch_ShouldPublish3(ref HashSet<string> cultures, string c, bool published, bool edited, bool isRoot, bool force)
@@ -1547,15 +1628,18 @@ namespace Umbraco.Core.Services.Implement
             if (culturesToPublish.Count == 0) // empty = already published
                 return new PublishResult(PublishResultType.SuccessPublishAlready, evtMsgs, document);
 
+            var saveEventArgs = new ContentSavingEventArgs(document, evtMsgs);
+            if (scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
+                return new PublishResult(PublishResultType.FailedPublishCancelledByEvent, evtMsgs, document);
+
             // publish & check if values are valid
             if (!publishCultures(document, culturesToPublish))
             {
                 //TODO: Based on this callback behavior there is no way to know which properties may have been invalid if this failed, see other results of FailedPublishContentInvalid
                 return new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, document);
-            }
-                
+            }   
 
-            var result = CommitDocumentChangesInternal(scope, document, userId, branchOne: true, branchRoot: isRoot);
+            var result = CommitDocumentChangesInternal(scope, document, saveEventArgs, userId, branchOne: true, branchRoot: isRoot);
             if (result.Success)
                 publishedDocuments.Add(document);
             return result;

--- a/src/Umbraco.Core/Services/PropertyValidationService.cs
+++ b/src/Umbraco.Core/Services/PropertyValidationService.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Collections;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Models;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Core.Services
+{
+    //TODO: We should make this an interface and inject it into the ContentService
+    internal class PropertyValidationService
+    {
+        private readonly PropertyEditorCollection _propertyEditors;
+        private readonly IDataTypeService _dataTypeService;
+
+        public PropertyValidationService(PropertyEditorCollection propertyEditors, IDataTypeService dataTypeService)
+        {
+            _propertyEditors = propertyEditors;
+            _dataTypeService = dataTypeService;
+        }
+
+        //TODO: Remove this method in favor of the overload specifying all dependencies
+        public PropertyValidationService()
+            : this(Current.PropertyEditors, Current.Services.DataTypeService)
+        {
+        }
+
+        /// <summary>
+        /// Validates the content item's properties pass validation rules
+        /// </summary>
+        /// <para>If the content type is variant, then culture can be either '*' or an actual culture, but neither 'null' nor
+        /// 'empty'. If the content type is invariant, then culture can be either '*' or null or empty.</para>
+        public bool IsPropertyDataValid(IContentBase content, out Property[] invalidProperties, string culture = "*")
+        {
+            // select invalid properties
+            invalidProperties = content.Properties.Where(x =>
+            {
+                // if culture is null, we validate invariant properties only
+                // if culture is '*' we validate both variant and invariant properties, automatically
+                // if culture is specific eg 'en-US' we both too, but explicitly
+
+                var varies = x.PropertyType.VariesByCulture();
+
+                if (culture == null)
+                    return !(varies || IsPropertyValid(x, null)); // validate invariant property, invariant culture
+
+                if (culture == "*")
+                    return !IsPropertyValid(x, culture); // validate property, all cultures
+
+                return varies
+                    ? !IsPropertyValid(x, culture) // validate variant property, explicit culture
+                    : !IsPropertyValid(x, null); // validate invariant property, explicit culture
+            })
+                .ToArray();
+
+            return invalidProperties.Length == 0;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the property has valid values.
+        /// </summary>
+        public bool IsPropertyValid(Property property, string culture = "*", string segment = "*")
+        {
+            //NOTE - the pvalue and vvalues logic in here is borrowed directly from the Property.Values setter so if you are wondering what that's all about, look there.
+            // The underlying Property._pvalue and Property._vvalues are not exposed but we can re-create these values ourselves which is what it's doing.
+
+            culture = culture.NullOrWhiteSpaceAsNull();
+            segment = segment.NullOrWhiteSpaceAsNull();
+
+            Property.PropertyValue pvalue = null;
+
+            // if validating invariant/neutral, and it is supported, validate
+            // (including ensuring that the value exists, if mandatory)
+            if ((culture == null || culture == "*") && (segment == null || segment == "*") && property.PropertyType.SupportsVariation(null, null))
+            {
+                pvalue = property.Values.FirstOrDefault(x => x.Culture == null && x.Segment == null);
+                if (!IsValidPropertyValue(property, pvalue?.EditedValue))
+                    return false;
+            }
+
+            // if validating only invariant/neutral, we are good
+            if (culture == null && segment == null)
+                return true;
+
+            // if nothing else to validate, we are good
+            if ((culture == null || culture == "*") && (segment == null || segment == "*") && !property.PropertyType.VariesByCulture())
+                return true;
+
+            // for anything else, validate the existing values (including mandatory),
+            // but we cannot validate mandatory globally (we don't know the possible cultures and segments)
+
+            var vvalues = property.Values.Count > (pvalue == null ? 0 : 1)
+                ? property.Values.Where(x => x != pvalue).ToDictionary(x => new CompositeNStringNStringKey(x.Culture, x.Segment), x => x)
+                : null;
+
+            if (vvalues == null) return culture == "*" || IsValidPropertyValue(property,null);
+
+            var pvalues = vvalues.Where(x =>
+                    property.PropertyType.SupportsVariation(x.Value.Culture, x.Value.Segment, true) && // the value variation is ok
+                    (culture == "*" || x.Value.Culture.InvariantEquals(culture)) && // the culture matches
+                    (segment == "*" || x.Value.Segment.InvariantEquals(segment))) // the segment matches
+                .Select(x => x.Value)
+                .ToList();
+
+            return pvalues.Count == 0 || pvalues.All(x => IsValidPropertyValue(property, x.EditedValue));
+        }
+
+        /// <summary>
+        /// Boolean indicating whether the passed in value is valid
+        /// </summary>
+        /// <param name="property"></param>
+        /// <param name="value"></param>
+        /// <returns>True is property value is valid, otherwise false</returns>
+        private bool IsValidPropertyValue(Property property, object value)
+        {
+            return IsPropertyValueValid(property.PropertyType, value);
+        }
+
+        /// <summary>
+        /// Determines whether a value is valid for this property type.
+        /// </summary>
+        private bool IsPropertyValueValid(PropertyType propertyType, object value)
+        {
+            var editor = _propertyEditors[propertyType.PropertyEditorAlias];
+            var configuration = _dataTypeService.GetDataType(propertyType.DataTypeId).Configuration;
+            var valueEditor = editor.GetValueEditor(configuration);
+            return !valueEditor.Validate(value, propertyType.Mandatory, propertyType.ValidationRegExp).Any();
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\MergeDateAndDateTimePropertyEditor.cs" />
     <Compile Include="PropertyEditors\DateTimeConfiguration.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\RenameLabelAndRichTextPropertyEditorAliases.cs" />
+    <Compile Include="Services\PropertyValidationService.cs" />
     <Compile Include="TypeLoaderExtensions.cs" />
     <Compile Include="Composing\WeightAttribute.cs" />
     <Compile Include="Composing\WeightedCollectionBuilderBase.cs" />

--- a/src/Umbraco.Tests/Models/VariationTests.cs
+++ b/src/Umbraco.Tests/Models/VariationTests.cs
@@ -364,6 +364,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void ContentPublishValuesWithMixedPropertyTypeVariations()
         {
+            var propertyValidationService = new PropertyValidationService(Current.Factory.GetInstance<PropertyEditorCollection>(), Current.Factory.GetInstance<ServiceContext>().DataTypeService);
             const string langFr = "fr-FR";
 
             // content type varies by Culture
@@ -383,9 +384,12 @@ namespace Umbraco.Tests.Models
 
             content.SetCultureName("hello", langFr);
 
-            Assert.IsFalse(content.PublishCulture(langFr)); // fails because prop1 is mandatory
+            Assert.IsTrue(content.PublishCulture(langFr));
+            Assert.IsFalse(propertyValidationService.IsPropertyDataValid(content, out _, langFr));// fails because prop1 is mandatory
+
             content.SetValue("prop1", "a", langFr);
-            Assert.IsFalse(content.PublishCulture(langFr)); // fails because prop2 is mandatory and invariant
+            Assert.IsTrue(content.PublishCulture(langFr));
+            Assert.IsFalse(propertyValidationService.IsPropertyDataValid(content, out _, langFr));// fails because prop2 is mandatory and invariant
             content.SetValue("prop2", "x");
             Assert.IsTrue(content.PublishCulture(langFr)); // now it's ok
 

--- a/src/Umbraco.Tests/Models/VariationTests.cs
+++ b/src/Umbraco.Tests/Models/VariationTests.cs
@@ -486,14 +486,15 @@ namespace Umbraco.Tests.Models
             prop.SetValue("a");
             Assert.AreEqual("a", prop.GetValue());
             Assert.IsNull(prop.GetValue(published: true));
+            var propertyValidationService = new PropertyValidationService(Current.Factory.GetInstance<PropertyEditorCollection>(), Current.Factory.GetInstance<ServiceContext>().DataTypeService);
 
-            Assert.IsTrue(prop.IsValid());
+            Assert.IsTrue(propertyValidationService.IsPropertyValid(prop));
 
             propertyType.Mandatory = true;
-            Assert.IsTrue(prop.IsValid());
+            Assert.IsTrue(propertyValidationService.IsPropertyValid(prop));
 
             prop.SetValue(null);
-            Assert.IsFalse(prop.IsValid());
+            Assert.IsFalse(propertyValidationService.IsPropertyValid(prop));
 
             // can publish, even though invalid
             prop.PublishValues();

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -18,6 +18,7 @@ using Umbraco.Core.Services.Implement;
 using Umbraco.Tests.Testing;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Cache;
+using Umbraco.Core.PropertyEditors;
 using Umbraco.Tests.LegacyXmlPublishedCache;
 
 namespace Umbraco.Tests.Services
@@ -986,7 +987,10 @@ namespace Umbraco.Tests.Services
             Assert.IsTrue(parent.Published);
 
             // content cannot publish values because they are invalid
-            Assert.IsNotEmpty(content.ValidateProperties());
+            var propertyValidationService = new PropertyValidationService(Factory.GetInstance<PropertyEditorCollection>(), ServiceContext.DataTypeService);
+            var isValid = propertyValidationService.IsPropertyDataValid(content, out var invalidProperties);
+            Assert.IsFalse(isValid);
+            Assert.IsNotEmpty(invalidProperties);
 
             // and therefore cannot be published,
             // because it did not have a published version at all


### PR DESCRIPTION
NOTE - no public API signatures have been changed for these fixes so these fixes won't interrupt Forms, Deploy or SK development

Fixes #4677

This fixes the issue mentioned above by ensuring that the Saving event is raised before the content.PublishCulture(...) method is executed so that the developer has the ability to set values before they are pushed into the publishing values of the model.

Further to this fix, it is necessary to separate the logic within content.PublishCulture(...) which was also validating property data internally. This leads to confusion when using the APIs and it is not clear what things are doing. Also the code to validate the property data had all sorts of TODOs in it because it existed in the wrong place (i.e. the Model was responsible for validating itself and relied on singletons). The property value validation logic is now inside an internal service, it still uses singletons in its ctor but I've added TODOs to fix that up. I didn't want to change too much at this stage since that would require changing the ContentService ctor. 

Another part of this whole issue is that because the ContentService performs property value validation, it previously meant that the Saving event could not fill in any required values before the validation took place which really sucks since a fundamental part of the Saving event is to populate default/required values if they haven't been filled in.

The changes within the ContentService is that the internal `CommitDocumentChanges` is __not__ used within the ContentService itself, i've added notes about that in there. All calls from within the ContentService make calls to `CommitDocumentChangesInternal` which requires an existing Scope and an instance of `ContentSavingEventArgs` which forces the user of this method to ensure that the Saving event is raised before the saving/publishing takes place. So it might look like there's lots of changes but mostly it's just that each method using `CommitDocumentChangesInternal` now creates it's own Scope and raises the Saving event before calling into the method.

I've added unit test to show this work:

* That during a SaveAndPublish, you can bind to Saving, change a value there and that value will carry through to be published (previously this would not happen)
* That during a SaveAndPublish, you can bind to Saving, fill in a required value that is currently empty and it will now pass the validation and continue on to be published (previously this would not happen)