### PR TITLE
use text-overflow for better look in narrow screens

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -166,9 +166,15 @@ a.umb-editor-header__close-split-view:hover {
     height: 30px;
 	text-decoration: none !important;
 	font-size: 13px;
-	//color: @gray-4;
     color: @ui-action-discreet-type;
-	//background-color: @white;
+    
+    max-width: 50%;
+    white-space: nowrap;
+    
+    span {
+        text-overflow: ellipsis;
+        overflow: hidden;
+    }
 }
 
 a.umb-variant-switcher__toggle {


### PR DESCRIPTION
fixes https://github.com/umbraco/Umbraco-CMS/issues/4811

solution should look like this:

![image](https://user-images.githubusercontent.com/6791648/55483818-ae548a00-5627-11e9-9948-f88d89fc7f59.png)
