### PR TITLE
V8: Fix the "selected" checkmark in tree picker search results

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -166,7 +166,9 @@ body.touch .umb-tree {
 }
 
 .umb-tree .umb-tree-node-checked > .umb-tree-item__inner > i[class^="icon-"],
-.umb-tree .umb-tree-node-checked > .umb-tree-item__inner > i[class*=" icon-"] {
+.umb-tree .umb-tree-node-checked > .umb-tree-item__inner > i[class*=" icon-"],
+.umb-tree .umb-tree-node-checked .umb-search-group-item-name > i[class^="icon-"],
+.umb-tree .umb-tree-node-checked .umb-search-group-item-name > i[class*=" icon-"] {
     font-family: 'icomoon' !important;
     color: @green !important;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4743

### Description

This PR fixes the issue described in #4743. When applied it looks like this:

![selectable-tree-picker-search-results](https://user-images.githubusercontent.com/7405322/53399880-0e16a000-39ad-11e9-85ff-9b2f8cb86c98.gif)

