### PR TITLE
V8: implements #5561 - Make more helpful message than "there are no allowed document types available"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -7,86 +7,103 @@
  * The controller for the content creation dialog
  */
 function contentCreateController($scope,
-  $routeParams,
-  contentTypeResource,
-  iconHelper,
-  $location,
-  navigationService,
-  blueprintConfig) {
-  
-  var mainCulture = $routeParams.mculture ? $routeParams.mculture : null;
+    $routeParams,
+    contentTypeResource,
+    iconHelper,
+    $location,
+    navigationService,
+    blueprintConfig,
+    authResource,
+    contentResource) {
 
-  function initialize() {
-    $scope.allowedTypes = null;
-    contentTypeResource.getAllowedTypes($scope.currentNode.id).then(function (data) {
-      $scope.allowedTypes = iconHelper.formatContentTypeIcons(data);
-    });
+    var mainCulture = $routeParams.mculture ? $routeParams.mculture : null;
 
-    $scope.selectContentType = true;
-    $scope.selectBlueprint = false;
-    $scope.allowBlank = blueprintConfig.allowBlank;
-  }
+    function initialize() {
+        $scope.allowedTypes = null;
+        contentTypeResource.getAllowedTypes($scope.currentNode.id).then(function (data) {
+            $scope.allowedTypes = iconHelper.formatContentTypeIcons(data);
+        });
 
-  function close() {
-    navigationService.hideMenu();
-  }
+        if ($scope.currentNode.id > -1) {
+            authResource.getCurrentUser().then(function(currentUser) {
+                if (currentUser.allowedSections.indexOf("settings") > -1) {
+                    $scope.hasSettingsAccess = true;
+                    contentResource.getById($scope.currentNode.id).then(function(data) {
+                        $scope.contentTypeId = data.contentTypeId;
+                    });
+                }
+            });
+        }
 
-  function createBlank(docType) {
-      $location
-          .path("/content/content/edit/" + $scope.currentNode.id)
-          .search("doctype", docType.alias)
-          .search("create", "true")
-          /* when we create a new node we want to make sure it uses the same 
-          language as what is selected in the tree */
-          .search("cculture", mainCulture);
-    close();
-  }
-
-  function createOrSelectBlueprintIfAny(docType) {
-    // map the blueprints into a collection that's sortable in the view
-    var blueprints = _.map(_.pairs(docType.blueprints || {}), function (pair) {
-      return {
-        id: pair[0],
-        name: pair[1]
-      };
-    });
-    $scope.docType = docType;
-    if (blueprints.length) {
-      if (blueprintConfig.skipSelect) {
-        createFromBlueprint(blueprints[0].id);
-      } else {
-        $scope.selectContentType = false;
-        $scope.selectBlueprint = true;
-        $scope.selectableBlueprints = blueprints;
-      }
-    } else {
-      createBlank(docType);
+        $scope.selectContentType = true;
+        $scope.selectBlueprint = false;
+        $scope.allowBlank = blueprintConfig.allowBlank;
     }
-  }
 
-  function createFromBlueprint(blueprintId) {
-    $location
-      .path("/content/content/edit/" + $scope.currentNode.id)
-          .search("doctype", $scope.docType.alias)
-          .search("create", "true")
-          .search("blueprintId", blueprintId);
-    close();
-  }
+    function close() {
+        navigationService.hideMenu();
+    }
 
-  $scope.closeDialog = function(showMenu) {
-    navigationService.hideDialog(showMenu);
-  };
+    function createBlank(docType) {
+        $location
+            .path("/content/content/edit/" + $scope.currentNode.id)
+            .search("doctype", docType.alias)
+            .search("create", "true")
+            /* when we create a new node we want to make sure it uses the same 
+            language as what is selected in the tree */
+            .search("cculture", mainCulture);
+        close();
+    }
 
-  $scope.createBlank = createBlank;
-  $scope.createOrSelectBlueprintIfAny = createOrSelectBlueprintIfAny;
-  $scope.createFromBlueprint = createFromBlueprint;
+    function createOrSelectBlueprintIfAny(docType) {
+        // map the blueprints into a collection that's sortable in the view
+        var blueprints = _.map(_.pairs(docType.blueprints || {}), function (pair) {
+            return {
+                id: pair[0],
+                name: pair[1]
+            };
+        });
+        $scope.docType = docType;
+        if (blueprints.length) {
+            if (blueprintConfig.skipSelect) {
+                createFromBlueprint(blueprints[0].id);
+            } else {
+                $scope.selectContentType = false;
+                $scope.selectBlueprint = true;
+                $scope.selectableBlueprints = blueprints;
+            }
+        } else {
+            createBlank(docType);
+        }
+    }
 
-  // the current node changes behind the scenes when the context menu is clicked without closing 
-  // the default menu first, so we must watch the current node and re-initialize accordingly
-  var unbindModelWatcher = $scope.$watch("currentNode", initialize);
-  $scope.$on('$destroy', function () {
-    unbindModelWatcher();
-  });
+    function createFromBlueprint(blueprintId) {
+        $location
+            .path("/content/content/edit/" + $scope.currentNode.id)
+            .search("doctype", $scope.docType.alias)
+            .search("create", "true")
+            .search("blueprintId", blueprintId);
+        close();
+    }
+
+    $scope.close = function() {
+        close();
+    }
+
+    $scope.closeDialog = function (showMenu) {
+        navigationService.hideDialog(showMenu);
+    };
+
+    $scope.createBlank = createBlank;
+    $scope.createOrSelectBlueprintIfAny = createOrSelectBlueprintIfAny;
+    $scope.createFromBlueprint = createFromBlueprint;
+
+    // the current node changes behind the scenes when the context menu is clicked without closing 
+    // the default menu first, so we must watch the current node and re-initialize accordingly
+    var unbindModelWatcher = $scope.$watch("currentNode", initialize);
+    $scope.$on('$destroy', function () {
+        unbindModelWatcher();
+    });
 
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/create.html
@@ -6,9 +6,15 @@
             <h5 ng-show="selectContentType"><localize key="create_createUnder">Create a page under</localize> {{currentNode.name}}</h5>
             <h5 ng-show="selectBlueprint"><localize key="blueprints_selectBlueprint">Select a blueprint</localize></h5>
 
-            <p class="abstract" ng-if="allowedTypes && allowedTypes.length === 0">
-                <localize key="create_noDocumentTypes" />
-            </p>
+            <div ng-if="allowedTypes && allowedTypes.length === 0">
+                <p class="abstract" ng-if="!hasSettingsAccess"><localize key="create_noDocumentTypesWithNoSettingsAccess"/></p>
+                <div ng-if="hasSettingsAccess">
+                    <p class="abstract"><localize key="create_noDocumentTypes" /></p>
+                    <a class="btn" href="#settings/documentTypes/edit/{{contentTypeId}}?view=permissions" ng-click="close()">
+                        <localize key="create_noDocumentTypesEditPermissions"/>
+                    </a>
+                </div>
+            </div>
 
             <ul class="umb-actions umb-actions-child" ng-if="selectContentType && allowedTypes.length > 0">
 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -56,7 +56,7 @@
 
         function onInit() {
             // get init values from model when in infinite mode
-            if(infiniteMode) {
+            if (infiniteMode) {
                 documentTypeId = $scope.model.id;
                 create = $scope.model.create;
                 noTemplate = $scope.model.notemplate;
@@ -89,8 +89,7 @@
                     "name": vm.labels.design,
                     "alias": "design",
                     "icon": "icon-document-dashed-line",
-                    "view": "views/documenttypes/views/design/design.html",
-                    "active": true
+                    "view": "views/documenttypes/views/design/design.html"
                 },
                 {
                     "name": vm.labels.listview,
@@ -291,6 +290,28 @@
                 });
 
             vm.page.navigation = buttons;
+            initializeActiveNavigationPanel();
+        }
+
+        function initializeActiveNavigationPanel() {
+            // Initialise first loaded panel based on page route paramater
+            // i.e. ?view=design|listview|permissions
+            var initialViewSetFromRouteParams = false;
+            var view = $routeParams.view;
+            if (view) {
+                var viewPath = "views/documenttypes/views/" + view + "/" + view + ".html";
+                for (var i = 0; i < vm.page.navigation.length; i++) {
+                    if (vm.page.navigation[i].view === viewPath) {
+                        vm.page.navigation[i].active = true;
+                        initialViewSetFromRouteParams = true;
+                        break;
+                    }
+                }
+            }
+
+            if (initialViewSetFromRouteParams === false) {
+                vm.page.navigation[0].active = true;
+            }
         }
 
         /* ---------- SAVE ---------- */

--- a/src/Umbraco.Web.UI.Client/src/views/media/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/create.html
@@ -4,9 +4,15 @@
 
 			<h5><localize key="create_createUnder">Create under</localize> {{currentNode.name}}</h5>
 
-			<p class="abstract" ng-show="allowedTypes && allowedTypes.length === 0">
-				<localize key="create_noMediaTypes" />
-			</p>
+            <div ng-if="allowedTypes && allowedTypes.length === 0">
+                <p class="abstract" ng-if="!hasSettingsAccess"><localize key="create_noMediaTypesWithNoSettingsAccess" /></p>
+                <div ng-if="hasSettingsAccess">
+                    <p class="abstract"><localize key="create_noMediaTypes" /></p>
+                    <a class="btn" href="#settings/mediaTypes/edit/{{mediaTypeId}}?view=permissions" ng-click="close()">
+                        <localize key="create_noMediaTypesEditPermissions" />
+                    </a>
+                </div>
+            </div>
 
 			<ul class="umb-actions umb-actions-child">
 
@@ -38,7 +44,7 @@
 	</div>
 
 	<div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
-		<button class="btn btn-info" ng-click="close()">
+		<button class="btn btn-info" ng-click="closeDialog()">
 			<localize key="buttons_somethingElse">Do something else</localize>
 		</button>
 	</div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.create.controller.js
@@ -6,13 +6,24 @@
  * @description
  * The controller for the media creation dialog
  */
-function mediaCreateController($scope, $routeParams, $location, mediaTypeResource, iconHelper, navigationService) {
+function mediaCreateController($scope, $location, mediaTypeResource, iconHelper, navigationService, authResource, mediaResource) {
 
     function initialize() {
         $scope.allowedTypes = null;
         mediaTypeResource.getAllowedTypes($scope.currentNode.id).then(function(data) {
             $scope.allowedTypes = iconHelper.formatContentTypeIcons(data);
         });
+
+        if ($scope.currentNode.id > -1) {
+            authResource.getCurrentUser().then(function(currentUser) {
+                if (currentUser.allowedSections.indexOf("settings") > -1) {
+                    $scope.hasSettingsAccess = true;
+                    mediaResource.getById($scope.currentNode.id).then(function (data) {
+                        $scope.mediaTypeId = data.contentType.id;
+                    });
+                }
+            });
+        }
     }
 
     $scope.createMediaItem = function(docType) {
@@ -21,6 +32,10 @@ function mediaCreateController($scope, $routeParams, $location, mediaTypeResourc
     };
 
     $scope.close = function() {
+        navigationService.hideMenu();
+    };
+
+    $scope.closeDialog = function () {
         const showMenu = true;
         navigationService.hideDialog(showMenu);
     };

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
@@ -12,7 +12,7 @@
     function MediaTypesEditController($scope, $routeParams, mediaTypeResource, 
         dataTypeResource, editorState, contentEditingHelper, formHelper, 
         navigationService, iconHelper, contentTypeHelper, notificationsService, 
-        $filter, $q, localizationService, overlayHelper, eventsService, angularHelper) {
+        $q, localizationService, overlayHelper, eventsService, angularHelper) {
 
         var vm = this;
         var evts = [];
@@ -36,7 +36,7 @@
 
         function onInit() {
             // get init values from model when in infinite mode
-            if(infiniteMode) {
+            if (infiniteMode) {
                 mediaTypeId = $scope.model.id;
                 create = $scope.model.create;
                 vm.saveButtonKey = "buttons_saveAndClose";
@@ -81,8 +81,7 @@
                     "name": vm.labels.design,
                     "alias": "design",
                     "icon": "icon-document-dashed-line",
-                    "view": "views/mediatypes/views/design/design.html",
-                    "active": true
+                    "view": "views/mediatypes/views/design/design.html"
                 },
                 {
                     "name": vm.labels.listview,
@@ -153,7 +152,30 @@
                     ]
                 }
             ];
+
+            initializeActiveNavigationPanel();
         });
+
+        function initializeActiveNavigationPanel() {
+            // Initialise first loaded page based on page route paramater
+            // i.e. ?view=design|listview|permissions
+            var initialViewSetFromRouteParams = false;
+            var view = $routeParams.view;
+            if (view) {
+                var viewPath = "views/mediatypes/views/" + view + "/" + view + ".html";
+                for (var i = 0; i < vm.page.navigation.length; i++) {
+                    if (vm.page.navigation[i].view === viewPath) {
+                        vm.page.navigation[i].active = true;
+                        initialViewSetFromRouteParams = true;
+                        break;
+                    }
+                }
+            }
+
+            if (initialViewSetFromRouteParams === false) {
+                vm.page.navigation[0].active = true;
+            }
+        }
 
         contentTypeHelper.checkModelsBuilderStatus().then(function (result) {
             vm.page.modelsBuilder = result;

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -329,8 +329,12 @@
     <key alias="createContentBlueprint">Select the document type you want to make a content template for</key>
     <key alias="enterFolderName">Enter a folder name</key>
     <key alias="updateData">Choose a type and a title</key>
-    <key alias="noDocumentTypes" version="7.0"><![CDATA[There are no allowed document types available. You must enable these in the settings section under <strong>"document types"</strong>.]]></key>
-    <key alias="noMediaTypes" version="7.0"><![CDATA[There are no allowed media types available. You must enable these in the settings section under <strong>"media types"</strong>.]]></key>
+    <key alias="noDocumentTypes" version="7.0"><![CDATA[There are no allowed document types available for creating content here. You must enable these in <strong>Document Types</strong> within the <strong>Settings</strong> section, by editing the <strong>Allowed child node types</strong> under <strong>Permissions</strong>.]]></key>
+    <key alias="noDocumentTypesWithNoSettingsAccess">The selected page in the content tree doesn't allow for any pages to be created below it.</key>
+    <key alias="noDocumentTypesEditPermissions">Edit permissions for this document type</key>
+    <key alias="noMediaTypes" version="7.0"><![CDATA[There are no allowed media types available for creating media here. You must enable these in <strong>Media Types Types</strong> within the <strong>Settings</strong> section, by editing the <strong>Allowed child node types</strong> under <strong>Permissions</strong>.]]></key>
+    <key alias="noMediaTypesWithNoSettingsAccess">The selected media in the tree doesn't allow for any other media to be created below it.</key>
+    <key alias="noMediaTypesEditPermissions">Edit permissions for this media type</key>
     <key alias="documentTypeWithoutTemplate">Document Type without a template</key>
     <key alias="newFolder">New folder</key>
     <key alias="newDataType">New data type</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -334,9 +334,12 @@
     <key alias="createContentBlueprint">Select the document type you want to make a content template for</key>
     <key alias="enterFolderName">Enter a folder name</key>
     <key alias="updateData">Choose a type and a title</key>
-    <key alias="noDocumentTypes" version="7.0"><![CDATA[There are no allowed document types available. You must enable these in the settings section under <strong>"document types"</strong>.]]></key>
-    <key alias="noMediaTypes" version="7.0"><![CDATA[There are no allowed media types available. You must enable these in the settings section under <strong>"media types"</strong>.]]></key>
-    <key alias="documentTypeWithoutTemplate">Document Type without a template</key>
+    <key alias="noDocumentTypes" version="7.0"><![CDATA[There are no allowed document types available for creating content here. You must enable these in <strong>Document Types</strong> within the <strong>Settings</strong> section, by editing the <strong>Allowed child node types</strong> under <strong>Permissions</strong>.]]></key>
+    <key alias="noDocumentTypesWithNoSettingsAccess">The selected page in the content tree doesn't allow for any pages to be created below it.</key>
+    <key alias="noDocumentTypesEditPermissions">Edit permissions for this document type</key>
+    <key alias="noMediaTypes" version="7.0"><![CDATA[There are no allowed media types available for creating media here. You must enable these in <strong>Media Types Types</strong> within the <strong>Settings</strong> section, by editing the <strong>Allowed child node types</strong> under <strong>Permissions</strong>.]]></key>
+    <key alias="noMediaTypesWithNoSettingsAccess">The selected media in the tree doesn't allow for any other media to be created below it.</key>
+    <key alias="noMediaTypesEditPermissions">Edit permissions for this media type</key>    <key alias="documentTypeWithoutTemplate">Document Type without a template</key>
     <key alias="newFolder">New folder</key>
     <key alias="newDataType">New data type</key>
     <key alias="newJavascriptFile">New JavaScript file</key>

--- a/src/Umbraco.Web/Models/ContentEditing/ContentItemBasic.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentItemBasic.cs
@@ -38,6 +38,8 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "updater")]
         public UserProfile Updater { get; set; }
 
+        public int ContentTypeId { get; set; }
+
         [DataMember(Name = "contentTypeAlias", IsRequired = true)]
         [Required(AllowEmptyStrings = false)]
         public string ContentTypeAlias { get; set; }

--- a/src/Umbraco.Web/Models/ContentEditing/ContentItemDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentItemDisplay.cs
@@ -108,6 +108,9 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "treeNodeUrl")]
         public string TreeNodeUrl { get; set; }
 
+        [DataMember(Name = "contentTypeId")]
+        public int ContentTypeId { get; set; }
+
         [DataMember(Name = "contentTypeAlias", IsRequired = true)]
         [Required(AllowEmptyStrings = false)]
         public string ContentTypeAlias { get; set; }

--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -73,6 +73,7 @@ namespace Umbraco.Web.Models.Mapping
             target.AllowedActions = GetActions(source);
             target.AllowedTemplates = GetAllowedTemplates(source);
             target.ContentApps = _commonMapper.GetContentApps(source);
+            target.ContentTypeId = source.ContentType.Id;
             target.ContentTypeAlias = source.ContentType.Alias;
             target.ContentTypeName = _localizedTextService.UmbracoDictionaryTranslate(source.ContentType.Name);
             target.DocumentType = _commonMapper.GetContentType(source, context);
@@ -117,6 +118,7 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll -Alias
         private void Map(IContent source, ContentItemBasic<ContentPropertyBasic> target, MapperContext context)
         {
+            target.ContentTypeId = source.ContentType.Id;
             target.ContentTypeAlias = source.ContentType.Alias;
             target.CreateDate = source.CreateDate;
             target.Edited = source.Edited;

--- a/src/Umbraco.Web/Models/Mapping/MediaMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MediaMapDefinition.cs
@@ -50,6 +50,7 @@ namespace Umbraco.Web.Models.Mapping
         {
             target.ContentApps = _commonMapper.GetContentApps(source);
             target.ContentType = _commonMapper.GetContentType(source, context);
+            target.ContentTypeId = source.ContentType.Id;
             target.ContentTypeAlias = source.ContentType.Alias;
             target.ContentTypeName = source.ContentType.Name;
             target.CreateDate = source.CreateDate;
@@ -75,6 +76,7 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll -Edited -Updater -Alias
         private void Map(IMedia source, ContentItemBasic<ContentPropertyBasic> target, MapperContext context)
         {
+            target.ContentTypeId = source.ContentType.Id;
             target.ContentTypeAlias = source.ContentType.Alias;
             target.CreateDate = source.CreateDate;
             target.Icon = source.ContentType.Icon;

--- a/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
@@ -76,6 +76,7 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll -Trashed -IsContainer -VariesByCulture
         private void Map(IMember source, MemberDisplay target, MapperContext context)
         {
+            target.ContentTypeId = source.ContentType.Id;
             target.ContentTypeAlias = source.ContentType.Alias;
             target.ContentTypeName = source.ContentType.Name;
             target.CreateDate = source.CreateDate;
@@ -101,6 +102,7 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll -Trashed -Edited -Updater -Alias -VariesByCulture
         private void Map(IMember source, MemberBasic target, MapperContext context)
         {
+            target.ContentTypeId = source.ContentType.Id;
             target.ContentTypeAlias = source.ContentType.Alias;
             target.CreateDate = source.CreateDate;
             target.Email = source.Email;
@@ -121,7 +123,7 @@ namespace Umbraco.Web.Models.Mapping
 
         //TODO: SD: I can't remember why this mapping is here?
         // Umbraco.Code.MapAll -Udi -Properties -ParentId -Path -SortOrder -Edited -Updater
-        // Umbraco.Code.MapAll -Trashed -Alias -ContentTypeAlias -VariesByCulture
+        // Umbraco.Code.MapAll -Trashed -Alias -ContentTypeId -ContentTypeAlias -VariesByCulture
         private void Map(MembershipUser source, MemberBasic target, MapperContext context)
         {
             target.CreateDate = source.CreationDate;


### PR DESCRIPTION
This PR has an implementation for #5561 (ported from U4-9734 on old tracker, and closed PR #1891.

Provides an alternative, clearer message for users that do and do not have access to document/media types for when trying to create content or media and no types can be created.

Where they do, provided a direct link to go to the page where allowable content types can be edited.

![image](https://user-images.githubusercontent.com/1993459/58759192-57cfd300-8526-11e9-855a-8b21dd39bf04.png)

