### PR TITLE
V8: Add optional culture parameter to UrlAbsolute extension

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -39,8 +39,9 @@ namespace Umbraco.Web
         /// Gets the absolute url for the content.
         /// </summary>
         /// <param name="content">The content.</param>
+        /// <param name="culture">The culture to get the url for (defaults to current culture)</param>
         /// <returns>The absolute url for the content.</returns>
-        public static string UrlAbsolute(this IPublishedContent content)
+        public static string UrlAbsolute(this IPublishedContent content, string culture = null)
         {
             // adapted from PublishedContentBase.Url
             switch (content.ItemType)
@@ -50,7 +51,7 @@ namespace Umbraco.Web
                         throw new InvalidOperationException("Cannot resolve a Url for a content item when Current.UmbracoContext is null.");
                     if (Current.UmbracoContext.UrlProvider == null)
                         throw new InvalidOperationException("Cannot resolve a Url for a content item when Current.UmbracoContext.UrlProvider is null.");
-                    return Current.UmbracoContext.UrlProvider.GetUrl(content.Id, true);
+                    return Current.UmbracoContext.UrlProvider.GetUrl(content.Id, true, culture);
                 case PublishedItemType.Media:
                     throw new NotSupportedException("AbsoluteUrl is not supported for media types.");
                 default:

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -39,9 +39,16 @@ namespace Umbraco.Web
         /// Gets the absolute url for the content.
         /// </summary>
         /// <param name="content">The content.</param>
-        /// <param name="culture">The culture to get the url for (defaults to current culture)</param>
         /// <returns>The absolute url for the content.</returns>
-        public static string UrlAbsolute(this IPublishedContent content, string culture = null)
+        public static string UrlAbsolute(this IPublishedContent content) => content.UrlAbsolute(null);
+
+        /// <summary>
+        /// Gets the absolute url for the content.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="culture">The culture to get the url for</param>
+        /// <returns>The absolute url for the content.</returns>
+        public static string UrlAbsolute(this IPublishedContent content, string culture)
         {
             // adapted from PublishedContentBase.Url
             switch (content.ItemType)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I find myself needing the absolute URL to all culture variants of a given page. Unfortunately the `UrlAbsolute()` extension method on `IPublishedContent` does not allow for specifying a culture for the absolute URL.

This PR fixes it. When applied you can specify a culture name in - e.g. `myPage.UrlAbsolute("da-DK")`. The culture name is optional, so `myPage.UrlAbsolute()` still works.

#### Breaking change?

Theoretically this is a breaking change. However, I really don't see it being breaking in any practical term:

- Code that references the extension method will be recompiled when upgrading Umbraco and rebuilding the project, so no problem there.
- Views that use the extension method will be recompiled at runtime after an upgrade, so no problem there either.

This leaves behind packages that reference the extension method. They may or may not break (there seem to be divided opinions when searching for any kind of concrete answers here). However, *if* indeed they break I'd rather break them this early in the V8 lifecycle than later on. 

The alternative is to have an overload of `UrlAbsolute()`, which *could* lead to compile time errors later on (`The call is ambiguous between the following methods or properties...`), and which would have to stay in the source forever.