### PR TITLE
V8: Remove underline under the info icon when hovering a media grid item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -132,6 +132,10 @@
    
    &:hover {
        text-decoration: underline;
+
+       i {
+           text-decoration: none;
+       }
    }
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4623

### Description

See #4623 for details.

Here's how it looks *without* this PR applied:

![image](https://user-images.githubusercontent.com/7405322/53694389-646d4f80-3dae-11e9-9936-99f771e37301.png)

...and here's how it looks *with* this PR applied:

![image](https://user-images.githubusercontent.com/7405322/53694399-836be180-3dae-11e9-9c4b-0a1bf106a061.png)

