### PR TITLE
v8: Nested content delete confirm

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.controller.js
@@ -84,7 +84,7 @@
                 overlayService.open(dialog);
             });
 
-            event.preventDefault()
+            event.preventDefault();
             event.stopPropagation();
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -12,8 +12,7 @@
                 ncAlias: "",
                 ncTabAlias: "",
                 nameTemplate: ""
-            }
-            );
+            });
         }
 
         $scope.remove = function (index) {
@@ -61,16 +60,12 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
     "$scope",
     "$interpolate",
     "$filter",
-    "$timeout",
     "contentResource",
     "localizationService",
+    "overlayService",
     "iconHelper",
 
-    function ($scope, $interpolate, $filter, $timeout, contentResource, localizationService, iconHelper) {
-
-        //$scope.model.config.contentTypes;
-        //$scope.model.config.minItems;
-        //$scope.model.config.maxItems;
+    function ($scope, $interpolate, $filter, contentResource, localizationService, overlayService, iconHelper) {
 
         var inited = false;
 
@@ -166,6 +161,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
         };
 
         $scope.editNode = function (idx) {
+            
             if ($scope.currentNode && $scope.currentNode.key == $scope.nodes[idx].key) {
                 $scope.currentNode = undefined;
             } else {
@@ -173,23 +169,47 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             }
         };
 
-        $scope.deleteNode = function (idx) {
+        $scope.deleteNode = function (node, event) {
+
+            const dialog = {
+                view: "views/propertyeditors/nestedcontent/overlays/delete.html",
+                submitButtonLabelKey: "contentTypeEditor_yesDelete",
+                node: node,
+                submit: function (model) {
+                    performDelete(model.node);
+                    overlayService.close();
+                },
+                close: function () {
+                    overlayService.close();
+                }
+            };
+
             if ($scope.nodes.length > $scope.model.config.minItems) {
                 if ($scope.model.config.confirmDeletes && $scope.model.config.confirmDeletes == 1) {
-                    localizationService.localize('content_nestedContentDeleteItem').then(function (value) {
-                        if (confirm(value)) {
-                            $scope.nodes.splice(idx, 1);
-                            $scope.setDirty();
-                            updateModel();
-                        }
+
+                    localizationService.localize("general_delete").then(value => {
+                        dialog.title = value;
+                        overlayService.open(dialog);
                     });
+
                 } else {
-                    $scope.nodes.splice(idx, 1);
-                    $scope.setDirty();
-                    updateModel();
+                    performDelete(node);
                 }
             }
-        };
+
+            event.preventDefault();
+            event.stopPropagation();
+        }
+
+        function performDelete(node) {
+
+            // remove from list
+            var index = $scope.nodes.indexOf(node);
+            $scope.nodes.splice(index, 1);
+
+            $scope.setDirty();
+            updateModel();
+        }
 
         $scope.getName = function (idx) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -213,7 +213,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             updateModel();
         }
 
-        $scope.getName = function (idx) {
+        $scope.getName = function (node, idx) {
 
             var name = "Item " + (idx + 1);
 
@@ -240,10 +240,9 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             }
 
             // Update the nodes actual name value
-            if ($scope.nodes[idx].name !== name) {
-                $scope.nodes[idx].name = name;
+            if (node.name !== name) {
+                node.name = name;
             }
-
 
             return name;
         };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -160,13 +160,15 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             $scope.overlayMenu.show = true;
         };
 
-        $scope.editNode = function (idx) {
+        $scope.editNode = function (node, event) {
             
-            if ($scope.currentNode && $scope.currentNode.key == $scope.nodes[idx].key) {
+            if ($scope.currentNode && $scope.currentNode.key == node.key) {
                 $scope.currentNode = undefined;
             } else {
-                $scope.currentNode = $scope.nodes[idx];
+                $scope.currentNode = node;
             }
+
+            event.stopPropagation();
         };
 
         $scope.deleteNode = function (node, event) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -9,7 +9,7 @@
 
                 <div class="umb-nested-content__header-bar" ng-click="$parent.editNode(node, $event)" ng-hide="$parent.singleMode">
 
-                    <div class="umb-nested-content__heading" ng-class="{'-with-icon': showIcons}"><i ng-if="showIcons" class="icon" ng-class="$parent.getIcon($index)"></i><span class="umb-nested-content__item-name" ng-bind="$parent.getName($index)"></span></div>
+                    <div class="umb-nested-content__heading" ng-class="{'-with-icon': showIcons}"><i ng-if="showIcons" class="icon" ng-class="$parent.getIcon($index)"></i><span class="umb-nested-content__item-name" ng-bind="$parent.getName(node, $index)"></span></div>
 
                     <div class="umb-nested-content__icons">
                         <a class="umb-nested-content__icon umb-nested-content__icon--edit" localize="title" title="general_edit" ng-class="{ 'umb-nested-content__icon--active' : $parent.realCurrentNode.id == node.id }" ng-click="$parent.editNode(node, $event)" ng-show="$parent.maxItems > 1" prevent-default>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -7,12 +7,12 @@
 
             <div class="umb-nested-content__item" ng-repeat="node in nodes track by node.key" ng-class="{ 'umb-nested-content__item--active' : $parent.realCurrentNode.key == node.key, 'umb-nested-content__item--single' : $parent.singleMode }">
 
-                <div class="umb-nested-content__header-bar" ng-click="$parent.editNode($index)" ng-hide="$parent.singleMode">
+                <div class="umb-nested-content__header-bar" ng-click="$parent.editNode(node, $event)" ng-hide="$parent.singleMode">
 
                     <div class="umb-nested-content__heading" ng-class="{'-with-icon': showIcons}"><i ng-if="showIcons" class="icon" ng-class="$parent.getIcon($index)"></i><span class="umb-nested-content__item-name" ng-bind="$parent.getName($index)"></span></div>
 
                     <div class="umb-nested-content__icons">
-                        <a class="umb-nested-content__icon umb-nested-content__icon--edit" localize="title" title="general_edit" ng-class="{ 'umb-nested-content__icon--active' : $parent.realCurrentNode.id == node.id }" ng-click="$parent.editNode($index); $event.stopPropagation();" ng-show="$parent.maxItems > 1" prevent-default>
+                        <a class="umb-nested-content__icon umb-nested-content__icon--edit" localize="title" title="general_edit" ng-class="{ 'umb-nested-content__icon--active' : $parent.realCurrentNode.id == node.id }" ng-click="$parent.editNode(node, $event)" ng-show="$parent.maxItems > 1" prevent-default>
                             <i class="icon icon-edit"></i>
                         </a>
                         <a class="umb-nested-content__icon umb-nested-content__icon--move" localize="title" title="actions_move" ng-click="$event.stopPropagation();" ng-show="$parent.nodes.length > 1" prevent-default>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -5,7 +5,7 @@
 
         <div class="umb-nested-content__items" ng-hide="nodes.length == 0" ui-sortable="sortableOptions" ng-model="nodes">
 
-            <div class="umb-nested-content__item" ng-repeat="node in nodes" ng-class="{ 'umb-nested-content__item--active' : $parent.realCurrentNode.key == node.key, 'umb-nested-content__item--single' : $parent.singleMode }">
+            <div class="umb-nested-content__item" ng-repeat="node in nodes track by node.key" ng-class="{ 'umb-nested-content__item--active' : $parent.realCurrentNode.key == node.key, 'umb-nested-content__item--single' : $parent.singleMode }">
 
                 <div class="umb-nested-content__header-bar" ng-click="$parent.editNode($index)" ng-hide="$parent.singleMode">
 
@@ -18,7 +18,7 @@
                         <a class="umb-nested-content__icon umb-nested-content__icon--move" localize="title" title="actions_move" ng-click="$event.stopPropagation();" ng-show="$parent.nodes.length > 1" prevent-default>
                             <i class="icon icon-navigation"></i>
                         </a>
-                        <a class="umb-nested-content__icon umb-nested-content__icon--delete" localize="title" title="general_delete" ng-class="{ 'umb-nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.deleteNode($index); $event.stopPropagation();" prevent-default>
+                        <a class="umb-nested-content__icon umb-nested-content__icon--delete" localize="title" title="general_delete" ng-class="{ 'umb-nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.deleteNode(node, $event)" prevent-default>
                             <i class="icon icon-trash"></i>
                         </a>
                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/overlays/delete.html
@@ -1,7 +1,7 @@
 ﻿<div>
 
     <div ng-if="model.node" class="umb-alert umb-alert--warning mb2">
-        This will remove the item <strong>{{model.node.name}}</strong>
+        <localize key="content_nestedContentDeleteItemWarning">This will delete the item</localize> <strong>{{model.node.name}}</strong>
     </div>
 
     <localize key="content_nestedContentDeleteItem">Are you sure you want to delete this item?</localize>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/overlays/delete.html
@@ -1,0 +1,9 @@
+﻿<div>
+
+    <div ng-if="model.node" class="umb-alert umb-alert--warning mb2">
+        This will remove the item <strong>{{model.node.name}}</strong>
+    </div>
+
+    <localize key="content_nestedContentDeleteItem">Are you sure you want to delete this item?</localize>
+
+</div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -261,6 +261,7 @@
     <key alias="scheduledPublishServerTime">Dette oversætter til den følgende tid på serveren:</key>
     <key alias="scheduledPublishDocumentation"><![CDATA[<a href="https://our.umbraco.com/documentation/Getting-Started/Data/Scheduled-Publishing/#timezones" target="_blank">Hvad betyder det?</a>]]></key>
     <key alias="nestedContentDeleteItem">Er du sikker på, at du vil slette dette element?</key>
+    <key alias="nestedContentDeleteItemWarning">Dette vil slette elementet</key>
     <key alias="nestedContentEditorNotSupported">Egenskaben %0% anvender editoren %1% som ikke er understøttet af Nested Content.</key>
     <key alias="addTextBox">Tilføj en ny tekstboks</key>
     <key alias="removeTextBox">Fjern denne tekstboks</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -271,6 +271,7 @@
     <key alias="scheduledPublishServerTime">This translates to the following time on the server:</key>
     <key alias="scheduledPublishDocumentation"><![CDATA[<a href="https://our.umbraco.com/documentation/Getting-Started/Data/Scheduled-Publishing/#timezones" target="_blank">What does this mean?</a>]]></key>
     <key alias="nestedContentDeleteItem">Are you sure you want to delete this item?</key>
+    <key alias="nestedContentDeleteItemWarning">This will delete the item</key>
     <key alias="nestedContentEditorNotSupported">Property %0% uses editor %1% which is not supported by Nested Content.</key>
     <key alias="addTextBox">Add another text box</key>
     <key alias="removeTextBox">Remove this text box</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -273,7 +273,10 @@
     <key alias="childItems" version="7.0">Child items</key>
     <key alias="target" version="7.0">Target</key>
     <key alias="scheduledPublishServerTime">This translates to the following time on the server:</key>
-    <key alias="scheduledPublishDocumentation"><![CDATA[<a href="https://our.umbraco.com/documentation/Getting-Started/Data/Scheduled-Publishing/#timezones" target="_blank">What does this mean?</a>]]></key><key alias="nestedContentDeleteItem">Are you sure you want to delete this item?</key><key alias="nestedContentEditorNotSupported">Property %0% uses editor %1% which is not supported by Nested Content.</key>
+    <key alias="scheduledPublishDocumentation"><![CDATA[<a href="https://our.umbraco.com/documentation/Getting-Started/Data/Scheduled-Publishing/#timezones" target="_blank">What does this mean?</a>]]></key>
+    <key alias="nestedContentDeleteItem">Are you sure you want to delete this item?</key>
+    <key alias="nestedContentDeleteItemWarning">This will delete the item</key>
+    <key alias="nestedContentEditorNotSupported">Property %0% uses editor %1% which is not supported by Nested Content.</key>
     <key alias="addTextBox">Add another text box</key>
     <key alias="removeTextBox">Remove this text box</key>
     <key alias="contentRoot">Content root</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR updates Nested Content to use an overlay confirm to be consistent with other confirm overlays in v8 UI instead of the traditional javascript confirm.

![2019-03-03_17-13-25](https://user-images.githubusercontent.com/2919859/53699565-02324000-3dea-11e9-84f8-5174d75eab82.png)

![image](https://user-images.githubusercontent.com/2919859/53699574-268e1c80-3dea-11e9-87d4-506922b95191.png)

Furthermore is update the editNode function to pass in the node object and also add track by on ng-repeat.