### PR TITLE
bigger area for add-property + only hover-state if you can edit property

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -90,6 +90,9 @@
 
 .umb-editor-header__name-and-description {
     margin-right: 20px;
+    .umb-panel-header-description {
+    	padding: 0 10px;
+    }
 }
 
 .-split-view-active .umb-editor-header__name-and-description {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -135,6 +135,28 @@ input.umb-group-builder__group-title-input:disabled:hover {
     margin-left: auto;
 }
 
+.umb-group-builder__group-add-property {
+    min-height: 46px;
+    margin-right: 30px;
+    margin-left: 270px;
+    border-radius: 3px;
+    
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    border: 1px dashed @gray-7;
+    background-color: transparent;
+    color: @ui-action-type;
+    font-weight: bold;
+    position: relative;
+    &:hover {
+        color:@ui-action-type-hover;
+        text-decoration: none;
+        border-color: @ui-active-type-hover;
+    }
+}
+
 /* ---------- PROPERTIES ---------- */
 
 .umb-group-builder__properties {
@@ -270,7 +292,7 @@ input.umb-group-builder__group-title-input:disabled:hover {
     }
 }
 
-.umb-group-builder__property-preview:hover {
+.umb-group-builder__property-preview:not(.-not-clickable):hover {
     &::after {
         opacity: .8;
     }
@@ -301,14 +323,29 @@ input.umb-group-builder__group-title-input:disabled:hover {
   opacity: 0.8
 }
 
+
+.umb-group-builder__open-settings {
+    position: absolute;
+    z-index:1;
+    top: 0;
+    bottom:0;
+    left: 0;
+    width: 100%;
+    background-color: transparent;
+    border: none;
+    &:focus {
+        outline:0;
+    }
+}
+
 .umb-group-builder__property-actions {
-  flex: 0 0 40px;
-  text-align: center;
-  margin: 15px 0 0 15px;
+    flex: 0 0 30px;
+    text-align: right;
+    margin-top: 9px;
 }
 
 .umb-group-builder__property-action {
-  margin: 0 0 10px 0;
+  margin: 10px 0 10px 0;
   display: block;
   font-size: 18px;
   position: relative;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -75,7 +75,7 @@
   display: flex;
   align-items: center;
   border-bottom: 1px solid @gray-9;
-  padding: 10px 15px;
+  padding: 10px 15px 10px 10px;
 }
 
 .umb-group-builder__group-title {
@@ -112,7 +112,7 @@ input.umb-group-builder__group-title-input {
 }
 
 input.umb-group-builder__group-title-input:disabled:hover {
-  border: none;
+    border-color: transparent;
 }
 
 .umb-group-builder__group-title-input:hover {
@@ -163,6 +163,7 @@ input.umb-group-builder__group-title-input:disabled:hover {
   list-style: none;
   margin: 0;
   padding: 15px;
+  padding-right: 5px;
   min-height: 35px; // the height of a sortable property
 }
 
@@ -250,6 +251,9 @@ input.umb-group-builder__group-title-input:disabled:hover {
   overflow: hidden;
   border-color: transparent;
   background: transparent;
+    &:focus {
+        border-color: @inputBorderFocus;
+    }
 }
 
 .umb-group-builder__property-meta-label textarea.ng-invalid {
@@ -269,6 +273,9 @@ input.umb-group-builder__group-title-input:disabled:hover {
   overflow: hidden;
   border-color: transparent;
   background: transparent;
+    &:focus {
+        border-color: @inputBorderFocus;
+    }
 }
 
 .umb-group-builder__property-preview {
@@ -287,19 +294,15 @@ input.umb-group-builder__group-title-input:disabled:hover {
         bottom: 0;
         left: 0;
         right: 0;
-        background: rgba(0,0,0,0.1);
+        background: rgba(225,225,225,.5);
         transition: opacity 120ms;
     }
 }
 
 .umb-group-builder__property-preview:not(.-not-clickable):hover {
     &::after {
-        opacity: .8;
+        opacity: .66;
     }
-}
-
-.umb-group-builder__property-preview:focus {
-    outline: none;
 }
 
 .umb-group-builder__property-preview.-not-clickable {
@@ -335,26 +338,42 @@ input.umb-group-builder__group-title-input:disabled:hover {
     border: none;
     &:focus {
         outline:0;
+        border: 1px solid @inputBorderFocus;
     }
 }
 
 .umb-group-builder__property-actions {
-    flex: 0 0 30px;
+    flex: 0 0 44px;
     text-align: right;
-    margin-top: 9px;
+    margin-top: 7px;
 }
 
 .umb-group-builder__property-action {
-  margin: 10px 0 10px 0;
-  display: block;
-  font-size: 18px;
-  position: relative;
-  cursor: pointer;
-  color: @ui-icon;
-}
-
-.umb-group-builder__property-action:hover {
-    color: @ui-icon-hover;
+    
+    position: relative;
+    margin: 5px 0;
+    
+    > button {
+        border: none;
+        
+        font-size: 18px;
+        position: relative;
+        cursor: pointer;
+        color: @ui-icon;
+        
+        margin: 0;
+        padding: 5px 10px;
+        width: auto;
+        overflow: visible;
+        background: transparent;
+        line-height: normal;
+        outline: 0;
+        -webkit-appearance: none;
+        
+        &:hover, &:focus  {
+            color: @ui-icon-hover;
+        }
+    }
 }
 
 .umb-group-builder__property-tags {
@@ -476,7 +495,7 @@ input.umb-group-builder__group-sort-value {
         font-size: 14px;
         color: @ui-action-type;
         
-        &:hover {
+        &:hover{
             text-decoration: none;
             color:@ui-action-type-hover;
             border-color:@ui-action-border-hover;

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -116,7 +116,7 @@
                         <!-- Add new property -->
                         <a href=""
                             data-element="property-add"
-                            class="btn btn-info"
+                            class="umb-group-builder__group-add-property"
                             ng-if="property.propertyState=='init' && !sortingMode"
                             hotkey="alt+shift+p"
                             hotkey-when="{{tab.tabState === 'active' && property.propertyState=='init'}}"
@@ -183,7 +183,7 @@
                             </div>
 
 
-                            <div tabindex="-1" class="umb-group-builder__property-preview" ng-click="editPropertyTypeSettings(property, tab)" ng-if="!sortingMode" ng-class="{'-not-clickable': !sortingMode && (property.inherited || property.locked)}">
+                            <div tabindex="-1" class="umb-group-builder__property-preview" ng-if="!sortingMode" ng-class="{'-not-clickable': !sortingMode && (property.inherited || property.locked)}">
 
                                 <div class="umb-group-builder__property-tags">
 
@@ -234,7 +234,7 @@
 
                                 </div>
 
-                                <ng-form name="propertyEditorPreviewForm" umb-disable-form-validation>
+                                <ng-form  class="umb-group-builder__property-preview-form" name="propertyEditorPreviewForm" umb-disable-form-validation ng-click="editPropertyTypeSettings(property, tab)">
                                         <umb-property-editor
                                             ng-if="property.view !== undefined"
                                             model="property"
@@ -242,10 +242,12 @@
                                         </umb-property-editor>
                                 </ng-form>
 
+                                <button class="umb-group-builder__open-settings" ng-if="!property.inherited && !property.locked" ng-click="editPropertyTypeSettings(property, tab)"></button>
+
                             </div>
 
                             <!-- row tools -->
-                            <div class="umb-group-builder__property-actions" ng-if="!sortingMode">
+                            <div class="umb-group-builder__property-actions">
 
                                 <div ng-if="!property.inherited">
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -234,12 +234,12 @@
 
                                 </div>
 
-                                <ng-form  class="umb-group-builder__property-preview-form" name="propertyEditorPreviewForm" umb-disable-form-validation ng-click="editPropertyTypeSettings(property, tab)">
-                                        <umb-property-editor
-                                            ng-if="property.view !== undefined"
-                                            model="property"
-                                            preview="true">
-                                        </umb-property-editor>
+                                <ng-form inert class="umb-group-builder__property-preview-form" name="propertyEditorPreviewForm" umb-disable-form-validation ng-click="editPropertyTypeSettings(property, tab)">
+                                    <umb-property-editor
+                                        ng-if="property.view !== undefined"
+                                        model="property"
+                                        preview="true">
+                                    </umb-property-editor>
                                 </ng-form>
 
                                 <button class="umb-group-builder__open-settings" ng-if="!property.inherited && !property.locked" ng-click="editPropertyTypeSettings(property, tab)"></button>
@@ -252,13 +252,13 @@
                                 <div ng-if="!property.inherited">
 
                                     <!-- settings for property -->
-                                    <div class="umb-group-builder__property-action" ng-click="editPropertyTypeSettings(property, tab)">
-                                        <i class="icon icon-settings"></i>
+                                    <div class="umb-group-builder__property-action">
+                                        <button class="icon icon-settings" ng-click="editPropertyTypeSettings(property, tab)"></button>
                                     </div>
 
                                     <!-- delete property -->
                                     <div ng-if="!property.locked" class="umb-group-builder__property-action">
-                                        <i class="icon-trash" ng-click="togglePrompt(property)"></i>
+                                        <button class="icon-trash" ng-click="togglePrompt(property)"></button>
                                         <umb-confirm-action
                                             ng-if="property.deletePrompt"
                                             direction="left"


### PR DESCRIPTION
Changed some UI of doc-type-editor a little bit.

- Bigger add-property button.
- Option buttons align right.
- Focus highlight on property-preview.
- Ability focus property-actions by keyboard-tabbing.

Before:
![image](https://user-images.githubusercontent.com/6791648/55810079-41d60100-5ae7-11e9-9f29-ec135953b66c.png)


After:
![image](https://user-images.githubusercontent.com/6791648/55810041-384c9900-5ae7-11e9-9b54-5d020cfdf0bc.png)
