### PR TITLE
V8: Make it possible to upload the same file twice or more

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfileupload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfileupload.directive.js
@@ -15,7 +15,9 @@ function umbFileUpload() {
             el.on('change', function (event) {
                 var files = event.target.files;
                 //emit event upward
-                scope.$emit("filesSelected", { files: files });                           
+                scope.$emit("filesSelected", { files: files });
+                //clear the element value - this allows us to pick the same file again and again
+                el.val('');
             });
         }
     };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4723

### Description

The issue described in #4723 applies to both the image cropper and the regular file upload.

Here's a GIF that shows the issue in effect:

![image-cropper-same-file-before](https://user-images.githubusercontent.com/7405322/53412463-b76b8f00-39c9-11e9-82d5-7018088bc1ab.gif)

### Testing this PR

1. Create a new file or image from the tree (don't upload an image to create it).
2. Pick an image and verify that the image is displayed.
3. Click "Remove image".
4. Pick the *same* image and verify that the image is displayed again.
5. Rinse and repeat.

It should look like this for image cropper:

![image-cropper-same-file-after](https://user-images.githubusercontent.com/7405322/53412563-fbf72a80-39c9-11e9-8af4-4081fad7de28.gif)

...and like this for regular file uploads:

![file-upload-same-file-after](https://user-images.githubusercontent.com/7405322/53412584-18936280-39ca-11e9-99e3-aa1180252519.gif)
