### PR TITLE
V8: Use the content type model when creating a "matching template"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
@@ -344,6 +344,12 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter, loca
                 $http.post(umbRequestHelper.getApiUrl("contentTypeApiBaseUrl", "Import", { file: file })),
                 "Failed to import document type " + file
             );
+        },
+
+        createDefaultTemplate: function (id) {
+            return umbRequestHelper.resourcePromise(
+                $http.post(umbRequestHelper.getApiUrl("contentTypeApiBaseUrl", "PostCreateDefaultTemplate", { id: id })),
+                'Failed to create default template for content type with id ' + id);
         }
     };
 }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.controller.js
@@ -9,7 +9,7 @@
 (function () {
     'use strict';
 
-    function TemplatesController($scope, entityResource, contentTypeHelper, templateResource, $routeParams) {
+    function TemplatesController($scope, entityResource, contentTypeHelper, templateResource, contentTypeResource, $routeParams) {
 
         /* ----------- SCOPE VARIABLES ----------- */
 
@@ -48,34 +48,25 @@
 
             vm.createTemplateButtonState = "busy";
 
-            templateResource.getScaffold(-1).then(function (template) {
-
-                template.alias = $scope.model.alias;
-                template.name = $scope.model.name;
-
-                templateResource.save(template).then(function (savedTemplate) {
-
-                    // add icon
-                    savedTemplate.icon = "icon-layout";
+            contentTypeResource.createDefaultTemplate($scope.model.id).then(function (savedTemplate) {
+                // add icon
+                savedTemplate.icon = "icon-layout";
                     
-                    vm.availableTemplates.push(savedTemplate);
-                    vm.canCreateTemplate = false;
+                vm.availableTemplates.push(savedTemplate);
+                vm.canCreateTemplate = false;
 
-                    $scope.model.allowedTemplates.push(savedTemplate);
+                $scope.model.allowedTemplates.push(savedTemplate);
 
-                    if ($scope.model.defaultTemplate === null) {
-                        $scope.model.defaultTemplate = savedTemplate;
-                    }
+                if ($scope.model.defaultTemplate === null) {
+                    $scope.model.defaultTemplate = savedTemplate;
+                }
 
-                    vm.createTemplateButtonState = "success";
-
-                }, function() {
-                    vm.createTemplateButtonState = "error";
-                });
+                vm.createTemplateButtonState = "success";
 
             }, function() {
                 vm.createTemplateButtonState = "error";
             });
+
         };
 
         function checkIfTemplateExists() {

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -322,6 +322,23 @@ namespace Umbraco.Web.Editors
             return display;
         }
 
+        public TemplateDisplay PostCreateDefaultTemplate(int id)
+        {
+            var contentType = Services.ContentTypeService.Get(id);
+            if (contentType == null)
+            {
+                throw new NullReferenceException("No content type found with id " + id);
+            }
+
+            var template = CreateTemplateForContentType(contentType.Alias, contentType.Name);
+            if (template == null)
+            {
+                throw new NullReferenceException("Could not create default template for content type with id " + id);
+            }
+
+            return Mapper.Map<TemplateDisplay>(template);
+        }
+
         private ITemplate CreateTemplateForContentType(string contentTypeAlias, string contentTypeName)
         {
             var template = Services.FileService.GetTemplate(contentTypeAlias);

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -327,13 +327,13 @@ namespace Umbraco.Web.Editors
             var contentType = Services.ContentTypeService.Get(id);
             if (contentType == null)
             {
-                throw new NullReferenceException("No content type found with id " + id);
+                throw new HttpResponseException(Request.CreateResponse(HttpStatusCode.NotFound, "No content type found with id " + id));
             }
 
             var template = CreateTemplateForContentType(contentType.Alias, contentType.Name);
             if (template == null)
             {
-                throw new NullReferenceException("Could not create default template for content type with id " + id);
+                throw new InvalidOperationException("Could not create default template for content type with id " + id);
             }
 
             return Mapper.Map<TemplateDisplay>(template);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5152

### Description

As @nielslyngsoe points out in #5152, the "Create matching template" functionality creates generic templates (same as when you create a template manually) - not content type specific ones.  And that's silly, since we know what content type the template is created for 😄 

This PR fixes it:

![matching-template-with-model](https://user-images.githubusercontent.com/7405322/55668299-8869f800-5868-11e9-8eb9-d5a73479fbb2.gif)

#### Testing this PR

1. Create a content type without a template and save it (it doesn't need any properties).
2. Hit "Create matching template" for the content type.
3. Open the created template and verify that it's generated for the specific content type - i.e. it inherits `@inherits Umbraco.Web.Mvc.UmbracoViewPage<[content type model class]>`