### PR TITLE
changed umb-checkbox model to be the boolean property, not a object c…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -22,9 +22,11 @@
 </pre>
 
 @param {boolean} model Set to <code>true</code> or <code>false</code> to set the checkbox to checked or unchecked.
+@param {string} id Set the id of the checkbox.
 @param {string} value Set the value of the checkbox.
 @param {string} name Set the name of the checkbox.
 @param {string} text Set the text for the checkbox label.
+@param {string} serverValidationField Set the val-server-field of the checkbox.
 @param {boolean} disabled Set the checkbox to be disabled.
 @param {boolean} required Set the checkbox to be required.
 @param {string} onChange Callback when the value of the input element changes.
@@ -33,38 +35,38 @@
 
 (function () {
     'use strict';
-
-    function CheckboxDirective() {
+    
+    
+    function UmbCheckboxController($timeout) {
         
-        function link(scope, el, attr, ctrl) {
-            
-            scope.callOnChange = function() {
-                scope.onChange({model:scope.model, value:scope.value});
-            }
-            
+        var vm = this;
+        
+        vm.callOnChange = function() {
+            $timeout(function(){
+                vm.onChange({model:vm.model, value:vm.value});
+            }, 0, false);
         }
-
         
-        var directive = {
-            restrict: 'E',
-            replace: true,
-            templateUrl: 'views/components/forms/umb-checkbox.html',
-            scope: {
-                model: "=",
-                value: "@",
-                name: "@",
-                text: "@",
-                disabled: "=",
-                required: "=",
-                onChange: "&"
-            },
-            link: link
-        };
-
-        return directive;
-
     }
+    
+    
+    var component = {
+        templateUrl: 'views/components/forms/umb-checkbox.html',
+        controller: UmbCheckboxController,
+        controllerAs: 'vm',
+        bindings: {
+            model: "=",
+            id: "@",
+            value: "@",
+            name: "@",
+            text: "@",
+            serverValidationField: "@",
+            disabled: "<",
+            required: "<",
+            onChange: "&"
+        }
+    };
 
-    angular.module('umbraco.directives').directive('umbCheckbox', CheckboxDirective);
+    angular.module('umbraco.directives').component('umbCheckbox', component);
 
 })();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -42,9 +42,9 @@
         var vm = this;
         
         vm.callOnChange = function() {
-            $timeout(function(){
+            $timeout(function() {
                 vm.onChange({model:vm.model, value:vm.value});
-            }, 0, false);
+            }, 0);
         }
         
     }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -35,6 +35,16 @@
     'use strict';
 
     function CheckboxDirective() {
+        
+        function link(scope, el, attr, ctrl) {
+            
+            scope.callOnChange = function() {
+                scope.onChange({model:scope.model, value:scope.value});
+            }
+            
+        }
+
+        
         var directive = {
             restrict: 'E',
             replace: true,
@@ -47,7 +57,8 @@
                 disabled: "=",
                 required: "=",
                 onChange: "&"
-            }
+            },
+            link: link
         };
 
         return directive;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -22,14 +22,14 @@
 </pre>
 
 @param {boolean} model Set to <code>true</code> or <code>false</code> to set the checkbox to checked or unchecked.
-@param {string} id Set the id of the checkbox.
+@param {string} input-id Set the <code>id</code> of the checkbox.
 @param {string} value Set the value of the checkbox.
 @param {string} name Set the name of the checkbox.
 @param {string} text Set the text for the checkbox label.
-@param {string} serverValidationField Set the val-server-field of the checkbox.
+@param {string} server-validation-field Set the <code>val-server-field</code> of the checkbox.
 @param {boolean} disabled Set the checkbox to be disabled.
 @param {boolean} required Set the checkbox to be required.
-@param {string} onChange Callback when the value of the input element changes.
+@param {string} on-change Callback when the value of the checkbox changed by interaction.
 
 **/
 
@@ -56,7 +56,7 @@
         controllerAs: 'vm',
         bindings: {
             model: "=",
-            id: "@",
+            inputId: "@",
             value: "@",
             name: "@",
             text: "@",

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -2,10 +2,10 @@
     <input type="checkbox" name="{{name}}"
            value="{{value}}"
            class="umb-form-check__input"
-           ng-model="model.checked"
+           ng-model="model"
            ng-disabled="disabled"
            ng-required="required"
-           ng-change="onChange(model)"/>
+           ng-change="callOnChange()"/>
 
     <span class="umb-form-check__state" aria-hidden="true">
         <span class="umb-form-check__check">

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -1,16 +1,19 @@
 <label class="checkbox umb-form-check umb-form-check--checkbox" ng-class="{ 'umb-form-check--disabled': disabled }">
-    <input type="checkbox" name="{{name}}"
-           value="{{value}}"
+    <input type="checkbox"
+           id="{{vm.id}}"
+           name="{{vm.name}}"
+           value="{{vm.value}}"
            class="umb-form-check__input"
-           ng-model="model"
-           ng-disabled="disabled"
-           ng-required="required"
-           ng-change="callOnChange()"/>
+           val-server-field="{{vm.serverValidationField}}"
+           ng-model="vm.model"
+           ng-disabled="vm.disabled"
+           ng-required="vm.required"
+           ng-change="vm.callOnChange()"/>
 
     <span class="umb-form-check__state" aria-hidden="true">
         <span class="umb-form-check__check">
             <i class="umb-form-check__icon icon-check"></i>
         </span>
     </span>
-    <span class="umb-form-check__text">{{text}}</span>
+    <span class="umb-form-check__text">{{vm.text}}</span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -1,6 +1,6 @@
 <label class="checkbox umb-form-check umb-form-check--checkbox" ng-class="{ 'umb-form-check--disabled': disabled }">
     <input type="checkbox"
-           id="{{vm.id}}"
+           id="{{vm.inputId}}"
            name="{{vm.name}}"
            value="{{vm.value}}"
            class="umb-form-check__input"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.controller.js
@@ -50,7 +50,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.CheckboxListContro
             //get all of the same values between the arrays
             var same = _.intersection($scope.model.value, selectedVals);
             //if the lengths are the same as the value, then we are in sync, just exit
-            if (same.length === $scope.model.value.length && same.length === selectedVals.length) {
+            if (same.length === $scope.model.value.length === selectedVals.length) {
                 return;
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.controller.js
@@ -50,8 +50,8 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.CheckboxListContro
             //get all of the same values between the arrays
             var same = _.intersection($scope.model.value, selectedVals);
             //if the lengths are the same as the value, then we are in sync, just exit
-            if (same.length == $scope.model.value.length === selectedVals.length) {
-                return; 
+            if (same.length === $scope.model.value.length && same.length === selectedVals.length) {
+                return;
             }
 
             $scope.selectedItems = [];
@@ -66,18 +66,14 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.CheckboxListContro
             }
         }
 
-        function changed(item) {
+        function changed(model, value) {
             
-            var index = _.findIndex($scope.model.value,
-                function (v) {
-                    return v === item.val;
-                }
-            );
+            var index = $scope.model.value.indexOf(value);
             
-            if (item.checked) {
+            if (model) {
                 //if it doesn't exist in the model, then add it
                 if (index < 0) {
-                    $scope.model.value.push(item.val);
+                    $scope.model.value.push(value);
                 }
             } else {
                 //if it exists in the model, then remove it

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.html
@@ -1,7 +1,7 @@
 ﻿<div class="umb-property-editor umb-checkboxlist" ng-controller="Umbraco.PropertyEditors.CheckboxListController">
     <ul class="unstyled">
         <li ng-repeat="item in selectedItems track by item.key">
-            <umb-checkbox name="{{model.alias}}" value="{{item.val}}" model="item" text="{{item.val}}" on-change="changed(item)" required="model.validation.mandatory && !model.value.length"></umb-checkbox>
+            <umb-checkbox name="{{model.alias}}" value="{{item.val}}" model="item.checked" text="{{item.val}}" on-change="changed(model, value)" required="model.validation.mandatory && !model.value.length"></umb-checkbox>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
Changed umb-checkbox model to be the boolean property, not a object containing a checked property.

This means that the on-change callback will receive the model and the value instead.

Test that umb-checkbox still works, currently only used in property-editor checkboxlist.