### PR TITLE
Updated allowed width for Umb-Section directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
@@ -42,7 +42,7 @@ function sectionsDirective($timeout, $window, navigationService, treeService, se
             function calculateWidth() {
                 $timeout(function () {
                     //total width minus room for avatar, search, and help icon
-                    var windowWidth = $(window).width() - 200;
+                    var windowWidth = $(window).width() - 150;
                     var sectionsWidth = 0;
                     scope.totalSections = scope.sections.length;
                     scope.maxSections = maxSections;


### PR DESCRIPTION
Solution for:
https://github.com/umbraco/Umbraco-CMS/issues/5020

I've changed the reserved space for search, help and profile in the app header to 150px from 200.
This is the max width we can go before we push the three buttons off screen.