### PR TITLE
V8: Support negative values for integer and decimal property editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
@@ -2,7 +2,7 @@
     <ng-form name="decimalFieldForm">
         <input name="decimalField"
                type="number"
-               pattern="[0-9]+([,\.][0-9]+)?"
+               pattern="[\-0-9]+([,\.][0-9]+)?"
                class="umb-property-editor umb-number"
                ng-model="model.value"
                val-server="value"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
@@ -2,7 +2,7 @@
     <ng-form name="integerFieldForm">
         <input name="integerField"
                type="number"
-               pattern="[0-9]*"
+               pattern="[\-0-9]*"
                class="umb-property-editor umb-number"
                ng-model="model.value"
                id="{{model.alias}}"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There's a regex validation error in the property editors for integer and decimal, which means you can't enter negative values, despite being able to define the data types with negative minimum values.

Consider this configuration for numeric (and similar for decimal):

![image](https://user-images.githubusercontent.com/7405322/58791180-0725ac00-85f2-11e9-817d-e68f31073250.png)

When editing content, negative values yield an unexpected validation error for integer and decimal properties:

![negative-values-before](https://user-images.githubusercontent.com/7405322/58791217-173d8b80-85f2-11e9-8d19-b09acda130a1.gif)

This PR fixes the regex validations, so negative values are supported (within the bounds of the datatype config, of course). When applied, editing content with integer and decimal properties works as you'd expect:

![negative-values-after](https://user-images.githubusercontent.com/7405322/58791348-523fbf00-85f2-11e9-9cc1-05168a32f96b.gif)
