### PR TITLE
V8: Fix mapping for search results

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Web.Models.Mapping
             mapper.Define<ITemplate, EntityBasic>((source, context) => new EntityBasic(), Map);
             mapper.Define<EntityBasic, ContentTypeSort>((source, context) => new ContentTypeSort(), Map);
             mapper.Define<IContentTypeComposition, EntityBasic>((source, context) => new EntityBasic(), Map);
-            mapper.Define<EntitySlim, SearchResultEntity>((source, context) => new SearchResultEntity(), Map);
+            mapper.Define<IEntitySlim, SearchResultEntity>((source, context) => new SearchResultEntity(), Map);
             mapper.Define<ISearchResult, SearchResultEntity>((source, context) => new SearchResultEntity(), Map);
             mapper.Define<ISearchResults, IEnumerable<SearchResultEntity>>((source, context) => context.MapEnumerable<ISearchResult, SearchResultEntity>(source));
             mapper.Define<IEnumerable<ISearchResult>, IEnumerable<SearchResultEntity>>((source, context) => context.MapEnumerable<ISearchResult, SearchResultEntity>(source));


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There's a slight error when the global search yields results:

![image](https://user-images.githubusercontent.com/7405322/56474351-09d0a580-6479-11e9-97df-d929cb17b1f6.png)

This is a side effect of #5087

When this PR is applied, the search works as expected:

![image](https://user-images.githubusercontent.com/7405322/56474429-19042300-647a-11e9-866a-8e4e87234fd3.png)

#### Testing this PR

Simple! Search for something that actually exists and verify that the results are shown as expected.