### PR TITLE
Alternate Preview Engine

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ContentRepository.cs
@@ -199,7 +199,7 @@ namespace Umbraco.Core.Persistence.Repositories
                                "DELETE FROM cmsContentXml WHERE nodeId = @Id",
                                "DELETE FROM cmsContent WHERE nodeId = @Id",
                                "DELETE FROM umbracoAccess WHERE nodeId = @Id",
-                               "DELETE FROM umbracoNode WHERE id = @Id"                               
+                               "DELETE FROM umbracoNode WHERE id = @Id"
                            };
             return list;
         }
@@ -468,7 +468,7 @@ namespace Umbraco.Core.Persistence.Repositories
             entity.Id = nodeDto.NodeId; //Set Id on entity to ensure an Id is set
             entity.Path = nodeDto.Path;
             entity.SortOrder = sortOrder;
-            entity.Level = level;            
+            entity.Level = level;
 
             //Create the Content specific data - cmsContent
             var contentDto = dto.ContentVersionDto.ContentDto;
@@ -644,7 +644,7 @@ namespace Umbraco.Core.Persistence.Repositories
                     contentVersionDto.Id = contentVerDto.Id;
                     Database.Update(contentVersionDto);
                 }
-                
+
                 Database.Update(dto);
             }
 
@@ -752,7 +752,7 @@ namespace Umbraco.Core.Persistence.Repositories
         public IEnumerable<IContent> GetBlueprints(IQuery<IContent> query)
         {
             Func<SqlTranslator<IContent>, Sql> translate = t => t.Translate();
-            
+
             var sqlFull = GetBaseQuery(BaseQueryType.FullMultiple);
             var translatorFull = new SqlTranslator<IContent>(sqlFull, query);
             var sqlIds = GetBaseQuery(BaseQueryType.Ids);
@@ -835,6 +835,61 @@ order by umbracoNode.{2}, umbracoNode.parentID, umbracoNode.sortOrder",
 
         }
 
+        public XmlDocument BuildPreviewXmlCache()
+        {
+            var xmlDoc = new XmlDocument();
+            var doctype = xmlDoc.CreateDocumentType("root", null, null,
+                ApplicationContext.Current.Services.ContentTypeService.GetContentTypesDtd());
+            xmlDoc.AppendChild(doctype);
+            var parent = xmlDoc.CreateElement("root");
+            var pIdAtt = xmlDoc.CreateAttribute("id");
+            pIdAtt.Value = "-1";
+            parent.Attributes.Append(pIdAtt);
+            xmlDoc.AppendChild(parent);
+
+            //Ensure that only nodes that have published versions are selected
+            var sql = string.Format(@"select umbracoNode.id, umbracoNode.parentID, umbracoNode.sortOrder, cmsPreviewXml.{0}, umbracoNode.{1} from umbracoNode
+inner join cmsPreviewXml on cmsPreviewXml.nodeId = umbracoNode.id and umbracoNode.nodeObjectType = @type
+inner join cmsDocument on cmsPreviewXml.versionId = cmsDocument.versionId and cmsDocument.newest=1
+order by umbracoNode.{2}, umbracoNode.parentID, umbracoNode.sortOrder",
+                SqlSyntax.GetQuotedColumnName("xml"),
+                SqlSyntax.GetQuotedColumnName("level"),
+                SqlSyntax.GetQuotedColumnName("level"));
+
+            XmlElement last = null;
+
+            //NOTE: Query creates a reader - does not load all into memory
+            foreach (var row in Database.Query<dynamic>(sql, new { type = NodeObjectTypeId }))
+            {
+                string parentId = ((int)row.parentID).ToInvariantString();
+                string xml = row.xml;
+                int sortOrder = row.sortOrder;
+
+                //if the parentid is changing
+                if (last != null && last.GetAttribute("parentID") != parentId)
+                {
+                    parent = xmlDoc.GetElementById(parentId);
+                    if (parent == null)
+                    {
+                        //Need to short circuit here, if the parent is not there it means that the parent is unpublished
+                        // and therefore the child is not published either so cannot be included in the xml cache
+                        continue;
+                    }
+                }
+
+                var xmlDocFragment = xmlDoc.CreateDocumentFragment();
+                xmlDocFragment.InnerXml = xml;
+
+                last = (XmlElement)parent.AppendChild(xmlDocFragment);
+
+                // fix sortOrder - see notes in UpdateSortOrder
+                last.Attributes["sortOrder"].Value = sortOrder.ToInvariantString();
+            }
+
+            return xmlDoc;
+
+        }
+
         public int CountPublished(string contentTypeAlias = null)
         {
             if (contentTypeAlias.IsNullOrWhiteSpace())
@@ -868,9 +923,9 @@ order by umbracoNode.{2}, umbracoNode.parentID, umbracoNode.sortOrder",
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="permission"></param>
-        /// <param name="groupIds"></param>        
+        /// <param name="groupIds"></param>
         public void AssignEntityPermission(IContent entity, char permission, IEnumerable<int> groupIds)
-        {            
+        {
             _permissionRepository.AssignEntityPermission(entity, permission, groupIds);
         }
 
@@ -882,7 +937,7 @@ order by umbracoNode.{2}, umbracoNode.parentID, umbracoNode.sortOrder",
         public EntityPermissionCollection GetPermissionsForEntity(int entityId)
         {
             return _permissionRepository.GetPermissionsForEntity(entityId);
-        }        
+        }
 
         /// <summary>
         /// Adds/updates content/published xml

--- a/src/Umbraco.Core/Persistence/Repositories/Interfaces/IContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Interfaces/IContentRepository.cs
@@ -19,6 +19,8 @@ namespace Umbraco.Core.Persistence.Repositories
         /// <returns></returns>
         XmlDocument BuildXmlCache();
 
+        XmlDocument BuildPreviewXmlCache();
+
         /// <summary>
         /// Get the count of published items
         /// </summary>

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2192,6 +2192,17 @@ namespace Umbraco.Core.Services
             }
         }
 
+        public XmlDocument BuildPreviewXmlCache()
+        {
+            using (var uow = UowProvider.GetUnitOfWork())
+            {
+                var repository = RepositoryFactory.CreateContentRepository(uow);
+                var result = repository.BuildPreviewXmlCache();
+                uow.Commit();
+                return result;
+            }
+        }
+
         /// <summary>
         /// Rebuilds all xml content in the cmsContentXml table for all documents
         /// </summary>

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -124,6 +124,8 @@ namespace Umbraco.Core.Services
         /// <returns></returns>
         XmlDocument BuildXmlCache();
 
+        XmlDocument BuildPreviewXmlCache();
+
         /// <summary>
         /// Rebuilds all xml content in the cmsContentXml table for all documents
         /// </summary>

--- a/src/Umbraco.Web/Cache/UnpublishedPageCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/UnpublishedPageCacheRefresher.cs
@@ -6,6 +6,7 @@ using Umbraco.Core.Cache;
 using Umbraco.Core.Models;
 using System.Linq;
 using Newtonsoft.Json;
+using umbraco.cms.businesslogic.web;
 using Umbraco.Core.Persistence.Repositories;
 using Umbraco.Core.Sync;
 
@@ -44,7 +45,7 @@ namespace Umbraco.Web.Cache
             return jsonObject;
         }
 
-      
+
         internal static string SerializeToJsonPayloadForPermanentDeletion(params int[] contentIds)
         {
             var items = contentIds.Select(x => new JsonPayload
@@ -61,12 +62,12 @@ namespace Umbraco.Web.Cache
         #region Sub classes
 
         internal enum OperationType
-        {            
+        {
             Deleted
         }
 
         internal class JsonPayload
-        {            
+        {
             public int Id { get; set; }
             public OperationType Operation { get; set; }
         }
@@ -79,6 +80,7 @@ namespace Umbraco.Web.Cache
             ClearAllIsolatedCacheByEntityType<IContent>();
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();
+            content.Instance.ClearPreviewXmlContent();
             base.RefreshAll();
         }
 
@@ -87,6 +89,9 @@ namespace Umbraco.Web.Cache
             ClearRepositoryCacheItemById(id);
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
             content.Instance.UpdateSortOrder(id);
+            var d = new Document(id);
+            content.Instance.UpdateDocumentCache(d);
+            content.Instance.UpdatePreviewXmlContent(d);
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();
             base.Refresh(id);
         }
@@ -97,6 +102,7 @@ namespace Umbraco.Web.Cache
             ClearRepositoryCacheItemById(id);
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();
+            content.Instance.ClearPreviewXmlContent(id);
             base.Remove(id);
         }
 
@@ -106,6 +112,9 @@ namespace Umbraco.Web.Cache
             ClearRepositoryCacheItemById(instance.Id);
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
             content.Instance.UpdateSortOrder(instance);
+            var d = new Document(instance);
+            content.Instance.UpdateDocumentCache(d);
+            content.Instance.UpdatePreviewXmlContent(d);
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();
             base.Refresh(instance);
         }
@@ -116,6 +125,7 @@ namespace Umbraco.Web.Cache
             ClearRepositoryCacheItemById(instance.Id);
             ClearAllIsolatedCacheByEntityType<PublicAccessEntry>();
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();
+            content.Instance.ClearPreviewXmlContent(instance.Id);
             base.Remove(instance);
         }
 
@@ -132,6 +142,7 @@ namespace Umbraco.Web.Cache
                 ApplicationContext.Current.Services.IdkMap.ClearCache(payload.Id);
                 ClearRepositoryCacheItemById(payload.Id);
                 content.Instance.UpdateSortOrder(payload.Id);
+                content.Instance.ClearPreviewXmlContent(payload.Id);
             }
 
             DistributedCache.Instance.ClearDomainCacheOnCurrentServer();

--- a/src/Umbraco.Web/PublishedCache/XmlPublishedCache/PublishedContentCache.cs
+++ b/src/Umbraco.Web/PublishedCache/XmlPublishedCache/PublishedContentCache.cs
@@ -523,6 +523,8 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
                 {
                     if (preview)
                     {
+                        if (PreviewContent.IsSinglePreview)
+                            return content.Instance.PreviewXmlContent;
                         var previewContent = PreviewContentCache.GetOrCreateValue(context); // will use the ctor with no parameters
                         previewContent.EnsureInitialized(context.UmbracoUser, StateHelper.Cookies.Preview.GetValue(), true, () =>
                         {

--- a/src/Umbraco.Web/umbraco.presentation/content.cs
+++ b/src/Umbraco.Web/umbraco.presentation/content.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Web;
 using System.Xml;
 using umbraco.BusinessLogic;
@@ -13,6 +14,7 @@ using umbraco.cms.businesslogic;
 using umbraco.cms.businesslogic.web;
 using umbraco.DataLayer;
 using umbraco.presentation.nodeFactory;
+using umbraco.presentation.preview;
 using Umbraco.Core;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Configuration;
@@ -275,6 +277,8 @@ namespace umbraco
 
                 safeXml.AcceptChanges();
             }
+
+            ClearPreviewXmlContent();
         }
 
         /// <summary>
@@ -474,6 +478,8 @@ namespace umbraco
                     safeXml.AcceptChanges();
                 }
             }
+
+            ClearPreviewXmlContent(id);
         }
 
         /// <summary>
@@ -666,6 +672,21 @@ namespace umbraco
 
             //_lastXmlChange = DateTime.UtcNow;
             _persisterTask = _persisterTask.Touch(); // _persisterTask != null because SyncToXmlFile == true
+        }
+
+        private static bool HasSchema(string contentTypeAlias, XmlDocument xml)
+        {
+            string subset = null;
+
+            // get current doctype
+            var n = xml.FirstChild;
+            while (n.NodeType != XmlNodeType.DocumentType && n.NextSibling != null)
+                n = n.NextSibling;
+            if (n.NodeType == XmlNodeType.DocumentType)
+                subset = ((XmlDocumentType)n).InternalSubset;
+
+            // ensure it contains the content type
+            return subset != null && subset.Contains(string.Format("<!ATTLIST {0} id ID #REQUIRED>", contentTypeAlias));
         }
 
         private static XmlDocument EnsureSchema(string contentTypeAlias, XmlDocument xml)
@@ -1256,6 +1277,192 @@ namespace umbraco
             if (BeforePublishNodeToContentCache != null)
             {
                 BeforePublishNodeToContentCache(node, e);
+            }
+        }
+
+        #endregion
+
+        #region Preview
+
+        private const string PreviewCacheKey = "umbraco.content.preview";
+
+        internal void ClearPreviewXmlContent()
+        {
+            if (PreviewContent.IsSinglePreview == false) return;
+
+            var runtimeCache = ApplicationContext.Current.ApplicationCache.RuntimeCache;
+            runtimeCache.ClearCacheItem(PreviewCacheKey);
+        }
+
+        internal void ClearPreviewXmlContent(int id)
+        {
+            if (PreviewContent.IsSinglePreview == false) return;
+
+            var runtimeCache = ApplicationContext.Current.ApplicationCache.RuntimeCache;
+            var xml = runtimeCache.GetCacheItem<XmlDocument>(PreviewCacheKey);
+            if (xml == null) return;
+
+            // Check if node present, before cloning
+            var x = xml.GetElementById(id.ToString());
+            if (x == null)
+                return;
+
+            // Find the document in the xml cache
+            // The document already exists in cache, so repopulate it
+            x.ParentNode.RemoveChild(x);
+        }
+
+        internal void UpdatePreviewXmlContent(Document d)
+        {
+            if (PreviewContent.IsSinglePreview == false) return;
+
+            var runtimeCache = ApplicationContext.Current.ApplicationCache.RuntimeCache;
+            var xml = runtimeCache.GetCacheItem<XmlDocument>(PreviewCacheKey);
+            if (xml == null) return;
+
+            var pnode = GetPreviewOrPublishedNode(d, xml, true);
+            var pattr = ((XmlElement)pnode).GetAttributeNode("sortOrder");
+            pattr.Value = d.sortOrder.ToString();
+            AddOrUpdatePreviewXmlNode(d.Id, d.Level, d.Level == 1 ? -1 : d.ParentId, pnode);
+        }
+
+        private void AddOrUpdatePreviewXmlNode(int id, int level, int parentId, XmlNode docNode)
+        {
+            var runtimeCache = ApplicationContext.Current.ApplicationCache.RuntimeCache;
+            var xml = runtimeCache.GetCacheItem<XmlDocument>(PreviewCacheKey);
+            if (xml == null) return;
+
+            // sanity checks
+            if (id != docNode.AttributeValue<int>("id"))
+                throw new ArgumentException("Values of id and docNode/@id are different.");
+            if (parentId != docNode.AttributeValue<int>("parentID"))
+                throw new ArgumentException("Values of parentId and docNode/@parentID are different.");
+
+            // find the document in the cache
+            XmlNode currentNode = xml.GetElementById(id.ToInvariantString());
+
+            // if the document is not there already then it's a new document
+            // we must make sure that its document type exists in the schema
+            if (currentNode == null && UseLegacySchema == false)
+            {
+                if (HasSchema(docNode.Name, xml) == false)
+                {
+                    runtimeCache.ClearCacheItem(PreviewCacheKey);
+                    return;
+                }
+            }
+
+            // find the parent
+            XmlNode parentNode = level == 1
+                ? xml.DocumentElement
+                : xml.GetElementById(parentId.ToInvariantString());
+
+            // no parent = cannot do anything
+            if (parentNode == null)
+                return;
+
+            // insert/move the node under the parent
+            if (currentNode == null)
+            {
+                // document not there, new node, append
+                currentNode = docNode;
+                parentNode.AppendChild(currentNode);
+            }
+            else
+            {
+                // document found... we could just copy the currentNode children nodes over under
+                // docNode, then remove currentNode and insert docNode... the code below tries to
+                // be clever and faster, though only benchmarking could tell whether it's worth the
+                // pain...
+
+                // first copy current parent ID - so we can compare with target parent
+                var moving = currentNode.AttributeValue<int>("parentID") != parentId;
+
+                if (docNode.Name == currentNode.Name)
+                {
+                    // name has not changed, safe to just update the current node
+                    // by transfering values eg copying the attributes, and importing the data elements
+                    TransferValuesFromDocumentXmlToPublishedXml(docNode, currentNode);
+
+                    // if moving, move the node to the new parent
+                    // else it's already under the right parent
+                    // (but maybe the sort order has been updated)
+                    if (moving)
+                        parentNode.AppendChild(currentNode); // remove then append to parentNode
+                }
+                else
+                {
+                    // name has changed, must use docNode (with new name)
+                    // move children nodes from currentNode to docNode (already has properties)
+                    var children = currentNode.SelectNodes(ChildNodesXPath);
+                    if (children == null) throw new Exception("oops");
+                    foreach (XmlNode child in children)
+                        docNode.AppendChild(child); // remove then append to docNode
+
+                    // and put docNode in the right place - if parent has not changed, then
+                    // just replace, else remove currentNode and insert docNode under the right parent
+                    // (but maybe not at the right position due to sort order)
+                    if (moving)
+                    {
+                        if (currentNode.ParentNode == null) throw new Exception("oops");
+                        currentNode.ParentNode.RemoveChild(currentNode);
+                        parentNode.AppendChild(docNode);
+                    }
+                    else
+                    {
+                        // replacing might screw the sort order
+                        parentNode.ReplaceChild(docNode, currentNode);
+                    }
+
+                    currentNode = docNode;
+                }
+            }
+
+            // if the nodes are not ordered, must sort
+            // (see U4-509 + has to work with ReplaceChild too)
+            //XmlHelper.SortNodesIfNeeded(parentNode, childNodesXPath, x => x.AttributeValue<int>("sortOrder"));
+
+            // but...
+            // if we assume that nodes are always correctly sorted
+            // then we just need to ensure that currentNode is at the right position.
+            // should be faster that moving all the nodes around.
+            XmlHelper.SortNode(parentNode, ChildNodesXPath, currentNode, x => x.AttributeValue<int>("sortOrder"));
+        }
+
+        // UpdateSortOrder is meant to update the Xml cache sort order on Save, 'cos that change
+        // should be applied immediately, even though the Xml cache is not updated on Saves - we
+        // don't have to do it for preview Xml since it is always fully updated - OTOH we have
+        // to ensure it *is* updated, in UnpublishedPageCacheRefresher
+
+        private XmlDocument LoadPreviewXmlContent()
+        {
+            try
+            {
+                LogHelper.Info<content>("Loading preview content from database...");
+                var xml = ApplicationContext.Current.Services.ContentService.BuildPreviewXmlCache();
+                LogHelper.Debug<content>("Done loading preview content");
+                return xml;
+            }
+            catch (Exception ee)
+            {
+                LogHelper.Error<content>("Error loading preview content", ee);
+            }
+
+            // An error of some sort must have stopped us from successfully generating
+            // the content tree, so lets return null signifying there is no content available
+            return null;
+        }
+
+        public XmlDocument PreviewXmlContent
+        {
+            get
+            {
+                if (PreviewContent.IsSinglePreview == false)
+                    throw new InvalidOperationException();
+
+                var runtimeCache = ApplicationContext.Current.ApplicationCache.RuntimeCache;
+                return runtimeCache.GetCacheItem<XmlDocument>(PreviewCacheKey, LoadPreviewXmlContent, TimeSpan.FromSeconds(PreviewContent.SinglePreviewCacheDurationSeconds), true,
+                    removedCallback: (key, removed, reason) => LogHelper.Debug<content>($"Removed preview xml from cache ({reason})"));
             }
         }
 

--- a/src/Umbraco.Web/umbraco.presentation/umbraco/preview/PreviewContent.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/preview/PreviewContent.cs
@@ -15,14 +15,14 @@ namespace umbraco.presentation.preview
     public enum PreviewMode
     {
         Unknown = 0, // default value
-        Vintage,
-        SinglePreview
+        Legacy,
+        Default
     }
 
     public class PreviewContent
     {
         private static PreviewMode _previewMode;
-        private const PreviewMode DefaultPreviewMode = PreviewMode.SinglePreview;
+        private const PreviewMode DefaultPreviewMode = PreviewMode.Default;
         private static int _singlePreviewCacheDurationSeconds = -1;
         private const int DefaultSinglePreviewCacheDurationSeconds = 60;
 
@@ -62,7 +62,7 @@ namespace umbraco.presentation.preview
             }
         }
 
-        public static bool IsSinglePreview => PreviewMode == PreviewMode.SinglePreview;
+        public static bool IsSinglePreview => PreviewMode == PreviewMode.Default;
 
         public XmlDocument XmlContent { get; set; }
         public Guid PreviewSet { get; set; }


### PR DESCRIPTION
Fixes #5059

This PR introduces a new Preview Engine for v7. It is managing one single preview Xml document (instead of one per preview) that is loaded from database, maintained in memory for some time, and eventually removed from memory.

Benefit: one single clone of the Xml document in memory, ever, instead of one per preview = reduces memory usage + CPU time to prepare all the clones.

Changes: previewing is now "all or nothing": either nothing is previewed, or all draft documents are previewed - one cannot preview changes made to a single document. Note that this is already the case in v8.

Configuration: 
* enabled by default, but it's possible to go back to the original Preview Engine by setting the `Umbraco.Preview.Mode` appSetting to `Vintage` -- not sure whether we want it by default or not? Also we may want to rename the options (currently, `Vintage` and `SinglePreview`).
* when enabled, keeps the Xml in memory for a sliding period of 1 minute, by default, unless a different number of seconds is configured via the `Umbraco.Preview.SinglePreview.CacheDurationSeconds` appSetting.

Review: code review + test that previewing still works ok