### PR TITLE
V8: Fix YSOD on variant content listview

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -127,7 +127,8 @@ namespace Umbraco.Web.Models.Mapping
             target.Owner = _commonMapper.GetOwner(source, context.Mapper);
             target.ParentId = source.ParentId;
             target.Path = source.Path;
-            target.Properties = source.Properties.Select(context.Mapper.Map<ContentPropertyBasic>);
+            // must pass the context through
+            target.Properties = source.Properties.Select(p => context.Mapper.Map<ContentPropertyBasic>(p, context));
             target.SortOrder = source.SortOrder;
             target.State = _basicStateMapper.Map(source, context);
             target.Trashed = source.Trashed;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5163

### Description

See #5163 for an error description/how to reproduce.

While doing #5180 it occurred to me that #5163 must be caused by the same problem. So this PR fixes #5163 by passing the mapping context to the property mapping, just like in #5180 .

Question is if it's really a great idea to let `MapperContext` expose `UmbracoMapper`? It's so tempting to perform the nested mappings with method groups using `context.Mapper.Map`, but in doing so the nested mapping is performed "out of context", which is the root cause for both of the issues mentioned above. All sorts of havoc can happen then, not necessarily limited to language variant mapping issues.

Off the top of my head I don't really have a great alternative, but it's food for thought.

/cc @zpqrtbnk 