### PR TITLE
V8: Handle checkbox value conversion from Nested Content

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
@@ -36,6 +36,10 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
             if (source is int)
                 return (int)source == 1;
 
+            // this is required for correct true/false handling in nested content elements
+            if (source is long)
+                return (long)source == 1;
+
             if (source is bool)
                 return (bool)source;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4812

### Description

Turns out the `YesNoValueConverter` can't handle the checkbox value output from the deserialized Nested Content property value. The deserialized checkbox  value output is a `long`.

I have added handling for `long` in `YesNoValueConverter` with this PR 😄 

#### Testing this PR

1. Create some Nested Content with at checkbox.
2. Verify that the rendered page output converts the checkbox value correctly.

#### Test template

You can use the template below for testing. It assumes that your Nested Content property is called "list" and that the element checkbox is called "enabled" (adjust the template to your testing setup).

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@{
	Layout = null;
}

<html>
    <body>
        <ul>
        @foreach(var element in Model.Value<IEnumerable<IPublishedElement>>("list")) {
            <li>Enabled: @element.Value("enabled") (@element.ContentType.Alias)</li>        
        }
        </ul>
    </body>
</html>
```
