### PR TITLE
V8: Make the tree annotations easier to see

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -228,40 +228,60 @@ body.touch .umb-tree {
     }
 }
 
-.umb-tree-item__annotation {
-    &::before {
-        font-family: 'icomoon';
-        position: absolute;
-        bottom: 0;
+.has-unpublished-version, .is-container, .protected {
+    > .umb-tree-item__inner {
+        > .umb-tree-item__annotation {
+            background-color: @white;
+            border-radius: 50%;
+            width: 12px;
+            height: 12px;
+            position: absolute;
+            margin-left: 12px;
+            top: 17px;
+
+            &::before {
+                font-family: 'icomoon';
+                position: absolute;
+                top: -4px;
+            }
+        }
+    }
+
+    &.current > .umb-tree-item__inner > .umb-tree-item__annotation {
+        background-color: @pinkLight;
     }
 }
 
 .has-unpublished-version > .umb-tree-item__inner > .umb-tree-item__annotation::before {
     content: "\e25a";
     color: @green;
-    font-size: 20px;
-    margin-left: -25px;
+    font-size: 23px;
+    margin-left: 16px;
+    left: -21px;
 }
 
 .is-container > .umb-tree-item__inner > .umb-tree-item__annotation::before {
     content: "\e04e";
     color: @blue;
     font-size: 9px;
-    margin-left: -20px;
+    margin-left: 2px;
+    left: 0px;
 }
 
 .protected > .umb-tree-item__inner > .umb-tree-item__annotation::before {
     content: "\e256";
     color: @red;
-    font-size: 20px;
-    margin-left: -25px;
+    font-size: 23px;
+    margin-left: -3px;
+    left: -2px;
 }
 
 .locked > .umb-tree-item__inner > .umb-tree-item__annotation::before {
     content: "\e0a7";
     color: @red;
     font-size: 9px;
-    margin-left: -20px;
+    margin-left: 2px;
+    left: 0px;
 }
 
 .no-access {

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -245,6 +245,10 @@ body.touch .umb-tree {
                 top: -4px;
             }
         }
+
+        &:hover > .umb-tree-item__annotation {
+            background-color: @ui-option-hover;
+        }
     }
 
     &.current > .umb-tree-item__inner > .umb-tree-item__annotation {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5232

### Description

See #5232 

When this PR is applied, the annotations look like this:

![image](https://user-images.githubusercontent.com/7405322/56159390-d1d2e980-5fc4-11e9-9cff-ca1c1a6a2923.png)

#### Testing this PR

I have tested this in Chrome and Firefox on PC. 

When testing, pay attention to the hover and selected states of the tree items. The annotation background color should follow those states (see picture above).
