### PR TITLE
V8: Login form accessibility improvements and form input tabbed focus styles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -126,6 +126,7 @@
         function togglePassword() {
             var elem = $("form[name='vm.loginForm'] input[name='password']");
             elem.attr("type", (elem.attr("type") === "text" ? "password" : "text"));
+            elem.focus();
             $(".password-text.show, .password-text.hide").toggle();
         }
 

--- a/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
@@ -18,7 +18,20 @@ function MainController($scope, $location, appState, treeService, notificationsS
     $scope.drawer = {};
     $scope.search = {};
     $scope.login = {};
+    $scope.tabbingActive = false;
     
+    // There are a number of ways to detect when a focus state should be shown when using the tab key and this seems to be the simplest solution. 
+    // For more information about this approach, see https://hackernoon.com/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2
+    function handleFirstTab(evt) {
+        if (evt.keyCode === 9) {
+            $scope.tabbingActive = true;
+            window.removeEventListener('keydown', handleFirstTab);
+        }
+    }
+
+    window.addEventListener("keydown", handleFirstTab);
+
+
     $scope.removeNotification = function (index) {
         notificationsService.remove(index);
     };

--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -250,7 +250,10 @@ input[type="color"],
   &:focus {
     border-color: @inputBorderFocus;
     outline: 0;
-    outline: none \9; /* IE6-9 */
+
+    .tabbing-active & {
+        outline: 2px solid @inputBorderTabFocus;
+    }
   }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -376,6 +376,7 @@
 @inputBackground:               @white;
 @inputBorder:                   @gray-8;
 @inputBorderFocus:              @gray-7;
+@inputBorderTabFocus:           @blue;
 @inputBorderRadius:             0;
 @inputDisabledBackground:       @gray-10;
 @formActionsBackground:         @gray-9;

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -376,7 +376,7 @@
 @inputBackground:               @white;
 @inputBorder:                   @gray-8;
 @inputBorderFocus:              @gray-7;
-@inputBorderTabFocus:           @blue;
+@inputBorderTabFocus:           @blueExtraDark;
 @inputBorderRadius:             0;
 @inputDisabledBackground:       @gray-10;
 @formActionsBackground:         @gray-9;

--- a/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
@@ -43,7 +43,7 @@
     @Html.RenderCssHere(
         new BasicPath("Umbraco", IOHelper.ResolveUrl(SystemDirectories.Umbraco)))
 </head>
-<body ng-class="{'touch':touchDevice, 'emptySection':emptySection, 'umb-drawer-is-visible':drawer.show, 'umb-tour-is-visible': tour.show}" ng-controller="Umbraco.MainController" id="umbracoMainPageBody">
+<body ng-class="{'touch':touchDevice, 'emptySection':emptySection, 'umb-drawer-is-visible':drawer.show, 'umb-tour-is-visible': tour.show, 'tabbing-active':tabbingActive}" ng-controller="Umbraco.MainController" id="umbracoMainPageBody">
 
     <noscript>
         <div style="margin: 10px;">


### PR DESCRIPTION
This PR does two main things, first off it adds a little bit of JavaScript that will add a `tabbing-active` class when a person hits the tab key. Using this, I have added a tab specific style for form inputs. This was initially going to be just for the login page, but add all the form inputs use the same styling it should improve some more form inputs throughout the backoffice.

This styling only comes into effect if a person uses the tab key. Once it is hit the styling will remain. This addition was inspired via the following article. https://hackernoon.com/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2. At Yoyo we often use https://github.com/ten1seven/what-input as it provided more control as to when you may want to add styles related to a persons input choice, but it also comes with some more complexity and another dependency so i figured i'd keep it simple.

![image](https://user-images.githubusercontent.com/6573613/56461541-aed17c80-63ac-11e9-9568-15e501c98e46.png)

![image](https://user-images.githubusercontent.com/6573613/56461594-64043480-63ad-11e9-8b93-e9ebfb405b4b.png)


The second part of the PR improved the toggle password button on the login form by focusing the person back to the password field when it is clicked.