### PR TITLE
V8: Can't save templates (missing mapping profile)

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/TemplateMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/TemplateMapDefinition.cs
@@ -31,7 +31,8 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll -GetFileContent
         private static void Map(TemplateDisplay source, ITemplate target, MapperContext context)
         {
-            ((Template)target).MasterTemplateAlias = source.MasterTemplateAlias;
+            // don't need to worry about mapping MasterTemplateAlias here;
+            // the template controller handles any changes made to the master template
             target.Name = source.Name;
             target.Alias = source.Alias;
             target.Content = source.Content;

--- a/src/Umbraco.Web/Models/Mapping/TemplateMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/TemplateMapDefinition.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Web.Models.Mapping
         public void DefineMaps(UmbracoMapper mapper)
         {
             mapper.Define<ITemplate, TemplateDisplay>((source, context) => new TemplateDisplay(), Map);
-            mapper.Define<TemplateDisplay, Template>((source, context) => new Template(source.Name, source.Alias), Map);
+            mapper.Define<TemplateDisplay, ITemplate>((source, context) => new Template(source.Name, source.Alias), Map);
         }
 
         // Umbraco.Code.MapAll
@@ -29,9 +29,9 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll -CreateDate -UpdateDate -DeleteDate
         // Umbraco.Code.MapAll -Path -VirtualPath -MasterTemplateId -IsMasterTemplate
         // Umbraco.Code.MapAll -GetFileContent
-        private static void Map(TemplateDisplay source, Template target, MapperContext context)
+        private static void Map(TemplateDisplay source, ITemplate target, MapperContext context)
         {
-            target.MasterTemplateAlias = source.MasterTemplateAlias;
+            ((Template)target).MasterTemplateAlias = source.MasterTemplateAlias;
             target.Name = source.Name;
             target.Alias = source.Alias;
             target.Content = source.Content;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Some recent changes to the mapping logic has resulted in this error when trying to save a template:

![image](https://user-images.githubusercontent.com/7405322/55578330-ed610900-5715-11e9-9192-08cf3452ff35.png)

I've been trying to backtrack it but I can't see which change caused this. However, updating the template mapping profiles to map both *to* and *from* `ITemplate` solves the issue (as is it only maps *from*).

Perhaps @zpqrtbnk has more insights on this?

#### Testing this PR

Verify that you can:

1. Create a template from scratch.
2. Create a document type with a template.
3. Add a master template to an existing template.
4. Change the master template of an existing template.
5. Remove the master template from an existing template.