### PR TITLE
V8: Don't show multiple open menus

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
@@ -101,14 +101,8 @@ angular.module('umbraco.directives')
         var eventBindings = [];
 
         function oneTimeClick(event) {
-                var el = event.target.nodeName;
-
-                //ignore link and button clicks
-                var els = ["INPUT","A","BUTTON"];
-                if(els.indexOf(el) >= 0){return;}
-
                 // ignore clicks on new overlay
-                var parents = $(event.target).parents("a,button,.umb-overlay,.umb-tour");
+                var parents = $(event.target).parents(".umb-overlay,.umb-tour");
                 if(parents.length > 0){
                     return;
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

For some odd reason, the `on-outside-click` directive isn't executed if a link, button or input field is clicked - no matter if the clicked element is outside the element that has the `on-outside-click` directive. This results in multiple menus being open at the same time:

![multiple-open-menus-before](https://user-images.githubusercontent.com/7405322/58759665-f1e74980-852d-11e9-9e21-dc4dc0064bc4.gif)

The reasoning behind ignoring these element types is lost in the wind, but it originates from 2015 (ef069e0a). By removing it, the menus using `on-outside-click` start behaving as you'd expect:

![multiple-open-menus-after](https://user-images.githubusercontent.com/7405322/58759670-25c26f00-852e-11e9-97ed-c41f6ae9619e.gif)

I have tested all usages of `on-outside-click`, and I can't find any issues with this change. Why interactions with these element types where explicitly ignored in the first place is beyond me... I believe that whatever the reason was, we're better off  *not* ignoring them.