### PR TITLE
Fixes the authorization for certain endpoints on the UsersController 

### DIFF
--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -605,12 +605,13 @@ namespace Umbraco.Web.Editors
             
             display.AddSuccessNotification(Services.TextService.Localize("speechBubbles/operationSavedHeader"), Services.TextService.Localize("speechBubbles/editUserSaved"));
             return display;
-        }        
+        }
 
         /// <summary>
         /// Disables the users with the given user ids
         /// </summary>
         /// <param name="userIds"></param>
+        [AdminUsersAuthorize("userIds")]
         public HttpResponseMessage PostDisableUsers([FromUri]int[] userIds)
         {
             if (userIds.Contains(Security.GetUserId()))
@@ -641,6 +642,7 @@ namespace Umbraco.Web.Editors
         /// Enables the users with the given user ids
         /// </summary>
         /// <param name="userIds"></param>
+        [AdminUsersAuthorize("userIds")]
         public HttpResponseMessage PostEnableUsers([FromUri]int[] userIds)
         {
             var users = Services.UserService.GetUsersById(userIds).ToArray();
@@ -664,6 +666,7 @@ namespace Umbraco.Web.Editors
         /// Unlocks the users with the given user ids
         /// </summary>
         /// <param name="userIds"></param>
+        [AdminUsersAuthorize("userIds")]
         public async Task<HttpResponseMessage> PostUnlockUsers([FromUri]int[] userIds)
         {
             if (userIds.Length <= 0)
@@ -696,6 +699,7 @@ namespace Umbraco.Web.Editors
                 Services.TextService.Localize("speechBubbles/unlockUsersSuccess", new[] { userIds.Length.ToString() }));
         }
 
+        [AdminUsersAuthorize("userIds")]
         public HttpResponseMessage PostSetUserGroupsOnUsers([FromUri]string[] userGroupAliases, [FromUri]int[] userIds)
         {
             var users = Services.UserService.GetUsersById(userIds).ToArray();
@@ -721,7 +725,8 @@ namespace Umbraco.Web.Editors
         /// Limited to users that haven't logged in to avoid issues with related records constrained
         /// with a foreign key on the user Id
         /// </remarks>
-        public async Task<HttpResponseMessage> PostDeleteNonLoggedInUser(int id)
+        [AdminUsersAuthorize]
+        public HttpResponseMessage PostDeleteNonLoggedInUser(int id)
         {
             var user = Services.UserService.GetUserById(id);
             if (user == null)

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -82,6 +82,7 @@ namespace Umbraco.Web.Editors
 
         [AppendUserModifiedHeader("id")]
         [FileUploadCleanupFilter(false)]
+        [AdminUsersAuthorize]
         public async Task<HttpResponseMessage> PostSetAvatar(int id)
         {
             return await PostSetAvatarInternal(Request, Services.UserService, ApplicationContext.ApplicationCache.StaticCache, id);
@@ -145,6 +146,7 @@ namespace Umbraco.Web.Editors
         }
 
         [AppendUserModifiedHeader("id")]
+        [AdminUsersAuthorize]
         public HttpResponseMessage PostClearAvatar(int id)
         {
             var found = Services.UserService.GetUserById(id);
@@ -183,6 +185,7 @@ namespace Umbraco.Web.Editors
         /// <param name="id"></param>
         /// <returns></returns>
         [OutgoingEditorModelEvent]
+        [AdminUsersAuthorize]
         public UserDisplay GetById(int id)
         {
             var user = Services.UserService.GetUserById(id);

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -832,6 +832,7 @@
     <Compile Include="WebApi\Binders\BlueprintItemBinder.cs" />
     <Compile Include="WebApi\Binders\MemberBinder.cs" />
     <Compile Include="WebApi\EnableDetailedErrorsAttribute.cs" />
+    <Compile Include="WebApi\Filters\AdminUsersAuthorizeAttribute.cs" />
     <Compile Include="WebApi\Filters\AngularAntiForgeryHelper.cs" />
     <Compile Include="WebApi\Filters\AppendCurrentEventMessagesAttribute.cs" />
     <Compile Include="WebApi\Filters\AppendUserModifiedHeaderAttribute.cs" />

--- a/src/Umbraco.Web/WebApi/Filters/AdminUsersAuthorizeAttribute.cs
+++ b/src/Umbraco.Web/WebApi/Filters/AdminUsersAuthorizeAttribute.cs
@@ -9,34 +9,48 @@ using Umbraco.Web.Editors;
 namespace Umbraco.Web.WebApi.Filters
 {
     /// <summary>
-    /// if the user being edited is an admin then we must ensure that the current user is also an admin
+    /// if the users being edited is an admin then we must ensure that the current user is also an admin
     /// </summary>
+    /// <remarks>
+    /// This will authorize against one or multiple ids
+    /// </remarks>
     public sealed class AdminUsersAuthorizeAttribute : AuthorizeAttribute
     {
+        private readonly string _parameterName;
+
+        public AdminUsersAuthorizeAttribute(string parameterName)
+        {
+            _parameterName = parameterName;
+        }
+
+        public AdminUsersAuthorizeAttribute() : this("id")
+        {            
+        }
+
         protected override bool IsAuthorized(HttpActionContext actionContext)
         {
-            if (actionContext.ActionArguments.TryGetValue("id", out var userId) == false)
+            int[] userIds;
+            if (actionContext.ActionArguments.TryGetValue(_parameterName, out var userId))
+            {
+                var intUserId = userId.TryConvertTo<int>();
+                if (intUserId)
+                    userIds = new[] {intUserId.Result};
+                else return base.IsAuthorized(actionContext);
+            }
+            else
             {
                 var queryString = actionContext.Request.GetQueryNameValuePairs();
-                var ids = queryString.Where(x => x.Key == "id").ToArray();
+                var ids = queryString.Where(x => x.Key == _parameterName).ToArray();
                 if (ids.Length == 0)
                     return base.IsAuthorized(actionContext);
-                userId = ids[0].Value;
+                userIds = ids.Select(x => x.Value.TryConvertTo<int>()).Where(x => x.Success).Select(x => x.Result).ToArray();
             }
 
-            if (userId == null) return base.IsAuthorized(actionContext);
-            var intUserId = userId.TryConvertTo<int>();
-            if (intUserId.Success == false)
-                return base.IsAuthorized(actionContext);
+            if (userIds.Length == 0) return base.IsAuthorized(actionContext);
 
-            var user = ApplicationContext.Current.Services.UserService.GetUserById(intUserId.Result);
-            if (user == null)
-                return base.IsAuthorized(actionContext);
-
-            //Perform authorization here to see if the current user can actually save this user with the info being requested
+            var users = ApplicationContext.Current.Services.UserService.GetUsersById(userIds);
             var authHelper = new UserEditorAuthorizationHelper(ApplicationContext.Current.Services.ContentService, ApplicationContext.Current.Services.MediaService, ApplicationContext.Current.Services.UserService, ApplicationContext.Current.Services.EntityService);
-            var canSaveUser = authHelper.IsAuthorized(UmbracoContext.Current.Security.CurrentUser, user, null, null, null);
-            return canSaveUser;
+            return users.All(user => authHelper.IsAuthorized(UmbracoContext.Current.Security.CurrentUser, user, null, null, null) != false);
         }
     }
 }

--- a/src/Umbraco.Web/WebApi/Filters/AdminUsersAuthorizeAttribute.cs
+++ b/src/Umbraco.Web/WebApi/Filters/AdminUsersAuthorizeAttribute.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using Umbraco.Core;
+using Umbraco.Web.Editors;
+
+namespace Umbraco.Web.WebApi.Filters
+{
+    /// <summary>
+    /// if the user being edited is an admin then we must ensure that the current user is also an admin
+    /// </summary>
+    public sealed class AdminUsersAuthorizeAttribute : AuthorizeAttribute
+    {
+        protected override bool IsAuthorized(HttpActionContext actionContext)
+        {
+            if (actionContext.ActionArguments.TryGetValue("id", out var userId) == false)
+            {
+                var queryString = actionContext.Request.GetQueryNameValuePairs();
+                var ids = queryString.Where(x => x.Key == "id").ToArray();
+                if (ids.Length == 0)
+                    return base.IsAuthorized(actionContext);
+                userId = ids[0].Value;
+            }
+
+            if (userId == null) return base.IsAuthorized(actionContext);
+            var intUserId = userId.TryConvertTo<int>();
+            if (intUserId.Success == false)
+                return base.IsAuthorized(actionContext);
+
+            var user = ApplicationContext.Current.Services.UserService.GetUserById(intUserId.Result);
+            if (user == null)
+                return base.IsAuthorized(actionContext);
+
+            //Perform authorization here to see if the current user can actually save this user with the info being requested
+            var authHelper = new UserEditorAuthorizationHelper(ApplicationContext.Current.Services.ContentService, ApplicationContext.Current.Services.MediaService, ApplicationContext.Current.Services.UserService, ApplicationContext.Current.Services.EntityService);
+            var canSaveUser = authHelper.IsAuthorized(UmbracoContext.Current.Security.CurrentUser, user, null, null, null);
+            return canSaveUser;
+        }
+    }
+}

--- a/src/Umbraco.Web/WebApi/Filters/UmbracoApplicationAuthorizeAttribute.cs
+++ b/src/Umbraco.Web/WebApi/Filters/UmbracoApplicationAuthorizeAttribute.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Web.Http;
 using System.Web.Http.Controllers;
 
 namespace Umbraco.Web.WebApi.Filters


### PR DESCRIPTION
The UsersController is responsible for editing users in the back office. We authorize access to all actions on this controller based on section access so if users don't have access to the users section, none of these actions will be authorized. We also go a step further with persisting users so that non-admins cannot save admins, however there are a few endpoints that will allow non-admins to view admin information and also change their avatars or disable them. 

This PR fixes that authorization.

Testing - ensure that normal user editing experience continues to work, that admins can edit other admins and users and that non-admins cannot edit, modify, etc... other admins. To go a step further test that a non admin cannot navigate directly to edit an admin (i.e. go do `/umbraco#/users/users/user/ID-OF-AN-ADMIN?subview=users`)

