### PR TITLE
Handle `loginModel.RedirectUrl` in Login partial

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/Login.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/Login.cshtml
@@ -40,4 +40,5 @@
         <button>Login</button>
     </fieldset>
 }
-
+
+

--- a/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/Login.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/Login.cshtml
@@ -1,4 +1,4 @@
-﻿@using System.Web.Mvc.Html
+@using System.Web.Mvc.Html
 @using ClientDependency.Core.Mvc
 @using Umbraco.Web
 @using Umbraco.Web.Models
@@ -40,4 +40,3 @@
         <button>Login</button>
     </fieldset>
 }
-

--- a/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/Login.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/Login.cshtml
@@ -1,4 +1,4 @@
-﻿@using System.Web.Mvc.Html
+@using System.Web.Mvc.Html
 @using ClientDependency.Core.Mvc
 @using Umbraco.Web
 @using Umbraco.Web.Models
@@ -7,6 +7,7 @@
 
 @{
     var loginModel = new LoginModel();
+    loginModel.RedirectUrl = HttpContext.Current.Request.Url.AbsolutePath;
 
     Html.EnableClientValidation();
     Html.EnableUnobtrusiveJavaScript();
@@ -20,6 +21,7 @@
 
 @using (Html.BeginUmbracoForm<UmbLoginController>("HandleLogin"))
 {
+    @Html.HiddenFor(m => loginModel.RedirectUrl)
     <fieldset>
         <legend>Login</legend>
 
@@ -38,3 +40,4 @@
         <button>Login</button>
     </fieldset>
 }
+

--- a/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/Login.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/Login.cshtml
@@ -1,4 +1,4 @@
-@using System.Web.Mvc.Html
+﻿@using System.Web.Mvc.Html
 @using ClientDependency.Core.Mvc
 @using Umbraco.Web
 @using Umbraco.Web.Models
@@ -40,5 +40,4 @@
         <button>Login</button>
     </fieldset>
 }
-
-
+


### PR DESCRIPTION
Facilitates redirecting to the originally requested URL upon successful login.

This is a v8 port of this original PR for v7: https://github.com/umbraco/Umbraco-CMS/pull/1727

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #5586 - The "steps to reproduce"  herein can be used for verifying that this solves the issue.

### Description

Makes the login process aware of where it's supposed to return to, once
authenticated, by populating the LoginModel's RedirectUrl property with the requested URL.

**NOTE 1:** While using `HttpContext.Current.Request.Url.AbsolutePath` works (verified in v8.0.2 on Umbraco Cloud) I seem to have read somewhere that using `HttpContext.Current` is not great/cool/correct/etc. - in that case, I would love to know what else to use.

**NOTE 2:** I tried my best to make my editor only change the _actual two lines_ needed (lines 10 + 24) but somehow managed to not succeed #h5is - will try to fix with a subsequent commit, which could then be squash-merged...
