### PR TITLE
Remove bold from default variant.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -12,7 +12,7 @@
                     <ins class="umb-language-picker__expand" ng-class="{'icon-navigation-down': !page.languageSelectorIsOpen, 'icon-navigation-up': page.languageSelectorIsOpen}" class="icon-navigation-right">&nbsp;</ins>
                 </div>
                 <div class="umb-language-picker__dropdown" ng-if="page.languageSelectorIsOpen">
-                    <a class="umb-language-picker__dropdown-item" ng-class="{'umb-language-picker__dropdown-item--current': language.active, 'bold': language.isDefault}" ng-click="selectLanguage(language)" ng-repeat="language in languages" href="">{{language.name}}</a>
+                    <a class="umb-language-picker__dropdown-item" ng-class="{'umb-language-picker__dropdown-item--current': language.active}" ng-click="selectLanguage(language)" ng-repeat="language in languages" href="">{{language.name}}</a>
                 </div>
             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -41,7 +41,7 @@
                     <umb-dropdown ng-if="vm.dropdownOpen" style="min-width: 100%; max-height: 250px; overflow-y: auto; margin-top: 5px;" on-close="vm.dropdownOpen = false" umb-keyboard-list>
                         <umb-dropdown-item class="umb-variant-switcher__item" ng-class="{'--current': variant.active, '--not-allowed': variantIsOpen(variant.language.culture), '--error': variantHasError(variant.language.culture)}" ng-repeat="variant in content.variants">
                             <a href="" class="umb-variant-switcher__name-wrapper" ng-click="selectVariant($event, variant)" prevent-default>
-                                <span class="umb-variant-switcher__name" ng-class="{'bold': variant.language.isDefault}">{{variant.language.name}}</span>
+                                <span class="umb-variant-switcher__name">{{variant.language.name}}</span>
                                 <umb-variant-state variant="variant" class="umb-variant-switcher__state"></umb-variant-state>
                             </a>
                             <div ng-if="splitViewOpen !== true && !variant.active" class="umb-variant-switcher__split-view" ng-click="openInSplitView($event, variant)">Open in split view</div>

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
@@ -39,7 +39,7 @@
                     <tr ng-repeat="language in vm.languages track by language.id" ng-click="vm.editLanguage(language)" style="cursor: pointer;">
                         <td>
                             <i class="icon-globe" style="color: #BBBABF; margin-right: 5px;"></i>
-                            <span ng-class="{'bold': language.isDefault}">{{ language.name }}</span>
+                            <span>{{ language.name }}</span>
                         </td>
                         <td>
                             <span>{{ language.culture }}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewpublish.html
@@ -3,19 +3,19 @@
         <div ng-if="!vm.languages">
             <p><localize key="prompt_confirmListViewPublish"></localize></p>
         </div>
-    
+
         <div ng-if="vm.languages.length > 1">
-    
+
             <div class="mb3">
                 <p><localize key="content_languagesToPublish"></localize></p>
             </div>
-    
+
             <div ng-if="vm.loading" style="min-height: 50px; position: relative;">
                 <umb-load-indicator></umb-load-indicator>
             </div>
-    
+
             <div class="umb-list umb-list--condensed" ng-if="!vm.loading">
-    
+
                 <div class="umb-list-item" ng-repeat="language in vm.languages track by language.id">
                     <ng-form name="publishLanguageSelectorForm">
                         <div class="flex">
@@ -28,20 +28,20 @@
                                 style="margin-right: 8px;" />
                             <div>
                                 <label for="{{language.culture}}" style="margin-bottom: 2px;">
-                                    <span ng-class="{'bold': language.isDefault}">{{ language.name }}</span>
+                                    <span>{{ language.name }}</span>
                                 </label>
-    
+
                                 <div class="umb-list-item__description">
                                     <span ng-if="language.isMandatory"><localize key="languages_mandatoryLanguage"></localize></span>
                                 </div>
-    
+
                             </div>
                         </div>
-    
+
                     </ng-form>
                 </div>
             </div>
-    
+
         </div>
-    
+
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.html
@@ -4,16 +4,16 @@
         <div ng-if="!vm.languages">
             <p><localize key="prompt_confirmListViewUnpublish"></localize></p>
         </div>
-    
+
         <!-- Multiple languages -->
         <div ng-if="vm.languages.length > 0">
 
             <div class="mb3">
                 <p><localize key="content_languagesToUnpublish"></localize></p>
             </div>
-                
+
             <div class="umb-list umb-list--condensed">
-        
+
                 <div class="umb-list-item" ng-repeat="language in vm.languages track by language.id">
                     <ng-form name="unpublishLanguageSelectorForm">
                         <div class="flex">
@@ -26,21 +26,21 @@
                                     style="margin-right: 8px;" />
                             <div>
                                 <label for="{{language.culture}}" style="margin-bottom: 2px;">
-                                    <span ng-class="{'bold': language.isDefault}">{{ language.name }}</span>
+                                    <span>{{ language.name }}</span>
                                 </label>
-        
+
                                 <div class="umb-list-item__description">
                                     <span ng-if="language.isMandatory"><localize key="languages_mandatoryLanguage"></localize></span>
                                 </div>
-        
+
                             </div>
                         </div>
-        
+
                     </ng-form>
                 </div>
 
             </div>
-    
+
         </div>
-        
+
     </div>


### PR DESCRIPTION
Marking the default language does not make much sense in a general perspective.
The default language is not necessary the fallback language and could therefor cause confusion.

This PR will remove the highlight of the default language.