### PR TITLE
V8: Fix node permissions YSOD (mapping issue)

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
@@ -167,6 +167,7 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll -Udi -Trashed -AdditionalData -Id -AssignedPermissions
         private void Map(IUserGroup source, AssignedUserGroupPermissions target, MapperContext context)
         {
+            target.Id = source.Id;
             target.Alias = source.Alias;
             target.Icon = source.Icon;
             target.Key = source.Key;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5171

### Description

See #5171 for details on the issue and how to replicate it. It's a side effect of #5087 - the UserGroup ID must be included when mapping UserGroup to AssignedUserGroupPermissions, otherwise things break 😄 

#### Testing this PR

Testing this PR is simple... if you can open the permissions dialog for an item in the content tree, the fix works 😆 