### PR TITLE
V8: Add culture as a param to the contentpicker to override the culture

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -355,6 +355,7 @@ When building a custom infinite editor view you can use the same components as a
          *
          * @param {Object} editor rendering options
          * @param {Boolean} editor.multiPicker Pick one or multiple items
+         * @param {String} editor.culture The culture for which we want to render the content tree
          * @param {Function} editor.submit Callback function when the submit button is clicked. Returns the editor model object
          * @param {Function} editor.close Callback function when the close button is clicked.
          *


### PR DESCRIPTION
### Prerequisites

See issue with detailed description of the feature: https://github.com/umbraco/Umbraco-CMS/issues/5527

### Description

When developing packages we often use the contentpicker in order to pick a content node. Now in V8 with culture variants we depend on the culture set by umbraco, eg mculture and cculture url params.

If we are working in the content section, then this is fine, but sometimes we are working on another section where we want to use the content picker and load a culture specific content tree.

Using the PR we can pass in a culture to the contentpicker which overrides the default behaviour inside umbraco and loads the content tree in the passed in culture.

It uses an ID so we can lookup the language first to see if its correct, if not then it will throw an exception.