### PR TITLE
Fixes #4144 - AllowManuallyChangingPassword Regression Fix

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -131,9 +131,9 @@ function MemberEditController($scope, $routeParams, $location, $q, $window, appS
             $scope.busy = true;
             $scope.page.saveButtonState = "busy";
 
-            //anytime a user is changing a member's password, we are in effect resetting it so we need to set that flag here
+            //anytime a user is changing a member's password without the oldPassword, we are in effect resetting it so we need to set that flag here
             var passwordProp = _.find(contentEditingHelper.getAllProps($scope.content), function (e) { return e.alias === '_umb_password' });
-            passwordProp.value.reset = true;
+            passwordProp.value.reset = !passwordProp.value.oldPassword && passwordProp.config.allowManuallyChangingPassword;
 
             memberResource.save($scope.content, $routeParams.create, fileManager.getFiles())
                 .then(function(data) {

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -133,7 +133,10 @@ function MemberEditController($scope, $routeParams, $location, $q, $window, appS
 
             //anytime a user is changing a member's password without the oldPassword, we are in effect resetting it so we need to set that flag here
             var passwordProp = _.find(contentEditingHelper.getAllProps($scope.content), function (e) { return e.alias === '_umb_password' });
-            passwordProp.value.reset = !passwordProp.value.oldPassword && passwordProp.config.allowManuallyChangingPassword;
+            if (!passwordProp.value.reset) {
+                //so if the admin is not explicitly resetting the password, flag it for resetting if a new password is being entered
+                passwordProp.value.reset = !passwordProp.value.oldPassword && passwordProp.config.allowManuallyChangingPassword;
+            }
 
             memberResource.save($scope.content, $routeParams.create, fileManager.getFiles())
                 .then(function(data) {

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -131,6 +131,10 @@ function MemberEditController($scope, $routeParams, $location, $q, $window, appS
             $scope.busy = true;
             $scope.page.saveButtonState = "busy";
 
+            //anytime a user is changing a member's password, we are in effect resetting it so we need to set that flag here
+            var passwordProp = _.find(contentEditingHelper.getAllProps($scope.content), function (e) { return e.alias === '_umb_password' });
+            passwordProp.value.reset = true;
+
             memberResource.save($scope.content, $routeParams.create, fileManager.getFiles())
                 .then(function(data) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -135,7 +135,10 @@
 
                 //anytime a user is changing another user's password, we are in effect resetting it so we need to set that flag here
                 if (vm.user.changePassword) {
-                    vm.user.changePassword.reset = !vm.user.changePassword.oldPassword && !vm.user.isCurrentUser;
+                    //NOTE: the check for allowManuallyChangingPassword is due to this legacy user membership provider setting, if that is true, then the current user
+                    //can change their own password without entering their current one (this is a legacy setting since that is a security issue but we need to maintain compat).
+                    //if allowManuallyChangingPassword=false, then we are using default settings and the user will need to enter their old password to change their own password.
+                    vm.user.changePassword.reset = (!vm.user.changePassword.oldPassword && !vm.user.isCurrentUser) || vm.changePasswordModel.config.allowManuallyChangingPassword;
                 }
 
                 vm.page.saveButtonState = "busy";

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -251,13 +251,12 @@
                     </umb-button>
                 </div>
                 <div>
-                    <umb-button type="button" ng-if="model.user.userDisplayState.key !== 'Invited'"
+                    <umb-button type="button" ng-if="model.user.userDisplayState.key !== 'Invited' && model.changePasswordModel.isChanging === false"
                                 button-style="[info,block]"
                                 action="model.toggleChangePassword()"
                                 label="Change password"
                                 label-key="general_changePassword"
                                 state="changePasswordButtonState"
-                                ng-if="model.changePasswordModel.isChanging === false"
                                 size="s">
                     </umb-button>
                 </div>

--- a/src/Umbraco.Web/Editors/PasswordChanger.cs
+++ b/src/Umbraco.Web/Editors/PasswordChanger.cs
@@ -250,25 +250,6 @@ namespace Umbraco.Web.Editors
                 return Attempt.Fail(new PasswordChangedModel { ChangeError = new ValidationResult("Cannot set an empty password", new[] { "value" }) });
             }
 
-            //This is an edge case and is only necessary for backwards compatibility:
-            if (umbracoBaseProvider != null && umbracoBaseProvider.AllowManuallyChangingPassword)
-            {
-                //this provider allows manually changing the password without the old password, so we can just do it
-                try
-                {
-                    var result = umbracoBaseProvider.ChangePassword(username, "", passwordModel.NewPassword);
-                    return result == false
-                        ? Attempt.Fail(new PasswordChangedModel { ChangeError = new ValidationResult("Could not change password, invalid username or password", new[] { "value" }) })
-                        : Attempt.Succeed(new PasswordChangedModel());
-                }
-                catch (Exception ex)
-                {
-                    _logger.WarnWithException<PasswordChanger>("Could not change member password", ex);
-                    return Attempt.Fail(new PasswordChangedModel { ChangeError = new ValidationResult("Could not change password, error: " + ex.Message + " (see log for full details)", new[] { "value" }) });
-                }
-            }
-
-
             //without being able to retrieve the original password, 
             //we cannot arbitrarily change the password without knowing the old one and no old password was supplied - need to return an error
             if (passwordModel.OldPassword.IsNullOrWhiteSpace() && membershipProvider.EnablePasswordRetrieval == false)


### PR DESCRIPTION
Fixes #4144 by adding back the code that was removed in this commit - b0292159331f62ca755fa855b5ed30a98974387d

## Test/Review notes
* Sanity check the changes
* Test you can change the password of a member when the web.config for the membership provider has `allowManuallyChangingPassword ` set to `true`