### PR TITLE
V7: Send notifications when an item is moved or restored

### DIFF
--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -73,6 +73,25 @@ namespace Umbraco.Web.Strategies
                                               applicationContext.Services.NotificationService.SendNotification(
                                                   content, ActionUnPublish.Instance, applicationContext));
 
+            //Send notifications for the move and restore actions
+            ContentService.Moved += (sender, args) =>
+            {
+                // notify about the move for all moved items
+                foreach(var moveInfo in args.MoveInfoCollection)
+                {
+                    applicationContext.Services.NotificationService.SendNotification(
+                        moveInfo.Entity, ActionMove.Instance, applicationContext
+                    );
+                }
+
+                // for any items being moved from the recycle bin (restored), explicitly notify about that too
+                foreach(var moveInfo in args.MoveInfoCollection.Where(m => m.OriginalPath.Contains(Constants.System.RecycleBinContentString)))
+                {
+                    applicationContext.Services.NotificationService.SendNotification(
+                        moveInfo.Entity, ActionRestore.Instance, applicationContext
+                    );
+                }
+            };
         }
 
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

You can subscribe notifications for when a content item is moved and when it is restored from the recycle bin. Unfortunately those notifications are never sent.

![image](https://user-images.githubusercontent.com/7405322/56461064-dfb1b180-63ac-11e9-92db-4d00035c1dee.png)

This PR fixes that.

#### Testing this PR

1. Create two users - A and B.
2. Subscribe user A to notifications for move and restore operations on a content item 
3. Let user B move the content item to a new location in the content tree.
4. Verify that user A is notified that the content was moved.
5. Let user B delete the content item and subsequently restore the content item to its previous location in the content tree.
6. Verify that user A is notified that the content was restored.
7. Verify that user A is also notified that the content was moved (as the content item is moved from the recycle bin, general move notifications should be sent as well as restore notifications).

The following SMTP configuration might make testing this a tad easier 😄 

```xml
<smtp from="you@rock.dk" deliveryMethod="SpecifiedPickupDirectory">
  <specifiedPickupDirectory pickupDirectoryLocation="Path\To\Site\Root\App_Data\MailDump" />
</smtp>
```