### PR TITLE
v8: Checkbox/radio with disabled state

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -25,8 +25,9 @@
 @param {string} value Set the value of the checkbox.
 @param {string} name Set the name of the checkbox.
 @param {string} text Set the text for the checkbox label.
+@param {boolean} disabled Set the checkbox to be disabled.
+@param {boolean} required Set the checkbox to be required.
 @param {string} onChange Callback when the value of the input element changes.
-
 
 **/
 
@@ -43,6 +44,7 @@
                 value: "@",
                 name: "@",
                 text: "@",
+                disabled: "=",
                 required: "=",
                 onChange: "&"
             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -25,7 +25,8 @@
 @param {string} value Set the value of the radiobutton.
 @param {string} name Set the name of the radiobutton.
 @param {string} text Set the text for the radiobutton label.
-
+@param {boolean} disabled Set the radiobutton to be disabled.
+@param {boolean} required Set the radiobutton to be required.
 
 **/
 
@@ -42,6 +43,7 @@
                 value: "@",
                 name: "@",
                 text: "@",
+                disabled: "=",
                 required: "="
             }
         };

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -9,71 +9,70 @@
     padding: 0;
     margin: 0;
     min-height: 22px;
+    line-height: 22px;
     cursor: pointer !important;
 
-    &__text{
+    &__text {
         margin: 0 0 0 26px;
         position: relative;
         top: -1px;
     }
 
-    &__input{
+    &__input {
         position: absolute;
         top: 0;
         left: 0;
         opacity: 0;
 
-        &:checked ~ .umb-form-check__state .umb-form-check__check{
+        &:checked ~ .umb-form-check__state .umb-form-check__check {
             border-color: @ui-option-type;
         }
 
         &:focus:checked ~ .umb-form-check .umb-form-check__check,
-        &:focus ~ .umb-form-check__state .umb-form-check__check{
+        &:focus ~ .umb-form-check__state .umb-form-check__check {
             border-color: @inputBorderFocus;
         }
 
-        &:checked ~ .umb-form-check__state{
-            .umb-form-check__check{
+        &:checked ~ .umb-form-check__state {
+            .umb-form-check__check {
                 // This only happens if the state has a radiobutton modifier
-                .umb-form-check--radiobutton &{
-                    &:before{
+                .umb-form-check--radiobutton & {
+                    &:before {
                         opacity: 1;
                         transform: scale(1);
                     }
                 }
-
                 // This only happens if state has the checkbox modifier
-                .umb-form-check--checkbox &{
-                    &:before{
+                .umb-form-check--checkbox & {
+                    &:before {
                         width: @checkboxWidth;
                         height: @checkboxHeight;
                     }
                 }
             }
-
             // This only happens if state has the checkbox modifier
-            .umb-form-check--checkbox &{
-                .umb-form-check__icon{
+            .umb-form-check--checkbox & {
+                .umb-form-check__icon {
                     opacity: 1;
                 }
             }
         }
     }
 
-    &__state{
+    &__state {
         height: 17px;
         position: absolute;
         top: 2px;
         left: 0;
     }
 
-    &__check{
+    &__check {
         position: relative;
         border: 1px solid @inputBorder;
         width: @checkboxWidth;
         height: @checkboxHeight;
 
-        &:before{
+        &:before {
             content: "";
             background: @ui-option-type;
             position: absolute;
@@ -83,12 +82,11 @@
             bottom: 0;
             margin: auto;
         }
-
         // This only happens if state has the radiobutton modifier
-        .umb-form-check--radiobutton &{
+        .umb-form-check--radiobutton & {
             border-radius: 100%;
 
-            &:before{
+            &:before {
                 width: 9px;
                 height: 9px;
                 border-radius: 100%;
@@ -97,10 +95,9 @@
                 transition: .15s ease-out;
             }
         }
-
         // This only happens if state has the checkbox modifier
-        .umb-form-check--checkbox &{
-            &:before{
+        .umb-form-check--checkbox & {
+            &:before {
                 width: 0;
                 height: 0;
                 transition: .05s ease-out;
@@ -108,14 +105,14 @@
         }
     }
 
-    &__icon{
+    &__icon {
         color: @white;
         text-align: center;
         font-size: 10px;
         opacity: 0;
         transition: .2s ease-out;
 
-        &:before{
+        &:before {
             position: absolute;
             top: -2px;
             right: 0;
@@ -123,5 +120,9 @@
             bottom: 0;
             margin: auto;
         }
+    }
+
+    &.umb-form-check--disabled {
+        opacity: 0.5;
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -15,7 +15,7 @@
     &__text {
         margin: 0 0 0 26px;
         position: relative;
-        top: -1px;
+        top: 0;
     }
 
     &__input {
@@ -62,8 +62,9 @@
     &__state {
         display: flex;
         height: 17px;
+        margin-top: 2px;
         position: absolute;
-        top: 2px;
+        top: 0;
         left: 0;
     }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -1,5 +1,5 @@
-@checkboxWidth: 15px;
-@checkboxHeight: 15px;
+@checkboxWidth: 16px;
+@checkboxHeight: 16px;
 
 .umb-form-check {
     display: flex;
@@ -61,7 +61,7 @@
 
     &__state {
         display: flex;
-        height: 17px;
+        height: 18px;
         margin-top: 2px;
         position: absolute;
         top: 0;
@@ -91,8 +91,8 @@
             border-radius: 100%;
 
             &:before {
-                width: 9px;
-                height: 9px;
+                width: 10px;
+                height: 10px;
                 border-radius: 100%;
                 opacity: 0;
                 transform: scale(0);
@@ -112,7 +112,7 @@
     &__icon {
         color: @white;
         text-align: center;
-        font-size: 10px;
+        font-size: 12px;
         opacity: 0;
         transition: .2s ease-out;
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -71,6 +71,7 @@
     &__check {
         display: flex;
         position: relative;
+        background: @white;
         border: 1px solid @inputBorder;
         width: @checkboxWidth;
         height: @checkboxHeight;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -116,8 +116,11 @@
         transition: .2s ease-out;
 
         &:before {
+            display: flex;
+            justify-content: center;
+            align-items: center;
             position: absolute;
-            top: -2px;
+            top: 0;
             right: 0;
             left: 0;
             bottom: 0;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -123,6 +123,7 @@
     }
 
     &.umb-form-check--disabled {
+        cursor: default !important;
         opacity: 0.5;
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -60,6 +60,7 @@
     }
 
     &__state {
+        display: flex;
         height: 17px;
         position: absolute;
         top: 2px;
@@ -67,6 +68,7 @@
     }
 
     &__check {
+        display: flex;
         position: relative;
         border: 1px solid @inputBorder;
         width: @checkboxWidth;

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -1,8 +1,9 @@
-<label class="checkbox umb-form-check umb-form-check--checkbox">
+<label class="checkbox umb-form-check umb-form-check--checkbox" ng-class="{ 'umb-form-check--disabled': disabled }">
     <input type="checkbox" name="{{name}}"
            value="{{value}}"
-           ng-model="model.checked"
            class="umb-form-check__input"
+           ng-model="model.checked"
+           ng-disabled="disabled"
            ng-required="required"
            ng-change="onChange(model)"/>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -7,7 +7,7 @@
            ng-required="required"
            ng-change="onChange(model)"/>
 
-    <div class="umb-form-check__state umb-form-check__state" aria-hidden="true">
+    <div class="umb-form-check__state" aria-hidden="true">
         <div class="umb-form-check__check">
             <i class="umb-form-check__icon icon-check"></i>
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -7,10 +7,10 @@
            ng-required="required"
            ng-change="onChange(model)"/>
 
-    <div class="umb-form-check__state" aria-hidden="true">
-        <div class="umb-form-check__check">
+    <span class="umb-form-check__state" aria-hidden="true">
+        <span class="umb-form-check__check">
             <i class="umb-form-check__icon icon-check"></i>
-        </div>
-    </div>
+        </span>
+    </span>
     <span class="umb-form-check__text">{{text}}</span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -6,7 +6,7 @@
         ng-disabled="disabled"
         ng-required="required" />
 
-    <div class="umb-form-check__state umb-form-check__state" aria-hidden="true">
+    <div class="umb-form-check__state" aria-hidden="true">
         <div class="umb-form-check__check"></div>
     </div>
     <span class="umb-form-check__text">{{text}}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -1,8 +1,9 @@
-<label class="radio umb-form-check umb-form-check--radiobutton">
+<label class="radio umb-form-check umb-form-check--radiobutton" ng-class="{ 'umb-form-check--disabled': disabled }">
     <input type="radio" name="{{name}}"
         value="{{value}}"
-        ng-model="model"
         class="umb-form-check__input"
+        ng-model="model"
+        ng-disabled="disabled"
         ng-required="required" />
 
     <div class="umb-form-check__state umb-form-check__state" aria-hidden="true">

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -6,8 +6,8 @@
         ng-disabled="disabled"
         ng-required="required" />
 
-    <div class="umb-form-check__state" aria-hidden="true">
-        <div class="umb-form-check__check"></div>
-    </div>
+    <span class="umb-form-check__state" aria-hidden="true">
+        <span class="umb-form-check__check"></span>
+    </span>
     <span class="umb-form-check__text">{{text}}</span>
 </label>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/4887

### Description
This PR fixes a few things:

- Add a disable state to checkbox/radiobutton directives by setting `disabled` attribute to `true` or `false`, e.g test this by adding the following to `checkboxlist` and `radiobuttons` property editors (or using the `umb-checkbox` or `umb-radiobutton` components in custom views).

`disabled="$index % 2 > 0"` or `disabled="$index % 2 === 0"` 

- Replacing nested `<div>` with `<span>` in `<label>` since it is not valid to use `<div>` as nested elements in labels.

- Adjust the styling a bit inclusive disabled style for custom styles checkbox/radiobutton.

![image](https://user-images.githubusercontent.com/2919859/53917131-239e6080-4064-11e9-91b2-7ea2700f0535.png)

![image](https://user-images.githubusercontent.com/2919859/53917169-387af400-4064-11e9-8d9c-e80aea0c9b9a.png)