### PR TITLE
v8 - uduf - Redirect away from page under the settings section when the page is deleted

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -5210,12 +5210,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5230,17 +5232,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5357,7 +5362,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5369,6 +5375,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5383,6 +5390,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5390,12 +5398,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5414,6 +5424,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5494,7 +5505,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5506,6 +5518,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5627,6 +5640,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -13,7 +13,7 @@
  * Section navigation and search, and maintain their state for the entire application lifetime
  *
  */
-function navigationService($routeParams, $location, $q, $timeout, $injector, eventsService, umbModelMapper, treeService, appState, editorState) {
+function navigationService($routeParams, $location, $q, $timeout, $injector, eventsService, umbModelMapper, treeService, appState) {
 
     //the promise that will be resolved when the navigation is ready
     var navReadyPromise = $q.defer();
@@ -26,18 +26,7 @@ function navigationService($routeParams, $location, $q, $timeout, $injector, eve
         navReadyPromise.resolve(mainTreeApi);
     });
 
-    eventsService.on("treeService.removeNode", function (e, args) {
-        //check to see if the current page has been removed
-     
-
-        var currentEditorState = editorState.getCurrent()
-        console.log("currentEditorState", currentEditorState);
-        if (currentEditorState && currentEditorState.id === args.node.id) {
-            //current page is loaded, so navigate to root
-            var section = appState.getSectionState("currentSection");
-            $location.path("/" + section);
-        }
-    });
+    
 
     //A list of query strings defined that when changed will not cause a reload of the route
     var nonRoutingQueryStrings = ["mculture", "cculture", "lq"];

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -13,7 +13,7 @@
  * Section navigation and search, and maintain their state for the entire application lifetime
  *
  */
-function navigationService($routeParams, $location, $q, $timeout, $injector, eventsService, umbModelMapper, treeService, appState) {
+function navigationService($routeParams, $location, $q, $timeout, $injector, eventsService, umbModelMapper, treeService, appState, editorState) {
 
     //the promise that will be resolved when the navigation is ready
     var navReadyPromise = $q.defer();
@@ -24,6 +24,19 @@ function navigationService($routeParams, $location, $q, $timeout, $injector, eve
     eventsService.on("app.navigationReady", function (e, args) {
         mainTreeApi = args.treeApi;
         navReadyPromise.resolve(mainTreeApi);
+    });
+
+    eventsService.on("treeService.removeNode", function (e, args) {
+        //check to see if the current page has been removed
+     
+
+        var currentEditorState = editorState.getCurrent()
+        console.log("currentEditorState", currentEditorState);
+        if (currentEditorState != null && currentEditorState.id === args.node.id) {
+            //current page is loaded, so navigate to root
+            var section = appState.getSectionState("currentSection");
+            $location.path("/" + section);
+        }
     });
 
     //A list of query strings defined that when changed will not cause a reload of the route

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -32,7 +32,7 @@ function navigationService($routeParams, $location, $q, $timeout, $injector, eve
 
         var currentEditorState = editorState.getCurrent()
         console.log("currentEditorState", currentEditorState);
-        if (currentEditorState != null && currentEditorState.id === args.node.id) {
+        if (currentEditorState && currentEditorState.id === args.node.id) {
             //current page is loaded, so navigate to root
             var section = appState.getSectionState("currentSection");
             $location.path("/" + section);

--- a/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
@@ -350,6 +350,9 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
             parent.children.splice(parent.children.indexOf(treeNode), 1);
 
             parent.hasChildren = parent.children.length !== 0;
+            
+            //Notify that the node has been removed
+            eventsService.emit("treeService.removeNode", { node: treeNode });
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/controllers/navigation.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/navigation.controller.js
@@ -10,7 +10,7 @@
  * @param {navigationService} navigationService A reference to the navigationService
  */
 function NavigationController($scope, $rootScope, $location, $log, $q, $routeParams, $timeout, $cookies, treeService, appState, navigationService, keyboardService, historyService, eventsService, angularHelper, languageResource, contentResource, editorState) {
-    console.log(2)
+
     //this is used to trigger the tree to start loading once everything is ready
     var treeInitPromise = $q.defer();
 

--- a/src/Umbraco.Web.UI.Client/src/controllers/navigation.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/navigation.controller.js
@@ -9,8 +9,8 @@
  *
  * @param {navigationService} navigationService A reference to the navigationService
  */
-function NavigationController($scope, $rootScope, $location, $log, $q, $routeParams, $timeout, $cookies, treeService, appState, navigationService, keyboardService, historyService, eventsService, angularHelper, languageResource, contentResource) {
-
+function NavigationController($scope, $rootScope, $location, $log, $q, $routeParams, $timeout, $cookies, treeService, appState, navigationService, keyboardService, historyService, eventsService, angularHelper, languageResource, contentResource, editorState) {
+    console.log(2)
     //this is used to trigger the tree to start loading once everything is ready
     var treeInitPromise = $q.defer();
 
@@ -248,6 +248,20 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
     evts.push(eventsService.on("appState.editors.close", function (name, args) {
         $scope.infiniteMode = args && args.editors.length > 0 ? true : false;
     }));
+
+    evts.push(eventsService.on("treeService.removeNode", function (e, args) {
+        //check to see if the current page has been removed
+
+        var currentEditorState = editorState.getCurrent()
+        if (currentEditorState && currentEditorState.id.toString() === args.node.id.toString()) {
+            //current page is loaded, so navigate to root
+            var section = appState.getSectionState("currentSection");
+            $location.path("/" + section);
+        }
+    }));
+
+
+    
 
     /**
      * Based on the current state of the application, this configures the scope variables that control the main tree and language drop down

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting content
  */
-function DataTypeDeleteController($scope, dataTypeResource, treeService, navigationService) {
+function DataTypeDeleteController($scope, $location, dataTypeResource, treeService, navigationService, appState) {
 
     $scope.performDelete = function() {
 
@@ -22,6 +22,12 @@ function DataTypeDeleteController($scope, dataTypeResource, treeService, navigat
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu();
         });
+
+        if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
+            //The deleted DataType is open, so redirect
+            var section = appState.getSectionState("currentSection");
+            $location.path("/" + section);
+        }
 
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.delete.controller.js
@@ -22,13 +22,6 @@ function DataTypeDeleteController($scope, $location, dataTypeResource, treeServi
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu();
         });
-
-        if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
-            //The deleted DataType is open, so redirect
-            var section = appState.getSectionState("currentSection");
-            $location.path("/" + section);
-        }
-
     };
 
     $scope.performContainerDelete = function () {

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.controller.js
@@ -6,8 +6,8 @@
  * @description
  * The controller for deleting content
  */
-function DocumentTypesDeleteController($scope, $location, dataTypeResource, contentTypeResource, treeService, navigationService, appState) {
-    
+function DocumentTypesDeleteController($scope, dataTypeResource, contentTypeResource, treeService, navigationService) {
+
     $scope.performDelete = function() {
 
         //mark it for deletion (used in the UI)
@@ -22,11 +22,6 @@ function DocumentTypesDeleteController($scope, $location, dataTypeResource, cont
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu(); 
 
-            if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
-                //The deleted doctype is open, so redirect 
-                var section = appState.getSectionState("currentSection");
-                $location.path("/" + section );
-            }
         });
 
     };

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.controller.js
@@ -6,8 +6,8 @@
  * @description
  * The controller for deleting content
  */
-function DocumentTypesDeleteController($scope, dataTypeResource, contentTypeResource, treeService, navigationService) {
-
+function DocumentTypesDeleteController($scope, $location, dataTypeResource, contentTypeResource, treeService, navigationService, appState) {
+    
     $scope.performDelete = function() {
 
         //mark it for deletion (used in the UI)
@@ -20,7 +20,13 @@ function DocumentTypesDeleteController($scope, dataTypeResource, contentTypeReso
 
             // TODO: Need to sync tree, etc...
             treeService.removeNode($scope.currentNode);
-            navigationService.hideMenu();
+            navigationService.hideMenu(); 
+
+            if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
+                //The deleted doctype is open, so redirect 
+                var section = appState.getSectionState("currentSection");
+                $location.path("/" + section );
+            }
         });
 
     };
@@ -38,6 +44,7 @@ function DocumentTypesDeleteController($scope, dataTypeResource, contentTypeReso
             // TODO: Need to sync tree, etc...
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu();
+
         });
 
     };

--- a/src/Umbraco.Web.UI.Client/src/views/macros/macros.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/macros.delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting macro items
  */
-function MacrosDeleteController($scope, $location, macroResource, navigationService, treeService) {
+function MacrosDeleteController($scope, $location, macroResource, navigationService, treeService, appState) {
     var vm = this;
     
     vm.name = $scope.currentNode.name;
@@ -18,6 +18,14 @@ function MacrosDeleteController($scope, $location, macroResource, navigationServ
             treeService.removeNode($scope.currentNode);
             
             navigationService.hideMenu();
+
+            if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
+                //The deleted Macro is open, so redirect
+                var section = appState.getSectionState("currentSection");
+                $location.path("/" + section);
+            }
+
+
         });
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/macros/macros.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/macros.delete.controller.js
@@ -18,14 +18,6 @@ function MacrosDeleteController($scope, $location, macroResource, navigationServ
             treeService.removeNode($scope.currentNode);
             
             navigationService.hideMenu();
-
-            if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
-                //The deleted Macro is open, so redirect
-                var section = appState.getSectionState("currentSection");
-                $location.path("/" + section);
-            }
-
-
         });
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.controller.js
@@ -21,12 +21,6 @@ function MediaTypesDeleteController($scope, $location, dataTypeResource, mediaTy
             // TODO: Need to sync tree, etc...
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu();
-
-            if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) { 
-             //The deleted MediaType is open, so redirect
-                var section = appState.getSectionState("currentSection");
-                $location.path("/" + section);
-            }
         });
 
     };

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the media type delete dialog
  */
-function MediaTypesDeleteController($scope, dataTypeResource, mediaTypeResource, treeService, navigationService) {
+function MediaTypesDeleteController($scope, $location, dataTypeResource, mediaTypeResource, treeService, navigationService, appState) {
 
     $scope.performDelete = function() {
 
@@ -21,6 +21,12 @@ function MediaTypesDeleteController($scope, dataTypeResource, mediaTypeResource,
             // TODO: Need to sync tree, etc...
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu();
+
+            if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) { 
+             //The deleted MediaType is open, so redirect
+                var section = appState.getSectionState("currentSection");
+                $location.path("/" + section);
+            }
         });
 
     };

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting member types
  */
-function MemberTypesDeleteController($scope, memberTypeResource, treeService, navigationService) {
+function MemberTypesDeleteController($scope, $location, memberTypeResource, treeService, navigationService, appState) {
 
     $scope.performDelete = function() {
 
@@ -21,6 +21,12 @@ function MemberTypesDeleteController($scope, memberTypeResource, treeService, na
             // TODO: Need to sync tree, etc...
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu();
+
+            if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
+               //The deleted MemberType is open, so redirect
+                var section = appState.getSectionState("currentSection");
+                $location.path("/" + section);
+            }
         });
 
     };

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting member types
  */
-function MemberTypesDeleteController($scope, $location, memberTypeResource, treeService, navigationService, appState) {
+function MemberTypesDeleteController($scope, memberTypeResource, treeService, navigationService) {
 
     $scope.performDelete = function() {
 
@@ -22,11 +22,6 @@ function MemberTypesDeleteController($scope, $location, memberTypeResource, tree
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu();
 
-            if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
-               //The deleted MemberType is open, so redirect
-                var section = appState.getSectionState("currentSection");
-                $location.path("/" + section);
-            }
         });
 
     };

--- a/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting partial view macros
  */
-function PartialViewMacrosDeleteController($scope, codefileResource, treeService, navigationService) {
+function PartialViewMacrosDeleteController($scope, $location, codefileResource, treeService, navigationService, appState) {
 
     $scope.performDelete = function() {
 
@@ -21,6 +21,12 @@ function PartialViewMacrosDeleteController($scope, codefileResource, treeService
                 // TODO: Need to sync tree, etc...
                 treeService.removeNode($scope.currentNode);
                 navigationService.hideMenu();
+
+                if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
+                    //The deleted PartialViewMacro is open, so redirect
+                    var section = appState.getSectionState("currentSection");
+                    $location.path("/" + section);
+                }
             });
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting partial view macros
  */
-function PartialViewMacrosDeleteController($scope, $location, codefileResource, treeService, navigationService, appState) {
+function PartialViewMacrosDeleteController($scope, codefileResource, treeService, navigationService) {
 
     $scope.performDelete = function() {
 
@@ -22,11 +22,6 @@ function PartialViewMacrosDeleteController($scope, $location, codefileResource, 
                 treeService.removeNode($scope.currentNode);
                 navigationService.hideMenu();
 
-                if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
-                    //The deleted PartialViewMacro is open, so redirect
-                    var section = appState.getSectionState("currentSection");
-                    $location.path("/" + section);
-                }
             });
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/partialviews/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviews/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting partial views
  */
-function PartialViewsDeleteController($scope, codefileResource, treeService, navigationService) {
+function PartialViewsDeleteController($scope, $location, codefileResource, treeService, navigationService, appState) {
 
     $scope.performDelete = function() {
 
@@ -24,6 +24,13 @@ function PartialViewsDeleteController($scope, codefileResource, treeService, nav
                 // TODO: Need to sync tree, etc...
                 treeService.removeNode($scope.currentNode);
                 navigationService.hideMenu();
+
+                if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
+                    //The deleted PartialView is open, so redirect
+                    var section = appState.getSectionState("currentSection");
+                    $location.path("/" + section);
+                }
+
             }, function (err) {
                 $scope.currentNode.loading = false;
                 $scope.error = err;

--- a/src/Umbraco.Web.UI.Client/src/views/partialviews/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviews/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting partial views
  */
-function PartialViewsDeleteController($scope, $location, codefileResource, treeService, navigationService, appState) {
+function PartialViewsDeleteController($scope, codefileResource, treeService, navigationService) {
 
     $scope.performDelete = function() {
 
@@ -24,12 +24,6 @@ function PartialViewsDeleteController($scope, $location, codefileResource, treeS
                 // TODO: Need to sync tree, etc...
                 treeService.removeNode($scope.currentNode);
                 navigationService.hideMenu();
-
-                if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
-                    //The deleted PartialView is open, so redirect
-                    var section = appState.getSectionState("currentSection");
-                    $location.path("/" + section);
-                }
 
             }, function (err) {
                 $scope.currentNode.loading = false;

--- a/src/Umbraco.Web.UI.Client/src/views/scripts/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/scripts/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting scripts
  */
-function ScriptsDeleteController($scope, $location, codefileResource, treeService, navigationService, appState) {
+function ScriptsDeleteController($scope, codefileResource, treeService, navigationService) {
 
     $scope.performDelete = function() {
 
@@ -21,12 +21,6 @@ function ScriptsDeleteController($scope, $location, codefileResource, treeServic
                 // TODO: Need to sync tree, etc...
                 treeService.removeNode($scope.currentNode);
                 navigationService.hideMenu();
-
-                if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
-                    //The deleted Script is open, so redirect
-                    var section = appState.getSectionState("currentSection");
-                    $location.path("/" + section);
-                }
 
             });
     };

--- a/src/Umbraco.Web.UI.Client/src/views/scripts/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/scripts/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting scripts
  */
-function ScriptsDeleteController($scope, codefileResource, treeService, navigationService) {
+function ScriptsDeleteController($scope, $location, codefileResource, treeService, navigationService, appState) {
 
     $scope.performDelete = function() {
 
@@ -21,6 +21,13 @@ function ScriptsDeleteController($scope, codefileResource, treeService, navigati
                 // TODO: Need to sync tree, etc...
                 treeService.removeNode($scope.currentNode);
                 navigationService.hideMenu();
+
+                if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
+                    //The deleted Script is open, so redirect
+                    var section = appState.getSectionState("currentSection");
+                    $location.path("/" + section);
+                }
+
             });
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting stylesheets
  */
-function StyleSheetsDeleteController($scope, $location, codefileResource, treeService, navigationService, appState) {
+function StyleSheetsDeleteController($scope, codefileResource, treeService, navigationService) {
 
     $scope.performDelete = function() {
 
@@ -18,12 +18,6 @@ function StyleSheetsDeleteController($scope, $location, codefileResource, treeSe
                 $scope.currentNode.loading = false;
                 treeService.removeNode($scope.currentNode);
                 navigationService.hideMenu();
-
-                if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
-                    //The deleted StyleSheet is open, so redirect
-                    var section = appState.getSectionState("currentSection");
-                    $location.path("/" + section);
-                }
             });
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting stylesheets
  */
-function StyleSheetsDeleteController($scope, codefileResource, treeService, navigationService) {
+function StyleSheetsDeleteController($scope, $location, codefileResource, treeService, navigationService, appState) {
 
     $scope.performDelete = function() {
 
@@ -18,6 +18,12 @@ function StyleSheetsDeleteController($scope, codefileResource, treeService, navi
                 $scope.currentNode.loading = false;
                 treeService.removeNode($scope.currentNode);
                 navigationService.hideMenu();
+
+                if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
+                    //The deleted StyleSheet is open, so redirect
+                    var section = appState.getSectionState("currentSection");
+                    $location.path("/" + section);
+                }
             });
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/templates/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the template delete dialog
  */
-function TemplatesDeleteController($scope, templateResource , treeService, navigationService) {
+function TemplatesDeleteController($scope, $location, templateResource, treeService, navigationService, appState) {
 
     $scope.performDelete = function() {
 
@@ -25,6 +25,14 @@ function TemplatesDeleteController($scope, templateResource , treeService, navig
             // TODO: Need to sync tree, etc...
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu();
+
+            if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
+                //The deleted Template is open, so redirect
+                var section = appState.getSectionState("currentSection");
+                $location.path("/" + section);
+            }
+
+
         }, function (err) {
             $scope.currentNode.loading = false;
             $scope.error = err;

--- a/src/Umbraco.Web.UI.Client/src/views/templates/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the template delete dialog
  */
-function TemplatesDeleteController($scope, $location, templateResource, treeService, navigationService, appState) {
+function TemplatesDeleteController($scope, templateResource, treeService, navigationService) {
 
     $scope.performDelete = function() {
 
@@ -25,13 +25,6 @@ function TemplatesDeleteController($scope, $location, templateResource, treeServ
             // TODO: Need to sync tree, etc...
             treeService.removeNode($scope.currentNode);
             navigationService.hideMenu();
-
-            if ("/" + $scope.currentNode.routePath.toLowerCase() === $location.path().toLowerCase()) {
-                //The deleted Template is open, so redirect
-                var section = appState.getSectionState("currentSection");
-                $location.path("/" + section);
-            }
-
 
         }, function (err) {
             $scope.currentNode.loading = false;


### PR DESCRIPTION
 Affects DataTypes, DocTypes, Macros, MediaTypes, Membertypes, PartialViewMacro,PartialViews, Scripts, Stylesheet & Templates

### Prerequisites

- [X ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this 

fixes #4489 

### Description
Deleting nodes in the settings section will now redirect to /settings if the deleted page is currently open. 

Redirection does not happen when the deleted node is not already open, so as not to loose changes in the open page.