### PR TITLE
[v8] Better type restrictions in the container

### DIFF
--- a/src/Umbraco.Core/Composing/Composition.cs
+++ b/src/Umbraco.Core/Composing/Composition.cs
@@ -92,21 +92,25 @@ namespace Umbraco.Core.Composing
         /// <inheritdoc />
         public void RegisterFor<TService, TTarget>(Lifetime lifetime = Lifetime.Transient)
             where TService : class
+            where TTarget : TService
             => _register.RegisterFor<TService, TTarget>(lifetime);
 
         /// <inheritdoc />
         public void RegisterFor<TService, TTarget>(Type implementingType, Lifetime lifetime = Lifetime.Transient)
             where TService : class
+            where TTarget : TService
             => _register.RegisterFor<TService, TTarget>(implementingType, lifetime);
 
         /// <inheritdoc />
         public void RegisterFor<TService, TTarget>(Func<IFactory, TService> factory, Lifetime lifetime = Lifetime.Transient)
             where TService : class
+            where TTarget : TService
             => _register.RegisterFor<TService, TTarget>(factory, lifetime);
 
         /// <inheritdoc />
         public void RegisterFor<TService, TTarget>(TService instance)
             where TService : class
+            where TTarget : TService
             => _register.RegisterFor<TService, TTarget>(instance);
 
         /// <inheritdoc />
@@ -190,32 +194,44 @@ namespace Umbraco.Core.Composing
         /// Registers a unique service for a target, as its own implementation.
         /// </summary>
         /// <remarks>Unique services have one single implementation, and a Singleton lifetime.</remarks>
+        /// <typeparam name="TService">The type you want to resolve as</typeparam>
+        /// <typeparam name="TTarget">The type for the registration base (eg: What would be constructed)</typeparam>
         public void RegisterUniqueFor<TService, TTarget>()
             where TService : class
+            where TTarget : TService
             => _uniques[GetUniqueName<TService, TTarget>()] = register => register.RegisterFor<TService, TTarget>(Lifetime.Singleton);
 
         /// <summary>
         /// Registers a unique service for a target, with an implementing type.
         /// </summary>
         /// <remarks>Unique services have one single implementation, and a Singleton lifetime.</remarks>
+        /// <typeparam name="TService">The type you want to resolve as</typeparam>
+        /// <typeparam name="TTarget">The type for the registration base (eg: What would be constructed)</typeparam>
         public void RegisterUniqueFor<TService, TTarget>(Type implementingType)
             where TService : class
+            where TTarget : TService
             => _uniques[GetUniqueName<TService, TTarget>()] = register => register.RegisterFor<TService, TTarget>(implementingType, Lifetime.Singleton);
 
         /// <summary>
         /// Registers a unique service for a target, with an implementation factory.
         /// </summary>
         /// <remarks>Unique services have one single implementation, and a Singleton lifetime.</remarks>
+        /// <typeparam name="TService">The type you want to resolve as</typeparam>
+        /// <typeparam name="TTarget">The type for the registration base (eg: What would be constructed)</typeparam>
         public void RegisterUniqueFor<TService, TTarget>(Func<IFactory, TService> factory)
             where TService : class
+            where TTarget : TService
             => _uniques[GetUniqueName<TService, TTarget>()] = register => register.RegisterFor<TService, TTarget>(factory, Lifetime.Singleton);
 
         /// <summary>
         /// Registers a unique service for a target, with an implementing instance.
         /// </summary>
         /// <remarks>Unique services have one single implementation, and a Singleton lifetime.</remarks>
+        /// <typeparam name="TService">The type you want to resolve as</typeparam>
+        /// <typeparam name="TTarget">The type for the registration base (eg: What would be constructed)</typeparam>
         public void RegisterUniqueFor<TService, TTarget>(TService instance)
             where TService : class
+            where TTarget : TService
             => _uniques[GetUniqueName<TService, TTarget>()] = register => register.RegisterFor<TService, TTarget>(instance);
 
         #endregion

--- a/src/Umbraco.Core/Composing/IRegister.cs
+++ b/src/Umbraco.Core/Composing/IRegister.cs
@@ -36,42 +36,54 @@ namespace Umbraco.Core.Composing
         /// <summary>
         /// Registers a service for a target, as its own implementation.
         /// </summary>
+        /// <typeparam name="TService">The type you want to resolve as</typeparam>
+        /// <typeparam name="TTarget">The type for the registration base (eg: What would be constructed)</typeparam>
         /// <remarks>
         /// There can only be one implementation or instanced registered for a service and target;
         /// what happens if many are registered is not specified.
         /// </remarks>
         void RegisterFor<TService, TTarget>(Lifetime lifetime = Lifetime.Transient)
-            where TService : class;
+            where TService : class
+            where TTarget : TService;
 
         /// <summary>
         /// Registers a service for a target, with an implementation type.
         /// </summary>
+        /// <typeparam name="TService">The type you want to resolve as</typeparam>
+        /// <typeparam name="TTarget">The type for the registration base (eg: What would be constructed)</typeparam>
         /// <remarks>
         /// There can only be one implementation or instanced registered for a service and target;
         /// what happens if many are registered is not specified.
         /// </remarks>
         void RegisterFor<TService, TTarget>(Type implementingType, Lifetime lifetime = Lifetime.Transient)
-            where TService : class;
+            where TService : class
+            where TTarget : TService;
 
         /// <summary>
         /// Registers a service for a target, with an implementation factory.
         /// </summary>
+        /// <typeparam name="TService">The type you want to resolve as</typeparam>
+        /// <typeparam name="TTarget">The type for the registration base (eg: What would be constructed)</typeparam>
         /// <remarks>
         /// There can only be one implementation or instanced registered for a service and target;
         /// what happens if many are registered is not specified.
         /// </remarks>
         void RegisterFor<TService, TTarget>(Func<IFactory, TService> factory, Lifetime lifetime = Lifetime.Transient)
-            where TService : class;
+            where TService : class
+            where TTarget : TService;
 
         /// <summary>
         /// Registers a service for a target, with an implementing instance.
         /// </summary>
+        /// <typeparam name="TService">The type you want to resolve as</typeparam>
+        /// <typeparam name="TTarget">The type for the registration base (eg: What would be constructed)</typeparam>
         /// <remarks>
         /// There can only be one implementation or instanced registered for a service and target;
         /// what happens if many are registered is not specified.
         /// </remarks>
         void RegisterFor<TService, TTarget>(TService instance)
-            where TService : class;
+            where TService : class
+            where TTarget : TService;
 
         /// <summary>
         /// Registers a base type for auto-registration.

--- a/src/Umbraco.Core/Composing/LightInject/LightInjectContainer.cs
+++ b/src/Umbraco.Core/Composing/LightInject/LightInjectContainer.cs
@@ -179,11 +179,13 @@ namespace Umbraco.Core.Composing.LightInject
         /// <inheritdoc />
         public void RegisterFor<TService, TTarget>(Lifetime lifetime = Lifetime.Transient)
             where TService : class
+            where TTarget : TService
             => RegisterFor<TService, TTarget>(typeof(TService), lifetime);
 
         /// <inheritdoc />
         public void RegisterFor<TService, TTarget>(Type implementingType, Lifetime lifetime = Lifetime.Transient)
             where TService : class
+            where TTarget : TService
         {
             // note that there can only be one implementation or instance registered "for" a service
             Container.Register(typeof(TService), implementingType, GetTargetedServiceName<TTarget>(), GetLifetime(lifetime));
@@ -192,6 +194,7 @@ namespace Umbraco.Core.Composing.LightInject
         /// <inheritdoc />
         public void RegisterFor<TService, TTarget>(Func<IFactory, TService> factory, Lifetime lifetime = Lifetime.Transient)
             where TService : class
+            where TTarget : TService
         {
             // note that there can only be one implementation or instance registered "for" a service
             Container.Register(f => factory(this), GetTargetedServiceName<TTarget>(), GetLifetime(lifetime));
@@ -200,6 +203,7 @@ namespace Umbraco.Core.Composing.LightInject
         /// <inheritdoc />
         public void RegisterFor<TService, TTarget>(TService instance)
             where TService : class
+            where TTarget : TService
             => Container.RegisterInstance(typeof(TService), instance, GetTargetedServiceName<TTarget>());
 
         private ILifetime GetLifetime(Lifetime lifetime)

--- a/src/Umbraco.Core/CompositionExtensions_Uniques.cs
+++ b/src/Umbraco.Core/CompositionExtensions_Uniques.cs
@@ -22,8 +22,11 @@ namespace Umbraco.Core
         /// <summary>
         /// Registers a unique service with an implementation type, for a target.
         /// </summary>
+        /// <typeparam name="TService">The type you want to resolve as</typeparam>
+        /// <typeparam name="TTarget">The type for the registration base (eg: What would be constructed)</typeparam>
         public static void RegisterUniqueFor<TService, TTarget, TImplementing>(this Composition composition)
             where TService : class
+            where TTarget : TService
             => composition.RegisterUniqueFor<TService, TTarget>(typeof(TImplementing));
 
         /// <summary>

--- a/src/Umbraco.Core/RegisterExtensions.cs
+++ b/src/Umbraco.Core/RegisterExtensions.cs
@@ -16,8 +16,11 @@ namespace Umbraco.Core
         /// <summary>
         /// Registers a service with an implementation type, for a target.
         /// </summary>
+        /// <typeparam name="TService">The type you want to resolve as</typeparam>
+        /// <typeparam name="TTarget">The type for the registration base (eg: What would be constructed)</typeparam>
         public static void RegisterFor<TService, TImplementing, TTarget>(this IRegister register, Lifetime lifetime = Lifetime.Transient)
             where TService : class
+            where TTarget : TService
             => register.RegisterFor<TService, TTarget>(typeof(TImplementing), lifetime);
 
         /// <summary>


### PR DESCRIPTION
This addresses #4726 in which you could create _compile type_ invalid registrations and not find out until runtime.