### PR TITLE
v8 - Added missing parameters to the JSdocs for editorService.iconPicker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -465,6 +465,8 @@ When building a custom infinite editor view you can use the same components as a
          * @description
          * Opens an icon picker in infinite editing, the submit callback returns the selected icon
          * @param {Object} editor rendering options
+         * @param {String} editor.icon The CSS class representing the icon - eg. "icon-autofill".
+         * @param {String} editor.color The CSS class representing the color - eg. "color-red".
          * @param {Callback} editor.submit Submits the editor
          * @param {Callback} editor.close Closes the editor
          * @returns {Object} editor object


### PR DESCRIPTION
When opening a new icon picker via the editor service, you can specify both the icon and the color to have them selected when the picker opens.

With this PR, I've added the `icon` and `color` to the JSdoc as they weren't already part of the documentation.