### PR TITLE
V8: Fix the back button for media type list views

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -286,7 +286,7 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
     /** Callback for when user clicks the back-icon */
     $scope.onBack = function() {
         if ($scope.page.listViewPath) {
-            $location.path($scope.page.listViewPath);
+            $location.path($scope.page.listViewPath.split("?")[0]);
         }
     };
     


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you have a media type with list view enabled, the server throws an error when you browse upwards through the tree (using the back button):

![media-list-view-back-before](https://user-images.githubusercontent.com/7405322/59054246-884f9e00-8893-11e9-97cb-c2c25fd22ef9.gif)

It happens because the backoffice attempts to load the parent node using an ID with a query string appended. This PR simply strips the query string part of the ID so the server can figure out which `GetById` method to use. 

When this PR is applied, things start working:

![media-list-view-back-after](https://user-images.githubusercontent.com/7405322/59054406-e8dedb00-8893-11e9-924a-6b3c703b196c.gif)
