### PR TITLE
V8: Make sure Nested Content item blueprints are listed in defined sort order

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.controller.js
@@ -8,6 +8,10 @@ function ItemPickerOverlay($scope, localizationService) {
                 $scope.model.title = value;
             });
         }
+
+        if (!$scope.model.orderBy) {
+            $scope.model.orderBy = "name";
+        }
     }
 
     $scope.selectItem = function(item) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
@@ -12,7 +12,7 @@
     </div>
 
     <ul class="umb-card-grid">
-        <li ng-repeat="availableItem in model.availableItems | compareArrays:model.selectedItems:'alias' | orderBy:'name' | filter:searchTerm"
+        <li ng-repeat="availableItem in model.availableItems | compareArrays:model.selectedItems:'alias' | orderBy:model.orderBy | filter:searchTerm"
             ng-click="selectItem(availableItem)"
             class="-three-in-row">
             <a class="umb-card-grid-item" href="" title="{{ availableItem.name }}">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -127,6 +127,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
                 show: false,
                 style: {},
                 filter: $scope.scaffolds.length > 15 ? true : false,
+                orderBy: "$index",
                 view: "itempicker",
                 event: $event,
                 submit: function(model) {                    


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The Nested Content config lets you define the order of the assigned item blueprints:

![image](https://user-images.githubusercontent.com/7405322/55832854-c1c78f80-5b16-11e9-8f12-c7691a637261.png)

However, the editor doesn't respect the defined order when adding new items - they're always sorted by name:

![image](https://user-images.githubusercontent.com/7405322/55832696-65647000-5b16-11e9-8741-da7b91d5dfc6.png)

This PR makes the itempicker overlay able to sort the items by a given property on its model - default remains "name". When applied the itempicker works as expected for Nested Content:

![image](https://user-images.githubusercontent.com/7405322/55833203-7e215580-5b17-11e9-88d6-fe78f93eda1f.png)
