### PR TITLE
v8: Show box shadow when hover user avatar

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-cards.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-cards.less
@@ -70,7 +70,6 @@
         }
 
         .umb-avatar {
-            //border: 1px solid @ui-option-type-hover;
             box-shadow: 0px 1px 3px rgba(0, 0, 0, .5);
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-cards.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-cards.less
@@ -63,12 +63,15 @@
 .umb-user-card__goToUser {
     &:hover, &:focus {
         text-decoration: none;
+
         .umb-user-card__name {
             text-decoration: underline;
             color: @ui-option-type-hover;
         }
+
         .umb-avatar {
-            border: 1px solid @ui-option-type-hover;
+            //border: 1px solid @ui-option-type-hover;
+            box-shadow: 0px 1px 3px rgba(0, 0, 0, .5);
         }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-table.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-table.less
@@ -15,14 +15,8 @@
 
     .umb-table-cell a {
 
-        .umb-avatar {
-            //border: 1px solid @ui-option-type-hover;
-            box-shadow: 0px 1px 3px transparent;
-        }
-
         &:hover, &:focus {
             .umb-avatar {
-                //border: 1px solid @ui-option-type-hover;
                 box-shadow: 0px 1px 3px rgba(0, 0, 0, .5);
             }
         }

--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-table.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-table.less
@@ -3,16 +3,27 @@
     .umb-user-table-col-avatar {
         flex: 0 0 32px;
         padding: 15px 0;
-        
+
+        > a {
+            overflow: visible;
+        }
+
         .umb-checkmark {
             margin-left:5px;
         }
     }
-    
+
     .umb-table-cell a {
+
+        .umb-avatar {
+            //border: 1px solid @ui-option-type-hover;
+            box-shadow: 0px 1px 3px transparent;
+        }
+
         &:hover, &:focus {
             .umb-avatar {
-                border: 1px solid @ui-option-type-hover;
+                //border: 1px solid @ui-option-type-hover;
+                box-shadow: 0px 1px 3px rgba(0, 0, 0, .5);
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I found it a bit annoying that the user avatar get a border on hover, which make the avatars jumping a bit, because they by default don't have a border.
https://github.com/umbraco/Umbraco-CMS/commit/873d230e0e9111b57ea2f2b6c18b06664f4cf647#diff-bad3fa4456572e4efd09a7e932ce19ea

I have added a bit box shadow, which I think looks better.

**Before**

![2019-05-18_14-37-43](https://user-images.githubusercontent.com/2919859/57969858-aacc5680-797a-11e9-803d-25ea6b000239.gif)


**After**

![2019-05-18_14-34-03](https://user-images.githubusercontent.com/2919859/57969711-21b51f80-797a-11e9-8b58-2a4d3be20bbd.gif)
