### PR TITLE
V8: Apply nicer log message wrapping

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -107,15 +107,15 @@
                                 Total Items: {{ vm.logItems.totalItems }}
                             </div>
 
-                            <table class="table table-hover" ng-if="vm.logItems.totalItems > 0">
+                            <table class="table table-hover" style="table-layout: fixed;" ng-if="vm.logItems.totalItems > 0">
                                 <thead>
                                     <tr>
-                                        <th style="min-width:100px;" ng-click="vm.toggleOrderBy()">
+                                        <th style="width: 20%;" ng-click="vm.toggleOrderBy()">
                                             Timestamp
                                             <ins class="icon-navigation-down" ng-class="{'icon-navigation-down': vm.logOptions.orderDirection === 'Descending', 'icon-navigation-up': vm.logOptions.orderDirection !== 'Descending'}">&nbsp;</ins>
                                         </th>
-                                        <th>Level</th>
-                                        <th>Machine</th>
+                                        <th style="width: 15%;">Level</th>
+                                        <th style="width: 20%;">Machine</th>
                                         <th>Message</th>
                                     </tr>
                                 </thead>
@@ -124,7 +124,7 @@
                                         <td>{{ log.Timestamp | date:'medium' }}</td>
                                         <td><umb-badge size="s" color="{{ log.logTypeColor }}">{{ log.Level }}</umb-badge></td>
                                         <td><small>{{ log.Properties.MachineName.Value }}</small></td>
-                                        <td>{{ log.RenderedMessage }}</td>
+                                        <td style="word-break: break-word;">{{ log.RenderedMessage }}</td>
                                     </tr>
 
                                     <!-- Log Details (Exception & Properties) -->


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5230

### Description

See #5230 

Currently the log viewer messages break out of the table if the window is too small to contain them - like this:

![log-viewer-before](https://user-images.githubusercontent.com/7405322/56191088-f3b38700-602b-11e9-8371-32cdc37099a4.gif)

With this PR applied, the messages stay inside the table:

![log-viewer-after](https://user-images.githubusercontent.com/7405322/56191112-01690c80-602c-11e9-891e-3fc333369e7d.gif)
