### PR TITLE
V8: Allow localizing content types and properties using language files

### DIFF
--- a/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
@@ -83,10 +83,10 @@ namespace Umbraco.Core.Services
         internal static string UmbracoDictionaryTranslate(this ILocalizedTextService manager, string text)
         {
             var cultureDictionary = CultureDictionary;
-            return UmbracoDictionaryTranslate(text, cultureDictionary);
+            return manager.UmbracoDictionaryTranslate(text, cultureDictionary);
         }
 
-        private static string UmbracoDictionaryTranslate(string text, ICultureDictionary cultureDictionary)
+        private static string UmbracoDictionaryTranslate(this ILocalizedTextService manager, string text, ICultureDictionary cultureDictionary)
         {
             if (text == null)
                 return null;
@@ -95,7 +95,14 @@ namespace Umbraco.Core.Services
                 return text;
 
             text = text.Substring(1);
-            return cultureDictionary[text].IfNullOrWhiteSpace(text);
+            var value = cultureDictionary[text];
+            if (value.IsNullOrWhiteSpace() == false)
+            {
+                return value;
+            }
+
+            value = manager.Localize(text.Replace('_', '/'));
+            return value.StartsWith("[") ? text : value;
         }
 
         private static ICultureDictionary CultureDictionary


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you want to localize content type and property names in the backoffice, you currently have to do it using the dictionary. This is convenient if you have the same languages in frontend and backoffice, but if you don't... well, things get messy

From a conceptual point of view, doing backoffice localization using the dictionary isn't terribly pretty, because the dictionary is pretty much a frontend thing.

So! This PR makes it possible to do the same localization of backoffice names using the language files. The naming follows the same convention as the dictionary based localization; you add the "#"-prefix and then specify the localization key as either `[area]/[key]` or `[area]_[key]` :

![image](https://user-images.githubusercontent.com/7405322/56879982-4bee7e00-6a5b-11e9-90d8-850c943e2a45.png)

The corresponding localization file (e.g. `en-US.user.xml`) would look something like this:

```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<language>
    <area alias="contentTypes">
        <key alias="home">Name for Home</key>
    </area>
    <area alias="properties">
        <key alias="title">Name for Title</key>
    </area>
</language>
```

And the result:

![image](https://user-images.githubusercontent.com/7405322/56880044-87894800-6a5b-11e9-8661-7050cf37840c.png)

![image](https://user-images.githubusercontent.com/7405322/56880036-79d3c280-6a5b-11e9-9e73-ca2e38f04d49.png)

#### Testing this PR

1. Create a content type and localize its name and properties as described above.
2. Create matching localizations in two user language files (e.g. `en-US.user.xml` and `da-DK.user.xml`).
3. Test both languages by flipping your backoffice user language.