### PR TITLE
Fix for Content App badges not being displayed (#4787)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
@@ -7,7 +7,7 @@
     ng-class="{'is-active': vm.item.active, '-has-error': vm.item.hasError}">
     <i class="icon {{ vm.item.icon }}"></i>
     <span class="umb-sub-views-nav-item-text">{{ vm.item.name }}</span>
-    <div ng-show="item.badge" class="badge -type-{{vm.item.badge.type}}">{{vm.item.badge.count}}</div>
+    <div ng-show="vm.item.badge" class="badge -type-{{vm.item.badge.type}}">{{vm.item.badge.count}}</div>
 </a>
 
 <ul class="dropdown-menu umb-sub-views-nav-item__anchor_dropdown" ng-if="vm.item.anchors && vm.item.anchors.length > 1">


### PR DESCRIPTION
- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this 

fixes #4787 

### Description
Fixes the badge not being displayed in Content Apps

To test:
1. Create a content app with the contents of the attached zip file ([ContentAppBadge.zip](https://github.com/umbraco/Umbraco-CMS/files/2912924/ContentAppBadge.zip))
2. Go to any page and click the "Click Me!" button
3. without the patch, the badge won't show although you will be able to see it by inspecting the html in dev tools
