### PR TITLE
V8: Disable the escape key in the "unsaved changes" dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
@@ -286,11 +286,11 @@ Opens an overlay to show a custom YSOD. </br>
 
             $(document).on("keydown.overlay-" + overlayNumber, function(event) {
 
-               if (event.which === 27) {
+                if (event.which === 27) {
 
                   numberOfOverlays = overlayHelper.getNumberOfOverlays();
 
-                  if (numberOfOverlays === overlayNumber) {
+                  if (numberOfOverlays === overlayNumber && !scope.model.disableEscKey) {
                       scope.$apply(function () {
                           scope.closeOverLay();
                       });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
@@ -165,6 +165,7 @@ function valFormManager(serverValidationManager, $rootScope, $timeout, $location
                             "title": labels.unsavedChangesTitle,
                             "content": labels.unsavedChangesContent,
                             "disableBackdropClick": true,
+                            "disableEscKey": true,
                             "submitButtonLabel": labels.stayButton,
                             "closeButtonLabel": labels.discardChangesButton,
                             submit: function() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The default ESC action for overlays is to close the dialog. Unfortunately for the "unsaved changes" this means you accept to discard the changes:

![image](https://user-images.githubusercontent.com/7405322/57716241-d3053e00-7678-11e9-9eb3-7fc8b239f294.png)

This PR explicitly disables the use of ESC in the "unsaved changes" dialog (the dialog can't be closed by clicking the backdrop either).

#### Testing this PR

1. Make some changes to some content.
2. Navigate away without saving the changes.
3. Hit ESC in the "unsaved changes" dialog.
4. Verify that ESC performs no action.
