### PR TITLE
V8: Fixes #5534 (saving a user with no groups fails validation, but no message is displayed)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -170,7 +170,8 @@
 
                         contentEditingHelper.handleSaveError({
                             redirectOnFailure: false,
-                            err: err
+                            err: err,
+                            showNotifications: true
                         });
                         
                         vm.page.saveButtonState = "error";


### PR DESCRIPTION
Fixes [issue #5534.](https://github.com/umbraco/Umbraco-CMS/issues/5534)  Just need to add the flag to show the notification I believe.