### PR TITLE
v8: Remove HTML characters in RTE prevalue description

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -25,7 +25,7 @@
         </div>
     </umb-control-group>
 
-    <umb-control-group label="Ignore user start nodes" description="Selecting this option allows a user to choose nodes that they normally don't have access to.<br /> <em>Note: this applies only to rich text editors in this grid editor.</em>">
+    <umb-control-group label="Ignore user start nodes" description="Selecting this option allows a user to choose nodes that they normally don't have access to. Note: this applies only to rich text editors in this grid editor.">
         <div>
             <label>
                 <umb-checkbox model="model.value.ignoreUserStartNodes"/>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This remove some html characters in description of rte prevalue, which is rendered as text.

![image](https://user-images.githubusercontent.com/2919859/58767470-bf6c3980-858b-11e9-95a7-27a49a4a91cc.png)

![image](https://user-images.githubusercontent.com/2919859/58767455-93e94f00-858b-11e9-9d91-77daa476ff7d.png)
