### PR TITLE
Introduce a maxlength on the name of the node

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -759,7 +759,7 @@ namespace Umbraco.Core.Services.Implement
 
             if (content.Name.Length > 255)
             {
-                throw new Exception("Name cannot be more than 255 characters in length.");
+                throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
             }
 
             var evtMsgs = EventMessagesFactory.Get();
@@ -877,7 +877,7 @@ namespace Umbraco.Core.Services.Implement
 
             if(content.Name.Length > 255)
             {
-                throw new Exception("Name cannot be more than 255 characters in length.");
+                throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
             }
 
             using (var scope = ScopeProvider.CreateScope())
@@ -912,7 +912,7 @@ namespace Umbraco.Core.Services.Implement
 
             if (content.Name.Length > 255)
             {
-                throw new Exception("Name cannot be more than 255 characters in length.");
+                throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
             }
 
             using (var scope = ScopeProvider.CreateScope())

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -757,7 +757,7 @@ namespace Umbraco.Core.Services.Implement
             if (publishedState != PublishedState.Published && publishedState != PublishedState.Unpublished)
                 throw new InvalidOperationException("Cannot save (un)publishing content, use the dedicated SavePublished method.");
 
-            if (content.Name.Length > 255)
+            if (content.Name != null && content.Name.Length > 255)
             {
                 throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
             }
@@ -875,7 +875,7 @@ namespace Umbraco.Core.Services.Implement
                     throw new NotSupportedException($"Culture \"{culture}\" is not supported by invariant content types.");
             }
 
-            if(content.Name.Length > 255)
+            if(content.Name != null && content.Name.Length > 255)
             {
                 throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
             }
@@ -910,7 +910,7 @@ namespace Umbraco.Core.Services.Implement
             if (content == null) throw new ArgumentNullException(nameof(content));
             if (cultures == null) throw new ArgumentNullException(nameof(cultures));
 
-            if (content.Name.Length > 255)
+            if (content.Name != null && content.Name.Length > 255)
             {
                 throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
             }

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -870,6 +870,11 @@ namespace Umbraco.Core.Services.Implement
                     throw new NotSupportedException($"Culture \"{culture}\" is not supported by invariant content types.");
             }
 
+            if(content.Name.Length > 256)
+            {
+                throw new Exception("Name cannot be more than 256 characters in length.");
+            }
+
             using (var scope = ScopeProvider.CreateScope())
             {
                 scope.WriteLock(Constants.Locks.ContentTree);

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -757,6 +757,11 @@ namespace Umbraco.Core.Services.Implement
             if (publishedState != PublishedState.Published && publishedState != PublishedState.Unpublished)
                 throw new InvalidOperationException("Cannot save (un)publishing content, use the dedicated SavePublished method.");
 
+            if (content.Name.Length > 255)
+            {
+                throw new Exception("Name cannot be more than 255 characters in length.");
+            }
+
             var evtMsgs = EventMessagesFactory.Get();
 
             using (var scope = ScopeProvider.CreateScope())
@@ -870,9 +875,9 @@ namespace Umbraco.Core.Services.Implement
                     throw new NotSupportedException($"Culture \"{culture}\" is not supported by invariant content types.");
             }
 
-            if(content.Name.Length > 256)
+            if(content.Name.Length > 255)
             {
-                throw new Exception("Name cannot be more than 256 characters in length.");
+                throw new Exception("Name cannot be more than 255 characters in length.");
             }
 
             using (var scope = ScopeProvider.CreateScope())
@@ -904,6 +909,11 @@ namespace Umbraco.Core.Services.Implement
         {
             if (content == null) throw new ArgumentNullException(nameof(content));
             if (cultures == null) throw new ArgumentNullException(nameof(cultures));
+
+            if (content.Name.Length > 255)
+            {
+                throw new Exception("Name cannot be more than 255 characters in length.");
+            }
 
             using (var scope = ScopeProvider.CreateScope())
             {

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -26,7 +26,7 @@
                             umb-auto-focus
                             val-server-field="{{serverValidationNameField}}"
                             required
-                            autocomplete="off" />
+                            autocomplete="off" maxlength="255" />
                     </ng-form>
 
                     <a ng-if="content.variants.length > 0 && hideChangeVariant !== true" class="umb-variant-switcher__toggle" href="" ng-click="vm.dropdownOpen = !vm.dropdownOpen">

--- a/src/Umbraco.Web/Models/ContentEditing/ContentVariantSave.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentVariantSave.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Web.Models.ContentEditing
 
         [DataMember(Name = "name", IsRequired = true)]
         [RequiredForPersistence(AllowEmptyStrings = false, ErrorMessage = "Required")]
-        [MaxLength(256, ErrorMessage ="Name must be less than 256 characters")]
+        [MaxLength(255, ErrorMessage ="Name must be less than 255 characters")]
         public string Name { get; set; }
 
         [DataMember(Name = "properties")]

--- a/src/Umbraco.Web/Models/ContentEditing/ContentVariantSave.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentVariantSave.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Validation;
@@ -16,6 +17,7 @@ namespace Umbraco.Web.Models.ContentEditing
 
         [DataMember(Name = "name", IsRequired = true)]
         [RequiredForPersistence(AllowEmptyStrings = false, ErrorMessage = "Required")]
+        [MaxLength(256, ErrorMessage ="Name must be less than 256 characters")]
         public string Name { get; set; }
 
         [DataMember(Name = "properties")]


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5007

If the content title is greater than 255 then we get a SQL Exception at the moment. I have added a maxlength="255" as a fix. I have also added it as a data annotation to the model and an exception is thrown in the service. The fix in the ContentService works for new nodes. I have not been able to get it working for an existing node if you try to save/publish it.

Poornima