### PR TITLE
Avoid removing a public method (used by forms 8.0.0)

### DIFF
--- a/src/Umbraco.Web/Editors/EditorModelEventManager.cs
+++ b/src/Umbraco.Web/Editors/EditorModelEventManager.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Web.Http.Filters;
 using Umbraco.Core.Dashboards;
 using Umbraco.Core.Events;
@@ -15,11 +17,15 @@ namespace Umbraco.Web.Editors
         public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<MediaItemDisplay>> SendingMediaModel;
         public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<MemberDisplay>> SendingMemberModel;
         public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<UserDisplay>> SendingUserModel;
-        public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<IEnumerable<Tab<IDashboardSlim>>>> SendingDashboardModel;
+
+        [Obsolete("Please Use SendingDashboardModelV2")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<IEnumerable<Tab<IDashboard>>>> SendingDashboardModel;
+        public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<IEnumerable<Tab<IDashboardSlim>>>> SendingDashboardModelV2;
 
         private static void OnSendingDashboardModel(HttpActionExecutedContext sender, EditorModelEventArgs<IEnumerable<Tab<IDashboardSlim>>> e)
         {
-            var handler = SendingDashboardModel;
+            var handler = SendingDashboardModelV2;
             handler?.Invoke(sender, e);
         }
 


### PR DESCRIPTION
Avoid introducing a breaking change that would break the compatibility for forms 8.0.0.

Re-introduce the method used by forms as `obsolete`. And re-name the new method.

Test:
- Install forms 8.0.0
  - Before this fix Umbraco would not start