### PR TITLE
V8: Fix missing image dimensions

### DIFF
--- a/src/Umbraco.Web/Media/ImageHelper.cs
+++ b/src/Umbraco.Web/Media/ImageHelper.cs
@@ -1,17 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Umbraco.Core;
-using Umbraco.Core.Configuration;
-using Umbraco.Core.Configuration.UmbracoSettings;
-using Umbraco.Core.IO;
-using Umbraco.Core.Media;
-using Umbraco.Core.Models;
-using Umbraco.Web.Composing;
 using Umbraco.Web.Media.Exif;
 
 namespace Umbraco.Web.Media
@@ -28,9 +18,9 @@ namespace Umbraco.Web.Media
         /// use potentially large amounts of memory.</remarks>
         public static Size GetDimensions(Stream stream)
         {   
+            //Try to load with exif
             try
             {
-                //Try to load with exif
                 var jpgInfo = ImageFile.FromStream(stream);
 
                 if (jpgInfo != null
@@ -45,11 +35,17 @@ namespace Umbraco.Web.Media
                         return new Size(width, height);
                     }
                 }
+            }
+            catch
+            {
+                //We will just swallow, just means we can't read exif data, we don't want to log an error either
+            }
 
-                //we have no choice but to try to read in via GDI
+            //we have no choice but to try to read in via GDI
+            try
+            {
                 using (var image = Image.FromStream(stream))
                 {
-
                     var fileWidth = image.Width;
                     var fileHeight = image.Height;
                     return new Size(fileWidth, fileHeight);
@@ -57,13 +53,10 @@ namespace Umbraco.Web.Media
             }
             catch (Exception)
             {
-                //We will just swallow, just means we can't read exif data, we don't want to log an error either
-                return new Size(Constants.Conventions.Media.DefaultSize, Constants.Conventions.Media.DefaultSize);
+                //We will just swallow, just means we can't read via GDI, we don't want to log an error either
             }
-            
+
+            return new Size(Constants.Conventions.Media.DefaultSize, Constants.Conventions.Media.DefaultSize);            
         }
-
-        
-
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is the V8 implementation of #5200 - same issue and same fix, but due to code restructuring from V7 to V8 the fix can't be merged ... thus another PR 🎉 

#### Testing this PR

Same procedure as for #5200:

1. Upload a few images of different formats to the media library and verify that their dimensions are saved correctly.
2. Upload [this](https://user-images.githubusercontent.com/5837521/52138261-915e0380-2644-11e9-927e-fe05ef73fa1e.jpg) image to the media library and verify that its dimensions are also saved correctly.
