### PR TITLE
V8: Make DoNotCloneAttribute public

### DIFF
--- a/src/Umbraco.Core/Models/DoNotCloneAttribute.cs
+++ b/src/Umbraco.Core/Models/DoNotCloneAttribute.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Core.Models
     /// * when the setter performs additional required logic other than just setting the underlying field
     ///
     /// </remarks>
-    internal class DoNotCloneAttribute : Attribute
+    public class DoNotCloneAttribute : Attribute
     {
 
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5160

### Description

Cleaning out easily fixed issues here... this PR makes `DoNotCloneAttribute` public as per #5160 