### PR TITLE
V8: Better support blueprints in multisite solutions (issue #5425)

### DIFF
--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -22,6 +22,7 @@ namespace Umbraco.Core
             /// </remarks>
             public const int UnknownUserId = 0;
 
+            public const int AdminGroupId = 1;
             public const string AdminGroupAlias = "admin";
             public const string SensitiveDataGroupAlias = "sensitiveData";
             public const string TranslatorGroupAlias = "translator";

--- a/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
@@ -69,6 +69,7 @@ namespace Umbraco.Core.Migrations.Install
             typeof (LockDto),
             typeof (UserGroupDto),
             typeof (User2UserGroupDto),
+            typeof (UserGroup2ContentTemplateDto),
             typeof (UserGroup2NodePermissionDto),
             typeof (UserGroup2AppDto),
             typeof (UserStartNodeDto),

--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -141,6 +141,7 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<MergeDateAndDateTimePropertyEditor>("{78BAF571-90D0-4D28-8175-EF96316DA789}");
             To<ChangeNuCacheJsonFormat>("{80C0A0CB-0DD5-4573-B000-C4B7C313C70D}");
             To<ConvertTinyMceAndGridMediaUrlsToLocalLink>("{B69B6E8C-A769-4044-A27E-4A4E18D1645A}");
+            To<AddUserGroupToContentTemplateTables>("{3E6E7580-F332-4C48-A152-9102443AAD10}");
 
             //FINAL
 

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/AddUserGroupToContentTemplateTables.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/AddUserGroupToContentTemplateTables.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
+{
+    public class AddUserGroupToContentTemplateTables : MigrationBase
+    {
+        public AddUserGroupToContentTemplateTables(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            var tables = SqlSyntax.GetTablesInSchema(Context.Database).ToList();
+
+            if (tables.InvariantContains("umbracoUserGroup2ContentTemplate") == false)
+            {
+                Create.Table<UserGroup2ContentTemplateDto>().Do();
+            }
+        }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
+++ b/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
@@ -50,6 +50,7 @@ namespace Umbraco.Core
                 public const string User2UserGroup = TableNamePrefix + "User2UserGroup";
                 public const string User2NodeNotify = TableNamePrefix + "User2NodeNotify";
                 public const string UserGroup2App = TableNamePrefix + "UserGroup2App";
+                public const string UserGroup2ContentTemplate = TableNamePrefix + "UserGroup2ContentTemplate";
                 public const string UserGroup2NodePermission = TableNamePrefix + "UserGroup2NodePermission";
                 public const string ExternalLogin = TableNamePrefix + "ExternalLogin";
 

--- a/src/Umbraco.Core/Persistence/Dtos/UserGroup2ContentTemplateDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/UserGroup2ContentTemplateDto.cs
@@ -1,0 +1,20 @@
+﻿using NPoco;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
+
+namespace Umbraco.Core.Persistence.Dtos
+{
+    [TableName(Constants.DatabaseSchema.Tables.UserGroup2ContentTemplate)]
+    [ExplicitColumns]
+    internal class UserGroup2ContentTemplateDto
+    {
+        [Column("userGroupId")]
+        [PrimaryKeyColumn(AutoIncrement = false, Name = "PK_umbracoUserGroup2ContentTemplate", OnColumns = "userGroupId, nodeId")]
+        [ForeignKey(typeof(UserGroupDto))]
+        public int UserGroupId { get; set; }
+
+        [Column("nodeId")]
+        [ForeignKey(typeof(NodeDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_umbracoUser2ContentTemplate_nodeId")]
+        public int NodeId { get; set; }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Repositories/IDocumentBlueprintRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDocumentBlueprintRepository.cs
@@ -6,16 +6,22 @@ namespace Umbraco.Core.Persistence.Repositories
     public interface IDocumentBlueprintRepository : IDocumentRepository
     {
         /// <summary>
-        /// Retrieves the user groups that have been assigned to the blueprint
+        /// Retrieves the user groups that have been assigned to the blueprint.
         /// </summary>
         /// <param name="id">Blueprint node Id</param>
         IEnumerable<IUserGroup> GetGroupsAssignedToBlueprint(int id);
 
         /// <summary>
-        /// Assigns the set of uer groups to the blueprint
+        /// Assigns the set of uer groups to the blueprint.
         /// </summary>
         /// <param name="id">Blueprint node Id</param>
         /// <param name="userGroupIds">User group Ids</param>
         void AssignGroupsToBlueprint(int id, int[] userGroupIds);
+
+        /// <summary>
+        /// Retrieves the blueprint Ids that are associated with the provided user groups.
+        /// </summary>
+        /// <param name="userGroupIds">Ids of user groups</param>
+        IEnumerable<int> GetBlueprintsAvailableToUserGroups(int[] userGroupIds);
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IDocumentBlueprintRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDocumentBlueprintRepository.cs
@@ -1,5 +1,21 @@
-﻿namespace Umbraco.Core.Persistence.Repositories
+﻿using System.Collections.Generic;
+using Umbraco.Core.Models.Membership;
+
+namespace Umbraco.Core.Persistence.Repositories
 {
     public interface IDocumentBlueprintRepository : IDocumentRepository
-    { }
+    {
+        /// <summary>
+        /// Retrieves the user groups that have been assigned to the blueprint
+        /// </summary>
+        /// <param name="id">Blueprint node Id</param>
+        IEnumerable<IUserGroup> GetGroupsAssignedToBlueprint(int id);
+
+        /// <summary>
+        /// Assigns the set of uer groups to the blueprint
+        /// </summary>
+        /// <param name="id">Blueprint node Id</param>
+        /// <param name="userGroupIds">User group Ids</param>
+        void AssignGroupsToBlueprint(int id, int[] userGroupIds);
+    }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentBlueprintRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentBlueprintRepository.cs
@@ -1,11 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Umbraco.Core.Cache;
-using Umbraco.Core.Configuration.UmbracoSettings;
+using Umbraco.Core.Models.Membership;
 using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.Dtos;
+using Umbraco.Core.Persistence.Factories;
 using Umbraco.Core.Scoping;
 
 namespace Umbraco.Core.Persistence.Repositories.Implement
 {
+
     /// <summary>
     /// Override the base content repository so we can change the node object type
     /// </summary>
@@ -25,5 +30,43 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         protected override bool EnsureUniqueNaming => false; // duplicates are allowed
 
         protected override Guid NodeObjectTypeId => Constants.ObjectTypes.DocumentBlueprint;
+
+        protected override IEnumerable<string> GetDeleteClauses()
+        {
+            var list = base.GetDeleteClauses().ToList();
+            list.Insert(0, "DELETE FROM " + Constants.DatabaseSchema.Tables.UserGroup2ContentTemplate + " WHERE nodeId = @id");
+            return list;
+        }
+
+        public IEnumerable<IUserGroup> GetGroupsAssignedToBlueprint(int id)
+        {
+            var sql = Sql()
+                .Select<UserGroupDto>()
+                .From<UserGroupDto>()
+                .InnerJoin<UserGroup2ContentTemplateDto>()
+                .On<UserGroupDto, UserGroup2ContentTemplateDto>(left => left.Id, right => right.UserGroupId)
+                .Where<UserGroup2ContentTemplateDto>(x => x.NodeId == id);
+            return Database.Fetch<UserGroupDto>(sql).Select(UserGroupFactory.BuildEntity).OrderBy(x => x.Name);
+        }
+
+        public void AssignGroupsToBlueprint(int id, int[] userGroupIds)
+        {
+            var sql = Sql().Delete<UserGroup2ContentTemplateDto>().Where<UserGroup2ContentTemplateDto>(x => x.NodeId == id);
+            Database.Execute(sql);
+            if (userGroupIds == null)
+            {
+                return;
+            }
+
+            foreach (var userGroupId in userGroupIds)
+            {
+                var dto = new UserGroup2ContentTemplateDto
+                    {
+                        NodeId = id,
+                        UserGroupId = userGroupId
+                    };
+                Database.Insert(dto);
+            }
+        }
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserGroupRepository.cs
@@ -280,6 +280,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                            {
                                "DELETE FROM umbracoUser2UserGroup WHERE userGroupId = @id",
                                "DELETE FROM umbracoUserGroup2App WHERE userGroupId = @id",
+                               "DELETE FROM umbracoUserGroup2ContentTemplate WHERE userGroupId = @id",
                                "DELETE FROM umbracoUserGroup2NodePermission WHERE userGroupId = @id",
                                "DELETE FROM umbracoUserGroup WHERE id = @id"
                            };

--- a/src/Umbraco.Core/Runtime/CoreInitialComposer.cs
+++ b/src/Umbraco.Core/Runtime/CoreInitialComposer.cs
@@ -17,6 +17,7 @@ using Umbraco.Core.Persistence.Mappers;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.PropertyEditors.Validators;
 using Umbraco.Core.Scoping;
+using Umbraco.Core.Security;
 using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
 using Umbraco.Core.Sync;
@@ -122,6 +123,8 @@ namespace Umbraco.Core.Runtime
 
             // by default, register a noop rebuilder
             composition.RegisterUnique<IPublishedSnapshotRebuilder, PublishedSnapshotRebuilder>();
+
+            composition.RegisterUnique<ICreatedBluePrintAssignmentToUserGroupBehaviour, DefaultCreatedBluePrintAssignmentToUserGroupBehaviour>();
         }
     }
 }

--- a/src/Umbraco.Core/Security/DefaultCreatedBluePrintAssignmentToUserGroupBehaviour.cs
+++ b/src/Umbraco.Core/Security/DefaultCreatedBluePrintAssignmentToUserGroupBehaviour.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.Membership;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Core.Security
+{
+    public class DefaultCreatedBluePrintAssignmentToUserGroupBehaviour : ICreatedBluePrintAssignmentToUserGroupBehaviour
+    {
+        private readonly IContentService _contentService;
+
+        public DefaultCreatedBluePrintAssignmentToUserGroupBehaviour(IContentService contentService)
+        {
+            _contentService = contentService ?? throw new ArgumentNullException(nameof(contentService));
+        }
+
+        public void AssignUserGroupsToBlueprint(IContent blueprint, IUser currentUser)
+        {
+            if (ShouldAssignUserGroupsToBlueprint(currentUser))
+            {
+                _contentService.AssignGroupsToBlueprintById(
+                    blueprint.Id,
+                    currentUser.Groups
+                        .Where(x => x.StartContentId.HasValue && x.StartContentId != Constants.System.Root)
+                        .Select(x => x.Id)
+                        .ToArray());
+            }
+        }
+
+        private static bool ShouldAssignUserGroupsToBlueprint(IUser currentUser)
+        {
+            return !currentUser.IsAdmin() &&
+                   currentUser.StartContentIds != null &&
+                   !currentUser.StartContentIds.Contains(Constants.System.Root);
+        }
+    }
+}

--- a/src/Umbraco.Core/Security/ICreatedBluePrintAssignmentToUserGroupBehaviour.cs
+++ b/src/Umbraco.Core/Security/ICreatedBluePrintAssignmentToUserGroupBehaviour.cs
@@ -1,0 +1,10 @@
+﻿using Umbraco.Core.Models;
+using Umbraco.Core.Models.Membership;
+
+namespace Umbraco.Core.Security
+{
+    public interface ICreatedBluePrintAssignmentToUserGroupBehaviour
+    {
+        void AssignUserGroupsToBlueprint(IContent blueprint, IUser currentUser);
+    }
+}

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -33,7 +33,7 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Gets blueprints for a content type.
         /// </summary>
-        IEnumerable<IContent> GetBlueprintsForContentTypes(int contentTypeId);
+        IEnumerable<IContent> GetBlueprintsForContentTypes(int contentTypeId, int[] userGroupIds = null);
 
         /// <summary>
         /// Gets blueprints for a content type.

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -31,6 +31,16 @@ namespace Umbraco.Core.Services
         IEnumerable<IContent> GetBlueprintsForContentTypes(params int[] documentTypeId);
 
         /// <summary>
+        /// Gets the collection of user groups assigned to the blueprint.
+        /// </summary>
+        IEnumerable<IUserGroup> GetGroupsAssignedToBlueprintById(int id);
+
+        /// <summary>
+        /// Assigns the set of uer groups to the blueprint
+        /// </summary>
+        void AssignGroupsToBlueprintById(int id, int[] userGroupIds);
+
+        /// <summary>
         /// Saves a blueprint.
         /// </summary>
         void SaveBlueprint(IContent content, int userId = Constants.Security.SuperUserId);

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -28,7 +28,17 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Gets blueprints for a content type.
         /// </summary>
-        IEnumerable<IContent> GetBlueprintsForContentTypes(params int[] documentTypeId);
+        IEnumerable<IContent> GetBlueprintsForContentTypes();
+
+        /// <summary>
+        /// Gets blueprints for a content type.
+        /// </summary>
+        IEnumerable<IContent> GetBlueprintsForContentTypes(int contentTypeId);
+
+        /// <summary>
+        /// Gets blueprints for a content type.
+        /// </summary>
+        IEnumerable<IContent> GetBlueprintsForContentTypes(int[] contentTypeIds, int[] userGroupIds = null);
 
         /// <summary>
         /// Gets the collection of user groups assigned to the blueprint.

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2903,9 +2903,9 @@ namespace Umbraco.Core.Services.Implement
             return GetBlueprintsForContentTypes(new int[0]);
         }
 
-        public IEnumerable<IContent> GetBlueprintsForContentTypes(int contentTypeId)
+        public IEnumerable<IContent> GetBlueprintsForContentTypes(int contentTypeId, int[] userGroupIds = null)
         {
-            return GetBlueprintsForContentTypes(new[] { contentTypeId });
+            return GetBlueprintsForContentTypes(new[] { contentTypeId }, userGroupIds);
         }
 
         public IEnumerable<IContent> GetBlueprintsForContentTypes(int[] contentTypeIds, int[] userGroupIds = null)

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2950,6 +2950,11 @@ namespace Umbraco.Core.Services.Implement
 
         public void AssignGroupsToBlueprintById(int id, int[] userGroupIds)
         {
+            if (userGroupIds == null || userGroupIds.Length == 0)
+            {
+                return;
+            }
+
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 scope.WriteLock(Constants.Locks.ContentTree);

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2915,6 +2915,25 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
+        public IEnumerable<IUserGroup> GetGroupsAssignedToBlueprintById(int id)
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                scope.ReadLock(Constants.Locks.ContentTree);
+                return _documentBlueprintRepository.GetGroupsAssignedToBlueprint(id);
+            }
+        }
+
+        public void AssignGroupsToBlueprintById(int id, int[] userGroupIds)
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                scope.WriteLock(Constants.Locks.ContentTree);
+                 _documentBlueprintRepository.AssignGroupsToBlueprint(id, userGroupIds);
+                scope.Complete();
+            }
+        }
+
         public void DeleteBlueprintsOfTypes(IEnumerable<int> contentTypeIds, int userId = Constants.Security.SuperUserId)
         {
             using (var scope = ScopeProvider.CreateScope())

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -237,6 +237,8 @@
     <Compile Include="PropertyEditors\DateTimeConfiguration.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\RenameLabelAndRichTextPropertyEditorAliases.cs" />
     <Compile Include="PublishedModelFactoryExtensions.cs" />
+    <Compile Include="Security\DefaultCreatedBluePrintAssignmentToUserGroupBehaviour.cs" />
+    <Compile Include="Security\ICreatedBluePrintAssignmentToUserGroupBehaviour.cs" />
     <Compile Include="Services\PropertyValidationService.cs" />
     <Compile Include="Composing\TypeCollectionBuilderBase.cs" />
     <Compile Include="TypeLoaderExtensions.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -225,10 +225,12 @@
     <Compile Include="Mapping\MapDefinitionCollectionBuilder.cs" />
     <Compile Include="Mapping\IMapDefinition.cs" />
     <Compile Include="Mapping\UmbracoMapper.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_1_0\AddUserGroupToContentTemplateTables.cs" />
     <Compile Include="Migrations\Upgrade\V_8_1_0\ConvertTinyMceAndGridMediaUrlsToLocalLink.cs" />
     <Compile Include="Models\CultureImpact.cs" />
     <Compile Include="Models\PublishedContent\ILivePublishedModelFactory.cs" />
     <Compile Include="Persistence\Dtos\PropertyTypeCommonDto.cs" />
+    <Compile Include="Persistence\Dtos\UserGroup2ContentTemplateDto.cs" />
     <Compile Include="Persistence\Repositories\Implement\ContentTypeCommonRepository.cs" />
     <Compile Include="Persistence\Repositories\IContentTypeCommonRepository.cs" />
     <Compile Include="Persistence\Repositories\Implement\LanguageRepositoryExtensions.cs" />

--- a/src/Umbraco.Tests/Persistence/SqlCeTableByTableTest.cs
+++ b/src/Umbraco.Tests/Persistence/SqlCeTableByTableTest.cs
@@ -521,5 +521,20 @@ namespace Umbraco.Tests.Persistence
                 scope.Complete();
             }
         }
+
+        [Test]
+        public void Can_Create_umbracoUserGroup2ContentTemplate_Table()
+        {
+            using (var scope = ScopeProvider.CreateScope())
+            {
+                var helper = new DatabaseSchemaCreator(scope.Database, Mock.Of<ILogger>());
+
+                helper.CreateTable<NodeDto>();
+                helper.CreateTable<UserGroupDto>();
+                helper.CreateTable<UserGroup2ContentTemplateDto>();
+
+                scope.Complete();
+            }
+        }
     }
 }

--- a/src/Umbraco.Tests/TestHelpers/TestWithDatabaseBase.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestWithDatabaseBase.cs
@@ -29,6 +29,7 @@ using Umbraco.Tests.Testing;
 using Umbraco.Core.Migrations.Install;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Persistence.Repositories;
+using Umbraco.Core.Security;
 using Umbraco.Tests.LegacyXmlPublishedCache;
 using Umbraco.Tests.Testing.Objects.Accessors;
 
@@ -75,6 +76,7 @@ namespace Umbraco.Tests.TestHelpers
             Composition.Register<ISqlSyntaxProvider, SqlCeSyntaxProvider>();
             Composition.Register(factory => PublishedSnapshotService);
             Composition.Register(factory => DefaultCultureAccessor);
+            Composition.RegisterUnique<ICreatedBluePrintAssignmentToUserGroupBehaviour, DefaultCreatedBluePrintAssignmentToUserGroupBehaviour>();
 
             Composition.WithCollectionBuilder<DataEditorCollectionBuilder>()
                 .Clear()

--- a/src/Umbraco.Tests/Web/Controllers/ContentControllerTests.cs
+++ b/src/Umbraco.Tests/Web/Controllers/ContentControllerTests.cs
@@ -21,12 +21,9 @@ using Umbraco.Tests.Testing;
 using Umbraco.Web;
 using Umbraco.Web.Editors;
 using Umbraco.Web.Models.ContentEditing;
-using Umbraco.Web.PublishedCache;
-
 using Task = System.Threading.Tasks.Task;
 using Umbraco.Core.Dictionary;
 using Umbraco.Web.PropertyEditors;
-using System;
 using Umbraco.Web.WebApi;
 using Umbraco.Web.Trees;
 using System.Globalization;
@@ -35,6 +32,7 @@ using Umbraco.Core.Cache;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;
+using Umbraco.Core.Security;
 using Umbraco.Web.Actions;
 
 namespace Umbraco.Tests.Web.Controllers
@@ -255,7 +253,8 @@ namespace Umbraco.Tests.Web.Controllers
                     Factory.GetInstance<AppCaches>(),
                     Factory.GetInstance<IProfilingLogger>(),
                     Factory.GetInstance<IRuntimeState>(),
-                    helper);
+                    helper,
+                    Factory.GetInstance<ICreatedBluePrintAssignmentToUserGroupBehaviour>());
 
                 return controller;
             }
@@ -288,7 +287,8 @@ namespace Umbraco.Tests.Web.Controllers
                     Factory.GetInstance<AppCaches>(),
                     Factory.GetInstance<IProfilingLogger>(),
                     Factory.GetInstance<IRuntimeState>(),
-                    helper);
+                    helper,
+                    Factory.GetInstance<ICreatedBluePrintAssignmentToUserGroupBehaviour>());
 
                 return controller;
             }
@@ -329,7 +329,8 @@ namespace Umbraco.Tests.Web.Controllers
                     Factory.GetInstance<AppCaches>(),
                     Factory.GetInstance<IProfilingLogger>(),
                     Factory.GetInstance<IRuntimeState>(),
-                    helper);
+                    helper,
+                    Factory.GetInstance<ICreatedBluePrintAssignmentToUserGroupBehaviour>());
 
                 return controller;
             }
@@ -375,7 +376,8 @@ namespace Umbraco.Tests.Web.Controllers
                     Factory.GetInstance<AppCaches>(),
                     Factory.GetInstance<IProfilingLogger>(),
                     Factory.GetInstance<IRuntimeState>(),
-                    helper);
+                    helper,
+                    Factory.GetInstance<ICreatedBluePrintAssignmentToUserGroupBehaviour>());
 
                 return controller;
             }
@@ -413,7 +415,8 @@ namespace Umbraco.Tests.Web.Controllers
                     Factory.GetInstance<AppCaches>(),
                     Factory.GetInstance<IProfilingLogger>(),
                     Factory.GetInstance<IRuntimeState>(),
-                    helper);
+                    helper,
+                    Factory.GetInstance<ICreatedBluePrintAssignmentToUserGroupBehaviour>());
 
                 return controller;
             }
@@ -457,7 +460,8 @@ namespace Umbraco.Tests.Web.Controllers
                     Factory.GetInstance<AppCaches>(),
                     Factory.GetInstance<IProfilingLogger>(),
                     Factory.GetInstance<IRuntimeState>(),
-                    helper);
+                    helper,
+                    Factory.GetInstance<ICreatedBluePrintAssignmentToUserGroupBehaviour>());
 
                 return controller;
             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbcontextdialog/umbcontextdialog.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbcontextdialog/umbcontextdialog.directive.js
@@ -1,12 +1,16 @@
 (function() {
     'use strict';
 
-    function UmbContextDialog(navigationService, keyboardService) {
+    function UmbContextDialog(navigationService, keyboardService, editorService) {
 
         function link($scope) {
             
-            $scope.outSideClick = function() {
-                navigationService.hideDialog();
+            $scope.outSideClick = function () {
+                // Only close dialog if there's not an editor open (e.g. a picker has been launched).  Clicks within the edito
+                // will trigger this functions, so we want to avoid closing the dialog that launched the editor.
+                if (editorService.getNumberOfEditors() === 0) {
+                    navigationService.hideDialog();
+                }
             }
 
             keyboardService.bind("esc", function() {

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -406,6 +406,29 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
                 });
         },
 
+        getGroupsAssignedToBlueprintById: function (id) {
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "contentApiBaseUrl",
+                        "GetGroupsAssignedToBlueprintById",
+                        [{ id: id }])),
+                'Failed to retrieve user groups assigned to blueprint for id ' + id);
+        },
+
+        assignGroupsToBlueprintById: function (id, userGroupIds) {
+            if (!id) {
+                throw "contentId cannot be null";
+            }
+            return umbRequestHelper.resourcePromise(
+                $http.post(
+                    umbRequestHelper.getApiUrl(
+                        "contentApiBaseUrl",
+                        "AssignGroupsToBlueprintById",
+                        { id: id, userGroupIds: userGroupIds })),
+                'Failed to assign user groups for blueprint id ' + id);
+        },
+
         getNotifySettingsById: function (id) {
             return umbRequestHelper.resourcePromise(
                 $http.get(

--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-group-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-group-preview.less
@@ -43,6 +43,7 @@
     flex: 0 0 auto;
     display: flex;
     align-items: center;
+    cursor: pointer;
 }
 
 .umb-user-group-preview__action {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.controller.js
@@ -30,7 +30,7 @@
                 $scope.model.selection = [];
             }
 
-            // get venues
+            // get user groups
             userGroupsResource.getUserGroups().then(function(userGroups){
                 vm.userGroups = userGroups;
                 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.html
@@ -83,7 +83,7 @@
                 <umb-button
                     type="button"
                     button-style="link"
-                    label-key="general_close"
+                    label-key="general_cancel"
                     shortcut="esc"
                     action="vm.close()">
                 </umb-button>

--- a/src/Umbraco.Web.UI.Client/src/views/contentblueprints/restricttousergroups.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/contentblueprints/restricttousergroups.controller.js
@@ -1,0 +1,71 @@
+/**
+ * @ngdoc controller
+ * @name Umbraco.Editors.ContentBlueprint.RestrictToUserGroupsController
+ * @function
+ * 
+ * @description
+ * The controller for assigning user groups to blueprints (conten templates)
+ */
+function RestrictToUserGroupsController($scope, navigationService, contentResource, editorService) {
+
+    var vm = this;
+
+    vm.removeSelectedItem = removeSelectedItem;
+    vm.openUserGroupPicker = openUserGroupPicker;
+    vm.saveChanges = saveChanges;
+
+    function onInit() {
+
+        vm.loading = true;
+        contentResource.getGroupsAssignedToBlueprintById($scope.currentNode.id).then(function (userGroups) {
+            vm.userGroups = userGroups;
+            vm.loading = false;
+        });
+
+    }
+
+    function removeSelectedItem(index, selection) {
+        if (selection && selection.length > 0) {
+            selection.splice(index, 1);
+        }
+    }
+
+    function openUserGroupPicker() {
+        var oldSelection = angular.copy(vm.userGroups);
+        var userGroupPicker = {
+            selection: vm.userGroups,
+            submit: function (model) {
+                // apply changes
+                if (model.selection) {
+                    vm.userGroups = model.selection;
+                }
+                editorService.close();
+            },
+            close: function () {
+                // roll back the selection
+                vm.userGroups = oldSelection;
+                editorService.close();
+            }
+        };
+        editorService.userGroupPicker(userGroupPicker);
+    }
+
+    function saveChanges() {
+
+        vm.submitButtonState = "busy";
+
+        var userGroupIds = vm.userGroups.map(a => a.id);
+        contentResource.assignGroupsToBlueprintById($scope.currentNode.id, userGroupIds).then(function () {
+            vm.submitButtonState = "success";
+            navigationService.hideDialog();
+        });
+    }
+
+    $scope.cancel = function () {
+        navigationService.hideDialog();        
+    };
+
+    onInit();
+}
+
+angular.module("umbraco").controller("Umbraco.Editors.ContentBlueprint.RestrictToUserGroupsController", RestrictToUserGroupsController);

--- a/src/Umbraco.Web.UI.Client/src/views/contentblueprints/restricttousergroups.html
+++ b/src/Umbraco.Web.UI.Client/src/views/contentblueprints/restricttousergroups.html
@@ -1,0 +1,40 @@
+<div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.ContentBlueprint.RestrictToUserGroupsController as vm">
+    <div class="umb-dialog-body" auto-scale="90">
+
+        <p>
+            <localize key="blueprints_groupsHelp"></localize>
+        </p>
+
+        <umb-user-group-preview ng-repeat="userGroup in vm.userGroups"
+                                icon="userGroup.icon"
+                                name="userGroup.name"
+                                allow-remove="true"
+                                hide-content-start-node="true"
+                                hide-media-start-node="true"
+                                on-remove="vm.removeSelectedItem($index, vm.userGroups)">
+        </umb-user-group-preview>
+
+        <a href=""
+           style="max-width: 100%;"
+           class="umb-node-preview-add"
+           ng-click="vm.openUserGroupPicker()"
+           prevent-default>
+            <localize key="general_add">Add</localize>
+        </a>
+
+    </div>
+
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+        <umb-button label-key="general_cancel"
+                    action="cancel()"
+                    type="button"
+                    button-style="link">
+        </umb-button>
+        <umb-button label-key="buttons_save"
+                    type="submit"
+                    ng-click="vm.saveChanges()"
+                    state="vm.submitButtonState"
+                    button-style="success">
+        </umb-button>
+    </div>
+</div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -49,6 +49,7 @@
     <key alias="setPermissions">Set permissions</key>
     <key alias="unlock">Unlock</key>
     <key alias="createblueprint">Create Content Template</key>
+    <key alias="restrictToUserGroups">Restrict To User Groups</key>
     <key alias="resendInvite">Resend Invitation</key>
   </area>
   <area alias="actionCategories">
@@ -305,6 +306,7 @@
     <key alias="createdBlueprintMessage">A Content Template was created from '%0%'</key>
     <key alias="duplicateBlueprintMessage">Another Content Template with the same name already exists</key>
     <key alias="blueprintDescription">A Content Template is pre-defined content that an editor can select to use as the basis for creating new content</key>
+    <key alias="groupsHelp">Select one or more user groups to restrict access to the selected content template to just members of those groups.  If no groups are selected, the content template is available to all.</key>
   </area>
   <area alias="media">
     <key alias="clickToUpload">Click to upload</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -49,6 +49,7 @@
     <key alias="setPermissions">Set permissions</key>
     <key alias="unlock">Unlock</key>
     <key alias="createblueprint">Create Content Template</key>
+    <key alias="restrictToUserGroups">Restrict To User Groups</key>
     <key alias="resendInvite">Resend Invitation</key>
   </area>
   <area alias="actionCategories">
@@ -309,6 +310,7 @@
     <key alias="createdBlueprintMessage">A Content Template was created from '%0%'</key>
     <key alias="duplicateBlueprintMessage">Another Content Template with the same name already exists</key>
     <key alias="blueprintDescription">A Content Template is pre-defined content that an editor can select to use as the basis for creating new content</key>
+    <key alias="groupsHelp">Select one or more user groups to restrict access to the selected content template to just members of those groups.  If no groups are selected, the content template is available to all.</key>
   </area>
   <area alias="media">
     <key alias="clickToUpload">Click to upload</key>

--- a/src/Umbraco.Web/Actions/ActionCollectionBuilder.cs
+++ b/src/Umbraco.Web/Actions/ActionCollectionBuilder.cs
@@ -1,23 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Umbraco.Core.Composing;
+﻿using Umbraco.Core.Composing;
+
 namespace Umbraco.Web.Actions
 {
     internal class ActionCollectionBuilder : LazyCollectionBuilderBase<ActionCollectionBuilder, ActionCollection, IAction>
     {
         protected override ActionCollectionBuilder This => this;
-
-        protected override IEnumerable<IAction> CreateItems(IFactory factory)
-        {
-            var items = base.CreateItems(factory).ToList();
-
-            //validate the items, no actions should exist that do not either expose notifications or permissions
-            var invalidItems = items.Where(x => !x.CanBePermissionAssigned && !x.ShowInNotifier).ToList();
-            if (invalidItems.Count == 0) return items;
-
-            var invalidActions = string.Join(", ", invalidItems.Select(x => "'" + x.Alias + "'"));
-            throw new InvalidOperationException($"Invalid actions {invalidActions}'. All {typeof(IAction)} implementations must be true for either {nameof(IAction.CanBePermissionAssigned)} or {nameof(IAction.ShowInNotifier)}.");
-        }
     }
 }

--- a/src/Umbraco.Web/Actions/ActionRestrictBlueprintToUserGroups.cs
+++ b/src/Umbraco.Web/Actions/ActionRestrictBlueprintToUserGroups.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Web.Actions
     {
         public char Letter => 'ü';
         public bool ShowInNotifier => false;
-        public bool CanBePermissionAssigned => true;
+        public bool CanBePermissionAssigned => false;
         public string Icon => "users";
         public string Alias => "restrictToUserGroups";
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Web/Actions/ActionRestrictBlueprintToUserGroups.cs
+++ b/src/Umbraco.Web/Actions/ActionRestrictBlueprintToUserGroups.cs
@@ -2,13 +2,13 @@
 
 namespace Umbraco.Web.Actions
 {
-    public class ActionCreateBlueprintFromContent : IAction
+    public class ActionRestrictBlueprintToUserGroups : IAction
     {
-        public char Letter => 'ï';
+        public char Letter => 'ü';
         public bool ShowInNotifier => false;
         public bool CanBePermissionAssigned => true;
-        public string Icon => "blueprint";
-        public string Alias => "createblueprint";
+        public string Icon => "users";
+        public string Alias => "restrictToUserGroups";
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
     }
 }

--- a/src/Umbraco.Web/Actions/IAction.cs
+++ b/src/Umbraco.Web/Actions/IAction.cs
@@ -5,9 +5,6 @@ namespace Umbraco.Web.Actions
     /// <summary>
     /// Defines a back office action that can be permission assigned or subscribed to for notifications
     /// </summary>
-    /// <remarks>
-    /// If an IAction returns false for both ShowInNotifier and CanBePermissionAssigned then the IAction should not exist
-    /// </remarks>
     public interface IAction : IDiscoverable
     {
         /// <summary>

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -265,6 +265,17 @@ namespace Umbraco.Web.Editors
             return content;
         }
 
+        public IEnumerable<UserGroupBasic> GetGroupsAssignedToBlueprintById(int id)
+        {
+            return Mapper.MapEnumerable<IUserGroup, UserGroupBasic>(Services.ContentService.GetGroupsAssignedToBlueprintById(id));
+        }
+
+        [HttpPost]
+        public void AssignGroupsToBlueprintById([FromUri]int id, [FromUri]int[] userGroupIds)
+        {
+            Services.ContentService.AssignGroupsToBlueprintById(id, userGroupIds);
+        }
+
         private static void SetupBlueprint(ContentItemDisplay content, IContent persistedContent)
         {
             content.AllowPreview = false;

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -566,7 +566,7 @@ namespace Umbraco.Web.Editors
         private void AssignUserGroupsToBlueprint(IContent blueprint)
         {
             // If user is non-admin and has a non-root content start node, we'll default the blueprint to only be available to
-            // other users in the same groups.
+            // other users in the same groups (that also have non-root, and non-null, start nodes).
             // That way, in for example a multi-site context, each "site"'s users will only have access to their own blueprints
             // even if document types and templates are shared.
             var currentUser = Security.CurrentUser;
@@ -574,14 +574,16 @@ namespace Umbraco.Web.Editors
             {
                 Services.ContentService.AssignGroupsToBlueprintById(
                     blueprint.Id,
-                    currentUser.Groups.Select(x => x.Id).ToArray());
+                    currentUser.Groups
+                        .Where(x => x.StartContentId.HasValue && x.StartContentId != Constants.System.Root)
+                        .Select(x => x.Id)
+                        .ToArray());
             }
         }
 
         private static bool ShouldAssignUserGroupsToBlueprint(IUser currentUser)
         {
             return !currentUser.IsAdmin() &&
-                   currentUser.Groups.Any() &&
                    currentUser.StartContentIds != null &&
                    !currentUser.StartContentIds.Contains(Constants.System.Root);
         }

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -441,7 +441,9 @@ namespace Umbraco.Web.Editors
             }
 
             //map the blueprints
-            var blueprints = Services.ContentService.GetBlueprintsForContentTypes(types.Select(x => x.Id).ToArray()).ToArray();
+            var contentTypeIds = types.Select(x => x.Id).ToArray();
+            var userGroupIds = Security.CurrentUser.Groups.Select(x => x.Id).ToArray();
+            var blueprints = Services.ContentService.GetBlueprintsForContentTypes(contentTypeIds, userGroupIds).ToArray();
             foreach (var basic in basics)
             {
                 var docTypeBluePrints = blueprints.Where(x => x.ContentTypeId == (int) basic.Id).ToArray();

--- a/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
@@ -372,7 +372,7 @@ namespace Umbraco.Web.Models.Mapping
                 .Where(x => x.CanBePermissionAssigned)
                 .Select(GetPermission)
                 .GroupBy(x => x.Category)
-                .ToDictionary(x => x.Key, x => (IEnumerable<Permission>)x.ToArray());
+                .ToDictionary(x => x.Key, x => (IEnumerable<Permission>)x.OrderBy(y => y.Name).ToArray());
         }
 
         private static string MapContentTypeIcon(EntitySlim entity)

--- a/src/Umbraco.Web/Trees/ContentBlueprintTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentBlueprintTreeController.cs
@@ -23,7 +23,6 @@ namespace Umbraco.Web.Trees
     [CoreTree]
     public class ContentBlueprintTreeController : TreeController
     {
-
         protected override TreeNode CreateRootNode(FormDataCollection queryStrings)
         {
             var root = base.CreateRootNode(queryStrings);
@@ -111,6 +110,7 @@ namespace Umbraco.Web.Trees
                 return menu;
             }
 
+            menu.Items.Add<ActionRestrictBlueprintToUserGroups>(Services.TextService, opensDialog: true);
             menu.Items.Add<ActionDelete>(Services.TextService, opensDialog: true);
 
             return menu;

--- a/src/Umbraco.Web/Trees/ContentBlueprintTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentBlueprintTreeController.cs
@@ -35,6 +35,7 @@ namespace Umbraco.Web.Trees
 
             return root;
         }
+
         protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
         {
             var nodes = new TreeNodeCollection();

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -107,6 +107,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Actions\ActionRestrictBlueprintToUserGroups.cs" />
     <Compile Include="AppBuilderExtensions.cs" />
     <Compile Include="AreaRegistrationContextExtensions.cs" />
     <Compile Include="AspNetHttpContextAccessor.cs" />


### PR DESCRIPTION
This PR is a solution for [issue #5425](https://github.com/umbraco/Umbraco-CMS/issues/5425), to better support blueprints (content templates) in multi-site solutions.

I've implemented the following:

- Added a new dialog available, from the content templates, created in the "Settings" section to allow them to be associated with user groups.
   - This involved a new table - `umbracoUserGroup2ContentTemplate` - so there's a migration to create this.
- When an editor sees the list of content templates to pick from when creating content, they only see those that match their user group(s).
    - They also see any content templates that aren't assigned to any user groups (so if the feature isn't used, the behaviour is as before).
- When an editor creates a content template from a content node, if the user is not an administrator and does not have the root content node set as their start node, the user groups they are in are automatically set on the content template.
    - The idea here is that if the editor manages just one section of the site, perhaps a single territory, they will only see content templates they, or others in that same section, have made.  They won't see those created in other sections, nor will editors of those other sections see their's.

![image](https://user-images.githubusercontent.com/1993459/58409776-11cfc680-8071-11e9-9e09-c7124ab97501.png)

As well as general review, please note this amend in case it's important and otherwise missed...

There was a comment on `IAction` stating _"If an IAction returns false for both ShowInNotifier and CanBePermissionAssigned then the IAction should not exist"_.  And some validation in `ActionCollectionBuilder` to ensure this is the case.  

To implement this feature I've created an action that doesn't adhere to this rule (it lives in "Settings" so content node permissions don't apply, and having a fine-grained permission for this when the user already has access to the "Settings" area doesn't seem useful; and there's no pressing need to be able to subscribe to notifications).

As such I've removed this comment and validation as part of this PR.  Obviously if I've missed something important as to why this check was in place, please let me know.