### PR TITLE
V8: Don't "Create matching template" before the content type is created

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.controller.js
@@ -79,6 +79,10 @@
         };
 
         function checkIfTemplateExists() {
+            if ($scope.model.id === 0) {
+                return;
+            }
+
             var existingTemplate = vm.availableTemplates.find(function (availableTemplate) {
                 return (availableTemplate.name === $scope.model.name || availableTemplate.placeholder);
             });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When creating a "Document Type without a template", you're given the option to "Create matching template" even before the content type is created. Attempting to do so causes a failure, albeit not very well handled:

![create-matching-template-fail](https://user-images.githubusercontent.com/7405322/53884841-bca98900-401c-11e9-92a3-92e8f5dc27e7.gif)

This PR simply removes the "Create matching template" button until the content type is actually created:

![create-matching-template-ok](https://user-images.githubusercontent.com/7405322/53884881-cd59ff00-401c-11e9-9bbe-944652a744e9.gif)
