### PR TITLE
#5362 - stops whole branch being re-indexed and save and republish node

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -1194,6 +1194,9 @@ namespace Umbraco.Core.Services.Implement
                 {
                     if (isNew == false && previouslyPublished == false)
                         changeType = TreeChangeTypes.RefreshBranch; // whole branch
+                    else if (isNew == false && previouslyPublished)
+                        changeType = TreeChangeTypes.RefreshNode; // single node
+                    
 
                     // invalidate the node/branch
                     if (!branchOne) // for branches, handled by SaveAndPublishBranch
@@ -2494,7 +2497,7 @@ namespace Umbraco.Core.Services.Implement
             var variesByCulture = content.ContentType.VariesByCulture();
 
             var impactsToPublish = culturesPublishing == null
-                ? new[] {CultureImpact.Invariant} //if it's null it's invariant
+                ? new[] { CultureImpact.Invariant } //if it's null it's invariant
                 : culturesPublishing.Select(x => CultureImpact.Explicit(x, _languageRepository.IsDefault(x))).ToArray();
 
             // publish the culture(s)
@@ -2885,7 +2888,7 @@ namespace Umbraco.Core.Services.Implement
             {
                 foreach (var property in blueprint.Properties)
                 {
-					var propertyCulture = property.PropertyType.VariesByCulture() ? culture : null;
+                    var propertyCulture = property.PropertyType.VariesByCulture() ? culture : null;
                     content.SetValue(property.Alias, property.GetValue(propertyCulture), propertyCulture);
                 }
 

--- a/src/Umbraco.Tests/Integration/ContentEventsTests.cs
+++ b/src/Umbraco.Tests/Integration/ContentEventsTests.cs
@@ -639,7 +639,7 @@ namespace Umbraco.Tests.Integration
             var m = 0;
             Assert.AreEqual($"{m:000}: ContentRepository/Refresh/{content.Id}.p+p", _events[i++].ToString());
             m++;
-            Assert.AreEqual($"{m:000}: ContentCacheRefresher/RefreshBranch/{content.Id}", _events[i++].ToString());
+            Assert.AreEqual($"{m:000}: ContentCacheRefresher/RefreshNode/{content.Id}", _events[i++].ToString());
         }
 
         [Test]


### PR DESCRIPTION
Currently for non-new, published nodes, change type is always set to `TreeChangeTypes.RefreshBranch `causing cache to be refreshed for the whole branch. Should be `TreeChangeTypes.RefreshNode` where the node is pre-existing and is being re-published. Change stops descendants being included in Cache refresh.

**I'm relatively new to Umbraco V8, this is also a first ever PR, so all feedback is greatly appreciated.**

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [issue 5362](https://github.com/umbraco/Umbraco-CMS/issues/5362)

### Description
Updated logic in `ContentService `to take into account that for existing, published nodes, when re-publishing, the `TreeTypeChange `should be `RefreshNode `and not `RefreshBranch`. Refreshing the branch causes all descendants to be processed when refreshing the cache, leading to excessively ling processing times when there are a large number of descendants.

`SaveAndPublishPublishedContent()` test updated to reflect changes to content service.


<!-- Thanks for contributing to Umbraco CMS! -->
