### PR TITLE
V7: Support any protocol in links containing "@" 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -850,9 +850,10 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
 				return;
 			}
 
-			// Is email and not //user@domain.com
-			if (href.indexOf('@') > 0 && href.indexOf('//') === -1 && href.indexOf('mailto:') === -1) {
-				href = 'mailto:' + href;
+		    // Is email and not //user@domain.com and protocol (e.g. mailto:, sip:) is not specified
+		    if (href.indexOf('@') > 0 && href.indexOf('//') === -1 && href.indexOf(':') === -1) {
+		        // assume it's a mailto link
+		        href = 'mailto:' + href;
 				insertLink();
 				return;
 			}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4947

### Description

See #4947 for an issue description.

Upon inspection it turns out that the RTE assumes any links with a "@" must be a "mailto:" link, and explicitly inserts "mailto:" if it's not present.

This PR removes this assumption and only defaults to "mailto:" if no protocol is specified in the link.

Here's how the link picker works when the PR is applied:

![rte-link-protocol](https://user-images.githubusercontent.com/7405322/54433159-7abec800-472b-11e9-86ba-b9e83408b50d.gif)

@nul800sebastiaan this PR should be able to merge to V8, but if you prefer I'll create a V8 PR instead.
