### PR TITLE
V8: Various UX improvements to the RTE configuration

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -231,13 +231,15 @@ label:not([for]) {
   align-items: center;
 }
 
-.controls-row > .vertical-align-items > input.umb-property-editor-tiny {
-  margin-left: 5px;
-  margin-right: 5px;
+.controls-row > .vertical-align-items > input.umb-property-editor-tiny,
+.controls-row > .vertical-align-items > input.umb-property-editor-small {
+    margin-left: 5px;
+    margin-right: 5px;
 }
 
-.controls-row > .vertical-align-items > input.umb-property-editor-tiny:first-child {
-  margin-left: 0;
+.controls-row > .vertical-align-items > input.umb-property-editor-tiny:first-child
+.controls-row > .vertical-align-items > input.umb-property-editor-small:first-child {
+    margin-left: 0;
 }
 
 .thumbnails .selected {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -1,6 +1,6 @@
 <div ng-controller="Umbraco.PrevalueEditors.RteController" class="rte-editor-preval">
 
-    <umb-control-group label="Toolbar" hide-label="false">
+    <umb-control-group label="Toolbar" description="Pick the toolbar options that should be available when editing">
         <div ng-repeat="cmd in tinyMceConfig.commands">
             <label>
                 <input type="checkbox"
@@ -16,7 +16,7 @@
         </div>
     </umb-control-group>
 
-    <umb-control-group label="Stylesheets" hide-label="0">
+    <umb-control-group label="Stylesheets" description="Pick the stylesheets whose editor styles should be available when editing">
         <div ng-repeat="css in stylesheets">
             <label>
                 <input type="checkbox"
@@ -28,16 +28,16 @@
         </div>
     </umb-control-group>
 
-    <umb-control-group label="Dimensions" description="Width x Height">
+    <umb-control-group label="Dimensions" description="Set the editor dimensions">
         <div class="vertical-align-items">
-            <input type="number" min="0" ng-model="model.value.dimensions.width" class="umb-property-editor-tiny" placeholder="Width" /> &times;
-            <input type="number" min="0" ng-model="model.value.dimensions.height" class="umb-property-editor-tiny" placeholder="Height" /> Pixels
+            <input type="number" min="0" ng-model="model.value.dimensions.width" class="umb-property-editor-small" title="Width" placeholder="Width" /> &times;
+            <input type="number" min="0" ng-model="model.value.dimensions.height" class="umb-property-editor-small" title="Height" placeholder="Height" /> Pixels
         </div>
     </umb-control-group>
 
-    <umb-control-group label="Maximum size for inserted images" description="0 to disable resizing">
+    <umb-control-group label="Maximum size for inserted images" description="Maximum width or height - enter 0 to disable resizing">
         <div class="vertical-align-items">
-            <input type="number" min="0" ng-model="model.value.maxImageSize" class="umb-property-editor-tiny" placeholder="Width/Height" /> Pixels
+            <input type="number" min="0" ng-model="model.value.maxImageSize" class="umb-property-editor-small" title="Maximum width or height" placeholder="Maximum width or height" /> Pixels
         </div>
     </umb-control-group>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

For a first-timer the RTE config isn't exactly forthcoming. The properties have either less than helpful help text or no help text at all, and the image max size input placeholders do not fit in the tiny input size:

![image](https://user-images.githubusercontent.com/7405322/55397767-40d12c80-5547-11e9-975d-f54f3d27ef1d.png)

This PR attempts to amend these shortcomings:

![image](https://user-images.githubusercontent.com/7405322/55397818-5c3c3780-5547-11e9-93f8-3a29fc6f6af7.png)
