### PR TITLE
V8: Update validation colors throughout the backoffice

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -250,3 +250,11 @@
 .form-horizontal .umb-overlay .controls {
     margin-left: 0 !important;
 }
+
+.umb-overlay .text-error {
+    color: @formErrorText;
+}
+
+.umb-overlay .text-success {
+    color: @formSuccessText;
+}

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -41,8 +41,8 @@
 @purple-washed:		    #F6F3FD;
 
 // UI Colors
-@red-d1:                #F02E28;// currently used for validation, and is hard coded inline in various html places :/
-@red:                   #D42054;// updated 2019 - should be used as validation! and is already in some cases like the .umb-validation-label
+@red-d1:                #F02E28;
+@red:                   #D42054;// updated 2019
 @red-l1:			    #e22c60;// updated 2019
 @red-l2:			    #FE8B88;
 @red-l3:			    #FFB2B0;
@@ -508,7 +508,7 @@
 @warningBorder:           transparent;
 
 @errorText:               @white;
-@errorBackground:         @red-d1;
+@errorBackground:         @red;
 @errorBorder:             transparent;
 
 @successText:             @white;

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
@@ -31,11 +31,11 @@
                             </span>
 
                             <span class="db" ng-messages="publishVariantSelectorForm.publishVariantSelector.$error" show-validation-on-submit>
-                                <span class="db umb-permission__description" style="color: #F02E28;" ng-message="valServerField">{{publishVariantSelectorForm.publishVariantSelector.errorMsg}}</span>
+                                <span class="db umb-permission__description text-error" ng-message="valServerField">{{publishVariantSelectorForm.publishVariantSelector.errorMsg}}</span>
                             </span>
 
                             <span class="db" ng-repeat="notification in variant.notifications">
-                                <span class="db umb-permission__description" style="color: #1FB572;">{{notification.message}}</span>
+                                <span class="db umb-permission__description text-success">{{notification.message}}</span>
                             </span>
                         </label>
                     </div>
@@ -63,7 +63,7 @@
                 </div>
 
                 <div ng-repeat="notification in variant.notifications">
-                    <div class="umb-permission__description" style="color: #1FB572;">{{notification.message}}</div>
+                    <div class="umb-permission__description text-success">{{notification.message}}</div>
                 </div>
 
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -57,11 +57,11 @@
                                 </span>
 
                                 <span class="db" ng-messages="publishVariantSelectorForm.publishVariantSelector.$error" show-validation-on-submit>
-                                    <span class="db umb-permission__description" style="color: #F02E28;" ng-message="valServerField">{{publishVariantSelectorForm.publishVariantSelector.errorMsg}}</span>
+                                    <span class="db umb-permission__description text-error" ng-message="valServerField">{{publishVariantSelectorForm.publishVariantSelector.errorMsg}}</span>
                                 </span>
 
                                 <span class="db" ng-repeat="notification in variant.notifications">
-                                    <span class="db umb-permission__description" style="color: #1FB572;">{{notification.message}}</span>
+                                    <span class="db umb-permission__description text-success">{{notification.message}}</span>
                                 </span>
                             </label>
                         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.html
@@ -34,11 +34,11 @@
                                 </span>
 
                                 <span class="db" ng-messages="saveVariantSelectorForm.saveVariantSelector.$error" show-validation-on-submit>
-                                    <span class="db umb-permission__description" style="color: #F02E28;" ng-message="valServerField">{{saveVariantSelectorForm.saveVariantSelector.errorMsg}}</span>
+                                    <span class="db umb-permission__description text-error" ng-message="valServerField">{{saveVariantSelectorForm.saveVariantSelector.errorMsg}}</span>
                                 </span>
 
                                 <span class="db" ng-repeat="notification in variant.notifications">
-                                    <span class="db umb-permission__description" style="color: #1FB572;">{{notification.message}}</span>
+                                    <span class="db umb-permission__description text-success">{{notification.message}}</span>
                                 </span>
                             </label>
                         </div>
@@ -77,11 +77,11 @@
                                 </span>
 
                                 <span class="db" ng-messages="saveVariantSelectorForm.saveVariantSelector.$error" show-validation-on-submit>
-                                    <span class="db umb-permission__description" style="color: #F02E28;" ng-message="valServerField">{{saveVariantSelectorForm.saveVariantSelector.errorMsg}}</span>
+                                    <span class="db umb-permission__description text-error" ng-message="valServerField">{{saveVariantSelectorForm.saveVariantSelector.errorMsg}}</span>
                                 </span>
 
                                 <span class="db" ng-repeat="notification in variant.notifications">
-                                    <span class="db umb-permission__description" style="color: #1FB572;">{{notification.message}}</span>
+                                    <span class="db umb-permission__description text-success">{{notification.message}}</span>
                                 </span>
                             </label>
                         </div>
@@ -109,7 +109,7 @@
                     </div>
 
                     <div ng-repeat="notification in variant.notifications">
-                        <div class="umb-permission__description" style="color: #1FB572;">{{notification.message}}</div>
+                        <div class="umb-permission__description text-success">{{notification.message}}</div>
                     </div>
                 </div>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.html
@@ -166,11 +166,11 @@
                                    val-server-field="{{variant.htmlId}}" />
 
                             <div ng-messages="scheduleSelectorForm.saveVariantReleaseDate.$error" show-validation-on-submit>
-                                <div class="umb-permission__description" style="color: #F02E28;" ng-message="valServerField">{{scheduleSelectorForm.saveVariantReleaseDate.errorMsg}}</div>
+                                <div class="umb-permission__description text-error" ng-message="valServerField">{{scheduleSelectorForm.saveVariantReleaseDate.errorMsg}}</div>
                             </div>
 
                             <div ng-repeat="notification in variant.notifications">
-                                <div class="umb-permission__description" style="color: #1FB572;">{{notification.message}}</div>
+                                <div class="umb-permission__description text-success">{{notification.message}}</div>
                             </div>
 
                         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.html
@@ -30,11 +30,11 @@
                             </span>
 
                             <span class="db" ng-messages="publishVariantSelectorForm.publishVariantSelector.$error" show-validation-on-submit>
-                                <span class="db umb-permission__description" style="color: #F02E28;" ng-message="valServerField">{{publishVariantSelectorForm.publishVariantSelector.errorMsg}}</span>
+                                <span class="db umb-permission__description text-error" ng-message="valServerField">{{publishVariantSelectorForm.publishVariantSelector.errorMsg}}</span>
                             </span>
 
                             <span class="db" ng-repeat="notification in variant.notifications">
-                                <span class="db umb-permission__description" style="color: #1FB572;">{{notification.message}}</span>
+                                <span class="db umb-permission__description text-success">{{notification.message}}</span>
                             </span>
                         </label>
                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -129,8 +129,8 @@
                                     <!-- Log Details (Exception & Properties) -->
                                     <tr ng-repeat-end ng-if="log.open">
                                         <td colspan="4">
-                                            <div ng-if="log.Exception" style="border-left:4px solid #fe6561; padding:0 10px 10px 10px; box-shadow:rgba(0,0,0,0.07) 2px 2px 10px">
-                                                <h3 style="color:#fe6561;">Exception</h3>
+                                            <div ng-if="log.Exception" style="border-left:4px solid #D42054; padding:0 10px 10px 10px; box-shadow:rgba(0,0,0,0.07) 2px 2px 10px">
+                                                <h3 class="text-error">Exception</h3>
                                                 <p style="white-space: pre-wrap;">{{ log.Exception }}</p>
                                             </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4645

### Description

This PR updates the red validation error color throughout the backoffice as described in #4645 - and at the same time it also fixes the hardcoded green colors in the various overlays.

Some screenshots of this PR applied:

![image](https://user-images.githubusercontent.com/7405322/53695440-30992680-3dbc-11e9-9377-aaf18f1b54d2.png)

![image](https://user-images.githubusercontent.com/7405322/53695444-40186f80-3dbc-11e9-9c67-88d3fb0a53f6.png)
