### PR TITLE
Toggle color picker labels squeeze spectrum color picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
@@ -1,5 +1,5 @@
 ﻿.umb-prevalues-multivalues {
-    width: 400px;
+    width: 425px;
     max-width: 100%;
 
     .umb-overlay & {

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -165,6 +165,8 @@
     .sp-replacer {
         display: inline-flex;
         margin-right: 18px;
+        border: solid 1px #d8d7d9;
+        border-radius : 3px;
     }
 
     label {

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -165,8 +165,8 @@
     .sp-replacer {
         display: inline-flex;
         margin-right: 18px;
-        border: solid 1px #d8d7d9;
-        border-radius : 3px;
+        border: solid 1px @gray-8;
+        border-radius: 3px;
     }
 
     label {


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <https://github.com/umbraco/Umbraco-CMS/issues/5381>

### Description
As said in the issue the spectrum color picker squeezes out when the label toggles. Also when you start adding colours with labels the label input box gets chopped off at the end and looks very squished. I have also removed the brownish border from the colour picker and used the grey rounded border. 

**Before**
![image](https://user-images.githubusercontent.com/3941753/57077340-b7e31780-6ce3-11e9-8d6c-a9c26a6ded5e.png)


**After**
![image](https://user-images.githubusercontent.com/3941753/57077257-7bafb700-6ce3-11e9-89e5-0c9a3f3ccc03.png)

Poornima