### PR TITLE
V8: Allow sorting manually by name in listviews

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
@@ -22,7 +22,7 @@
                     <localize key="general_status">Status</localize>
                 </div>
                 <div class="umb-table-cell" ng-repeat="column in vm.itemProperties track by column.alias">
-                    <a class="umb-table-head__link" title="Sort by {{ column.header }}" href="#"
+                    <a class="umb-table-head__link" href="#"
                        ng-click="vm.sort(column.alias, column.allowSorting, column.isSystem)"
                        ng-class="{'sortable':column.allowSorting}" prevent-default>
                         <span ng-bind="column.header"></span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
@@ -11,8 +11,12 @@
 
                 </div>
                 <div class="umb-table-cell umb-table__name">
-                    <localize key="general_name">Name</localize>
-                    <i class="umb-table-head__icon icon" ng-class="{'icon-navigation-up': vm.isSortDirection('Name', 'asc'), 'icon-navigation-down': vm.isSortDirection('Name', 'desc')}"></i>
+                    <a class="umb-table-head__link sortable" href="#"
+                        ng-click="vm.sort('Name', true, true)"
+                        prevent-default>
+                        <localize key="general_name">Name</localize>
+                        <i class="umb-table-head__icon icon" ng-class="{'icon-navigation-up': vm.isSortDirection('Name', 'asc'), 'icon-navigation-down': vm.isSortDirection('Name', 'desc')}"></i>
+                    </a>
                 </div>
                 <div class="umb-table-cell" ng-show="vm.items[0].state">
                     <localize key="general_status">Status</localize>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Listviews can be configured to sort by item name. However you can't click the "Name" column title to change the sort order, or to sort by item name if the listview is configured to sort by something else. 

In other words: For whatever reason you can't manually sort by item name in the listviews. It seems to be an oversight, as the server side is fully capable of doing that sorting... so this PR adds sorting on "Name":

![listview-sort-by-name](https://user-images.githubusercontent.com/7405322/56060655-c8007a80-5d67-11e9-81ee-c6d522ef37b6.gif)

I have also removed the hardcoded "Sort by [column]" title on the listview column title links. I think it's obvious that you click the column title to sort, so the column title isn't strictly necessary. And since we don't have an existing translation for "Sort by [column]", I have opted to simply remove it.
