### PR TITLE
Remove the Link to the out-of-date editors manual

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html
@@ -5,7 +5,6 @@
         <h5>Find out more:</h5>
         <ul>
             <li>Read more about working with the items in Settings <a class="btn-link -underline" href="https://our.umbraco.com/documentation/Getting-Started/Backoffice/Sections/" target="_blank">in the Documentation section</a> of Our Umbraco</li>
-            <li>Download the <a class="btn-link -underline" href="https://our.umbraco.com/projects/website-utilities/umbraco-7-editors-manual" target="_blank">Editors Manual</a> for details on working with the Umbraco UI</li>
             <li>Ask a question in the <a class="btn-link -underline" href="https://our.umbraco.com/forum" target="_blank">Community Forum</a></li>
             <li>Watch our <a class="btn-link -underline" href="https://umbraco.tv" target="_blank">tutorial videos</a> (some are free, some require a subscription)</li>
             <li>Find out about our <a class="btn-link -underline" href="https://umbraco.com/products/" target="_blank">productivity boosting tools and commercial support</a></li>


### PR DESCRIPTION
Issue discussed here: https://github.com/umbraco/Umbraco-CMS/issues/5370

Removing in the short term the link to the out-of-date Editor's Manual (v7.1)
