### PR TITLE
v8: Increase z-index of umb-editor-footer

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -296,7 +296,7 @@ a.umb-variant-switcher__toggle {
 	padding: 10px 20px;
 	background: @white;
 	border-top: 1px solid @gray-9;
-	z-index: 1;
+	z-index: 30;
 	bottom: 0;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4979

### Description
Increase z-index of .umb-editor-footer so dropup is above grid editor hover overlay and doctype inherited label.