### PR TITLE
V8: Make async file logging possible with serilog

### DIFF
--- a/build/NuSpecs/UmbracoCms.nuspec
+++ b/build/NuSpecs/UmbracoCms.nuspec
@@ -58,6 +58,7 @@
         <!-- config transforms -->
         <!-- beware! config transforms not supported by PackageReference -->
         <file src="tools\Web.config.install.xdt" target="Content\Web.config.install.xdt" />
+        <file src="tools\serilog.config.install.xdt" target="Content\config\serilog.config.install.xdt" />
         <file src="tools\ClientDependency.config.install.xdt" target="Content\config\ClientDependency.config.install.xdt" />
         <file src="tools\umbracoSettings.config.install.xdt" target="Content\config\umbracoSettings.config.install.xdt" />
         <file src="tools\Views.Web.config.install.xdt" target="Views\Web.config.install.xdt" /> <!-- FIXME: Content\ !! and then... transform?! -->

--- a/build/NuSpecs/tools/serilog.config.install.xdt
+++ b/build/NuSpecs/tools/serilog.config.install.xdt
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">>
+    <appSettings>
+
+        <add key="serilog:using:File" value="Umbraco.Core" xdt:Transform="SetAttributes(value)" xdt:Locator="Match(key)"/>
+        <add key="serilog:write-to:File.shared" value="false" xdt:Transform="SetAttributes(value)" xdt:Locator="Match(key)"/>
+        <add key="serilog:write-to:File.buffered" value="true" xdt:Transform="InsertIfMissing" xdt:Locator="Match(key)"/>
+        <add key="serilog:write-to:File.async" value="true" xdt:Transform="InsertIfMissing" xdt:Locator="Match(key)"/>
+        <add key="serilog:write-to:File.asyncKeepFileOpen" value="false" xdt:Transform="InsertIfMissing" xdt:Locator="Match(key)"/>
+
+    </appSettings>
+</configuration>

--- a/build/NuSpecs/tools/serilog.config.install.xdt
+++ b/build/NuSpecs/tools/serilog.config.install.xdt
@@ -3,10 +3,7 @@
     <appSettings>
 
         <add key="serilog:using:File" value="Umbraco.Core" xdt:Transform="SetAttributes(value)" xdt:Locator="Match(key)"/>
-        <add key="serilog:write-to:File.shared" value="false" xdt:Transform="SetAttributes(value)" xdt:Locator="Match(key)"/>
-        <add key="serilog:write-to:File.buffered" value="true" xdt:Transform="InsertIfMissing" xdt:Locator="Match(key)"/>
-        <add key="serilog:write-to:File.async" value="true" xdt:Transform="InsertIfMissing" xdt:Locator="Match(key)"/>
-        <add key="serilog:write-to:File.asyncKeepFileOpen" value="false" xdt:Transform="InsertIfMissing" xdt:Locator="Match(key)"/>
+        <add key="serilog:write-to:File.shared" xdt:Transform="Remove" xdt:Locator="Match(key)"/>
 
     </appSettings>
 </configuration>

--- a/src/Umbraco.Core/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Core/Logging/Serilog/LoggerConfigExtensions.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Text;
 using System.Web;
 using Serilog;
+using Serilog.Configuration;
+using Serilog.Core;
 using Serilog.Events;
+using Serilog.Formatting;
 using Serilog.Formatting.Compact;
 using Umbraco.Core.Logging.Serilog.Enrichers;
 
@@ -35,7 +39,7 @@ namespace Umbraco.Core.Logging.Serilog
                 .Enrich.With<HttpSessionIdEnricher>()
                 .Enrich.With<HttpRequestNumberEnricher>()
                 .Enrich.With<HttpRequestIdEnricher>();
-            
+
             return logConfig;
         }
 
@@ -50,13 +54,61 @@ namespace Umbraco.Core.Logging.Serilog
             //Main .txt logfile - in similar format to older Log4Net output
             //Ends with ..txt as Date is inserted before file extension substring
             logConfig.WriteTo.File($@"{AppDomain.CurrentDomain.BaseDirectory}\App_Data\Logs\UmbracoTraceLog.{Environment.MachineName}..txt",
-                    shared: true,
-                    rollingInterval: RollingInterval.Day,
-                    restrictedToMinimumLevel: minimumLevel,
-                    retainedFileCountLimit: null, //Setting to null means we keep all files - default is 31 days
-                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss,fff} [P{ProcessId}/D{AppDomainId}/T{ThreadId}] {Log4NetLevel}  {SourceContext} - {Message:lj}{NewLine}{Exception}");
+                shared: true,
+                rollingInterval: RollingInterval.Day,
+                restrictedToMinimumLevel: minimumLevel,
+                retainedFileCountLimit: null, //Setting to null means we keep all files - default is 31 days
+                outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss,fff} [P{ProcessId}/D{AppDomainId}/T{ThreadId}] {Log4NetLevel}  {SourceContext} - {Message:lj}{NewLine}{Exception}");
 
             return logConfig;
+        }
+
+
+        /// <remarks>
+        ///    Used in config - If renamed or moved to other assembly the config file also has be updated.
+        /// </remarks>
+        public static LoggerConfiguration File(this LoggerSinkConfiguration configuration, ITextFormatter formatter,
+            string path,
+            bool shared = false,
+            bool buffered = false,
+            LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose,
+            LoggingLevelSwitch levelSwitch = null,
+            long? fileSizeLimitBytes = 1073741824,
+            TimeSpan? flushToDiskInterval = null,
+            RollingInterval rollingInterval = RollingInterval.Infinite,
+            bool rollOnFileSizeLimit = false,
+            int? retainedFileCountLimit = 31,
+            Encoding encoding = null,
+            bool async = false,
+            bool asyncBlockWhenFull = false,
+            int asyncBufferSize = 10000)
+        {
+            LoggerConfiguration GetFileSink(LoggerSinkConfiguration c)
+            {
+                return c.File(
+                    formatter,
+                    path,
+                    restrictedToMinimumLevel,
+                    fileSizeLimitBytes,
+                    levelSwitch,
+                    buffered,
+                    shared,
+                    flushToDiskInterval,
+                    rollingInterval,
+                    rollOnFileSizeLimit,
+                    retainedFileCountLimit,
+                    encoding);
+            }
+
+            if ( async )
+            {
+
+                return configuration.Async(c => GetFileSink(c), blockWhenFull: asyncBlockWhenFull, bufferSize: asyncBufferSize);
+            }
+            else
+            {
+                return GetFileSink(configuration);
+            }
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Logging/Serilog/SerilogLogger.cs
+++ b/src/Umbraco.Core/Logging/Serilog/SerilogLogger.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Core.Logging.Serilog
     ///<summary>
     /// Implements <see cref="ILogger"/> on top of Serilog.
     ///</summary>
-    public class SerilogLogger : ILogger
+    public class SerilogLogger : ILogger, IDisposable
     {
         /// <summary>
         /// Initialize a new instance of the <see cref="SerilogLogger"/> class with a configuration file.
@@ -270,6 +270,11 @@ namespace Umbraco.Core.Logging.Serilog
         public void Verbose(Type reporting, string messageTemplate, params object[] propertyValues)
         {
             LoggerFor(reporting).Verbose(messageTemplate, propertyValues);
+        }
+
+        public void Dispose()
+        {
+            Log.CloseAndFlush();
         }
     }
 }

--- a/src/Umbraco.Core/Logging/Viewer/JsonLogViewer.cs
+++ b/src/Umbraco.Core/Logging/Viewer/JsonLogViewer.cs
@@ -39,7 +39,7 @@ namespace Umbraco.Core.Logging.Viewer
             for (var day = startDate.Date; day.Date <= endDate.Date; day = day.AddDays(1))
             {
                 //Filename ending to search for (As could be multiple)
-                var filesToFind = $"*{day:yyyyMMdd}.json";
+                var filesToFind = GetSearchPattern(day);
 
                 var filesForCurrentDay = Directory.GetFiles(logDirectory, filesToFind);
 
@@ -50,6 +50,11 @@ namespace Umbraco.Core.Logging.Viewer
             //Check if the log size is not greater than 100Mb (FileSizeCap)
             var logSizeAsMegabytes = fileSizeCount / 1024 / 1024;
             return logSizeAsMegabytes <= FileSizeCap;
+        }
+
+        private string GetSearchPattern(DateTime day)
+        {
+            return $"*{day:yyyyMMdd}*.json";
         }
 
         protected override IReadOnlyList<LogEvent> GetLogs(DateTimeOffset startDate, DateTimeOffset endDate, ILogFilter filter, int skip, int take)
@@ -66,7 +71,7 @@ namespace Umbraco.Core.Logging.Viewer
             for (var day = startDate.Date; day.Date <= endDate.Date; day = day.AddDays(1))
             {
                 //Filename ending to search for (As could be multiple)
-                var filesToFind = $"*{day:yyyyMMdd}.json";
+                var filesToFind = GetSearchPattern(day);
 
                 var filesForCurrentDay = Directory.GetFiles(logDirectory, filesToFind);
 

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -55,6 +55,12 @@
   </ItemGroup>
   <ItemGroup>
     <!-- note: NuGet deals with transitive references now -->
+    <PackageReference Include="Serilog.Sinks.Async">
+      <Version>1.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="Serilog.Sinks.Map">
+      <Version>1.0.0</Version>
+    </PackageReference>
     <PackageReference Include="Umbraco.Code">
       <Version>1.0.5</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Umbraco.Web.UI/config/serilog.Release.config
+++ b/src/Umbraco.Web.UI/config/serilog.Release.config
@@ -20,13 +20,10 @@
         <add key="serilog:using:File" value="Umbraco.Core" />
         <add key="serilog:write-to:File.formatter" value="Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact" />
         <add key="serilog:write-to:File.path" value="%BASEDIR%\App_Data\Logs\UmbracoTraceLog.%MACHINENAME%..json" />
-        <add key="serilog:write-to:File.shared" value="false" />
-        <add key="serilog:write-to:File.buffered" value="true" />
         <add key="serilog:write-to:File.restrictedToMinimumLevel" value="Debug" />
         <add key="serilog:write-to:File.retainedFileCountLimit" value="" /> <!-- Number of log files to keep (or remove value to keep all files) -->
         <add key="serilog:write-to:File.rollingInterval" value="Day" /> <!-- Create a new log file every Minute/Hour/Day/Month/Year/infinite -->
-        <add key="serilog:write-to:File.async" value="true" />
-        <add key="serilog:write-to:File.asyncKeepFileOpen" value="false" />
+
 
         <!-- Optional TXT log file -->
         <!--<add key="serilog:using:File" value="Serilog.Sinks.File" /> -->

--- a/src/Umbraco.Web.UI/config/serilog.Release.config
+++ b/src/Umbraco.Web.UI/config/serilog.Release.config
@@ -21,6 +21,7 @@
         <add key="serilog:write-to:File.formatter" value="Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact" />
         <add key="serilog:write-to:File.path" value="%BASEDIR%\App_Data\Logs\UmbracoTraceLog.%MACHINENAME%..json" />
         <add key="serilog:write-to:File.shared" value="false" />
+        <add key="serilog:write-to:File.buffered" value="true" />
         <add key="serilog:write-to:File.restrictedToMinimumLevel" value="Debug" />
         <add key="serilog:write-to:File.retainedFileCountLimit" value="" /> <!-- Number of log files to keep (or remove value to keep all files) -->
         <add key="serilog:write-to:File.rollingInterval" value="Day" /> <!-- Create a new log file every Minute/Hour/Day/Month/Year/infinite -->

--- a/src/Umbraco.Web.UI/config/serilog.Release.config
+++ b/src/Umbraco.Web.UI/config/serilog.Release.config
@@ -20,11 +20,12 @@
         <add key="serilog:using:File" value="Umbraco.Core" />
         <add key="serilog:write-to:File.formatter" value="Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact" />
         <add key="serilog:write-to:File.path" value="%BASEDIR%\App_Data\Logs\UmbracoTraceLog.%MACHINENAME%..json" />
-        <add key="serilog:write-to:File.shared" value="true" />
+        <add key="serilog:write-to:File.shared" value="false" />
         <add key="serilog:write-to:File.restrictedToMinimumLevel" value="Debug" />
         <add key="serilog:write-to:File.retainedFileCountLimit" value="" /> <!-- Number of log files to keep (or remove value to keep all files) -->
         <add key="serilog:write-to:File.rollingInterval" value="Day" /> <!-- Create a new log file every Minute/Hour/Day/Month/Year/infinite -->
         <add key="serilog:write-to:File.async" value="true" />
+        <add key="serilog:write-to:File.asyncKeepFileOpen" value="false" />
 
         <!-- Optional TXT log file -->
         <!--<add key="serilog:using:File" value="Serilog.Sinks.File" /> -->

--- a/src/Umbraco.Web.UI/config/serilog.Release.config
+++ b/src/Umbraco.Web.UI/config/serilog.Release.config
@@ -17,13 +17,14 @@
 
         <!-- Default JSON log file -->
         <!-- This is used by the default log viewer in the Umbraco backoffice -->
-        <add key="serilog:using:File" value="Serilog.Sinks.File" />
+        <add key="serilog:using:File" value="Umbraco.Core" />
         <add key="serilog:write-to:File.formatter" value="Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact" />
         <add key="serilog:write-to:File.path" value="%BASEDIR%\App_Data\Logs\UmbracoTraceLog.%MACHINENAME%..json" />
         <add key="serilog:write-to:File.shared" value="true" />
         <add key="serilog:write-to:File.restrictedToMinimumLevel" value="Debug" />
         <add key="serilog:write-to:File.retainedFileCountLimit" value="" /> <!-- Number of log files to keep (or remove value to keep all files) -->
         <add key="serilog:write-to:File.rollingInterval" value="Day" /> <!-- Create a new log file every Minute/Hour/Day/Month/Year/infinite -->
+        <add key="serilog:write-to:File.async" value="true" />
 
         <!-- Optional TXT log file -->
         <!--<add key="serilog:using:File" value="Serilog.Sinks.File" /> -->

--- a/src/Umbraco.Web/UmbracoApplicationBase.cs
+++ b/src/Umbraco.Web/UmbracoApplicationBase.cs
@@ -6,6 +6,7 @@ using System.Web.Hosting;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Logging;
+using Umbraco.Core.Logging.Serilog;
 
 namespace Umbraco.Web
 {
@@ -143,6 +144,7 @@ namespace Umbraco.Web
                 Current.Logger.Info<UmbracoApplicationBase>("Application shutdown. Reason: {ShutdownReason}", HostingEnvironment.ShutdownReason);
             }
 
+            Current.Logger.DisposeIfDisposable();
             // dispose the container and everything
             Current.Reset();
         }

--- a/src/umbraco.sln
+++ b/src/umbraco.sln
@@ -74,7 +74,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{E3F9F378
 		..\build\NuSpecs\tools\install.ps1 = ..\build\NuSpecs\tools\install.ps1
 		..\build\NuSpecs\tools\Readme.txt = ..\build\NuSpecs\tools\Readme.txt
 		..\build\NuSpecs\tools\ReadmeUpgrade.txt = ..\build\NuSpecs\tools\ReadmeUpgrade.txt
-		..\build\NuSpecs\tools\trees.config.install.xdt = ..\build\NuSpecs\tools\trees.config.install.xdt
+		..\build\NuSpecs\tools\serilog.config.install.xdt = ..\build\NuSpecs\tools\serilog.config.install.xdt
 		..\build\NuSpecs\tools\Web.config.install.xdt = ..\build\NuSpecs\tools\Web.config.install.xdt
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/5373
Fixes https://github.com/umbraco/Umbraco-CMS/issues/5236

- Added custom extension method to configure the file serilog file sink to be wrapped in the async sink
- Added options to close the file after each log event
- Disposes the actual logger if disposable on application shutdown (necessary to flush the log-queue before application shutdown)
- Changed the default config to use async logging and close the file after each log event


Test steps:
 - The logging need to work, both for async and sync logging 😄 
 - Test the different combinations of the configurations
   - Sync (with keep file open)
   - Async with keep file open
   - Async with close file after log 
      - Test that the file can be deleted at anytime