### PR TITLE
Temp 5596 grid edit alttext

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -518,7 +518,6 @@ When building a custom infinite editor view you can use the same components as a
          * @param {Object} editor.itemDetails the media item details - focalPoint, altText, caption etc
          * @param {String} editor.imageUrl the url of the media item
          * @param {String} editor.cropSize the selected crop size for the item
-         * @param {Boolean} ediotr.fromRte set to true when the dialog is triggered from a media picker in the rte toolbar - hides the caption field
          * @param {Callback} editor.submit Submits the editor
          * @param {Callback} editor.close Closes the editor
          * @returns {Object} editor object

--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -518,6 +518,7 @@ When building a custom infinite editor view you can use the same components as a
          * @param {Object} editor.itemDetails the media item details - focalPoint, altText, caption etc
          * @param {String} editor.imageUrl the url of the media item
          * @param {String} editor.cropSize the selected crop size for the item
+         * @param {Boolean} ediotr.fromRte set to true when the dialog is triggered from a media picker in the rte toolbar - hides the caption field
          * @param {Callback} editor.submit Submits the editor
          * @param {Callback} editor.close Closes the editor
          * @returns {Object} editor object

--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -506,6 +506,27 @@ When building a custom infinite editor view you can use the same components as a
             editor.updatedMediaNodes = [];
             open(editor);
         }
+        
+        /**
+         * @ngdoc method
+         * @name umbraco.services.editorService#mediaPickerDetails
+         * @methodOf umbraco.services.editorService
+         *
+         * @description
+         * Opens a media picker detail in infinite editing, the submit callback returns the media item
+         * @param {Object} editor rendering options
+         * @param {Object} editor.itemDetails the media item details - focalPoint, altText, caption etc
+         * @param {String} editor.imageUrl the url of the media item
+         * @param {String} editor.cropSize the selected crop size for the item
+         * @param {Callback} editor.submit Submits the editor
+         * @param {Callback} editor.close Closes the editor
+         * @returns {Object} editor object
+         */
+        function mediaPickerDetails(editor) {
+            editor.view = "views/common/infiniteeditors/mediapicker/mediapickerdetails.html";
+            editor.size = "small";
+            open(editor);
+        }        
 
         /**
          * @ngdoc method
@@ -887,6 +908,7 @@ When building a custom infinite editor view you can use the same components as a
             rollback: rollback,
             linkPicker: linkPicker,
             mediaPicker: mediaPicker,
+            mediaPickerDetails: mediaPickerDetails,
             iconPicker: iconPicker,
             documentTypeEditor: documentTypeEditor,
             mediaTypeEditor: mediaTypeEditor,

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1185,34 +1185,55 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
             //Create the insert media plugin
             self.createMediaPicker(args.editor, function (currentTarget, userData) {
-                var startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
-                var startNodeIsVirtual = userData.startMediaIds.length !== 1;
+                
+                // when editing, go straight to the details dialog
+                if (currentTarget) {
+                    var mediaPickerDetails = {
+                        itemDetails: currentTarget,
+                        imageUrl: currentTarget.url,  
+                        fromRte: true,
+                        submit: function (model) {
+                            self.insertMediaInEditor(args.editor, model.itemDetails);
+                            editorService.close();
+                        },
+                        close: function (model) {
+                            self.insertMediaInEditor(args.editor, model.itemDetails);
+                            editorService.close();
+                        }
+                    };
 
-                var ignoreUserStartNodes = getIgnoreUserStartNodes(args);
-                if (ignoreUserStartNodes) {
-                    ignoreUserStartNodes = true;
-                    startNodeId = -1;
-                    startNodeIsVirtual = true;
+                    editorService.mediaPickerDetails(mediaPickerDetails);
                 }
+                else {
+                    var startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
+                    var startNodeIsVirtual = userData.startMediaIds.length !== 1;
 
-                var mediaPicker = {
-                    currentTarget: currentTarget,
-                    onlyImages: true,
-                    showDetails: true,
-                    fromRte: true,
-                    disableFolderSelect: true,
-                    startNodeId: startNodeId,
-                    startNodeIsVirtual: startNodeIsVirtual,
-                    ignoreUserStartNodes: ignoreUserStartNodes,
-                    submit: function (model) {
-                        self.insertMediaInEditor(args.editor, model.selection[0]);
-                        editorService.close();
-                    },
-                    close: function () {
-                        editorService.close();
+                    var ignoreUserStartNodes = getIgnoreUserStartNodes(args);
+                    if (ignoreUserStartNodes) {
+                        ignoreUserStartNodes = true;
+                        startNodeId = -1;
+                        startNodeIsVirtual = true;
                     }
-                };
-                editorService.mediaPicker(mediaPicker);
+
+                    var mediaPicker = {
+                        currentTarget: currentTarget,
+                        onlyImages: true,
+                        showDetails: true,
+                        disableFolderSelect: true,
+                        fromRte: true,
+                        startNodeId: startNodeId,                        
+                        startNodeIsVirtual: startNodeIsVirtual,
+                        ignoreUserStartNodes: ignoreUserStartNodes,
+                        submit: function (model) {
+                            self.insertMediaInEditor(args.editor, model.selection[0]);
+                            editorService.close();
+                        },
+                        close: function () {
+                            editorService.close();
+                        }
+                    };
+                    editorService.mediaPicker(mediaPicker);
+                }
             });
 
             //Create the embedded plugin

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1185,7 +1185,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
             //Create the insert media plugin
             self.createMediaPicker(args.editor, function (currentTarget, userData) {
-
                 var startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
                 var startNodeIsVirtual = userData.startMediaIds.length !== 1;
 
@@ -1200,6 +1199,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                     currentTarget: currentTarget,
                     onlyImages: true,
                     showDetails: true,
+                    fromRte: true,
                     disableFolderSelect: true,
                     startNodeId: startNodeId,
                     startNodeIsVirtual: startNodeIsVirtual,

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -459,8 +459,16 @@
     }
 }
 
+// Control states 
+.control-active--show {
+    display:none;
+}
 
-
+.umb-grid .umb-row .umb-control.-active {
+    .control-active--show {
+        display:block;
+    }
+}
 
 
 // Title bar and tools

--- a/src/Umbraco.Web.UI.Client/src/less/utilities/_spacing.less
+++ b/src/Umbraco.Web.UI.Client/src/less/utilities/_spacing.less
@@ -57,3 +57,7 @@
 .mb5 { margin-bottom: @spacing-extra-large; }
 .mb6 { margin-bottom: @spacing-extra-extra-large; }
 .mb7 { margin-bottom: @spacing-extra-extra-extra-large; }
+
+/* internal padding is still spacing... */
+.p5 { padding: 5px; }
+.p10 { padding:10px; }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -298,7 +298,6 @@ angular.module("umbraco")
                     imageUrl: $scope.target.url,  
                     cropSize: $scope.cropSize, 
                     submit: function (model) {
-                        debugger; 
                         $scope.model.selection.push(model.itemDetails);
                         $scope.model.submit($scope.model);    
                         editorService.close();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -292,11 +292,11 @@ angular.module("umbraco")
             }
 
             $scope.openDetailsDialog = function() {
-                
                 var mediaPickerDetails = {
                     itemDetails: $scope.target,
                     imageUrl: $scope.target.url,  
                     cropSize: $scope.cropSize, 
+                    fromRte: $scope.model.fromRte,
                     submit: function (model) {
                         $scope.model.selection.push(model.itemDetails);
                         $scope.model.submit($scope.model);    

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -296,7 +296,6 @@ angular.module("umbraco")
                     itemDetails: $scope.target,
                     imageUrl: $scope.target.url,  
                     cropSize: $scope.cropSize, 
-                    fromRte: $scope.model.fromRte,
                     submit: function (model) {
                         $scope.model.selection.push(model.itemDetails);
                         $scope.model.submit($scope.model);    

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -11,7 +11,7 @@ angular.module("umbraco")
                             includeSubFolders: data[1]
                         }
                     });
-            }
+            } 
 
             var dialogOptions = $scope.model;
 
@@ -292,26 +292,29 @@ angular.module("umbraco")
             }
 
             $scope.openDetailsDialog = function() {
-
-                $scope.mediaPickerDetailsOverlay = {};
-                $scope.mediaPickerDetailsOverlay.show = true;
-
-                $scope.mediaPickerDetailsOverlay.submit = function(model) {
-                    $scope.model.selection.push($scope.target);
-                    $scope.model.submit($scope.model);
-
-                    $scope.mediaPickerDetailsOverlay.show = false;
-                    $scope.mediaPickerDetailsOverlay = null;
+                
+                var mediaPickerDetails = {
+                    itemDetails: $scope.target,
+                    imageUrl: $scope.target.url,  
+                    cropSize: $scope.cropSize, 
+                    submit: function (model) {
+                        debugger; 
+                        $scope.model.selection.push(model.itemDetails);
+                        $scope.model.submit($scope.model);    
+                        editorService.close();
+                    },
+                    close: function (model) {
+                        $scope.model.selection.push(model.itemDetails);
+                        $scope.model.submit($scope.model); 
+                        editorService.close();
+                    } 
                 };
-
-                $scope.mediaPickerDetailsOverlay.close = function(oldModel) {
-                    $scope.mediaPickerDetailsOverlay.show = false;
-                    $scope.mediaPickerDetailsOverlay = null;
-                };
+                
+                editorService.mediaPickerDetails(mediaPickerDetails);
             };
 
             var debounceSearchMedia = _.debounce(function() {
-                    $scope.$apply(function() {
+                    $scope.$apply(function() { 
                         if ($scope.searchOptions.filter) {
                             searchMedia();
                         } else {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
@@ -116,50 +116,7 @@
                     <localize key="general_searchNoResult"></localize>
                 </umb-empty-state>
 
-            </div>
-
-            <umb-overlay ng-if="mediaPickerDetailsOverlay.show" model="mediaPickerDetailsOverlay" position="right">
-
-                <div class="umb-control-group">
-
-                    <div ng-if="target.url">
-                        <umb-image-gravity
-                            src="target.url"
-                            center="target.focalPoint">
-                        </umb-image-gravity>
-                    </div>
-
-                    <div ng-if="cropSize">
-
-                        <h5>
-                            <localize key="general_preview">Preview</localize>
-                        </h5>
-
-                        <umb-image-thumbnail center="target.focalPoint" src="target.url" height="{{cropSize.height}}" width="{{cropSize.width}}"
-                            max-size="400">
-                        </umb-image-thumbnail>
-
-                    </div>
-
-                </div>
-
-                <div class="umb-control-group">
-                    <label>
-                        <localize key="@general_url"></localize>
-                    </label>
-                    <input type="text" localize="placeholder" placeholder="@general_url" class="umb-property-editor umb-textstring" ng-model="target.url"
-                        ng-disabled="target.id" />
-                </div>
-
-                <div class="umb-control-group">
-                    <label>
-                        <localize key="@content_altTextOptional"></localize>
-                    </label>
-                    <input type="text" class="umb-property-editor umb-textstring" ng-model="target.altText" />
-                </div>
-
-
-            </umb-overlay>
+            </div>       
 
         </form>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapickerdetails.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapickerdetails.controller.js
@@ -1,0 +1,24 @@
+//used for the media picker details overlay
+(function () {
+    'use strict';
+
+    function mediaDetails($scope) {
+
+        // deep clone the original state to allow cancelling via close button
+        var originalModel = JSON.parse(JSON.stringify($scope.model));
+        
+        $scope.submit = function () {
+            if ($scope.model.submit) {
+                $scope.model.submit($scope.model);
+            }
+        };
+
+        $scope.close = function () {
+            if ($scope.model.close) {
+                $scope.model.close(originalModel);
+            }
+        };
+    }
+    angular.module('umbraco').controller('Umbraco.Editors.MediaPickerDetailsController', ['$scope', mediaDetails]);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapickerdetails.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapickerdetails.html
@@ -40,7 +40,7 @@
                        ng-disabled="model.itemDetails.id" />
             </div>
 
-            <div class="umb-control-group">
+            <div class="umb-control-group" ng-if="!model.fromRte">
                 <label>
                     <localize key="@content_captionOptional"></localize>
                 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapickerdetails.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapickerdetails.html
@@ -1,0 +1,81 @@
+<div ng-controller="Umbraco.Editors.MediaPickerDetailsController">
+    <umb-editor-view>
+        
+        <umb-editor-header
+            name="model.title"
+            name-locked="true"
+            hide-alias="true"
+            hide-icon="true"
+            hide-description="true">
+        </umb-editor-header>
+
+        <umb-editor-container>
+            <div class="umb-control-group">
+                <div ng-if="model.imageUrl">
+                    <umb-image-gravity src="model.imageUrl" center="model.item.focalPoint"></umb-image-gravity>
+                </div>
+
+                <div ng-if="model.cropSize">
+
+                    <h5>
+                        <localize key="general_preview">Preview</localize>
+                    </h5>
+
+                    <umb-image-thumbnail center="model.item.focalPoint" src="model.imageUrl" height="{{model.cropSize.height}}" width="{{model.cropSize.width}}" max-size="400">
+                    </umb-image-thumbnail>
+
+                </div>
+
+            </div>
+
+            <div class="umb-control-group">
+                <label>
+                    <localize key="@general_url"></localize>
+                </label>
+                <input type="text" 
+                       localize="placeholder" 
+                       placeholder="@general_url" 
+                       class="umb-property-editor umb-textstring" 
+                       ng-model="model.imageUrl" 
+                       ng-disabled="model.itemDetails.id" />
+            </div>
+
+            <div class="umb-control-group">
+                <label>
+                    <localize key="@content_captionOptional"></localize>
+                </label>
+                <input type="text" 
+                       class="umb-property-editor umb-textstring" 
+                       ng-model="model.itemDetails.caption" />
+            </div>
+
+            <div class="umb-control-group">
+                <label>
+                    <localize key="@content_altTextOptional"></localize>
+                </label>
+                <input type="text" 
+                       class="umb-property-editor umb-textstring" 
+                       ng-model="model.itemDetails.altText" />
+            </div>
+        </umb-editor-container>
+
+        <umb-editor-footer>
+            <umb-editor-footer-content-right>
+
+                <umb-button action="close()" 
+                            button-style="link" 
+                            shortcut="esc" 
+                            label-key="general_cancel" 
+                            type="button">
+                </umb-button>
+
+                <umb-button button-style="success" 
+                            label-key="general_ok" 
+                            type="button"                             
+                            action="submit()">
+                </umb-button>
+
+            </umb-editor-footer-content-right>
+        </umb-editor-footer>
+    </umb-editor-view>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapickerdetails.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapickerdetails.html
@@ -40,7 +40,7 @@
                        ng-disabled="model.itemDetails.id || model.itemDetails.udi" />
             </div>
 
-            <div class="umb-control-group" ng-if="!model.fromRte">
+            <div class="umb-control-group">
                 <label>
                     <localize key="@content_captionOptional"></localize>
                 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapickerdetails.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapickerdetails.html
@@ -37,7 +37,7 @@
                        placeholder="@general_url" 
                        class="umb-property-editor umb-textstring" 
                        ng-model="model.imageUrl" 
-                       ng-disabled="model.itemDetails.id" />
+                       ng-disabled="model.itemDetails.id || model.itemDetails.udi" />
             </div>
 
             <div class="umb-control-group" ng-if="!model.fromRte">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
@@ -1,90 +1,101 @@
 angular.module("umbraco")
     .controller("Umbraco.PropertyEditors.Grid.MediaController",
-    function ($scope, $timeout, userService, editorService) {
-        var ignoreUserStartNodes = Object.toBoolean($scope.model.config.ignoreUserStartNodes);
-        
-        
-        $scope.thumbnailUrl = getThumbnailUrl();
-        
-        
-        if (!$scope.model.config.startNodeId) {
-            if (ignoreUserStartNodes === true) {
-                $scope.model.config.startNodeId = -1;
-                $scope.model.config.startNodeIsVirtual = true;
+        function ($scope, $timeout, userService, editorService) {
+            var ignoreUserStartNodes = Object.toBoolean($scope.model.config.ignoreUserStartNodes);
 
-            } else {
-                userService.getCurrentUser().then(function (userData) {
-                    $scope.model.config.startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
-                    $scope.model.config.startNodeIsVirtual = userData.startMediaIds.length !== 1;
-                });
+            function updateControlValue(selectedImage) {
+                $scope.control.value = {
+                    focalPoint: selectedImage.focalPoint,
+                    id: selectedImage.id,
+                    udi: selectedImage.udi,
+                    image: selectedImage.image,
+                    caption: selectedImage.caption,
+                    altText: selectedImage.altText
+                };
+
+                setThumbnailUrl();
             }
-        }
-        
-        $scope.setImage = function(){
-            var startNodeId = $scope.model.config && $scope.model.config.startNodeId ? $scope.model.config.startNodeId : undefined;
-            var startNodeIsVirtual = startNodeId ? $scope.model.config.startNodeIsVirtual : undefined;
-            var mediaPicker = {
-                startNodeId: startNodeId,
-                startNodeIsVirtual: startNodeIsVirtual,
-                ignoreUserStartNodes: ignoreUserStartNodes,
-                cropSize: $scope.control.editor.config && $scope.control.editor.config.size ? $scope.control.editor.config.size : undefined,
-                showDetails: true,
-                disableFolderSelect: true,
-                onlyImages: true,
-                submit: function(model) {
-                    var selectedImage = model.selection[0];
-                   
-                    $scope.control.value = {
-                        focalPoint: selectedImage.focalPoint,
-                        id: selectedImage.id,
-                        udi: selectedImage.udi,
-                        image: selectedImage.image,
-                        caption: selectedImage.altText
-                    };
-                    
-                    editorService.close();
-                },
-                close: function() {
-                    editorService.close();
-                }
-            }
-            
-            editorService.mediaPicker(mediaPicker);
-        };
-        
-        $scope.$watch('control.value', function(newValue, oldValue) {
-            if(angular.equals(newValue, oldValue)){
-                return; // simply skip that
-            }
-            
-            $scope.thumbnailUrl = getThumbnailUrl();
-        }, true);
-        
-        function getThumbnailUrl() {
 
-            if($scope.control.value && $scope.control.value.image) {
-                var url = $scope.control.value.image;
+            function setThumbnailUrl() {
 
-                if($scope.control.editor.config && $scope.control.editor.config.size){
-                    url += "?width=" + $scope.control.editor.config.size.width;
-                    url += "&height=" + $scope.control.editor.config.size.height;
-                    url += "&animationprocessmode=first";
+                var url = null;
 
-                    if($scope.control.value.focalPoint){
-                        url += "&center=" + $scope.control.value.focalPoint.top +"," + $scope.control.value.focalPoint.left;
-                        url += "&mode=crop";
+                if ($scope.control.value && $scope.control.value.image) {
+                    url = $scope.control.value.image;
+
+                    if ($scope.control.editor.config && $scope.control.editor.config.size) {
+                        url += "?width=" + $scope.control.editor.config.size.width;
+                        url += "&height=" + $scope.control.editor.config.size.height;
+                        url += "&animationprocessmode=first";
+
+                        if ($scope.control.value.focalPoint) {
+                            url += "&center=" + $scope.control.value.focalPoint.top + "," + $scope.control.value.focalPoint.left;
+                            url += "&mode=crop";
+                        }
+                    }
+
+                    // set default size if no crop present (moved from the view)
+                    if (url.indexOf('?') == -1) {
+                        url += "?width=800&upscale=false&animationprocessmode=false"
                     }
                 }
 
-                // set default size if no crop present (moved from the view)
-                if (url.indexOf('?') == -1)
-                {
-                    url += "?width=800&upscale=false&animationprocessmode=false"
-                }
-                return url;
-            }
-            
-            return null;
-        };
+                $scope.thumbnailUrl = url
+            };
+    
+            setThumbnailUrl();
 
-});
+            if (!$scope.model.config.startNodeId) {
+                if (ignoreUserStartNodes === true) {
+                    $scope.model.config.startNodeId = -1;
+                    $scope.model.config.startNodeIsVirtual = true;
+
+                } else {
+                    userService.getCurrentUser().then(function (userData) {
+                        $scope.model.config.startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
+                        $scope.model.config.startNodeIsVirtual = userData.startMediaIds.length !== 1;
+                    });
+                }
+            }
+
+            $scope.editImage = function () {
+                var mediaPickerDetails = {
+                    itemDetails: $scope.control.value,
+                    imageUrl: $scope.control.value.image,
+                    cropSize: $scope.control.editor.config && $scope.control.editor.config.size ? $scope.control.editor.config.size : undefined,
+                    submit: function (model) {
+                        updateControlValue(model.itemDetails);
+                        editorService.close();
+                    },
+                    close: function (model) {
+                        updateControlValue(model.itemDetails);
+                        editorService.close();
+                    }
+                };
+                
+                editorService.mediaPickerDetails(mediaPickerDetails);
+            };
+
+            $scope.setImage = function () {
+                var startNodeId = $scope.model.config && $scope.model.config.startNodeId ? $scope.model.config.startNodeId : undefined;
+                var startNodeIsVirtual = startNodeId ? $scope.model.config.startNodeIsVirtual : undefined;
+                var mediaPicker = {
+                    startNodeId: startNodeId,
+                    startNodeIsVirtual: startNodeIsVirtual,
+                    ignoreUserStartNodes: ignoreUserStartNodes,
+                    cropSize: $scope.control.editor.config && $scope.control.editor.config.size ? $scope.control.editor.config.size : undefined,
+                    showDetails: true,
+                    disableFolderSelect: true,
+                    onlyImages: true,
+                    submit: function (model) {
+                        updateControlValue(model.selection[0]);
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                }
+
+                editorService.mediaPicker(mediaPicker);
+            };
+        });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.html
@@ -6,11 +6,21 @@
 	</div>
 
 	<div ng-if="thumbnailUrl !== null">
-		<img
-			ng-click="setImage()"
-			ng-src="{{thumbnailUrl}}"
-			class="fullSizeImage" />
-        <input type="text" class="caption" ng-model="control.value.caption" localize="placeholder" placeholder="@grid_placeholderImageCaption" />
- 	</div>
+		<img ng-src="{{thumbnailUrl}}"
+			class="fullSizeImage" /> 
+        
+        <div class="flex justify-end p5">
+            <div class="umb-button">            
+                <button type="button" 
+                    ng-click="setImage()" 
+                    class="btn btn-info control-active--show">Select new</button>
+            </div>
+            <div class="umb-button">
+                <button type="button" 
+                        ng-click="editImage()" 
+                        class="btn btn-info control-active--show">Edit</button>
+            </div>
 
+        </div>
+ 	</div>
 </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -247,6 +247,7 @@
     <key alias="statistics">Statistik</key>
     <key alias="titleOptional">Titel (valgfri)</key>
     <key alias="altTextOptional">Alternativ tekst (valgfri)</key>
+    <key alias="captionOptional">Billedtekst (valgfri)</key>
     <key alias="type">Type</key>
     <key alias="unpublish">Afpublicér</key>
     <key alias="unpublished">Afpubliceret</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
@@ -150,6 +150,7 @@
     <key alias="statistics">Statistiken</key>
     <key alias="titleOptional">Titel (optional)</key>
     <key alias="altTextOptional">Alternativtext (optional)</key>
+    <key alias="captionOptional">Bildbeschriftung (optional)</key>
     <key alias="type">Typ</key>
     <key alias="unpublish">Veröffentlichung widerrufen</key>
     <key alias="updateDate">Zuletzt bearbeitet am</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -257,6 +257,7 @@
     <key alias="statistics">Statistics</key>
     <key alias="titleOptional">Title (optional)</key>
     <key alias="altTextOptional">Alternative text (optional)</key>
+    <key alias="captionOptional">Caption (optional)</key>
     <key alias="type">Type</key>
     <key alias="unpublish">Unpublish</key>
     <key alias="unpublished">Unpublished</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -260,6 +260,7 @@
     <key alias="statistics">Statistics</key>
     <key alias="titleOptional">Title (optional)</key>
     <key alias="altTextOptional">Alternative text (optional)</key>
+    <key alias="captionOptional">Caption (optional)</key>
     <key alias="type">Type</key>
     <key alias="unpublish">Unpublish</key>
     <key alias="unpublished">Draft</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/es.xml
@@ -197,7 +197,8 @@
     <key alias="statistics">Estadísticas</key>
     <key alias="titleOptional">Título (opcional)</key>
     <key alias="altTextOptional">Texto alternativo (opcional)</key>
-    <key alias="type">Tipo</key>
+    <key alias="captionOptional">Subtítulo (opcional)</key>
+      <key alias="type">Tipo</key>
     <key alias="unpublish">Ocultar</key>
     <key alias="updateDate">Última actualización</key>
     <key alias="updateDateDesc" version="7.0">Fecha/hora este documento fue modificado</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
@@ -202,6 +202,7 @@
     <key alias="statistics">Statistiques</key>
     <key alias="titleOptional">Titre (optionnel)</key>
     <key alias="altTextOptional">Texte alternatif (optionnel)</key>
+    <key alias="captionOptional">Légende (optionnel)</key>
     <key alias="type">Type</key>
     <key alias="unpublish">Dépublier</key>
     <key alias="unpublished">Dépublié</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ja.xml
@@ -151,6 +151,7 @@
     <key alias="statistics">統計</key>
     <key alias="titleOptional">タイトル (オプション)</key>
     <key alias="altTextOptional">代替テキスト (オプション)</key>
+    <key alias="captionOptional">キャプション (オプション)</key>
     <key alias="type">型</key>
     <key alias="unpublish">非公開</key>
     <key alias="updateDate">最終更新日時</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nb.xml
@@ -148,6 +148,7 @@
     <key alias="statistics">Statistikk</key>
     <key alias="titleOptional">Tittel (valgfri)</key>
     <key alias="altTextOptional">Alternativ tekst (valgfri)</key>
+    <key alias="altTextOptional">Bildetekst (valgfri)</key>
     <key alias="type">Type</key>
     <key alias="unpublish">Avpubliser</key>
     <key alias="updateDate">Sist endret</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -159,6 +159,7 @@
     <key alias="statistics">Statistieken</key>
     <key alias="titleOptional">Titel (optioneel)</key>
     <key alias="altTextOptional">Alternatieve tekst (optioneel)</key>
+    <key alias="captionOptional">Onderschrift (optioneel)</key>
     <key alias="type">Type</key>
     <key alias="unpublish">Depubliceren</key>
     <key alias="updateDate">Laatst gewijzigd</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/pl.xml
@@ -194,6 +194,7 @@
     <key alias="statistics">Statystyki</key>
     <key alias="titleOptional">Tytuł (opcjonalny)</key>
     <key alias="altTextOptional">Alternatywny tekst (opcjonalny)</key>
+    <key alias="captionOptional">Podpis (optioneel)</key>
     <key alias="type">Typ</key>
     <key alias="unpublish">Cofnij publikację</key>
     <key alias="updateDate">Ostatnio edytowany</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
@@ -196,7 +196,8 @@
     <key alias="alternativeTextHelp">(как бы Вы описали изображение по телефону)</key>
     <key alias="alternativeUrls">Альтернативные ссылки</key>
     <key alias="altTextOptional">Альтернативный текст (необязательно)</key>
-    <key alias="childItems" version="7.0">Элементы списка</key>
+    <key alias="captionOptional">подпись (необязательно)</key>
+     <key alias="childItems" version="7.0">Элементы списка</key>
     <key alias="clickToEdit">Нажмите для правки этого элемента</key>
     <key alias="contentRoot">Начальный узел содержимого</key>
     <key alias="createBy">Создано пользователем</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
@@ -120,6 +120,7 @@
     <key alias="alternativeTextHelp">(hur skulle du beskriva denna bild för någon över telefon)</key>
     <key alias="alternativeUrls">Alternativa länkar</key>
     <key alias="altTextOptional">Alternativ text (optionell)</key>
+    <key alias="captionOptional">Rubrik (optionell)</key>
     <key alias="childItems">Underliggande noder</key>
     <key alias="clickToEdit">Klicka för att redigera detta objekt</key>
     <key alias="createBy">Skapad av</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
@@ -150,6 +150,7 @@
     <key alias="statistics">istatistik</key>
     <key alias="titleOptional">Başlık (isteğe bağlı)</key>
     <key alias="altTextOptional">Alternatif metin (isteğe bağlı)</key>
+    <key alias="captionOptional">Altyazı (isteğe bağlı)</key>
     <key alias="type">tip</key>
     <key alias="unpublish">Yayından</key>
     <key alias="updateDate">Son düzenleme</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/zh.xml
@@ -157,7 +157,8 @@
     <key alias="sortHelp">拖拽项目或单击列头即可排序，可以按住Shift多选。</key>
     <key alias="statistics">统计</key>
     <key alias="titleOptional">标题（可选）</key>
-    <key alias="altTextOptional">Alternative text (optional)</key>
+    <key alias="altTextOptional">替代文字 (可选的)</key>
+    <key alias="captionOptional">字幕 (可选的)</key>
     <key alias="type">类型</key>
     <key alias="unpublish">取消发布</key>
     <key alias="updateDate">最近编辑</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/zh_tw.xml
@@ -155,6 +155,7 @@
     <key alias="statistics">統計</key>
     <key alias="titleOptional">標題（可選）</key>
     <key alias="altTextOptional">其他說明文字（可選）</key>
+    <key alias="captionOptional">標題（可選）</key>
     <key alias="type">類型</key>
     <key alias="unpublish">取消發佈</key>
     <key alias="updateDate">最近編輯</key>

--- a/src/Umbraco.Web.UI/config/tinyMceConfig.config
+++ b/src/Umbraco.Web.UI/config/tinyMceConfig.config
@@ -60,7 +60,7 @@ thead[id|class],tfoot[id|class],#td[id|lang|dir|class|colspan|rowspan|width|heig
 -span[class|align|style],-pre[class|align|style],address[class|align|style],-h1[id|dir|class|align|style],-h2[id|dir|class|align|style],
 -h3[id|dir|class|align|style],-h4[id|dir|class|align|style],-h5[id|dir|class|align|style],-h6[id|style|dir|class|align|style],hr[class|style],small[class|style],
 dd[id|class|title|style|dir|lang],dl[id|class|title|style|dir|lang],dt[id|class|title|style|dir|lang],object[class|id|width|height|codebase|*],
-param[name|value|_value|class],embed[type|width|height|src|class|*],map[name|class],area[shape|coords|href|alt|target|class],bdo[class],button[class],iframe[*]]]>
+param[name|value|_value|class],embed[type|width|height|src|class|*],map[name|class],area[shape|coords|href|alt|target|class],bdo[class],button[class],iframe[*],figure,figcaption]]>
     </validElements>
     <invalidElements>font</invalidElements>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Refer to #9681 for a fresh take on this PR - this was 18 months old, lot has changed since then...

### Description
Current editing flow when adding an image in the grid doesn't allow the editor to easily update the alt text - it is set when adding the image, and can only be modified by removing and re-adding the image, which means losing any value set for the caption.

This change modifies the grid media editor to show only the image (no more caption text), with two new buttons - one launching the media picker dialog to select a new image, the other opening the media picker details dialog to edit the caption and alt text.

The details dialog was previously inline in the mediapicker view, which made reuse impossible. I've split it out into a new infinite editor and made it available on editorService as .mediaPickerDetails(). With that change in place I've also updated the mediapicker to use the infinite editor when placing an image in the grid.