### PR TITLE
Make range slider to pick "initial value 2" as the start value

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -33,11 +33,11 @@
         configureDefaults();
 
         // format config to fit slider plugin
-        const start = $scope.model.config.enableRange ? [$scope.model.config.initVal1, $scope.model.config.initVal2] : [$scope.model.config.initVal1];
         const step = $scope.model.config.step;
         const tooltips = $scope.model.config.enableRange ? [true, true] : [true];
         const min = $scope.model.config.minVal ? [$scope.model.config.minVal] : [$scope.model.config.minVal];
         const max = $scope.model.config.maxVal ? [$scope.model.config.maxVal] : [$scope.model.config.maxVal];
+        const start = $scope.model.config.enableRange ? [$scope.model.config.initVal2, max] : [$scope.model.config.initVal1];
 
         // setup default
         $scope.sliderOptions = {


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

When the slider datatype has "enable range" checked the start value is pulled from the "Initial value" field rather than the "Initial value 2" field. I have changed it so that sliders without "Enable Range" look up at "Initial value" as the start value and the ones with "Enable Range" has "Intial Value 2" as the start value. The range is defined as "Initial Value 2" - "Maximum value"

**Before**

![before1](https://user-images.githubusercontent.com/3941753/56600418-8639c480-65f0-11e9-8897-b53581fedaa7.PNG)

![image](https://user-images.githubusercontent.com/3941753/56600676-27c11600-65f1-11e9-8a59-29a7d6fcb91c.png)

**After**

![image](https://user-images.githubusercontent.com/3941753/56600470-a79ab080-65f0-11e9-9c8f-1b999b2b6e57.png)

![image](https://user-images.githubusercontent.com/3941753/56600508-c13bf800-65f0-11e9-8e31-3662d257d23f.png)

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
