### PR TITLE
fix 4217 — datatype edits updates in content editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -116,6 +116,13 @@
         function isContentCultureVariant() {
             return $scope.content.variants.length > 1;
         }
+        
+        function reload() {
+            $scope.page.loading = true;
+            loadContent().then(function() {
+                $scope.page.loading = false;
+            });
+        }
 
         function bindEvents() {
             //bindEvents can be called more than once and we don't want to have multiple bound events
@@ -123,13 +130,10 @@
                 eventsService.unsubscribe(evts[e]);
             }
 
-            evts.push(eventsService.on("editors.content.reload", function (name, args) {
+            evts.push(eventsService.on("editors.documentType.saved", function (name, args) {
                 // if this content item uses the updated doc type we need to reload the content item
-                if(args && args.node && args.node.key === $scope.content.key) {
-                    $scope.page.loading = true;
-                    loadContent().then(function() {
-                        $scope.page.loading = false;
-                    });
+                if(args && args.documentType && $scope.content.documentType.id === args.documentType.id) {
+                    reload();
                 }
             }));
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -147,7 +147,7 @@
                     id: documentType.id,
                     submit: function (model) {
                         const args = { node: scope.node };
-                        eventsService.emit('editors.content.reload', args);
+                        eventsService.emit("editors.content.reload", args);
                         editorService.close();
                     },
                     close: function () {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.controller.js
@@ -10,7 +10,8 @@
 (function () {
     "use strict";
 
-    function DataTypeSettingsController($scope, dataTypeResource, dataTypeHelper, localizationService, notificationsService, overlayService, formHelper) {
+    function DataTypeSettingsController($scope, dataTypeResource, dataTypeHelper, 
+        localizationService, notificationsService, overlayService, formHelper, eventsService) {
 
         var vm = this;
 
@@ -103,27 +104,33 @@
 
             var preValues = dataTypeHelper.createPreValueProps(vm.dataType.preValues);
             
-            dataTypeResource.save(vm.dataType, preValues, $scope.model.create).then(function(newDataType) {
-                $scope.model.dataType = newDataType;
-                vm.saveButtonState = "success";
+            dataTypeResource.save(vm.dataType, preValues, $scope.model.create).then(
+                function(newDataType) {
+                    $scope.model.dataType = newDataType;
+                    
+                    var args = { dataType: newDataType };
+                    eventsService.emit("editors.dataTypeSettings.saved", args);
+                    
+                    vm.saveButtonState = "success";
 
-                if ($scope.model && $scope.model.submit) {
-                    $scope.model.submit($scope.model);
-                }
-            }, function(err) {
-                vm.saveButtonState = "error";
-     
-                 if(err.status === 400) {
-                    if (err.data && (err.data.ModelState)) {
-                        
-                        formHelper.handleServerValidation(err.data.ModelState);
+                    if ($scope.model && $scope.model.submit) {
+                        $scope.model.submit($scope.model);
+                    }
+                }, function(err) {
+                    vm.saveButtonState = "error";
+                    
+                    if(err.status === 400) {
+                        if (err.data && (err.data.ModelState)) {
+                            
+                            formHelper.handleServerValidation(err.data.ModelState);
 
-                        for (var e in err.data.ModelState) {
-                            notificationsService.error("Validation", err.data.ModelState[e][0]);
+                            for (var e in err.data.ModelState) {
+                                notificationsService.error("Validation", err.data.ModelState[e][0]);
+                            }
                         }
                     }
                 }
-            });
+            );
             
         }
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/4217

Test notes:
- Go to a content node
- Open its document-type as infinity editing.
- Open a property.
- Open the settings of the data-type.
- Save the data type settings.
- close the property.
- close the document-type.
- see that the change has been updated on the property on the content-node.