### PR TITLE
V8: Fix "multiple" macro parameter property editor configuration

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationEditor.cs
@@ -13,12 +13,15 @@ namespace Umbraco.Core.PropertyEditors
     /// </summary>
     public class ConfigurationEditor : IConfigurationEditor
     {
+        private IDictionary<string, object> _defaultConfiguration;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurationEditor"/> class.
         /// </summary>
         public ConfigurationEditor()
         {
             Fields = new List<ConfigurationField>();
+            _defaultConfiguration = new Dictionary<string, object>();
         }
 
         /// <summary>
@@ -61,7 +64,10 @@ namespace Umbraco.Core.PropertyEditors
 
         /// <inheritdoc />
         [JsonProperty("defaultConfig")]
-        public virtual IDictionary<string, object> DefaultConfiguration => new Dictionary<string, object>();
+        public virtual IDictionary<string, object> DefaultConfiguration {
+            get => _defaultConfiguration;
+            internal set => _defaultConfiguration = value;
+        }
 
         /// <inheritdoc />
         public virtual object DefaultConfigurationObject => DefaultConfiguration;

--- a/src/Umbraco.Core/PropertyEditors/DataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditor.cs
@@ -173,7 +173,13 @@ namespace Umbraco.Core.PropertyEditors
         /// </summary>
         protected virtual IConfigurationEditor CreateConfigurationEditor()
         {
-            return new ConfigurationEditor();
+            var editor = new ConfigurationEditor();
+            // pass the default configuration if this is not a property value editor
+            if((Type & EditorType.PropertyValue) == 0)
+            {
+                editor.DefaultConfiguration = _defaultConfiguration;
+            }
+            return editor;
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5214

### Description

This PR ensures that macro parameter property editors are given their default configuration when mapping, thus solving #5214.

When the PR is applied, the multiple content picker works as expected when used as a macro parameter:

![macro-parameter-config](https://user-images.githubusercontent.com/7405322/56198923-24032180-603c-11e9-98e6-e4adabb0ae45.gif)

I have tested all "multiple" macro parameter property editors, and from the looks of it, "Multiple Tab Picker" and "Multiple Content Type Picker" do not actually support picking multiple items clientside, despite their configuration telling them to (when this PR is applied, that is). Fixing those property editors is beyond the scope of this PR.
