### PR TITLE
V8 improved focus state of umb-form-check inputs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
@@ -24,7 +24,6 @@ function MainController($scope, $location, appState, treeService, notificationsS
     // For more information about this approach, see https://hackernoon.com/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2
     function handleFirstTab(evt) {
         if (evt.keyCode === 9) {
-            console.log("handleFirstTab")
             $scope.tabbingActive = true;
             $scope.$digest();
             window.removeEventListener('keydown', handleFirstTab);
@@ -35,7 +34,6 @@ function MainController($scope, $location, appState, treeService, notificationsS
     function disableTabbingActive(evt) {
         $scope.tabbingActive = false;
         $scope.$digest();
-            console.log("disableTabbingActive")
         window.removeEventListener('mousedown', disableTabbingActive);
         window.addEventListener("keydown", handleFirstTab);
     }

--- a/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
@@ -24,7 +24,9 @@ function MainController($scope, $location, appState, treeService, notificationsS
     // For more information about this approach, see https://hackernoon.com/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2
     function handleFirstTab(evt) {
         if (evt.keyCode === 9) {
+            console.log("handleFirstTab")
             $scope.tabbingActive = true;
+            $scope.$digest();
             window.removeEventListener('keydown', handleFirstTab);
             window.addEventListener('mousedown', disableTabbingActive);
         }
@@ -32,6 +34,8 @@ function MainController($scope, $location, appState, treeService, notificationsS
     
     function disableTabbingActive(evt) {
         $scope.tabbingActive = false;
+        $scope.$digest();
+            console.log("disableTabbingActive")
         window.removeEventListener('mousedown', disableTabbingActive);
         window.addEventListener("keydown", handleFirstTab);
     }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -30,23 +30,13 @@
         }
         &:checked ~ .umb-form-check__state .umb-form-check__check {
             border-color: @ui-option-type;
-            background-color: @ui-option-type;
         }
         &:checked:hover ~ .umb-form-check__state .umb-form-check__check {
             &::before {
                 background: @ui-option-type-hover;
             }
         }
-
-        &:focus:checked ~ .umb-form-check .umb-form-check__check,
-        &:focus ~ .umb-form-check__state .umb-form-check__check {
-            border-color: @inputBorderFocus;
-            
-            .tabbing-active & {
-                outline: 2px solid @inputBorderTabFocus;
-            }
-        }
-
+        
         &:checked ~ .umb-form-check__state {
             .umb-form-check__check {
                 // This only happens if the state has a radiobutton modifier
@@ -71,6 +61,17 @@
                 }
             }
         }
+    }
+    
+    
+    .tabbing-active &.umb-form-check--radiobutton &__input:focus ~ .umb-form-check__state .umb-form-check__check {
+        //outline: 2px solid @inputBorderTabFocus;
+        border: 2px solid @inputBorderTabFocus;
+        margin: -1px;
+    }
+    .tabbing-active &.umb-form-check--checkbox &__input:focus ~ .umb-form-check__state .umb-form-check__check {
+        outline: 2px solid @inputBorderTabFocus;
+        border-color: white;
     }
 
     &__state {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -71,6 +71,8 @@
     }
     .tabbing-active &.umb-form-check--checkbox &__input:focus ~ .umb-form-check__state .umb-form-check__check {
         outline: 2px solid @inputBorderTabFocus;
+    }
+    .tabbing-active &.umb-form-check--checkbox &__input:checked:focus ~ .umb-form-check__state .umb-form-check__check {
         border-color: white;
     }
 


### PR DESCRIPTION
Improved focus state of umb checkbox and umb radiobutton.

Now it should look like this, when tabbing through:
![image](https://user-images.githubusercontent.com/6791648/57072627-a8150480-6cde-11e9-847a-e6494d7b2e03.png)

![image](https://user-images.githubusercontent.com/6791648/57072618-9cc1d900-6cde-11e9-875e-e475f2025507.png)

