### PR TITLE
ng-switch-default directive typo in macropicker.html

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dialogs/macropicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dialogs/macropicker.html
@@ -2,7 +2,7 @@
 	
 	<div class="umb-panel-body no-header with-footer umb-scrollable" ng-switch on="dialogMode">
 		<div class="umb-control-group">
-			<div ng-switch-when="list" ng-swicth-default class="tab-content form-horizontal umb-el-wrap">
+			<div ng-switch-when="list" ng-switch-default class="tab-content form-horizontal umb-el-wrap">
 					<ul class="nav nav-tabs nav-stacked">	
 						<li ng-repeat="macro in macros">
 							<a href="#" ng-click="configureMacro(macro)" prevent-default>


### PR DESCRIPTION
looks like it is just a typo :) fixed

### Prerequisites
May be it would never couse a bug , while ng-switch-when="list" always takes a value, but typos it is not good anyway.

### Description
I was found that typo accidentally while search an another markup issue in backoffice, so I don't know how to check it. 

