### PR TITLE
Corrected `EntityController.ConvertToObjectType` return type for MemberType

### DIFF
--- a/src/Umbraco.Web/Editors/EntityController.cs
+++ b/src/Umbraco.Web/Editors/EntityController.cs
@@ -893,7 +893,7 @@ namespace Umbraco.Web.Editors
                 case UmbracoEntityTypes.Media:
                     return UmbracoObjectTypes.Media;
                 case UmbracoEntityTypes.MemberType:
-                    return UmbracoObjectTypes.MediaType;
+                    return UmbracoObjectTypes.MemberType;
                 case UmbracoEntityTypes.MemberGroup:
                     return UmbracoObjectTypes.MemberGroup;
                 case UmbracoEntityTypes.MediaType:


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I found that when making a call to the `entityResource.getAll` (AngularJS) with the entity-type of "MemberType", it would return the entities for "MediaType".

Digging deeper, I found in the `EntityController` class, the switch statement in the `ConvertToObjectType` method was returning the wrong `UmbracoObjectTypes` enum.

See here: https://github.com/umbraco/Umbraco-CMS/blob/release-8.0.2/src/Umbraco.Web/Editors/EntityController.cs#L852-L853

I wasn't able to find any unit-tests for `EntityController`, so there's nothing automated to test this. But I've checked with `entityResource.getAll` and it now returns Member Types for me, (as expected).
