### PR TITLE
V8: Fix "sort by document type" YSOD in listviews

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -379,6 +379,20 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 return "variantName";
             }
 
+            // content type alias is invariant
+            if(ordering.OrderBy.InvariantEquals("contentTypeAlias"))
+            {
+                var joins = Sql()
+                    .InnerJoin<ContentTypeDto>("ctype").On<ContentDto, ContentTypeDto>((content, contentType) => content.ContentTypeId == contentType.NodeId, aliasRight: "ctype");
+
+                // see notes in ApplyOrdering: the field MUST be selected + aliased
+                sql = Sql(InsertBefore(sql, "FROM", ", " + SqlSyntax.GetFieldName<ContentTypeDto>(x => x.Alias, "ctype") + " AS ordering "), sql.Arguments);
+
+                sql = InsertJoins(sql, joins);
+
+                return "ordering";
+            }
+
             // previously, we'd accept anything and just sanitize it - not anymore
             throw new NotSupportedException($"Ordering by {ordering.OrderBy} not supported.");
         }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -186,15 +186,9 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
 
     //update all of the system includeProperties to enable sorting
     _.each($scope.options.includeProperties, function (e, i) {
+        e.allowSorting = true;
 
-        //NOTE: special case for contentTypeAlias, it's a system property that cannot be sorted
-        // to do that, we'd need to update the base query for content to include the content type alias column
-        // which requires another join and would be slower. BUT We are doing this for members so not sure it makes a diff?
-        if (e.alias != "contentTypeAlias") {
-            e.allowSorting = true;
-        }
-
-        // Another special case for members, only fields on the base table (cmsMember) can be used for sorting
+        // Special case for members, only fields on the base table (cmsMember) can be used for sorting
         if (e.isSystem && $scope.entityType == "member") {
             e.allowSorting = e.alias == 'username' || e.alias == 'email';
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If the default ordering in a listview is set to "Document Type", the backend breaks miserably:

![image](https://user-images.githubusercontent.com/7405322/56054506-515b8100-5d57-11e9-9017-40e4f9fa82a3.png)

The issue was originally reported in #5233 for V7 but clearly also applies to V8. The issue is present in  listviews for all types (content, media and members).

This PR fixes the issue:

![image](https://user-images.githubusercontent.com/7405322/56054710-d47cd700-5d57-11e9-9944-44611b0ff158.png)

#### Testing this PR

The PR should be tested for both content, media and members:

1. Add "Document Type" as column in the listview and use it for the default ordering:
![image](https://user-images.githubusercontent.com/7405322/56054881-4c4b0180-5d58-11e9-9fca-b10793df57c8.png)
2. Verify that the items in the listview are indeed sorted as expected.
3. Verify that the listview can be sorted manually by "Document Type" by clicking the list view column header.