### PR TITLE
V8: Linkpicker should support anchor links without base URL

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -990,7 +990,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 }
             }
 
-            if (!href) {
+            if (!href && !target.anchor) {
                 editor.execCommand('unlink');
                 return;
             }
@@ -1002,6 +1002,10 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
                 insertLink();
                 return;
+            }
+
+            if (!href) {
+                href = "";
             }
 
 		    // Is email and not //user@domain.com and protocol (e.g. mailto:, sip:) is not specified


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5295 (although for V8)

### Description

The linkpicker doesn't allow for linking to anchor links on the current page. It should be possible to submit the linkpicker simply with the "anchor" field filled out (nothing in the "Link" field), but it isn't:

![linkpicker-anchor-without-url-before](https://user-images.githubusercontent.com/7405322/59082854-3e979f80-88f5-11e9-9558-d22fbd40a5e8.gif)

This PR fixes the issue... when the PR is applied, here's how the linkpicker behaves:

![linkpicker-anchor-without-url-after](https://user-images.githubusercontent.com/7405322/59082850-3ccddc00-88f5-11e9-90dd-411805658ca0.gif)

#### Testing this PR

To test this PR, make sure that:

1.You can create anchor links without filling out the "Link" field.
2. You can create external links both with and without anchors by filling out the "Link" field.
3. You can create internal links both with and without anchors by picking a node in the linkpicker tree.

