### PR TITLE
V8: Fix the Nested Content title overflow

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -56,13 +56,20 @@
     -webkit-user-select: none;
     -o-user-select: none;
     user-select: none;
+
+    &:hover {
+        .umb-nested-content__heading .umb-nested-content__item-name {
+            padding-right: 60px;
+        }
+    }
+
 }
 
 .umb-nested-content__heading {
     line-height: 20px;
     position: relative;
     margin-top:1px;
-    padding: 15px 20px;
+    padding: 15px 5px;
     color:@ui-option-type;
     border-radius: 3px 3px 0 0;
     
@@ -71,16 +78,21 @@
     }
 
     i {
-        display: inline;
-        margin-right: 10px;
+        position: absolute;
+        margin-top: -1px;
     }
 
     .umb-nested-content__item-name {
-        display: inline;
+        display: block;
         max-height: 20px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding-left: 5px;
+
+        &.--has-icon {
+            padding-left: 20px;
+        }
     }
     
 }
@@ -89,9 +101,10 @@
     opacity: 0;
     transition: opacity 120ms ease-in-out;
     position: absolute;
-    right: 8px;
-    top: 4px;
+    right: 0;
+    top: 3px;
     padding: 5px;
+    background-color: @white;
 }
 
 .umb-nested-content__item--active > .umb-nested-content__header-bar {
@@ -99,6 +112,9 @@
         background-color: @ui-active;
         &:hover {
             color:@ui-option-type;
+        }
+        .umb-nested-content__item-name {
+            padding-right: 60px;
         }
     }
     .umb-nested-content__icons {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -91,7 +91,7 @@
         padding-left: 5px;
 
         &.--has-icon {
-            padding-left: 20px;
+            padding-left: 30px;
         }
     }
     

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -12,7 +12,7 @@
 
                 <div class="umb-nested-content__header-bar" ng-click="$parent.editNode($index)" ng-hide="$parent.singleMode">
 
-                    <div class="umb-nested-content__heading"><i ng-if="showIcons" class="icon" ng-class="$parent.getIcon($index)"></i><span class="umb-nested-content__item-name" ng-bind="$parent.getName($index)"></span></div>
+                    <div class="umb-nested-content__heading"><i ng-if="showIcons" class="icon" ng-class="$parent.getIcon($index)"></i><span class="umb-nested-content__item-name" ng-class="{'--has-icon': showIcons}" ng-bind="$parent.getName($index)"></span></div>
 
                     <div class="umb-nested-content__icons">
                         <a class="umb-nested-content__icon umb-nested-content__icon--copy" title="{{copyIconTitle}}" ng-click="clickCopy($event, node);" ng-if="showCopy" prevent-default>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The title overflow handling introduced in #2457 has been broken at some point, leaving long item titles looking rather off:

![nc-wrap-before](https://user-images.githubusercontent.com/7405322/58975946-91266e00-87c6-11e9-9ed1-8255cde75a07.gif)

This PR fixes it 😄 

While I was at it, I removed a bit of the left and right padding for the items, so they look a tad more in line with e.g. the MNTP items.

Here's a preview of how NC works with this PR applied:

![nc-wrap-with-icons](https://user-images.githubusercontent.com/7405322/58976029-c632c080-87c6-11e9-8779-b02557e827f1.gif)

...and here's an preview of the same, only without item icons:

![nc-wrap-without-icons](https://user-images.githubusercontent.com/7405322/58976044-d21e8280-87c6-11e9-8131-17d174588f08.gif)

/cc @nielslyngsoe 