### PR TITLE
V8: Use the skip and take parameters in GetVersionsSlim

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -230,9 +230,9 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var sql = GetBaseQuery(QueryType.Many, false)
                 .Where<NodeDto>(x => x.NodeId == nodeId)
                 .OrderByDescending<ContentVersionDto>(x => x.Current)
-                .AndByDescending<ContentVersionDto>(x => x.VersionDate);
-
-            return MapDtosToContent(Database.Fetch<DocumentDto>(sql), true, true);
+                .AndByDescending<ContentVersionDto>(x => x.VersionDate)
+                ;
+            return MapDtosToContent(Database.Fetch<DocumentDto>(sql), true, true).Skip(skip).Take(take);
         }
 
         public override IContent GetVersion(int versionId)

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -230,8 +230,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var sql = GetBaseQuery(QueryType.Many, false)
                 .Where<NodeDto>(x => x.NodeId == nodeId)
                 .OrderByDescending<ContentVersionDto>(x => x.Current)
-                .AndByDescending<ContentVersionDto>(x => x.VersionDate)
-                ;
+                .AndByDescending<ContentVersionDto>(x => x.VersionDate);
+
             return MapDtosToContent(Database.Fetch<DocumentDto>(sql), true, true).Skip(skip).Take(take);
         }
 


### PR DESCRIPTION
Use the skip and take parameters in `GetVersionsSlim`

Fixes https://github.com/umbraco/Umbraco-CMS/issues/4990