### PR TITLE
V8: Add validation to the Version and UmbracoVersion properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -26,6 +26,9 @@
 
         vm.buttonLabel = "";
 
+        vm.packageVersionRegex = /^(\d+\.)(\d+\.)?(\*|\d+)$/;
+        vm.umbracoVersionRegex = /^(\d+\.)(\d+\.)(\*|\d+)$/;
+
         const packageId = $routeParams.id;
         const create = $routeParams.create;
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -26,8 +26,7 @@
 
         vm.buttonLabel = "";
 
-        vm.packageVersionRegex = /^(\d+\.)(\d+\.)?(\*|\d+)$/;
-        vm.umbracoVersionRegex = /^(\d+\.)(\d+\.)(\*|\d+)$/;
+        vm.versionRegex = /^(\d+\.)(\d+\.)(\*|\d+)$/;
 
         const packageId = $routeParams.id;
         const create = $routeParams.create;

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -36,7 +36,7 @@
                         </umb-control-group>
 
                         <umb-control-group label="Version" required="true">
-                            <input class="umb-property-editor" name="version" type="text" ng-model="vm.package.version" val-server-field="model.Version" required ng-pattern="vm.packageVersionRegex" />
+                            <input class="umb-property-editor" name="version" type="text" ng-model="vm.package.version" val-server-field="model.Version" required ng-pattern="vm.versionRegex" />
 
                             <span ng-messages="editPackageForm.version.$error" show-validation-on-submit >
                                 <span class="help-inline" ng-message="required"><localize key="general_required">Required</localize></span>
@@ -54,7 +54,7 @@
                         </umb-control-group>-->
 
                         <umb-control-group label="Umbraco version">
-                            <input class="umb-property-editor" name="umbracoVersion" type="text" ng-model="vm.package.umbracoVersion" val-server-field="model.umbracoVersion" ng-pattern="vm.umbracoVersionRegex" />
+                            <input class="umb-property-editor" name="umbracoVersion" type="text" ng-model="vm.package.umbracoVersion" val-server-field="model.umbracoVersion" ng-pattern="vm.versionRegex" />
 
                             <span ng-messages="editPackageForm.umbracoVersion.$error" show-validation-on-submit >
                                 <span class="help-inline" ng-message="valServerField">{{editPackageForm.umbracoVersion.errorMsg}}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -36,7 +36,7 @@
                         </umb-control-group>
 
                         <umb-control-group label="Version" required="true">
-                            <input class="umb-property-editor" name="version" type="text" ng-model="vm.package.version" val-server-field="model.Version" required />
+                            <input class="umb-property-editor" name="version" type="text" ng-model="vm.package.version" val-server-field="model.Version" required ng-pattern="vm.packageVersionRegex" />
 
                             <span ng-messages="editPackageForm.version.$error" show-validation-on-submit >
                                 <span class="help-inline" ng-message="required"><localize key="general_required">Required</localize></span>
@@ -54,7 +54,7 @@
                         </umb-control-group>-->
 
                         <umb-control-group label="Umbraco version">
-                            <input class="umb-property-editor" name="umbracoVersion" type="text" ng-model="vm.package.umbracoVersion" val-server-field="model.umbracoVersion" />
+                            <input class="umb-property-editor" name="umbracoVersion" type="text" ng-model="vm.package.umbracoVersion" val-server-field="model.umbracoVersion" ng-pattern="vm.umbracoVersionRegex" />
 
                             <span ng-messages="editPackageForm.umbracoVersion.$error" show-validation-on-submit >
                                 <span class="help-inline" ng-message="valServerField">{{editPackageForm.umbracoVersion.errorMsg}}</span>


### PR DESCRIPTION
### Prerequisites

See issue 5528: V8 - Install local package gives error: incorrect version

### Description

We need to help the user when entering a version for his package and which umbraco version it uses. For the package version we can enter v1.0.0 which results in an error when installing the package in Umbraco in the backoffice.

So, we added 2 regular expressions in the edit package controller:
- One for package version which allows versions of format 1.0 or 1.0.0
- One for Umbraco version which allows versions of format 1.0.0

