### PR TITLE
V8: Use umb-load-indicator when loading the RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/rte.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte.less
@@ -5,10 +5,6 @@
     position: relative;
     
     .umb-property-editor--limit-width();
-
-    .-loading {
-        position: absolute;
-    }
 }
 
 .umb-rte .mce-tinymce {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
@@ -1,5 +1,5 @@
 <div ng-controller="Umbraco.PropertyEditors.RTEController" class="umb-property-editor umb-rte">
-    <div class="-loading" ng-if="isLoading"><localize key="general_loading">Loading</localize>...</div>
+    <umb-load-indicator ng-if="isLoading"></umb-load-indicator>
 
     <div ng-style="{ visibility :  isLoading ? 'hidden' : 'visible'}"
          id="{{textAreaHtmlId}}" class="umb-rte-editor"></div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

While the RTE is initalizing it shows the text "Loading...": 

![rte-loading-before](https://user-images.githubusercontent.com/7405322/57712807-85390780-7671-11e9-8c8d-eb4ba2d87f14.gif)

This PR replaces the text with the default loading indicator: 

![rte-loading-after](https://user-images.githubusercontent.com/7405322/57712826-92ee8d00-7671-11e9-9aad-bf819f67d3b9.gif)

... just a bit of niceness 😄