### PR TITLE
V8: YSOD when creating the same content type twice (mapping issue)

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
@@ -246,7 +246,13 @@ namespace Umbraco.Web.Models.Mapping
             {
                 var templates = _fileService.GetTemplates(source.AllowedTemplates.ToArray());
                 target.AllowedTemplates = source.AllowedTemplates
-                    .Select(x => context.Mapper.Map<EntityBasic>(templates.SingleOrDefault(t => t.Alias == x)))
+                    .Select(x =>
+                    {
+                        var template = templates.SingleOrDefault(t => t.Alias == x);
+                        return template != null
+                            ? context.Mapper.Map<EntityBasic>(template)
+                            : null;
+                    })
                     .WhereNotNull()
                     .ToArray();
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When creating a new content type on latest, things blow up if you accidentally attempt to create a new content type with the same alias as an existing one:

![image](https://user-images.githubusercontent.com/7405322/55631176-b4797080-57b7-11e9-9c97-2bacbbc640e7.png)

Looks like this is a side effect of #5087. The mapper doesn't like it when the source object is null, which is the case here.

When this PR is applied, the expected validation error occurs instead of the YSOD:

![image](https://user-images.githubusercontent.com/7405322/55631111-8c8a0d00-57b7-11e9-85d4-083d67d3be42.png)

/cc @zpqrtbnk 
