### PR TITLE
V8: Use "group" instead of "tab" on Nested Content config

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -8,7 +8,7 @@
                         <localize key="content_documentType">Document Type</localize>
                     </th>
                     <th>
-                        <localize key="editcontenttype_tab">Tab</localize>
+                        <localize key="general_group">Group</localize>
                     </th>
                     <th>
                         <localize key="template_template">Template</localize>
@@ -51,8 +51,8 @@
     <br/>
     <div class="umb-nested-content__help-text" ng-show="showHelpText">
         <p>
-            <b><localize key="editcontenttype_tab">Tab</localize>:</b><br/>
-            Select the tab who's properties should be displayed. If left blank, the first tab on the doc type will be used.
+            <b><localize key="general_group">Group</localize>:</b><br/>
+            Select the group whose properties should be displayed. If left blank, the first group on the document type will be used.
         </p>
         <p>
             <b><localize key="template_template">Template</localize>:</b><br/>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -609,6 +609,7 @@
     <key alias="first">Første</key>
     <key alias="general">Generelt</key>
     <key alias="groups">Grupper</key>
+    <key alias="group">Gruppe</key>
     <key alias="height">Højde</key>
     <key alias="help">Hjælp</key>
     <key alias="hide">Skjul</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -631,6 +631,7 @@
     <key alias="first">First</key>
     <key alias="general">General</key>
     <key alias="groups">Groups</key>
+    <key alias="group">Group</key>
     <key alias="height">Height</key>
     <key alias="help">Help</key>
     <key alias="hide">Hide</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -634,6 +634,7 @@
     <key alias="first">First</key>
     <key alias="general">General</key>
     <key alias="groups">Groups</key>
+    <key alias="group">Group</key>
     <key alias="height">Height</key>
     <key alias="help">Help</key>
     <key alias="hide">Hide</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Nested Content is still referring to document type "tabs", even though they were renamed to "groups" in V8:

![image](https://user-images.githubusercontent.com/7405322/55030086-e0ecfa00-500b-11e9-8eac-fd84ef918f16.png)

This PR fixes that little inconsistency:

![image](https://user-images.githubusercontent.com/7405322/55029988-a8e5b700-500b-11e9-86b1-2a95545b9346.png)
