### PR TITLE
V7: Send notifications for content rollback

### DIFF
--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -73,6 +73,10 @@ namespace Umbraco.Web.Strategies
                                               applicationContext.Services.NotificationService.SendNotification(
                                                   content, ActionUnPublish.Instance, applicationContext));
 
+            //Send notifications for the rollback action
+            ContentService.RolledBack += (sender, args) => applicationContext.Services.NotificationService.SendNotification(
+                                                               args.Entity, ActionRollback.Instance, applicationContext
+                                                           );
         }
 
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

_This is the V7 equivalent of #5301_

You can subscribe to notifications for when rollback is performed on content. Unfortunately these notifications are never sent.

This PR fixes that.

#### Testing this PR

1. Create two users - A and B.
2. Create a content item that has multiple versions.
3. Subscribe user A to the rollback event on that content item.
4. Let user B perform rollback on the content item. 
5. Verify that user A is notified about the rollback.

**Hint:** This SMTP configuration might make testing a bit easier 😄 

```xml
<smtp from="you@rock.dk" deliveryMethod="SpecifiedPickupDirectory">
  <specifiedPickupDirectory pickupDirectoryLocation="Path\To\Site\Root\App_Data\MailDump" />
</smtp>
```
