### PR TITLE
V8: Fix the active state for nested content in nested content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -106,7 +106,7 @@
     }
 }
 
-.umb-nested-content__item--active {
+.umb-nested-content__item--active > .umb-nested-content__header-bar {
     .umb-nested-content__heading {
         background-color: @ui-active;
         &:hover {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

dc66807d introduced some really nice new colors for active state on Nested Content. Unfortunately it makes nested Nested Content look a bit _too_ active:

![image](https://user-images.githubusercontent.com/7405322/56984612-bb14c100-6b86-11e9-9718-b03917e30f84.png)

This PR fixes it so the new active state color also works for nested Nested Content:

![image](https://user-images.githubusercontent.com/7405322/56984592-ad5f3b80-6b86-11e9-9b84-9b36ad38b82d.png)

/cc @nielslyngsoe 