### PR TITLE
5565 fix for configuration of TineMCE size

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -41,10 +41,19 @@ angular.module("umbraco")
             $q.all(promises).then(function (result) {
 
                 var standardConfig = result[promises.length - 1];
-
+                
+                var width = parseInt(editorConfig.dimensions.width, 10) || null
+                var height = parseInt(editorConfig.dimensions.height, 10) || null
+                
+                if (height !== null) {
+                    standardConfig.plugins.splice(standardConfig.plugins.indexOf("autoresize"), 1);
+                }
+                
                 //create a baseline Config to extend upon
                 var baseLineConfigObj = {
-                    maxImageSize: editorConfig.maxImageSize
+                    maxImageSize: editorConfig.maxImageSize,
+                    width: width,
+                    height: height
                 };
 
                 angular.extend(baseLineConfigObj, standardConfig);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -42,8 +42,8 @@ angular.module("umbraco")
 
                 var standardConfig = result[promises.length - 1];
                 
-                var width = parseInt(editorConfig.dimensions.width, 10) || null
-                var height = parseInt(editorConfig.dimensions.height, 10) || null
+                var width = parseInt(editorConfig.dimensions.width, 10) || null;
+                var height = parseInt(editorConfig.dimensions.height, 10) || null;
                 
                 if (height !== null) {
                     standardConfig.plugins.splice(standardConfig.plugins.indexOf("autoresize"), 1);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -20,6 +20,13 @@ angular.module("umbraco")
                 editorConfig.maxImageSize = tinyMceService.defaultPrevalues().maxImageSize;
             }
 
+            var width = parseInt(editorConfig.dimensions.width, 10) || null;
+            var height = parseInt(editorConfig.dimensions.height, 10) || null;
+
+            $scope.containerWidth = editorConfig.mode === "distraction-free" ? (width ? width : "auto") : "auto";
+            $scope.containerHeight = editorConfig.mode === "distraction-free" ? (height ? height : "auto") : "auto";
+            $scope.containerOverflow = editorConfig.mode === "distraction-free" ? (height ? "auto" : "inherit") : "inherit";
+
             var promises = [];
 
             //queue file loading
@@ -41,9 +48,6 @@ angular.module("umbraco")
             $q.all(promises).then(function (result) {
 
                 var standardConfig = result[promises.length - 1];
-                
-                var width = parseInt(editorConfig.dimensions.width, 10) || null;
-                var height = parseInt(editorConfig.dimensions.height, 10) || null;
                 
                 if (height !== null) {
                     standardConfig.plugins.splice(standardConfig.plugins.indexOf("autoresize"), 1);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
@@ -1,6 +1,6 @@
 <div ng-controller="Umbraco.PropertyEditors.RTEController" class="umb-property-editor umb-rte">
     <umb-load-indicator ng-if="isLoading"></umb-load-indicator>
 
-    <div ng-style="{ visibility :  isLoading ? 'hidden' : 'visible'}"
+    <div ng-style="{ visibility :  isLoading ? 'hidden' : 'visible', width :containerWidth, height: containerHeight, overflow: containerOverflow}"
          id="{{textAreaHtmlId}}" class="umb-rte-editor"></div>
 </div>


### PR DESCRIPTION
**This fix includes:**

- Parse dimensions to configuration of TinyMCE
- remove autoresize if height is set (was not needed for width to take action)

Fixes https://github.com/umbraco/Umbraco-CMS/issues/5565

**Test notes:**
Test that TineMCE with no dimensions falls back to default width + auto height.
Test that TineMCE with a set WIDTH only changes the appearance width.
test that TineMCE with a set HEIGHT only changes the appearance height.
Test that TineMCE with WIDTH and HEIGHT set is affecting both dimensions.