### PR TITLE
V8: YSOD when saving variant content (mapping issue)

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -64,7 +64,8 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll
         private static void Map(IContent source, ContentPropertyCollectionDto target, MapperContext context)
         {
-            target.Properties = source.Properties.Select(context.Mapper.Map<ContentPropertyDto>);
+            // must pass the context through
+            target.Properties = source.Properties.Select(p => context.Mapper.Map<ContentPropertyDto>(p, context));
         }
 
         // Umbraco.Code.MapAll -AllowPreview -Errors -PersistedContent


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Right now we can't save variant content - it explodes with this YSOD:

![image](https://user-images.githubusercontent.com/7405322/55674421-c12fbe80-58b4-11e9-9702-6cba5c6e1acb.png)

The problem is related to #5087

The problem occurs because the original mapping context isn't passed when mapping content properties. Thus the original mapping culture is missing when the actual property mapping takes places, and things go sideways from there.

This PR ensures that the current context is passed when mapping content properties.