### PR TITLE
V8: Default nested content item names to the item type name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -190,28 +190,43 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
 
         $scope.getName = function (idx) {
 
-            var name = "Item " + (idx + 1);
+            var name = "";
 
             if ($scope.model.value[idx]) {
 
                 var contentType = $scope.getContentTypeConfig($scope.model.value[idx].ncContentTypeAlias);
 
-                if (contentType != null && contentType.nameExp) {
-                    // Run the expression against the stored dictionary value, NOT the node object
-                    var item = $scope.model.value[idx];
+                if (contentType != null) {
+                    // first try getting a name using the configured label template
+                    if (contentType.nameExp) {
+                        // Run the expression against the stored dictionary value, NOT the node object
+                        var item = $scope.model.value[idx];
 
-                    // Add a temporary index property
-                    item["$index"] = (idx + 1);
+                        // Add a temporary index property
+                        item["$index"] = (idx + 1);
 
-                    var newName = contentType.nameExp(item);
-                    if (newName && (newName = $.trim(newName))) {
-                        name = newName;
+                        var newName = contentType.nameExp(item);
+                        if (newName && (newName = $.trim(newName))) {
+                            name = newName;
+                        }
+
+                        // Delete the index property as we don't want to persist it
+                        delete item["$index"];
                     }
 
-                    // Delete the index property as we don't want to persist it
-                    delete item["$index"];
+                    // if we still do not have a name and we have multiple content types to choose from, use the content type name (same as is shown in the content type picker)
+                    if (!name && $scope.scaffolds.length > 1) {
+                        var scaffold = $scope.getScaffold(contentType.ncAlias);
+                        if (scaffold) {
+                            name = scaffold.contentTypeName;
+                        }
+                    }
                 }
 
+            }
+
+            if (!name) {
+                name = "Item " + (idx + 1);
             }
 
             // Update the nodes actual name value


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Nested Content item names default to `Item [$index]` if there is no label template defined in the Nested Content config. This makes perfect sense for list of items where there is only one item type to choose from (i.e. the item type picker is never shown).

However if there are multiple item types to choose from, the nondescript `Item [$index]` label starts making less sense - then you only have the item icon to help you tell the items apart (if indeed the icon is shown):

![image](https://user-images.githubusercontent.com/7405322/57008646-c94bf700-6bf1-11e9-97d7-4eca5b8e0924.png)

This PR makes Nested Content use the item type name instead of `Item [$index]` as the default item name for Nested Content properties with multiple items available:

![nested-content-item-name](https://user-images.githubusercontent.com/7405322/57009906-ca812200-6bf9-11e9-9e38-f1a661c1d592.gif)
