### PR TITLE
V8: Don't apply changes instantly when editing content type properties

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1319,6 +1319,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="elementHeading">Er en Element-type</key>
     <key alias="elementDescription">En Element-type er tiltænkt brug i f.eks. Nested Content, ikke i indholdstræet</key>
     <key alias="elementDoesNotSupport">Dette benyttes ikke for en Element-type</key>
+    <key alias="propertyHasChanges">Du har lavet ændringer til denne egenskab. Er du sikker på at du vil kassere dem?</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Tilføj sprog</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1595,6 +1595,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="elementHeading">Is an Element type</key>
     <key alias="elementDescription">An Element type is meant to be used for instance in Nested Content, and not in the tree</key>
     <key alias="elementDoesNotSupport">This is not applicable for an Element type</key>
+    <key alias="propertyHasChanges">You have made changes to this property. Are you sure you want to discard them?</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1608,6 +1608,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="elementHeading">Is an Element type</key>
     <key alias="elementDescription">An Element type is meant to be used for instance in Nested Content, and not in the tree</key>
     <key alias="elementDoesNotSupport">This is not applicable for an Element type</key>
+    <key alias="propertyHasChanges">You have made changes to this property. Are you sure you want to discard them?</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5428

### Description

See #5428 for details.

When this PR is applied, changes to content type properties are applied when the user submits the edit dialog. If the edit dialog has unsaved changes and the user clicks "Close", the user is prompted to keep or discard these changes.

#### Preview: Edit existing property

![edit-property-1](https://user-images.githubusercontent.com/7405322/58377635-58e08d80-7f85-11e9-832b-bba1c7b21180.gif)

#### Preview: Add new property

![edit-property-2](https://user-images.githubusercontent.com/7405322/58377636-5bdb7e00-7f85-11e9-8601-a201ba0bcb30.gif)
