### PR TITLE
V7: Linkpicker should support anchor links without base URL

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -836,7 +836,7 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
 				}
 			}
 
-			if (!href) {
+            if (!href && !target.anchor) {
 				editor.execCommand('unlink');
 				return;
 			}
@@ -849,6 +849,10 @@ function tinyMceService($log, imageHelper, $http, $timeout, macroResource, macro
 				insertLink();
 				return;
 			}
+
+		    if (!href) {
+		        href = "";
+            }
 
 		    // Is email and not //user@domain.com and protocol (e.g. mailto:, sip:) is not specified
 		    if (href.indexOf('@') > 0 && href.indexOf('//') === -1 && href.indexOf(':') === -1) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5295

### Description

_This is a backport of #5608_

The linkpicker doesn't allow for linking to anchor links on the current page. It should be possible to submit the linkpicker simply with the "anchor" field filled out (nothing in the "Link" field), but it isn't:

![linkpicker-anchor-link-before](https://user-images.githubusercontent.com/7405322/59086916-8a514580-8903-11e9-8fc3-c6da163b675b.gif)

This PR fixes the issue... when the PR is applied, here's how the linkpicker behaves:

![linkpicker-anchor-link](https://user-images.githubusercontent.com/7405322/59086925-92a98080-8903-11e9-9e8e-4c15ea22dd32.gif)

#### Testing this PR

To test this PR, make sure that:

1.You can create anchor links without filling out the "Link" field.
2. You can create external links both with and without anchors by filling out the "Link" field.
3. You can create internal links both with and without anchors by picking a node in the linkpicker tree.

