### PR TITLE
dropdownFlexible can no longer store separate label and value for items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.html
@@ -5,7 +5,7 @@
             ng-switch-default
             ng-change="updateSingleDropdownValue()"
             ng-model="model.singleDropdownValue"
-            ng-options="item.value as item.value for item in model.config.items"
+            ng-options="item.id as item.value for item in model.config.items"
             ng-required="model.validation.mandatory">
         <option></option>
     </select>
@@ -16,6 +16,6 @@
             ng-switch-when="true"
             multiple
             ng-model="model.value"
-            ng-options="item.value as item.value for item in model.config.items"
+            ng-options="item.id as item.value for item in model.config.items"
             ng-required="model.validation.mandatory"></select>
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
<!-- A description of the changes proposed in the pull-request and how to test these changes -->
In an Umbraco 7 installation, using a dropdownFlexible property editor allows you to set separate values and labels. This functionality has been changed in v8.

v7
![image](https://user-images.githubusercontent.com/200450/53803247-08d0cc80-3f3c-11e9-981e-a41df813d6cc.png)

v8
![image](https://user-images.githubusercontent.com/200450/53803207-efc81b80-3f3b-11e9-8a05-7a072c0667e4.png)



<!-- Thanks for contributing to Umbraco CMS! -->
