### PR TITLE
V8: Support auto focus on ACE editor and use it for RTE source view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbaceeditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbaceeditor.directive.js
@@ -281,6 +281,10 @@
                         opts.callbacks.unshift(options.onLoad);
                     }
 
+                    if (opts.autoFocus === true) {
+                        acee.focus();
+                    }
+
                     // EVENTS
 
                     // unbind old change listener

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/codeeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/codeeditor.controller.js
@@ -17,7 +17,8 @@
                 fontSize: "14px",
                 enableSnippets: false, //The Razor mode snippets are awful (Need a way to override these)
                 enableBasicAutocompletion: true,
-                enableLiveAutocompletion: false
+                enableLiveAutocompletion: false,
+                wrap: true
             },
             onLoad: function(aceEditor) {
                 vm.aceEditor = aceEditor;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/codeeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/codeeditor.controller.js
@@ -12,6 +12,7 @@
             mode: "razor",
             theme: "chrome",
             showPrintMargin: false,
+            autoFocus: true,
             advanced: {
                 fontSize: "14px",
                 enableSnippets: false, //The Razor mode snippets are awful (Need a way to override these)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5363

### Description

See excellent steps to reproduce in #5363.

This PR introduces an option to auto focus the ACE editor, and said option is then used for the RTE source view. When applied it works like this:

![rte-code-view-focus](https://user-images.githubusercontent.com/7405322/57129012-87f44c80-6d95-11e9-9aa0-8dd52ff07d81.gif)
