### PR TITLE
V7: Send delete notifications when content is moved to the recycle bin

### DIFF
--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -59,12 +59,10 @@ namespace Umbraco.Web.Strategies
                     applicationContext.Services.NotificationService.SendNotification(updatedEntities, ActionUpdate.Instance, applicationContext);
                 };
 
-            //Send notifications for the delete action
-            ContentService.Deleted += (sender, args) =>
-                                      args.DeletedEntities.ForEach(
-                                          content =>
-                                          applicationContext.Services.NotificationService.SendNotification(
-                                              content, ActionDelete.Instance, applicationContext));
+            //Send notifications for the delete (send to recycle bin) action
+            ContentService.Trashed += (sender, args) => applicationContext.Services.NotificationService.SendNotification(
+                                                            args.MoveInfoCollection.Select(mi => mi.Entity), ActionDelete.Instance, applicationContext
+                                                        );
            
             //Send notifications for the unpublish action
             ContentService.UnPublished += (sender, args) =>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#5244 raised an issue for V8 about delete notifications. That issue is also present in V7.

This PR makes Umbraco send delete notifications when content is moved to the recycle bin instead of when it's deleted entirely (which doesn't work anyway, as explained in #5244). This is equivalent to the fix implemented for V8. For more background see the discussion [here](https://github.com/umbraco/Umbraco-CMS/issues/5244#issuecomment-483296311).

#### Testing this PR

1. Create two users - A and B.
2. Subscribe user A to the delete event on a content item. 
3. Let user B delete the content item (move it to the recycle bin).
4. Verify that user A is notified about the content being deleted.

**Hint:** This SMTP configuration might make testing a bit easier 😄 

```xml
<smtp from="you@rock.dk" deliveryMethod="SpecifiedPickupDirectory">
  <specifiedPickupDirectory pickupDirectoryLocation="Path\To\Site\Root\App_Data\MailDump" />
</smtp>
```