### PR TITLE
V8: Use a picker to select allowed types for MNTP

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -370,6 +370,28 @@ When building a custom infinite editor view you can use the same components as a
 
         /**
          * @ngdoc method
+         * @name umbraco.services.editorService#contentTypePicker
+         * @methodOf umbraco.services.editorService
+         *
+         * @description
+         * Opens a content type picker in infinite editing, the submit callback returns an array of selected items
+         *
+         * @param {Object} editor rendering options
+         * @param {Boolean} editor.multiPicker Pick one or multiple items
+         * @param {Function} editor.submit Callback function when the submit button is clicked. Returns the editor model object
+         * @param {Function} editor.close Callback function when the close button is clicked.
+         *
+         * @returns {Object} editor object
+         */
+        function contentTypePicker(editor) {
+            editor.view = "views/common/infiniteeditors/treepicker/treepicker.html";
+            editor.size = "small";
+            editor.section = "settings";
+            editor.treeAlias = "documentTypes";
+            open(editor);
+        }
+        /**
+         * @ngdoc method
          * @name umbraco.services.editorService#copy
          * @methodOf umbraco.services.editorService
          *
@@ -881,6 +903,7 @@ When building a custom infinite editor view you can use the same components as a
             mediaEditor: mediaEditor,
             contentEditor: contentEditor,
             contentPicker: contentPicker,
+            contentTypePicker: contentTypePicker,
             copy: copy,
             move: move,
             embed: embed,

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -93,6 +93,14 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
                     });
                 }
             }
+            if (vm.treeAlias === "documentTypes") {
+                vm.entityType = "DocumentType";
+                if (!$scope.model.title) {
+                    localizationService.localize("defaultdialogs_selectContentType").then(function(value){
+                        $scope.model.title = value;
+                    });
+                }
+            }
             else if (vm.treeAlias === "member" || vm.section === "member") {
                 vm.entityType = "Member";
                 if (!$scope.model.title) {

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/contenttypepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/contenttypepicker.controller.js
@@ -1,0 +1,54 @@
+function ContentTypePickerController($scope, contentTypeResource, editorService, angularHelper) {
+    var vm = this;
+    vm.loading = false;
+    vm.contentTypes = [];
+    vm.remove = remove;
+    vm.add = add;
+
+    var allContentTypes = null;
+
+    function init() {
+        vm.loading = true;
+        contentTypeResource.getAll().then(function (all) {
+            allContentTypes = all;
+            vm.loading = false;
+            // the model value is a comma separated list of content type aliases
+            var currentContentTypes = _.map(($scope.model.value || "").split(","), function (s) { return s.trim(); });
+            vm.contentTypes = _.filter(allContentTypes, function (contentType) {
+                return currentContentTypes.indexOf(contentType.alias) >= 0;
+            });
+        });
+    }
+
+    function add() {
+        editorService.contentTypePicker({
+            multiPicker: true,
+            submit: function (model) {
+                var newContentTypes = _.map(model.selection, function (selected) {
+                    return _.findWhere(allContentTypes, {udi: selected.udi});
+                });
+                vm.contentTypes = _.uniq(_.union(vm.contentTypes, newContentTypes));
+                updateModel();
+                editorService.close();
+            },
+            close: function () {
+                editorService.close();
+            }
+        });
+    }
+
+    function remove(contentType) {
+        vm.contentTypes = _.without(vm.contentTypes, contentType);
+        updateModel();
+    }
+
+    function updateModel() {
+        // the model value is a comma separated list of content type aliases
+        $scope.model.value = _.pluck(vm.contentTypes, "alias").join();
+        angularHelper.getCurrentForm($scope).$setDirty();
+    }
+
+    init();
+}
+
+angular.module('umbraco').controller("Umbraco.PrevalueEditors.ContentTypePickerController", ContentTypePickerController);

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/contenttypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/contenttypepicker.html
@@ -1,0 +1,23 @@
+<div ng-controller="Umbraco.PrevalueEditors.ContentTypePickerController as vm" class="umb-property-editor umb-contenttypepicker">
+
+    <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+
+    <div ng-show="!vm.loading">
+        <umb-node-preview ng-repeat="contentType in vm.contentTypes"
+                          class="mt1"
+                          icon="contentType.icon"
+                          name="contentType.name"
+                          allow-remove="true"
+                          allow-edit="false"
+                          on-remove="vm.remove(contentType)">
+        </umb-node-preview>
+
+        <a class="umb-node-preview-add"
+           href=""
+           ng-click="vm.add()"
+           prevent-default>
+            <localize key="general_add">Add</localize>
+        </a>
+    </div>
+
+</div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -434,6 +434,7 @@
     <key alias="selectLink">Vælg link</key>
     <key alias="selectMacro">Vælg makro</key>
     <key alias="selectContent">Vælg indhold</key>
+    <key alias="selectContentType">Vælg indholdstype</key>
     <key alias="selectMediaStartNode">Vælg medie startnode</key>
     <key alias="selectMember">Vælg medlem</key>
     <key alias="selectMemberGroup">Vælg medlemsgruppe</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -447,6 +447,7 @@
     <key alias="selectLink">Select link</key>
     <key alias="selectMacro">Select macro</key>
     <key alias="selectContent">Select content</key>
+    <key alias="selectContentType">Select content type</key>
     <key alias="selectMediaStartNode">Select media start node</key>
     <key alias="selectMember">Select member</key>
     <key alias="selectMemberGroup">Select member group</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -451,6 +451,7 @@
     <key alias="selectLink">Select link</key>
     <key alias="selectMacro">Select macro</key>
     <key alias="selectContent">Select content</key>
+    <key alias="selectContentType">Select content type</key>
     <key alias="selectMediaStartNode">Select media start node</key>
     <key alias="selectMember">Select member</key>
     <key alias="selectMemberGroup">Select member group</key>

--- a/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfiguration.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("startNode", "Node type", "treesource")]
         public MultiNodePickerConfigurationTreeSource TreeSource { get; set; }
 
-        [ConfigurationField("filter", "Allow items of type", "textstring", Description = "Separate with comma")]
+        [ConfigurationField("filter", "Allow items of type", "contenttypepicker", Description = "Select the applicable content types")]
         public string Filter { get; set; }
 
         [ConfigurationField("minNumber", "Minimum number of items", "number")]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The current configuration of allowed types for the MNTP isn't really very nice, nor very much in line with the rest of the config:

![image](https://user-images.githubusercontent.com/7405322/58153176-b8c9f200-7c6e-11e9-9da0-4b8c35b83504.png)

This PR swaps the comma separated list of aliases for a picker style configuration:

![mntp-pick-allowed-types](https://user-images.githubusercontent.com/7405322/58153233-d0a17600-7c6e-11e9-80cc-e9e6f3955cb9.gif)

The underlying data model remains the same. In the future we should probably consider swapping it for a list of UDI's, but that's beyond the scope of this PR.

#### Testing this PR

1. Create an MNTP and verify that you can configure its filter using the new picker.
2. Add the MNTP to a content type and verify that the filter works when using the MNTP.