### PR TITLE
V8: Show loading indicator while the Nested Content editor is loading

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -96,7 +96,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
 
     function ($scope, $interpolate, $filter, $timeout, contentResource, localizationService, iconHelper) {
 
-        var inited = false;
+        $scope.inited = false;
 
         _.each($scope.model.config.contentTypes, function (contentType) {
             contentType.nameExp = !!contentType.nameTemplate
@@ -381,7 +381,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
                     $scope.currentNode = $scope.nodes[0];
                 }
 
-                inited = true;
+                $scope.inited = true;
             }
         }
 
@@ -421,7 +421,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             if ($scope.realCurrentNode) {
                 $scope.$broadcast("ncSyncVal", { key: $scope.realCurrentNode.key });
             }
-            if (inited) {
+            if ($scope.inited) {
                 var newValues = [];
                 for (var i = 0; i < $scope.nodes.length; i++) {
                     var node = $scope.nodes[i];

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -95,8 +95,6 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
     "eventsService",
     
     function ($scope, $interpolate, $filter, $timeout, contentResource, localizationService, iconHelper, clipboardService, eventsService) {
-
-        $scope.inited = false;
         
         var contentTypeAliases = [];
         _.each($scope.model.config.contentTypes, function (contentType) {
@@ -114,6 +112,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
         $scope.realCurrentNode = undefined;
         $scope.scaffolds = undefined;
         $scope.sorting = false;
+        $scope.inited = false;
 
         $scope.minItems = $scope.model.config.minItems || 0;
         $scope.maxItems = $scope.model.config.maxItems || 0;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -1,7 +1,10 @@
 ﻿<div id="umb-nested-content--{{model.id}}" class="umb-nested-content"
      ng-controller="Umbraco.PropertyEditors.NestedContent.PropertyEditorController"
      ng-class="{'umb-nested-content--narrow':!wideMode, 'umb-nested-content--wide':wideMode}">
-    <ng-form>
+
+    <umb-load-indicator ng-if="!inited"></umb-load-indicator>
+
+    <ng-form ng-if="inited">
 
         <div class="umb-nested-content__items" ng-hide="nodes.length == 0" ui-sortable="sortableOptions" ng-model="nodes">
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The Nested Content editor has to fetch scaffolds for all item types before it's ready. While doing so the editor looks empty, even if it has items - the items won't show until scaffolds have all loaded.

As the list of item types grow for the Nested Content config, the load time starts to show, and for a moment (or more, depending on network latency and server location), the editor is left wondering (or panicking):

![nc-load-indicator-before](https://user-images.githubusercontent.com/7405322/57552056-ed82a300-736a-11e9-9030-5b46a9e7e24d.gif)

This PR adds a loading indicator to the Nested Content editor so it looks like it's doing something while loading:

![nc-load-indicator-after](https://user-images.githubusercontent.com/7405322/57552145-418d8780-736b-11e9-963c-d65dabd4021d.gif)

