### PR TITLE
V8: Make it possible to save content property data (mapping issue)

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -64,7 +64,9 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll
         private static void Map(IContent source, ContentPropertyCollectionDto target, MapperContext context)
         {
-            target.Properties = source.Properties.Select(context.Map<ContentPropertyDto>);
+            // must evaluate this collection immediately, otherwise it gets re-evaluated on every access
+            // to the collection and any subsequent changes potentially overwritten 
+            target.Properties = source.Properties.Select(context.Map<ContentPropertyDto>).ToArray();
         }
 
         // Umbraco.Code.MapAll -AllowPreview -Errors -PersistedContent

--- a/src/Umbraco.Web/Models/Mapping/MediaMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MediaMapDefinition.cs
@@ -42,7 +42,9 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll
         private static void Map(IMedia source, ContentPropertyCollectionDto target, MapperContext context)
         {
-            target.Properties = source.Properties.Select(context.Map<ContentPropertyDto>);
+            // must evaluate this collection immediately, otherwise it gets re-evaluated on every access
+            // to the collection and any subsequent changes potentially overwritten 
+            target.Properties = source.Properties.Select(context.Map<ContentPropertyDto>).ToArray();
         }
 
         // Umbraco.Code.MapAll -Properties -Errors -Edited -Updater -Alias -IsContainer

--- a/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
@@ -149,7 +149,9 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll
         private static void Map(IMember source, ContentPropertyCollectionDto target, MapperContext context)
         {
-            target.Properties = source.Properties.Select(context.Map<ContentPropertyDto>);
+            // must evaluate this collection immediately, otherwise it gets re-evaluated on every access
+            // to the collection and any subsequent changes potentially overwritten 
+            target.Properties = source.Properties.Select(context.Map<ContentPropertyDto>).ToArray();
         }
 
         private MembershipScenario GetMembershipScenario()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5183

### Description

#5183 describes how content property data can't be saved. Turns out the issue also affects media and members.

It's a side effect of #5087

This PR fixes the problem by forcefully evaluating the saved properties collection during mapping.

#### Testing this PR

Verify that you can create and edit property data of:

1. Content - both variant and invariant.
2. Media (i.e. upload a new image and subsequently change the image property).
3. Members (requires a custom member type with extra editable properties).

#### Some considerations 

`IEnumerable<>` is widely used for collections on the models throughout the codebase. As such the mappings of these collections are susceptible to repeatable execution if they're not evaluated (e.g. `.ToArray()`) during mapping. This may "only" result in harmless extra mapping work, or it may result in errors like this one.

Take the mapping of content properties that's addressed by this PR as an example. It is currently executed 5 times in the course of `ContentController.PostSave()`, when really it should only be executed once. This means `ContentPropertyDtoMapper.Map()` is also executed 5 times per property being saved. 

In my test case the content has 4 languages with 8 properties. Instead of `ContentPropertyDtoMapper.Map()` being invoked 32 times (one for each property, 4x8=32), it's invoked 160 times. 

I'm not sure if the mapper can or even should attempt to perform some eager evaluation of collections? But I'm thinking it might be an idea to do some code profiling of various mapping scenarios. It could help determine the scope of this.

/cc @zpqrtbnk a.k.a. Poor Guy Being Spammed By Me