### PR TITLE
WIP: Quirky situation when limiting a user or user-group to a start node thats not placed in the root.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -287,10 +287,10 @@ body.touch .umb-tree {
     left: 0px;
 }
 
-.no-access {
-    .umb-tree-icon,
-    .root-link,
-    .umb-tree-item__label {
+.no-access > .umb-tree-item__inner {
+    > .umb-tree-icon,
+    > .root-link,
+    > .umb-tree-item__label {
         color: @gray-7;
         cursor: not-allowed;
     }

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -196,22 +196,22 @@ namespace Umbraco.Web.Trees
                 entityId = entity.Id;
             }
 
-            IEntitySlim[] result;
+            //IEntitySlim[] result;
 
             // if a request is made for the root node but user has no access to
             // root node, return start nodes instead
-            if (entityId == Constants.System.Root && UserStartNodes.Contains(Constants.System.Root) == false)
-            {
-                result = UserStartNodes.Length > 0
-                    ? Services.EntityService.GetAll(UmbracoObjectType, UserStartNodes).ToArray()
-                    : Array.Empty<IEntitySlim>();
-            }
-            else
-            {
-                result = GetChildrenFromEntityService(entityId).ToArray();
-            }
+            //if (entityId == Constants.System.Root && UserStartNodes.Contains(Constants.System.Root) == false)
+            //{
+            //    result = UserStartNodes.Length > 0
+            //        ? Services.EntityService.GetAll(UmbracoObjectType, UserStartNodes).ToArray()
+            //        : Array.Empty<IEntitySlim>();
+            //}
+            //else
+            //{
+            //    result = GetChildrenFromEntityService(entityId).ToArray();
+            //}
 
-            return result;
+            return GetChildrenFromEntityService(entityId).ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION


### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #4696

### Description
I have uncomment some logic that does not make sense to me. Maybe someone from the core team knows why or what need to be changed. But for me the following line will always be false because entityId can't be the root and UserStartNodes never contains root:

`if (entityId == Constants.System.Root && UserStartNodes.Contains(Constants.System.Root) == false)`

To test it you add a subnode in content tree or media tree as a startnode to a user. Then you will get the strange behavior.

![53170657-f1f7b500-35e0-11e9-8dde-5cdce84f190f](https://user-images.githubusercontent.com/5310629/57329149-74d5d980-7113-11e9-92e3-ac0ddb43ea7c.png)