### PR TITLE
V8: Use umb-checkbox in the delete mediatype confirm

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the media type delete dialog
  */
-function MediaTypesDeleteController($scope, mediaTypeResource, treeService, navigationService) {
+function MediaTypesDeleteController($scope, mediaTypeResource, treeService, navigationService, localizationService) {
 
     $scope.performDelete = function() {
 
@@ -45,6 +45,14 @@ function MediaTypesDeleteController($scope, mediaTypeResource, treeService, navi
     $scope.cancel = function() {
         navigationService.hideDialog();
     };
+
+    $scope.labels = {};
+    localizationService
+        .format(["contentTypeEditor_yesDelete", "contentTypeEditor_andAllMediaItems"], "%0% " + $scope.currentNode.name + " %1%")
+        .then(function (data) {
+            $scope.labels.deleteConfirm = data;
+        });
+
 }
 
 angular.module("umbraco").controller("Umbraco.Editors.MediaTypes.DeleteController", MediaTypesDeleteController);

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.html
@@ -24,10 +24,8 @@
 
                 <hr />
 
-                <label class="checkbox">
-                	<input type="checkbox" ng-model="confirmed" />
-                    <localize key="contentTypeEditor_yesDelete">Yes, delete</localize> {{currentNode.name}} <localize key="contentTypeEditor_andAllMediaItems">and all media items using this type</localize>
-                </label>
+                <umb-checkbox model="confirmed" text="{{labels.deleteConfirm}}">
+                </umb-checkbox>
 
                 <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel">
                 </umb-confirm>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR replaces the default checkbox with umb-checkbox in the delete mediatype confirmation dialog (it is the media type equivalent of #4982).

Currently the dialog looks like this:

![image](https://user-images.githubusercontent.com/7405322/54311949-fb6bb000-45d5-11e9-8601-7c10a0fb2726.png)

With this PR applied, the dialog looks like this:

![image](https://user-images.githubusercontent.com/7405322/54311975-0a526280-45d6-11e9-99b1-d2df0dd8e1b4.png)
