### PR TITLE
V8: Remove accordion group behavior from media editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/apps/content/content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/apps/content/content.html
@@ -1,12 +1,11 @@
 <div class="form-horizontal" ng-controller="Umbraco.Editors.Media.Apps.ContentController as vm">
-    <div class="umb-expansion-panel" data-element="group-{{group.alias}}" ng-repeat="group in content.tabs | filter: { hide : '!' + true } track by group.label">
+    <div class="umb-group-panel" data-element="group-{{group.alias}}" ng-repeat="group in content.tabs | filter: { hide : '!' + true } track by group.label">
 
-        <div class="umb-expansion-panel__header" ng-click="group.open = !group.open">
+        <div class="umb-group-panel__header">
             <div>{{ group.label }}</div>
-            <ins class="umb-expansion-panel__expand" ng-class="{'icon-navigation-down': !group.open, 'icon-navigation-up': group.open}">&nbsp;</ins>
         </div>
 
-        <div class="umb-expansion-panel__content" ng-show="group.open">
+        <div class="umb-group-panel__content">
             <umb-property data-element="property-{{property.alias}}" ng-repeat="property in group.properties" property="property">
                 <umb-property-editor model="property"></umb-property-editor>
             </umb-property>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4740

### Description

This PR removes the accordion group behavior for media. See #4740 for more details

![image](https://user-images.githubusercontent.com/7405322/54077430-77a18300-42b8-11e9-8b8d-1719752df140.png)

When this PR is applied, the accordion collapse/expand functionality (as shown above) no longer applies to media editing.