### PR TITLE
V8: Relation type alias is "generating" when editing an existing relation type

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/RelationMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/RelationMapDefinition.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Web.Models.Mapping
             mapper.Define<RelationTypeSave, IRelationType>(Map);
         }
 
-        // Umbraco.Code.MapAll -Icon -Trashed -Alias -AdditionalData
+        // Umbraco.Code.MapAll -Icon -Trashed -AdditionalData
         // Umbraco.Code.MapAll -Relations -ParentId -Notifications
         private static void Map(IRelationType source, RelationTypeDisplay target, MapperContext context)
         {
@@ -23,6 +23,7 @@ namespace Umbraco.Web.Models.Mapping
             target.IsBidirectional = source.IsBidirectional;
             target.Key = source.Key;
             target.Name = source.Name;
+            target.Alias = source.Alias;
             target.ParentObjectType = source.ParentObjectType;
             target.Udi = Udi.Create(Constants.UdiEntityType.RelationType, source.Key);
             target.Path = "-1," + source.Id;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When editing an existing relation type, the relation type alias lists as "generating" for a bit. This is because the actual alias isn't sent to the client and thus it starts generating a new one.

![relation-type-alias](https://user-images.githubusercontent.com/7405322/55687907-a3c12a00-5972-11e9-8d82-f57839e910c6.gif)

~It's a side effect of #5087~

Besides this being a bit of an eyesore, there is also a potential problem embedded in it. If the relation type name and alias do not match (e.g. if you have renamed the relation type after the initial alias generation), the correct alias is never shown since it's re-generated on every load.

This PR adds the alias to the server side mapping, thus solving the issue.  