### PR TITLE
V8: Don't allow opening an uncreated template

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-grid-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-grid-selector.html
@@ -6,7 +6,7 @@
             <div class="umb-grid-selector__item-content">
                 <i class="umb-grid-selector__item-icon {{ defaultItem.icon }}"></i>
                 <div class="umb-grid-selector__item-label">{{ defaultItem.name }}</div>
-                <div><a href="" class="umb-grid-selector__item-default-label -blue" ng-click="openTemplate(defaultItem)"><localize key="general_open">Open</localize></a></div>
+                <div ng-show="defaultItem.id"><a href="" class="umb-grid-selector__item-default-label -blue" ng-click="openTemplate(defaultItem)"><localize key="general_open">Open</localize></a></div>
                 <span class="umb-grid-selector__item-default-label">(<localize key="general_default">Default</localize> {{itemLabel}})</span>
             </div>
             <i class="umb-grid-selector__item-remove icon-trash" ng-if="selectedItems.length === 1" ng-click="removeDefaultItem()"></i>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When creating a new content type, the default template has an "open" option - despite it not yet being created. When you click the "open" option, things fail rather miserably:

![open-uncreated-template](https://user-images.githubusercontent.com/7405322/53885559-5aea1e80-401e-11e9-8cf3-e55f4eede164.gif)

This PR removes the "open" option until the content type (and in turn, the template) is created:

![image](https://user-images.githubusercontent.com/7405322/53885770-d946c080-401e-11e9-999c-9a04c14f9853.png)

