### PR TITLE
V8: Don't load the breadcrumb twice when editing content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -67,16 +67,12 @@
             //We fetch all ancestors of the node to generate the footer breadcrumb navigation
             if (!$scope.page.isNew) {
                 if (content.parentId && content.parentId !== -1) {
-                    entityResource.getAncestors(content.id, "document", $scope.culture)
-                        .then(function (anc) {
-                            $scope.ancestors = anc;
-                        });
+                    loadBreadcrumb();
                     $scope.$watch('culture',
                         function (value, oldValue) {
-                            entityResource.getAncestors(content.id, "document", value)
-                                .then(function (anc) {
-                                    $scope.ancestors = anc;
-                                });
+                            if (value !== oldValue) {
+                                loadBreadcrumb();
+                            }
                         });
                 }
             }
@@ -86,6 +82,12 @@
             resetVariantFlags();
         }
 
+        function loadBreadcrumb() {
+            entityResource.getAncestors($scope.content.id, "document", $scope.culture)
+                .then(function (anc) {
+                    $scope.ancestors = anc;
+                });
+        }
 
         /**
          * This will reset isDirty flags if save is true.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The same call to `GetAncestors` is performed twice in a row for no apparent reason when editing content:

![image](https://user-images.githubusercontent.com/7405322/57679914-b93e0980-762c-11e9-8d49-6bc0e6c0a5f4.png)

Turns out it's the breadcrumb generation that's not double checking for changes in culture before re-fetching the ancestors for the breadcrumb. This PR fixes that. When applied, the ancestors are only fetched once when loading the content editor:

![image](https://user-images.githubusercontent.com/7405322/57679854-9ad80e00-762c-11e9-9e83-0eaf998b867b.png)

#### Testing this PR

1. Verify that the content breadcrumb is correct when editing content.
![image](https://user-images.githubusercontent.com/7405322/57680168-4a14e500-762d-11e9-8edc-ee1152fa4676.png)
2. For variant content, verify that the breadcrumb updates correctly when changing the language being edited.
