### PR TITLE
V8: Fix the MNTP min/max items validation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -33,7 +33,6 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     /** Performs validation based on the renderModel data */
     function validate() {
         if ($scope.contentPickerForm) {
-            angularHelper.getCurrentForm($scope).$setDirty();
             //Validate!
             if ($scope.model.config && $scope.model.config.minNumber && parseInt($scope.model.config.minNumber) > $scope.renderModel.length) {
                 $scope.contentPickerForm.minCount.$setValidity("minCount", false);
@@ -65,7 +64,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         //model if it changes (i.e. based on server updates, or if used in split view, etc...)
         $scope.$watch("model.value", function (newVal, oldVal) {
             if (newVal !== oldVal) {
-                syncRenderModel();
+                syncRenderModel(true);
             }
         });
     }
@@ -379,7 +378,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         }
         else {
             $scope.renderModel = [];
-            if (validate) {
+            if (doValidation) {
                 validate();
             }
             setSortingState($scope.renderModel);
@@ -459,6 +458,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
             //everything is loaded, start the watch on the model
             startWatch();
             subscribe();
+            validate();
         });
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4687

### Description

This PR fixes the min/max items validation described in #4687. 

With this PR applied, the MNTP behaves like this when both min and max items are defined:

![mntp-bounds-validation](https://user-images.githubusercontent.com/7405322/56690614-2d485a00-66de-11e9-8f1a-45871d31d53e.gif)

When only min items is defined:

![image](https://user-images.githubusercontent.com/7405322/56690810-a6e04800-66de-11e9-9b2f-3c8b9417ce39.png)

And when only max items is defined:

![image](https://user-images.githubusercontent.com/7405322/56690865-c8d9ca80-66de-11e9-9da9-c438d2190bc4.png)

#### Testing this PR

Four test cases must be covered for the MNTP:

1. No min/max items defined.
2. Only min items defined.
3. Only max items defined.
4. Both min and max items defined.