### PR TITLE
Fixed published state for unpublishing culture

### DIFF
--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -238,7 +238,7 @@ namespace Umbraco.Core.Models
             foreach (var property in content.Properties)
                 property.UnpublishValues(culture);
 
-            content.PublishedState = PublishedState.Publishing;
+            content.PublishedState = PublishedState.Unpublishing;
         }
 
         public static void ClearPublishInfos(this IContent content)


### PR DESCRIPTION
### Description
Fixes the `PublishedState` of content when unpublishing. It was set to `Published` but has been changed to `Unpublished`.

This resulted in the Unpublish event not being triggered when unpublishing content. Instead, the Published event was triggered.