### PR TITLE
Added in new browser targets for Babel config

### DIFF
--- a/src/Umbraco.Web.UI.Client/.babelrc
+++ b/src/Umbraco.Web.UI.Client/.babelrc
@@ -1,3 +1,10 @@
 {
-    "presets": ["@babel/preset-env"]
+    "presets": [
+        [
+            "@babel/preset-env",
+            {
+                "targets": "last 2 version, not dead, > 0.5%, not ie 11"
+            }
+        ]
+    ]
 }


### PR DESCRIPTION
Fixes #4894

Setup to support the last two versions of Chrome, Firefox, Safari. Exclue "dead" browsers. Exclude browsers with less that 0.5% market share and exclude IE11 (woot!)

You can test this browser query here:

https://browserl.ist/?q=last+2+version%2C+not+dead%2C+%3E+0.5%25%2C+not+ie+11

And see a list of browsers we will support (feel free to have a play with the query and see what gets included/excluded).

To test...well just run the `gulp dev` build task and make sure it runs without any errors. As we don't use ES6 as yet Babel isn't adding any polyfills so all the javascript files remain the same size in my tests. But this does future proof us from accidently making bloated javascript files in the future if we started using ES6 without this rule in place so its a good back stop to have in place (and its future proof in a way as it will include forever green field browsers which auto update like Chrome, etc. without needing to update this config).