### PR TITLE
V7 - Umbraco automatic redirects don't always get generated

### DIFF
--- a/src/Umbraco.Web/Routing/RedirectTrackingEventHandler.cs
+++ b/src/Umbraco.Web/Routing/RedirectTrackingEventHandler.cs
@@ -177,11 +177,13 @@ namespace Umbraco.Web.Routing
                     // change the IUrlSegmentProvider to support being able to determine if a
                     // segment is going to change for an entity. See notes in IUrlSegmentProvider.
 
-                    var oldEntity = ApplicationContext.Current.Services.ContentService.GetById(entity.Id);
-                    if (oldEntity == null) continue;
-                    var oldSegment = oldEntity.GetUrlSegment();
+                    // we want the last published version, not the last saved
+                    // otherwise redirects aren't created if content is saved, with save+publish happening later
+                    var publishedEntity = ApplicationContext.Current.Services.ContentService.GetPublishedVersion(entity.Id);
+                    if (publishedEntity == null) continue;
+                    var publishedSegment = publishedEntity.GetUrlSegment();
                     var newSegment = entity.GetUrlSegment();
-                    process = oldSegment != newSegment;
+                    process = publishedSegment != newSegment;
                 }
 
                 // skip if no segment change


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #4860 

### Description
Per the issue description:
 - Install a clean version of Umbraco
 - Run through the installer and let the starter kit install
 - Goto the biker-jacket page in the back office
 - Visit the current URL for the biker-jacket page and confirm the page works (do not close this page we need it later)
 - In the back office, change the name of the page from "Biker Jacket" to "Biker Jacket Changed"
 - Click SAVE - NOT Save and Publish
 - Confirm original URL still works (from step 4)
 - Click Save and Publish
 - Refresh original URL (from step 4 or step 7)
 - Get 404 Page not found error because no redirect is in place.
 - Confirm that the new URL is a valid URL by getting it from the info tab of the page.

Why does this happen? The redirect tracking handler gets the latest from the DB via the content service, and compares its URL segment to that of the entity being published. 

That's fine when we're dealing with a save+publish but if the content is saved, then save+publish occurs later, we have an extra save event which means the getById call returns an entity with the same URL (remember, the name was changed prior to the first save) as the one being published, so no redirect is created, even though the newly published entity will have a different URL to the previous published version. At least, that's my take on what's happening.

To fix it, rather than getting by ID, we need the previous published version as it will have the last published URL for the entity. Any subsequent URL changes between two publishing events don't matter since they would never have been public so no need for redirecting.

