### PR TITLE
V8: Fix the layout for editing datatypes in infinite edit mode

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.html
@@ -11,7 +11,7 @@
             hide-description="true">
         </umb-editor-header>
 
-        <umb-editor-container>
+        <umb-editor-container class="form-horizontal">
 
             <umb-load-indicator
                 ng-if="vm.loadingDataType">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5154

### Description

This PR fixes the layout of the datatype editor when editing datatypes in infinite editing mode (see #5154 for details).

When applied the editor behaves like this:

![dataype-infinite-editing](https://user-images.githubusercontent.com/7405322/55711636-5df57780-59ed-11e9-958d-0deb05cb17bf.gif)
