### PR TITLE
V8: Automatically close "Cultures and Hostnames" on successful save

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.assigndomain.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.assigndomain.controller.js
@@ -116,6 +116,7 @@
                     if(response.valid) {
 
                         vm.submitButtonState = "success";
+                        closeDialog();
 
                     // show validation messages for each domain
                     } else {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4699

### Description

This PR ensures that the "Culture and Hostnames" dialog is automatically closed after a successful save. 

When this PR is applied, the dialog behaves like this:

![assign-domain-autoclose](https://user-images.githubusercontent.com/7405322/54418264-aa0e0e80-4704-11e9-8512-a04f31e5be2f.gif)
