### PR TITLE
V8: Vertically center the button carets in the grid RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -611,6 +611,10 @@
         padding-bottom: 8px;
         padding-left: 6px;
         line-height: inherit;
+
+        .mce-caret {
+            margin-top: 6px;
+        }
     }
 
     &:not(.mce-menubtn) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5231

### Description

As @bjarnef points out in #5231, the carets in the grid RTE buttons aren't vertically aligned correctly. They should be center aligned, but they look a few pixels off:

![image](https://user-images.githubusercontent.com/7405322/56989095-ef41af00-6b91-11e9-98ea-4af81a622dd1.png)

This PR fixes the problem:

![image](https://user-images.githubusercontent.com/7405322/56989017-b6093f00-6b91-11e9-8433-f3d330e110dd.png)

**Note:** This problem does _not_ apply to the normal RTE.
