### PR TITLE
V8: Remove accordion group behavior from member editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/member/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/edit.html
@@ -18,14 +18,13 @@
 
          <umb-editor-container class="form-horizontal">
 
-            <div class="umb-expansion-panel" ng-repeat="group in content.tabs track by group.label">
+            <div class="umb-group-panel" ng-repeat="group in content.tabs track by group.label">
 
-                <div class="umb-expansion-panel__header" ng-click="group.open = !group.open">
+                <div class="umb-group-panel__header">
                     <div>{{ group.label }}</div>
-                    <ins class="umb-expansion-panel__expand" ng-class="{'icon-navigation-down': !group.open, 'icon-navigation-up': group.open}" class="icon-navigation-right">&nbsp;</ins>
                 </div>
 
-                <div class="umb-expansion-panel__content" ng-show="group.open">
+                <div class="umb-group-panel__content">
                     <umb-property data-element="property-{{group.alias}}" ng-repeat="property in group.properties track by property.alias" property="property">
                         <umb-property-editor model="property"></umb-property-editor>
                     </umb-property>

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -44,11 +44,6 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
 
                     editorState.set($scope.content);
 
-                    // set all groups to open
-                    angular.forEach($scope.content.tabs, function(group){
-                        group.open = true;
-                    });
-
                     $scope.page.loading = false;
 
                 });
@@ -62,11 +57,6 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
                     setHeaderNameState($scope.content);
 
                     editorState.set($scope.content);
-
-                    // set all groups to open
-                    angular.forEach($scope.content.tabs, function(group){
-                        group.open = true;
-                    });
 
                     $scope.page.loading = false;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4740

### Description

This PR removes the accordion group behavior for members. See #4740 for more details.

![image](https://user-images.githubusercontent.com/7405322/54077476-204fe280-42b9-11e9-96d8-417516cf388b.png)

When this PR is applied, the accordion collapse/expand functionality (as shown above) no longer applies to member editing.
