### PR TITLE
V8: Update the title of the macro view picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/macro.settings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/macro.settings.controller.js
@@ -15,9 +15,15 @@ function MacrosSettingsController($scope, editorService, localizationService) {
     $scope.model.openViewPicker = openViewPicker;
     $scope.model.removeMacroView = removeMacroView;
 
+    var labels = {};
+
+    localizationService.localizeMany(["macro_selectViewFile"]).then(function(data) {
+        labels.selectViewFile = data[0];
+    });
+
     function openViewPicker() {
         const controlPicker = {
-            title: "Select view",
+            title: labels.selectViewFile,
             section: "settings",
             treeAlias: "partialViewMacros",
             entityType: "partialView",

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1338,6 +1338,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="enterMacroName">Indtast makronavn</key>
     <key alias="parameters">Parametre</key>
     <key alias="parametersDescription">Definer de parametre, der skal være tilgængelige, når du bruger denne makro.</key>
+    <key alias="selectViewFile">Vælg partial view makrofil</key>
   </area>
   <area alias="templateEditor">
     <key alias="alternativeField">Alternativt felt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1614,6 +1614,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="enterMacroName">Enter macro name</key>
     <key alias="parameters">Parameters</key>
     <key alias="parametersDescription">Define the parameters that should be available when using this macro.</key>
+    <key alias="selectViewFile">Select partial view macro file</key>
   </area>
   <area alias="modelsBuilder">
     <key alias="buildingModels">Building models</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1623,6 +1623,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="enterMacroName">Enter macro name</key>
     <key alias="parameters">Parameters</key>
     <key alias="parametersDescription">Define the parameters that should be available when using this macro.</key>
+    <key alias="selectViewFile">Select partial view macro file</key>
   </area>
   <area alias="modelsBuilder">
     <key alias="buildingModels">Building models</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4417

### Description

As requested in #4417, this PR changes the title of the macro view picker from "Select view" (hardcoded english) to "Select partial view macro file" (localized).

#### Testing this PR

1. Make sure you have some partial view macro files.
2. Create a macro.
3. Verify the new title when picking the macro view file:

![image](https://user-images.githubusercontent.com/7405322/54913083-49e04f00-4ef2-11e9-9002-8497fb02e489.png)
