### PR TITLE
V8: Fix the style of the public access confirmation button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/protect.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/protect.html
@@ -127,7 +127,7 @@
                 <div class="alert alert-success" ng-bind-html="vm.success.message"></div>
                 <umb-button type="button"
                             action="vm.close()"
-                            button-style="action"
+                            button-style="success"
                             label-key="general_ok">
                 </umb-button>
             </umb-pane>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Just a little consistency update here: The "OK" button in the public access confirmation dialog (after saving public access setup) is the wrong color:

![image](https://user-images.githubusercontent.com/7405322/55103175-43a3cb80-50c8-11e9-9f18-dc29b177c8f7.png)

This PR makes it the right color 😆 
