### PR TITLE
V7: Fix missing image dimensions

### DIFF
--- a/src/Umbraco.Core/IO/MediaFileSystem.cs
+++ b/src/Umbraco.Core/IO/MediaFileSystem.cs
@@ -377,21 +377,28 @@ namespace Umbraco.Core.IO
                         return new Size(width, height);
                     }
                 }
+            }
+            catch
+            {
+                //We will just swallow, just means we can't read exif data, we don't want to log an error either
+            }
 
-                //we have no choice but to try to read in via GDI
+            //we have no choice but to try to read in via GDI
+            try
+            {
                 using (var image = Image.FromStream(stream))
                 {
-
                     var fileWidth = image.Width;
                     var fileHeight = image.Height;
                     return new Size(fileWidth, fileHeight);
                 }
             }
-            catch (Exception)
+            catch
             {
-                //We will just swallow, just means we can't read exif data, we don't want to log an error either
-                return new Size(Constants.Conventions.Media.DefaultSize, Constants.Conventions.Media.DefaultSize);
+                //We will just swallow, just means we can't read via GDI, we don't want to log an error either
             }
+
+            return new Size(Constants.Conventions.Media.DefaultSize, Constants.Conventions.Media.DefaultSize);
         }
 
         #endregion


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5195 (and https://github.com/umbraco/Umbraco-CMS/issues/3990)

### Description

See #5195. 

When we read image dimensions, we first attempt doing so using EXIF data because it's faster and more memory efficient. If that fails we fall back to using GDI. Unfortunately for some images, the EXIF data read fails with an exception, which currently prevents the GDI attempt and thus results in images being listed with the default 200x200px dimensions.

This PR splits the dimension read attempts into two separate `try/catch` blocks to ensure that EXIT failures do not prevent the use of GDI.

#### Testing this PR

1. Upload a few images of different formats to the media library and verify that their dimensions are saved correctly.
2. Upload [this](https://user-images.githubusercontent.com/5837521/52138261-915e0380-2644-11e9-927e-fe05ef73fa1e.jpg) image to the media library and verify that its dimensions are also saved correctly.

#### V8 considerations

This issue is likely in V8. However, V8 code restructuring means this PR can't be merged to V8, so I'll test it and submit another PR for V8 if required. 

Update: PR for V8 in #5201