### PR TITLE
Create new Nuget Symbol packags - snupkg

### DIFF
--- a/build/NuSpecs/UmbracoCms.Core.nuspec
+++ b/build/NuSpecs/UmbracoCms.Core.nuspec
@@ -54,6 +54,5 @@
 
         <!-- symbols -->
         <file src="$BuildTmp$\bin\Umbraco.Core.pdb" target="lib" />
-        <file src="$BuildTmp$\..\src\Umbraco.Core\**\*.cs" exclude="$BuildTmp$\..\src\**\TemporaryGeneratedFile*.cs" target="src\Umbraco.Core" />
     </files>
 </package>

--- a/build/NuSpecs/UmbracoCms.Web.nuspec
+++ b/build/NuSpecs/UmbracoCms.Web.nuspec
@@ -59,8 +59,6 @@
 
         <!-- symbols -->
         <file src="$BuildTmp$\bin\Umbraco.Web.pdb" target="lib" />
-        <file src="$BuildTmp$\..\src\Umbraco.Web\**\*.cs" exclude="$BuildTmp$\..\src\**\TemporaryGeneratedFile*.cs" target="src\Umbraco.Web" />
         <file src="$BuildTmp$\bin\Umbraco.Examine.pdb" target="lib" />
-        <file src="$BuildTmp$\..\src\Umbraco.Examine\**\*.cs" exclude="$BuildTmp$\..\src\**\TemporaryGeneratedFile*.cs" target="src\Umbraco.Examine" />
     </files>
 </package>

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -387,13 +387,13 @@
     &$this.BuildEnv.NuGet Pack "$nuspecs\UmbracoCms.Core.nuspec" `
         -Properties BuildTmp="$($this.BuildTemp)" `
         -Version "$($this.Version.Semver.ToString())" `
-        -Symbols -Verbosity detailed -outputDirectory "$($this.BuildOutput)" > "$($this.BuildTemp)\nupack.cmscore.log"
+        -Symbols -SymbolPackageFormat snupkg -Verbosity detailed -outputDirectory "$($this.BuildOutput)" > "$($this.BuildTemp)\nupack.cmscore.log"
     if (-not $?) { throw "Failed to pack NuGet UmbracoCms.Core." }
 
     &$this.BuildEnv.NuGet Pack "$nuspecs\UmbracoCms.Web.nuspec" `
         -Properties BuildTmp="$($this.BuildTemp)" `
         -Version "$($this.Version.Semver.ToString())" `
-        -Symbols -Verbosity detailed -outputDirectory "$($this.BuildOutput)" > "$($this.BuildTemp)\nupack.cmsweb.log"
+        -Symbols -SymbolPackageFormat snupkg -Verbosity detailed -outputDirectory "$($this.BuildOutput)" > "$($this.BuildTemp)\nupack.cmsweb.log"
     if (-not $?) { throw "Failed to pack NuGet UmbracoCms.Web." }
 
     &$this.BuildEnv.NuGet Pack "$nuspecs\UmbracoCms.nuspec" `


### PR DESCRIPTION
Update powershell to use the snupkg format for symbol package to be hosted on nuget.org symbol server

An advisory from Nuget team is to no longer include the C# .cs files in the src folder of a nuget package

> We recommend using source link, portable pdbs, and publishing the snupkg to nuget.org with your package.
>
>No src directory necessary with that story.

https://twitter.com/rrelyea/status/1120711234645479424


## Further details & resources
https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg

https://blog.nuget.org/20181116/Improved-debugging-experience-with-the-NuGet-org-symbol-server-and-snupkg.html

### MyGet Support
https://myget.uservoice.com/forums/135675-general/suggestions/36274102-support-snupkg-symbol-packages-and-pushing-them-t

https://docs.myget.org/docs/reference/symbols

## Next Steps
* Update Azure DevOps build pipelines as we do not directly use the entire build.ps1 file
* Once the CI build pipeline is updated - we can test consuming from MyGet symbol server

## Build Pipeline Suggestions
* Update `Use NuGet 4.3.0` to use latest/newer version of Nuget as flag `-symbolpackageformat snupkg` is a newer feature than in 4.3.0
* Will need to update create nuget package steps to include/use an explicit command as opposed to nuget pack

>The SymbolPackageFormat property can have one of the two values: symbols.nupkg (the default) or snupkg. If the SymbolPackageFormat property is not specified, it defaults to symbols.nupkg and a legacy symbol package will be created.

https://stackoverflow.com/a/54245444

## Release Pipeline suggestion
I don't think any changes will need to be made as far as I know as long MyGet.org works in the same way or receiving the .snupkg & .nupkg

>You can also push both primary and symbol packages at the same time using the below command. Both .nupkg and .snupkg files need to be present in the current folder.
>
> `nuget push MyPackage.nupkg`