### PR TITLE
V8: prettier outline on media picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -238,6 +238,7 @@
 
 
 .umb-mediapicker .add-link {
+    position: relative;
     display: flex;
     justify-content:center;
     align-items:center;
@@ -249,9 +250,25 @@
 
     transition: all 150ms ease-in-out;
 
+    &:focus,
     &:hover {
         color: @ui-action-discreet-type-hover;
         border-color: @ui-action-discreet-type-hover;
+    }
+    
+    &:focus {
+        outline: none;
+        .tabbing-active &:after {
+            content: '';
+            position: absolute;
+            z-index: 10000;
+            top: -6px;
+            bottom: -6px;
+            left: -6px;
+            right: -6px;
+            border-radius: 3px;
+            box-shadow: 0 0 2px @blueMid, inset 0 0 2px 1px @blueMid;
+        }
     }
 }
 


### PR DESCRIPTION
Prettier focus outline on media picker picker.

After:
![image](https://user-images.githubusercontent.com/6791648/56651341-1cb9c480-6689-11e9-92a5-a6cc40f341af.png)
