### PR TITLE
Icon Constants consistency

### DIFF
--- a/src/Umbraco.Core/Constants-Icons.cs
+++ b/src/Umbraco.Core/Constants-Icons.cs
@@ -5,19 +5,29 @@
         public static class Icons
         {
             /// <summary>
-            /// System contenttype icon
+            /// System default icon
             /// </summary>
-            public const string ContentType = "icon-arrangement";
+            public const string DefaultIcon = Content;
 
             /// <summary>
-            /// System datatype icon
+            /// System content icon
+            /// </summary>
+            public const string Content = "icon-document";
+
+            /// <summary>
+            /// System content type icon
+            /// </summary>
+            public const string ContentType = "icon-item-arrangement";
+
+            /// <summary>
+            /// System data type icon
             /// </summary>
             public const string DataType = "icon-autofill";
 
             /// <summary>
-            /// System property editor icon
+            /// System list view icon
             /// </summary>
-            public const string PropertyEditor = "icon-autofill";
+            public const string ListView = "icon-thumbnail-list";
 
             /// <summary>
             /// System macro icon
@@ -25,19 +35,59 @@
             public const string Macro = "icon-settings-alt";
 
             /// <summary>
+            /// System media file icon
+            /// </summary>
+            public const string MediaFile = "icon-document";
+
+            /// <summary>
+            /// System media folder icon
+            /// </summary>
+            public const string MediaFolder = "icon-folder";
+
+            /// <summary>
+            /// System media image icon
+            /// </summary>
+            public const string MediaImage = "icon-picture";
+
+            /// <summary>
+            /// System media type icon
+            /// </summary>
+            public const string MediaType = "icon-thumbnails";
+
+            /// <summary>
             /// System member icon
             /// </summary>
             public const string Member = "icon-user";
 
             /// <summary>
-            /// System member icon
+            /// System member group icon
+            /// </summary>
+            public const string MemberGroup = "icon-users-alt";
+
+            /// <summary>
+            /// System member type icon
             /// </summary>
             public const string MemberType = "icon-users";
+
+            /// <summary>
+            /// System property editor icon
+            /// </summary>
+            public const string PropertyEditor = "icon-autofill";
 
             /// <summary>
             /// System member icon
             /// </summary>
             public const string Template = "icon-layout";
+
+            /// <summary>
+            /// System user icon
+            /// </summary>
+            public const string User = "icon-user";
+
+            /// <summary>
+            /// System user group icon
+            /// </summary>
+            public const string UserGroup = "icon-users";
         }
     }
 }

--- a/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
@@ -155,10 +155,10 @@ namespace Umbraco.Core.Migrations.Install
 
         private void CreateContentTypeData()
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false, new ContentTypeDto { PrimaryKey = 532, NodeId = 1031, Alias = Constants.Conventions.MediaTypes.Folder, Icon = "icon-folder", Thumbnail = "icon-folder", IsContainer = false, AllowAtRoot = true, Variations = (byte) ContentVariation.Nothing });
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false, new ContentTypeDto { PrimaryKey = 533, NodeId = 1032, Alias = Constants.Conventions.MediaTypes.Image, Icon = "icon-picture", Thumbnail = "icon-picture", AllowAtRoot = true, Variations = (byte) ContentVariation.Nothing });
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false, new ContentTypeDto { PrimaryKey = 534, NodeId = 1033, Alias = Constants.Conventions.MediaTypes.File, Icon = "icon-document", Thumbnail = "icon-document", AllowAtRoot = true, Variations = (byte) ContentVariation.Nothing });
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false, new ContentTypeDto { PrimaryKey = 531, NodeId = 1044, Alias = Constants.Conventions.MemberTypes.DefaultAlias, Icon = "icon-user", Thumbnail = "icon-user", Variations = (byte) ContentVariation.Nothing });
+            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false, new ContentTypeDto { PrimaryKey = 532, NodeId = 1031, Alias = Constants.Conventions.MediaTypes.Folder, Icon = Constants.Icons.MediaFolder, Thumbnail = Constants.Icons.MediaFolder, IsContainer = false, AllowAtRoot = true, Variations = (byte) ContentVariation.Nothing });
+            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false, new ContentTypeDto { PrimaryKey = 533, NodeId = 1032, Alias = Constants.Conventions.MediaTypes.Image, Icon = Constants.Icons.MediaImage, Thumbnail = Constants.Icons.MediaImage, AllowAtRoot = true, Variations = (byte) ContentVariation.Nothing });
+            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false, new ContentTypeDto { PrimaryKey = 534, NodeId = 1033, Alias = Constants.Conventions.MediaTypes.File, Icon = Constants.Icons.MediaFile, Thumbnail = Constants.Icons.MediaFile, AllowAtRoot = true, Variations = (byte) ContentVariation.Nothing });
+            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false, new ContentTypeDto { PrimaryKey = 531, NodeId = 1044, Alias = Constants.Conventions.MemberTypes.DefaultAlias, Icon = Constants.Icons.Member, Thumbnail = Constants.Icons.Member, Variations = (byte) ContentVariation.Nothing });
         }
 
         private void CreateUserData()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -136,7 +136,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             //set a default icon if one is not specified
             if (entity.Icon.IsNullOrWhiteSpace())
             {
-                entity.Icon = "icon-user";
+                entity.Icon = Constants.Icons.Member;
             }
 
             //By Convention we add 9 standard PropertyTypes to an Umbraco MemberType

--- a/src/Umbraco.Web/ContentApps/ContentEditorContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentEditorContentAppFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.ContentEditing;
 using Umbraco.Core.Models.Membership;
@@ -23,7 +24,7 @@ namespace Umbraco.Web.ContentApps
                     {
                         Alias = "umbContent",
                         Name = "Content",
-                        Icon = "icon-document",
+                        Icon = Constants.Icons.Content,
                         View = "views/content/apps/content/content.html",
                         Weight = Weight
                     });
@@ -36,7 +37,7 @@ namespace Umbraco.Web.ContentApps
                     {
                         Alias = "umbContent",
                         Name = "Content",
-                        Icon = "icon-document",
+                        Icon = Constants.Icons.Content,
                         View = "views/media/apps/content/content.html",
                         Weight = Weight
                     });

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -373,7 +373,7 @@ namespace Umbraco.Web.Editors
             else
                 ct = new ContentType(parentId);
 
-            ct.Icon = "icon-document";
+            ct.Icon = Constants.Icons.Content;
 
             var dto = Mapper.Map<IContentType, DocumentTypeDisplay>(ct);
             return dto;

--- a/src/Umbraco.Web/Editors/MediaTypeController.cs
+++ b/src/Umbraco.Web/Editors/MediaTypeController.cs
@@ -135,7 +135,10 @@ namespace Umbraco.Web.Editors
         }
         public MediaTypeDisplay GetEmpty(int parentId)
         {
-            var ct = new MediaType(parentId) {Icon = "icon-picture"};
+            var ct = new MediaType(parentId)
+            {
+                Icon = Constants.Icons.MediaImage
+            };
 
             var dto = Mapper.Map<IMediaType, MediaTypeDisplay>(ct);
             return dto;

--- a/src/Umbraco.Web/Editors/MemberTypeController.cs
+++ b/src/Umbraco.Web/Editors/MemberTypeController.cs
@@ -102,7 +102,7 @@ namespace Umbraco.Web.Editors
         public MemberTypeDisplay GetEmpty()
         {
             var ct = new MemberType(-1);
-            ct.Icon = "icon-user";
+            ct.Icon = Constants.Icons.Member;
 
             var dto = Mapper.Map<IMemberType, MemberTypeDisplay>(ct);
             return dto;

--- a/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Web.Models.Mapping
             target.Udi = Udi.Create(ObjectTypes.GetUdiType(source.NodeObjectType), source.Key);
 
             if (source.NodeObjectType == Constants.ObjectTypes.Member && target.Icon.IsNullOrWhiteSpace())
-                target.Icon = "icon-user";
+                target.Icon = Constants.Icons.Member;
 
             // NOTE: we're mapping the objects in AdditionalData by object reference here.
             // it works fine for now, but it's something to keep in mind in the future
@@ -83,7 +83,7 @@ namespace Umbraco.Web.Models.Mapping
         private static void Map(IUser source, EntityBasic target, MapperContext context)
         {
             target.Alias = source.Username;
-            target.Icon = "icon-user";
+            target.Icon = Constants.Icons.User;
             target.Id = source.Id;
             target.Key = source.Key;
             target.Name = source.Name;
@@ -95,7 +95,7 @@ namespace Umbraco.Web.Models.Mapping
         private static void Map(ITemplate source, EntityBasic target, MapperContext context)
         {
             target.Alias = source.Alias;
-            target.Icon = "icon-layout";
+            target.Icon = Constants.Icons.Template;
             target.Id = source.Id;
             target.Key = source.Key;
             target.Name = source.Name;
@@ -138,15 +138,15 @@ namespace Umbraco.Web.Models.Mapping
             if (target.Icon.IsNullOrWhiteSpace())
             {
                 if (source.NodeObjectType == Constants.ObjectTypes.Member)
-                    target.Icon = "icon-user";
+                    target.Icon = Constants.Icons.Member;
                 else if (source.NodeObjectType == Constants.ObjectTypes.DataType)
-                    target.Icon = "icon-autofill";
+                    target.Icon = Constants.Icons.DataType;
                 else if (source.NodeObjectType == Constants.ObjectTypes.DocumentType)
-                    target.Icon = "icon-item-arrangement";
+                    target.Icon = Constants.Icons.ContentType;
                 else if (source.NodeObjectType == Constants.ObjectTypes.MediaType)
-                    target.Icon = "icon-thumbnails";
+                    target.Icon = Constants.Icons.MediaType;
                 else if (source.NodeObjectType == Constants.ObjectTypes.TemplateType)
-                    target.Icon = "icon-newspaper-alt";
+                    target.Icon = Constants.Icons.Template;
             }
         }
 
@@ -161,7 +161,7 @@ namespace Umbraco.Web.Models.Mapping
             //get the icon if there is one
             target.Icon = source.Values.ContainsKey(UmbracoExamineIndex.IconFieldName)
                 ? source.Values[UmbracoExamineIndex.IconFieldName]
-                : "icon-document";
+                : Constants.Icons.DefaultIcon;
 
             target.Name = source.Values.ContainsKey("nodeName") ? source.Values["nodeName"] : "[no name]";
 

--- a/src/Umbraco.Web/Models/Mapping/MacroMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MacroMapDefinition.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Web.Models.Mapping
         private static void Map(IMacro source, EntityBasic target, MapperContext context)
         {
             target.Alias = source.Alias;
-            target.Icon = "icon-settings-alt";
+            target.Icon = Constants.Icons.Macro;
             target.Id = source.Id;
             target.Key = source.Key;
             target.Name = source.Name;

--- a/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
@@ -126,7 +126,7 @@ namespace Umbraco.Web.Models.Mapping
         {
             target.CreateDate = source.CreationDate;
             target.Email = source.Email;
-            target.Icon = "icon-user";
+            target.Icon = Constants.Icons.Member;
             target.Id = int.MaxValue;
             target.Key = source.ProviderUserKey.TryConvertTo<Guid>().Result;
             target.Name = source.UserName;

--- a/src/Umbraco.Web/Models/Mapping/MemberTabsAndPropertiesMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberTabsAndPropertiesMapper.cs
@@ -96,7 +96,7 @@ namespace Umbraco.Web.Models.Mapping
                         linkText = source.ContentType.Name,
                         url = memberTypeLink,
                         target = "_self",
-                        icon = "icon-item-arrangement"
+                        icon = Constants.Icons.ContentType
                     }
                 };
                 docTypeProperty.View = "urllist";

--- a/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
@@ -179,7 +179,7 @@ namespace Umbraco.Web.Models.Mapping
             target.DefaultPermissions = MapUserGroupDefaultPermissions(source);
 
             if (target.Icon.IsNullOrWhiteSpace())
-                target.Icon = "icon-users";
+                target.Icon = Constants.Icons.UserGroup;
         }
 
         // Umbraco.Code.MapAll -Trashed -Alias -AssignedPermissions
@@ -194,7 +194,7 @@ namespace Umbraco.Web.Models.Mapping
             target.Udi = Udi.Create(ObjectTypes.GetUdiType(source.NodeObjectType), source.Key);
 
             if (source.NodeObjectType == Constants.ObjectTypes.Member && target.Icon.IsNullOrWhiteSpace())
-                target.Icon = "icon-user";
+                target.Icon = Constants.Icons.Member;
         }
 
         // Umbraco.Code.MapAll -ContentStartNode -MediaStartNode -Sections -Notifications -Udi
@@ -350,7 +350,7 @@ namespace Umbraco.Web.Models.Mapping
                 target.ContentStartNode = CreateRootNode(_textService.Localize("content/contentRoot"));
 
             if (target.Icon.IsNullOrWhiteSpace())
-                target.Icon = "icon-users";
+                target.Icon = Constants.Icons.UserGroup;
         }
 
         private IDictionary<string, IEnumerable<Permission>> MapUserGroupDefaultPermissions(IUserGroup source)

--- a/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a list-view editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.ListView, "List view", "listview", HideLabel = true, Group = "lists", Icon = "icon-item-arrangement")]
+    [DataEditor(Constants.PropertyEditors.Aliases.ListView, "List view", "listview", HideLabel = true, Group = "lists", Icon = Constants.Icons.ListView)]
     public class ListViewPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/MacroContainerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MacroContainerPropertyEditor.cs
@@ -5,7 +5,7 @@ using Umbraco.Core.PropertyEditors;
 namespace Umbraco.Web.PropertyEditors
 {
     // TODO: MacroContainerPropertyEditor is deprecated, but what's the alternative?
-    [DataEditor(Constants.PropertyEditors.Aliases.MacroContainer, "(Obsolete) Macro Picker", "macrocontainer", ValueType = ValueTypes.Text, Group="rich content", Icon="icon-settings-alt", IsDeprecated = true)]
+    [DataEditor(Constants.PropertyEditors.Aliases.MacroContainer, "(Obsolete) Macro Picker", "macrocontainer", ValueType = ValueTypes.Text, Group = "rich content", Icon = Constants.Icons.Macro, IsDeprecated = true)]
     public class MacroContainerPropertyEditor : DataEditor
     {
         public MacroContainerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/MediaPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPickerPropertyEditor.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Web.PropertyEditors
     /// Represents a media picker property editor.
     /// </summary>
     [DataEditor(Constants.PropertyEditors.Aliases.MediaPicker, EditorType.PropertyValue | EditorType.MacroParameter,
-        "Media Picker", "mediapicker", ValueType = ValueTypes.Text, Group = "media", Icon = "icon-picture")]
+        "Media Picker", "mediapicker", ValueType = ValueTypes.Text, Group = "media", Icon = Constants.Icons.MediaImage)]
     public class MediaPickerPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/MemberGroupPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MemberGroupPickerPropertyEditor.cs
@@ -4,7 +4,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.MemberGroupPicker, "Member Group Picker", "membergrouppicker", ValueType = ValueTypes.Text, Group = "People", Icon = "icon-users")]
+    [DataEditor(Constants.PropertyEditors.Aliases.MemberGroupPicker, "Member Group Picker", "membergrouppicker", ValueType = ValueTypes.Text, Group = "People", Icon = Constants.Icons.MemberGroup)]
     public class MemberGroupPickerPropertyEditor : DataEditor
     {
          public MemberGroupPickerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/MemberPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MemberPickerPropertyEditor.cs
@@ -4,7 +4,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.MemberPicker, "Member Picker", "memberpicker", ValueType = ValueTypes.String, Group = "People", Icon = "icon-user")]
+    [DataEditor(Constants.PropertyEditors.Aliases.MemberPicker, "Member Picker", "memberpicker", ValueType = ValueTypes.String, Group = "People", Icon = Constants.Icons.Member)]
     public class MemberPickerPropertyEditor : DataEditor
     {
         public MemberPickerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/UserPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/UserPickerPropertyEditor.cs
@@ -6,7 +6,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.UserPicker, "User picker", "entitypicker", ValueType = ValueTypes.Integer, Group = "People", Icon = "icon-user")]
+    [DataEditor(Constants.PropertyEditors.Aliases.UserPicker, "User picker", "entitypicker", ValueType = ValueTypes.Integer, Group = "People", Icon = Constants.Icons.User)]
     public class UserPickerPropertyEditor : DataEditor
     {
         public UserPickerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
+++ b/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
@@ -385,9 +385,9 @@ namespace Umbraco.Web.Search
                 var m = _mapper.Map<SearchResultEntity>(result);
 
                 //if no icon could be mapped, it will be set to document, so change it to picture
-                if (m.Icon == "icon-document")
+                if (m.Icon == Constants.Icons.DefaultIcon)
                 {
-                    m.Icon = "icon-user";
+                    m.Icon = Constants.Icons.Member;
                 }
 
                 if (result.Values.ContainsKey("email") && result.Values["email"] != null)
@@ -418,9 +418,9 @@ namespace Umbraco.Web.Search
             {
                 var m = _mapper.Map<SearchResultEntity>(result);
                 //if no icon could be mapped, it will be set to document, so change it to picture
-                if (m.Icon == "icon-document")
+                if (m.Icon == Constants.Icons.DefaultIcon)
                 {
-                    m.Icon = "icon-picture";
+                    m.Icon = Constants.Icons.MediaImage;
                 }
                 yield return m;
             }

--- a/src/Umbraco.Web/Trees/ContentBlueprintTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentBlueprintTreeController.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Web.Trees
                 nodes.AddRange(docTypeEntities
                     .Select(entity =>
                     {
-                        var treeNode = CreateTreeNode(entity, Constants.ObjectTypes.DocumentBlueprint, id, queryStrings, "icon-item-arrangement", true);
+                        var treeNode = CreateTreeNode(entity, Constants.ObjectTypes.DocumentBlueprint, id, queryStrings, Constants.Icons.ContentType, true);
                         treeNode.Path = $"-1,{entity.Id}";
                         treeNode.NodeType = "document-type-blueprints";
                         // TODO: This isn't the best way to ensure a no operation process for clicking a node but it works for now.

--- a/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
@@ -57,7 +57,7 @@ namespace Umbraco.Web.Trees
                         // since 7.4+ child type creation is enabled by a config option. It defaults to on, but can be disabled if we decide to.
                         // need this check to keep supporting sites where children have already been created.
                         var hasChildren = dt.HasChildren;
-                        var node = CreateTreeNode(dt, Constants.ObjectTypes.DocumentType, id, queryStrings, "icon-item-arrangement", hasChildren);
+                        var node = CreateTreeNode(dt, Constants.ObjectTypes.DocumentType, id, queryStrings, Constants.Icons.ContentType, hasChildren);
 
                         node.Path = dt.Path;
                         return node;

--- a/src/Umbraco.Web/Trees/DataTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/DataTypeTreeController.cs
@@ -53,11 +53,11 @@ namespace Umbraco.Web.Trees
                     .OrderBy(entity => entity.Name)
                     .Select(dt =>
                     {
-                        var node = CreateTreeNode(dt.Id.ToInvariantString(), id, queryStrings, dt.Name, "icon-autofill", false);
+                        var node = CreateTreeNode(dt.Id.ToInvariantString(), id, queryStrings, dt.Name, Constants.Icons.DataType, false);
                         node.Path = dt.Path;
                         if (systemListViewDataTypeIds.Contains(dt.Id))
                         {
-                            node.Icon = "icon-thumbnail-list";
+                            node.Icon = Constants.Icons.ListView;
                         }
                         return node;
                     }));

--- a/src/Umbraco.Web/Trees/FilesTreeController.cs
+++ b/src/Umbraco.Web/Trees/FilesTreeController.cs
@@ -14,6 +14,6 @@ namespace Umbraco.Web.Trees
 
         protected override string[] Extensions => ExtensionsStatic;
 
-        protected override string FileIcon => "icon-document";
+        protected override string FileIcon => Constants.Icons.MediaFile;
     }
 }

--- a/src/Umbraco.Web/Trees/MacrosTreeController.cs
+++ b/src/Umbraco.Web/Trees/MacrosTreeController.cs
@@ -36,7 +36,7 @@ namespace Umbraco.Web.Trees
                         id,
                         queryStrings,
                         macro.Name,
-                        "icon-settings-alt",
+                        Constants.Icons.Macro,
                         false));
                 }
             }

--- a/src/Umbraco.Web/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTypeTreeController.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Web.Trees
                         // since 7.4+ child type creation is enabled by a config option. It defaults to on, but can be disabled if we decide to.
                         // need this check to keep supporting sites where children have already been created.
                         var hasChildren = dt.HasChildren;
-                        var node = CreateTreeNode(dt, Constants.ObjectTypes.MediaType, id, queryStrings, "icon-thumbnails", hasChildren);
+                        var node = CreateTreeNode(dt, Constants.ObjectTypes.MediaType, id, queryStrings, Constants.Icons.MediaType, hasChildren);
 
                         node.Path = dt.Path;
                         return node;

--- a/src/Umbraco.Web/Trees/MemberGroupTreeController.cs
+++ b/src/Umbraco.Web/Trees/MemberGroupTreeController.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Web.Trees
         {
             return Services.MemberGroupService.GetAll()
                 .OrderBy(x => x.Name)
-                .Select(dt => CreateTreeNode(dt.Id.ToString(), id, queryStrings, dt.Name, "icon-item-arrangement", false));
+                .Select(dt => CreateTreeNode(dt.Id.ToString(), id, queryStrings, dt.Name, Constants.Icons.MemberGroup, false));
         }
 
         protected override TreeNode CreateRootNode(FormDataCollection queryStrings)

--- a/src/Umbraco.Web/Trees/MemberTreeController.cs
+++ b/src/Umbraco.Web/Trees/MemberTreeController.cs
@@ -80,7 +80,7 @@ namespace Umbraco.Web.Trees
                     "-1",
                     queryStrings,
                     member.Name,
-                    "icon-user",
+                    Constants.Icons.Member,
                     false,
                     "",
                     Udi.Create(ObjectTypes.GetUdiType(Constants.ObjectTypes.Member), member.Key));
@@ -110,7 +110,7 @@ namespace Umbraco.Web.Trees
                     "-1",
                     queryStrings,
                     member.UserName,
-                    "icon-user",
+                    Constants.Icons.Member,
                     false);
 
                 return node;
@@ -124,14 +124,14 @@ namespace Umbraco.Web.Trees
             if (id == Constants.System.RootString)
             {
                 nodes.Add(
-                        CreateTreeNode(Constants.Conventions.MemberTypes.AllMembersListId, id, queryStrings, Services.TextService.Localize("member/allMembers"), "icon-users", true,
+                        CreateTreeNode(Constants.Conventions.MemberTypes.AllMembersListId, id, queryStrings, Services.TextService.Localize("member/allMembers"), Constants.Icons.MemberType, true,
                             queryStrings.GetRequiredValue<string>("application") + TreeAlias.EnsureStartsWith('/') + "/list/" + Constants.Conventions.MemberTypes.AllMembersListId));
 
                 if (_isUmbracoProvider)
                 {
                     nodes.AddRange(Services.MemberTypeService.GetAll()
                         .Select(memberType =>
-                            CreateTreeNode(memberType.Alias, id, queryStrings, memberType.Name, "icon-users", true,
+                            CreateTreeNode(memberType.Alias, id, queryStrings, memberType.Name, Constants.Icons.MemberType, true,
                                 queryStrings.GetRequiredValue<string>("application") + TreeAlias.EnsureStartsWith('/') + "/list/" + memberType.Alias)));
                 }
             }

--- a/src/Umbraco.Web/Trees/MemberTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/MemberTypeTreeController.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Web.Trees
         {
             return Services.MemberTypeService.GetAll()
                 .OrderBy(x => x.Name)
-                .Select(dt => CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings, "icon-item-arrangement", false));
+                .Select(dt => CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings, Constants.Icons.MemberType, false));
         }
     }
 }

--- a/src/Umbraco.Web/Trees/UserTreeController.cs
+++ b/src/Umbraco.Web/Trees/UserTreeController.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Web.Trees
 
             //this will load in a custom UI instead of the dashboard for the root node
             root.RoutePath = $"{Constants.Applications.Users}/{Constants.Trees.Users}/users";
-            root.Icon = "icon-users";
+            root.Icon = Constants.Icons.UserGroup;
 
             root.HasChildren = false;
             return root;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I wanted to reference some of the Umbraco (default) system icons in a new package I'm working on, and spotted that the [`Constants.Icons.ContentType` was set to `"icon-arrangement"`](https://github.com/umbraco/Umbraco-CMS/blob/release-8.0.2/src/Umbraco.Core/Constants-Icons.cs#L18) - which doesn't exist.  Then I checked if it was used elsewhere - which it wasn't. Then I got carried away with replacing any hard-coded icon references with the appropriate reference.

In terms of testing, I've checked around the back-office for the various trees/sections/components that got updated.
