### PR TITLE
V8: Fix glitch in umb-checkbox background

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -26,6 +26,7 @@
 
         &:checked ~ .umb-form-check__state .umb-form-check__check {
             border-color: @ui-option-type;
+            background-color: @ui-option-type;
         }
 
         &:focus:checked ~ .umb-form-check .umb-form-check__check,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

A lot of the time `umb-checkbox` appears to have a 1px white border to the left and sometimes also at the bottom or top when it's checked:

![image](https://user-images.githubusercontent.com/7405322/54310474-bdb95800-45d2-11e9-8eb4-f6299817c083.png)

It's some weird browser glitch; if you zoom in on the checkbox, the white borders disappear (sometimes they reappear again depending on zoom level):

![image](https://user-images.githubusercontent.com/7405322/54310519-dde91700-45d2-11e9-8ba4-ad5b38fef405.png)

This PR adds the "selected" color as background to checked checkboxes. This seems to make the browser play nice:

![image](https://user-images.githubusercontent.com/7405322/54310601-0a049800-45d3-11e9-83c5-f534ee1e019f.png)
