### PR TITLE
Fixes #5605 (emptying the recycle bin with a protected page and associated login page throws a SQL error)

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -205,7 +205,10 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.ContentVersionCultureVariation + " WHERE versionId IN (SELECT id FROM " + Constants.DatabaseSchema.Tables.ContentVersion + " WHERE nodeId = @id)",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.ContentVersion + " WHERE nodeId = @id",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.Content + " WHERE nodeId = @id",
+                "DELETE FROM " + Constants.DatabaseSchema.Tables.AccessRule + " WHERE accessId IN (SELECT id FROM " + Constants.DatabaseSchema.Tables.Access + " WHERE nodeId = @id OR loginNodeId = @id OR noAccessNodeId = @id)",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.Access + " WHERE nodeId = @id",
+                "DELETE FROM " + Constants.DatabaseSchema.Tables.Access + " WHERE loginNodeId = @id",
+                "DELETE FROM " + Constants.DatabaseSchema.Tables.Access + " WHERE noAccessNodeId = @id",
                 "DELETE FROM " + Constants.DatabaseSchema.Tables.Node + " WHERE id = @id"
             };
             return list;


### PR DESCRIPTION
This was happening as not all related records from the public access tables were being deleted leading to the SQL error due to violation of the foreign key constraints.

This PR adds the necessary additional DELETE statements.

To test:

- Create a page to act as the login page for restricted documents
- Create a page to act as the no access page
- Create a page restricted to member group or member, selecting the login page and no access page
- Delete all the pages
- Observe that you can now empty the recycle bin

Just to note, I didn't get the SQL error every time for the current code-base - it seems to matter what order the pages have been created in.  If the login and no access pages are created first, I'll get the error, otherwise I wouldn't.  This may be effectively random or may be that it's deleting in order of node Id.