### PR TITLE
Re-adding outline to the umb-button__button for focus states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,3 @@ build/temp/
 
 # eof
 /src/Umbraco.Web.UI.Client/TESTS-*.xml
-src/Umbraco.Web.UI.Client/Web.config

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ build/temp/
 
 # eof
 /src/Umbraco.Web.UI.Client/TESTS-*.xml
+src/Umbraco.Web.UI.Client/Web.config

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button.less
@@ -3,10 +3,6 @@
    display: inline-block;
 }
 
- .umb-button__button:focus {
-   outline: none;
-}
-
 .umb-button__button {
     position: relative;
 }


### PR DESCRIPTION
### Prerequisites
This is in relation to the accessibility issues on ticket #5277 - Bug number 4 from the table

### Description
Bottom publishing options ('Preview', 'Save', 'Save and publish') have insufficient focus (tab) state

I have removed the CSS that prevented the browser default outline from showing on these buttons

![Screen Shot 2019-04-23 at 14 36 22](https://user-images.githubusercontent.com/44576021/56594807-6224b600-65e5-11e9-96c2-b8731372f52a.png)
