### PR TITLE
V8: Make sure to hide the member types when creating a new member

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/member/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/create.html
@@ -6,7 +6,7 @@
             <ul class="umb-actions umb-actions-child">
 
                 <li class="umb-action" ng-repeat="docType in allowedTypes">
-                    <a class="umb-action-link" href="#member/member/edit/{{currentNode.id}}?doctype={{docType.alias}}&create=true" ng-click="nav.hideNavigation()">
+                    <a class="umb-action-link" href="#member/member/edit/{{currentNode.id}}?doctype={{docType.alias}}&create=true" ng-click="hideActions()">
                         <i class="large icon {{docType.icon}}"></i>
                         <span class="menu-label">
                             {{docType.name}}

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.create.controller.js
@@ -16,7 +16,10 @@ function memberCreateController($scope, memberTypeResource, iconHelper, navigati
         const showMenu = true;
         navigationService.hideDialog(showMenu);
     };
-    
+
+    $scope.hideActions = function () {
+        navigationService.hideNavigation();
+    };
 }
 
 angular.module('umbraco').controller("Umbraco.Editors.Member.CreateController", memberCreateController);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4699

### Description

As described in #4699, the "Create a new member" dialog is prone to get very sticky; it doesn't hide itself when a member type is selected:

![create-member-before](https://user-images.githubusercontent.com/7405322/53643342-18969b00-3c34-11e9-9ff5-953abc7aba62.gif)

This PR fixes it, so the dialog closes upon member type selection:

![create-member-after](https://user-images.githubusercontent.com/7405322/53643368-26e4b700-3c34-11e9-8b87-5075123deb20.gif)
