### PR TITLE
V8: Translation in the culture and hostnames panel. 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/assigndomain.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/assigndomain.html
@@ -5,7 +5,7 @@
     <form name="vm.domainForm" ng-submit="vm.save()" novalidate>
 
         <div ng-hide="vm.loading" class="umb-dialog-body">
-            
+
             <umb-pane ng-if="!currentNode.metaData.variesByCulture">
                 <h5 class="umb-pane-title"><localize key="assignDomain_setLanguage">Culture</localize></h5>
                 <label for="assignDomain_language" class="control-label"><localize key="general_language"></localize></label>
@@ -18,14 +18,14 @@
 
                 <h5 class="umb-pane-title"><localize key="assignDomain_setDomains">Domains</localize></h5>
                 <small class="db" style="margin-bottom: 10px;">
-                    <localize key="assignDomain_domainHelp"></localize>
+                    <localize key="assignDomain_domainHelpWithVariants"></localize>
                 </small>
                 <div class="umb-el-wrap  hidelabel">
                     <table class="table table-condensed table-bordered domains" style="margin-bottom: 10px;" ng-if="vm.domains.length > 0">
                         <thead>
                             <tr>
                                 <th>
-                                    <localize key="assignDomain_domain"></localize>                    
+                                    <localize key="assignDomain_domain"></localize>
                                     <span class="umb-control-required">*</span>
                                 </th>
                                 <th>
@@ -45,17 +45,17 @@
                                     <span ng-show="domain.duplicate" class="help-inline"><localize key="assignDomain_duplicateDomain"></localize><span ng-show="domain.other">({{domain.other}})</span></span>
                                 </td>
                                 <td>
-                                    <select 
-                                        style="width: 100%; margin-bottom: 0;" 
-                                        name="domain_language_{{$index}}" 
-                                        class="language" 
-                                        ng-model="domain.lang" 
+                                    <select
+                                        style="width: 100%; margin-bottom: 0;"
+                                        name="domain_language_{{$index}}"
+                                        class="language"
+                                        ng-model="domain.lang"
                                         ng-options="lang.name for lang in vm.languages"
                                         required>
                                     </select>
                                 </td>
                                 <td>
-                                    <umb-button 
+                                    <umb-button
                                         icon="icon-trash"
                                         action="vm.removeDomain($index)"
                                         type="button"
@@ -66,8 +66,8 @@
                         </tbody>
                     </table>
                 </div>
-                
-                <umb-button 
+
+                <umb-button
                     label-key="assignDomain_addNew"
                     action="vm.addDomain()"
                     type="button"
@@ -80,14 +80,14 @@
 
         <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
 
-            <umb-button 
+            <umb-button
                 label-key="general_close"
                 action="vm.closeDialog()"
                 type="button"
                 button-style="link">
             </umb-button>
 
-            <umb-button 
+            <umb-button
                 label-key="buttons_save"
                 type="submit"
                 button-style="success"
@@ -97,5 +97,5 @@
         </div>
 
     </form>
-    
+
 </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
@@ -47,8 +47,6 @@
     <key alias="domainCreated">Nová doména '%0%' byla vytvořena</key>
     <key alias="domainDeleted">Doména '%0%' je odstraněna</key>
     <key alias="domainExists">Doména '%0%' už byla přiřazena</key>
-    <key alias="domainHelp"><![CDATA[Platná doménová jména jsou: "example.com", "www.example.com", "example.com:8080" nebo
-        "https://www.example.com/".<br /><br />Jednoúrovňové cesty v doménách jsou podporovány, např. "example.com/en". Měli byste se jich nicméně vyvarovat. Raději použijte nastavení kultury výše.]]></key>
     <key alias="domainUpdated">Doména '%0%' byla aktualizována</key>
     <key alias="orEdit">Editace aktuálních domén</key>
     <key alias="inherit">Dědit</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -95,7 +95,8 @@
     <key alias="domainExists">Domænet '%0%' er oprettet</key>
     <key alias="domainUpdated">Domænet '%0%' er nu opdateret</key>
     <key alias="orEdit">eller rediger nuværende domæner</key>
-    <key alias="domainHelp">f.eks. ditdomaene.com, www.ditdomaene.com</key>
+    <key alias="domainHelpWithVariants"><![CDATA[Gyldige domænenavne er: "example.com", "www.example.com", "example.com:8080" eller "https://www.example.com/".
+     Yderlgiere understøttes også første niveau af stien efter domænet, f.eks. "Example.com/en" eller "/en". ]]></key>
     <key alias="inherit">Nedarv</key>
     <key alias="setLanguage">Sprog</key>
     <key alias="setLanguageHelp"><![CDATA[Indstil sproget for noder under den aktuelle node,<br /> eller nedarv sprog fra forældre noder. Gælder også<br />

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
@@ -52,7 +52,6 @@
     <key alias="domainExists">Die Domain '%0%' ist bereits zugeordnet</key>
     <key alias="domainUpdated">Domain '%0%' aktualisiert</key>
     <key alias="orEdit">Domains bearbeiten</key>
-    <key alias="domainHelp">Beispiel: example.com, www.example.com</key>
     <key alias="inherit">Vererben</key>
     <key alias="setLanguage">Kultur</key>
     <key alias="setLanguageHelp">Definiert die Kultureinstellung für untergeordnete Elemente dieses Elements oder vererbt vom übergeordneten Element. Wird auch auf das aktuelle Element angewendet, sofern auf tieferer Ebene keine Domain zugeordnet ist.</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -96,9 +96,8 @@
     <key alias="domainExists">Domain '%0%' has already been assigned</key>
     <key alias="domainUpdated">Domain '%0%' has been updated</key>
     <key alias="orEdit">Edit Current Domains</key>
-    <key alias="domainHelp"><![CDATA[Valid domain names are: "example.com", "www.example.com", "example.com:8080" or
-        "https://www.example.com/". One-level paths in domains are supported, eg. "example.com/en". However, they
-        should be avoided. Better use the culture setting above.]]></key>
+      <key alias="domainHelpWithVariants"><![CDATA[Valid domain names are: "example.com", "www.example.com", "example.com:8080", or "https://www.example.com/".
+     Furthermore also one-level paths in domains are supported, eg. "example.com/en" or "/en".]]></key>
     <key alias="inherit">Inherit</key>
     <key alias="setLanguage">Culture</key>
         <key alias="setLanguageHelp">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -96,9 +96,8 @@
     <key alias="domainExists">Domain '%0%' has already been assigned</key>
     <key alias="domainUpdated">Domain '%0%' has been updated</key>
     <key alias="orEdit">Edit Current Domains</key>
-    <key alias="domainHelp"><![CDATA[Valid domain names are: "example.com", "www.example.com", "example.com:8080" or
-        "https://www.example.com/". One-level paths in domains are supported, eg. "example.com/en". However, they
-        should be avoided. Better use the culture setting above.]]></key>
+    <key alias="domainHelpWithVariants"><![CDATA[Valid domain names are: "example.com", "www.example.com", "example.com:8080", or "https://www.example.com/".
+     Furthermore also one-level paths in domains are supported, eg. "example.com/en" or "/en".]]></key>
     <key alias="inherit">Inherit</key>
     <key alias="setLanguage">Culture</key>
     <key alias="setLanguageHelp"><![CDATA[Set the culture for nodes below the current node,<br /> or inherit culture from parent nodes. Will also apply<br />

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/es.xml
@@ -86,8 +86,6 @@
     <key alias="domainExists">El dominio'%0%' ya ha sido asignado</key>
     <key alias="domainUpdated">El dominio %0% ha sido actualizado</key>
     <key alias="orEdit">Editar dominios actuales</key>
-    <key alias="domainHelp"><![CDATA[p.ej.: "tudominio.com", "www.tudominio.com", "tudominio.com:8080" o
-        "https://www.tudominio.com/".<br /><br />Los dominios de un nivel están soportados, por ej. "example.com/en". De todas formas deberían de evitarse. Mejor usar la configuración cultural especificada arriba.]]></key>
     <key alias="inherit">Heredar</key>
         <key alias="setLanguage">Idioma</key>
         <key alias="setLanguageHelp">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
@@ -88,9 +88,6 @@
     <key alias="domainExists">Domaine '%0%' déjà assigné</key>
     <key alias="domainUpdated">Domaine '%0%' mis à jour</key>
     <key alias="orEdit">Editer les domaines actuels</key>
-    <key alias="domainHelp"><![CDATA[Les formats de domaines suivants sont autorisés : "example.com", "www.example.com", "example.com:8080" ou
-        "https://www.example.com/".<br /><br />Les domaines contenant un chemin d'un niveau sont autorisés, ex : "example.com/en". Pour autant, cela
-        devrait être évité. Utilisez plutôt la gestion de la culture et des noms d'hôte.]]></key>
     <key alias="inherit">Hériter</key>
     <key alias="setLanguage">Culture</key>
     <key alias="setLanguageHelp"><![CDATA[Définir la culture pour les noeuds enfants du noeud courant,<br /> ou hériter de la culture des noeuds parents. S'appliquera aussi<br />

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/he.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/he.xml
@@ -41,7 +41,6 @@
     <key alias="domainCreated">הדומיין החדש %0% נוסף בהצלחה</key>
     <key alias="domainDeleted">הדומיין %0% נמחק</key>
     <key alias="domainExists">הדומיין %0% כבר מוקצה</key>
-    <key alias="domainHelp">לדוגמא: yourdomain.com, www.yourdomain.com</key>
     <key alias="domainUpdated">הדומיין %0% עודכן בהצלחה</key>
     <key alias="orEdit">ערוך דומיין נוכחי</key>
   </area>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/it.xml
@@ -41,7 +41,6 @@
     <key alias="domainCreated"><![CDATA[Il dominio '%0%' è stato creato]]></key>
     <key alias="domainDeleted"><![CDATA[Il dominio '%0%' è stato cancellato]]></key>
     <key alias="domainExists"><![CDATA[Il dominio '%0%' è già stato assegnato]]></key>
-    <key alias="domainHelp"><![CDATA[per esempio: yourdomain.com, www.yourdomain.com]]></key>
     <key alias="domainUpdated"><![CDATA[Il dominio '%0%' è stato aggiornato]]></key>
     <key alias="invalidDomain">Hostname non valido</key>
     <key alias="orEdit">Modifica il dominio corrente</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ja.xml
@@ -52,7 +52,6 @@
     <key alias="domainExists">ドメイン '%0%' は既に割り当てられています</key>
     <key alias="domainUpdated">ドメイン '%0%' は更新されました</key>
     <key alias="orEdit">ドメインの編集</key>
-    <key alias="domainHelp"><![CDATA[有効なドメイン名は、"example.com"、"www.example.com"、"example.com:8080"、"https://www.example.com/" などです。ドメインで 1 レベル パスがサポートされます。ただし、それらは回避する必要があります。代わりに上記のカルチャ設定を使用してください。]]></key>
     <key alias="inherit">継承</key>
     <key alias="setLanguage">カルチャの割り当て</key>
     <key alias="setLanguageHelp"><![CDATA[現在のノードの下のノードのカルチャを設定または親ノードからカルチャを継承。以下のドメインが適用されない場合、現在のノードにも適用します。]]></key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ko.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ko.xml
@@ -40,7 +40,6 @@
     <key alias="domainCreated">새로운 '%0%' 도메인이 생성되었습니다</key>
     <key alias="domainDeleted">'%0%' 도메인이 삭제되었습니다</key>
     <key alias="domainExists">'%0%' 도메인이 이미 존재합니다</key>
-    <key alias="domainHelp">예제: yourdomain.com, www.yourdomain.com</key>
     <key alias="domainUpdated">'%0%' 도메인이 업데이트 되었습니다</key>
     <key alias="orEdit">현재 도메인 수정</key>
   </area>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -50,8 +50,7 @@
     <key alias="domainExists">Domenet '%0%' er allerede tilknyttet</key>
     <key alias="domainUpdated">Domenet '%0%' er nå oppdatert</key>
     <key alias="orEdit">eller rediger eksisterende domener</key>
-    <key alias="domainHelp"><![CDATA[Gyldige domenenavn er: "eksempel.no", "www.eksempel.no", "eksempel.no:8080" eller "https://www.eksempel.no/".<br/><br/>Stier med ett nivå støttes, f.eks. "eksempel.com/no". Imidlertid bør det unngås. Bruk heller språkinnstillingen over.]]></key>
-    <key alias="inherit">Arv</key>
+   <key alias="inherit">Arv</key>
     <key alias="setLanguage">Språk</key>
     <key alias="setLanguageHelp"><![CDATA[Sett språk for underordnede noder eller arv språk fra overordnet.<br/>Vil også gjelde denne noden, med mindre et underordnet domene også gjelder.]]></key>
     <key alias="setDomains">Domener</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -55,9 +55,6 @@
     <key alias="domainExists">Domein '%0' is al aanwezig</key>
     <key alias="domainUpdated">Domein '%0%' is bijgewerkt</key>
     <key alias="orEdit">Bewerk huidige domeinen</key>
-    <key alias="domainHelp"><![CDATA[Geldige domeinnamen zijn: "example.com", "www.example.com", "example.com:8080" of
-        "https://www.example.com/".<br /><br />Zgn. 'one-level' paden in domeinen worden ondersteund, bijv. "example.com/en". Echter, ze
-        zouden moeten worden vermeden. Gebruik bij voorkeur de cultuurinstelling hierboven.]]></key>
     <key alias="inherit">Overerven</key>
     <key alias="setLanguage">Cultuur</key>
     <key alias="setLanguageHelp"><![CDATA[Zet de cultuur voor de nodes onder de huidige node,<br /> of erf de cultuur over van de oudernodes. Zal ook van toepassing <br />

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/pl.xml
@@ -86,9 +86,6 @@
     <key alias="domainExists">Domena '%0%' jest aktualnie przypisana</key>
     <key alias="domainUpdated">Domena '%0%' została zaktualizowana</key>
     <key alias="orEdit">Edytuj Aktualne Domeny</key>
-    <key alias="domainHelp"><![CDATA[Poprawne domeny to: "example.com", "www.example.com", "example.com:8080" lub
-    "https://www.example.com/". Wspierane są jednopoziomowe ścieżki domen, np. "example.com/en" jednakże powinno się ich unikać.
-    Preferowane jest użycie powyższych ustawień języka.]]></key>
     <key alias="inherit">Odziedziczona</key>
     <key alias="setLanguage">Język</key>
     <key alias="setLanguageHelp"><![CDATA[Wybierz język dla węzła,<br /> lub wybierz dziedziczenie języka z węzła rodzica. Zostanie to zastosowane<br />

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/pt.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/pt.xml
@@ -40,7 +40,6 @@
     <key alias="domainCreated">Novo domínio '%0%' foi criado</key>
     <key alias="domainDeleted">Domínio '%0%' foi removido</key>
     <key alias="domainExists">Domínio '%0%' já foi designado</key>
-    <key alias="domainHelp">ou seja: seudominio.com, www.seudominio.com</key>
     <key alias="domainUpdated">Domínio '%0%' foi atualizado</key>
     <key alias="orEdit">Editar Domínios Atuais</key>
   </area>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
@@ -78,9 +78,6 @@
     <key alias="domainCreated">Создан новый домен '%0%'</key>
     <key alias="domainDeleted">Домен '%0%' удален</key>
     <key alias="domainExists">Домен с именем '%0%' уже существует</key>
-    <key alias="domainHelp"><![CDATA[Примеры допустимых доменных имен: "example.com", "www.example.com", "example.com:8080" или
-        "https://www.example.com/".<br /><br />Также здесь допустимы части адресов URL первого уровня, например "example.com/en",
-        однако их следует по возможности избегать. Рекомендуется использовать настройку культуры (языка), расположенную выше.]]></key>
     <key alias="domainUpdated">Домен '%0%' обновлен</key>
     <key alias="duplicateDomain">Такой домен уже назначен.</key>
     <key alias="inherit">Унаследовать</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
@@ -43,7 +43,6 @@
     <key alias="domainCreated">Har skapat domännamnet %0%</key>
     <key alias="domainDeleted">Har tagit bort domännamnet %0%</key>
     <key alias="domainExists">Domänen %0% är redan tillagd</key>
-    <key alias="domainHelp">t.ex.: dittdomannamn.se, www.dittdomannamn.se</key>
     <key alias="domainUpdated">Domännamnet %0% har uppdaterats</key>
     <key alias="duplicateDomain">Domänen är redan tilldelad</key>
     <key alias="inherit">Ärv</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
@@ -52,11 +52,6 @@
     <key alias="domainExists">Domain '%0%' zaten atanmış</key>
     <key alias="domainUpdated">Domain '%0%' güncellendi</key>
     <key alias="orEdit">Geçerli domain düzenle</key>
-    <key alias="domainHelp"><![CDATA[
-    Geçerli alan adları şunlardır : " umbraco.com ", " www.umbraco.com ", " umbraco.com:8080 " ya da
-        " https://www.umbraco.com/ " . <br /> etki /> bir düzey yollar desteklenir <br , örneğin . " umbraco.com/en " . Bununla birlikte,
-        kaçınılmalıdır. Daha yukarıdaki kültür ayarını kullanın
-    ]]></key>
     <key alias="inherit">Miras Al</key>
     <key alias="setLanguage">Kültür</key>
     <key alias="setLanguageHelp"><![CDATA[Geçerli düğümün altındaki düğümler için kültür Set <br /> veya üst düğümleri kültürünü devralır. Ayrıca <br /> geçerli olacaktır

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/zh.xml
@@ -55,9 +55,6 @@
     <key alias="domainExists">域名 '%0%' 已使用</key>
     <key alias="domainUpdated">域名 '%0%' 已更新</key>
     <key alias="orEdit">编辑当前域名</key>
-    <key alias="domainHelp"><![CDATA[例如：example.com、www.example.com、example.com:8080、<br/>
-        https://www.example.com/、example.com/en、……使用 * 代表任意域名，<br/>
-        只需要设置语言部分即可。]]></key>
     <key alias="inherit">继承</key>
     <key alias="setLanguage">语言</key>
     <key alias="setLanguageHelp"><![CDATA[为当前节点及子节点设置语言，<br />

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
@@ -52,9 +52,6 @@
     <key alias="domainExists">功能變數名稱 '%0%' 已使用</key>
     <key alias="domainUpdated">功能變數名稱 '%0%' 已更新</key>
     <key alias="orEdit">編輯當前功能變數名稱</key>
-    <key alias="domainHelp"><![CDATA[合格的網域名稱："example.com"，"www.example.com"，"example.com:8080" 或
-        "https://www.example.com/"。也可以使用一層路徑，如： "example.com/en"。但是，最好避免。
-        建議使用上面的文化設定。]]></key>
     <key alias="inherit">繼承</key>
     <key alias="setLanguage">語言</key>
     <key alias="setLanguageHelp"><![CDATA[改變目前節點以下其餘節點的文化設定，<br />或從父節點繼承文化設定。<br />


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/4683

Translation in the culture and hostnames panel.  Our recommendation in V8 is opposite to V7, therefore a new key is introduced

The old (now unused) key is removed from all languages