### PR TITLE
WIP: Make test APIs easier to re-use in unit tests

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeFactory.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Core.Models.PublishedContent
     /// <summary>
     /// Provides a default implementation for <see cref="IPublishedContentTypeFactory"/>.
     /// </summary>
-    internal class PublishedContentTypeFactory : IPublishedContentTypeFactory
+    public class PublishedContentTypeFactory : IPublishedContentTypeFactory
     {
         private readonly IPublishedModelFactory _publishedModelFactory;
         private readonly PropertyValueConverterCollection _propertyValueConverters;
@@ -32,13 +32,33 @@ namespace Umbraco.Core.Models.PublishedContent
         }
 
         // for tests
-        internal PublishedContentType CreateContentType(int id, string alias, IEnumerable<PublishedPropertyType> propertyTypes, ContentVariation variations = ContentVariation.Nothing, bool isElement = false)
+        /// <summary>
+        /// Only for unit tests
+        /// REVIEW: Make protected?
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="alias"></param>
+        /// <param name="propertyTypes"></param>
+        /// <param name="variations"></param>
+        /// <param name="isElement"></param>
+        /// <returns></returns>
+        public PublishedContentType CreateContentType(int id, string alias, IEnumerable<PublishedPropertyType> propertyTypes, ContentVariation variations = ContentVariation.Nothing, bool isElement = false)
         {
             return new PublishedContentType(id, alias, PublishedItemType.Content, Enumerable.Empty<string>(), propertyTypes, variations, isElement);
         }
 
         // for tests
-        internal PublishedContentType CreateContentType(int id, string alias, IEnumerable<string> compositionAliases, IEnumerable<PublishedPropertyType> propertyTypes, ContentVariation variations = ContentVariation.Nothing, bool isElement = false)
+        /// <summary>
+        /// Only for unit tests
+        /// REVIEW: Make protected?
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="alias"></param>
+        /// <param name="propertyTypes"></param>
+        /// <param name="variations"></param>
+        /// <param name="isElement"></param>
+        /// <returns></returns>
+        public PublishedContentType CreateContentType(int id, string alias, IEnumerable<string> compositionAliases, IEnumerable<PublishedPropertyType> propertyTypes, ContentVariation variations = ContentVariation.Nothing, bool isElement = false)
         {
             return new PublishedContentType(id, alias, PublishedItemType.Content, compositionAliases, propertyTypes, variations, isElement);
         }
@@ -55,8 +75,17 @@ namespace Umbraco.Core.Models.PublishedContent
             return new PublishedPropertyType(contentType, propertyTypeAlias, dataTypeId, true, variations, _propertyValueConverters, _publishedModelFactory, this);
         }
 
-        // for tests
-        internal PublishedPropertyType CreatePropertyType(string propertyTypeAlias, int dataTypeId, bool umbraco = false, ContentVariation variations = ContentVariation.Nothing)
+        /// <summary>
+        /// For unit testing only
+        /// REVIEW: Make protected? - AKA Should this possibly be made public in "adapter class" or from class in test lib? (or should tests just pass the content type?)
+        /// TODO: Property type alias
+        /// </summary>
+        /// <param name="propertyTypeAlias"></param>
+        /// <param name="dataTypeId"></param>
+        /// <param name="umbraco"></param>
+        /// <param name="variations"></param>
+        /// <returns></returns>
+        public PublishedPropertyType CreatePropertyType(string propertyTypeAlias, int dataTypeId, bool umbraco = false, ContentVariation variations = ContentVariation.Nothing)
         {
             return new PublishedPropertyType(propertyTypeAlias, dataTypeId, umbraco, variations, _propertyValueConverters, _publishedModelFactory, this);
         }

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentLanguageVariantTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentLanguageVariantTests.cs
@@ -58,7 +58,7 @@ namespace Umbraco.Tests.PublishedContent
                 .Returns((string c) => languages.SingleOrDefault(y => y.IsoCode == c));
         }
 
-        internal override void PopulateCache(PublishedContentTypeFactory factory, SolidPublishedContentCache cache)
+        protected override void PopulateCache(PublishedContentTypeFactory factory, SolidPublishedContentCache cache)
         {
             var prop1Type = factory.CreatePropertyType("prop1", 1, variations: ContentVariation.Culture);
             var welcomeType = factory.CreatePropertyType("welcomeText", 1, variations: ContentVariation.Culture);

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentMoreTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentMoreTests.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Tests.PublishedContent
     [UmbracoTest(TypeLoader = UmbracoTestOptions.TypeLoader.PerFixture)]
     public class PublishedContentMoreTests : PublishedContentSnapshotTestBase
     {
-        internal override void PopulateCache(PublishedContentTypeFactory factory, SolidPublishedContentCache cache)
+        protected override void PopulateCache(PublishedContentTypeFactory factory, SolidPublishedContentCache cache)
         {
             var props = new[]
                 {

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentSnapshotTestBase.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentSnapshotTestBase.cs
@@ -97,6 +97,6 @@ namespace Umbraco.Tests.PublishedContent
             return caches;
         }
 
-        internal abstract void PopulateCache(PublishedContentTypeFactory factory, SolidPublishedContentCache cache);
+        protected abstract void PopulateCache(PublishedContentTypeFactory factory, SolidPublishedContentCache cache);
     }
 }

--- a/src/Umbraco.Tests/PublishedContent/SolidPublishedSnapshot.cs
+++ b/src/Umbraco.Tests/PublishedContent/SolidPublishedSnapshot.cs
@@ -44,7 +44,10 @@ namespace Umbraco.Tests.PublishedContent
         { }
     }
 
-    class SolidPublishedContentCache : PublishedCacheBase, IPublishedContentCache, IPublishedMediaCache
+    /// <summary>
+    /// For unit testing. Routing is not implemented and will throw. PR welcome. :)
+    /// </summary>
+    public class SolidPublishedContentCache : PublishedCacheBase, IPublishedContentCache, IPublishedMediaCache
     {
         private readonly Dictionary<int, IPublishedContent> _content = new Dictionary<int, IPublishedContent>();
 
@@ -156,7 +159,7 @@ namespace Umbraco.Tests.PublishedContent
         }
     }
 
-    class SolidPublishedContent : IPublishedContent
+    public class SolidPublishedContent : IPublishedContent
     {
         #region Constructor
 
@@ -254,7 +257,7 @@ namespace Umbraco.Tests.PublishedContent
         #endregion
     }
 
-    internal class SolidPublishedProperty : IPublishedProperty
+    public class SolidPublishedProperty : IPublishedProperty
     {
         public PublishedPropertyType PropertyType { get; set; }
         public string Alias { get; set; }

--- a/src/Umbraco.Tests/TestHelpers/TestObjects-Mocks.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestObjects-Mocks.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Tests.TestHelpers
     /// <summary>
     /// Provides objects for tests.
     /// </summary>
-    internal partial class TestObjects
+    public partial class TestObjects
     {
         /// <summary>
         /// Gets a mocked IUmbracoDatabaseFactory.

--- a/src/Umbraco.Tests/TestHelpers/TestObjects.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestObjects.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Tests.TestHelpers
     /// <summary>
     /// Provides objects for tests.
     /// </summary>
-    internal partial class TestObjects
+    public partial class TestObjects
     {
         private readonly IRegister _register;
 

--- a/src/Umbraco.Tests/Testing/TestOptionAttributeBase.cs
+++ b/src/Umbraco.Tests/Testing/TestOptionAttributeBase.cs
@@ -27,9 +27,13 @@ namespace Umbraco.Tests.Testing
             var test = TestContext.CurrentContext.Test;
             var typeName = test.ClassName;
             var methodName = test.MethodName;
-            var type = Type.GetType(typeName, true);
+            var type = Type.GetType(typeName, false);
             if (type == null)
-                throw new Exception("panic"); // makes no sense
+            {
+//                throw new Exception("panic"); // makes no sense
+                // REVIEW: But happens anyway since we can't discover tests in assemblies referencing this for some reason. However, might be able to figure something out. (AKA. Blew up, quickfix)
+                return new TOptions();
+            }
             var methodInfo = type.GetMethod(methodName); // what about overloads?
             var options = GetTestOptions<TOptions>(methodInfo);
             return options;

--- a/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
@@ -88,7 +88,7 @@ namespace Umbraco.Tests.Testing
 
         protected bool FirstTestInFixture = true;
 
-        internal TestObjects TestObjects { get; private set; }
+        public TestObjects TestObjects { get; private set; }
 
         private static TypeLoader _commonTypeLoader;
 

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -5210,12 +5210,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5230,17 +5232,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5357,7 +5362,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5369,6 +5375,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5383,6 +5390,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5390,12 +5398,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5414,6 +5424,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5494,7 +5505,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5506,6 +5518,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5627,6 +5640,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/Umbraco.Web/PublishedCache/PublishedCacheBase.cs
+++ b/src/Umbraco.Web/PublishedCache/PublishedCacheBase.cs
@@ -8,7 +8,7 @@ using Umbraco.Core.Xml;
 
 namespace Umbraco.Web.PublishedCache
 {
-    abstract class PublishedCacheBase : IPublishedCache
+    public abstract class PublishedCacheBase : IPublishedCache
     {
         public bool PreviewDefault { get; }
 


### PR DESCRIPTION
This is a continuation of a thread started on our:  
https://our.umbraco.com/forum/contributing-to-umbraco-cms//96915-publicize-andor-make-api-for-stubbing-of-published-content

I'm attempting to rebuild my unit test samples for V8. I want to start with making published content and content types easier to set up in tests. In order to do that quite a few things need to go public or protected.  
The current attempt exposes too much from core. Stuff there is marked with REVIEW:. (Two classes)  
It is by any means not ready for merge, but I want to make the PR to be able to discuss the changes.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Make tests in https://github.com/lars-erik/umbraco-unit-testing-samples/tree/master-v8 work.  
To verify:

- Clone the project
- Add a reference path for both test related projects to a build of this PR's Umbraco.Tests output.
- Run the tests. :)
