### PR TITLE
V8: Fix broken culture variance toggle on content type properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -505,6 +505,7 @@
               property.showOnMemberProfile = propertyModel.showOnMemberProfile;
               property.memberCanEdit = propertyModel.memberCanEdit;
               property.isSensitiveValue = propertyModel.isSensitiveValue;
+              property.allowCultureVariant = propertyModel.allowCultureVariant;
 
               // update existing data types
               if(model.updateSameDataTypes) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Looks like yours truly introduced a nasty bug with #5522 ... we can no longer create culture variant properties!

![culture-variance-broken](https://user-images.githubusercontent.com/7405322/59012155-147fa800-8837-11e9-96c2-f79b0af01518.gif)

Luckily I can fix what I have broken... and this PR fixes it 😄 