### PR TITLE
Multi URL Picker enhancements: Content property and only save manually entered link name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -1,192 +1,185 @@
 //used for the media picker dialog
-angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
-    function ($scope, eventsService, dialogService, entityResource, contentResource, mediaHelper, userService, localizationService, tinyMceService) {
-        var dialogOptions = $scope.model;
+angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController", function ($scope, eventsService, entityResource, contentResource, mediaHelper, userService, localizationService, tinyMceService) {
+    if (!$scope.model.title) {
+        $scope.model.title = localizationService.localize("defaultdialogs_selectLink");
+    }
 
-        var searchText = "Search...";
-        localizationService.localize("general_search").then(function (value) {
-            searchText = value + "...";
-        });
+    $scope.placeholders_entername = localizationService.localize("placeholders_entername");
 
-        if (!$scope.model.title) {
-            $scope.model.title = localizationService.localize("defaultdialogs_selectLink");
-        }
+    $scope.dialogTreeEventHandler = $({});
+    $scope.model.target = {};
+    $scope.searchInfo = {
+        searchFromId: null,
+        searchFromName: null,
+        showSearch: false,
+        ignoreUserStartNodes: $scope.model.ignoreUserStartNodes,
+        results: [],
+        selectedSearchResults: []
+    };
+    $scope.customTreeParams = $scope.model.ignoreUserStartNodes ? "ignoreUserStartNodes=" + $scope.model.ignoreUserStartNodes : "";
+    $scope.showTarget = $scope.model.hideTarget !== true;
 
-        $scope.dialogTreeEventHandler = $({});
-        $scope.model.target = {};
-        $scope.searchInfo = {
-            searchFromId: null,
-            searchFromName: null,
-            showSearch: false,
-            ignoreUserStartNodes: dialogOptions.ignoreUserStartNodes,
-            results: [],
-            selectedSearchResults: []
-        };
-        $scope.customTreeParams = dialogOptions.ignoreUserStartNodes ? "ignoreUserStartNodes=" + dialogOptions.ignoreUserStartNodes : "";
-        $scope.showTarget = $scope.model.hideTarget !== true;
+    if ($scope.model.currentTarget) {
+        // clone the current target so we don't accidentally update the caller's model while manipulating $scope.model.target
+        $scope.model.target = angular.copy($scope.model.currentTarget);
 
-        if (dialogOptions.currentTarget) {
-            // clone the current target so we don't accidentally update the caller's model while manipulating $scope.model.target
-            $scope.model.target = angular.copy(dialogOptions.currentTarget);
-            //if we have a node ID, we fetch the current node to build the form data
-            if ($scope.model.target.id || $scope.model.target.udi) {
+        // if we have a node ID, we fetch the current node to build the form data
+        if ($scope.model.target.id || $scope.model.target.udi) {
+            // will be either a udi or an int
+            var id = $scope.model.target.udi ? $scope.model.target.udi : $scope.model.target.id;
 
-                //will be either a udi or an int
-                var id = $scope.model.target.udi ? $scope.model.target.udi : $scope.model.target.id;
-
-                // is it a content link?
-                if (!$scope.model.target.isMedia) {
-                    // get the content path
-                    entityResource.getPath(id, "Document").then(function (path) {
-                        //now sync the tree to this path
-                        $scope.dialogTreeEventHandler.syncTree({
-                            path: path,
-                            tree: "content"
-                        });
+            // is it a content link?
+            if (!$scope.model.target.isMedia) {
+                // get the content path
+                entityResource.getPath(id, "Document").then(function (path) {
+                    // now sync the tree to this path
+                    $scope.dialogTreeEventHandler.syncTree({
+                        path: path,
+                        tree: "content"
                     });
+                });
 
-                    // if a link exists, get the properties to build the anchor name list
-                    contentResource.getById(id, { ignoreUserStartNodes: dialogOptions.ignoreUserStartNodes }).then(function (resp) {
-                        $scope.model.target.url = resp.urls[0];
-                        $scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
-                    });
-                }
-            } else if ($scope.model.target.url.length) {
-                // a url but no id/udi indicates an external link - trim the url to remove the anchor/qs
-                // only do the substring if there's a # or a ?
-                var indexOfAnchor = $scope.model.target.url.search(/(#|\?)/);
-                if (indexOfAnchor > -1) {
-                    // populate the anchor
-                    $scope.model.target.anchor = $scope.model.target.url.substring(indexOfAnchor);
-                    // then rewrite the model and populate the link
-                    $scope.model.target.url = $scope.model.target.url.substring(0, indexOfAnchor);
-                }
-            }
-        } else if (dialogOptions.anchors) {
-            $scope.anchorValues = dialogOptions.anchors;
-        }
-
-        function nodeSelectHandler(ev, args) {
-            if (args && args.event) {
-                args.event.preventDefault();
-                args.event.stopPropagation();
-            }
-
-            eventsService.emit("dialogs.linkPicker.select", args);
-
-            if ($scope.currentNode) {
-                //un-select if there's a current one selected
-                $scope.currentNode.selected = false;
-            }
-
-            $scope.currentNode = args.node;
-            $scope.currentNode.selected = true;
-            $scope.model.target.id = args.node.id;
-            $scope.model.target.udi = args.node.udi;
-            $scope.model.target.name = args.node.name;
-
-            if (args.node.id < 0) {
-                $scope.model.target.url = "/";
-            } else {
-                contentResource.getById(args.node.id, { ignoreUserStartNodes: dialogOptions.ignoreUserStartNodes }).then(function (resp) {
+                // if a link exists, get the properties to build the anchor name list
+                contentResource.getById(id, { ignoreUserStartNodes: $scope.model.ignoreUserStartNodes }).then(function (resp) {
                     $scope.model.target.url = resp.urls[0];
                     $scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
                 });
             }
-
-            if (!angular.isUndefined($scope.model.target.isMedia)) {
-                delete $scope.model.target.isMedia;
+        } else if ($scope.model.target.url) {
+            // a url but no id/udi indicates an external link - trim the url to remove the anchor/qs
+            // only do the substring if there's a # or a ?
+            var indexOfAnchor = $scope.model.target.url.search(/(#|\?)/);
+            if (indexOfAnchor > -1) {
+                // populate the anchor
+                $scope.model.target.anchor = $scope.model.target.url.substring(indexOfAnchor);
+                // then rewrite the model and populate the link
+                $scope.model.target.url = $scope.model.target.url.substring(0, indexOfAnchor);
             }
         }
+    } else if ($scope.model.anchors) {
+        $scope.anchorValues = $scope.model.anchors;
+    }
 
-        function nodeExpandedHandler(ev, args) {
-            // open mini list view for list views
-            if (args.node.metaData.isContainer) {
-                openMiniListView(args.node);
-            }
+    function nodeSelectHandler(ev, args) {
+        if (args && args.event) {
+            args.event.preventDefault();
+            args.event.stopPropagation();
         }
 
-        $scope.switchToMediaPicker = function () {
-            userService.getCurrentUser().then(function (userData) {
-                var startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
-                var startNodeIsVirtual = userData.startMediaIds.length !== 1;
+        eventsService.emit("dialogs.linkPicker.select", args);
 
-                if (dialogOptions.ignoreUserStartNodes) {
-                    startNodeId = -1;
-                    startNodeIsVirtual = true;
+        if ($scope.currentNode) {
+            // un-select if there's a current one selected
+            $scope.currentNode.selected = false;
+        }
+
+        $scope.currentNode = args.node;
+        $scope.currentNode.selected = true;
+        $scope.model.target.id = args.node.id;
+        $scope.model.target.udi = args.node.udi;
+        $scope.model.target[$scope.model.useNodeName ? 'nodeName' : 'name'] = args.node.name;
+
+        if (args.node.id < 0) {
+            $scope.model.target.url = "/";
+        } else {
+            contentResource.getById(args.node.id, { ignoreUserStartNodes: $scope.model.ignoreUserStartNodes }).then(function (resp) {
+                $scope.model.target.url = resp.urls[0];
+                $scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
+            });
+        }
+
+        if (!angular.isUndefined($scope.model.target.isMedia)) {
+            delete $scope.model.target.isMedia;
+        }
+    }
+
+    function nodeExpandedHandler(ev, args) {
+        // open mini list view for list views
+        if (args.node.metaData.isContainer) {
+            openMiniListView(args.node);
+        }
+    }
+
+    $scope.switchToMediaPicker = function () {
+        userService.getCurrentUser().then(function (userData) {
+            var startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
+            var startNodeIsVirtual = userData.startMediaIds.length !== 1;
+
+            if ($scope.model.ignoreUserStartNodes) {
+                startNodeId = -1;
+                startNodeIsVirtual = true;
+            }
+            $scope.mediaPickerOverlay = {
+                view: "mediapicker",
+                startNodeId: startNodeId,
+                startNodeIsVirtual: startNodeIsVirtual,
+                show: true,
+                ignoreUserStartNodes: $scope.model.ignoreUserStartNodes,
+                submit: function (model) {
+                    var media = model.selectedImages[0];
+
+                    $scope.model.target.id = media.id;
+                    $scope.model.target.udi = media.udi;
+                    $scope.model.target.isMedia = true;
+                    $scope.model.target[$scope.model.useNodeName ? 'nodeName' : 'name'] = media.name;
+                    $scope.model.target.url = mediaHelper.resolveFile(media);
+
+                    $scope.mediaPickerOverlay.show = false;
+                    $scope.mediaPickerOverlay = null;
+
+                    // make sure the content tree has nothing highlighted 
+                    $scope.dialogTreeEventHandler.syncTree({
+                        path: "-1",
+                        tree: "content"
+                    });
                 }
-                $scope.mediaPickerOverlay = {
-                    view: "mediapicker",
-                    startNodeId: startNodeId,
-                    startNodeIsVirtual: startNodeIsVirtual,
-                    show: true,
-                    ignoreUserStartNodes: dialogOptions.ignoreUserStartNodes,
-                    submit: function (model) {
-                        var media = model.selectedImages[0];
-
-                        $scope.model.target.id = media.id;
-                        $scope.model.target.udi = media.udi;
-                        $scope.model.target.isMedia = true;
-                        $scope.model.target.name = media.name;
-                        $scope.model.target.url = mediaHelper.resolveFile(media);
-
-                        $scope.mediaPickerOverlay.show = false;
-                        $scope.mediaPickerOverlay = null;
-
-                        // make sure the content tree has nothing highlighted 
-                        $scope.dialogTreeEventHandler.syncTree({
-                            path: "-1",
-                            tree: "content"
-                        });
-                    }
-                };
-            });
-        };
-
-        $scope.hideSearch = function () {
-            $scope.searchInfo.showSearch = false;
-            $scope.searchInfo.searchFromId = null;
-            $scope.searchInfo.searchFromName = null;
-            $scope.searchInfo.results = [];
-        }
-
-        // method to select a search result
-        $scope.selectResult = function (evt, result) {
-            result.selected = result.selected === true ? false : true;
-            nodeSelectHandler(evt, {
-                event: evt,
-                node: result
-            });
-        };
-
-        //callback when there are search results
-        $scope.onSearchResults = function (results) {
-            $scope.searchInfo.results = results;
-            $scope.searchInfo.showSearch = true;
-        };
-
-        $scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
-        $scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
-
-        $scope.$on('$destroy', function () {
-            $scope.dialogTreeEventHandler.unbind("treeNodeSelect", nodeSelectHandler);
-            $scope.dialogTreeEventHandler.unbind("treeNodeExpanded", nodeExpandedHandler);
+            };
         });
+    };
 
-        // Mini list view
-        $scope.selectListViewNode = function (node) {
-            node.selected = node.selected === true ? false : true;
-            nodeSelectHandler({}, {
-                node: node
-            });
-        };
+    $scope.hideSearch = function () {
+        $scope.searchInfo.showSearch = false;
+        $scope.searchInfo.searchFromId = null;
+        $scope.searchInfo.searchFromName = null;
+        $scope.searchInfo.results = [];
+    }
 
-        $scope.closeMiniListView = function () {
-            $scope.miniListView = undefined;
-        };
+    // method to select a search result
+    $scope.selectResult = function (evt, result) {
+        result.selected = result.selected === true ? false : true;
+        nodeSelectHandler(evt, {
+            event: evt,
+            node: result
+        });
+    };
 
-        function openMiniListView(node) {
-            $scope.miniListView = node;
-        }
+    // callback when there are search results
+    $scope.onSearchResults = function (results) {
+        $scope.searchInfo.results = results;
+        $scope.searchInfo.showSearch = true;
+    };
 
+    $scope.dialogTreeEventHandler.bind("treeNodeSelect", nodeSelectHandler);
+    $scope.dialogTreeEventHandler.bind("treeNodeExpanded", nodeExpandedHandler);
+
+    $scope.$on('$destroy', function () {
+        $scope.dialogTreeEventHandler.unbind("treeNodeSelect", nodeSelectHandler);
+        $scope.dialogTreeEventHandler.unbind("treeNodeExpanded", nodeExpandedHandler);
     });
+
+    // Mini list view
+    $scope.selectListViewNode = function (node) {
+        node.selected = node.selected === true ? false : true;
+        nodeSelectHandler({}, {
+            node: node
+        });
+    };
+
+    $scope.closeMiniListView = function () {
+        $scope.miniListView = undefined;
+    };
+
+    function openMiniListView(node) {
+        $scope.miniListView = node;
+    }
+});

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
@@ -24,9 +24,8 @@
 
     <umb-control-group label="@defaultdialogs_nodeNameLinkPicker">
         <input type="text"
-               localize="placeholder"
-               placeholder="@placeholders_entername"
-               class="umb-editor umb-textstring"
+               placeholder="{{model.useNodeName && model.target.nodeName ? model.target.nodeName : placeholders_entername}}"
+               class="umb-editor umb-textstring -full-width-input"
                ng-model="model.target.name" />
     </umb-control-group>
 
@@ -50,7 +49,7 @@
                                  search-from-id="{{searchInfo.searchFromId}}"
                                  search-from-name="{{searchInfo.searchFromName}}"
                                  show-search="{{searchInfo.showSearch}}"
-								 ignore-user-startnodes="{{searchInfo.ignoreUserStartNodes}}"
+                                 ignore-user-startnodes="{{searchInfo.ignoreUserStartNodes}}"
                                  section="{{section}}">
             </umb-tree-search-box>
 
@@ -65,7 +64,7 @@
                 <umb-tree section="content"
                           hideheader="true"
                           hideoptions="true"
-						  customtreeparams="{{customTreeParams}}"
+                          customtreeparams="{{customTreeParams}}"
                           eventhandler="dialogTreeEventHandler"
                           enablelistviewexpand="true"
                           isdialog="true"

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html
@@ -1,5 +1,12 @@
 <div ng-controller="Umbraco.Overlays.LinkPickerController">
 
+    <umb-control-group label="@defaultdialogs_nodeNameLinkPicker">
+        <input type="text"
+               placeholder="{{model.useNodeName && model.target.nodeName ? model.target.nodeName : placeholders_entername}}"
+               class="umb-editor umb-textstring -full-width-input"
+               ng-model="model.target.name" />
+    </umb-control-group>
+
     <umb-control-group label="@defaultdialogs_urlLinkPicker" class="umb-property--pull">
         <input type="text"
                localize="placeholder"
@@ -20,13 +27,6 @@
         <datalist id="anchors">
             <option value="{{a}}" ng-repeat="a in anchorValues"></option>
         </datalist>
-    </umb-control-group>
-
-    <umb-control-group label="@defaultdialogs_nodeNameLinkPicker">
-        <input type="text"
-               placeholder="{{model.useNodeName && model.target.nodeName ? model.target.nodeName : placeholders_entername}}"
-               class="umb-editor umb-textstring -full-width-input"
-               ng-model="model.target.name" />
     </umb-control-group>
 
     <umb-control-group ng-if="showTarget" label="@content_target">

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
@@ -1,5 +1,5 @@
 <div>
-  <umb-empty-state ng-if="results.length === 0" position="center">
+  <umb-empty-state ng-if="results.length === 0">
     <localize key="general_searchNoResult"></localize>
   </umb-empty-state>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -1,5 +1,4 @@
-function multiUrlPickerController($scope, angularHelper, localizationService, entityResource, iconHelper) {
-
+angular.module("umbraco").controller("Umbraco.PropertyEditors.MultiUrlPickerController", function ($scope, angularHelper, localizationService, entityResource, iconHelper) {
     $scope.renderModel = [];
 
     if ($scope.preview) {
@@ -61,6 +60,7 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
     $scope.openLinkPicker = function (link, $index) {
         var target = link ? {
             name: link.name,
+            nodeName: link.nodeName,
             anchor: link.queryString,
             // the linkPicker breaks if it get an udi for media
             udi: link.isMedia ? null : link.udi,
@@ -70,6 +70,7 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
         
         $scope.linkPickerOverlay = {
             view: "linkpicker",
+            useNodeName: true,
             currentTarget: target,
             ignoreUserStartNodes: $scope.model.config.ignoreUserStartNodes === "1",
             show: true,
@@ -79,6 +80,7 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
                     if (model.target.anchor && model.target.anchor[0] !== '?' && model.target.anchor[0] !== '#') {
                         model.target.anchor = (model.target.anchor.indexOf('=') === -1 ? '#' : '?') + model.target.anchor;
                     }
+
                     if (link) {
                         if (link.isMedia && link.url === model.target.url) {
                             // we can assume the existing media item is changed and no new file has been selected
@@ -88,14 +90,16 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
                             link.isMedia = model.target.isMedia;
                         }
 
-                        link.name = model.target.name || model.target.url || model.target.anchor;
+                        link.name = model.target.name;
+                        link.nodeName = model.target.nodeName;
                         link.queryString = model.target.anchor;
                         link.target = model.target.target;
                         link.url = model.target.url;
                     } else {
                         link = {
                             isMedia: model.target.isMedia,
-                            name: model.target.name || model.target.url || model.target.anchor,
+                            name: model.target.name,
+                            nodeName: model.target.nodeName,
                             queryString: model.target.anchor,
                             target: model.target.target,
                             udi: model.target.udi,
@@ -128,7 +132,4 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
             }
         };
     };
-}
-
-angular.module("umbraco").controller("Umbraco.PropertyEditors.MultiUrlPickerController", multiUrlPickerController);
-
+});

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -73,6 +73,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.MultiUrlPickerCont
             useNodeName: true,
             currentTarget: target,
             ignoreUserStartNodes: $scope.model.config.ignoreUserStartNodes === "1",
+            hideTarget: $scope.model.config.hideTarget === "1",
             show: true,
             submit: function (model) {
                 if (model.target.url || model.target.anchor) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.html
@@ -7,7 +7,7 @@
             <umb-node-preview
                 ng-repeat="link in renderModel"
                 icon="link.icon"
-                name="link.name"
+                name="link.name || link.nodeName"
                 published="link.published"
                 description="link.url + (link.queryString ? link.queryString : '')"
                 sortable="!sortableOptions.disabled"

--- a/src/Umbraco.Web/Models/ContentEditing/LinkDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/LinkDisplay.cs
@@ -15,6 +15,9 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "name")]
         public string Name { get; set; }
 
+        [DataMember(Name = "nodeName")]
+        public string NodeName { get; set; }
+
         [DataMember(Name = "published")]
         public bool Published { get; set; }
 

--- a/src/Umbraco.Web/Models/Link.cs
+++ b/src/Umbraco.Web/Models/Link.cs
@@ -2,12 +2,49 @@
 
 namespace Umbraco.Web.Models
 {
+    /// <summary>
+    /// Represents a link (e.g. to content, media or an external URL).
+    /// </summary>
     public class Link
     {
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target.
+        /// </summary>
+        /// <value>
+        /// The target.
+        /// </value>
         public string Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of link.
+        /// </summary>
+        /// <value>
+        /// The type of link.
+        /// </value>
         public LinkType Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UDI.
+        /// </summary>
+        /// <value>
+        /// The UDI.
+        /// </value>
         public Udi Udi { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL.
+        /// </summary>
+        /// <value>
+        /// The URL.
+        /// </value>
         public string Url { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/Link.cs
+++ b/src/Umbraco.Web/Models/Link.cs
@@ -1,4 +1,5 @@
 ﻿using Umbraco.Core;
+using Umbraco.Core.Models;
 
 namespace Umbraco.Web.Models
 {
@@ -38,6 +39,14 @@ namespace Umbraco.Web.Models
         /// The UDI.
         /// </value>
         public Udi Udi { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content.
+        /// </summary>
+        /// <value>
+        /// The content.
+        /// </value>
+        public IPublishedContent Content { get; set; }
 
         /// <summary>
         /// Gets or sets the URL.

--- a/src/Umbraco.Web/Models/LinkType.cs
+++ b/src/Umbraco.Web/Models/LinkType.cs
@@ -1,9 +1,21 @@
 ﻿namespace Umbraco.Web.Models
 {
+    /// <summary>
+    /// Represents the type of link.
+    /// </summary>
     public enum LinkType
     {
+        /// <summary>
+        /// Represents a link to content.
+        /// </summary>
         Content,
+        /// <summary>
+        /// Represents a link to media.
+        /// </summary>
         Media,
+        /// <summary>
+        /// Represents a link to an external URL.
+        /// </summary>
         External
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Web.PropertyEditors
 
                 try
                 {
-                    var umbHelper = new UmbracoHelper(UmbracoContext.Current);
+                    var umbracoContext = UmbracoContext.Current;
                     var services = ApplicationContext.Current.Services;
                     var entityService = services.EntityService;
                     var contentTypeService = services.ContentTypeService;
@@ -119,7 +119,7 @@ namespace Umbraco.Web.PropertyEditors
                             Target = dto.Target,
                             Trashed = false,
                             Udi = dto.Udi,
-                            Url = dto.Url ?? "",
+                            Url = dto.Url ?? string.Empty,
                         };
 
                         links.Add(link);
@@ -139,6 +139,8 @@ namespace Umbraco.Web.PropertyEditors
                         }
                         else
                         {
+                            link.NodeName = entity.Name;
+
                             var entityType =
                                 Equals(entity.AdditionalData["NodeObjectTypeId"], Constants.ObjectTypes.MediaGuid)
                                     ? Constants.UdiEntityType.Media
@@ -167,7 +169,7 @@ namespace Umbraco.Web.PropertyEditors
                                 link.Published = Equals(entity.AdditionalData["IsPublished"], true);
 
                                 if (link.Trashed == false)
-                                    link.Url = umbHelper.Url(entity.Id, UrlProviderMode.Relative);
+                                    link.Url = umbracoContext.UrlProvider.GetUrl(entity.Id, UrlProviderMode.Relative);
                             }
                             else
                             {
@@ -183,7 +185,7 @@ namespace Umbraco.Web.PropertyEditors
                                 if (link.Trashed)
                                     continue;
 
-                                var media = umbHelper.TypedMedia(entity.Id);
+                                var media = umbracoContext.MediaCache.GetById(entity.Id);
                                 if (media != null)
                                     link.Url = media.Url;
                             }

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
@@ -51,6 +51,13 @@ namespace Umbraco.Web.PropertyEditors
                     View = "number",
                     Name = "Maximum number of items"
                 });
+                Fields.Add(new PreValueField
+                {
+                    Key = "hideTarget",
+                    View = "boolean",
+                    Name = "Hide target",
+                    Description = "Hides the option to open the link in a new window or tab."
+                });
             }
         }
 

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerPropertyConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerPropertyConverter.cs
@@ -72,6 +72,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
             foreach (var dto in dtos)
             {
+                var name = dto.Name;
                 var type = LinkType.External;
                 var url = dto.Url;
                 IPublishedContent content = null;
@@ -94,12 +95,17 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                     if (content == null)
                         continue;
 
+                    if (string.IsNullOrEmpty(name))
+                    {
+                        name = content.Name;
+                    }
+
                     url = content.Url;
                 }
 
                 var link = new Link
                 {
-                    Name = dto.Name,
+                    Name = name,
                     Target = dto.Target,
                     Type = type,
                     Udi = dto.Udi,


### PR DESCRIPTION
This PR adds two enhancements to the recently integrated Multi URL Picker (https://github.com/umbraco/Umbraco-CMS/pull/2323):

**1. `Content` property on the `Link` model (as commented on https://github.com/umbraco/Umbraco-CMS/pull/2323#discussion_r249716153)**
Adding the `Content` property was quite simple, as the `MultiUrlPickerPropertyConverter` already gets the content or media as `IPublishedContent`. This allows easy access to any additional properties, e.g. an overview image that's rendered with the linked content or a thumbnail (with alt-text) of the linked media item. I think the ease of use justifies doing an additional query using the `Udi` (e.g. `Umbraco.TypedContent(link.Udi)` or `Umbraco.TypedMedia(link.Udi)`).

**2. Only save manually entered link name**
The current link picker overlay sets the link name to the selected content or media item, but this has the following problems:
- Entering a (custom) link name and then selecting a node overwrites the entered text (as the name/title input is shown before the node pickers, this is a quite common/understandable order of doing things);
- If the linked node name is changed, the link name is not automatically updated, so editors might have to find all referencing links to update the link name;
- Because of the above, translating content (by duplicating and editing or using other tools) requires more text to be changed and when changing the links to point to the duplicated child nodes, require the custom text to be stored somewhere, so it's not overwritten.

![02qB9Ll3tS](https://user-images.githubusercontent.com/1051287/57571764-49eccd80-7412-11e9-831c-a224f524529d.gif)
