### PR TITLE
V8/feature/5443 add publish menu hotkeys

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -197,6 +197,8 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, notifica
                             letter: ch,
                             labelKey: "buttons_schedulePublish",
                             handler: args.methods.schedulePublish,
+                            hotKey: "alt+shift+s",
+                            hotKeyWhenHidden: true,
                             alias: "schedulePublish",
                             addEllipsis: "true"
                         };
@@ -207,6 +209,8 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, notifica
                             letter: ch,
                             labelKey: "buttons_publishDescendants",
                             handler: args.methods.publishDescendants,
+                            hotKey: "alt+shift+p",
+                            hotKeyWhenHidden: true,
                             alias: "publishDescendant",
                             addEllipsis: "true"
                         };

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
@@ -23,7 +23,7 @@
       <span class="caret"></span>
    </a>
 
-   <umb-dropdown ng-if="subButtons.length > 0 && dropdown.isOpen" class="umb-button-group__sub-buttons" on-close="closeDropdown()" ng-class="{'-align-right': float === 'right'}">
+   <umb-dropdown ng-show="subButtons.length > 0 && dropdown.isOpen" class="umb-button-group__sub-buttons" on-close="closeDropdown()" ng-class="{'-align-right': float === 'right'}">
       <umb-dropdown-item ng-repeat="subButton in subButtons">
          <a data-element="{{subButton.alias ? 'button-' + subButton.alias : 'button-group-secondary-' + $index }}" href="#" ng-click="executeMenuItem(subButton)" hotkey="{{subButton.hotKey}}" hotkey-when-hidden="{{subButton.hotKeyWhenHidden}}" prevent-default>
             <localize key="{{subButton.labelKey}}">{{subButton.labelKey}}</localize>


### PR DESCRIPTION
### Prerequisites

This fixes https://github.com/umbraco/Umbraco-CMS/issues/5443

### Description
- Added hotkey for `Schedule...` (alt+shift+s)
- Added hotkey for `Publish with descendants...` (alt+shift+p)
- Updated publish sub-menu rendering so that hotkeys work. (previously the existing unpublish hotkey was not working because it was clicking a non-existing element) 

![umbraco2](https://user-images.githubusercontent.com/686835/57694642-2f019f80-7644-11e9-89f3-3e5cfcddbfb6.gif)

