### PR TITLE
V8: Improve the filtering in the datatype picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.controller.js
@@ -10,7 +10,7 @@
 (function() {
     "use strict";
 
-    function DataTypePicker($scope, dataTypeResource, dataTypeHelper, contentTypeResource, localizationService, editorService) {
+    function DataTypePicker($scope, $filter, dataTypeResource, dataTypeHelper, contentTypeResource, localizationService, editorService) {
 
         var vm = this;
 
@@ -119,13 +119,28 @@
             $scope.model.itemDetails = null;
 
             if (vm.searchTerm) {
-                vm.showFilterResult = true;
                 vm.showTabs = false;
+
+                var regex = new RegExp(vm.searchTerm, "i");
+                vm.filterResult = {
+                    userConfigured: filterCollection(vm.userConfigured, regex),
+                    typesAndEditors: filterCollection(vm.typesAndEditors, regex)
+                };
             } else {
-                vm.showFilterResult = false;
+                vm.filterResult = null;
                 vm.showTabs = true;
             }
+        }
 
+        function filterCollection(collection, regex) {
+            return _.map(_.keys(collection), function (key) {
+                return {
+                    group: key,
+                    dataTypes: $filter('filter')(collection[key], function (dataType) {
+                        return regex.test(dataType.name) || regex.test(dataType.alias);
+                    })
+                }
+            });
         }
 
         function showDetailsOverlay(property) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.html
@@ -79,13 +79,13 @@
                         </umb-tab-content>
                     </div>
                     <!-- FILTER RESULTS -->
-                    <div ng-if="vm.showFilterResult">
+                    <div ng-if="vm.filterResult">
                         <h5 class="-border-bottom -black"><localize key="contentTypeEditor_reuse"></localize></h5>
-                        <div ng-repeat="(key,value) in vm.userConfigured">
-                            <div ng-if="(value | filter:vm.searchTerm).length > 0">
-                                <h5>{{key}}</h5>
+                        <div ng-repeat="result in vm.filterResult.userConfigured">
+                            <div ng-if="result.dataTypes.length > 0">
+                                <h5>{{result.group}}</h5>
                                 <ul class="umb-card-grid" ng-mouseleave="vm.hideDetailsOverlay()">
-                                    <li ng-repeat="dataType in value | orderBy:'name' | filter: vm.searchTerm"
+                                    <li ng-repeat="dataType in result.dataTypes | orderBy:'name'"
                                         ng-mouseover="vm.showDetailsOverlay(dataType)"
                                         ng-click="vm.pickDataType(dataType)"
                                         class="-four-in-row">
@@ -101,11 +101,11 @@
                             </div>
                         </div>
                         <h5 class="-border-bottom -black"><localize key="contentTypeEditor_availableEditors"></localize></h5>
-                        <div ng-repeat="(key,value) in vm.typesAndEditors">
-                            <div ng-if="(value | filter:vm.searchTerm).length > 0">
-                                <h5>{{key}}</h5>
+                        <div ng-repeat="result in vm.filterResult.typesAndEditors">
+                            <div ng-if="result.dataTypes.length > 0">
+                                <h5>{{result.group}}</h5>
                                 <ul class="umb-card-grid" ng-mouseleave="vm.hideDetailsOverlay()">
-                                    <li ng-repeat="systemDataType in value | orderBy:'name' | filter: vm.searchTerm"
+                                    <li ng-repeat="systemDataType in result.dataTypes | orderBy:'name'"
                                         ng-mouseover="vm.showDetailsOverlay(systemDataType)"
                                         ng-click="vm.pickEditor(systemDataType)"
                                         class="-four-in-row">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4936

### Description

This PR rewrites the filtering in the datatype picker to fix #4936. With this PR applied, the filter explicitly searches the datatype name and alias (editor type) instead of the entire datatype object as is the case today.

Compared to the current solution, this PR cuts the angular filtering in half, as the current solution applies the same filtering twice for each group of available datatypes (user defined and system defined).

When this PR is applied, the datatype picker behaves like this:

![filter-datatypes](https://user-images.githubusercontent.com/7405322/54526857-5c014100-4978-11e9-8bcc-1921451e92ff.gif)
