### PR TITLE
Added a check for and delete descendants when deleting a dictionary item

### DIFF
--- a/src/Umbraco.Web/Editors/DictionaryController.cs
+++ b/src/Umbraco.Web/Editors/DictionaryController.cs
@@ -52,6 +52,13 @@ namespace Umbraco.Web.Editors
             if (foundDictionary == null)
                 throw new HttpResponseException(HttpStatusCode.NotFound);
 
+            var foundDictionaryDescendants = Services.LocalizationService.GetDictionaryItemDescendants(foundDictionary.Key);
+
+            foreach (var dictionaryItem in foundDictionaryDescendants)
+            {
+                Services.LocalizationService.Delete(dictionaryItem, Security.CurrentUser.Id);
+            }
+
             Services.LocalizationService.Delete(foundDictionary, Security.CurrentUser.Id);
 
             return Request.CreateResponse(HttpStatusCode.OK);


### PR DESCRIPTION
Updated Pull Request: https://github.com/umbraco/Umbraco-CMS/pull/5517

When deleting a dictionary item the descendants of that item are not removed. This will throw errors in the backoffice and requires manual deletion in the database.

Steps to test this PR are:

Create a dictionary item structure similar to this:

Parent
--Child 1
---Grandchild 1
Delete parent and all descendants are removed without errors.

At Codegarden I discussed with Claus Jensen if we should alter the warning message but we concluded that this is expected behavior if you delete a parent.

Please let me know if I need to change something.