### PR TITLE
V8: Always show file names for media/files without thumbnail

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -4,7 +4,7 @@
             <!--<i ng-show="item.selected" class="icon-check umb-media-grid__checkmark"></i>-->
             <a ng-if="allowOnClickEdit === 'true'" ng-click="clickEdit(item, $event)" ng-href="" class="icon-edit umb-media-grid__edit"></a>
 
-            <div data-element="media-grid-item-edit" class="umb-media-grid__item-overlay" ng-class="{'-locked': item.selected || !item.file}" ng-click="clickItemName(item, $event, $index)">
+            <div data-element="media-grid-item-edit" class="umb-media-grid__item-overlay" ng-class="{'-locked': item.selected || !item.file || !item.thumbnail}" ng-click="clickItemName(item, $event, $index)">
                 <i ng-if="onDetailsHover" class="icon-info umb-media-grid__info" ng-mouseover="hoverItemDetails(item, $event, true)" ng-mouseleave="hoverItemDetails(item, $event, false)"></i>
                 <div class="umb-media-grid__item-name">{{item.name}}</div>
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5198

### Description

See #5198 

This PR forces the filename of media without thumbnails (e.g. PDF or SVG) to be visible at all times - as is they're only shown on hover, making it nearly impossible to find the right file.

This change applies both to the media picker, the MNTP and the media library folder view.

Here's how the pickers behave with this PR applied:

![media-file-names-visible-picker](https://user-images.githubusercontent.com/7405322/55775928-44126e00-5a9b-11e9-92e6-8c08c947d238.gif)

And here's how the media library folders behave:

![media-file-names-visible-library](https://user-images.githubusercontent.com/7405322/55775944-542a4d80-5a9b-11e9-9e49-5d57dd72fa07.gif)
