### PR TITLE
V8: Use umb-checkbox for "open in new window" in the link picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -5,13 +5,13 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
         var vm = this;
         var dialogOptions = $scope.model;
 
-        var searchText = "Search...";
-
         vm.submit = submit;
         vm.close = close;
+        vm.toggleOpenInNewWindow = toggleOpenInNewWindow;
 
-        localizationService.localize("general_search").then(function (value) {
-            searchText = value + "...";
+        vm.labels = {};
+        localizationService.localizeMany(["defaultdialogs_openInNewWindow"]).then(function (data) {
+            vm.labels.openInNewWindow = data[0];
         });
 
         if (!$scope.model.title) {
@@ -87,8 +87,13 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
                     $scope.model.target.anchor = $scope.model.target.url.substring(indexOfAnchor);
                     // then rewrite the model and populate the link
                     $scope.model.target.url = $scope.model.target.url.substring(0, indexOfAnchor);
-                }            }
-        } else if (dialogOptions.anchors) {
+                }
+            }
+
+            // need to translate the link target ("_blank" or "") into a boolean value for umb-checkbox 
+            vm.openInNewWindow = $scope.model.target.target === "_blank";
+        } 
+        else if (dialogOptions.anchors) {
             $scope.anchorValues = dialogOptions.anchors;
         }
 
@@ -209,6 +214,10 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
 
         function openMiniListView(node) {
             $scope.miniListView = node;
+        }
+
+        function toggleOpenInNewWindow(model, value) {
+            $scope.model.target.target = model ? "_blank" : "";
         }
 
         function close() {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
@@ -49,13 +49,11 @@
                     </umb-control-group>
                 
                     <umb-control-group ng-if="showTarget" label="@content_target">
-                        <label class="checkbox no-indent">
-                            <input type="checkbox"
-                                    ng-model="model.target.target"
-                                    ng-true-value="'_blank'"
-                                    ng-false-value="" /> 
-                            <localize key="defaultdialogs_openInNewWindow">Opens the linked document in a new window or tab</localize>
-                        </label>
+                        <umb-checkbox
+                                      model="vm.openInNewWindow"
+                                      on-change="vm.toggleOpenInNewWindow(model, value)"
+                                      text="{{vm.labels.openInNewWindow}}">
+                        </umb-checkbox>
                     </umb-control-group>
 
                     <div class="umb-control-group">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR replaces the default checkbox with `umb-checkbox` for "open in new window" in the link picker.

Here's the link picker as it currently looks:

![image](https://user-images.githubusercontent.com/7405322/54317995-2ad5e900-45e5-11e9-9523-e3d5b0beca7a.png)

With this PR applied it looks like this:

![image](https://user-images.githubusercontent.com/7405322/54317825-966b8680-45e4-11e9-9e41-28f0d0fd39dc.png)
