### PR TITLE
V8: Hide empty sticky bar in Grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -1,10 +1,9 @@
 <div ng-controller="Umbraco.PropertyEditors.GridController" class="umb-grid umb-property-editor clearfix" id="umb-grid">
 
-    <umb-editor-sub-header style="background-color: white;">
+    <umb-editor-sub-header ng-if="showReorderButton()" style="background-color: white;">
 
         <umb-editor-sub-header-content-right>
             <umb-button
-                ng-if="showReorderButton()"
                 type="button"
                 icon="icon-navigation"
                 button-style="link"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4706

### Description

As described in #4706, the sticky bar in the Grid containing the "Reorder" action button should only be visible if reordering the Grid content is actually viable.

This PR fixes it - it looks like this:

![grid-hide-empty-sticky-bar](https://user-images.githubusercontent.com/7405322/53681024-a8dfe900-3ce3-11e9-9109-0326eb66b7f4.gif)
