### PR TITLE
V8: Add keyboard support for navigating search results

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsearch.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsearch.directive.js
@@ -13,7 +13,7 @@
         }
     };
     
-    function umbSearchController($timeout, $element, backdropService, searchService, focusService) {
+    function umbSearchController($timeout, backdropService, searchService, focusService) {
 
         var vm = this;
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-search.html
@@ -1,5 +1,5 @@
 
-<div class="umb-search" on-outside-click="vm.closeSearch()" ng-keyup="vm.handleKeyUp($event)">
+<div class="umb-search" on-outside-click="vm.closeSearch()" ng-keydown="vm.handleKeyDown($event)">
 
     <div class="flex items-center">
         <i class="umb-search-input-icon icon-search" ng-click="vm.focusSearch()"></i>
@@ -18,7 +18,7 @@
         <div class="umb-search-group" ng-repeat="(key, group) in vm.searchResults">
             <div class="umb-search-group__title">{{key}}</div>
             <ul class="umb-search-items">
-                <li class="umb-search-item" ng-repeat="result in group.results">
+                <li class="umb-search-item" ng-repeat="result in group.results" active-result="{{result === vm.activeResult}}">
                     <a class="umb-search-result__link" ng-href="#/{{result.editorPath}}" ng-click="vm.clickItem(result)">
                         <i class="umb-search-result__icon {{result.icon}}"></i>
                         <span class="umb-search-result__meta">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The global search dialog can be opened with Ctrl+Space, which is awesome! Unfortunately you can't navigate your way through the search results using the up and down arrow keys. 

This PR adds that feature to the global search:

![search-keyboard-support](https://user-images.githubusercontent.com/7405322/58084369-01c06e80-7bbb-11e9-903a-6baf773eedac.gif)

#### Testing this PR

Simple! Search for something and use the up/down keys to navigate through the results. Then open a result by hitting enter. If things doesn't blow up and you end the right place, the PR works 😎 