### PR TITLE
Remove unneeded initialization of UmbracoHelper

### DIFF
--- a/src/Umbraco.Web/Editors/TemplateQueryController.cs
+++ b/src/Umbraco.Web/Editors/TemplateQueryController.cs
@@ -67,8 +67,6 @@ namespace Umbraco.Web.Editors
 
         public QueryResultModel PostTemplateQuery(QueryModel model)
         {
-            var umbraco = new UmbracoHelper(UmbracoContext);
-
             var queryResult = new QueryResultModel();
 
             var sb = new StringBuilder();
@@ -79,7 +77,7 @@ namespace Umbraco.Web.Editors
 
             timer.Start();
 
-            var currentPage = umbraco.TypedContentAtRoot().FirstOrDefault();
+            var currentPage = this.Umbraco.TypedContentAtRoot().FirstOrDefault();
             timer.Stop();
 
             var pointerNode = currentPage;
@@ -87,7 +85,7 @@ namespace Umbraco.Web.Editors
             // adjust the "FROM"
             if (model != null && model.Source != null && model.Source.Id > 0)
             {
-                var targetNode = umbraco.TypedContent(model.Source.Id);
+                var targetNode = this.Umbraco.TypedContent(model.Source.Id);
 
                 if (targetNode != null)
                 {

--- a/src/Umbraco.Web/Extensions/UdiExtensions.cs
+++ b/src/Umbraco.Web/Extensions/UdiExtensions.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Umbraco.Core;
 using Umbraco.Core.Models;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.Extensions
 {
@@ -16,24 +17,20 @@ namespace Umbraco.Web.Extensions
             var guidUdi = udi as GuidUdi;
             if (guidUdi == null) return null;
 
+            var umbracoContext = UmbracoContext.Current;
+            if (umbracoContext == null) return null;
+
             var umbracoType = Constants.UdiEntityType.ToUmbracoObjectType(guidUdi.EntityType);
 
-            var umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
-            var entityService = ApplicationContext.Current.Services.EntityService;
             switch (umbracoType)
             {
                 case UmbracoObjectTypes.Document:
-                    return umbracoHelper.TypedContent(guidUdi.Guid);
+                    return umbracoContext.ContentCache.GetById(guidUdi.Guid);
                 case UmbracoObjectTypes.Media:
-                    var mediaAttempt = entityService.GetIdForKey(guidUdi.Guid, umbracoType);
-                    if (mediaAttempt.Success)
-                        return umbracoHelper.TypedMedia(mediaAttempt.Result);
-                    break;
+                    return umbracoContext.MediaCache.GetById(guidUdi.Guid);
                 case UmbracoObjectTypes.Member:
-                    var memberAttempt = entityService.GetIdForKey(guidUdi.Guid, umbracoType);
-                    if (memberAttempt.Success)
-                        return umbracoHelper.TypedMember(memberAttempt.Result);
-                    break;
+                    var membershipHelper = new MembershipHelper(umbracoContext);
+                    return membershipHelper.GetByProviderKey(guidUdi.Guid);
             }
 
             return null;

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Web.PropertyEditors
 
                 try
                 {
-                    var umbHelper = new UmbracoHelper(UmbracoContext.Current);
+                    var umbracoContext = UmbracoContext.Current;
                     var services = ApplicationContext.Current.Services;
                     var entityService = services.EntityService;
                     var contentTypeService = services.ContentTypeService;
@@ -167,7 +167,7 @@ namespace Umbraco.Web.PropertyEditors
                                 link.Published = Equals(entity.AdditionalData["IsPublished"], true);
 
                                 if (link.Trashed == false)
-                                    link.Url = umbHelper.Url(entity.Id, UrlProviderMode.Relative);
+                                    link.Url = umbracoContext.UrlProvider.GetUrl(entity.Id, UrlProviderMode.Relative);
                             }
                             else
                             {
@@ -183,7 +183,7 @@ namespace Umbraco.Web.PropertyEditors
                                 if (link.Trashed)
                                     continue;
 
-                                var media = umbHelper.TypedMedia(entity.Id);
+                                var media = umbracoContext.MediaCache.GetById(entity.Id);
                                 if (media != null)
                                     link.Url = media.Url;
                             }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/ContentPickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/ContentPickerPropertyConverter.cs
@@ -8,7 +8,6 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.Globalization;
 
 using Umbraco.Core;
 using Umbraco.Core.Configuration;
@@ -33,8 +32,8 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         /// </summary>
         private static readonly List<string> PropertiesToExclude = new List<string>()
         {
-            Constants.Conventions.Content.InternalRedirectId.ToLower(CultureInfo.InvariantCulture),
-            Constants.Conventions.Content.Redirect.ToLower(CultureInfo.InvariantCulture)
+            Constants.Conventions.Content.InternalRedirectId,
+            Constants.Conventions.Content.Redirect
         };
 
         /// <summary>
@@ -111,24 +110,20 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             if (umbracoContext == null)
                 return source;
 
-            if ((propertyType.PropertyTypeAlias != null && PropertiesToExclude.Contains(propertyType.PropertyTypeAlias.ToLower(CultureInfo.InvariantCulture))) == false)
+            // Do not convert source for excluded properties
+            if (propertyType.PropertyTypeAlias == null || PropertiesToExclude.InvariantContains(propertyType.PropertyTypeAlias))
+                return source;
+
+            if (source is int sourceInt)
             {
-                IPublishedContent content;
-                if (source is int sourceInt)
-                {
-                    content = umbracoContext.ContentCache.GetById(sourceInt);
-                    if (content != null)
-                        return content;
-                }
-                else if (source is Udi sourceUdi)
-                {
-                    content = umbracoContext.ContentCache.GetById(sourceUdi);
-                    if (content != null)
-                        return content;
-                }
+                return umbracoContext.ContentCache.GetById(sourceInt);
+            }
+            else if (source is Udi sourceUdi)
+            {
+                return umbracoContext.ContentCache.GetById(sourceUdi);
             }
 
-            return source;
+            return null;
         }
 
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/ContentPickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/ContentPickerPropertyConverter.cs
@@ -7,7 +7,6 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -16,7 +15,6 @@ using Umbraco.Core.Configuration;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
-using Umbraco.Web.Extensions;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
@@ -57,6 +55,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             {
                 return propertyType.PropertyEditorAlias.Equals(Constants.PropertyEditors.ContentPickerAlias);
             }
+
             return false;
         }
 
@@ -80,9 +79,11 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             var attemptConvertInt = source.TryConvertTo<int>();
             if (attemptConvertInt.Success)
                 return attemptConvertInt.Result;
+
             var attemptConvertUdi = source.TryConvertTo<Udi>();
             if (attemptConvertUdi.Success)
                 return attemptConvertUdi.Result;
+
             return null;
         }
 
@@ -104,32 +105,29 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
         {
             if (source == null)
-            {
                 return null;
-            }
 
-            if (UmbracoContext.Current == null) return source;
+            var umbracoContext = UmbracoContext.Current;
+            if (umbracoContext == null)
+                return source;
 
             if ((propertyType.PropertyTypeAlias != null && PropertiesToExclude.Contains(propertyType.PropertyTypeAlias.ToLower(CultureInfo.InvariantCulture))) == false)
             {
                 IPublishedContent content;
-                if (source is int)
+                if (source is int sourceInt)
                 {
-                    var sourceInt = (int)source;
-                    content = UmbracoContext.Current.ContentCache.GetById(sourceInt);
-                    if(content != null)
+                    content = umbracoContext.ContentCache.GetById(sourceInt);
+                    if (content != null)
                         return content;
                 }
-                else
+                else if (source is Udi sourceUdi)
                 {
-                    var sourceUdi = source as Udi;
-                    if (sourceUdi == null) return null;
-                    var umbHelper = new UmbracoHelper(UmbracoContext.Current);
-                    content = umbHelper.TypedContent(sourceUdi);
+                    content = umbracoContext.ContentCache.GetById(sourceUdi);
                     if (content != null)
                         return content;
                 }
             }
+
             return source;
         }
 
@@ -152,6 +150,5 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         {
             return source.ToString();
         }
-
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/LegacyRelatedLinksEditorValueConvertor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/LegacyRelatedLinksEditorValueConvertor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Xml;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -9,28 +8,29 @@ using Umbraco.Core.Logging;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.PropertyEditors.ValueConverters;
-using Umbraco.Web.Extensions;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
     [DefaultPropertyValueConverter(typeof(JsonValueConverter))] //this shadows the JsonValueConverter
     [PropertyValueType(typeof(JArray))]
-    [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]    
+    [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]
     public class LegacyRelatedLinksEditorValueConvertor : PropertyValueConverterBase
     {
-
         public override bool IsConverter(PublishedPropertyType propertyType)
         {
             if (UmbracoConfig.For.UmbracoSettings().Content.EnablePropertyValueConverters == false)
             {
                 return propertyType.PropertyEditorAlias.Equals(Constants.PropertyEditors.RelatedLinksAlias);
             }
+
             return false;
         }
 
         public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
         {
-            if (source == null) return null;
+            if (source == null)
+                return null;
+
             var sourceString = source.ToString();
 
             if (sourceString.DetectIsJson())
@@ -38,39 +38,40 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                 try
                 {
                     var obj = JsonConvert.DeserializeObject<JArray>(sourceString);
-                    
-                    //update the internal links if we have a context
-                    if (UmbracoContext.Current == null) return obj;
 
-                    var helper = new UmbracoHelper(UmbracoContext.Current);
+                    //update the internal links if we have a context
+                    var umbracoContext = UmbracoContext.Current;
+                    if (umbracoContext == null)
+                        return obj;
+
                     foreach (var a in obj)
                     {
                         var type = a.Value<string>("type");
-                        if (type.IsNullOrWhiteSpace() == false)
+                        if (type.IsNullOrWhiteSpace() == false && type == "internal")
                         {
-                            if (type == "internal")
+                            switch (propertyType.PropertyEditorAlias)
                             {
-                                switch (propertyType.PropertyEditorAlias)
-                                {
-                                    case Constants.PropertyEditors.RelatedLinksAlias:
-                                        var intLinkId = a.Value<int>("link");
-                                        var intLink = helper.NiceUrl(intLinkId);
-                                        a["link"] = intLink;
-                                        break;
-                                    case Constants.PropertyEditors.RelatedLinks2Alias:
-                                        var strLinkId = a.Value<string>("link");
-                                        var udiAttempt = strLinkId.TryConvertTo<Udi>();
-                                        if (udiAttempt)
-                                        {
-                                            var content = helper.TypedContent(udiAttempt.Result);
-                                            if (content == null) break;
-                                            a["link"] = helper.NiceUrl(content.Id);
-                                        }
-                                        break;
-                                }                                    
+                                case Constants.PropertyEditors.RelatedLinksAlias:
+                                    var intLinkId = a.Value<int>("link");
+                                    var intLink = umbracoContext.UrlProvider.GetUrl(intLinkId);
+                                    a["link"] = intLink;
+                                    break;
+                                case Constants.PropertyEditors.RelatedLinks2Alias:
+                                    var strLinkId = a.Value<string>("link");
+                                    var udiAttempt = strLinkId.TryConvertTo<Udi>();
+                                    if (udiAttempt)
+                                    {
+                                        var content = umbracoContext.ContentCache.GetById(udiAttempt.Result);
+                                        if (content == null)
+                                            break;
+
+                                        a["link"] = umbracoContext.UrlProvider.GetUrl(content.Id);
+                                    }
+                                    break;
                             }
                         }
                     }
+
                     return obj;
                 }
                 catch (Exception ex)
@@ -85,26 +86,27 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
         public override object ConvertSourceToXPath(PublishedPropertyType propertyType, object source, bool preview)
         {
-            if (source == null) return null;
-            var sourceString = source.ToString();
+            if (source == null)
+                return null;
 
+            var sourceString = source.ToString();
             if (sourceString.DetectIsJson())
             {
                 try
                 {
-                    var obj = JsonConvert.DeserializeObject<Array>(sourceString);
+                    var obj = JsonConvert.DeserializeObject<JArray>(sourceString);
 
                     var d = new XmlDocument();
                     var e = d.CreateElement("links");
                     d.AppendChild(e);
-                    
-                    foreach (dynamic link in obj)
+
+                    foreach (var link in obj)
                     {
                         var ee = d.CreateElement("link");
-                        ee.SetAttribute("title", link.title);
-                        ee.SetAttribute("link", link.link);
-                        ee.SetAttribute("type", link.type);
-                        ee.SetAttribute("newwindow", link.newWindow);
+                        ee.SetAttribute("title", link.Value<string>("title"));
+                        ee.SetAttribute("link", link.Value<string>("link"));
+                        ee.SetAttribute("type", link.Value<string>("type"));
+                        ee.SetAttribute("newwindow", link.Value<string>("newWindow"));
 
                         e.AppendChild(ee);
                     }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MacroContainerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MacroContainerValueConverter.cs
@@ -36,13 +36,13 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
             try
             {
-                var umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
+                var umbracoComponentRenderer = new UmbracoComponentRenderer(UmbracoContext.Current);
                 MacroTagParser.ParseMacros(
                     source,
                     //callback for when text block is found
                     textBlock => sb.Append(textBlock),
                     //callback for when macro syntax is found
-                    (macroAlias, macroAttributes) => sb.Append(umbracoHelper.RenderMacro(
+                    (macroAlias, macroAttributes) => sb.Append(umbracoComponentRenderer.RenderMacro(
                         macroAlias,
                         //needs to be explicitly casted to Dictionary<string, object>
                         macroAttributes.ConvertTo(x => (string)x, x => x)).ToString()));

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MemberPickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MemberPickerPropertyConverter.cs
@@ -42,30 +42,22 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
         public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
         {
-            if (source == null)
-                return null;
-
             var umbracoContext = UmbracoContext.Current;
             if (umbracoContext == null)
                 return source;
 
             var membershipHelper = new MembershipHelper(umbracoContext);
 
-            IPublishedContent member;
             if (source is int sourceInt)
             {
-                member = membershipHelper.GetById(sourceInt);
-                if (member != null)
-                    return member;
+                return membershipHelper.GetById(sourceInt);
             }
             else if (source is GuidUdi sourceUdi)
             {
-                member = membershipHelper.GetByProviderKey(sourceUdi.Guid);
-                if (member != null)
-                    return member;
+                return membershipHelper.GetByProviderKey(sourceUdi.Guid);
             }
 
-            return source;
+            return null;
         }
 
     }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MemberPickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MemberPickerPropertyConverter.cs
@@ -3,7 +3,6 @@ using Umbraco.Core.Configuration;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
-using Umbraco.Web.Extensions;
 using Umbraco.Web.Security;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
@@ -24,6 +23,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             {
                 return propertyType.PropertyEditorAlias.Equals(Constants.PropertyEditors.MemberPickerAlias);
             }
+
             return false;
         }
 
@@ -32,9 +32,11 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             var attemptConvertInt = source.TryConvertTo<int>();
             if (attemptConvertInt.Success)
                 return attemptConvertInt.Result;
+
             var attemptConvertUdi = source.TryConvertTo<Udi>();
             if (attemptConvertUdi.Success)
                 return attemptConvertUdi.Result;
+
             return null;
         }
 
@@ -43,20 +45,22 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             if (source == null)
                 return null;
 
-            if (UmbracoContext.Current == null) return source;
+            var umbracoContext = UmbracoContext.Current;
+            if (umbracoContext == null)
+                return source;
 
-            var umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
+            var membershipHelper = new MembershipHelper(umbracoContext);
+
             IPublishedContent member;
-            if (source is int)
-            {                    
-                member = umbracoHelper.TypedMember((int)source);
+            if (source is int sourceInt)
+            {
+                member = membershipHelper.GetById(sourceInt);
                 if (member != null)
                     return member;
             }
-            else
+            else if (source is GuidUdi sourceUdi)
             {
-                var sourceUdi = source as Udi;
-                member = umbracoHelper.TypedMember(sourceUdi);
+                member = membershipHelper.GetByProviderKey(sourceUdi.Guid);
                 if (member != null)
                     return member;
             }

--- a/src/umbraco.MacroEngines/RazorDataTypeModels/HtmlStringDataTypeModel.cs
+++ b/src/umbraco.MacroEngines/RazorDataTypeModels/HtmlStringDataTypeModel.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using System.Web;
 using Umbraco.Core;
 using Umbraco.Core.Macros;
@@ -9,36 +6,36 @@ using Umbraco.Web;
 
 namespace umbraco.MacroEngines.RazorDataTypeModels
 {
-	/// <summary>
-	/// This ensures that the RTE renders with HtmlString encoding and also ensures that the macro contents in it
-	/// render properly too.
-	/// </summary>
+    /// <summary>
+    /// This ensures that the RTE renders with HtmlString encoding and also ensures that the macro contents in it
+    /// render properly too.
+    /// </summary>
     [RazorDataTypeModel(Constants.PropertyEditors.TinyMCEv3, 90)]
     public class HtmlStringDataTypeModel : IRazorDataTypeModel
     {
         public bool Init(int CurrentNodeId, string PropertyData, out object instance)
         {
-			//we're going to send the string through the macro parser and create the output string.
-			if (UmbracoContext.Current != null)
-			{
-				var sb = new StringBuilder();
-				var umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
-				MacroTagParser.ParseMacros(
-					PropertyData,
-					//callback for when text block is found
-					textBlock => sb.Append(textBlock),
-					//callback for when macro syntax is found
-					(macroAlias, macroAttributes) => sb.Append(umbracoHelper.RenderMacro(
-						macroAlias,
-						//needs to be explicitly casted to Dictionary<string, object>
-						macroAttributes.ConvertTo(x => (string)x, x => (object)x)).ToString()));
-				instance = new HtmlString(sb.ToString());
-			}			
-			else
-			{
-				//we have no umbraco context, so best we can do is convert to html string
-				instance = new HtmlString(PropertyData);
-			}			
+            //we're going to send the string through the macro parser and create the output string.
+            if (UmbracoContext.Current != null)
+            {
+                var sb = new StringBuilder();
+                var umbracoComponentRenderer = new UmbracoComponentRenderer(UmbracoContext.Current);
+                MacroTagParser.ParseMacros(
+                    PropertyData,
+                    //callback for when text block is found
+                    textBlock => sb.Append(textBlock),
+                    //callback for when macro syntax is found
+                    (macroAlias, macroAttributes) => sb.Append(umbracoComponentRenderer.RenderMacro(
+                        macroAlias,
+                        //needs to be explicitly casted to Dictionary<string, object>
+                        macroAttributes.ConvertTo(x => (string)x, x => x)).ToString()));
+                instance = new HtmlString(sb.ToString());
+            }
+            else
+            {
+                //we have no umbraco context, so best we can do is convert to html string
+                instance = new HtmlString(PropertyData);
+            }
             return true;
         }
     }


### PR DESCRIPTION
This is a follow-up of PR #5216: initializing a new instance of `UmbracoHelper` is not needed in almost all cases, as the `ContentCache` and `MediaCache` of the `UmbracoContext` can be used instead.