### PR TITLE
V8: Show the content app for media folders with content properties

### DIFF
--- a/src/Umbraco.Web/ContentApps/ContentEditorContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentEditorContentAppFactory.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Web.ContentApps
                         Weight = Weight
                     });
 
-                case IMedia media when !media.ContentType.IsContainer && media.ContentType.Alias != Core.Constants.Conventions.MediaTypes.Folder:
+                case IMedia media when !media.ContentType.IsContainer || media.Properties.Count > 0:
                     return _mediaApp ?? (_mediaApp = new ContentApp
                     {
                         Alias = "umbContent",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4764

### Description

For some reason the content app is explicitly disabled for media folders (container types) as described in #4764. 

This PR adds the content app for media folders if one or more properties are defined on the folder media type.

It looks like this:

![content-app-on-media-folders](https://user-images.githubusercontent.com/7405322/53515338-06005280-3aca-11e9-872c-69678e91f49c.gif)
