### PR TITLE
Case insensitive section comparison

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/routes.js
+++ b/src/Umbraco.Web.UI.Client/src/routes.js
@@ -39,10 +39,14 @@ app.config(function ($routeProvider) {
                                         $route.current.params.section = "content";
                                     }
 
+                                    var found = _.find(user.allowedSections, function (s) {
+                                        return s.localeCompare($route.current.params.section, undefined, { sensitivity: 'accent' }) === 0;
+                                    })
+
                                     // U4-5430, Benjamin Howarth
                                     // We need to change the current route params if the user only has access to a single section
                                     // To do this we need to grab the current user's allowed sections, then reject the promise with the correct path.
-                                    if (user.allowedSections.indexOf($route.current.params.section) > -1) {
+                                    if (found) {
                                         //this will resolve successfully so the route will continue
                                         return $q.when(true);
                                     } else {
@@ -119,7 +123,7 @@ app.config(function ($routeProvider) {
                 sectionService.getSectionsForUser().then(function(sections) {
                     //find the one we're requesting
                     var found = _.find(sections, function(s) {
-                        return s.alias === $routeParams.section;
+                        return s.alias.localeCompare($routeParams.section, undefined, { sensitivity: 'accent' }) === 0;
                     })
                     if (found && found.routePath) {
                         //there's a custom route path so redirect

--- a/src/Umbraco.Web/Services/SectionService.cs
+++ b/src/Umbraco.Web/Services/SectionService.cs
@@ -39,6 +39,6 @@ namespace Umbraco.Web.Services
 
         /// <inheritdoc />
         public ISection GetByAlias(string appAlias)
-            => GetSections().FirstOrDefault(t => t.Alias == appAlias);
+            => GetSections().FirstOrDefault(t => t.Alias.Equals(appAlias, StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

To test the issue you'll have to
- Add a new section with a camel-cased name, like 'MySection'
- Create a tree where the nodes RoutePath is created manually and lower cased: 'mysection/mytree/edit/123'
- Create a plugin with the tree views as '~/App_Plugin/MySection/backoffice/MyTree/edit.html' with an edit.html

Without the fix, clicking the nodes in the tree will redirect to 'content' because it can't find the route as the 'mysection' in the url doesn't match 'MySection'.

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4654

### Description
I have replaced the comparisons of the section alias to make it case insensitive. I have found this occurs in three placesL 2 routes and the service that finds the section tree.

<!-- Thanks for contributing to Umbraco CMS! -->
