### PR TITLE
V8: Always update URLs on save no matter which app is active

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -344,8 +344,8 @@
                     loadAuditTrail(true);
                     loadRedirectUrls();
                     setNodePublishStatus();
-                    updateCurrentUrls();
                 }
+                updateCurrentUrls();
             });
 
             //ensure to unregister from all events!


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4855

### Description

See #4855 for details on how to reproduce.

With this PR applied, the content URLs are updated no matter which app is active at the time of save:

![update-content-urls](https://user-images.githubusercontent.com/7405322/53833747-925abb80-3f89-11e9-8e72-5028a2fb2595.gif)
