### PR TITLE
#4715 - V8 - IE11: section name underline not in correct position

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -37,7 +37,8 @@ ul.sections>li>a::after {
 	height: 4px;
 	width: 100%;
 	background-color: @pinkLight;
-	position: absolute;
+    position: absolute;
+    left: 0;
 	bottom: -4px;
 	border-radius: 3px 3px 0 0;
 	opacity: 0;


### PR DESCRIPTION
This is a small CSS update to fix the position of the section name underline in IE11
