### PR TITLE
V7: Allow explicitly sorting allowed child types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbchildselector.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbchildselector.directive.js
@@ -188,6 +188,22 @@ Use this directive to render a ui component for selecting child items to a paren
               syncParentIcon();
             }));
 
+            // sortable options for allowed child content types
+            scope.sortableOptions = {
+                axis: "y",
+                containment: "parent",
+                distance: 10,
+                opacity: 0.7,
+                tolerance: "pointer",
+                scroll: true,
+                zIndex: 6000,
+                update: function (e, ui) {
+                    if(scope.onSort) {
+                        scope.onSort();
+                    }
+                }
+            };
+
             // clean up
             scope.$on('$destroy', function(){
               // unbind watchers
@@ -209,7 +225,8 @@ Use this directive to render a ui component for selecting child items to a paren
                 parentIcon: "=",
                 parentId: "=",
                 onRemove: "=",
-                onAdd: "="
+                onAdd: "=",
+                onSort: "="
             },
             link: link
         };

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-child-selector.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-child-selector.less
@@ -23,6 +23,9 @@
 
 .umb-child-selector__children-container {
   margin-left: 30px;
+  .umb-child-selector__child {
+      cursor: move;
+  }
 }
 
 .umb-child-selector__child-description {

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
@@ -14,7 +14,7 @@
         </div>
     </div>
 
-    <div class="umb-child-selector__children-container">
+    <div class="umb-child-selector__children-container" ui-sortable="sortableOptions" ng-model="selectedChildren">
 
         <div class="umb-child-selector__child" ng-repeat="selectedChild in selectedChildren">
             <div class="umb-child-selector__child-description">

--- a/src/Umbraco.Web.UI.Client/src/views/content/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/create.html
@@ -10,7 +10,7 @@
 
         <ul class="umb-actions umb-actions-child" ng-show="selectContentType">
 
-            <li data-element="action-create-{{docType.alias}}" ng-repeat="docType in allowedTypes | orderBy:'name':false">
+            <li data-element="action-create-{{docType.alias}}" ng-repeat="docType in allowedTypes">
                 <a ng-click="createOrSelectBlueprintIfAny(docType)">
                     <i class="large {{docType.icon}}"></i>
                     <span class="menu-label">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
@@ -9,7 +9,7 @@
 (function() {
     'use strict';
 
-    function PermissionsController($scope, contentTypeResource, iconHelper, contentTypeHelper, localizationService) {
+    function PermissionsController($scope, $timeout, contentTypeResource, iconHelper, contentTypeHelper, localizationService) {
 
         /* ----------- SCOPE VARIABLES ----------- */
 
@@ -23,6 +23,7 @@
 
         vm.addChild = addChild;
         vm.removeChild = removeChild;
+        vm.sortChildren = sortChildren;
         vm.toggle = toggle;
 
         /* ---------- INIT ---------- */
@@ -74,6 +75,13 @@
            // remove from content type model
            var selectedChildIndex = $scope.model.allowedContentTypes.indexOf(selectedChild.id);
            $scope.model.allowedContentTypes.splice(selectedChildIndex, 1);
+        }
+
+        function sortChildren() {
+            // we need to wait until the next digest cycle for vm.selectedChildren to be updated
+            $timeout(function () {
+                $scope.model.allowedContentTypes = _.pluck(vm.selectedChildren, "id");
+            });
         }
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
@@ -33,7 +33,8 @@
                     parent-icon="model.icon"
                     parent-id="model.id"
                     on-add="vm.addChild"
-                    on-remove="vm.removeChild">
+                    on-remove="vm.removeChild"
+                    on-sort="vm.sortChildren">
             </umb-child-selector>
 
             <umb-overlay

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.controller.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
 
-    function PermissionsController($scope, mediaTypeResource, iconHelper, contentTypeHelper, localizationService) {
+    function PermissionsController($scope, $timeout, mediaTypeResource, iconHelper, contentTypeHelper, localizationService) {
 
         /* ----------- SCOPE VARIABLES ----------- */
 
@@ -13,6 +13,7 @@
 
         vm.addChild = addChild;
         vm.removeChild = removeChild;
+        vm.sortChildren = sortChildren;
         vm.toggle = toggle;
 
         /* ---------- INIT ---------- */
@@ -64,6 +65,13 @@
            // remove from content type model
            var selectedChildIndex = $scope.model.allowedContentTypes.indexOf(selectedChild.id);
            $scope.model.allowedContentTypes.splice(selectedChildIndex, 1);
+        }
+
+        function sortChildren() {
+            // we need to wait until the next digest cycle for vm.selectedChildren to be updated
+            $timeout(function () {
+                $scope.model.allowedContentTypes = _.pluck(vm.selectedChildren, "id");
+            });
         }
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.html
@@ -33,7 +33,8 @@
                     parent-icon="model.icon"
                     parent-id="model.id"
                     on-add="vm.addChild"
-                    on-remove="vm.removeChild">
+                    on-remove="vm.removeChild"
+                    on-sort="vm.sortChildren">
             </umb-child-selector>
 
             <umb-overlay

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -390,11 +390,11 @@ namespace Umbraco.Web.Editors
                     return Enumerable.Empty<ContentTypeBasic>();
                 }
 
-                var ids = contentItem.ContentType.AllowedContentTypes.Select(x => x.Id.Value).ToArray();
+                var ids = contentItem.ContentType.AllowedContentTypes.OrderBy(c => c.SortOrder).Select(x => x.Id.Value).ToArray();
 
                 if (ids.Any() == false) return Enumerable.Empty<ContentTypeBasic>();
 
-                types = Services.ContentTypeService.GetAllContentTypes(ids).ToList();
+                types = Services.ContentTypeService.GetAllContentTypes(ids).OrderBy(c => ids.IndexOf(c.Id)).ToList();
             }
 
             var basics = types.Select(Mapper.Map<IContentType, ContentTypeBasic>).ToList();
@@ -417,7 +417,7 @@ namespace Umbraco.Web.Editors
                 }
             }
 
-            return basics;
+            return basics.OrderBy(c => contentId == Constants.System.Root ? c.Name : string.Empty);
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Editors/MediaTypeController.cs
+++ b/src/Umbraco.Web/Editors/MediaTypeController.cs
@@ -239,11 +239,11 @@ namespace Umbraco.Web.Editors
                     return Enumerable.Empty<ContentTypeBasic>();
                 }
 
-                var ids = contentItem.ContentType.AllowedContentTypes.Select(x => x.Id.Value).ToArray();
+                var ids = contentItem.ContentType.AllowedContentTypes.OrderBy(c => c.SortOrder).Select(x => x.Id.Value).ToArray();
 
                 if (ids.Any() == false) return Enumerable.Empty<ContentTypeBasic>();
 
-                types = Services.ContentTypeService.GetAllMediaTypes(ids).ToList();
+                types = Services.ContentTypeService.GetAllMediaTypes(ids).OrderBy(c => ids.IndexOf(c.Id)).ToList();
             }
 
             var basics = types.Select(Mapper.Map<IMediaType, ContentTypeBasic>).ToList();
@@ -254,7 +254,7 @@ namespace Umbraco.Web.Editors
                 basic.Description = TranslateItem(basic.Description);
             }
 
-            return basics.OrderBy(x => x.Name);
+            return basics.OrderBy(c => contentId == Constants.System.Root ? c.Name : string.Empty);
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Models/Mapping/ContentTypeModelMapperExtensions.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeModelMapperExtensions.cs
@@ -137,7 +137,7 @@ namespace Umbraco.Web.Models.Mapping
 
                 .ForMember(
                     dto => dto.AllowedContentTypes,
-                    expression => expression.MapFrom(dto => dto.AllowedContentTypes.Select(x => x.Id.Value)))
+                    expression => expression.MapFrom(dto => dto.AllowedContentTypes.OrderBy(c => c.SortOrder).Select(x => x.Id.Value)))
 
                 .ForMember(
                     dto => dto.CompositeContentTypes,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4923

### Description

This is the V7 backport of #4927 which allows explicitly sorting the allowed child content types as described in #4923.

It works for both content and media.

For content/media types allowed at root, the current sort order (by name) is preserved.

When applied it looks like this:

![allowed-types-ordering](https://user-images.githubusercontent.com/7405322/54089377-a5de9b80-4368-11e9-93e8-659b9b13d7c9.gif)
