### PR TITLE
V8: Add busy state to <umb-confirm/> OK button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirm.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirm.directive.js
@@ -60,6 +60,7 @@ function confirmDirective() {
         link: function (scope, element, attr, ctrl) {
             scope.showCancel = false;
             scope.showConfirm = false;
+            scope.confirmButtonState = "init";
 
             if (scope.onConfirm) {
                 scope.showConfirm = true;
@@ -67,6 +68,15 @@ function confirmDirective() {
 
             if (scope.onCancel) {
                 scope.showCancel = true;
+            }
+
+            scope.confirm = function () {
+                if (!scope.onConfirm) {
+                    return;
+                }
+
+                scope.confirmButtonState = "busy";
+                scope.onConfirm();
             }
         }
     };

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm.html
@@ -1,9 +1,21 @@
 <div>
     <p ng-hide="!caption" class="umb-abstract">{{caption}}</p>
     <div class="umb-pane btn-toolbar umb-btn-toolbar">
-    	<div class="control-group umb-control-group">
-    		<a ng-if="showCancel" href class="btn btn-link" ng-click="onCancel()"><localize key="general_cancel">Cancel</localize></a>
-    		<a ng-if="showConfirm" href class="btn btn-{{confirmButtonStyle || 'primary'}}" ng-click="onConfirm()"><localize key="general_ok">Ok</localize></a>
-    	</div>
+        <div class="control-group umb-control-group">
+            <umb-button ng-if="showCancel"
+                        type="button"
+                        action="onCancel()"
+                        button-style="link"
+                        disabled="confirmButtonState === 'busy'"
+                        label-key="general_cancel">
+            </umb-button>
+            <umb-button ng-if="showConfirm"
+                        type="button"
+                        action="confirm()"
+                        button-style="{{confirmButtonStyle || 'primary'}}"
+                        state="confirmButtonState"
+                        label-key="general_ok">
+            </umb-button>
+        </div>
 	</div>
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The `<umb-confirm/>` directive (typically used when deleting stuff) doesn't have a busy/loading state when the OK button is clicked. This isn't terribly helpful for the editors, specially not for long running operations like deleting a bunch of content or a large tree of dictionary items.

This PR adds the spinner to the OK button to let the editors know that things are happening:

![confirm-busy-state](https://user-images.githubusercontent.com/7405322/56084634-fe0c3000-5e35-11e9-9e75-889f3155684a.gif)

#### Testing this PR

Simple, really... delete something (some content, a dictionary item, a data type) and verify that:

1. The "Cancel" button/link still works.
2. The "OK" button still works.
3. The "OK" button shows a spinner when clicked, and the "Cancel" button/link is disabled.