### PR TITLE
The ImageCropperPropertyValueEditor doesn't convert values in ConvertDbToString correctly

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
@@ -174,7 +174,12 @@ namespace Umbraco.Web.PropertyEditors
             // more magic here ;-(
             var configuration = dataTypeService.GetDataType(propertyType.DataTypeId).ConfigurationAs<ImageCropperConfiguration>();
             var crops = configuration?.Crops ?? Array.Empty<ImageCropperConfiguration.Crop>();
-            return "{src: '" + val + "', crops: " + crops + "}";
+
+            return JsonConvert.SerializeObject(new
+            {
+                src = val,
+                crops = crops
+            });
         }
     }
 }


### PR DESCRIPTION
It is trying to serialize as json but it is failing since it's just concatenating objects and the ToString() of the crops is not the actual json of the crops.  Have fixed this to properly serialize.