### PR TITLE
Remember focus from before search opened + unbind shortcuts when backdrop is open

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function AppHeaderDirective(eventsService, appState, userService) {
+    function AppHeaderDirective(eventsService, appState, userService, focusService) {
 
         function link(scope, el, attr, ctrl) {
 
@@ -54,7 +54,9 @@
                     }
                 });
             }));
-
+            
+            scope.rememberFocus = focusService.rememberFocus;
+            
             scope.searchClick = function() {
                 var showSearch = appState.getSearchState("show");
                 appState.setSearchState("show", !showSearch);

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsearch.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsearch.directive.js
@@ -27,7 +27,7 @@
         vm.focusSearch = focusSearch;
         
         //we need to capture the focus before this element is initialized.
-        vm.focusBeforeOpening = focusService.lastKnownFocus;
+        vm.focusBeforeOpening = focusService.getLastKnownFocus();
 
         function onInit() {
             vm.searchQuery = "";

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsearch.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsearch.directive.js
@@ -13,7 +13,7 @@
         }
     };
     
-    function umbSearchController($timeout, backdropService, searchService) {
+    function umbSearchController($timeout, backdropService, searchService, focusService) {
 
         var vm = this;
 
@@ -25,6 +25,9 @@
         vm.handleKeyUp = handleKeyUp;
         vm.closeSearch = closeSearch;
         vm.focusSearch = focusSearch;
+        
+        //we need to capture the focus before this element is initialized.
+        vm.focusBeforeOpening = focusService.lastKnownFocus;
 
         function onInit() {
             vm.searchQuery = "";
@@ -70,6 +73,10 @@
          * @param {object} event
          */
         function handleKeyUp(event) {
+            
+            event.stopPropagation();
+            event.preventDefault();
+            
             // esc
             if(event.keyCode === 27) {
                 closeSearch();
@@ -80,6 +87,9 @@
          * Used to proxy a callback
          */
         function closeSearch() {
+            if(vm.focusBeforeOpening) {
+                vm.focusBeforeOpening.focus();
+            }
             if(vm.onClose) {
                 vm.onClose();
             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/hotkey.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/hotkey.directive.js
@@ -4,7 +4,7 @@
 **/
 
 angular.module("umbraco.directives")
-    .directive('hotkey', function($window, keyboardService, $log) {
+    .directive('hotkey', function($window, keyboardService, $log, focusService) {
 
         return function(scope, el, attrs) {
 
@@ -28,7 +28,9 @@ angular.module("umbraco.directives")
                     }
 
                     keyboardService.bind(keyCombo, function() {
-
+                        
+                        focusService.rememberFocus();
+                        
                         var element = $(el);
                         var activeElementType = document.activeElement.tagName;
                         var clickableElements = ["A", "BUTTON"];
@@ -47,6 +49,8 @@ angular.module("umbraco.directives")
                                 } else {
                                     element.trigger("click");
                                 }
+                                
+                                keyboardService.stopPropagation()
 
                             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/hotkey.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/hotkey.directive.js
@@ -49,8 +49,6 @@ angular.module("umbraco.directives")
                                 } else {
                                     element.trigger("click");
                                 }
-                                
-                                keyboardService.stopPropagation()
 
                             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
@@ -295,7 +295,8 @@ Opens an overlay to show a custom YSOD. </br>
                           scope.closeOverLay();
                       });
                   }
-
+                  
+                  event.stopPropagation();
                   event.preventDefault();
                }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -164,9 +164,22 @@ When building a custom infinite editor view you can use the same components as a
     "use strict";
 
     function editorService(eventsService, keyboardService, $timeout) {
-
+        
+        
         let editorsKeyboardShorcuts = [];
         var editors = [];
+        var isEnabled = true;
+        
+        
+        // events for backdrop
+        eventsService.on("appState.backdrop", function (name, args) {
+            if (args.show === true) {
+                blur();
+            } else {
+                focus();
+            }
+        });
+        
 
         /**
          * @ngdoc method
@@ -191,7 +204,43 @@ When building a custom infinite editor view you can use the same components as a
         function getNumberOfEditors() {
             return editors.length;
         };
+        
+        /**
+         * @ngdoc method
+         * @name umbraco.services.editorService#blur
+         * @methodOf umbraco.services.editorService
+         *
+         * @description
+         * Method to tell editors that they are begin blurred.
+         */
+        function blur() {
 
+            /* keyboard shortcuts will be overwritten by the new infinite editor
+                so we need to store the shortcuts for the current editor so they can be rebound
+                when the infinite editor closes
+            */
+            unbindKeyboardShortcuts();
+            isEnabled = false;
+        }
+        /**
+         * @ngdoc method
+         * @name umbraco.services.editorService#blur
+         * @methodOf umbraco.services.editorService
+         *
+         * @description
+         * Method to tell editors that they are gaining focus again.
+         */
+        function focus() {
+            if(isEnabled === false) {
+                /* keyboard shortcuts will be overwritten by the new infinite editor
+                    so we need to store the shortcuts for the current editor so they can be rebound
+                    when the infinite editor closes
+                */
+                rebindKeyboardShortcuts();
+                isEnabled = true;
+            }
+        }
+        
         /**
          * @ngdoc method
          * @name umbraco.services.editorService#open

--- a/src/Umbraco.Web.UI.Client/src/common/services/focus.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/focus.service.js
@@ -1,0 +1,72 @@
+/**
+ @ngdoc service
+ * @name umbraco.services.focusService
+ *
+ * @description
+ * <b>Added in Umbraco 8.1</b>. Application-wide service for focus related stuff.
+ * 
+ */
+
+(function () {
+    "use strict";
+
+    function focusService() {
+        
+        
+        function focusInApp(e) {
+            service.currentFocus = e.target;
+        }
+        document.addEventListener('focusin', focusInApp);
+        
+        
+        var service = {
+            currentFocus: null,
+            
+            /**
+    		 * @ngdoc property
+             * @name umbraco.services.focusService#lastKnownFocus
+		     * @propertyOf umbraco.services.focusService
+             *
+             * @description
+             * A element set to be remembered, the directive using this should store the value of this to make sure that its not changed white using that directive.
+             * This variable is avaiable for directives that are not able to figure out the focused element on init, and there this service will help remembering it untill the directive is initialized.
+             * 
+             */
+            lastKnownFocus: null,
+            
+            /**
+             * @ngdoc function
+             * @name umbraco.services.focusService#rememberFocus
+             * @methodOf umbraco.services.focusService
+             * @function
+             *
+             * @description
+             * Call this before a new focus is begin set, to be able to return to the focus before a given scenario.
+             * 
+             */
+            rememberFocus: function() {
+                service.lastKnownFocus = service.currentFocus;
+            },
+            
+            /**
+             * @ngdoc function
+             * @name umbraco.services.focusService#setLastKnownFocus
+             * @methodOf umbraco.services.focusService
+             * @function
+             *
+             * @description
+             * Overwrite the element remembered as the last known element in focus.
+             * 
+             */
+            setLastKnownFocus: function(element) {
+                service.lastKnownFocus = element;
+            }
+        };
+
+        return service;
+
+    }
+    
+    angular.module("umbraco.services").factory("focusService", focusService);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/common/services/focus.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/focus.service.js
@@ -26,12 +26,13 @@
         var service = {
             
             /**
-    		 * @ngdoc property
-             * @name umbraco.services.focusService#lastKnownFocus
-		     * @propertyOf umbraco.services.focusService
+            * @ngdoc function
+            * @name umbraco.services.focusService#getLastKnownFocus
+            * @methodOf umbraco.services.focusService
+            * @function
              *
              * @description
-             * A element set to be remembered, the directive using this should store the value of this to make sure that its not changed white using that directive.
+             * Gives the element that was set to be remembered, the directive using this should store the value of this to make sure that its not changed white using that directive.
              * This variable is avaiable for directives that are not able to figure out the focused element on init, and there this service will help remembering it untill the directive is initialized.
              * 
              */

--- a/src/Umbraco.Web.UI.Client/src/common/services/focus.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/focus.service.js
@@ -13,14 +13,17 @@
     function focusService() {
         
         
+        var currentFocus = null;
+        var lastKnownFocus = null;
+        
+        
         function focusInApp(e) {
-            service.currentFocus = e.target;
+            currentFocus = e.target;
         }
         document.addEventListener('focusin', focusInApp);
         
         
         var service = {
-            currentFocus: null,
             
             /**
     		 * @ngdoc property
@@ -32,7 +35,9 @@
              * This variable is avaiable for directives that are not able to figure out the focused element on init, and there this service will help remembering it untill the directive is initialized.
              * 
              */
-            lastKnownFocus: null,
+            getLastKnownFocus: function() {
+                return lastKnownFocus;
+            },
             
             /**
              * @ngdoc function
@@ -45,7 +50,7 @@
              * 
              */
             rememberFocus: function() {
-                service.lastKnownFocus = service.currentFocus;
+                lastKnownFocus = currentFocus;
             },
             
             /**
@@ -59,7 +64,7 @@
              * 
              */
             setLastKnownFocus: function(element) {
-                service.lastKnownFocus = element;
+                lastKnownFocus = element;
             }
         };
 

--- a/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/controllers/main.controller.js
@@ -8,7 +8,9 @@
  * The main application controller
  * 
  */
-function MainController($scope, $location, appState, treeService, notificationsService, userService, historyService, updateChecker, assetsService, eventsService, tmhDynamicLocale, localStorageService, editorService, overlayService) {
+function MainController($scope, $location, appState, treeService, notificationsService, 
+    userService, historyService, updateChecker, assetsService, eventsService, 
+    tmhDynamicLocale, localStorageService, editorService, overlayService, focusService) {
 
     //the null is important because we do an explicit bool check on this in the view
     $scope.authenticated = null;

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
@@ -1,7 +1,7 @@
 <div>
 
     <div class="umb-app-header">
-        
+
         <umb-sections
             ng-if="authenticated"
             sections="sections">
@@ -10,7 +10,7 @@
         <div class="flex items-center">
             <ul class="umb-app-header__actions">
                 <li data-element="global-search" class="umb-app-header__action">
-                    <a href="#" hotkey="ctrl+space" ng-click="searchClick()" prevent-default style="font-size: 20px;">
+                    <a href="#" hotkey="ctrl+space" ng-click="searchClick()" ng-mousedown="rememberFocus()" prevent-default style="font-size: 20px;">
                         <i class="umb-app-header__action-icon icon-search"></i>
                     </a>
                 </li>
@@ -44,4 +44,3 @@
     </umb-overlay>
 
 </div>
-


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/5131

This PR contains:

- Added a Focus-Service that can be used to retrieve the previous focus.
- Returns to the previous focused element when closing search.
- Disables keyboard shortcuts on editors when backdrop is opened.

Should work like this:
![search_remember_focus](https://user-images.githubusercontent.com/6791648/57287579-1e877d00-70b8-11e9-9ae8-f917a382193d.gif)


And if navigating by keyboard, the escape keyboard-button should only close one layer at a time:
![search_remember_focus_by_keyboard](https://user-images.githubusercontent.com/6791648/57287582-21826d80-70b8-11e9-862b-616b6a1c6815.gif)
