### PR TITLE
V8: Use umb-checkbox in the delete datatype confirm

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting content
  */
-function DataTypeDeleteController($scope, dataTypeResource, treeService, navigationService) {
+function DataTypeDeleteController($scope, dataTypeResource, treeService, navigationService, localizationService) {
 
     $scope.performDelete = function() {
 
@@ -44,6 +44,13 @@ function DataTypeDeleteController($scope, dataTypeResource, treeService, navigat
     $scope.cancel = function() {
         navigationService.hideDialog();
     };
+
+    $scope.labels = {};
+    localizationService
+        .format(["editdatatype_yesDelete", "editdatatype_andAllRelated"], "%0% " + $scope.currentNode.name + " %1%")
+        .then(function (data) {
+            $scope.labels.deleteConfirm = data;
+        });
 }
 
 angular.module("umbraco").controller("Umbraco.Editors.DataType.DeleteController", DataTypeDeleteController);

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/delete.html
@@ -20,10 +20,8 @@
 
                 <hr />
 
-                <label class="checkbox">
-                    <input type="checkbox" ng-model="confirmed" />
-                    <localize key="editdatatype_yesDelete">Yes, delete</localize> <strong>{{currentNode.name}}</strong> <localize key="editdatatype_andAllRelated">and all property types & property data using this data type</localize>
-                </label>
+                <umb-checkbox model="confirmed" text="{{labels.deleteConfirm}}">
+                </umb-checkbox>
 
                 <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel">
                 </umb-confirm>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR replaces the default checkbox with umb-checkbox in the delete datatype confirmation dialog (it is the datatype equivalent of #4982).

Currently the dialog looks like this:

![image](https://user-images.githubusercontent.com/7405322/54312720-e859df80-45d7-11e9-80f2-56e036c386fb.png)

With this PR applied, the dialog looks like this:

![image](https://user-images.githubusercontent.com/7405322/54312761-00c9fa00-45d8-11e9-9877-6e64fc03fff7.png)
