### PR TITLE
Fix unable to manually set member password via backoffice

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/users/changepassword.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/users/changepassword.directive.js
@@ -94,6 +94,8 @@
       //if there was a previously generated password displaying, clear it
       $scope.passwordValues.generatedPassword = null;
       $scope.passwordValues.confirm = null;
+      $scope.passwordValues.reset = false;
+
     };
 
     $scope.cancelChange = function () {

--- a/src/Umbraco.Web/Editors/PasswordChanger.cs
+++ b/src/Umbraco.Web/Editors/PasswordChanger.cs
@@ -177,11 +177,11 @@ namespace Umbraco.Web.Editors
             //Are we resetting the password?
             //This flag indicates that either an admin user is changing another user's password without knowing the original password
             // or that the password needs to be reset to an auto-generated one.
-            if (passwordModel.Reset.HasValue && passwordModel.Reset.Value)
+            if (passwordModel.Reset.HasValue)
             {
                 //if a new password is supplied then it's an admin user trying to change another user's password without knowing the original password
                 //this is only possible when using a membership provider if the membership provider supports AllowManuallyChangingPassword
-                if (passwordModel.NewPassword.IsNullOrWhiteSpace() == false)
+                if (!passwordModel.Reset.Value && passwordModel.NewPassword.IsNullOrWhiteSpace() == false)
                 {
                     if (membershipProvider is MembershipProviderBase umbracoBaseProvider && umbracoBaseProvider.AllowManuallyChangingPassword)
                     {


### PR DESCRIPTION
### Prerequisites

Branched from `dev-v7` as issue was found on project using Umbraco 7.13.2.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/4144.

### Description

When viewing a member in the backoffice, if the user clicks "Change Password", the code will now set the `reset` value to `false`. When the page is submitted the logic in `PasswordChanger.ChangePasswordWithMembershipProvider` will now check if the `reset` property has a value, if it does it's assumes someone is trying to change a password via the backoffice, then the other checks will occur (whether the user can change the password, whether changing passwords is configured, etc...).