### PR TITLE
V8: Make sure that the color picker labels are always shown

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
@@ -66,7 +66,7 @@
 (function () {
     'use strict';
 
-    function ToggleDirective(localizationService, eventsService) {
+    function ToggleDirective(localizationService, eventsService, $timeout) {
 
         function link(scope, el, attr, ctrl) {
 
@@ -75,7 +75,11 @@
 
             function onInit() {
                 setLabelText();
-                eventsService.emit("toggleValue", { value: scope.checked });
+                // must wait until the current digest cycle is finished before we emit this event on init, 
+                // otherwise other property editors might not yet be ready to receive the event
+                $timeout(function () {
+                    eventsService.emit("toggleValue", { value: scope.checked });
+                });
             }
 
             function setLabelText() {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
@@ -79,7 +79,7 @@
                 // otherwise other property editors might not yet be ready to receive the event
                 $timeout(function () {
                     eventsService.emit("toggleValue", { value: scope.checked });
-                });
+                }, 100);
             }
 
             function setLabelText() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5393

### Description

See #5393 for a description on how to reproduce and test this PR 😄 

When this PR is applied, the color picker property configuration behaves like this:

![color-picker-labels-enabled](https://user-images.githubusercontent.com/7405322/57123565-8a00e000-6d82-11e9-9b7b-316eb7b234fe.gif)
