### PR TITLE
V8: Fix the flickering when browsing up and down already loaded trees

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/application/animations.less
+++ b/src/Umbraco.Web.UI.Client/src/less/application/animations.less
@@ -40,10 +40,6 @@
 
 // TREE ANIMATION
 
-.umb-tree-item.ng-animate {
-    display: none;
-}
-
 .umb-tree-item--deleted.ng-leave {
     animation: leave 600ms cubic-bezier(0.445, 0.050, 0.550, 0.950);
     display: block;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5403

### Description

As described in #5403, tree child nodes flicker when you browse up and down an already loaded part of the tree:

![tree-flicker-before](https://user-images.githubusercontent.com/7405322/58397277-8a725b00-8050-11e9-8c46-59c58146c071.gif)

I have performed a JS deep dive, and as far as I can tell there are no nodes being removed and re-added to the DOM. This is purely a CSS issue (basically it's an animation issue).

With this PR applied, the flickering goes away:

![tree-flicker-after](https://user-images.githubusercontent.com/7405322/58397336-c9081580-8050-11e9-98ac-410500169f3d.gif)

#### Testing this PR

1. Create a tree structure that is 3 levels deep.
2. Browse up and down the structure and verify that there is no flickering going on for the children in the structure.
3. Delete a node and verify that the delete animation still works.