### PR TITLE
v8: Fix package download

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -384,6 +384,8 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
                     // Get the filename from the x-filename header or default to "download.bin"
                     var filename = headers['x-filename'] || 'download.bin';
 
+                    filename = decodeURIComponent(filename);
+
                     // Determine the content type from the header or default to "application/octet-stream"
                     var contentType = headers['content-type'] || octetStreamMime;
 

--- a/src/Umbraco.Web/Editors/PackageController.cs
+++ b/src/Umbraco.Web/Editors/PackageController.cs
@@ -104,7 +104,10 @@ namespace Umbraco.Web.Editors
                         {
                             FileName = fileName
                         },
-                        ContentType = new MediaTypeHeaderValue( "application/octet-stream")
+                        ContentType = new MediaTypeHeaderValue("application/octet-stream")
+                        {
+                            CharSet = Encoding.UTF8.WebName
+                        }
                     }
                 }
             };

--- a/src/Umbraco.Web/Editors/PackageController.cs
+++ b/src/Umbraco.Web/Editors/PackageController.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
+using System.Web;
 using System.Web.Http;
 using Semver;
 using Umbraco.Core.IO;
@@ -113,7 +115,7 @@ namespace Umbraco.Web.Editors
             };
 
             // Set custom header so umbRequestHelper.downloadFile can save the correct filename
-            response.Headers.Add("x-filename", fileName);
+            response.Headers.Add("x-filename", HttpUtility.UrlEncode(fileName));
 
             return response;
         }

--- a/src/Umbraco.Web/Editors/PackageController.cs
+++ b/src/Umbraco.Web/Editors/PackageController.cs
@@ -96,6 +96,8 @@ namespace Umbraco.Web.Editors
 
             var fileName = Path.GetFileName(package.PackagePath);
 
+            var encoding = Encoding.UTF8;
+
             var response = new HttpResponseMessage
             {
                 Content = new StreamContent(File.OpenRead(fullPath))
@@ -104,18 +106,18 @@ namespace Umbraco.Web.Editors
                     {
                         ContentDisposition = new ContentDispositionHeaderValue("attachment")
                         {
-                            FileName = fileName
+                            FileName = HttpUtility.UrlEncode(fileName, encoding)
                         },
                         ContentType = new MediaTypeHeaderValue("application/octet-stream")
                         {
-                            CharSet = Encoding.UTF8.WebName
+                            CharSet = encoding.WebName
                         }
                     }
                 }
             };
 
             // Set custom header so umbRequestHelper.downloadFile can save the correct filename
-            response.Headers.Add("x-filename", HttpUtility.UrlEncode(fileName));
+            response.Headers.Add("x-filename", HttpUtility.UrlEncode(fileName, encoding));
 
             return response;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4965

### Description
This PR fixes package download, so e.g. a package named `Ørskov Test Package` is downloaded as `Ørskov_Test_Package_1.0.0.zip` instead of `Ã_rskov_Test_Package_1.0.0.zip`.

It seems to work both using `HttpUtility.UrlEncode(fileName)` and `Uri.EscapeDataString(fileName)`.