### PR TITLE
V8: Make header name input look OK when disabled 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -108,7 +108,7 @@ input.umb-editor-header__name-input {
 	margin-bottom: 0;
 	font-weight: bold;
 	box-sizing: border-box;
-	height: 30px;
+	height: 32px;
 	line-height: 32px;
 	width: 100%;
 	padding: 0 10px;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

ff8f9083 introduced a variance between `height` and `line-height` for the name input field. It results in a subtle vertical displacement of the field. That is... subtle until it's disabled in list view, where the displacement can clearly be seen as a 2px whitespace under the field:

![image](https://user-images.githubusercontent.com/7405322/53303746-701cbb80-386e-11e9-9c9b-29c0c3e879a3.png)

I've been trying to figure out what the reason was behind the change and I can't see any; so this PR reverts it and thus turns the dimmed input back to this: 

![image](https://user-images.githubusercontent.com/7405322/53303683-e40a9400-386d-11e9-8700-487759bf3936.png)

@nielslyngsoe should probably review this as ff8f9083 was his change - maybe there's a test case I haven't thought of 😄 