### PR TITLE
v8: Fix padding for the umb-checkbox component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -6,7 +6,7 @@
     flex-wrap: wrap;
     align-items: center;
     position: relative;
-    padding: 0;
+    padding: 0 !important;
     margin: 0;
     min-height: 22px;
     line-height: 22px;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #5637 

### Description

I have forced the padding to always be 0 by using !important - Preferably I would have solved this in a better way but it's really hard to avoid other selectors hitting element and the codebase is big so we're going to get by using !important for now.

This fixes some of the large gaps between the checkbox and the label text when used in the link picker and in the configuration of the rich text editor

Looking forward to your feedback 😃 

**Link picker before**
![insert-link-dialog-checkbox-before](https://user-images.githubusercontent.com/1932158/59197721-44f67780-8b92-11e9-99c6-c34c8c06bef5.png)

**Link picker after**
![insert-link-dialog-checkbox-after](https://user-images.githubusercontent.com/1932158/59197736-4c1d8580-8b92-11e9-8fec-9c5206cb32bb.png)

**RTE config before**
![rte-config-before](https://user-images.githubusercontent.com/1932158/59197746-52abfd00-8b92-11e9-8626-dc9c59c658d1.png)

**RTE config after**
![rte-config-after](https://user-images.githubusercontent.com/1932158/59197761-5dff2880-8b92-11e9-8d0a-13cc0c84cbf3.png)
