### PR TITLE
V8: Add back button to listviews for members

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/member/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/edit.html
@@ -13,8 +13,10 @@
             menu="page.menu"
             hide-icon="true"
             hide-description="true"
-            hide-alias="true">
-         </umb-editor-header>
+            hide-alias="true"
+            show-back-button="showBack()"
+            on-back="onBack()">
+          </umb-editor-header>
 
          <umb-editor-container class="form-horizontal">
 

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -192,6 +192,17 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
 
     };
 
+    $scope.showBack = function () {
+        return !!$scope.page.listViewPath;
+    }
+
+    /** Callback for when user clicks the back-icon */
+    $scope.onBack = function () {
+        if ($scope.page.listViewPath) {
+            $location.path($scope.page.listViewPath);
+        }
+    };
+
     $scope.export = function() {
         var memberKey = $scope.content.key;
         memberResource.exportMemberData(memberKey);

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -15,13 +15,8 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
     $scope.page.menu.currentSection = appState.getSectionState("currentSection");
     $scope.page.menu.currentNode = null; //the editors affiliated node
     $scope.page.nameLocked = false;
-    $scope.page.listViewPath = null;
     $scope.page.saveButtonState = "init";
     $scope.page.exportButton = "init";
-
-    $scope.page.listViewPath = ($routeParams.page && $routeParams.listName)
-        ? "/member/member/list/" + $routeParams.listName + "?page=" + $routeParams.page
-        : null;
 
     //build a path to sync the tree with
     function buildTreePath(data) {
@@ -193,13 +188,15 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
     };
 
     $scope.showBack = function () {
-        return !!$scope.page.listViewPath;
+        return !!$routeParams.listName;
     }
 
     /** Callback for when user clicks the back-icon */
     $scope.onBack = function () {
-        if ($scope.page.listViewPath) {
-            $location.path($scope.page.listViewPath);
+        $location.path("/member/member/list/" + $routeParams.listName);
+        $location.search("listName", null);
+        if ($routeParams.page) {
+            $location.search("page", $routeParams.page);
         }
     };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds the back link known from content and users/groups to member editing. 

Due to a bit of broken behavior in the listview (see #5149), this PR can currently only be tested by opening the member for editing in a new window. It looks like this:

![member-back-to-list](https://user-images.githubusercontent.com/7405322/55556501-12d71e00-56e8-11e9-8945-060b0a385ee9.gif)
