### PR TITLE
v8: Add umbLoader directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbloader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbloader.directive.js
@@ -43,6 +43,9 @@ Use this directive to generate a loading indicator.
         angular.module("umbraco").controller("My.Controller", Controller);
     })();
 </pre>
+
+@param {string=} position The loader position ("top", "bottom").
+
 **/
 
 (function() {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbloader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbloader.directive.js
@@ -50,10 +50,18 @@ Use this directive to generate a loading indicator.
 
   function UmbLoaderDirective() {
 
+    function link(scope, el, attr, ctrl) {
+        
+    }
+
     var directive = {
-      restrict: 'E',
-      replace: true,
-      templateUrl: 'views/components/umb-loader.html'
+        restrict: 'E',
+        replace: true,
+        templateUrl: 'views/components/umb-loader.html',
+        scope: {
+            position: "@?"
+        },
+        link: link
     };
 
     return directive;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbloader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbloader.directive.js
@@ -1,0 +1,64 @@
+/**
+@ngdoc directive
+@name umbraco.directives.directive:umbLoader
+@restrict E
+
+@description
+Use this directive to generate a loading indicator.
+
+<h3>Markup example</h3>
+<pre>
+    <div ng-controller="My.Controller as vm">
+
+        <umb-loader
+            ng-if="vm.loading">
+        </umb-loader>
+
+        <div class="content" ng-if="!vm.loading">
+            <p>{{content}}</p>
+        </div>
+
+    </div>
+</pre>
+
+<h3>Controller example</h3>
+<pre>
+    (function () {
+        "use strict";
+
+        function Controller(myService) {
+
+            var vm = this;
+
+            vm.content = "";
+            vm.loading = true;
+
+            myService.getContent().then(function(content){
+                vm.content = content;
+                vm.loading = false;
+            });
+
+        }
+
+        angular.module("umbraco").controller("My.Controller", Controller);
+    })();
+</pre>
+**/
+
+(function() {
+  'use strict';
+
+  function UmbLoaderDirective() {
+
+    var directive = {
+      restrict: 'E',
+      replace: true,
+      templateUrl: 'views/components/umb-loader.html'
+    };
+
+    return directive;
+  }
+  
+  angular.module('umbraco.directives').directive('umbLoader', UmbLoaderDirective);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbloadindicator.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbloadindicator.directive.js
@@ -39,7 +39,7 @@ Use this directive to generate a loading indicator.
             });
 
         }
-½
+
         angular.module("umbraco").controller("My.Controller", Controller);
     })();
 </pre>

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -120,6 +120,7 @@
 @import "components/umb-form-check.less";
 @import "components/umb-locked-field.less";
 @import "components/umb-tabs.less";
+@import "components/umb-loader.less";
 @import "components/umb-load-indicator.less";
 @import "components/umb-breadcrumbs.less";
 @import "components/umb-media-grid.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-tour.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-tour.less
@@ -1,8 +1,12 @@
-.umb-tour__loader {
-    background: @white;
-    z-index: @zindexTourModal;
+.umb-loader-wrapper.umb-tour__loader {
+    margin: 0;
     position: fixed;
-    height: 5px;
+    z-index: @zindexTourModal;
+
+    .umb-loader {
+        background-color: @white;
+        height: 5px;
+    }
 }
 
 .umb-tour__pulse {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-loader.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-loader.less
@@ -1,0 +1,36 @@
+// Loading Animation
+// ------------------------
+
+.umb-loader {
+    background-color: @blue;
+    margin-top: 0;
+    margin-left: -100%;
+    animation-name: bounce_loadingProgressG;
+    animation-duration: 1s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+    width: 100%;
+    height: 2px;
+}
+
+@keyframes bounce_loadingProgressG {
+    0% {
+        margin-left: -100%;
+    }
+
+    100% {
+        margin-left: 100%;
+    }
+}
+
+.umb-loader-wrapper {
+    position: absolute;
+    right: 0;
+    left: 0;
+    margin: 10px 0;
+    overflow: hidden;
+}
+
+.umb-loader-wrapper.-bottom {
+    bottom: 0;
+}

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-loader.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-loader.less
@@ -31,6 +31,12 @@
     overflow: hidden;
 }
 
+.umb-loader-wrapper.-top {
+    top: 0;
+    bottom: auto;
+}
+
 .umb-loader-wrapper.-bottom {
+    top: auto;
     bottom: 0;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -485,42 +485,6 @@ table thead a {
     color:@green;
 }
 
-// Loading Animation
-// ------------------------
-
-.umb-loader{
-    background-color: @blue;
-    margin-top:0;
-    margin-left:-100%;
-    animation-name:bounce_loadingProgressG;
-    animation-duration:1s;
-    animation-iteration-count:infinite;
-    animation-timing-function:linear;
-    width:100%;
-    height:2px;
-}
-
-@keyframes bounce_loadingProgressG{
-    0%{
-        margin-left:-100%;
-    }
-    100%{
-        margin-left:100%;
-    }
-}
-
-.umb-loader-wrapper {
-    position: absolute;
-    right: 0;
-    left: 0;
-    margin: 10px 0;
-    overflow: hidden;
-}
-
-.umb-loader-wrapper.-bottom {
-	bottom: 0;
-}
-
 // Helpers
 
 .strong {

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-tour.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-tour.html
@@ -1,6 +1,7 @@
 <div class="umb-tour">
 
-    <div class="umb-loader umb-tour__loader" ng-if="loadingStep"></div>
+    <umb-loader class="umb-tour__loader" ng-if="loadingStep"></umb-loader>
+
     <div class="umb-tour__pulse"></div>
 
     <div class="umb-tour__popover shadow-depth-2" ng-class="{'umb-tour__popover--l': model.currentStep.type === 'intro' || model.currentStepIndex === model.steps.length}">

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-loader.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-loader.html
@@ -1,3 +1,3 @@
-<div class="umb-loader-wrapper">
+<div class="umb-loader-wrapper" ng-class="{ '-top': position === 'top', '-bottom': position === 'bottom' }">
     <div class="umb-loader"></div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-loader.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-loader.html
@@ -1,0 +1,3 @@
+<div class="umb-loader-wrapper">
+    <div class="umb-loader"></div>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/copy.html
@@ -24,9 +24,7 @@
                 <localize key="actions_toInTheTreeStructureBelow">to in the tree structure below</localize>
             </p>
 
-            <div class="umb-loader-wrapper" ng-show="busy">
-                <div class="umb-loader"></div>
-            </div>
+            <umb-loader ng-show="busy"></umb-loader>
 
             <div ng-hide="success">
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/emptyrecyclebin.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/emptyrecyclebin.html
@@ -1,9 +1,8 @@
 <div class="umb-dialog" ng-controller="Umbraco.Editors.Content.EmptyRecycleBinController">
     <div class="umb-dialog-body">
         <umb-pane>
-            <div class="umb-loader-wrapper" ng-show="busy">
-                <div class="umb-loader"></div>
-            </div>
+
+            <umb-loader ng-show="busy"></umb-loader>
 
             <p class="abstract">
                 <localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.

--- a/src/Umbraco.Web.UI.Client/src/views/content/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/move.html
@@ -24,9 +24,7 @@
                 <localize key="actions_toInTheTreeStructureBelow">to in the tree structure below</localize>
             </p>
 
-            <div class="umb-loader-wrapper" ng-show="busy">
-                <div class="umb-loader"></div>
-            </div>
+            <umb-loader ng-show="busy"></umb-loader>
 
             <div ng-hide="success">
 

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/move.html
@@ -7,9 +7,7 @@
                 <localize key="editdatatype_selectFolder">Select the folder to move</localize> <strong>{{source.name}}</strong>&nbsp;<localize key="editdatatype_inTheTree">to in the tree structure below</localize>
             </p>
 
-            <div class="umb-loader-wrapper" ng-show="busy">
-                <div class="umb-loader"></div>
-            </div>
+            <umb-loader ng-show="busy"></umb-loader>
 
             <div ng-show="error">
                 <div class="alert alert-error">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
@@ -7,9 +7,7 @@
                 <localize key="contentTypeEditor_folderToCopy">Select the folder to copy</localize> <strong>{{source.name}}</strong>&nbsp;<localize key="contentTypeEditor_structureBelow">to in the tree structure below</localize>
             </p>
 
-            <div class="umb-loader-wrapper" ng-show="busy">
-                <div class="umb-loader"></div>
-            </div>
+            <umb-loader ng-show="busy"></umb-loader>
 
             <div ng-show="error">
                 <div class="alert alert-error">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
@@ -7,9 +7,7 @@
                 <localize key="contentTypeEditor_folderToMove">Select the folder to move</localize> <strong>{{source.name}}</strong>&nbsp;<localize key="contentTypeEditor_structureBelow">to in the tree structure below</localize>
             </p>
 
-            <div class="umb-loader-wrapper" ng-show="busy">
-                <div class="umb-loader"></div>
-            </div>
+            <umb-loader ng-show="busy"></umb-loader>
 
             <div ng-show="error">
                 <div class="alert alert-error">

--- a/src/Umbraco.Web.UI.Client/src/views/media/emptyrecyclebin.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/emptyrecyclebin.html
@@ -2,9 +2,8 @@
     <div class="umb-dialog-body">
         
         <umb-pane>
-            <div class="umb-loader-wrapper" ng-show="busy">
-                <div class="umb-loader"></div>
-            </div>
+
+            <umb-loader ng-show="busy"></umb-loader>
 
             <p class="abstract">
                 <localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
@@ -7,9 +7,7 @@
                 <localize key="contentTypeEditor_folderToCopy">Select the folder to copy</localize> <strong>{{source.name}}</strong>&nbsp;<localize key="contentTypeEditor_structureBelow">to in the tree structure below</localize>
             </p>
 
-            <div class="umb-loader-wrapper" ng-show="busy">
-                <div class="umb-loader"></div>
-            </div>
+            <umb-loader ng-show="busy"></umb-loader>
 
             <div ng-show="error">
                 <div class="alert alert-error">

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
@@ -7,9 +7,7 @@
                     <localize key="contentTypeEditor_folderToMove">Select the folder to move</localize> <strong>{{source.name}}</strong>&nbsp;<localize key="contentTypeEditor_structureBelow">to in the tree structure below</localize>
             </p>
 
-            <div class="umb-loader-wrapper" ng-show="busy">
-                <div class="umb-loader"></div>
-            </div>
+            <umb-loader ng-show="busy"></umb-loader>
 
             <div ng-show="error">
                 <div class="alert alert-error">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -98,6 +98,7 @@
                    <div class="umb-loader-wrapper -bottom" ng-show="actionInProgress">
                        <div class="umb-loader"></div>
                    </div>
+
                </umb-editor-sub-header-section>
 
            </umb-editor-sub-header-content-left>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -95,9 +95,7 @@
                    <strong ng-show="!actionInProgress">{{ selectedItemsCount() }} <localize key="general_of">of</localize> {{ listViewResultSet.items.length }} <localize key="general_selected">selected</localize></strong>
                    <strong ng-show="actionInProgress" ng-bind="bulkStatus"></strong>
 
-                   <div class="umb-loader-wrapper -bottom" ng-show="actionInProgress">
-                       <div class="umb-loader"></div>
-                   </div>
+                   <umb-loader position="bottom" ng-show="actionInProgress"></umb-loader>
 
                </umb-editor-sub-header-section>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4958

### Description
This PR replaces a few places where `.umb-loader` is used with this `<umb-loader>` directive.

The `umb-loader` added in embed preview here https://github.com/umbraco/Umbraco-CMS/blob/91c52cffc8b7c70dc956f6c6610460be2d1adc51/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/embed/embed.controller.js#L40 is replaced by `<umb-load-indicator>` directive is this PR https://github.com/umbraco/Umbraco-CMS/pull/4899