### PR TITLE
V8: changed button styles for a better low hanging-fruit solution

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
@@ -13,7 +13,8 @@
                     type="button"
                     size="s"
                     action="vm.disableUrlTracker($event)"
-                    label-key="redirectUrls_disableUrlTracker">
+                    label-key="redirectUrls_disableUrlTracker"
+                    button-style="white">
                 </umb-button>
 
                 <umb-button
@@ -22,7 +23,8 @@
                     size="s"
                     button-style="success"
                     action="vm.enableUrlTracker()"
-                    label-key="redirectUrls_enableUrlTracker">
+                    label-key="redirectUrls_enableUrlTracker"
+                    button-style="success">
                 </umb-button>
 
             </umb-editor-sub-header-section>


### PR DESCRIPTION
PR adding style to redirect management "enable/disable"-redirect button
This is a fast fix to avoid having grey buttons that are enabled, cause before they looked disabled.