### PR TITLE
V8: Add back button to listviews in media

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -14,7 +14,9 @@
                                hide-description="true"
                                hide-alias="true"
                                navigation="content.apps"
-                               on-select-navigation-item="appChanged(item)">
+                               on-select-navigation-item="appChanged(item)"
+                               show-back-button="!!page.listViewPath"
+                               on-back="onBack()">
             </umb-editor-header>
 
             <umb-editor-container>

--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -15,7 +15,7 @@
                                hide-alias="true"
                                navigation="content.apps"
                                on-select-navigation-item="appChanged(item)"
-                               show-back-button="!!page.listViewPath"
+                               show-back-button="showBack()"
                                on-back="onBack()">
             </umb-editor-header>
 

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -279,6 +279,10 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
         }
     }
 
+    $scope.showBack = function () {
+        return !infiniteMode && !!$scope.page.listViewPath;
+    }
+
     /** Callback for when user clicks the back-icon */
     $scope.onBack = function() {
         if ($scope.page.listViewPath) {

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -9,7 +9,7 @@
 function mediaEditController($scope, $routeParams, $q, appState, mediaResource, 
     entityResource, navigationService, notificationsService, localizationService, 
     serverValidationManager, contentEditingHelper, fileManager, formHelper, 
-    editorState, umbRequestHelper, $http, eventsService) {
+    editorState, umbRequestHelper, $http, eventsService, $location) {
     
     var evts = [];
     var nodeId = null;
@@ -279,6 +279,13 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
         }
     }
 
+    /** Callback for when user clicks the back-icon */
+    $scope.onBack = function() {
+        if ($scope.page.listViewPath) {
+            $location.path($scope.page.listViewPath);
+        }
+    };
+    
     //ensure to unregister from all events!
     $scope.$on('$destroy', function () {
         for (var e in evts) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When navigating content within listviews there's a back button that lets you navigate up the hierachy until you reach the root node level. That back button does not show when navigating media - e.g. folders with listview enabled.

This PR adds the back button:

![media-listview-back](https://user-images.githubusercontent.com/7405322/55342595-70c9f280-54a9-11e9-93fc-f94c90e99a0c.gif)

#### Testing this PR

1. Enable list view on the default media folder if it isn't already.
2. Create a folder structure in the media library.
3. Verify that the back button appears as soon as you start navigating downwards through the structure.
4. Verify that the back button takes you to the parent folder.
5. Add a media picker to a content type and edit some content of that type.
6. Open the media picker, navigate at least one level down through the structure and edit one of the folders there.
7. Verify that the back button does *not* appear in the infinite editing layer.