### PR TITLE
V7: Don't send notifications for children of the subscribed entity

### DIFF
--- a/src/Umbraco.Core/Services/NotificationService.cs
+++ b/src/Umbraco.Core/Services/NotificationService.cs
@@ -101,9 +101,6 @@ namespace Umbraco.Core.Services
             //exit if there are no entities
             if (entitiesL.Count == 0) return;
 
-            //put all entity's paths into a list with the same indicies
-            var paths = entitiesL.Select(x => x.Path.Split(',').Select(int.Parse).ToArray()).ToArray();
-
             // lazily get versions
             var prevVersionDictionary = new Dictionary<int, IContentBase>();
 
@@ -133,10 +130,9 @@ namespace Umbraco.Core.Services
                     for (var j = 0; j < entitiesL.Count; j++)
                     {
                         var content = entitiesL[j];
-                        var path = paths[j];
                         
                         // test if the notification applies to the path ie to this entity
-                        if (path.Contains(notifications[i].EntityId) == false) continue; // next entity
+                        if (content.Id != notifications[i].EntityId) continue; // next entity
                         
                         if (prevVersionDictionary.ContainsKey(content.Id) == false)
                         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

_This is the V7 equivalent of #5286 - seems the exact same problem exists in V7._

When subscribing to notifications for a content entity, you're notified about the same actions on all children.

For example: If content A has children and you subscribe to the move event on content A, you're notified both for content A _and_ all its children when the content A is moved.

#### Testing this PR

1. Create two users - A and B.
2. Subscribe user A to the move events on a content item that has children.
3. Let user B move the content item. 
4. Verify that user A is notified only about the content item being moved - not any of the children.


#### On purpose?

@nul800sebastiaan points out that this behavior is on purpose [here](https://github.com/umbraco/Umbraco-CMS/pull/5286#issuecomment-485955141). #5286 needs clarifying before this PR can move forward.