### PR TITLE
V8: Tree node annotation "pending changes" should take precendence over "is listview"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -236,18 +236,18 @@ body.touch .umb-tree {
     }
 }
 
-.has-unpublished-version > .umb-tree-item__inner > .umb-tree-item__annotation::before {
-    content: "\e25a";
-    color: @green;
-    font-size: 20px;
-    margin-left: -25px;
-}
-
 .is-container > .umb-tree-item__inner > .umb-tree-item__annotation::before {
     content: "\e04e";
     color: @blue;
     font-size: 9px;
     margin-left: -20px;
+}
+
+.has-unpublished-version > .umb-tree-item__inner > .umb-tree-item__annotation::before {
+    content: "\e25a";
+    color: @green;
+    font-size: 20px;
+    margin-left: -25px;
 }
 
 .protected > .umb-tree-item__inner > .umb-tree-item__annotation::before {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

For some reason, the "is listview" annotation on tree nodes takes precedence over "has pending changes":

![image](https://user-images.githubusercontent.com/7405322/56097828-a800c080-5ef9-11e9-9d82-a823595d9bb1.png)

As "is listview" is implicit on the document type and static of nature, I would expect the "has pending changes" annotation to take precedence, just like the "is not publicly accessible" does. So this PR changes things around:

![image](https://user-images.githubusercontent.com/7405322/56097767-00838e00-5ef9-11e9-930a-feef04e4f460.png)
