### PR TITLE
V8: Fix JS error when the RTE has unconfigured dimensions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -20,8 +20,8 @@ angular.module("umbraco")
                 editorConfig.maxImageSize = tinyMceService.defaultPrevalues().maxImageSize;
             }
 
-            var width = parseInt(editorConfig.dimensions.width, 10) || null;
-            var height = parseInt(editorConfig.dimensions.height, 10) || null;
+            var width = editorConfig.dimensions ? parseInt(editorConfig.dimensions.width, 10) || null : null;
+            var height = editorConfig.dimensions ? parseInt(editorConfig.dimensions.height, 10) || null : null;
 
             $scope.containerWidth = editorConfig.mode === "distraction-free" ? (width ? width : "auto") : "auto";
             $scope.containerHeight = editorConfig.mode === "distraction-free" ? (height ? height : "auto") : "auto";


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

49c76c74 introduced some dimension parsing that causes RTE's with unconfigured dimensions to crash miserably:

![image](https://user-images.githubusercontent.com/7405322/59010514-d9c74100-8831-11e9-9521-0ef13af5da6d.png)

This PR adds a bit of null checking to the RTE dimension parsing, so RTE's actually load again 😄 