### PR TITLE
5420: v8 Invited user keeps showing as "has not logged in yet"

### DIFF
--- a/src/Umbraco.Web/Editors/CurrentUserController.cs
+++ b/src/Umbraco.Web/Editors/CurrentUserController.cs
@@ -135,6 +135,8 @@ namespace Umbraco.Web.Editors
 
             //They've successfully set their password, we can now update their user account to be approved
             Security.CurrentUser.IsApproved = true;
+            //They've successfully set their password, and will now get fully logged into the back office, so the lastlogindate is set so the backoffice shows they have logged in
+            Security.CurrentUser.LastLoginDate = DateTime.UtcNow;
             Services.UserService.Save(Security.CurrentUser);
 
             //now we can return their full object since they are now really logged into the back office


### PR DESCRIPTION
This fixes https://github.com/umbraco/Umbraco-CMS/issues/5420

### Description
- Invite a new user to the backoffice
- user will set username/password
- DateTime of login will be set now, was not set before

