### PR TITLE
V8: Add IsVisible extension on IPublishedElement

### DIFF
--- a/src/Umbraco.Web/PublishedElementExtensions.cs
+++ b/src/Umbraco.Web/PublishedElementExtensions.cs
@@ -170,5 +170,23 @@ namespace Umbraco.Web
         }
 
         #endregion
+
+        #region IsSomething
+
+        /// <summary>
+        /// Gets a value indicating whether the content is visible.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <returns>A value indicating whether the content is visible.</returns>
+        /// <remarks>A content is not visible if it has an umbracoNaviHide property with a value of "1". Otherwise,
+        /// the content is visible.</remarks>
+        public static bool IsVisible(this IPublishedElement content)
+        {
+            // rely on the property converter - will return default bool value, ie false, if property
+            // is not defined, or has no value, else will return its value.
+            return content.Value<bool>(Constants.Conventions.Content.NaviHide) == false;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5039

### Description

This PR adds `IsVisible()` as an extension method on `IPublishedElement` as described in #5039.

#### Demo

Given a Nested Content configuration with an element that contains a textstring property named *text* and this template:

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@{
	Layout = null;
}
<html>
    <body>
        <h1>Hello nested content</h1> 
        <p>
            <ul>
                @foreach(var element in Model.Value<IEnumerable<IPublishedElement>>("elements").Where(e => e.IsVisible())){
                    <li>@(element.Value("text"))</li>
                }
            </ul>
        </p>
    </body>
</html>
```

...the behavior is like this:

![element-isvisible](https://user-images.githubusercontent.com/7405322/54757511-a8ec4e00-4bea-11e9-8ae5-c6b4042b4ce6.gif)
