### PR TITLE
V7: Fix "sort by document type" in media listviews

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/MediaRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/MediaRepository.cs
@@ -95,7 +95,9 @@ namespace Umbraco.Core.Persistence.Repositories
                 .InnerJoin<ContentDto>(SqlSyntax)
                 .On<ContentVersionDto, ContentDto>(SqlSyntax, left => left.NodeId, right => right.NodeId)
                 .InnerJoin<NodeDto>(SqlSyntax)
-                .On<ContentDto, NodeDto>(SqlSyntax, left => left.NodeId, right => right.NodeId);
+                .On<ContentDto, NodeDto>(SqlSyntax, left => left.NodeId, right => right.NodeId)
+                .InnerJoin<ContentTypeDto>(SqlSyntax)
+                .On<ContentTypeDto, ContentDto>(SqlSyntax, left => left.NodeId, right => right.ContentTypeId);
 
             if (includeFilePaths)
             {

--- a/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/VersionableRepositoryBase.cs
@@ -703,6 +703,8 @@ ORDER BY contentNodeId, versionId, propertytypeid
                 // Members only
                 case "USERNAME":
                     return "cmsMember.LoginName";
+                case "CONTENTTYPEALIAS":
+                    return "cmsContentType.alias";
                 default:
                     //ensure invalid SQL cannot be submitted
                     return Regex.Replace(orderBy, @"[^\w\.,`\[\]@-]", "");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5233

### Description

#5245 fixes #5233 for content and members. This PR fixes #5233 for media. See #5233 for steps to reproduce (just do the same for media). 

When this PR is applied, the media listview works with "Document Type" ordering:

![image](https://user-images.githubusercontent.com/7405322/56055612-2fafc900-5d5a-11e9-9856-ecf78b24fc40.png)

#### Things to consider before merging this PR

This PR builds on top of #5245. 

The reason why this is a separate PR from #5245 is that it adds an extra `JOIN` between `ContentDto` and `ContentTypeDto` in the query that's used for pretty much every single operation in `MediaRepository` - including all `Get` operations! 

To be honest I'm not sure it's worth it to fix #5233 for media. Obviously the scenario is a rare one, or the issue would have been raised a long time ago. We could simply choose not to support the scenario for media instead and probably be better off. But that's a decision for HQ to make.
