### PR TITLE
V8: Allow nested content without blueprints

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -127,6 +127,9 @@
     border-radius: 200px;
     text-decoration: none !important;
 }
+.umb-nested-content__icon.umb-nested-content__icon--disabled:hover {
+    cursor: default;
+}
 
 .umb-nested-content__icon:hover,
 .umb-nested-content__icon--active

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -34,7 +34,7 @@
                         <input type="text" ng-model="config.nameTemplate" />
                     </td>
                     <td>
-                        <a class="btn btn-danger" ng-click="remove($index)" ng-show="model.value.length > 1">
+                        <a class="btn btn-danger" ng-click="remove($index)">
                             <localize key="general_delete">Delete</localize>
                         </a>
                     </td>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -37,7 +37,7 @@
         </div>
 
         <div class="umb-nested-content__footer-bar" ng-hide="nodes.length >= maxItems">
-            <a href class="umb-nested-content__icon" ng-click="openNodeTypePicker($event)" prevent-default>
+            <a href class="umb-nested-content__icon" ng-class="{ 'umb-nested-content__icon--disabled': !scaffolds.length }" ng-click="openNodeTypePicker($event)" prevent-default>
                 <i class="icon icon-add"></i>
             </a>
         </div>

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
@@ -35,9 +35,9 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         public override Type GetPropertyValueType(PublishedPropertyType propertyType)
         {
             var contentTypes = propertyType.DataType.ConfigurationAs<NestedContentConfiguration>().ContentTypes;
-            return contentTypes.Length > 1
-                ? typeof (IEnumerable<IPublishedElement>)
-                : typeof (IEnumerable<>).MakeGenericType(ModelType.For(contentTypes[0].Alias));
+            return contentTypes.Length == 1
+                ? typeof (IEnumerable<>).MakeGenericType(ModelType.For(contentTypes[0].Alias))
+                : typeof (IEnumerable<IPublishedElement>);
         }
 
         /// <inheritdoc />
@@ -57,9 +57,9 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             {
                 var configuration = propertyType.DataType.ConfigurationAs<NestedContentConfiguration>();
                 var contentTypes = configuration.ContentTypes;
-                var elements = contentTypes.Length > 1
-                    ? new List<IPublishedElement>()
-                    : PublishedModelFactory.CreateModelList(contentTypes[0].Alias);
+                var elements = contentTypes.Length == 1
+                    ? PublishedModelFactory.CreateModelList(contentTypes[0].Alias)
+                    : new List<IPublishedElement>();
 
                 var value = (string)inter;
                 if (string.IsNullOrWhiteSpace(value)) return elements;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4685 

### Description

#4685 calls for the ability to create NC configs without item blueprints to ease the workflow when working with infinite editing. 

This PR implements that change. Note that I have opted to retain the default row in the item blueprints when creating a new NC datatype, but it's possible to delete it. Coupled with #4776 this should give the best experience when setting up things: NC doesn't really make sense to use without blueprints, so a validation error stating that you need at least one blueprint (#4776) + an option to move along by deleting the default row (this PR) is in my opinion the best approach.

It looks like this:

![nested-content-without-blueprints](https://user-images.githubusercontent.com/7405322/53488280-27434d80-3a8e-11e9-9fab-72aa26ca0d20.gif)

**Note:** Don't attempt to submit the NC config with a blank default row. It breaks stuff (#4776 fixes it).