### PR TITLE
V8: Fix navigation partial view template

### DIFF
--- a/src/Umbraco.Core/Services/Implement/FileService.cs
+++ b/src/Umbraco.Core/Services/Implement/FileService.cs
@@ -1034,10 +1034,12 @@ namespace Umbraco.Core.Services.Implement
                 //strip the @inherits if it's there
                 snippetContent = StripPartialViewHeader(snippetContent);
 
-                //Update Model.Content. to be Model. when used as PartialView
+                //Update Model.Content to be Model when used as PartialView
                 if (partialViewType == PartialViewType.PartialView)
                 {
-                    snippetContent = snippetContent.Replace("Model.Content.", "Model.");
+                    snippetContent = snippetContent
+                        .Replace("Model.Content.", "Model.")
+                        .Replace("(Model.Content)", "(Model)");
                 }
 
                 var content = $"{partialViewHeader}{Environment.NewLine}{snippetContent}";


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5155

### Description

This PR updates the replace logic that turns a partial view macro template into a partial view template (introduced in e2d4110) to handle the case where `Model.Content` is used as a parameter - for example in the navigation partial view template (see #5155 for further details).

#### Navigation template

With this PR applied, the navigation partial view template looks like this:

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@using Umbraco.Web


@*
    This snippet displays a list of links of the pages immediately under the top-most page in the content tree.
    This is the home page for a standard website.
    It also highlights the current active page/section in the navigation with the CSS class "current".
*@

@{ var selection = Model.Root().Children.Where(x => x.IsVisible()).ToArray(); }

@if (selection.Length > 0)
{
    <ul>
        @foreach (var item in selection)
        {
            <li class="@(item.IsAncestorOrSelf(Model) ? "current" : null)">
                <a href="@item.Url">@item.Name</a>
            </li>
        }
    </ul>
}
```

#### Testing this PR

1. Create a new partial view based on the "Navigation" snippet.
2. Verify that `item.IsAncestorOrSelf()` is performed on `Model` and not `Model.Content` in the `foreach` loop.