### PR TITLE
V7: Add content type alias to content "general" info box

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -198,9 +198,10 @@
                         style="max-width: 100%; margin-bottom: 0;"
                         icon="node.icon"
                         name="node.contentTypeName"
+                        alias="documentType.alias"
                         allow-open="allowOpen"
                         on-open="openDocumentType(documentType)"
-						open-url="previewOpenUrl">
+                        open-url="previewOpenUrl">
                     </umb-node-preview>
                 </umb-control-group>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4920

### Description

This PR adds the content type alias as hover title on the content type in the "General" info box, as requested in #4920:

![image](https://user-images.githubusercontent.com/7405322/55380065-54689d00-551f-11e9-834c-ecd0379292dc.png)

### Merging note

The content type alias is already shown in V8, so don't merge this PR to V8.