### PR TITLE
V8: Add methods for fetching multiple members to UmbracoHelper

### DIFF
--- a/src/Umbraco.Web/Security/MembershipHelper.cs
+++ b/src/Umbraco.Web/Security/MembershipHelper.cs
@@ -289,9 +289,44 @@ namespace Umbraco.Web.Security
             return MemberCache.GetByProviderKey(key);
         }
 
+        public virtual IEnumerable<IPublishedContent> GetByProviderKey(IEnumerable<object> keys)
+        {
+            return keys?.Select(GetByProviderKey).WhereNotNull() ?? new IPublishedContent[0];
+        }
+
+        public virtual IEnumerable<IPublishedContent> GetByProviderKey(params object[] keys)
+        {
+            return keys?.Select(GetByProviderKey).WhereNotNull() ?? new IPublishedContent[0];
+        }
+
         public virtual IPublishedContent GetById(int memberId)
         {
             return MemberCache.GetById(memberId);
+        }
+
+        public virtual IEnumerable<IPublishedContent> GetById(IEnumerable<int> memberIds)
+        {
+            return memberIds?.Select(GetById).WhereNotNull() ?? new IPublishedContent[0];
+        }
+
+        public virtual IEnumerable<IPublishedContent> GetById(params int[] memberIds)
+        {
+            return memberIds?.Select(GetById).WhereNotNull() ?? new IPublishedContent[0];
+        }
+
+        public virtual IPublishedContent GetById(Guid memberId)
+        {
+            return GetByProviderKey(memberId);
+        }
+
+        public virtual IEnumerable<IPublishedContent> GetById(IEnumerable<Guid> memberIds)
+        {
+            return GetByProviderKey(memberIds.OfType<object>());
+        }
+
+        public virtual IEnumerable<IPublishedContent> GetById(params Guid[] memberIds)
+        {
+            return GetByProviderKey(memberIds.OfType<object>());
         }
 
         public virtual IPublishedContent GetByUsername(string username)

--- a/src/Umbraco.Web/Security/MembershipHelper.cs
+++ b/src/Umbraco.Web/Security/MembershipHelper.cs
@@ -289,14 +289,14 @@ namespace Umbraco.Web.Security
             return MemberCache.GetByProviderKey(key);
         }
 
-        public virtual IEnumerable<IPublishedContent> GetByProviderKey(IEnumerable<object> keys)
+        public virtual IEnumerable<IPublishedContent> GetByProviderKeys(IEnumerable<object> keys)
         {
-            return keys?.Select(GetByProviderKey).WhereNotNull() ?? new IPublishedContent[0];
+            return keys?.Select(GetByProviderKey).WhereNotNull() ?? Enumerable.Empty<IPublishedContent>();
         }
 
-        public virtual IEnumerable<IPublishedContent> GetByProviderKey(params object[] keys)
+        public virtual IEnumerable<IPublishedContent> GetByProviderKeys(params object[] keys)
         {
-            return keys?.Select(GetByProviderKey).WhereNotNull() ?? new IPublishedContent[0];
+            return keys?.Select(GetByProviderKey).WhereNotNull() ?? Enumerable.Empty<IPublishedContent>();
         }
 
         public virtual IPublishedContent GetById(int memberId)
@@ -304,14 +304,14 @@ namespace Umbraco.Web.Security
             return MemberCache.GetById(memberId);
         }
 
-        public virtual IEnumerable<IPublishedContent> GetById(IEnumerable<int> memberIds)
+        public virtual IEnumerable<IPublishedContent> GetByIds(IEnumerable<int> memberIds)
         {
-            return memberIds?.Select(GetById).WhereNotNull() ?? new IPublishedContent[0];
+            return memberIds?.Select(GetById).WhereNotNull() ?? Enumerable.Empty<IPublishedContent>();
         }
 
-        public virtual IEnumerable<IPublishedContent> GetById(params int[] memberIds)
+        public virtual IEnumerable<IPublishedContent> GetByIds(params int[] memberIds)
         {
-            return memberIds?.Select(GetById).WhereNotNull() ?? new IPublishedContent[0];
+            return memberIds?.Select(GetById).WhereNotNull() ?? Enumerable.Empty<IPublishedContent>();
         }
 
         public virtual IPublishedContent GetById(Guid memberId)
@@ -319,14 +319,14 @@ namespace Umbraco.Web.Security
             return GetByProviderKey(memberId);
         }
 
-        public virtual IEnumerable<IPublishedContent> GetById(IEnumerable<Guid> memberIds)
+        public virtual IEnumerable<IPublishedContent> GetByIds(IEnumerable<Guid> memberIds)
         {
-            return GetByProviderKey(memberIds.OfType<object>());
+            return GetByProviderKeys(memberIds.OfType<object>());
         }
 
-        public virtual IEnumerable<IPublishedContent> GetById(params Guid[] memberIds)
+        public virtual IEnumerable<IPublishedContent> GetByIds(params Guid[] memberIds)
         {
-            return GetByProviderKey(memberIds.OfType<object>());
+            return GetByProviderKeys(memberIds.OfType<object>());
         }
 
         public virtual IPublishedContent GetByUsername(string username)

--- a/src/Umbraco.Web/Security/MembershipHelper.cs
+++ b/src/Umbraco.Web/Security/MembershipHelper.cs
@@ -294,11 +294,6 @@ namespace Umbraco.Web.Security
             return keys?.Select(GetByProviderKey).WhereNotNull() ?? Enumerable.Empty<IPublishedContent>();
         }
 
-        public virtual IEnumerable<IPublishedContent> GetByProviderKeys(params object[] keys)
-        {
-            return keys?.Select(GetByProviderKey).WhereNotNull() ?? Enumerable.Empty<IPublishedContent>();
-        }
-
         public virtual IPublishedContent GetById(int memberId)
         {
             return MemberCache.GetById(memberId);
@@ -309,22 +304,12 @@ namespace Umbraco.Web.Security
             return memberIds?.Select(GetById).WhereNotNull() ?? Enumerable.Empty<IPublishedContent>();
         }
 
-        public virtual IEnumerable<IPublishedContent> GetByIds(params int[] memberIds)
-        {
-            return memberIds?.Select(GetById).WhereNotNull() ?? Enumerable.Empty<IPublishedContent>();
-        }
-
         public virtual IPublishedContent GetById(Guid memberId)
         {
             return GetByProviderKey(memberId);
         }
 
         public virtual IEnumerable<IPublishedContent> GetByIds(IEnumerable<Guid> memberIds)
-        {
-            return GetByProviderKeys(memberIds.OfType<object>());
-        }
-
-        public virtual IEnumerable<IPublishedContent> GetByIds(params Guid[] memberIds)
         {
             return GetByProviderKeys(memberIds.OfType<object>());
         }

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -291,7 +291,7 @@ namespace Umbraco.Web
 
         public IEnumerable<IPublishedContent> Member(IEnumerable<int> ids)
         {
-            return MembershipHelper.GetById(ids);
+            return MembershipHelper.GetByIds(ids);
         }
 
         public IEnumerable<IPublishedContent> Member(IEnumerable<string> ids)
@@ -301,7 +301,7 @@ namespace Umbraco.Web
 
         public IEnumerable<IPublishedContent> Member(IEnumerable<Guid> ids)
         {
-            return MembershipHelper.GetById(ids);
+            return MembershipHelper.GetByIds(ids);
         }
 
         public IEnumerable<IPublishedContent> Member(IEnumerable<Udi> ids)
@@ -326,7 +326,7 @@ namespace Umbraco.Web
 
         public IEnumerable<IPublishedContent> Member(params Guid[] ids)
         {
-            return MembershipHelper.GetById(ids);
+            return MembershipHelper.GetByIds(ids);
         }
 
         public IEnumerable<IPublishedContent> Member(params Udi[] ids)

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -289,52 +289,52 @@ namespace Umbraco.Web
             return asInt ? MembershipHelper.GetById(asInt.Result) : MembershipHelper.GetByProviderKey(id);
         }
 
-        public IEnumerable<IPublishedContent> Member(IEnumerable<int> ids)
+        public IEnumerable<IPublishedContent> Members(IEnumerable<int> ids)
         {
             return MembershipHelper.GetByIds(ids);
         }
 
-        public IEnumerable<IPublishedContent> Member(IEnumerable<string> ids)
+        public IEnumerable<IPublishedContent> Members(IEnumerable<string> ids)
         {
             return ids.Select(Member).WhereNotNull();
         }
 
-        public IEnumerable<IPublishedContent> Member(IEnumerable<Guid> ids)
+        public IEnumerable<IPublishedContent> Members(IEnumerable<Guid> ids)
         {
             return MembershipHelper.GetByIds(ids);
         }
 
-        public IEnumerable<IPublishedContent> Member(IEnumerable<Udi> ids)
+        public IEnumerable<IPublishedContent> Members(IEnumerable<Udi> ids)
         {
             return ids.Select(Member).WhereNotNull();
         }
 
-        public IEnumerable<IPublishedContent> Member(IEnumerable<object> ids)
+        public IEnumerable<IPublishedContent> Members(IEnumerable<object> ids)
         {
             return ids.Select(Member).WhereNotNull();
         }
 
-        public IEnumerable<IPublishedContent> Member(params int[] ids)
+        public IEnumerable<IPublishedContent> Members(params int[] ids)
         {
             return ids.Select(Member).WhereNotNull();
         }
 
-        public IEnumerable<IPublishedContent> Member(params string[] ids)
+        public IEnumerable<IPublishedContent> Members(params string[] ids)
         {
             return ids.Select(Member).WhereNotNull();
         }
 
-        public IEnumerable<IPublishedContent> Member(params Guid[] ids)
+        public IEnumerable<IPublishedContent> Members(params Guid[] ids)
         {
             return MembershipHelper.GetByIds(ids);
         }
 
-        public IEnumerable<IPublishedContent> Member(params Udi[] ids)
+        public IEnumerable<IPublishedContent> Members(params Udi[] ids)
         {
             return ids.Select(Member).WhereNotNull();
         }
 
-        public IEnumerable<IPublishedContent> Member(params object[] ids)
+        public IEnumerable<IPublishedContent> Members(params object[] ids)
         {
             return ids.Select(Member).WhereNotNull();
         }

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -264,7 +264,7 @@ namespace Umbraco.Web
 
         public IPublishedContent Member(Guid id)
         {
-            return MembershipHelper.GetByProviderKey(id);
+            return MembershipHelper.GetById(id);
         }
 
         public IPublishedContent Member(object id)
@@ -288,55 +288,55 @@ namespace Umbraco.Web
             var asInt = id.TryConvertTo<int>();
             return asInt ? MembershipHelper.GetById(asInt.Result) : MembershipHelper.GetByProviderKey(id);
         }
-        
+
         public IEnumerable<IPublishedContent> Member(IEnumerable<int> ids)
         {
-            return ids.Select(id => Member(id)).WhereNotNull();
+            return MembershipHelper.GetById(ids);
         }
 
         public IEnumerable<IPublishedContent> Member(IEnumerable<string> ids)
         {
-            return ids.Select(id => Member(id)).WhereNotNull();
+            return ids.Select(Member).WhereNotNull();
         }
 
         public IEnumerable<IPublishedContent> Member(IEnumerable<Guid> ids)
         {
-            return ids.Select(id => Member(id)).WhereNotNull();
+            return MembershipHelper.GetById(ids);
         }
 
         public IEnumerable<IPublishedContent> Member(IEnumerable<Udi> ids)
         {
-            return ids.Select(id => Member(id)).WhereNotNull();
+            return ids.Select(Member).WhereNotNull();
         }
 
         public IEnumerable<IPublishedContent> Member(IEnumerable<object> ids)
         {
-            return ids.Select(id => Member(id)).WhereNotNull();
+            return ids.Select(Member).WhereNotNull();
         }
 
         public IEnumerable<IPublishedContent> Member(params int[] ids)
         {
-            return ids.Select(id => Member(id)).WhereNotNull();
+            return ids.Select(Member).WhereNotNull();
         }
 
         public IEnumerable<IPublishedContent> Member(params string[] ids)
         {
-            return ids.Select(id => Member(id)).WhereNotNull();
+            return ids.Select(Member).WhereNotNull();
         }
 
         public IEnumerable<IPublishedContent> Member(params Guid[] ids)
         {
-            return ids.Select(id => Member(id)).WhereNotNull();
+            return MembershipHelper.GetById(ids);
         }
 
         public IEnumerable<IPublishedContent> Member(params Udi[] ids)
         {
-            return ids.Select(id => Member(id)).WhereNotNull();
+            return ids.Select(Member).WhereNotNull();
         }
 
         public IEnumerable<IPublishedContent> Member(params object[] ids)
         {
-            return ids.Select(id => Member(id)).WhereNotNull();
+            return ids.Select(Member).WhereNotNull();
         }
 
         #endregion

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -288,6 +288,56 @@ namespace Umbraco.Web
             var asInt = id.TryConvertTo<int>();
             return asInt ? MembershipHelper.GetById(asInt.Result) : MembershipHelper.GetByProviderKey(id);
         }
+        
+        public IEnumerable<IPublishedContent> Member(IEnumerable<int> ids)
+        {
+            return ids.Select(id => Member(id)).WhereNotNull();
+        }
+
+        public IEnumerable<IPublishedContent> Member(IEnumerable<string> ids)
+        {
+            return ids.Select(id => Member(id)).WhereNotNull();
+        }
+
+        public IEnumerable<IPublishedContent> Member(IEnumerable<Guid> ids)
+        {
+            return ids.Select(id => Member(id)).WhereNotNull();
+        }
+
+        public IEnumerable<IPublishedContent> Member(IEnumerable<Udi> ids)
+        {
+            return ids.Select(id => Member(id)).WhereNotNull();
+        }
+
+        public IEnumerable<IPublishedContent> Member(IEnumerable<object> ids)
+        {
+            return ids.Select(id => Member(id)).WhereNotNull();
+        }
+
+        public IEnumerable<IPublishedContent> Member(params int[] ids)
+        {
+            return ids.Select(id => Member(id)).WhereNotNull();
+        }
+
+        public IEnumerable<IPublishedContent> Member(params string[] ids)
+        {
+            return ids.Select(id => Member(id)).WhereNotNull();
+        }
+
+        public IEnumerable<IPublishedContent> Member(params Guid[] ids)
+        {
+            return ids.Select(id => Member(id)).WhereNotNull();
+        }
+
+        public IEnumerable<IPublishedContent> Member(params Udi[] ids)
+        {
+            return ids.Select(id => Member(id)).WhereNotNull();
+        }
+
+        public IEnumerable<IPublishedContent> Member(params object[] ids)
+        {
+            return ids.Select(id => Member(id)).WhereNotNull();
+        }
 
         #endregion
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4837

### Description

#4837 calls for being able to fetch multiple members in one go using `UmbracoHelper`. This PR adds the overloads that allows this (same way as for content and media).

#### Testing this PR

Provided you have some members, using the following template on any content item will list all members using some of the new methods. And no, this template is definitively *not* the way you'd normally do things 😆 

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@{
  Layout = null;
  var allMembers = global::Umbraco.Web.Composing.Current.Services.MemberService.GetAllMembers();
}
<html>
  <body>
    <h3>Get by Ids</h3>
    <ul>
      @foreach(var member in Umbraco.Members(allMembers.Select(m => m.Id))) {
        <li>@member.Name</li>
      }
    </ul>
    <h3>Get by Keys</h3>
    <ul>
      @foreach(var member in Umbraco.Members(allMembers.Select(m => m.Key))) {
        <li>@member.Name</li>
      }
    </ul>
    <h3>Get by string Ids</h3>
    <ul>
      @foreach(var member in Umbraco.Members(allMembers.Select(m => m.Id.ToString()))) {
        <li>@member.Name</li>
      }
    </ul>
  </body>
</html>
```