### PR TITLE
V8: Remove preload from HSTS healthcheck

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2036,7 +2036,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="noSniffSetHeaderInConfigSuccess">A setting to create a header protecting against MIME sniffing vulnerabilities has been added to your web.config file.</key>
     <key alias="hSTSCheckHeaderFound"><![CDATA[The header <strong>Strict-Transport-Security</strong>, also known as the HSTS-header, was found.]]></key>
     <key alias="hSTSCheckHeaderNotFound"><![CDATA[The header <strong>Strict-Transport-Security</strong> was not found.]]></key>
-    <key alias="hSTSSetHeaderInConfigDescription">Adds the header 'Strict-Transport-Security' with the value 'max-age=10886400; preload' to the httpProtocol/customHeaders section of web.config. Use this fix only if you will have your domains running with https for the next 18 weeks (minimum).</key>
+    <key alias="hSTSSetHeaderInConfigDescription">Adds the header 'Strict-Transport-Security' with the value 'max-age=10886400' to the httpProtocol/customHeaders section of web.config. Use this fix only if you will have your domains running with https for the next 18 weeks (minimum).</key>
     <key alias="hSTSSetHeaderInConfigSuccess">The HSTS header has been added to your web.config file.</key>
     <key alias="xssProtectionCheckHeaderFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was found.]]></key>
     <key alias="xssProtectionCheckHeaderNotFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was not found.]]></key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2050,7 +2050,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="noSniffSetHeaderInConfigSuccess">A setting to create a header protecting against MIME sniffing vulnerabilities has been added to your web.config file.</key>
     <key alias="hSTSCheckHeaderFound"><![CDATA[The header <strong>Strict-Transport-Security</strong>, also known as the HSTS-header, was found.]]></key>
     <key alias="hSTSCheckHeaderNotFound"><![CDATA[The header <strong>Strict-Transport-Security</strong> was not found.]]></key>
-    <key alias="hSTSSetHeaderInConfigDescription">Adds the header 'Strict-Transport-Security' with the value 'max-age=10886400; preload' to the httpProtocol/customHeaders section of web.config. Use this fix only if you will have your domains running with https for the next 18 weeks (minimum).</key>
+    <key alias="hSTSSetHeaderInConfigDescription">Adds the header 'Strict-Transport-Security' with the value 'max-age=10886400' to the httpProtocol/customHeaders section of web.config. Use this fix only if you will have your domains running with https for the next 18 weeks (minimum).</key>
     <key alias="hSTSSetHeaderInConfigSuccess">The HSTS header has been added to your web.config file.</key>
     <key alias="xssProtectionCheckHeaderFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was found.]]></key>
     <key alias="xssProtectionCheckHeaderNotFound"><![CDATA[The header <strong>X-XSS-Protection</strong> was not found.]]></key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
@@ -1813,7 +1813,7 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="noSniffSetHeaderInConfigSuccess">Une configuration a été ajoutée dans votre fichier web.config pour créer un header protégeant contre les vulnérabilités de MIME sniffing.</key>
     <key alias="hSTSCheckHeaderFound"><![CDATA[L'en-tête <strong>Strict-Transport-Security</strong>, aussi connu sous le nom de HSTS-header, a été trouvé.]]></key>
     <key alias="hSTSCheckHeaderNotFound"><![CDATA[L'en-tête <strong>Strict-Transport-Security</strong>, aussi connu sous le nom de HSTS-header, n'a pas été trouvé.]]></key>
-    <key alias="hSTSSetHeaderInConfigDescription">Ajoute l'en-tête 'Strict-Transport-Security' avec la valeur 'max-age=10886400; preload' à la section httpProtocol/customHeaders du fichier web.config. Utilisez cette correction uniquement si vos domaines vont fonctionner en https pour les 18 prochaines semaines (minimum).</key>
+    <key alias="hSTSSetHeaderInConfigDescription">Ajoute l'en-tête 'Strict-Transport-Security' avec la valeur 'max-age=10886400' à la section httpProtocol/customHeaders du fichier web.config. Utilisez cette correction uniquement si vos domaines vont fonctionner en https pour les 18 prochaines semaines (minimum).</key>
     <key alias="hSTSSetHeaderInConfigSuccess">L'en-tête HSTS a été ajouté dans votre fichier web.config.</key>
     <key alias="xssProtectionCheckHeaderFound"><![CDATA[L'en-tête <strong>X-XSS-Protection</strong> a été trouvé.]]></key>
     <key alias="xssProtectionCheckHeaderNotFound"><![CDATA[L'en-tête <strong>X-XSS-Protection</strong> n'a pas été trouvé.]]></key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
@@ -743,7 +743,7 @@
     <key alias="noSniffSetHeaderInConfigSuccess">Значение, добавляющее заголовок, препятствующий использованию MIME-уязвимостей, успешно добавлено в файл web.config.</key>
     <key alias="hSTSCheckHeaderFound"><![CDATA[Заголовок <strong>Strict-Transport-Security</strong>, известный также как HSTS-header, обнаружен.]]></key>
     <key alias="hSTSCheckHeaderNotFound"><![CDATA[Заголовок <strong>Strict-Transport-Security</strong> не найден.]]></key>
-    <key alias="hSTSSetHeaderInConfigDescription">Добавляет заголовок 'Strict-Transport-Security' и его значение 'max-age=10886400; preload' в секцию httpProtocol/customHeaders файла web.config. Применяйте этот способ только в случае, если доступ к Вашим сайтам будет осуществляться по протоколу https как минимум ближайшие 18 недель.</key>
+    <key alias="hSTSSetHeaderInConfigDescription">Добавляет заголовок 'Strict-Transport-Security' и его значение 'max-age=10886400' в секцию httpProtocol/customHeaders файла web.config. Применяйте этот способ только в случае, если доступ к Вашим сайтам будет осуществляться по протоколу https как минимум ближайшие 18 недель.</key>
     <key alias="hSTSSetHeaderInConfigSuccess">Заголовок HSTS-header успешно добавлен в файл web.config.</key>
     <key alias="xssProtectionCheckHeaderFound"><![CDATA[Заголовок <strong>X-XSS-Protection</strong> обнаружен.]]></key>
     <key alias="xssProtectionCheckHeaderNotFound"><![CDATA[Заголовок <strong>X-XSS-Protection</strong> не найден.]]></key>

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HstsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HstsCheck.cs
@@ -11,9 +11,9 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
     public class HstsCheck : BaseHttpHeaderCheck
     {
         // The check is mostly based on the instructions in the OWASP CheatSheet
-        // (https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet)
+        // (https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.md)
         // and the blog post of Troy Hunt (https://www.troyhunt.com/understanding-http-strict-transport/)
-        // If you want do to it perfectly, you have to submit it https://hstspreload.appspot.com/,
+        // If you want do to it perfectly, you have to submit it https://hstspreload.org/,
         // but then you should include subdomains and I wouldn't suggest to do that for Umbraco-sites.
         public HstsCheck(IRuntimeState runtime, ILocalizedTextService textService)
             : base(runtime, textService, "Strict-Transport-Security", "max-age=10886400", "hSTS", true)

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HstsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HstsCheck.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
     [HealthCheck(
         "E2048C48-21C5-4BE1-A80B-8062162DF124",
         "Cookie hijacking and protocol downgrade attacks Protection (Strict-Transport-Security Header (HSTS))",
-        Description = "Checks if your site, when running with HTTPS, contains the Strict-Transport-Security Header (HSTS). If not, it adds with a default of 100 days.",
+        Description = "Checks if your site, when running with HTTPS, contains the Strict-Transport-Security Header (HSTS). If not, it adds with a default of 126 days.",
         Group = "Security")]
     public class HstsCheck : BaseHttpHeaderCheck
     {

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HstsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HstsCheck.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         // If you want do to it perfectly, you have to submit it https://hstspreload.appspot.com/,
         // but then you should include subdomains and I wouldn't suggest to do that for Umbraco-sites.
         public HstsCheck(IRuntimeState runtime, ILocalizedTextService textService)
-            : base(runtime, textService, "Strict-Transport-Security", "max-age=10886400; preload", "hSTS", true)
+            : base(runtime, textService, "Strict-Transport-Security", "max-age=10886400", "hSTS", true)
         {
         }
     }

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HstsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HstsCheck.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
     [HealthCheck(
         "E2048C48-21C5-4BE1-A80B-8062162DF124",
         "Cookie hijacking and protocol downgrade attacks Protection (Strict-Transport-Security Header (HSTS))",
-        Description = "Checks if your site, when running with HTTPS, contains the Strict-Transport-Security Header (HSTS). If not, it adds with a default of 126 days.",
+        Description = "Checks if your site, when running with HTTPS, contains the Strict-Transport-Security Header (HSTS). If not, it adds with a default of 18 weeks.",
         Group = "Security")]
     public class HstsCheck : BaseHttpHeaderCheck
     {


### PR DESCRIPTION
### Prerequisites

This fixes https://github.com/umbraco/Umbraco-CMS/issues/5292

### Description

- Removed `preload` from HSTS header and healthcheck translations
- Updated the outdated HSTS urls to the correct ones
- Corrected the header description from 100 days to 18 weeks (10886400 seconds)

![umbraco](https://user-images.githubusercontent.com/686835/57371237-26175680-718a-11e9-9ad8-70246af8c54c.gif)

