### PR TITLE
V8: Updated Constant.System.Root references (to use correct constant, and others)

### DIFF
--- a/src/Umbraco.Core/Compose/RelateOnTrashComponent.cs
+++ b/src/Umbraco.Core/Compose/RelateOnTrashComponent.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Core.Compose
 
         private static void ContentService_Moved(IContentService sender, MoveEventArgs<IContent> e)
         {
-            foreach (var item in e.MoveInfoCollection.Where(x => x.OriginalPath.Contains(Constants.System.RecycleBinContent.ToInvariantString())))
+            foreach (var item in e.MoveInfoCollection.Where(x => x.OriginalPath.Contains(Constants.System.RecycleBinContentString)))
             {
                 var relationService = Current.Services.RelationService;
                 const string relationTypeAlias = Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias;

--- a/src/Umbraco.Core/Compose/RelateOnTrashComponent.cs
+++ b/src/Umbraco.Core/Compose/RelateOnTrashComponent.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Core.Compose
 
         private static void MediaService_Moved(IMediaService sender, MoveEventArgs<IMedia> e)
         {
-            foreach (var item in e.MoveInfoCollection.Where(x => x.OriginalPath.Contains(Constants.System.RecycleBinMedia.ToInvariantString())))
+            foreach (var item in e.MoveInfoCollection.Where(x => x.OriginalPath.Contains(Constants.System.RecycleBinMediaString)))
             {
                 var relationService = Current.Services.RelationService;
                 const string relationTypeAlias = Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteAlias;

--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -93,7 +93,6 @@ namespace Umbraco.Core
             /// </summary>
             public const string DisableElectionForSingleServer = "Umbraco.Core.DisableElectionForSingleServer";
 
-            
             /// <summary>
             /// Debug specific web.config AppSetting keys for Umbraco
             /// </summary>

--- a/src/Umbraco.Core/Constants-Applications.cs
+++ b/src/Umbraco.Core/Constants-Applications.cs
@@ -145,11 +145,11 @@
 
             public const string PartialViewMacros = "partialViewMacros";
 
-			public const string LogViewer = "logViewer";
+            public const string LogViewer = "logViewer";
 
             public static class Groups
             {
-				public const string Settings = "settingsGroup";
+                public const string Settings = "settingsGroup";
 
                 public const string Templating = "templatingGroup";
 

--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -92,10 +92,10 @@ namespace Umbraco.Core
                 /// </summary>
                 public const string Extension = "umbracoExtension";
 
-				/// <summary>
-				/// The default height/width of an image file if the size can't be determined from the metadata
-				/// </summary>
-				public const int DefaultSize = 200;
+                /// <summary>
+                /// The default height/width of an image file if the size can't be determined from the metadata
+                /// </summary>
+                public const int DefaultSize = 200;
             }
 
             /// <summary>
@@ -209,71 +209,71 @@ namespace Umbraco.Core
                 public static Dictionary<string, PropertyType> GetStandardPropertyTypeStubs()
                 {
                     return new Dictionary<string, PropertyType>
+                    {
                         {
+                            Comments,
+                            new PropertyType(PropertyEditors.Aliases.TextArea, ValueStorageType.Ntext, true, Comments)
                             {
-                                Comments,
-                                new PropertyType(PropertyEditors.Aliases.TextArea, ValueStorageType.Ntext, true, Comments)
-                                    {
-                                        Name = CommentsLabel
-                                    }
-                            },
-                            {
-                                FailedPasswordAttempts,
-                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Integer, true, FailedPasswordAttempts)
-                                    {
-                                        Name = FailedPasswordAttemptsLabel
-                                    }
-                            },
-                            {
-                                IsApproved,
-                                new PropertyType(PropertyEditors.Aliases.Boolean, ValueStorageType.Integer, true, IsApproved)
-                                    {
-                                        Name = IsApprovedLabel
-                                    }
-                            },
-                            {
-                                IsLockedOut,
-                                new PropertyType(PropertyEditors.Aliases.Boolean, ValueStorageType.Integer, true, IsLockedOut)
-                                    {
-                                        Name = IsLockedOutLabel
-                                    }
-                            },
-                            {
-                                LastLockoutDate,
-                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Date, true, LastLockoutDate)
-                                    {
-                                        Name = LastLockoutDateLabel
-                                    }
-                            },
-                            {
-                                LastLoginDate,
-                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Date, true, LastLoginDate)
-                                    {
-                                        Name = LastLoginDateLabel
-                                    }
-                            },
-                            {
-                                LastPasswordChangeDate,
-                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Date, true, LastPasswordChangeDate)
-                                    {
-                                        Name = LastPasswordChangeDateLabel
-                                    }
-                            },
-                            {
-                                PasswordAnswer,
-                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Nvarchar, true, PasswordAnswer)
-                                    {
-                                        Name = PasswordAnswerLabel
-                                    }
-                            },
-                            {
-                                PasswordQuestion,
-                                new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Nvarchar, true, PasswordQuestion)
-                                    {
-                                        Name = PasswordQuestionLabel
-                                    }
+                                Name = CommentsLabel
                             }
-                        };
+                        },
+                        {
+                            FailedPasswordAttempts,
+                            new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Integer, true, FailedPasswordAttempts)
+                            {
+                                Name = FailedPasswordAttemptsLabel
+                            }
+                        },
+                        {
+                            IsApproved,
+                            new PropertyType(PropertyEditors.Aliases.Boolean, ValueStorageType.Integer, true, IsApproved)
+                            {
+                                Name = IsApprovedLabel
+                            }
+                        },
+                        {
+                            IsLockedOut,
+                            new PropertyType(PropertyEditors.Aliases.Boolean, ValueStorageType.Integer, true, IsLockedOut)
+                            {
+                                Name = IsLockedOutLabel
+                            }
+                        },
+                        {
+                            LastLockoutDate,
+                            new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Date, true, LastLockoutDate)
+                            {
+                                Name = LastLockoutDateLabel
+                            }
+                        },
+                        {
+                            LastLoginDate,
+                            new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Date, true, LastLoginDate)
+                            {
+                                Name = LastLoginDateLabel
+                            }
+                        },
+                        {
+                            LastPasswordChangeDate,
+                            new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Date, true, LastPasswordChangeDate)
+                            {
+                                Name = LastPasswordChangeDateLabel
+                            }
+                        },
+                        {
+                            PasswordAnswer,
+                            new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Nvarchar, true, PasswordAnswer)
+                            {
+                                Name = PasswordAnswerLabel
+                            }
+                        },
+                        {
+                            PasswordQuestion,
+                            new PropertyType(PropertyEditors.Aliases.Label, ValueStorageType.Nvarchar, true, PasswordQuestion)
+                            {
+                                Name = PasswordQuestionLabel
+                            }
+                        }
+                    };
                 }
             }
 

--- a/src/Umbraco.Core/Constants-Icons.cs
+++ b/src/Umbraco.Core/Constants-Icons.cs
@@ -1,17 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Umbraco.Core
+﻿namespace Umbraco.Core
 {
     public static partial class Constants
     {
         public static class Icons
         {
-
-
             /// <summary>
             /// System contenttype icon
             /// </summary>
@@ -42,12 +34,10 @@ namespace Umbraco.Core
             /// </summary>
             public const string MemberType = "icon-users";
 
-
             /// <summary>
             /// System member icon
             /// </summary>
             public const string Template = "icon-layout";
-
         }
     }
 }

--- a/src/Umbraco.Core/Constants-Indexes.cs
+++ b/src/Umbraco.Core/Constants-Indexes.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.ComponentModel;
-
-namespace Umbraco.Core
+﻿namespace Umbraco.Core
 {
     public static partial class Constants
     {

--- a/src/Umbraco.Core/Constants-ObjectTypes.cs
+++ b/src/Umbraco.Core/Constants-ObjectTypes.cs
@@ -123,7 +123,6 @@ namespace Umbraco.Core
             public static readonly Guid Template = new Guid(Strings.Template);
 
             public static readonly Guid ContentItem = new Guid(Strings.ContentItem);
-
         }
     }
 }

--- a/src/Umbraco.Core/Constants-PackageRepository.cs
+++ b/src/Umbraco.Core/Constants-PackageRepository.cs
@@ -3,7 +3,7 @@
     public static partial class Constants
     {
         /// <summary>
-        ///     Defines the constants used for the Umbraco package repository
+        /// Defines the constants used for the Umbraco package repository
         /// </summary>
         public static class PackageRepository
         {

--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -34,7 +34,6 @@ namespace Umbraco.Core
                 /// </summary>
                 public const string ContentPicker = "Umbraco.ContentPicker";
 
-   
                 /// <summary>
                 /// DateTime.
                 /// </summary>

--- a/src/Umbraco.Core/Constants-Web.cs
+++ b/src/Umbraco.Core/Constants-Web.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.ComponentModel;
-
-namespace Umbraco.Core
+﻿namespace Umbraco.Core
 {
     public static partial class Constants
     {
@@ -22,7 +19,6 @@ namespace Umbraco.Core
             public const string PreviewCookieName = "UMB_PREVIEW";
 
             public const string InstallerCookieName = "umb_installId";
-
         }
     }
 }

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -156,7 +156,7 @@ namespace Umbraco.Core.Models
 
         internal static bool HasContentBinAccess(this IUser user, IEntityService entityService)
         {
-            return ContentPermissionsHelper.HasPathAccess(Constants.System.RecycleBinContent.ToInvariantString(), user.CalculateContentStartNodeIds(entityService), Constants.System.RecycleBinContent);
+            return ContentPermissionsHelper.HasPathAccess(Constants.System.RecycleBinContentString, user.CalculateContentStartNodeIds(entityService), Constants.System.RecycleBinContent);
         }
 
         internal static bool HasMediaRootAccess(this IUser user, IEntityService entityService)

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -166,7 +166,7 @@ namespace Umbraco.Core.Models
 
         internal static bool HasMediaBinAccess(this IUser user, IEntityService entityService)
         {
-            return ContentPermissionsHelper.HasPathAccess(Constants.System.RecycleBinMedia.ToInvariantString(), user.CalculateMediaStartNodeIds(entityService), Constants.System.RecycleBinMedia);
+            return ContentPermissionsHelper.HasPathAccess(Constants.System.RecycleBinMediaString, user.CalculateMediaStartNodeIds(entityService), Constants.System.RecycleBinMedia);
         }
 
         internal static bool HasPathAccess(this IUser user, IContent content, IEntityService entityService)

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -151,7 +151,7 @@ namespace Umbraco.Core.Models
 
         internal static bool HasContentRootAccess(this IUser user, IEntityService entityService)
         {
-            return ContentPermissionsHelper.HasPathAccess(Constants.System.Root.ToInvariantString(), user.CalculateContentStartNodeIds(entityService), Constants.System.RecycleBinContent);
+            return ContentPermissionsHelper.HasPathAccess(Constants.System.RootString, user.CalculateContentStartNodeIds(entityService), Constants.System.RecycleBinContent);
         }
 
         internal static bool HasContentBinAccess(this IUser user, IEntityService entityService)
@@ -161,7 +161,7 @@ namespace Umbraco.Core.Models
 
         internal static bool HasMediaRootAccess(this IUser user, IEntityService entityService)
         {
-            return ContentPermissionsHelper.HasPathAccess(Constants.System.Root.ToInvariantString(), user.CalculateMediaStartNodeIds(entityService), Constants.System.RecycleBinMedia);
+            return ContentPermissionsHelper.HasPathAccess(Constants.System.RootString, user.CalculateMediaStartNodeIds(entityService), Constants.System.RecycleBinMedia);
         }
 
         internal static bool HasMediaBinAccess(this IUser user, IEntityService entityService)
@@ -327,7 +327,7 @@ namespace Umbraco.Core.Models
                 ? entityService.GetAllPaths(objectType, asn).ToDictionary(x => x.Id, x => x.Path)
                 : new Dictionary<int, string>();
 
-            paths[Constants.System.Root] = Constants.System.Root.ToString(); // entityService does not get that one
+            paths[Constants.System.Root] = Constants.System.RootString; // entityService does not get that one
 
             var binPath = GetBinPath(objectType);
 

--- a/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
+++ b/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
@@ -69,7 +69,7 @@ namespace Umbraco.Core
 
                 public const string Tag = /*TableNamePrefix*/ "cms" + "Tags";
                 public const string TagRelationship = /*TableNamePrefix*/ "cms" + "TagRelationship";
-                
+
                 public const string KeyValue = TableNamePrefix + "KeyValue";
 
                 public const string AuditEntry = TableNamePrefix + "Audit";

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -61,7 +61,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             // move to parent (or -1), update path, save
             moving.ParentId = parentId;
             var movingPath = moving.Path + ","; // save before changing
-            moving.Path = (container == null ? Constants.System.Root.ToString() : container.Path) + "," + moving.Id;
+            moving.Path = (container == null ? Constants.System.RootString : container.Path) + "," + moving.Id;
             moving.Level = container == null ? 1 : container.Level + 1;
             Save(moving);
 

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -1922,7 +1922,7 @@ namespace Umbraco.Core.Services.Implement
             // if uow is not immediate, content.Path will be updated only when the UOW commits,
             // and because we want it now, we have to calculate it by ourselves
             //paths[content.Id] = content.Path;
-            paths[content.Id] = (parent == null ? (parentId == Constants.System.RecycleBinContent ? "-1,-20" : "-1") : parent.Path) + "," + content.Id;
+            paths[content.Id] = (parent == null ? (parentId == Constants.System.RecycleBinContent ? "-1,-20" : Constants.System.RootString) : parent.Path) + "," + content.Id;
 
             const int pageSize = 500;
             var page = 0;

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -533,7 +533,7 @@ namespace Umbraco.Core.Services.Implement
             //null check otherwise we get exceptions
             if (content.Path.IsNullOrWhiteSpace()) return Enumerable.Empty<IContent>();
 
-            var rootId = Constants.System.Root.ToInvariantString();
+            var rootId = Constants.System.RootString;
             var ids = content.Path.Split(',')
                 .Where(x => x != rootId && x != content.Id.ToString(CultureInfo.InvariantCulture)).Select(int.Parse).ToArray();
             if (ids.Any() == false)

--- a/src/Umbraco.Core/Services/Implement/MediaService.cs
+++ b/src/Umbraco.Core/Services/Implement/MediaService.cs
@@ -995,7 +995,7 @@ namespace Umbraco.Core.Services.Implement
             // if uow is not immediate, content.Path will be updated only when the UOW commits,
             // and because we want it now, we have to calculate it by ourselves
             //paths[media.Id] = media.Path;
-            paths[media.Id] = (parent == null ? (parentId == Constants.System.RecycleBinMedia ? "-1,-21" : "-1") : parent.Path) + "," + media.Id;
+            paths[media.Id] = (parent == null ? (parentId == Constants.System.RecycleBinMedia ? "-1,-21" : Constants.System.RootString) : parent.Path) + "," + media.Id;
 
             const int pageSize = 500;
             var page = 0;

--- a/src/Umbraco.Core/UdiEntityType.cs
+++ b/src/Umbraco.Core/UdiEntityType.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Core
 
             internal static Dictionary<string, UdiType> GetTypes()
             {
-                return new Dictionary<string,UdiType>
+                return new Dictionary<string, UdiType>
                 {
                     { Unknown, UdiType.Unknown },
 

--- a/src/Umbraco.Web/Editors/CodeFileController.cs
+++ b/src/Umbraco.Web/Editors/CodeFileController.cs
@@ -94,7 +94,7 @@ namespace Umbraco.Web.Editors
 
             // if the parentId is root (-1) then we just need an empty string as we are
             // creating the path below and we don't want -1 in the path
-            if (parentId == Core.Constants.System.Root.ToInvariantString())
+            if (parentId == Core.Constants.System.RootString)
             {
                 parentId = string.Empty;
             }
@@ -276,7 +276,7 @@ namespace Umbraco.Web.Editors
             // Make sure that the root virtual path ends with '/'
             codeFileDisplay.VirtualPath = codeFileDisplay.VirtualPath.EnsureEndsWith("/");
 
-            if (id != Core.Constants.System.Root.ToInvariantString())
+            if (id != Core.Constants.System.RootString)
             {
                 codeFileDisplay.VirtualPath += id.TrimStart("/").EnsureEndsWith("/");
                 //if it's not new then it will have a path, otherwise it won't

--- a/src/Umbraco.Web/Models/Trees/TreeRootNode.cs
+++ b/src/Umbraco.Web/Models/Trees/TreeRootNode.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Web.Models.Trees
     [DataContract(Name = "node", Namespace = "")]
     public sealed class TreeRootNode : TreeNode
     {
-        private static readonly string RootId = Core.Constants.System.Root.ToString(CultureInfo.InvariantCulture);
+        private static readonly string RootId = Core.Constants.System.RootString;
         private bool _isGroup;
         private bool _isSingleNodeTree;
 

--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -71,7 +71,7 @@ namespace Umbraco.Web.Trees
                 //if there are no trees defined for this section but the section is defined then we can have a simple
                 //full screen section without trees
                 var name = Services.TextService.Localize("sections/" + application);
-                return TreeRootNode.CreateSingleTreeRoot(Constants.System.Root.ToInvariantString(), null, null, name, TreeNodeCollection.Empty, true);
+                return TreeRootNode.CreateSingleTreeRoot(Constants.System.RootString, null, null, name, TreeNodeCollection.Empty, true);
             }
 
             // handle request for a specific tree / or when there is only one tree
@@ -114,7 +114,7 @@ namespace Umbraco.Web.Trees
 
                 // otherwise it's a section with all empty trees, aka a fullscreen section
                 // todo is this true? what if we just failed to TryGetRootNode on all of them? SD: Yes it's true but we should check the result of TryGetRootNode and throw?
-                return TreeRootNode.CreateSingleTreeRoot(Constants.System.Root.ToInvariantString(), null, null, name, TreeNodeCollection.Empty, true);
+                return TreeRootNode.CreateSingleTreeRoot(Constants.System.RootString, null, null, name, TreeNodeCollection.Empty, true);
             }
 
             // for many groups
@@ -180,7 +180,7 @@ namespace Umbraco.Web.Trees
             var rootNode = await GetRootNode(tree, querystring);
 
             var sectionRoot = TreeRootNode.CreateSingleTreeRoot(
-                Constants.System.Root.ToInvariantString(),
+                Constants.System.RootString,
                 rootNode.ChildNodesUrl,
                 rootNode.MenuUrl,
                 rootNode.Name,

--- a/src/Umbraco.Web/Trees/ContentBlueprintTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentBlueprintTreeController.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Web.Trees
             var entities = Services.EntityService.GetChildren(Constants.System.Root, UmbracoObjectTypes.DocumentBlueprint).ToArray();
 
             //check if we're rendering the root in which case we'll render the content types that have blueprints
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 //get all blueprint content types
                 var contentTypeAliases = entities.Select(x => ((ContentEntitySlim) x).ContentTypeAlias).Distinct();
@@ -91,7 +91,7 @@ namespace Umbraco.Web.Trees
         {
             var menu = new MenuItemCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 // root actions
                 menu.Items.Add<ActionNew>(Services.TextService, opensDialog: true);

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -109,7 +109,7 @@ namespace Umbraco.Web.Trees
 
         protected override MenuItemCollection PerformGetMenuForNode(string id, FormDataCollection queryStrings)
         {
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 var menu = new MenuItemCollection();
 

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -120,7 +120,7 @@ namespace Umbraco.Web.Trees
         {
             var nodes = new TreeNodeCollection();
 
-            var rootIdString = Constants.System.Root.ToString(CultureInfo.InvariantCulture);
+            var rootIdString = Constants.System.RootString;
             var hasAccessToRoot = UserStartNodes.Contains(Constants.System.Root);
 
             var startNodeId = queryStrings.HasKey(TreeQueryStringParameters.StartNodeId)
@@ -256,7 +256,7 @@ namespace Umbraco.Web.Trees
         protected sealed override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
         {
             //check if we're rendering the root
-            if (id == Constants.System.Root.ToInvariantString() && UserStartNodes.Contains(Constants.System.Root))
+            if (id == Constants.System.RootString && UserStartNodes.Contains(Constants.System.Root))
             {
                 var altStartId = string.Empty;
 
@@ -264,7 +264,7 @@ namespace Umbraco.Web.Trees
                     altStartId = queryStrings.GetValue<string>(TreeQueryStringParameters.StartNodeId);
 
                 //check if a request has been made to render from a specific start node
-                if (string.IsNullOrEmpty(altStartId) == false && altStartId != "undefined" && altStartId != Constants.System.Root.ToString(CultureInfo.InvariantCulture))
+                if (string.IsNullOrEmpty(altStartId) == false && altStartId != "undefined" && altStartId != Constants.System.RootString)
                 {
                     id = altStartId;
                 }
@@ -272,7 +272,7 @@ namespace Umbraco.Web.Trees
                 var nodes = GetTreeNodesInternal(id, queryStrings);
 
                 //only render the recycle bin if we are not in dialog and the start id id still the root
-                if (IsDialog(queryStrings) == false && id == Constants.System.Root.ToInvariantString())
+                if (IsDialog(queryStrings) == false && id == Constants.System.RootString)
                 {
                     nodes.Add(CreateTreeNode(
                         RecycleBinId.ToInvariantString(),

--- a/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Web.Trees
         {
             var menu = new MenuItemCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 //set the default to create
                 menu.DefaultMenuAlias = ActionNew.ActionAlias;

--- a/src/Umbraco.Web/Trees/DataTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/DataTypeTreeController.cs
@@ -96,7 +96,7 @@ namespace Umbraco.Web.Trees
         {
             var menu = new MenuItemCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 //set the default to create
                 menu.DefaultMenuAlias = ActionNew.ActionAlias;

--- a/src/Umbraco.Web/Trees/DictionaryTreeController.cs
+++ b/src/Umbraco.Web/Trees/DictionaryTreeController.cs
@@ -58,7 +58,7 @@ namespace Umbraco.Web.Trees
 
             Func<IDictionaryItem, string> ItemSort() => item => item.ItemKey;
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 nodes.AddRange(
                     Services.LocalizationService.GetRootDictionaryItems().OrderBy(ItemSort()).Select(
@@ -104,7 +104,7 @@ namespace Umbraco.Web.Trees
 
             menu.Items.Add<ActionNew>(Services.TextService, opensDialog: true);
 
-            if (id != Constants.System.Root.ToInvariantString())
+            if (id != Constants.System.RootString)
                 menu.Items.Add<ActionDelete>(Services.TextService, true, opensDialog: true);
 
             menu.Items.Add(new RefreshNode(Services.TextService, true));

--- a/src/Umbraco.Web/Trees/FileSystemTreeController.cs
+++ b/src/Umbraco.Web/Trees/FileSystemTreeController.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Web.Trees
 
         protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
         {
-            var path = string.IsNullOrEmpty(id) == false && id != Constants.System.Root.ToInvariantString()
+            var path = string.IsNullOrEmpty(id) == false && id != Constants.System.RootString
                 ? HttpUtility.UrlDecode(id).TrimStart("/")
                 : "";
 
@@ -84,7 +84,7 @@ namespace Umbraco.Web.Trees
         {
             var root = base.CreateRootNode(queryStrings);
             //check if there are any children
-            root.HasChildren = GetTreeNodes(Constants.System.Root.ToInvariantString(), queryStrings).Any();
+            root.HasChildren = GetTreeNodes(Constants.System.RootString, queryStrings).Any();
             return root;
         }
 
@@ -139,14 +139,14 @@ namespace Umbraco.Web.Trees
         protected override MenuItemCollection GetMenuForNode(string id, FormDataCollection queryStrings)
         {
             //if root node no need to visit the filesystem so lets just create the menu and return it
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 return GetMenuForRootNode(queryStrings);
             }
 
             var menu = new MenuItemCollection();
 
-            var path = string.IsNullOrEmpty(id) == false && id != Constants.System.Root.ToInvariantString()
+            var path = string.IsNullOrEmpty(id) == false && id != Constants.System.RootString
                 ? HttpUtility.UrlDecode(id).TrimStart("/")
                 : "";
 

--- a/src/Umbraco.Web/Trees/MacrosTreeController.cs
+++ b/src/Umbraco.Web/Trees/MacrosTreeController.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Web.Trees
         {
             var nodes = new TreeNodeCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 foreach (var macro in Services.MacroService.GetAll())
                 {
@@ -50,7 +50,7 @@ namespace Umbraco.Web.Trees
         {
             var menu = new MenuItemCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 //Create the normal create action
                 menu.Items.Add<ActionNew>(Services.TextService);

--- a/src/Umbraco.Web/Trees/MediaTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTreeController.cs
@@ -86,7 +86,7 @@ namespace Umbraco.Web.Trees
             //set the default
             menu.DefaultMenuAlias = ActionNew.ActionAlias;
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 // if the user's start node is not the root then the only menu item to display is refresh
                 if (UserStartNodes.Contains(Constants.System.Root) == false)

--- a/src/Umbraco.Web/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTypeTreeController.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Web.Trees
         {
             var menu = new MenuItemCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 // set the default to create
                 menu.DefaultMenuAlias = ActionNew.ActionAlias;

--- a/src/Umbraco.Web/Trees/MemberTreeController.cs
+++ b/src/Umbraco.Web/Trees/MemberTreeController.cs
@@ -121,7 +121,7 @@ namespace Umbraco.Web.Trees
         {
             var nodes = new TreeNodeCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 nodes.Add(
                         CreateTreeNode(Constants.Conventions.MemberTypes.AllMembersListId, id, queryStrings, Services.TextService.Localize("member/allMembers"), "icon-users", true,
@@ -148,7 +148,7 @@ namespace Umbraco.Web.Trees
         {
             var menu = new MenuItemCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 // root actions
                 if (_provider.IsUmbracoMembershipProvider())

--- a/src/Umbraco.Web/Trees/MemberTypeAndGroupTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/MemberTypeAndGroupTreeControllerBase.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Web.Trees
         {
             var menu = new MenuItemCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 // root actions
                 menu.Items.Add(new CreateChildEntity(Services.TextService));

--- a/src/Umbraco.Web/Trees/RelationTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/RelationTypeTreeController.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Web.Trees
         {
             var menu = new MenuItemCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 //Create the normal create action
                 menu.Items.Add<ActionNew>(Services.TextService.Localize("actions", ActionNew.ActionAlias));
@@ -41,7 +41,7 @@ namespace Umbraco.Web.Trees
         {
             var nodes = new TreeNodeCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 nodes.AddRange(Services.RelationService.GetAllRelationTypes()
                     .Select(rt => CreateTreeNode(rt.Id.ToString(), id, queryStrings, rt.Name,

--- a/src/Umbraco.Web/Trees/TemplatesTreeController.cs
+++ b/src/Umbraco.Web/Trees/TemplatesTreeController.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Web.Trees
         {
             var nodes = new TreeNodeCollection();
 
-            var found = id == Constants.System.Root.ToInvariantString()
+            var found = id == Constants.System.RootString
                 ? Services.FileService.GetTemplates(-1)
                 : Services.FileService.GetTemplates(int.Parse(id));
 
@@ -77,7 +77,7 @@ namespace Umbraco.Web.Trees
             var item = menu.Items.Add<ActionNew>(Services.TextService, opensDialog: true);
             item.NavigateToRoute($"{queryStrings.GetRequiredValue<string>("application")}/templates/edit/{id}?create=true");
 
-            if (id == Constants.System.Root.ToInvariantString())
+            if (id == Constants.System.RootString)
             {
                 //refresh action
                 menu.Items.Add(new RefreshNode(Services.TextService, true));

--- a/src/Umbraco.Web/Trees/TreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/TreeControllerBase.cs
@@ -173,7 +173,7 @@ namespace Umbraco.Web.Trees
         /// <returns></returns>
         protected virtual TreeNode CreateRootNode(FormDataCollection queryStrings)
         {
-            var rootNodeAsString = Constants.System.Root.ToString(CultureInfo.InvariantCulture);
+            var rootNodeAsString = Constants.System.RootString;
             var currApp = queryStrings.GetValue<string>(TreeQueryStringParameters.Application);
 
             var node = new TreeNode(


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

~~If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->~~

### Description

I'd noticed there were several `Constants.System.Root.ToInvariantString()` calls, (e.g. to convert the `int` to a `string`), but there is an existing `Constants.System.RootString` constant (`string`). So I've swapped them over.

This should reduce the number of string conversions / new allocations. A teeny-weeny CPU/memory improvement. 😉 

I also did the `Constants.System.RecycleBinContent` and `Constants.System.RecycleBinMedia` references too.

I've re-ran all the unit-tests in Visual Studio, all passed - and checked the CMS back-office, navigated around the content section.

I wouldn't say that I've done extensive testing against an existing/populated Umbraco instance, since this felt like a low-risk code change.