### PR TITLE
V8: umb-confirm button cursor should be "pointer"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-confirm-action.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-confirm-action.less
@@ -102,6 +102,7 @@
   border-radius: 40px;
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
   font-size: 18px;
+  cursor: pointer;
 }
 
 .umb_confirm-action__overlay-action:hover {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The cursor should be "pointer" when hovering the `umb-confirm` action buttons. Right now the cursor defaults to whatever is dictated by the elements behind the buttons, which looks particularly awkward when content types are in "reorder" mode:

![confirm-cursor-before](https://user-images.githubusercontent.com/7405322/57999908-5b4f6d00-7ad7-11e9-9972-84b331f29925.gif)

In other words... This PR enforces "pointer" on the `umb-confirm` action buttons:

![confirm-cursor-after](https://user-images.githubusercontent.com/7405322/57999923-6a361f80-7ad7-11e9-99cf-ec0b921ecf5b.gif)
