### PR TITLE
V8: Fix the "Language" dropdown in the "Culture and Hostnames" dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.assigndomain.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.assigndomain.controller.js
@@ -46,8 +46,7 @@
 
                     if (data.language !== "undefined") {
                         var lang = vm.languages.filter(function (l) {
-                            return matchLanguageById(l, data.language.Id);
-
+                            return matchLanguageById(l, data.language);
                         });
                         if (lang.length > 0) {
                             vm.language = lang[0];


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4975

### Description

See #4975 for a description on how to reproduce the issue.

As it turns out, the selected culture/language is already saved; the UI just doesn't display it correctly. This PR fixes it; when applied the dialog works like this:

![inherit-culture](https://user-images.githubusercontent.com/7405322/54497140-85c65380-48f7-11e9-8983-76a388088339.gif)
