### PR TITLE
V8: Don't explode when passing bad parameters to log resource

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/log.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/log.resource.js
@@ -53,7 +53,7 @@ function logResource($q, $http, umbRequestHelper) {
         * 
         * @param {Object} options options object
         * @param {Int} options.id the id of the entity
-        * @param {Int} options.pageSize if paging data, number of nodes per page, default = 10, set to 0 to disable paging
+        * @param {Int} options.pageSize if paging data, number of nodes per page, default = 10
         * @param {Int} options.pageNumber if paging data, current page index, default = 1
         * @param {String} options.orderDirection can be `Ascending` or `Descending` - Default: `Descending`
         * @param {Date} options.sinceDate if provided this will only get log entries going back to this date
@@ -122,7 +122,7 @@ function logResource($q, $http, umbRequestHelper) {
          * </pre> 
          * 
          * @param {Object} options options object
-         * @param {Int} options.pageSize if paging data, number of nodes per page, default = 10, set to 0 to disable paging
+         * @param {Int} options.pageSize if paging data, number of nodes per page, default = 10
          * @param {Int} options.pageNumber if paging data, current page index, default = 1
          * @param {String} options.orderDirection can be `Ascending` or `Descending` - Default: `Descending`
          * @param {Date} options.sinceDate if provided this will only get log entries going back to this date

--- a/src/Umbraco.Web/Editors/LogController.cs
+++ b/src/Umbraco.Web/Editors/LogController.cs
@@ -20,10 +20,15 @@ namespace Umbraco.Web.Editors
         [UmbracoApplicationAuthorize(Core.Constants.Applications.Content, Core.Constants.Applications.Media)]
         public PagedResult<AuditLog> GetPagedEntityLog(int id,
             int pageNumber = 1,
-            int pageSize = 0,
+            int pageSize = 10,
             Direction orderDirection = Direction.Descending,
             DateTime? sinceDate = null)
         {
+            if (pageSize <= 0 || pageNumber <= 0)
+            {
+                return new PagedResult<AuditLog>(0, pageNumber, pageSize);
+            }
+
             long totalRecords;
             var dateQuery = sinceDate.HasValue ? SqlContext.Query<IAuditItem>().Where(x => x.CreateDate >= sinceDate) : null;
             var result = Services.AuditService.GetPagedItemsByEntity(id, pageNumber - 1, pageSize, out totalRecords, orderDirection, customFilter: dateQuery);
@@ -39,10 +44,15 @@ namespace Umbraco.Web.Editors
 
         public PagedResult<AuditLog> GetPagedCurrentUserLog(
             int pageNumber = 1,
-            int pageSize = 0,
+            int pageSize = 10,
             Direction orderDirection = Direction.Descending,
             DateTime? sinceDate = null)
         {
+            if (pageSize <= 0 || pageNumber <= 0)
+            {
+                return new PagedResult<AuditLog>(0, pageNumber, pageSize);
+            }
+
             long totalRecords;
             var dateQuery = sinceDate.HasValue ? SqlContext.Query<IAuditItem>().Where(x => x.CreateDate >= sinceDate) : null;
             var userId = Security.GetUserId().ResultOr(0);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5092

### Description

Fixes #5092 by safeguarding the logging API serverside.

Note that:

1. The issue also occurs when specifying `pageNumber` <= 0.
2. The entity log (`getPagedEntityLog`) is also affected by the same issue. 

These issues are fixed in this PR as well.

#### Testing this PR

Request `getPagedUserLog` and `getPagedEntityLog` with `pageSize` <= 0 or `pageNumber` <= 0 and verify that you'll get an empty result from the server:

```js
	logResource.getPagedUserLog({
			pageSize: 0,
			pageNumber: 1,
			orderDirection: "Descending",
			sinceDate: new Date(2018, 1, 1)
		})
		.then(function(response) {
			console.log("User log", response);
		});	

	logResource.getPagedEntityLog({
			id: 1064, // make sure this an ID of some existing content
			pageSize: 0,
			pageNumber: 1,
			orderDirection: "Descending",
			sinceDate: new Date(2018, 1, 1)
		})
		.then(function(response) {
			console.log("Entity log", response);
		});	
```

This plugin can be used to test: [TestPlugin.zip](https://github.com/umbraco/Umbraco-CMS/files/3017952/TestPlugin.zip) - just unzip it and visit the fancy *[testPluginDashboard]* dashboard on the content root. It logs the results to the console (actually it's the same code as above).
