### PR TITLE
V8: Fix "ambient scope" error when creating content template from content

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2862,7 +2862,7 @@ namespace Umbraco.Core.Services.Implement
         {
             if (blueprint == null) throw new ArgumentNullException(nameof(blueprint));
 
-            var contentType = _contentTypeRepository.Get(blueprint.ContentType.Id);
+            var contentType = GetContentType(blueprint.ContentType.Alias);
             var content = new Content(name, -1, contentType);
             content.Path = string.Concat(content.ParentId.ToString(), ",", content.Id);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4774

### Description

This PR fixes the problem with "missing ambient scope" as described in #4774 

#### Testing this PR

It's simple, really: Create a content template from some content. If it works, the PR works 😄 

But... there are another couple of issues with creating content templates from content, one of which being you can't create content templates from culture variant content. So this PR can only be tested with culture *in*variant content. I'm looking into that other issue now.

*Update*: PRs for other issues are #4783 and #4784 