### PR TITLE
Hover state class changed for accessibility

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
@@ -39,4 +39,5 @@
 .umb-app-header__action a:hover .umb-app-header__action-icon,
 .umb-app-header__action a:focus .umb-app-header__action-icon {
     opacity: 1;
+    color: @pinkLight;
 }


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

This links to the issue [5157](https://github.com/umbraco/Umbraco-CMS/pull/5157)


Now, upon hover, the icon looks like this:

![image](https://user-images.githubusercontent.com/49522266/56053522-3b948e80-5d4c-11e9-9cef-fb79a698a3bd.png)

which is far pinker than before and in keeping with the behaviours throughout the cms.


### Description
As a mob, the attendees of the Warsaw leg of the umbraco roadshow picked this issue from a list and then changed the colour of the item upon hover for accessibility.

We are, of course, open to feedback and did have quite a bit of discussion over whether we had gone far enough to address the issue. As a mob, though, we decided it was a good place to ask for feedback.

<!-- Thanks for contributing to Umbraco CMS! -->
