### PR TITLE
V8: UX update for content/media sort dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/hacks.less
+++ b/src/Umbraco.Web.UI.Client/src/less/hacks.less
@@ -221,3 +221,12 @@ pre {
     border: 0;
   }
 }
+
+/* Styling for content/media sort order dialog */
+.sort-order {
+    td.tree-icon {
+        font-size:20px;
+        width:20px;
+        padding-right:0;
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/views/content/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/sort.html
@@ -1,6 +1,6 @@
 <div ng-controller="Umbraco.Editors.Content.SortController as vm" ng-cloak>
     
-        <div class="umb-dialog-body with-footer">
+        <div class="umb-dialog-body with-footer sort-order">
             
             <div class="umb-pane">
 
@@ -19,7 +19,7 @@
                     <table class="table table-condensed table-sortable" ng-if="vm.children">
                         <thead>
                             <tr>
-                                <th>
+                                <th colspan="2">
                                     <a ng-href="#" ng-click="vm.sort('name')" prevent-default>
                                         <localize key="general_name"></localize>
                                         <span ng-if="vm.sortOrder.column === 'name'">
@@ -37,22 +37,13 @@
                                         </span>
                                     </a>
                                 </th>
-                                <th>
-                                    <a ng-href="#" ng-click="vm.sort('sortOrder')" prevent-default>
-                                        <localize key="sort_sortOrder"></localize>
-                                        <span ng-if="vm.sortOrder.column === 'sortOrder'">
-                                            <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
-                                            <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
-                                        </span>
-                                    </a>
-                                </th>
                             </tr>
                         </thead>
                         <tbody ui-sortable="vm.sortableOptions" ng-model="vm.children">
                             <tr ng-repeat="child in vm.children">
+                                <td class="tree-icon"><i class="{{ child.icon }}"></i></td>
                                 <td>{{ child.name }}</td>
                                 <td>{{ child.createDate }}</td>
-                                <td>{{ child.sortOrder }}</td>
                             </tr>
                         </tbody>
                     </table>
@@ -86,4 +77,3 @@
         </div>
     
     </div>
-    

--- a/src/Umbraco.Web.UI.Client/src/views/media/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/sort.html
@@ -1,6 +1,6 @@
 <div ng-controller="Umbraco.Editors.Media.SortController as vm" ng-cloak>
     
-    <div class="umb-dialog-body with-footer">
+    <div class="umb-dialog-body with-footer sort-order">
         
         <div class="umb-pane">
 
@@ -19,7 +19,7 @@
                 <table class="table table-condensed table-sortable" ng-if="vm.children">
                     <thead>
                         <tr>
-                            <th>
+                            <th colspan="2">
                                 <a ng-href="#" ng-click="vm.sort('name')" prevent-default>
                                     <localize key="general_name"></localize>
                                     <span ng-if="vm.sortOrder.column === 'name'">
@@ -37,22 +37,13 @@
                                     </span>
                                 </a>
                             </th>
-                            <th>
-                                <a ng-href="#" ng-click="vm.sort('sortOrder')" prevent-default>
-                                    <localize key="sort_sortOrder"></localize>
-                                    <span ng-if="vm.sortOrder.column === 'sortOrder'">
-                                        <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
-                                        <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
-                                    </span>
-                                </a>
-                            </th>
                         </tr>
                     </thead>
                     <tbody ui-sortable="vm.sortableOptions" ng-model="vm.children">
                         <tr ng-repeat="child in vm.children">
+                            <td class="tree-icon"><i class="{{ child.icon }}"></i></td>
                             <td>{{ child.name }}</td>
                             <td>{{ child.createDate }}</td>
-                            <td>{{ child.sortOrder }}</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I figured the sort dialogs could use a little TLC. Specifically:

1. The item icons provide valuable information in the tree, but they are missing in the sort dialog.
2. The sort order column adds no real value for the editors, it's just noise.

![image](https://user-images.githubusercontent.com/7405322/57754240-409f8180-76ee-11e9-8068-6e32124b34a3.png)

So... This PR removes the sort order column and adds the item icons. This applies to both the content and media sort dialogs:

![image](https://user-images.githubusercontent.com/7405322/57753372-485e2680-76ec-11e9-8d26-25629e4885d7.png)

