### PR TITLE
Re-adding focus states for the .umb-tree links

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -12,7 +12,6 @@
     }
 
     a, a:hover {
-        outline: none;
         text-decoration: none;
     }
 


### PR DESCRIPTION
### Prerequisites

Related to #2577 accessibility bug number 19

No focus (tab) state present for the content tree items, have removed the outline:0 rule.

<img width="232" alt="Screen Shot 2019-04-24 at 11 41 01" src="https://user-images.githubusercontent.com/44576021/56653598-dca51280-6685-11e9-93df-951607a209cc.png">
