### PR TITLE
V8: Send notifications for content rollback

### DIFF
--- a/src/Umbraco.Web/Compose/NotificationsComponent.cs
+++ b/src/Umbraco.Web/Compose/NotificationsComponent.cs
@@ -46,6 +46,9 @@ namespace Umbraco.Web.Compose
 
             //Send notifications for the unpublish action
             ContentService.Unpublished += (sender, args) => _notifier.Notify(_actions.GetAction<ActionUnpublish>(), args.PublishedEntities.ToArray());
+
+            //Send notifications for the rollback action
+            ContentService.RolledBack += (sender, args) => _notifier.Notify(_actions.GetAction<ActionRollback>(), args.Entity);
         }
 
         public void Terminate()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

You can subscribe to notifications for when rollback is performed on content. Unfortunately these notifications are never sent.

This PR fixes that.

#### Testing this PR

1. Create two users - A and B.
2. Create a content item that has multiple versions.
3. Subscribe user A to the rollback event on that content item.
4. Let user B perform rollback on the content item. 
5. Verify that user A is notified about the rollback.

**Hint:** This SMTP configuration might make testing a bit easier 😄 

```xml
<smtp from="you@rock.dk" deliveryMethod="SpecifiedPickupDirectory">
  <specifiedPickupDirectory pickupDirectoryLocation="Path\To\Site\Root\App_Data\MailDump" />
</smtp>
```
