### PR TITLE
v8 - uduf - Fixes hotkey for navigation between apps and content apps

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditornavigationitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditornavigationitem.directive.js
@@ -42,7 +42,7 @@
                 item: '=',
                 onOpen: '&',
                 onOpenAnchor: '&',
-                index: '@'
+                hotkey: '<'
             }
         });
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
@@ -1,10 +1,10 @@
 <a data-element="sub-view-{{vm.item.alias}}"
-    tabindex="-1"
-    ng-href=""
-    ng-click="vm.clicked()"
-    hotkey="{{vm.index+1}}"
-    hotkey-when-hidden="true"
-    ng-class="{'is-active': vm.item.active, '-has-error': vm.item.hasError}">
+   tabindex="-1"
+   ng-href=""
+   ng-click="vm.clicked()"
+   hotkey="{{::vm.hotkey}}"
+   hotkey-when-hidden="true"
+   ng-class="{'is-active': vm.item.active, '-has-error': vm.item.hasError}">
     <i class="icon {{ vm.item.icon }}"></i>
     <span class="umb-sub-views-nav-item-text">{{ vm.item.name }}</span>
     <div ng-show="item.badge" class="badge -type-{{vm.item.badge.type}}">{{vm.item.badge.count}}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
@@ -7,7 +7,7 @@
                 item="navItem"
                 on-open="openNavigationItem(item)"
                 on-open-anchor="openAnchorItem(item, anchor)"
-                index="{{$index}}">
+                hotkey="$index + 1">
             </umb-editor-navigation-item>
         </div>
     </li>


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/4757

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4757

It also partially fixes https://github.com/umbraco/Umbraco-CMS/issues/4795 with the cycling of apps.

### Description

#### How to test
1. Go to `Users` section
2. Create a new user
3. Use Auto-fill for either the name or email address
4. You should see that the active App/Content App does not change
5. You should be able to successfully save the user

When editing/adding a new Document Type or in any other section, you should be able to cycle through the different Apps/Content Apps using numbers from 1 to 4 (or more if they exist).

CAUTION: The magic number 11 set as a hotkey will bring back this issue.  

Done at UDUF 2019 with the help of @dallascharter and @Shazwazza 
