### PR TITLE
ReadOnlyValueController - Fixes filter

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/readonlyvalue/readonlyvalue.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/readonlyvalue/readonlyvalue.controller.js
@@ -14,13 +14,7 @@
 function ReadOnlyValueController($rootScope, $scope, $filter) {
 
     function formatDisplayValue() {
-        
-        if ($scope.model.config &&
-        angular.isArray($scope.model.config) &&
-        $scope.model.config.length > 0 &&
-        $scope.model.config[0] &&
-        $scope.model.config.filter) {
-
+        if ($scope.model.config && $scope.model.config.filter) {
             if ($scope.model.config.format) {
                 $scope.displayvalue = $filter($scope.model.config.filter)($scope.model.value, $scope.model.config.format);
             } else {
@@ -29,12 +23,11 @@ function ReadOnlyValueController($rootScope, $scope, $filter) {
         } else {
             $scope.displayvalue = $scope.model.value;
         }
-
     }
 
     //format the display value on init:
     formatDisplayValue();
-    
+
     $scope.$watch("model.value", function (newVal, oldVal) {
         //cannot just check for !newVal because it might be an empty string which we 
         //want to look for.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Back story. I was looking for a way to alter the display text for a Label (readonly editor), specifically I wanted to display the `umbracoBytes` field in a friendlier way, e.g. instead of "43654", show "42.6Kb".

Instead of creating my own full property editor for this, I dug through Umbraco source to find a way to do this with minimal code.  I'd noticed that the "readonlyvalue" view had a controller... and that had some checks for extra config options, specifically a `filter` option.  Which was ideal for my scenario.

https://github.com/umbraco/Umbraco-CMS/blob/release-8.0.2/src/Umbraco.Web.UI.Client/src/views/propertyeditors/readonlyvalue/readonlyvalue.controller.js#L18-L22

So I created a stub property editor, (inheriting from the `LabelPropertyEditor`), set the "filter" config to use a custom AngularJs filter... was all looking good, except it didn't work! 😕 

Turns out that the controller code checks if the `config` is an array, but with how config options are set, this would now be an object (a representation of a C# `Dictionary<string, object>`).
So the previous code would never allow a filter to be set.

I tweaked the check to on the object's property, which enabled the filter to be applied.

---

I'm not sure if this satisfies the "added steps to test this contribution" or not? I can provide code snippets, but I didn't want to go over-the-top just yet.
