### PR TITLE
V8: Automatically hide the context menu after reloading a node

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/menuactions.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/menuactions.service.js
@@ -71,7 +71,9 @@ function umbracoMenuActions(treeService, $location, navigationService, appState,
             if (treeRoot && treeRoot.root) {
                 var treeNode = treeService.getDescendantNode(treeRoot.root, args.entity.id, args.treeAlias);
                 if (treeNode) {
-                    treeService.loadNodeChildren({ node: treeNode, section: args.section });
+                    treeService.loadNodeChildren({ node: treeNode, section: args.section }).then(function () {
+                        navigationService.hideMenu();
+                    });
                 }                
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I don't think there's any reason why the tree node context menu should stay open after performing a reload of the node... so this PR ensures that the context menu automatically closes after the reload:

![reload-auto-close](https://user-images.githubusercontent.com/7405322/58608016-fe577200-82a1-11e9-88f8-2c2d4d0f7a2e.gif)
