### PR TITLE
V8: Reload listview after moving items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -583,6 +583,8 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
             .then(function () {
                 //executes if all is successful, let's sync the tree
                 if (newPath) {
+                    // reload the current view so the moved items are no longer shown
+                    $scope.reloadView($scope.contentId);
 
                     //we need to do a double sync here: first refresh the node where the content was moved,
                     // then refresh the node where the content was moved from


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When moving items from a list view container, the items are still listed and selected within the container after the move operation completes:

![list-view-move-reload-before](https://user-images.githubusercontent.com/7405322/55349120-294b6280-54b9-11e9-9c52-f00d134da3a9.gif)

With this PR the list view reloads itself after the move operation, thus removing the moved items from the view:

![list-view-move-reload](https://user-images.githubusercontent.com/7405322/55349129-32d4ca80-54b9-11e9-8793-e3b282a2aa4b.gif)
