### PR TITLE
V8: Support stylesheets in subfolders in the RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -48,7 +48,14 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         if (configuredStylesheets) {
             angular.forEach(configuredStylesheets, function (val, key) {
 
-                stylesheets.push(Umbraco.Sys.ServerVariables.umbracoSettings.cssPath + "/" + val + ".css");
+                if (val.indexOf(Umbraco.Sys.ServerVariables.umbracoSettings.cssPath + "/") === 0) {
+                    // current format (full path to stylesheet)
+                    stylesheets.push(val);
+                }
+                else {
+                    // legacy format (stylesheet name only) - must prefix with stylesheet folder and postfix with ".css"
+                    stylesheets.push(Umbraco.Sys.ServerVariables.umbracoSettings.cssPath + "/" + val + ".css");
+                }
 
                 promises.push(stylesheetResource.getRulesByName(val).then(function (rules) {
                     angular.forEach(rules, function (rule) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -40,13 +40,16 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
             $scope.stylesheets = stylesheets;
         });
 
-        $scope.selected = function(cmd, alias, lookup){
-            if (lookup && angular.isArray(lookup)) {
-                cmd.selected = lookup.indexOf(alias) >= 0;
-                return cmd.selected;
-            }
-            return false;
+        $scope.commandSelected = function(cmd) {
+            cmd.selected = $scope.model.value.toolbar.indexOf(cmd.alias) >= 0;
+            return cmd.selected;
         };
+
+        $scope.cssSelected = function (css) {
+            // support both current format (full stylesheet path) and legacy format (stylesheet name only) 
+            css.selected = $scope.model.value.stylesheets.indexOf(css.path) >= 0 ||$scope.model.value.stylesheets.indexOf(css.name) >= 0;
+            return css.selected;
+        }
 
         $scope.selectCommand = function(command){
             var index = $scope.model.value.toolbar.indexOf(command.alias);
@@ -60,11 +63,16 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
 
         $scope.selectStylesheet = function (css) {
 
-            var index = $scope.model.value.stylesheets.indexOf(css.name);
+            // find out if the stylesheet is already selected; first look for the full stylesheet path (current format)
+            var index = $scope.model.value.stylesheets.indexOf(css.path);
+            if (index === -1) {
+                // ... then look for the stylesheet name (legacy format)
+                index = $scope.model.value.stylesheets.indexOf(css.name);
+            }
 
-            if(css.selected && index === -1){
-                $scope.model.value.stylesheets.push(css.name);
-            }else if(index >= 0){
+            if(index === -1){
+                $scope.model.value.stylesheets.push(css.path);
+            }else{
                 $scope.model.value.stylesheets.splice(index, 1);
             }
         };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -4,7 +4,7 @@
         <div ng-repeat="cmd in tinyMceConfig.commands">
             <label>
                 <input type="checkbox"
-                       ng-checked="selected(cmd, cmd.alias, model.value.toolbar)"
+                       ng-checked="commandSelected(cmd)"
                        ng-model="cmd.selected"
                        ng-change="selectCommand(cmd)" />
 
@@ -20,7 +20,7 @@
         <div ng-repeat="css in stylesheets">
             <label>
                 <input type="checkbox"
-                       ng-checked="selected(css, css.name, model.value.stylesheets)"
+                       ng-checked="cssSelected(css)"
                        ng-model="css.selected"
                        ng-change="selectStylesheet(css)" />
                 {{css.name}}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4932

### Description

This PR ensures that stylesheets in subfolders can be used in the RTE. See #4932 for details.

#### Backwards compatibility 

Currently only the stylesheet name is saved as part of the RTE config. This PR changes things around so the full path to the stylesheet is saved instead of the name. To ensure backwards compatibility with existing RTE configs, all usages of the RTE stylesheets config have been updated to work with both formats.

#### Testing this PR

1. **Before you apply this PR,** make sure you have an RTE configured with one or more stylesheets from the stylesheets root folder (to test backwards compatibility).
2. After applying this PR, ensure that the currently selected stylesheets still work in the RTE and that they are still listed as selected in the RTE configuration.
3. Create a new stylesheet with RTE rules in a sub folder under the stylesheets root folder.
4. Select the new stylesheet as part of the RTE configuration.
![image](https://user-images.githubusercontent.com/7405322/54920880-b06e6880-4f04-11e9-8462-7411df104d2f.png)
5. Verify that the new stylesheet rules are now part of the RTE, alongside the already selected stylesheet rules.

