### PR TITLE
Add back the ability to use a custom 2-factor auth screen

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -190,7 +190,10 @@
         }
 
         function loginSubmit(login, password) {
-
+            
+            // make sure that we are returning to the login view.
+            vm.view = "login";
+            
             // TODO: Do validation properly like in the invite password update
 
             //if the login and password are not empty we need to automatically

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -56,6 +56,7 @@
         vm.getStarted = getStarted;
         vm.inviteSavePassword = inviteSavePassword;
         vm.showLogin = showLogin;
+        vm.show2FALogin = show2FALogin;
         vm.showRequestPasswordReset = showRequestPasswordReset;
         vm.showSetPassword = showSetPassword;
         vm.loginSubmit = loginSubmit;
@@ -219,7 +220,7 @@
                     //is Two Factor required?
                     if (reason.status === 402) {
                         vm.errorMsg = "Additional authentication required";
-                        show2FALoginDialog(reason.data.twoFactorView, submit);
+                        show2FALogin();
                     }
                     else {
                         vm.loginStates.submitButton = "error";
@@ -403,8 +404,12 @@
             });
         }
 
-        function show2FALoginDialog(view, callback) {
-            // TODO: show 2FA window
+        function show2FALogin() {
+            
+            vm.errorMsg = '';
+            resetInputValidation();
+            vm.view = "2fa-login";
+            
         }
 
         function resetInputValidation() {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -56,7 +56,6 @@
         vm.getStarted = getStarted;
         vm.inviteSavePassword = inviteSavePassword;
         vm.showLogin = showLogin;
-        vm.show2FALogin = show2FALogin;
         vm.showRequestPasswordReset = showRequestPasswordReset;
         vm.showSetPassword = showSetPassword;
         vm.loginSubmit = loginSubmit;
@@ -70,7 +69,9 @@
         ).then(function (data) {
             vm.labels.usernameLabel = data[0];
             vm.labels.usernamePlaceholder = data[1];
-        })                        
+        })            
+        
+        vm.twoFactor = {};
 
         function onInit() {
 
@@ -220,7 +221,8 @@
                     //is Two Factor required?
                     if (reason.status === 402) {
                         vm.errorMsg = "Additional authentication required";
-                        show2FALogin();
+                        show2FALogin(reason.data.twoFactorView, $scope.loginSubmit);
+
                     }
                     else {
                         vm.loginStates.submitButton = "error";
@@ -404,10 +406,12 @@
             });
         }
 
-        function show2FALogin() {
+        function show2FALogin(viewPath, submitCallback) {
             
             vm.errorMsg = '';
             resetInputValidation();
+            vm.twoFactor.submitCallback = submitCallback;
+            vm.twoFactor.view = viewPath;
             vm.view = "2fa-login";
             
         }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -16,7 +16,6 @@
     function UmbLoginController($scope, $location, currentUserResource, formHelper, mediaHelper, umbRequestHelper, Upload, localizationService, userService, externalLoginInfo, resetPasswordCodeInfo, $timeout, authResource, $q) {
 
         const vm = this;
-        let twoFactorloginDialog = null;
 
         vm.invitedUser = null;
 
@@ -69,7 +68,7 @@
         ).then(function (data) {
             vm.labels.usernameLabel = data[0];
             vm.labels.usernamePlaceholder = data[1];
-        })            
+        });
         
         vm.twoFactor = {};
 
@@ -224,8 +223,7 @@
                     //is Two Factor required?
                     if (reason.status === 402) {
                         vm.errorMsg = "Additional authentication required";
-                        show2FALogin(reason.data.twoFactorView, $scope.loginSubmit);
-                        
+                        show2FALoginDialog(reason.data.twoFactorView);
                     }
                     else {
                         vm.loginStates.submitButton = "error";
@@ -409,14 +407,12 @@
             });
         }
 
-        function show2FALogin(viewPath, submitCallback) {
-            
-            vm.errorMsg = '';
-            resetInputValidation();
-            vm.twoFactor.submitCallback = submitCallback;
+        function show2FALoginDialog(viewPath) {
+            vm.twoFactor.submitCallback = function submitCallback() {
+                vm.onLogin();
+            }
             vm.twoFactor.view = viewPath;
             vm.view = "2fa-login";
-            
         }
 
         function resetInputValidation() {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -189,7 +189,7 @@
             vm.view = "set-password";
         }
 
-        function loginSubmit(login, password) {
+        function loginSubmit() {
             
             // make sure that we are returning to the login view.
             vm.view = "login";
@@ -200,7 +200,7 @@
             // validate them - this is because if there are validation errors on the server
             // then the user has to change both username & password to resubmit which isn't ideal,
             // so if they're not empty, we'll just make sure to set them to valid.
-            if (login && password && login.length > 0 && password.length > 0) {
+            if (vm.login && vm.password && vm.login.length > 0 && vm.password.length > 0) {
                 vm.loginForm.username.$setValidity('auth', true);
                 vm.loginForm.password.$setValidity('auth', true);
             }
@@ -211,7 +211,7 @@
 
             vm.loginStates.submitButton = "busy";
 
-            userService.authenticate(login, password)
+            userService.authenticate(vm.login, vm.password)
                 .then(function (data) {
                     vm.loginStates.submitButton = "success";
                     userService._retryRequestQueue(true);
@@ -225,7 +225,7 @@
                     if (reason.status === 402) {
                         vm.errorMsg = "Additional authentication required";
                         show2FALogin(reason.data.twoFactorView, $scope.loginSubmit);
-
+                        
                     }
                     else {
                         vm.loginStates.submitButton = "error";

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -260,10 +260,7 @@
                 </div>
 
                 <div ng-show="vm.view == '2fa-login'">
-
-                    <h1>2FA Login dialog</h1>
-                    <p>Here you go...</p>
-
+                    <div ng-include='vm.twoFactor.view'></div>
                 </div>
 
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -258,6 +258,14 @@
                         <a class="muted" href="#" prevent-default ng-click="vm.showLogin()"><localize key="login_returnToLogin">Return to login form</localize></a>
                     </div>
                 </div>
+
+                <div ng-show="vm.view == '2fa-login'">
+
+                    <h1>2FA Login dialog</h1>
+                    <p>Here you go...</p>
+
+                </div>
+
             </div>
         </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -146,7 +146,7 @@
 
                     </div>
 
-                    <form method="POST" name="vm.loginForm" ng-submit="vm.loginSubmit(vm.login, vm.password)">
+                    <form method="POST" name="vm.loginForm" ng-submit="vm.loginSubmit()">
 
                         <div class="control-group" ng-show="vm.loginForm.$invalid">
                             <div class="text-error">{{vm.errorMsg}}</div>

--- a/src/Umbraco.Web/Editors/AuthenticationController.cs
+++ b/src/Umbraco.Web/Editors/AuthenticationController.cs
@@ -329,7 +329,7 @@ namespace Umbraco.Web.Editors
         public async Task<IEnumerable<string>> Get2FAProviders()
         {
             var userId = await SignInManager.GetVerifiedUserIdAsync();
-            if (userId < 0)
+            if (userId < Core.Constants.Security.SuperUserId)
             {
                 Logger.Warn<AuthenticationController>("Get2FAProviders :: No verified user found, returning 404");
                 throw new HttpResponseException(HttpStatusCode.NotFound);
@@ -345,7 +345,7 @@ namespace Umbraco.Web.Editors
                 throw new HttpResponseException(HttpStatusCode.NotFound);
 
             var userId = await SignInManager.GetVerifiedUserIdAsync();
-            if (userId < 0)
+            if (userId < Core.Constants.Security.SuperUserId)
             {
                 Logger.Warn<AuthenticationController>("Get2FAProviders :: No verified user found, returning 404");
                 throw new HttpResponseException(HttpStatusCode.NotFound);
@@ -475,8 +475,7 @@ namespace Umbraco.Web.Editors
 
             if (UserManager != null)
             {
-                var userId = -1;
-                int.TryParse(User.Identity.GetUserId(), out userId);
+                int.TryParse(User.Identity.GetUserId(), out var userId);
                 UserManager.RaiseLogoutSuccessEvent(userId);
             }
 

--- a/src/Umbraco.Web/Editors/AuthenticationController.cs
+++ b/src/Umbraco.Web/Editors/AuthenticationController.cs
@@ -329,7 +329,7 @@ namespace Umbraco.Web.Editors
         public async Task<IEnumerable<string>> Get2FAProviders()
         {
             var userId = await SignInManager.GetVerifiedUserIdAsync();
-            if (userId < Core.Constants.Security.SuperUserId)
+            if (userId == int.MinValue)
             {
                 Logger.Warn<AuthenticationController>("Get2FAProviders :: No verified user found, returning 404");
                 throw new HttpResponseException(HttpStatusCode.NotFound);
@@ -345,7 +345,7 @@ namespace Umbraco.Web.Editors
                 throw new HttpResponseException(HttpStatusCode.NotFound);
 
             var userId = await SignInManager.GetVerifiedUserIdAsync();
-            if (userId < Core.Constants.Security.SuperUserId)
+            if (userId == int.MinValue)
             {
                 Logger.Warn<AuthenticationController>("Get2FAProviders :: No verified user found, returning 404");
                 throw new HttpResponseException(HttpStatusCode.NotFound);

--- a/src/Umbraco.Web/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web/Security/BackOfficeSignInManager.cs
@@ -227,7 +227,7 @@ namespace Umbraco.Web.Security
         }
 
         /// <summary>
-        /// Get the user id that has been verified already or the SuperUserId minus 1.
+        /// Get the user id that has been verified already or int.MinValue if the user has not been verified yet
         /// </summary>
         /// <returns></returns>
         /// <remarks>
@@ -240,7 +240,7 @@ namespace Umbraco.Web.Security
             {
                 return ConvertIdFromString(result.Identity.GetUserId());
             }
-            return Constants.Security.SuperUserId - 1;
+            return int.MinValue;
         }
 
         /// <summary>
@@ -269,12 +269,12 @@ namespace Umbraco.Web.Security
         /// This is implemented because we cannot override GetVerifiedUserIdAsync and instead we have to shadow it
         /// so due to this and because we are using an INT as the TKey and not an object, it can never be null. Adding to that
         /// the default(int) value returned by the base class is always a valid user (i.e. the admin) so we just have to duplicate
-        /// all of this code to check for SuperUserId-1 instead.
+        /// all of this code to check for int.MinValue
         /// </remarks>
         public override async Task<SignInStatus> TwoFactorSignInAsync(string provider, string code, bool isPersistent, bool rememberBrowser)
         {
             var userId = await GetVerifiedUserIdAsync();
-            if (userId == Constants.Security.SuperUserId - 1)
+            if (userId == int.MinValue)
             {
                 return SignInStatus.Failure;
             }
@@ -306,12 +306,12 @@ namespace Umbraco.Web.Security
         /// This is implemented because we cannot override GetVerifiedUserIdAsync and instead we have to shadow it
         /// so due to this and because we are using an INT as the TKey and not an object, it can never be null. Adding to that
         /// the default(int) value returned by the base class is always a valid user (i.e. the admin) so we just have to duplicate
-        /// all of this code to check for SuperUserId-1 instead.
+        /// all of this code to check for int.MinVale instead.
         /// </remarks>
         public override async Task<bool> SendTwoFactorCodeAsync(string provider)
         {
             var userId = await GetVerifiedUserIdAsync();
-            if (userId == Constants.Security.SuperUserId - 1)
+            if (userId == int.MinValue)
                 return false;
 
             var token = await UserManager.GenerateTwoFactorTokenAsync(userId, provider);

--- a/src/Umbraco.Web/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web/Security/BackOfficeSignInManager.cs
@@ -227,7 +227,7 @@ namespace Umbraco.Web.Security
         }
 
         /// <summary>
-        /// Get the user id that has been verified already or -1.
+        /// Get the user id that has been verified already or the SuperUserId minus 1.
         /// </summary>
         /// <returns></returns>
         /// <remarks>
@@ -240,7 +240,7 @@ namespace Umbraco.Web.Security
             {
                 return ConvertIdFromString(result.Identity.GetUserId());
             }
-            return -1;
+            return Constants.Security.SuperUserId - 1;
         }
 
         /// <summary>
@@ -269,12 +269,12 @@ namespace Umbraco.Web.Security
         /// This is implemented because we cannot override GetVerifiedUserIdAsync and instead we have to shadow it
         /// so due to this and because we are using an INT as the TKey and not an object, it can never be null. Adding to that
         /// the default(int) value returned by the base class is always a valid user (i.e. the admin) so we just have to duplicate
-        /// all of this code to check for -1 instead.
+        /// all of this code to check for SuperUserId-1 instead.
         /// </remarks>
         public override async Task<SignInStatus> TwoFactorSignInAsync(string provider, string code, bool isPersistent, bool rememberBrowser)
         {
             var userId = await GetVerifiedUserIdAsync();
-            if (userId == -1)
+            if (userId == Constants.Security.SuperUserId - 1)
             {
                 return SignInStatus.Failure;
             }
@@ -306,12 +306,12 @@ namespace Umbraco.Web.Security
         /// This is implemented because we cannot override GetVerifiedUserIdAsync and instead we have to shadow it
         /// so due to this and because we are using an INT as the TKey and not an object, it can never be null. Adding to that
         /// the default(int) value returned by the base class is always a valid user (i.e. the admin) so we just have to duplicate
-        /// all of this code to check for -1 instead.
+        /// all of this code to check for SuperUserId-1 instead.
         /// </remarks>
         public override async Task<bool> SendTwoFactorCodeAsync(string provider)
         {
             var userId = await GetVerifiedUserIdAsync();
-            if (userId == -1)
+            if (userId == Constants.Security.SuperUserId - 1)
                 return false;
 
             var token = await UserManager.GenerateTwoFactorTokenAsync(userId, provider);


### PR DESCRIPTION
There was a few things missing and completely broken from the v7 2-factor-auth implementation:

- This TODO was never completed `// TODO: show 2FA window`
- Added a 2factor view to the login dialog, which loads an external (plugin-provided) view, like `../App_Plugins/2FactorAuthentication/2fa-login.html` for example
- The external view needs to be able to signal back to the login screen that all is well, added `submitCallback()` for that
- Some of the code was relying on the OLD v7 behavior that user 0 was the SuperUser (first created user in the system). This is now user -1 so it had to change

To test, drop these 2FA files in your solution, this is a "pretend" Google Auth provider, which always gives you access no matter what Google Auth code you type in, just type "test", it's all good.

[2fatest.zip](https://github.com/umbraco/Umbraco-CMS/files/3138115/2fatest.zip)

