### PR TITLE
V8: Hide "Create new" header in Nested Content create item dialog if all items are filtered out

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
@@ -30,7 +30,7 @@
         </li>
     </ul>
 
-    <div class="umb-overlay__section-header" ng-if="::(model.pasteItems | filter:searchTerm).length > 0">
+    <div class="umb-overlay__section-header" ng-if="(model.availableItems | filter:searchTerm).length > 0">
         <h5><localize key="content_createEmpty">Create new</localize></h5>
     </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When you have more than 12 item types to choose from in Nested Content, a filter bar appears in the item type picker.

With the introduction of copy/paste (#5353), the applicable copied items are also filtered, which makes perfect sense. 

![image](https://user-images.githubusercontent.com/7405322/57553748-c24e8280-736f-11e9-8899-f71ffb22b149.png)

The "Paste from clipboard" header disappears if your filtering doesn't yield any results within the copied items... but the "Create new" header is still visible if your filtering doesn't yield any results within the item types:

![image](https://user-images.githubusercontent.com/7405322/57553646-6e439e00-736f-11e9-9aac-32967ea1c960.png)

This PR fixes just that:

![image](https://user-images.githubusercontent.com/7405322/57553678-89161280-736f-11e9-8283-9677a453db0f.png)

/cc @nielslyngsoe 

#### Testing this PR

1. Create a NC config with 13 item types (yikes! copy content type is your friend here!).
2. Copy some items from within an NC editor of that type.
3. Select "Add Content" on the NC editor.
4. Use the filter to filter out all item types, leaving only (some of) the copied items as selectable in the item picker.
5. Verify that the "Create new" header is not displayed.
