### PR TITLE
V8: Use umb-checkbox for selection in the groups view 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.controller.js
@@ -63,12 +63,10 @@
                 return;
 
             if (userGroup.selected) {
+                vm.selection.push(userGroup.group.id);
+            } else {
                 var index = selection.indexOf(userGroup.group.id);
                 selection.splice(index, 1);
-                userGroup.selected = false;
-            } else {
-                userGroup.selected = true;
-                vm.selection.push(userGroup.group.id);
             }
 
             if(event){

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
@@ -79,18 +79,16 @@
         </thead>
         <tbody>
             <tr ng-repeat="group in vm.userGroups | filter:vm.filter"
-                ng-click="vm.goToUserGroup(group)"
-                ng-class="{'cursor-pointer': group.hasAccess, 'cursor-not-allowed': !group.hasAccess, '--selected': group.selected}">
+                ng-class="{'--selected': group.selected}">
 
                 <td style="padding-right: 5px">
-                    <input
-                        ng-show="group.hasAccess && group.group.alias !== 'admin' && group.group.alias !== 'translator'"
-                        type="checkbox"
-                        ng-model="group.selected"
-                        ng-click="vm.selectUserGroup(group, vm.selection, $event)"
-                        style="width: 20px; height: 100px;"/>
+                    <umb-checkbox model="group.selected"
+                                  on-change="vm.selectUserGroup(group, vm.selection, $event)"
+                                  ng-show="group.hasAccess && group.group.alias !== 'admin' && group.group.alias !== 'translator'">
+                    </umb-checkbox>
                 </td>
-                <td>
+                <td ng-click="vm.goToUserGroup(group)"
+                    ng-class="{'cursor-pointer': group.hasAccess, 'cursor-not-allowed': !group.hasAccess}">
                     <umb-user-group-preview
                         style="border-bottom: none; margin-bottom: 0; padding: 0;"
                         icon="group.group.icon"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR replaces the default (albeit quite large) selection checkbox in the groups view with `umb-checkbox`. When applied, the groups view behaves like this:

![group-checkbox](https://user-images.githubusercontent.com/7405322/54554501-dd76c480-49b4-11e9-93e8-58af07e41ed6.gif)
