### PR TITLE
MemberModelMapper to return member groups ordered alphabetically

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberModelMapper.cs
@@ -178,6 +178,7 @@ namespace Umbraco.Web.Models.Mapping
             var result = Roles.GetAllRoles().Distinct()
                 // if a role starts with __umbracoRole we won't show it as it's an internal role used for public access
                 .Where(x => x.StartsWith(Constants.Conventions.Member.InternalRolePrefix) == false)
+                .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(x => x, x => false);
 
             // if user has no roles, just return the dictionary


### PR DESCRIPTION
MemberModelMapper.GetMemberGroupValue - order member groups alphabetically by name.

### Prerequisites

This fixes: https://github.com/umbraco/Umbraco-CMS/issues/5507

### Description
This is used in ContentPropertyDisplay class - for UI purposes only.

![image](https://user-images.githubusercontent.com/1976680/58177503-68698900-7c9c-11e9-95c0-7d4f18bec722.png)
