### PR TITLE
V8: Don't show "Reload" for list view nodes

### DIFF
--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -248,8 +248,11 @@ namespace Umbraco.Web.Trees
 	                OpensDialog = true
 	            });
             }
-			
-            menu.Items.Add(new RefreshNode(Services.TextService, true));
+
+            if((item is DocumentEntitySlim documentEntity && documentEntity.IsContainer) == false)
+            {
+                menu.Items.Add(new RefreshNode(Services.TextService, true));
+            }
 
             return menu;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The "Reload" context action seems rather pointless for list view nodes, as their children aren't shown in the tree... so this PR removes the "Reload" action for list view nodes:

![list-view-no-reload](https://user-images.githubusercontent.com/7405322/58608163-a1a88700-82a2-11e9-81e9-c00f4a52031b.gif)
