### PR TITLE
V8: Datatype configs are not validated in infinite editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.controller.js
@@ -99,6 +99,10 @@
         }
 
         function submit() {
+            if (!formHelper.submitForm({ scope: $scope })) {
+                return;
+            }
+
             vm.saveButtonState = "busy";
 
             var preValues = dataTypeHelper.createPreValueProps(vm.dataType.preValues);

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.html
@@ -1,7 +1,8 @@
 <div ng-controller="Umbraco.Editors.DataTypeSettingsController as vm">
-<umb-editor-view data-element="editor-data-type-settings">
 
-    <form novalidate name="dataTypeSettingsForm" val-form-manager>
+<form novalidate name="dataTypeSettingsForm" val-form-manager>
+
+    <umb-editor-view data-element="editor-data-type-settings">
 
         <umb-editor-header
             name="model.title"
@@ -66,7 +67,8 @@
             </umb-editor-footer-content-right>
         </umb-editor-footer>
 
-    </form>
+    </umb-editor-view>
 
-</umb-editor-view>
+</form>
+
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4685 (in part)

### Description

As-is there's no validation of datatype configurations when creating new datatypes or editing existing ones in infinite editing. This leads to issues like #4685 where datatypes are missing some mandatory configuration.

This PR adds the missing validation on the clientside:

![datatype-config-validation-infinite-editing](https://user-images.githubusercontent.com/7405322/53486515-3a075380-3a89-11e9-850e-51517061022b.gif)
