### PR TITLE
V8: Ensure "pointer" cursor for all links with ng-click 

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/scaffolding.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/scaffolding.less
@@ -28,6 +28,11 @@ a:focus {
   color: @linkColorHover;
   text-decoration: underline;
 }
+a[ng-click],
+a[data-ng-click],
+a[x-ng-click] {
+  cursor: pointer;
+}
 
 
 // Images


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5404

### Description

As @bjarnef points out on https://github.com/umbraco/Umbraco-CMS/pull/5494#issuecomment-493857337, there seems to be missing a general style rule to add define the "pointer" cursor for links with `ng-click` but no `href` - e.g. `<a ng-click="vm.something()">...`. This means that links in several places no longer have the "pointer" cursor, including:

- The variant language selector
- The split view close button
- The user avatar
- The `umb-confirm` directive buttons
- The "open template" links from content type

![ng-links-missing-pointer-before](https://user-images.githubusercontent.com/7405322/58681403-79855a80-836c-11e9-9c53-35dc10aaedcc.gif)

This PR fixes it. I have chosen the cautious path that adds "pointer" cursor specifically to links - not to all types of tags with `ng-click`.

With this PR applied, the same operations as seen above behave like this:

![ng-links-missing-pointer-after](https://user-images.githubusercontent.com/7405322/58681451-bc473280-836c-11e9-9496-b92e5a7d0149.gif)

If this PR is accepted, it supersedes #5494 and #5414 