### PR TITLE
V7: Fix "sort by document type" in content listviews

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
@@ -703,6 +703,8 @@ ORDER BY contentNodeId, versionId, propertytypeid
                 // Members only
                 case "USERNAME":
                     return "cmsMember.LoginName";
+                case "CONTENTTYPEALIAS":
+                    return "cmsContentType.alias";
                 default:
                     //ensure invalid SQL cannot be submitted
                     return Regex.Replace(orderBy, @"[^\w\.,`\[\]@-]", "");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5233

### Description

See #5233 for steps to reproduce. 

Note that it doesn't have to be a custom listview to produce this error, it also happens on the default list view if you add "Document Type" to "Columns Displayed" and set "Document Type" as "Order By".

Also note that the same issue exists for media and members. This PR solves the issue for members as well (although there's another little naming bug going on there - PR probably later on), but it does *not* solve the problem for media. I have a solution for media as well, but as it entails adding extra load on the SQL server, I will push a separate PR later.

Last note: This issue is also in V8. I have a PR almost ready to fix that. Will push later.