### PR TITLE
v7: Replace the old checkbox markup with the new umb-checkbox directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -25,6 +25,7 @@
 @param {string} value Set the value of the checkbox.
 @param {string} name Set the name of the checkbox.
 @param {string} text Set the text for the checkbox label.
+@param {string} localize Pass a localization key (Optional).
 
 
 **/
@@ -42,6 +43,7 @@
                 value: "@",
                 name: "@",
                 text: "@",
+                localize: "@",
                 required: "="
             }
         };

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -24,8 +24,9 @@
 @param {boolean} model Set to <code>true</code> or <code>false</code> to set the checkbox to checked or unchecked.
 @param {string} value Set the value of the checkbox.
 @param {string} name Set the name of the checkbox.
-@param {string} text Set the text for the checkbox label.
-@param {string} localize Pass a localization key (Optional).
+@param {string} text Set up to two texts for the checkbox label.
+@param {string} localize Set up to two localization keys seperated by a pipe (Optional).
+@param {string} nodetext Pass a current node so we can have {{localizedText1}} {{nodeName}} {{localizedText2}}
 
 
 **/
@@ -44,6 +45,7 @@
                 name: "@",
                 text: "@",
                 localize: "@",
+                nodetext: "=",
                 required: "="
             }
         };

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -6,7 +6,7 @@
     flex-wrap: wrap;
     align-items: center;
     position: relative;
-    padding: 0;
+    padding: 0 !important;
     margin: 0;
 
     &__text{

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.html
@@ -70,7 +70,7 @@
         value="model.property.validation.mandatory"
         model="model.property.validation.mandatory"
         required="false"
-        localize="@validation_fieldIsMandatory"
+        localize="validation_fieldIsMandatory"
         text="Field is mandatory"
         >
      </umb-checkbox>

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/contenttypeeditor/propertysettings/propertysettings.html
@@ -65,10 +65,15 @@
 
        <h5><localize key="validation_validation"></localize></h5>
 
-      <label class="checkbox no-indent">
-         <input type="checkbox" ng-model="model.property.validation.mandatory" focus-when="{{vm.focusOnMandatoryField}}">
-         <localize key="validation_fieldIsMandatory"></localize>
-      </label>
+      <umb-checkbox
+        name="property-validation"
+        value="model.property.validation.mandatory"
+        model="model.property.validation.mandatory"
+        required="false"
+        localize="@validation_fieldIsMandatory"
+        text="Field is mandatory"
+        >
+     </umb-checkbox>
 
       <select class="umb-dropdown" ng-options="validationType.name for validationType in vm.validationTypes" ng-model="vm.selectedValidationType" ng-change="vm.changeValidationType(vm.selectedValidationType)">
          <option value=""><localize key="validation_validation">Validation</localize></option>
@@ -91,7 +96,7 @@
    <div class="umb-control-group clearfix" ng-if="model.contentType === 'memberType'">
 
        <h5><localize key="general_options"></localize></h5>
-       
+
        <label class="checkbox no-indent">
            <input type="checkbox" ng-model="model.property.showOnMemberProfile">
            <localize key="contentTypeEditor_showOnMemberProfile"></localize>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -10,5 +10,11 @@
             <i class="umb-form-check__icon icon-check"></i>
         </div>
     </div>
-    <span class="umb-form-check__text">{{text}}</span>
+    <!-- If no localize key has been passed let's just render the text value as it is -->
+    <span class="umb-form-check__text" ng-if="localize.length === 0">{{text}}</span>
+
+    <!-- If a localize key has been passed let's use the localize directive -->
+    <span class="umb-form-check__text" ng-if="localize.length > 0">
+        <localize key="{{localize}}">{{text}}</localize>
+    </span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -21,7 +21,7 @@
     <!-- If a localise key AND a nodetext has been passed let's use them here-->
     <span class="umb-form-check__text" ng-if="localize.length > 0 && nodetext.length > 0">
             <localize key="{{localize.split('|')[0]}}">{{text.split('|')[0]}}</localize>
-                {{nodetext}}
+                <strong>{{nodetext}}</strong>
             <localize key="{{localize.split('|')[1]}}">{{text.split('|')[1]}}</localize>
         </span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -13,8 +13,15 @@
     <!-- If no localize key has been passed let's just render the text value as it is -->
     <span class="umb-form-check__text" ng-if="localize.length === 0">{{text}}</span>
 
-    <!-- If a localize key has been passed let's use the localize directive -->
-    <span class="umb-form-check__text" ng-if="localize.length > 0">
+    <!-- If a localize key has been passed and the genericText is not let's use the localize directive -->
+    <span class="umb-form-check__text" ng-if="localize.length > 0 && nodetext === undefined">
         <localize key="{{localize}}">{{text}}</localize>
     </span>
+
+    <!-- If a localise key AND a nodetext has been passed let's use them here-->
+    <span class="umb-form-check__text" ng-if="localize.length > 0 && nodetext.length > 0">
+            <localize key="{{localize.split('|')[0]}}">{{text.split('|')[0]}}</localize>
+                {{nodetext}}
+            <localize key="{{localize.split('|')[1]}}">{{text.split('|')[1]}}</localize>
+        </span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/delete.html
@@ -1,6 +1,6 @@
 <div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.DataType.DeleteController">
     <div class="umb-dialog-body">
-        
+
         <p class="umb-abstract">
             <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize>&nbsp;<strong>{{currentNode.name}}</strong> ?
         </p>
@@ -20,10 +20,16 @@
 
                 <hr />
 
-                <label class="checkbox">
-                    <input type="checkbox" ng-model="confirmed" />
-                    <localize key="editdatatype_yesDelete">Yes, delete</localize> <strong>{{currentNode.name}}</strong> <localize key="editdatatype_andAllRelated">and all property types & property data using this data type</localize>
-                </label>
+                <umb-checkbox
+                    name="delete-datatype"
+                    value="confirmed"
+                    model="confirmed"
+                    required="false"
+                    localize="editdatatype_yesDelete|editdatatype_andAllRelated"
+                    text="Yes, delete|and all property types & property data using this data type"
+                    nodetext="currentNode.name"
+                    >
+                </umb-checkbox>
 
                 <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel">
                 </umb-confirm>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -85,16 +85,30 @@
             <umb-control-group label="Name of the Parent Document Type" hide-label="false">
                 <input type="text" name="collectionName" ng-model="model.collectionName" class="umb-textstring textstring input-block-level" umb-auto-focus required />
                 <span ng-if="model.disableTemplates === false">
-                    <input id="collectionCreateTemplate" name="collectionCreateTemplate" type="checkbox" ng-model="model.collectionCreateTemplate" style="margin-top: 0;" />
-                    <label for="collectionCreateTemplate" style="margin-bottom: 0; padding-left: 2px;">Create template for the Parent Document Type</label>
+                    <umb-checkbox
+                        name="collectionCreateTemplate"
+                        value="model.collectionCreateTemplate"
+                        model="model.collectionCreateTemplate"
+                        required="false"
+                        localize=""
+                        text="Create template for the Parent Document Type"
+                        >
+                    </umb-checkbox>
                 </span>
             </umb-control-group>
 
             <umb-control-group label="Name of the Item Document Type" hide-label="false">
                 <input type="text" name="collectionItemName" ng-model="model.collectionItemName" class="umb-textstring textstring input-block-level" required />
                 <span ng-if="model.disableTemplates === false">
-                    <input id="collectionItemCreateTemplate" name="collectionItemCreateTemplate" type="checkbox" ng-model="model.collectionItemCreateTemplate" style="margin-top: 0;" />
-                    <label for="collectionItemCreateTemplate" style="margin-bottom: 0; padding-left: 2px;">Create template for the Item Document Type</label>
+                    <umb-checkbox
+                        name="collectionItemCreateTemplate"
+                        value="model.collectionItemCreateTemplate"
+                        model="model.collectionItemCreateTemplate"
+                        required="false"
+                        localize=""
+                        text="Create template for the Item Document Type"
+                        >
+                    </umb-checkbox>
                 </span>
             </umb-control-group>
 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.html
@@ -28,10 +28,16 @@
 
                 <hr />
 
-                <label class="checkbox">
-                	<input type="checkbox" ng-model="confirmed" />
-                    <localize key="contentTypeEditor_yesDelete">Yes, delete</localize> {{currentNode.name}} <localize key="contentTypeEditor_andAllDocuments">and all documents using this type</localize>
-                </label>
+                <umb-checkbox
+                    name="delete-documenttype"
+                    value="confirmed"
+                    model="confirmed"
+                    required="false"
+                    localize="contentTypeEditor_yesDelete|contentTypeEditor_andAllDocuments"
+                    text="Yes, delete|and all documents using this type"
+                    nodetext="currentNode.name"
+                    >
+                </umb-checkbox>
 
                 <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel">
                 </umb-confirm>

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.html
@@ -24,10 +24,16 @@
 
                 <hr />
 
-                <label class="checkbox">
-                	<input type="checkbox" ng-model="confirmed" />
-                    <localize key="contentTypeEditor_yesDelete">Yes, delete</localize> {{currentNode.name}} <localize key="contentTypeEditor_andAllMediaItems">and all media items using this type</localize>
-                </label>
+                <umb-checkbox
+                    name="delete-mediatype"
+                    value="confirmed"
+                    model="confirmed"
+                    required="false"
+                    localize="contentTypeEditor_yesDelete|contentTypeEditor_andAllMediaItems"
+                    text="Yes, delete|and all media items using this type"
+                    nodetext="currentNode.name"
+                    >
+                </umb-checkbox>
 
                 <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel">
                 </umb-confirm>

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.html
@@ -14,7 +14,7 @@
         <hr />
 
         <umb-checkbox
-            name="delete-mediatype"
+            name="delete-membertype"
             value="confirmed"
             model="confirmed"
             required="false"

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.html
@@ -13,10 +13,16 @@
 
         <hr />
 
-        <label class="checkbox">
-            <input type="checkbox" ng-model="confirmed" />
-            <localize key="contentTypeEditor_yesDelete">Yes, delete</localize> {{currentNode.name}} <localize key="contentTypeEditor_andAllMembers">and all members using this type</localize>
-        </label>
+        <umb-checkbox
+            name="delete-mediatype"
+            value="confirmed"
+            model="confirmed"
+            required="false"
+            localize="contentTypeEditor_yesDelete|contentTypeEditor_andAllMembers"
+            text="Yes, delete|and all members using this type"
+            nodetext="currentNode.name"
+            >
+        </umb-checkbox>
 
         <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel">
         </umb-confirm>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5185

### Description

I have replaced the old input checkboxes that had the default browser styling to using the umb-checkbox directive, which has some custom styling and makes the UI look nicer.

Throughout my little adventure I realized that the directive needed to be extended a bit so I have made it possible to add

- A dictionary/localization key with the "localize" attribute that accepts up to 2 value delimited by the pipe character ( | )
- A nodetext
- An option to pass two to the "text" parameter delimited by the pipe sign ( | )

This makes it possible to pass strings that can be translated using dictionary items and it also make it possible to construct a dynamic string like "Yes, delete <strong>{{nodeText}}</strong> and all of the..." where "Yes, delete" is the first localizable text before the pipe and "and all of the..." is the text after the pipe sign.

This means that the following places have been changed to using the directive
- Property validation when adding a new property on a document type
- The "Add templates" checkboxes in the "Document type collection create dialogue"
- The delete dialogues for
  - Document types
  - Datatypes
  - Media types
  - Members

All of the delete dialogues have also been unified so they all highlight the name of the node that is about to be deleted. Before this change this was only highlighted when deleting datatypes.

### Before / After

**Property validation**

Before:
![checkbox-propertysettings-before](https://user-images.githubusercontent.com/1932158/55688862-1683d280-597e-11e9-8998-3ed910310afc.png)

After:
![checkbox-propertysettings-after](https://user-images.githubusercontent.com/1932158/55688865-21d6fe00-597e-11e9-90fb-168f37004520.png)


**The delete dialogue (Only one screendump added since they all look the same)**

Before: 
![delete-dialogue-before](https://user-images.githubusercontent.com/1932158/55688870-2c919300-597e-11e9-843d-aa3bf01bd45a.png)

After:
![delete-dialogue-after](https://user-images.githubusercontent.com/1932158/55688873-33200a80-597e-11e9-807e-8cd58de9ea25.png)


**The document type collection create dialogue (Showing before and after in the same screendump)**
![create-collection-dialogue-before-after](https://user-images.githubusercontent.com/1932158/55688878-3ca97280-597e-11e9-951c-36252ff4f07d.png)
