### PR TITLE
V8: Use umb-checkbox in the delete membertype confirm

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting member types
  */
-function MemberTypesDeleteController($scope, memberTypeResource, treeService, navigationService) {
+function MemberTypesDeleteController($scope, memberTypeResource, treeService, navigationService, localizationService) {
 
     $scope.performDelete = function() {
 
@@ -29,6 +29,14 @@ function MemberTypesDeleteController($scope, memberTypeResource, treeService, na
     $scope.cancel = function() {
         navigationService.hideDialog();
     };
+
+    $scope.labels = {};
+    localizationService
+        .format(["contentTypeEditor_yesDelete", "contentTypeEditor_andAllMembers"], "%0% " + $scope.currentNode.name + " %1%")
+        .then(function (data) {
+            $scope.labels.deleteConfirm = data;
+        });
+
 }
 
 angular.module("umbraco").controller("Umbraco.Editors.MemberTypes.DeleteController", MemberTypesDeleteController);

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.html
@@ -2,7 +2,7 @@
     <div class="umb-dialog-body">
 
         <p class="abstract">
-        	<localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong>?
+            <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong>?
         </p>
 
         <p>
@@ -13,10 +13,8 @@
 
         <hr />
 
-        <label class="checkbox">
-            <input type="checkbox" ng-model="confirmed" />
-            <localize key="contentTypeEditor_yesDelete">Yes, delete</localize> {{currentNode.name}} <localize key="contentTypeEditor_andAllMembers">and all members using this type</localize>
-        </label>
+        <umb-checkbox model="confirmed" text="{{labels.deleteConfirm}}">
+        </umb-checkbox>
 
         <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel">
         </umb-confirm>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR replaces the default checkbox with umb-checkbox in the delete membertype confirmation dialog (it is the membertype equivalent of #4982).

Currently the dialog looks like this:

![image](https://user-images.githubusercontent.com/7405322/54313506-cbbea700-45d9-11e9-9b4f-395399e3c2e8.png)

With this PR applied, the dialog looks like this:

![image](https://user-images.githubusercontent.com/7405322/54313534-df6a0d80-45d9-11e9-9ebe-ad700c12e1d4.png)
