### PR TITLE
#5277 Adding correct button element,styling to remove default styles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-tour.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-tour.less
@@ -74,6 +74,9 @@
     font-size: 19px;
     color: @gray-7;
     cursor: pointer;
+    background: transparent;
+    padding: 0;
+    border: none;
 }
 
 .umb-tour-step__close:hover,

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umbtour/umb-tour-step.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umbtour/umb-tour-step.html
@@ -2,7 +2,7 @@
 
 
     <div ng-if="hideClose !== true">
-        <i class="icon-wrong umb-tour-step__close" ng-click="close()"></i>
+        <button class="icon-wrong umb-tour-step__close" ng-click="close()"></button>
     </div>
 
     <div ng-transclude></div>


### PR DESCRIPTION
### Prerequisites

In relation to #5277 bug number 11 from the table

### Description

I have swapped an `<i>` for a `<button>` so it's more semantic and inherits native focus states. I also removed default button styles with CSS so appearance is unaffected.

<img width="1286" alt="Screen Shot 2019-04-24 at 11 13 17" src="https://user-images.githubusercontent.com/44576021/56652221-c47fc400-6682-11e9-9f2a-9b95d07d1e3b.png">
