### PR TITLE
V8: Fix duplicate alias exception in "convert media URLs" migration

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
 
             var sqlPropertyData = Sql()
                 .Select<PropertyDataDto>()
-                    .AndSelect<PropertyTypeDto>()
+                    .AndSelect<PropertyTypeDto>(x => x.Alias)
                     .AndSelect<DataTypeDto>()
                 .From<PropertyDataDto>()
                     .InnerJoin<PropertyTypeDto>().On<PropertyDataDto, PropertyTypeDto>((left, right) => left.PropertyTypeId == right.Id)

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
@@ -26,9 +26,8 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                 RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
             var sqlPropertyData = Sql()
-                .Select<PropertyDataDto>()
-                    .AndSelect<PropertyTypeDto>(x => x.Alias)
-                    .AndSelect<DataTypeDto>()
+                .Select<PropertyDataDto>(x => x.Id, x => x.TextValue)
+                    .AndSelect<DataTypeDto>(x => x.EditorAlias)
                 .From<PropertyDataDto>()
                     .InnerJoin<PropertyTypeDto>().On<PropertyDataDto, PropertyTypeDto>((left, right) => left.PropertyTypeId == right.Id)
                     .InnerJoin<DataTypeDto>().On<PropertyTypeDto, DataTypeDto>((left, right) => left.DataTypeId == right.NodeId)
@@ -64,7 +63,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                     property.TextValue = UpdateMediaUrls(mediaLinkPattern, value);
                 }
 
-                Database.Update(property);
+                Database.Update(property, x => x.TextValue);
             }
 
             Context.AddPostMigration<RebuildPublishedSnapshot>();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There's an error in the migration introduced with #5209 (`ConvertTinyMceAndGridMediaUrlsToLocalLink`) that efficiently makes it impossible to migrate to v8.1.0 - the installer throws an exception due to an invalid SQL syntax: `The column aliases must be unique. [ Name of duplicate alias = Id ]`.

The offending SQL looks like this (notice the duplicate `as [Id]`):

```sql
SELECT [umbracoPropertyData].[id] AS [Id], [umbracoPropertyData].[versionId] AS [VersionId], [umbracoPropertyData].[propertyTypeId] AS [PropertyTypeId], [umbracoPropertyData].[languageId] AS [LanguageId], [umbracoPropertyData].[segment] AS [Segment], [umbracoPropertyData].[intValue] AS [IntegerValue], [umbracoPropertyData].[decimalValue] AS [DecimalValue], [umbracoPropertyData].[dateValue] AS [DateValue], [umbracoPropertyData].[varcharValue] AS [VarcharValue], [umbracoPropertyData].[textValue] AS [TextValue]
, [cmsPropertyType].[id] AS [Id], [cmsPropertyType].[dataTypeId] AS [DataTypeId], [cmsPropertyType].[contentTypeId] AS [ContentTypeId], [cmsPropertyType].[propertyTypeGroupId] AS [PropertyTypeGroupId], [cmsPropertyType].[Alias] AS [Alias], [cmsPropertyType].[Name] AS [Name], [cmsPropertyType].[sortOrder] AS [SortOrder], [cmsPropertyType].[mandatory] AS [Mandatory], [cmsPropertyType].[validationRegExp] AS [ValidationRegExp], [cmsPropertyType].[Description] AS [Description], [cmsPropertyType].[variations] AS [Variations], [cmsPropertyType].[UniqueID] AS [UniqueId]
, [umbracoDataType].[nodeId] AS [NodeId], [umbracoDataType].[propertyEditorAlias] AS [EditorAlias], [umbracoDataType].[dbType] AS [DbType], [umbracoDataType].[config] AS [Configuration]
FROM [umbracoPropertyData]
INNER JOIN [cmsPropertyType]
ON ([umbracoPropertyData].[propertyTypeId] = [cmsPropertyType].[id])
INNER JOIN [umbracoDataType]
ON ([cmsPropertyType].[dataTypeId] = [umbracoDataType].[nodeId])
WHERE ((([umbracoDataType].[propertyEditorAlias] = @0) OR ([umbracoDataType].[propertyEditorAlias] = @1)))
```

This PR fixes the migration by leaving out all the columns from `cmsPropertyType` except `Alias`. It works fine since the migration doesn't actually use these data for anything.
