### PR TITLE
V8: Allow mixing languages with and without region

### DIFF
--- a/src/Umbraco.Web/Editors/LanguageController.cs
+++ b/src/Umbraco.Web/Editors/LanguageController.cs
@@ -103,6 +103,13 @@ namespace Umbraco.Web.Editors
             // this is prone to race conditions but the service will not let us proceed anyways
             var existing = Services.LocalizationService.GetLanguageByIsoCode(language.IsoCode);
 
+            // the localization service might return the generic language even when queried for specific ones (e.g. "da" when queried for "da-DK")
+            // - we need to handle that explicitly
+            if (existing.IsoCode != language.IsoCode)
+            {
+                existing = null;
+            }
+
             if (existing != null && language.Id != existing.Id)
             {
                 //someone is trying to create a language that already exist


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4935

### Description

#4519 introduced the issue described in #4935. This PR fixes it. See #4935 for steps to reproduce.

#### Side note

/cc @nul800sebastiaan 

Mixing frontend and backoffice languages might not be terribly brilliant. Perhaps we should consider if localizing the backoffice using the dictionary is really the brightest of ideas. We have other means of custom localization in the backoffice using language files. This would probably be more meaningful in the long run... anyway - food for thought.