### PR TITLE
Fixes inserting an image into the grid rte since it doesn't get resized correctly

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -17,11 +17,12 @@ angular.module("umbraco")
             if (!editorConfig || angular.isString(editorConfig)) {
                 editorConfig = tinyMceService.defaultPrevalues();
             }
-
-            var promises = [];
-            if (!editorConfig.maxImageSize && editorConfig.maxImageSize != 0) {
+            //make sure there's a max image size
+            if (!editorConfig.maxImageSize && editorConfig.maxImageSize !== 0) {
                 editorConfig.maxImageSize = tinyMceService.defaultPrevalues().maxImageSize;
             }
+
+            var promises = [];
 
             //queue file loading
             if (typeof tinymce === "undefined") { // Don't reload tinymce if already loaded
@@ -43,7 +44,7 @@ angular.module("umbraco")
 
                 var standardConfig = result[promises.length - 1];
 
-                //create a baseline Config to exten upon
+                //create a baseline Config to extend upon
                 var baseLineConfigObj = {
                     maxImageSize: editorConfig.maxImageSize
                 };


### PR DESCRIPTION
If you insert a large image into the rte in the grid, it will not be resized to the `maxImageSize` pre-value. The pre-value is actually just not set correctly to the tinymce config.

There is code in our tinymce service that does the resizing in `insertMediaInEditor` and we do a check for `editor.settings.maxImageSize` which is undefined. This does work correctly in the normal rte, just not inside the grid.

Further investigation looks like we get the maxImageSize from pre-values, if it's not there we use a default (500), then we create a default tinymce config and merge that to a custom tinymce config which contains a custom `maxImageSize` config value, then we init tinymce with this config.

In the grid rte, this `maxImageSize` is not done so this custom setting doesn't get passed to tinymce which means it doesn't get used in the `insertMediaInEditor` method.

So the code fixes this up and uses the same logic that is in the normal rte controller. I realize there's code duplication but trust me, there is far less between these 2 things than there ever has been. Still be good to cleanup more of it in time but for now this is an easy fix.

Testing:

* Test inserting an image into the normal rte, you'll see it adhere's to the max image size specified in the rte pre-values
* Do the same for the rte in the grid and make sure it works based on the max image size in the grid prevalues
* Also make sure that any toolbar changes you make in the grid pre-values work as expected and that the correct toolbars show up