### PR TITLE
V8: Replace listview bulk action permission checkboxes with umb-toggle

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -921,13 +921,6 @@
 }
 
 //
-// Nested boolean (e.g. list view bulk action permissions)
-// -------------------------------------------------------
-.umb-nested-boolean label {margin-bottom: 8px; float: left; width: 320px;}
-.umb-nested-boolean label span {float: left; width: 80%;}
-.umb-nested-boolean label input[type='checkbox'] {margin-right: 10px; float: left;}
-
-//
 // Custom styles of property editors in property preview in document type editor
 // -----------------------------------------------------------------------------
 .umb-group-builder__property-preview {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/bulkActionPermissions.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/bulkActionPermissions.prevalues.html
@@ -1,32 +1,47 @@
 ﻿<div class="umb-property-editor">
-    <div class="umb-nested-boolean">
-        <label>
-            <input type="checkbox" ng-model="model.value.allowBulkPublish" id="allowBulkPublish"/>
-            <span>Allow bulk publish (content only)</span>
-        </label>
-    </div>
-    <div class="umb-nested-boolean">
-        <label>
-            <input type="checkbox" ng-model="model.value.allowBulkUnpublish" id="allowBulkUnpublish" />
-            <span>Allow bulk unpublish (content only)</span>
-        </label>
-    </div>
-    <div class="umb-nested-boolean">
-        <label>
-            <input type="checkbox" ng-model="model.value.allowBulkCopy" id="allowBulkCopy" />
-            <span>Allow bulk copy (content only)</span>
-        </label>
-    </div>
-    <div class="umb-nested-boolean">
-        <label>
-            <input type="checkbox" ng-model="model.value.allowBulkMove" id="allowBulkMove" />
-            <span>Allow bulk move</span>
-        </label>
-    </div>
-    <div class="umb-nested-boolean">
-        <label>
-            <input type="checkbox" ng-model="model.value.allowBulkDelete" id="allowBulkDelete" />
-            <span>Allow bulk delete</span>
-        </label>
-    </div>
+
+    <umb-toggle checked="model.value.allowBulkPublish"
+                on-click="model.value.allowBulkPublish = !model.value.allowBulkPublish"
+                show-labels="true"
+                label-position="right"
+                label-off="Allow bulk publish (content only)"
+                label-on="Allow bulk publish (content only)"
+                class="mb1">
+    </umb-toggle>
+
+    <umb-toggle checked="model.value.allowBulkUnpublish"
+                on-click="model.value.allowBulkUnpublish = !model.value.allowBulkUnpublish"
+                show-labels="true"
+                label-position="right"
+                label-off="Allow bulk unpublish (content only)"
+                label-on="Allow bulk unpublish (content only)"
+                class="mb1">
+    </umb-toggle>
+
+    <umb-toggle checked="model.value.allowBulkCopy"
+                on-click="model.value.allowBulkCopy = !model.value.allowBulkCopy"
+                show-labels="true"
+                label-position="right"
+                label-off="Allow bulk copy (content only)"
+                label-on="Allow bulk copy (content only)"
+                class="mb1">
+    </umb-toggle>
+
+    <umb-toggle checked="model.value.allowBulkMove"
+                on-click="model.value.allowBulkMove = !model.value.allowBulkMove"
+                show-labels="true"
+                label-position="right"
+                label-off="Allow bulk move"
+                label-on="Allow bulk move"
+                class="mb1">
+    </umb-toggle>
+
+    <umb-toggle checked="model.value.allowBulkDelete"
+                on-click="model.value.allowBulkDelete = !model.value.allowBulkDelete"
+                show-labels="true"
+                label-position="right"
+                label-off="Allow bulk delete"
+                label-on="Allow bulk delete">
+    </umb-toggle>
+
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR replaces the system checkboxes for listview bulk action permissions with `umb-toggle`.

This is how it currently looks:

![image](https://user-images.githubusercontent.com/7405322/55409577-8e0ec780-5562-11e9-8409-20730a1054b9.png)

This is how it looks with this PR applied:

![image](https://user-images.githubusercontent.com/7405322/55409519-79caca80-5562-11e9-8247-a8a492f4c0b9.png)

#### Checkboxes or toggles?

I have chosen toggles over checkboxes as it aligns better with e.g. member group permission editing. However I can easily change this PR to use `umb-checkbox` instead if that's preferred.
