### PR TITLE
V8: Fix broken listview pagination when using the back link

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbpagination.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbpagination.directive.js
@@ -100,7 +100,7 @@ Use this directive to generate a pagination.
                 for (i = 0; i < scope.totalPages; i++) {
                     scope.pagination.push({
                         val: (i + 1),
-                        isActive: scope.pageNumber === (i + 1)
+                        isActive: scope.pageNumber == (i + 1)
                     });
                 }
             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbpagination.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbpagination.directive.js
@@ -91,6 +91,10 @@ Use this directive to generate a pagination.
       function link(scope, el, attr, ctrl) {
 
          function activate() {
+            // page number is sometimes a string - let's make sure it's an int before we do anything with it
+            if (scope.pageNumber) {
+                scope.pageNumber = parseInt(scope.pageNumber);
+            }
 
             scope.pagination = [];
              
@@ -100,7 +104,7 @@ Use this directive to generate a pagination.
                 for (i = 0; i < scope.totalPages; i++) {
                     scope.pagination.push({
                         val: (i + 1),
-                        isActive: scope.pageNumber == (i + 1)
+                        isActive: scope.pageNumber === (i + 1)
                     });
                 }
             }

--- a/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
@@ -45,7 +45,7 @@
 (function () {
     'use strict';
 
-    function listViewHelper(localStorageService) {
+    function listViewHelper($location, localStorageService, urlHelper) {
 
         var firstSelectedIndex = 0;
         var localStorageKey = "umblistViewLayout";
@@ -511,6 +511,32 @@
         }
 
         
+        /**
+        * @ngdoc method
+        * @name umbraco.services.listViewHelper#editItem
+        * @methodOf umbraco.services.listViewHelper
+        *
+        * @description
+        * Method for opening an item in a list view for editing.
+        *
+        * @param {Object} item The item to edit
+        */
+        function editItem(item) {
+            if (!item.editPath) {
+                return;
+            }
+            var parts = item.editPath.split("?");
+            var path = parts[0];
+            var params = parts[1]
+                ? urlHelper.getQueryStringParams("?" + parts[1])
+                : {};
+
+            $location.path(path);
+            for (var p in params) {
+                $location.search(p, params[p])
+            }
+        }
+        
         function isMatchingLayout(id, layout) {
             // legacy format uses "nodeId", be sure to look for both
             return layout.id === id || layout.nodeId === id;
@@ -530,7 +556,8 @@
           isSelectedAll: isSelectedAll,
           setSortingDirection: setSortingDirection,
           setSorting: setSorting,
-          getButtonPermissions: getButtonPermissions
+          getButtonPermissions: getButtonPermissions,
+          editItem: editItem
 
         };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/grid/grid.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/grid/grid.listviewlayout.controller.js
@@ -117,7 +117,7 @@
         }
         
         function goToItem(item, $event, $index) {
-            $location.path($scope.entityType + '/' + $scope.entityType + '/edit/' + item.id);
+            listViewHelper.editItem(item);
         }
 
         activate();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function ListViewListLayoutController($scope, listViewHelper, $location, mediaHelper, mediaTypeHelper) {
+    function ListViewListLayoutController($scope, listViewHelper, mediaHelper, mediaTypeHelper, urlHelper) {
 
         var vm = this;
         var umbracoSettings = Umbraco.Sys.ServerVariables.umbracoSettings;
@@ -53,8 +53,7 @@
         }
 
         function clickItem(item) {
-            // if item.id is 2147483647 (int.MaxValue) use item.key
-            $location.path($scope.entityType + '/' + $scope.entityType + '/edit/' + (item.id === 2147483647 ? item.key : item.id));
+            listViewHelper.editItem(item);
         }
 
         function isSortDirection(col, direction) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When a listview is paginated, the back link always returns to page 1:

![image](https://user-images.githubusercontent.com/7405322/55537015-84e53e00-56bb-11e9-8b18-4cdccd576731.png)

This happens because we don't use `editPath` of the items in the list when opening them for editing (unless they're opened in a new window), thus discarding the pagination info needed when returning to the list.

The issue applies both to the "list" and "card" layout of listviews.

With this PR applied, the back link behaves as expected:

![listview-back-pagination](https://user-images.githubusercontent.com/7405322/55537148-d392d800-56bb-11e9-80e7-0f5fac69c839.gif)

As an added bonus the PR gets rid of a few of the hardcoded edit entity paths 😄 
