### PR TITLE
Updated reference to dev-v7 as dev-v8 is now the default branch

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -3,7 +3,7 @@
 
 _You are browsing the Umbraco v8 branch. Umbraco 8 is currently under development._
 
-_Looking for Umbraco version 7? [Click here](https://github.com/umbraco/Umbraco-CMS) to go to the v7 branch._
+_Looking for Umbraco version 7? [Click here](https://github.com/umbraco/Umbraco-CMS/tree/dev-v7) to go to the v7 branch._
 
 _Ready to try out Version 8? [See the quick start guide](V8_GETTING_STARTED.md)._
 


### PR DESCRIPTION
The link back to the no-longer-default `dev-v7` branch should be updated.


