### PR TITLE
V8: Missing "metadata" breaks media picker (mapping issue)

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
@@ -45,6 +45,13 @@ namespace Umbraco.Web.Models.Mapping
             if (source.NodeObjectType == Constants.ObjectTypes.Member && target.Icon.IsNullOrWhiteSpace())
                 target.Icon = "icon-user";
 
+            // NOTE: we're mapping the objects in AdditionalData by object reference here.
+            // it works fine for now, but it's something to keep in mind in the future
+            foreach(var kvp in source.AdditionalData)
+            {
+                target.AdditionalData[kvp.Key] = kvp.Value;
+            }
+
             target.AdditionalData.Add("IsContainer", source.IsContainer);
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The media picker (or rather, the media resolver) depends on  the data in`IEntitySlim.AdditionalData` being included when mapping `IEntitySlim` to `EntityBasic`. Right now it's omitted, and that causes a general lack of thumbnails in the media picker:

![image](https://user-images.githubusercontent.com/7405322/55668265-c1ee3380-5867-11e9-931e-b85a6bd708ea.png)

It's a side effect of #5087

This PR adds `AdditionalData` to the mapping. Note that since `AdditionalData` is a `Dictionary<string, object>`, the mapping is done by object reference. It seems to work fine, but perhaps down the road it should be replaced with deep cloning or even strongly typed mapping.

With this PR applied, the media picker is happy again:

![image](https://user-images.githubusercontent.com/7405322/55668254-9408ef00-5867-11e9-8732-e080ec20eb3e.png)
