### PR TITLE
Making Umb-Toggle round

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -14,9 +14,9 @@
     cursor: pointer;
     align-items: center;
     display: flex;
-    width: 48px;
-    height: 24px;
-    border-radius: 3px;
+    width: 38px;
+    height: 18px;
+    border-radius: 10px;
     border: 1px solid @inputBorder;
     background-color: @inputBorder;
     position: relative;
@@ -49,14 +49,14 @@
     top: 1px;
     left: 1px;
     display: block;
-    width: 22px;
-    height: 22px;
+    width: 16px;
+    height: 16px;
     background-color: @white;
-    border-radius: 2px;
+    border-radius: 8px;
     transition: transform 120ms ease-in-out, background-color 120ms;
     
     .umb-toggle.umb-toggle--checked & {
-        transform: translateX(24px);
+        transform: translateX(20px);
         background-color: white;
     }
     
@@ -67,20 +67,22 @@
 
 .umb-toggle__icon {
     position: absolute;
+    font-size: 12px;
     line-height: 1em;
     text-decoration: none;
     transition: all 0.2s ease;
 }
 
 .umb-toggle__icon--left {
-    left: 6px;
-    color: @ui-btn;
-    transition: color 120ms;
+    left: 5px;
+    color: white;
+    transition: opacity 120ms;
+    opacity: 0;
     // .umb-toggle:hover & {
     //     color: @ui-btn-hover;
     // }
     .umb-toggle--checked & {
-        color: white;
+        opacity: 1;
     }
     .umb-toggle.umb-toggle--checked:hover & {
         color: white;
@@ -90,6 +92,10 @@
 .umb-toggle__icon--right {
     right: 5px;
     color: @ui-btn;
+    transition: opacity 120ms;
+    .umb-toggle--checked & {
+        opacity: 0;
+    }
     .umb-toggle:hover & {
         color: @ui-btn-hover;
     }


### PR DESCRIPTION
Turning the Umb-toggle into a more square form for a V8 look, showed to be confusing since users can be confused by the square shape which leads to thinking that the two components of the button are two separate things.

Making the toggle round again will provide a stronger relation to toggles known from Android and iOS and gives a better visual understanding of the component begin one thing.

As well I have changed the size to match the size of checkboxes and radiobuttons.

Before:
![image](https://user-images.githubusercontent.com/6791648/55870947-f163af80-5b89-11e9-8177-8fbf5616cec7.png)

After:
![image](https://user-images.githubusercontent.com/6791648/55870778-9af67100-5b89-11e9-973f-7b464b8e86ef.png)
