### PR TITLE
Fixes LogViewer if JSON log contains malformed JSON lines

### DIFF
--- a/src/Umbraco.Core/Logging/Viewer/JsonLogViewer.cs
+++ b/src/Umbraco.Core/Logging/Viewer/JsonLogViewer.cs
@@ -123,7 +123,7 @@ namespace Umbraco.Core.Logging.Viewer
             catch (JsonReaderException ex)
             {
                 // As we are reading/streaming one line at a time in the JSON file
-                // Thus we can not rpeort the line number, as it will always be 1
+                // Thus we can not report the line number, as it will always be 1
                 _logger.Error<JsonLogViewer>(ex, "Unable to parse a line in the JSON log file");
 
                 evt = null;

--- a/src/Umbraco.Core/Logging/Viewer/LogViewerComposer.cs
+++ b/src/Umbraco.Core/Logging/Viewer/LogViewerComposer.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Core.Logging.Viewer
     {
         public void Compose(Composition composition)
         {
-            composition.SetLogViewer(_ => new JsonLogViewer());
+            composition.SetLogViewer(_ => new JsonLogViewer(composition.Logger));
         }
     }
 }

--- a/src/Umbraco.Tests/Logging/LogviewerTests.cs
+++ b/src/Umbraco.Tests/Logging/LogviewerTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using Moq;
+using NUnit.Framework;
 using System;
 using System.IO;
 using System.Linq;
@@ -47,7 +48,8 @@ namespace Umbraco.Tests.Logging
             File.Copy(exampleLogfilePath, _newLogfilePath, true);
             File.Copy(exampleSearchfilePath, _newSearchfilePath, true);
 
-            _logViewer = new JsonLogViewer(logsPath: _newLogfileDirPath, searchPath: _newSearchfilePath);
+            var logger = Mock.Of<Core.Logging.ILogger>();
+            _logViewer = new JsonLogViewer(logger, logsPath: _newLogfileDirPath, searchPath: _newSearchfilePath);
         }
 
         [OneTimeTearDown]


### PR DESCRIPTION
We will ignore malformed log lines in the JSON log file - so the rest of the logviewer continues to work