### PR TITLE
V8: Make it possible to open/view files in the media library

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -762,8 +762,7 @@
 }
 
 .umb-fileupload .file-icon {
-  text-align: center;
-  display: block;
+  display: inline-block;
   position: relative;
   padding: 5px 0;
 
@@ -782,7 +781,7 @@
     line-height: 130%;
     position: absolute;
     top: 45px;
-    left: 110px;
+    left: 10px;
   }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
@@ -26,19 +26,26 @@
                         </div>
                     </div>
 
-                    <div class="span4 thumbnail" ng-if="!file.isImage && file.extension != 'svg'">
-                        <span class="file-icon-wrap">
-                            <span class="file-icon">
-                                <i class="icon icon-document"></i>
-                                <span ng-if="file.isClientSide">.{{file.extension}}</span>
-                                <a ng-if="!file.isClientSide" href="{{file.fileSrc}}" target="_blank">
+                    <div ng-if="!file.isImage && file.extension != 'svg'">
+                        <a class="span6 thumbnail tc" ng-show="!file.isClientSide" ng-href="{{file.fileName}}" target="_blank">
+                            <span class="file-icon-wrap">
+                                <span class="file-icon">
+                                    <i class="icon icon-document"></i>
                                     <span>.{{file.extension}}</span>
-                                </a>
+                                </span>
                             </span>
-                        </span>
-                        <div style="text-align: center">{{file.fileName}}</div>
+                            <div>{{file.fileName}}</div>
+                        </a>
+                        <div class="span6 thumbnail tc" ng-show="file.isClientSide">
+                            <span class="file-icon-wrap">
+                                <span class="file-icon">
+                                    <i class="icon icon-document"></i>
+                                    <span>.{{file.extension}}</span>
+                                </span>
+                            </span>
+                            <div>{{file.fileName}}</div>
+                        </div>
                     </div>
-
                 </div>
 
                 <div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5349

### Description

As described in #5349 you can't click the file icon of a non-image file to open the file in a new tab.

Also, somewhere along the line the icon extension placement and styling became broken for existing/saved files. It should be shown with a solid background color on top of the file icon, but it looks like this:

![image](https://user-images.githubusercontent.com/7405322/56854780-6bdb5000-693c-11e9-8677-d723dfec9297.png)

This PR addresses both issues. When applied the file upload behaves like this for non-image files:

![media-file-open](https://user-images.githubusercontent.com/7405322/56854790-86adc480-693c-11e9-82ce-a8a53a94651c.gif)

#### Testing this PR

1. Upload a text file to the media library.
2. Open the file for editing.
3. Verify that the file extension is placed correctly on top of the file icon.
4. Verify that you can open the file by clicking the icon.
5. Remove the file and add a new one without saving.
6. Verify that you can't open the new file (because it's not uploaded yet).

