### PR TITLE
Fix noPasswordManager name for docs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/util/noPasswordManager.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/util/noPasswordManager.directive.js
@@ -1,6 +1,6 @@
 ﻿/**
 * @ngdoc directive
-* @name umbraco.directives.directive:no-password-manager
+* @name umbraco.directives.directive:noPasswordManager
 * @attribte
 * @function
 * @description


### PR DESCRIPTION
Fix `noPasswordManager` for documentation.
https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:no-password-manager

Note the different naming in the sidebar menu ;)

Btw. can we increase the sidebar width a bit and/or the page container width to avoid all those horizontal scrollbars in the sidebar? 😁 

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Just a simple and nice fix :)