### PR TITLE
V8: Fixed issue when creating variant content templates,

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2875,7 +2875,14 @@ namespace Umbraco.Core.Services.Implement
             {
                 foreach (var property in blueprint.Properties)
                 {
-                    content.SetValue(property.Alias, property.GetValue(culture), culture);
+                    if (property.PropertyType.VariesByCulture())
+                    {
+                        content.SetValue(property.Alias, property.GetValue(culture), culture);
+                    }
+                    else
+                    {
+                        content.SetValue(property.Alias, property.GetValue());
+                    }
                 }
 
                 content.Name = blueprint.Name;


### PR DESCRIPTION
 Fixed issue when creating variant content templates, but the properties is invariant. Before this change an exception was thrown

Steps to reproduce:
- Create a variant doc type with a invariant property
- Create some content from the new doc type
- Create a content template from the new content
  - Before we got this exception:
 
![image](https://user-images.githubusercontent.com/1561480/54181792-fb699400-449f-11e9-9317-16c0d70d599f.png)


