### PR TITLE
V8: Ensure consistency in the way panels are spaced

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/html/umb-expansion-panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/html/umb-expansion-panel.less
@@ -1,7 +1,7 @@
 .umb-expansion-panel {
     background: @white;
     border-radius: 3px;
-    margin-bottom: 16px;
+    margin-bottom: 20px;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.16);
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-box.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-box.less
@@ -1,7 +1,7 @@
 .umb-box {
     background: @white;
     border-radius: 3px;
-    margin-bottom: 8px;
+    margin-bottom: 20px;
     box-shadow: 0 1px 1px 0 rgba(0,0,0,.16);
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5094

### Description

As described in #5094, the various panel types are vertically spaced differently throughout the UI. This PR makes the spacing consistent (20px).

The following parts are directly affected by this change (read: you can tell there's a difference, because they have multiple panels on the same page):

- Edit user
- Edit group
- Content info app
- Log viewer
- Edit macro
- Package details
- Edit member
- Create (edit) package

### Examples

#### Content info app

The most prominent example is probably the content info app, because it's the most visited in the list above. It currently looks like this:

![image](https://user-images.githubusercontent.com/7405322/55167750-dc425600-5171-11e9-963e-d25f63f814bb.png)

With this PR applied it looks like this:

![image](https://user-images.githubusercontent.com/7405322/55167166-bb2d3580-5170-11e9-8ad0-292bc5a4a563.png)

#### Edit user

Another example is edit user. It currently looks like this:

![image](https://user-images.githubusercontent.com/7405322/55167866-08f66d80-5172-11e9-8768-4875e2c5c331.png)

With this PR applied, it looks like this:

![image](https://user-images.githubusercontent.com/7405322/55167499-68a04900-5171-11e9-85b8-9f78d1803f69.png)


#### Log viewer

Final example is the log viewer. It currently looks like this:

![image](https://user-images.githubusercontent.com/7405322/55167687-bddc5a80-5171-11e9-8d16-71c788754490.png)

With this PR applied, it looks like this:

![image](https://user-images.githubusercontent.com/7405322/55167620-9eddc880-5171-11e9-8d46-0c2f1209fbf6.png)

