### PR TITLE
V8: Don't show the recycle bin in tree pickers/dialogs

### DIFF
--- a/src/Umbraco.Web/Trees/TreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/TreeControllerBase.cs
@@ -366,7 +366,7 @@ namespace Umbraco.Web.Trees
         /// <returns></returns>
         protected bool IsDialog(FormDataCollection queryStrings)
         {
-            return queryStrings.GetValue<bool>(TreeQueryStringParameters.IsDialog);
+            return queryStrings.GetValue<string>(TreeQueryStringParameters.Use) == "dialog";
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Trees/TreeQueryStringParameters.cs
+++ b/src/Umbraco.Web/Trees/TreeQueryStringParameters.cs
@@ -5,7 +5,7 @@
     /// </summary>
     internal struct TreeQueryStringParameters
     {
-        public const string IsDialog = "isDialog";
+        public const string Use = "use";
         public const string Application = "application";
         public const string StartNodeId = "startNodeId";
         //public const string OnNodeClick = "OnNodeClick";


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4659

### Description

#4659 describes an issue for the link picker. This is actually a general issue: The recycle bin is shown in all content pickers, and you're even allowed to pick items from it. The recycle bin also causes a JS error.

The issue originates from a query string parameter rename in commit 585abf29.

#### As-is

![image](https://user-images.githubusercontent.com/7405322/54189466-265ce380-44b2-11e9-81af-5d684b233e80.png)

![image](https://user-images.githubusercontent.com/7405322/54189393-ff9ead00-44b1-11e9-94aa-3b16d7100992.png)

![image](https://user-images.githubusercontent.com/7405322/54189588-68862500-44b2-11e9-813a-4ec49989c37f.png)

#### With this PR applied

![image](https://user-images.githubusercontent.com/7405322/54189216-9c147f80-44b1-11e9-8055-0ef1ae768428.png)

![image](https://user-images.githubusercontent.com/7405322/54189264-b77f8a80-44b1-11e9-8b21-6c487bf5c5e7.png)

