### PR TITLE
V8: Created content templates from content do not use the specified template name

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2878,14 +2878,11 @@ namespace Umbraco.Core.Services.Implement
                     content.SetValue(property.Alias, property.GetValue(culture), culture);
                 }
 
-                content.Name = blueprint.Name;
                 if (!string.IsNullOrEmpty(culture))
                 {
                     content.SetCultureInfo(culture, blueprint.GetCultureName(culture), now);
                 }
             }
-
-
 
             return content;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When creating content templates from content it looks like the original content item name is used for the template, rather than the name given when creating the template. This PR ensures that the specified template name is used instead.

#### Testing this PR

First of all you can't test this PR until #4782 is merged in.

1. Create a content template from some culture *in*variant content.
2. Make sure to name the template something else than the content item name (the suggested name).
3. Verify that the template is indeed created using the specified template name, not the original content item name.