### PR TITLE
V8: Add auto-focus to the default action in overlay dialogs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
@@ -95,7 +95,8 @@ Use this directive to render an umbraco button. The directive can be used to gen
                 size: "@?",
                 alias: "@?",
                 addEllipsis: "@?",
-                showCaret: "@?"
+                showCaret: "@?",
+                autoFocus: "@?"
             }
         });
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautofocus.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautofocus.directive.js
@@ -9,8 +9,10 @@ angular.module("umbraco.directives")
                 }
             };
 
-            $timeout(function() {
-                update();
-            });
+            if (attr.umbAutoFocus !== "false") {
+                $timeout(function() {
+                    update();
+                });
+            }
     };
 });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
@@ -311,9 +311,8 @@ Opens an overlay to show a custom YSOD. </br>
                      var submitOnEnter = document.activeElement.hasAttribute("overlay-submit-on-enter");
                      var submitOnEnterValue = submitOnEnter ? document.activeElement.getAttribute("overlay-submit-on-enter") : "";
 
-                     if(clickableElements.indexOf(activeElementType) === 0) {
-                        document.activeElement.trigger("click");
-                        event.preventDefault();
+                     if(clickableElements.indexOf(activeElementType) >= 0) {
+                         // don't do anything, let the browser Enter key handle this
                      } else if(activeElementType === "TEXTAREA" && !submitOnEnter) {
 
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
@@ -15,7 +15,7 @@
         </span>
     </a>
 
-    <button ng-if="vm.type === 'button'" type="button" class="btn umb-button__button {{vm.style}} umb-button--{{vm.size}}" ng-click="vm.clickButton($event)" hotkey="{{vm.shortcut}}" hotkey-when-hidden="{{vm.shortcutWhenHidden}}" ng-disabled="vm.disabled">
+    <button ng-if="vm.type === 'button'" type="button" class="btn umb-button__button {{vm.style}} umb-button--{{vm.size}}" ng-click="vm.clickButton($event)" hotkey="{{vm.shortcut}}" hotkey-when-hidden="{{vm.shortcutWhenHidden}}" ng-disabled="vm.disabled" umb-auto-focus="{{vm.autoFocus && !vm.disabled ? 'true' : 'false'}}">
         <span class="umb-button__content" ng-class="{'-hidden': vm.innerState !== 'init'}">
             <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon"></i>
             {{vm.buttonLabel}}
@@ -23,7 +23,7 @@
         </span>
     </button>
 
-    <button ng-if="vm.type === 'submit'" type="submit" class="btn umb-button__button {{vm.style}} umb-button--{{vm.size}}" hotkey="{{vm.shortcut}}" hotkey-when-hidden="{{vm.shortcutWhenHidden}}" ng-disabled="vm.disabled">
+    <button ng-if="vm.type === 'submit'" type="submit" class="btn umb-button__button {{vm.style}} umb-button--{{vm.size}}" hotkey="{{vm.shortcut}}" hotkey-when-hidden="{{vm.shortcutWhenHidden}}" ng-disabled="vm.disabled" umb-auto-focus="{{vm.autoFocus && !vm.disabled ? 'true' : 'false'}}">
         <span class="umb-button__content" ng-class="{'-hidden': vm.innerState !== 'init'}">
             <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon"></i>
             {{vm.buttonLabel}}

--- a/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
@@ -50,7 +50,8 @@
                         label="Confirm"
                         type="button"
                         disabled="!directive.enableConfirmButton"
-                        action="submitForm(model)">
+                        action="submitForm(model)"
+                        auto-focus="true">
                     </umb-button>
                 </div>
             </div>
@@ -74,7 +75,8 @@
                     type="button"
                     disabled="model.disableSubmitButton"
                     action="submitForm(model)"
-                    state="model.submitButtonState">
+                    state="model.submitButtonState"
+                    auto-focus="true">
                 </umb-button>
             </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This one may be a bit controversial... but here goes 😄 

There are a few issues with using keyboard input (tabbing and enter) around in overlay dialogs:

1. The "unsaved changes" dialog completely breaks the backoffice if you hit enter in it 💥
![unsaved-changes-enter-errors](https://user-images.githubusercontent.com/7405322/57728513-66983800-7694-11e9-9000-ee3fb4298bfd.gif)
2. If you hit enter in the save/publish/... dialogs for variant content, the default action is *always* fired when you hit enter, no matter if you have tabbed your way to the other actions.
![tab-publish-before](https://user-images.githubusercontent.com/7405322/57728560-7e6fbc00-7694-11e9-873d-f0cd60acddd2.gif)
3. Depending on the action that opens a dialog, you can't immediately tab your way to the buttons in the dialog, as the active HTML element is actually still somewhere underneath the overlay (!). This is very evident in the "unsaved changes" dialog, but also the save dialog for variant content suffers from this (first tab will activate the save and publish button underneath the overlay).
![tab-order-before](https://user-images.githubusercontent.com/7405322/57729444-79137100-7696-11e9-9b15-cd9da7bde052.gif)

This PR introduces an option to set auto-focus on `umb-button`, and utilizes said option on the default action in the overlay dialogs. This means that the default action always has immediate focus, and thus will be invoked when you hit enter (unless you tab away).

The controversial bit of this PR is actually two fold:

1. The default action button is highlighted (because it has focus). Personally I think it makes sense; now you can actually decode what's going to happen if you hit enter (even if the highlight color is a bit vague... fixing that is part of the accessibility initiative if I'm not mistaken).
![image](https://user-images.githubusercontent.com/7405322/57728686-cc84bf80-7694-11e9-8703-b703d00a2ee0.png)

2. Since the default action has focus, you need to shift+tab to access the other actions (as you need to go backwards in tab order). The upside is that you actually *can* use the other actions now.
![tab-publish-after](https://user-images.githubusercontent.com/7405322/57729211-effc3a00-7695-11e9-8d6e-6b94b38b1500.gif)

