### PR TITLE
V8: Add/fix empty state in users and groups search

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function UserGroupsController($scope, $timeout, $location, userService, userGroupsResource, 
+    function UserGroupsController($scope, $timeout, $location, $filter, userService, userGroupsResource, 
         formHelper, localizationService, listViewHelper) {
 
         var vm = this;
@@ -31,6 +31,7 @@
                         ug.hasAccess = user.userGroups.indexOf(ug.alias) !== -1 || user.userGroups.indexOf("admin") !== -1;
                         return ug;
                     });
+                    vm.filteredUserGroups = vm.userGroups;
 
                     vm.loading = false;
                 });
@@ -117,6 +118,14 @@
             });
             vm.selection = [];
         }
+
+        var unbindFilterWatcher = $scope.$watch("vm.filter", function (newVal, oldVal) {
+            vm.filteredUserGroups = $filter('filter')(vm.userGroups, vm.filter);
+        });
+
+        $scope.$on("$destroy", function () {
+            unbindFilterWatcher();
+        });
 
         onInit();
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
@@ -70,7 +70,7 @@
         </div>
     </div>
 
-    <div class="umb-table" ng-if="!vm.loading">
+    <div class="umb-table" ng-if="!vm.loading && vm.filteredUserGroups.length">
 
         <div class="umb-table-head">
             <div class="umb-table-row">
@@ -84,7 +84,7 @@
 
         <div class="umb-table-body">
             <div class="umb-table-row"
-                ng-repeat="group in vm.userGroups | filter:vm.filter track by $index"
+                ng-repeat="group in vm.filteredUserGroups track by $index"
                 ng-click="vm.selectUserGroup(group, $index, $event)"
                 ng-class="{'-selected': group.selected, '-selectable': group.hasAccess && group.alias !== 'admin' && group.alias !== 'translator'}">
 
@@ -118,5 +118,10 @@
             </div>
         </div>
     </div>
+
+    <!-- Empty states -->
+    <umb-empty-state ng-if="!vm.loading && !vm.filteredUserGroups.length" position="center">
+        <localize key="general_searchNoResult"></localize>
+    </umb-empty-state>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -173,7 +173,7 @@
 
         <!-- Empty states -->
         <umb-empty-state
-            ng-if="!vm.users && vm.usersOptions.filter.length > 0"
+            ng-if="!vm.loading && !vm.users.length && vm.usersOptions.filter.length > 0"
             position="center">
             <localize key="general_searchNoResult"></localize>
         </umb-empty-state>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5406

### Description

As described in #5406, the empty search result state is either broken or missing for users and groups searches. 

This PR fixes them. When applied the users and groups searches work like this:

![users-groups-empty-state](https://user-images.githubusercontent.com/7405322/57197511-66978a00-6f68-11e9-9508-96bc254b0d77.gif)
