### PR TITLE
V7: Send notifications when an item is copied

### DIFF
--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -73,6 +73,10 @@ namespace Umbraco.Web.Strategies
                                               applicationContext.Services.NotificationService.SendNotification(
                                                   content, ActionUnPublish.Instance, applicationContext));
 
+            //Send notifications for the copy action
+            ContentService.Copied += (sender, args) => applicationContext.Services.NotificationService.SendNotification(
+                args.Original, ActionCopy.Instance, applicationContext
+            );
         }
 
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

You can subscribe notifications for when a content item is copied. Unfortunately those notifications are never sent.

This PR fixes that.

#### Testing this PR

1. Create two users - A and B.
2. Subscribe user A to the copy operation on a content item 
3. Let user B create a copy the content item.
4. Verify that user A is notified about the copy operation.

The following SMTP configuration might make testing this a tad easier 😄 

```xml
<smtp from="you@rock.dk" deliveryMethod="SpecifiedPickupDirectory">
  <specifiedPickupDirectory pickupDirectoryLocation="Path\To\Site\Root\App_Data\MailDump" />
</smtp>
```