### PR TITLE
Gulp root variable change

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulp/config.js
+++ b/src/Umbraco.Web.UI.Client/gulp/config.js
@@ -41,12 +41,13 @@ module.exports = {
             assets: "./src/assets/**"
         }
     },
-    root: "../Umbraco.Web.UI/Umbraco/",
+    root: "../Umbraco.Web.UI/",
     targets: {
-        js: "js/",
-        lib: "lib/",
-        views: "views/",
-        css: "assets/css/",
-        assets: "assets/"
+        js: "Umbraco/js/",
+        lib: "Umbraco/lib/",
+        views: "Umbraco/views/",
+        plugins: "App_Plugins/",
+        css: "Umbraco/assets/css/",
+        assets: "Umbraco/assets/"
     }
 };

--- a/src/Umbraco.Web.UI.Client/gulp/config.js
+++ b/src/Umbraco.Web.UI.Client/gulp/config.js
@@ -46,7 +46,6 @@ module.exports = {
         js: "Umbraco/js/",
         lib: "Umbraco/lib/",
         views: "Umbraco/views/",
-        plugins: "App_Plugins/",
         css: "Umbraco/assets/css/",
         assets: "Umbraco/assets/"
     }


### PR DESCRIPTION
I want the root variable in our Gulp-script to point to the root of the project, not including the "/Umbraco/" folder. In this way we are able to use the gulp script for a broader usage.