### PR TITLE
Check for and delete descendants when deleting a dictionary item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
@@ -42,7 +42,7 @@ function sectionsDirective($timeout, $window, navigationService, treeService, se
             function calculateWidth() {
                 $timeout(function () {
                     //total width minus room for avatar, search, and help icon
-                    var windowWidth = $(window).width() - 200;
+                    var windowWidth = $(window).width()-150;
                     var sectionsWidth = 0;
                     scope.totalSections = scope.sections.length;
                     scope.maxSections = maxSections;

--- a/src/Umbraco.Web/Editors/DictionaryController.cs
+++ b/src/Umbraco.Web/Editors/DictionaryController.cs
@@ -48,9 +48,16 @@ namespace Umbraco.Web.Editors
         public HttpResponseMessage DeleteById(int id)
         {
             var foundDictionary = Services.LocalizationService.GetDictionaryItemById(id);
-
+            
             if (foundDictionary == null)
                 throw new HttpResponseException(HttpStatusCode.NotFound);
+
+            var foundDictionaryDescendants = Services.LocalizationService.GetDictionaryItemDescendants(foundDictionary.Key);
+
+            foreach (var dictionaryItem in foundDictionaryDescendants)
+            {
+                Services.LocalizationService.Delete(dictionaryItem, Security.CurrentUser.Id);
+            }
 
             Services.LocalizationService.Delete(foundDictionary, Security.CurrentUser.Id);
 


### PR DESCRIPTION
When deleting a dictionary item the descendants of that item are not removed. This will throw errors in the backoffice and requires manual deletion in the database.

Steps to test this PR are:

Create a dictionary item structure similar to this:
- Parent
--Child 1
---Grandchild 1

Delete parent and all descendants are removed without errors.

At Codegarden I discussed with Claus Jensen if we should alter the warning message but we concluded that this is expected behavior if you delete a parent.

Please let me know if I need to change something.