### PR TITLE
V8: MNTP improvements when configured to select only one item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -157,6 +157,11 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     // pre-value config on to the dialog options
     angular.extend(dialogOptions, $scope.model.config);
 
+    // if we can't pick more than one item, explicitly disable multiPicker in the dialog options
+    if ($scope.model.config.maxNumber && parseInt($scope.model.config.maxNumber) === 1) {
+        dialogOptions.multiPicker = false;
+    }
+
     // add the current filter (if any) as title for the filtered out nodes
     if ($scope.model.config.filter) {
         localizationService.localize("contentPicker_allowedItemTypes", [$scope.model.config.filter]).then(function (data) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR changes the MNTP behavior when it's configured to select max one item:
- It should convert its value to `IPublishedContent`, not `IEnumerable<IPublishedContent>` (for consistency, since MediaPicker, MultiUrlPicker and DropdownFlexible does the same thing for single select modes).
- The picker dialog should not allow multi-select.

#### Testing this PR

1. Configure an MNTP with max items = 1 and use it on a content type 
![image](https://user-images.githubusercontent.com/7405322/57978706-82903680-7a12-11e9-9c62-63562d529a8f.png)
2. Configure another MNTP with no restrictions on number of items selected and use it on the same content type
3. Verify that the content picker dialog for the MNTP with max items = 1 does not allow multi-select:
![mntp-single-mode](https://user-images.githubusercontent.com/7405322/57978739-034f3280-7a13-11e9-9019-a87cb8bb43a9.gif)
4. Verify that when the content is being rendered, the MNTP with max items = 1 returns `IPublishedContent` and the other MNTP returns `IEnumerable<IPublishedContent>`. You can use this template:
```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@{
	Layout = null;
}
<html>
    <body>
        <h3>Single</h3>
        @{
            var content = Model.Value<IPublishedContent>("treePickerSingle");
            if(content != null) {
                @: @content.Name
            }
            else {
                @: No content selected
            }
        }
        <h3>Multiple</h3>
        <ul>
        @foreach(var element in Model.Value<IEnumerable<IPublishedContent>>("TreePickerMultiple")) {
            <li>@element.Name</li>
        }
        </ul>
    </body>
</html>
```