### PR TITLE
Fixes front-end validation (4627)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
@@ -62,8 +62,8 @@ function valPropertyMsg(serverValidationManager) {
                 if (!watcher) {
                     watcher = scope.$watch("currentProperty.value",
                         function (newValue, oldValue) {
-
-                            if (!newValue || angular.equals(newValue, oldValue)) {
+                            
+                            if (angular.equals(newValue, oldValue)) {
                                 return;
                             }
 
@@ -78,10 +78,12 @@ function valPropertyMsg(serverValidationManager) {
                             // based on other errors. We'll also check if there's no other validation errors apart from valPropertyMsg, if valPropertyMsg
                             // is the only one, then we'll clear.
 
-                            if ((errCount === 1 && angular.isArray(formCtrl.$error.valPropertyMsg)) || (formCtrl.$invalid && angular.isArray(formCtrl.$error.valServer))) {
+                            if (errCount === 0 || (errCount === 1 && angular.isArray(formCtrl.$error.valPropertyMsg)) || (formCtrl.$invalid && angular.isArray(formCtrl.$error.valServer))) {
                                 scope.errorMsg = "";
                                 formCtrl.$setValidity('valPropertyMsg', true);
-                                stopWatch();
+                            } else if (showValidation && scope.errorMsg === "") {
+                                formCtrl.$setValidity('valPropertyMsg', false);
+                                scope.errorMsg = getErrorMsg();
                             }
                         }, true);
                 }
@@ -152,6 +154,7 @@ function valPropertyMsg(serverValidationManager) {
                 showValidation = true;
                 if (hasError && scope.errorMsg === "") {
                     scope.errorMsg = getErrorMsg();
+                    startWatch();
                 }
                 else if (!hasError) {
                     scope.errorMsg = "";


### PR DESCRIPTION
This PR fixes https://github.com/umbraco/Umbraco-CMS/issues/4627
& fixes https://github.com/umbraco/Umbraco-CMS/issues/4976
Plus it makes it possible for front-end validations to re-appear if the validation returns to an invalid state in the same validation-session.

Test notes:
- You need a DocType with two mandatory properties.
- Create a new content node of the given DocType.
- Try to Save, you will see two errors appearing.
- Fill out the first mandatory field, and see now that the validation-message goes away instantly.
- Fill out the first input again.
- Try to make that field empty again, see that the validation-message reappears.
- Fill out the second input.
- Try to make that field empty again, see that the validation-message reappears.
- Fill out the second input again.
- Save again.