### PR TITLE
Fixes notifications issue for new variant saving, allows "soft redirect" for creating

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/SimilarNodeName.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/SimilarNodeName.cs
@@ -99,7 +99,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
                 if (uniqueing)
                 {
-                    if (name.NumPos > 0 && name.Name.StartsWith(nodeName) && name.NumVal == uniqueNumber)
+                    if (name.NumPos > 0 && name.Name.InvariantStartsWith(nodeName) && name.NumVal == uniqueNumber)
                         uniqueNumber++;
                     else
                         break;

--- a/src/Umbraco.Tests/Persistence/Repositories/SimilarNodeNameTests.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/SimilarNodeNameTests.cs
@@ -75,6 +75,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         [TestCase(0, "Alpha", "Alpha (3)")]
         [TestCase(0, "Kilo (1)", "Kilo (1) (1)")] // though... we might consider "Kilo (2)"
         [TestCase(6, "Kilo (1)", "Kilo (1)")] // because of the id
+        [TestCase(0, "alpha", "alpha (3)")]
         [TestCase(0, "", " (1)")]
         [TestCase(0, null, " (1)")]
         public void Test(int nodeId, string nodeName, string expected)

--- a/src/Umbraco.Tests/Persistence/Repositories/SimilarNodeNameTests.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/SimilarNodeNameTests.cs
@@ -36,6 +36,8 @@ namespace Umbraco.Tests.Persistence.Repositories
                 Assert.IsTrue(result > 0, "Expected >0 but was " + result);
         }
 
+        
+
         [Test]
         public void OrderByTest()
         {
@@ -95,6 +97,22 @@ namespace Umbraco.Tests.Persistence.Repositories
             };
 
             Assert.AreEqual(expected, SimilarNodeName.GetUniqueName(names, nodeId, nodeName));
+        }
+
+        [Test]
+        public void TestMany()
+        {
+            var names = new[]
+            {
+                new SimilarNodeName { Id = 1, Name = "Alpha (2)" },
+                new SimilarNodeName { Id = 2, Name = "Test" },
+                new SimilarNodeName { Id = 3, Name = "Test (1)" },
+                new SimilarNodeName { Id = 4, Name = "Test (2)" },
+                new SimilarNodeName { Id = 22, Name = "Test (1) (1)" },
+            };
+
+            //fixme - this will yield "Test (2)" which is already in use
+            Assert.AreEqual("Test (3)", SimilarNodeName.GetUniqueName(names, 0, "Test"));
         }
     }
 }

--- a/src/Umbraco.Tests/Persistence/Repositories/SimilarNodeNameTests.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/SimilarNodeNameTests.cs
@@ -100,6 +100,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         }
 
         [Test]
+        [Explicit("This test fails! We need to fix up the logic")]
         public void TestMany()
         {
             var names = new[]

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -937,7 +937,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
@@ -955,7 +955,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -1176,7 +1176,7 @@
     "array-slice": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-      "integrity": "sha1-42jqFfibxwaff/uJrsOmx9SsItQ=",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
       "dev": true
     },
     "array-sort": {
@@ -1535,7 +1535,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -1551,7 +1551,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -1566,7 +1566,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -1740,7 +1740,7 @@
     "buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
       "dev": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
@@ -1750,7 +1750,7 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
       "dev": true
     },
     "buffer-crc32": {
@@ -2436,7 +2436,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -2559,7 +2559,7 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha1-+XJgj/DOrWi4QaFqky0LGDeRgU4=",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "core-util-is": {
@@ -3493,7 +3493,7 @@
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -4061,7 +4061,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "dev": true,
       "requires": {
@@ -4263,7 +4263,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
         }
@@ -4358,7 +4358,7 @@
     "eslint-scope": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha1-UL8wcekzi83EMzF5Sgy1M/ATYXI=",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -4368,13 +4368,13 @@
     "eslint-utils": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha1-moUbqJ7nxGA0b5fPiTnHKYgn5RI=",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
       "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
     },
     "espree": {
@@ -4397,7 +4397,7 @@
     "esquery": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -4406,7 +4406,7 @@
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
@@ -4482,7 +4482,7 @@
     "exec-buffer": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
-      "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
+      "integrity": "sha1-sWhtvZBMfPmC5lLB9aebHlVzCCs=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4691,7 +4691,7 @@
         "fill-range": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "dev": true,
           "requires": {
             "is-number": "^2.1.0",
@@ -5244,7 +5244,7 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
       "dev": true
     },
     "fs-extra": {
@@ -5309,8 +5309,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5331,14 +5330,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5353,20 +5350,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5483,8 +5477,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5496,7 +5489,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5511,7 +5503,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5519,14 +5510,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5545,7 +5534,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5626,8 +5614,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5639,7 +5626,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5725,8 +5711,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5762,7 +5747,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5782,7 +5766,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5826,14 +5809,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6030,7 +6011,7 @@
     "global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-      "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
         "global-prefix": "^1.0.1",
@@ -6621,7 +6602,7 @@
     "gulp-eslint": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-5.0.0.tgz",
-      "integrity": "sha1-KiaECV93Syz3kxAmIHjFbMehK1I=",
+      "integrity": "sha512-9GUqCqh85C7rP9120cpxXuZz2ayq3BZc85pCTuPJS03VQYxne0aWPIXWx6LSvsGPa3uRqtSO537vaugOh+5cXg==",
       "dev": true,
       "requires": {
         "eslint": "^5.0.1",
@@ -8072,7 +8053,7 @@
     "is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-      "integrity": "sha1-OV4a6EsR8mrReV5zwXN45IowFXY=",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
         "is-relative": "^1.0.0",
@@ -8367,7 +8348,7 @@
     "is-relative": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-      "integrity": "sha1-obtpNc6MXboei5dUubLcwCDiJg0=",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
         "is-unc-path": "^1.0.0"
@@ -8376,7 +8357,7 @@
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-retry-allowed": {
@@ -8424,7 +8405,7 @@
     "is-unc-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-      "integrity": "sha1-1zHoiY7QkKEsNSrS6u1Qla0yLJ0=",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
         "unc-path-regex": "^0.1.2"
@@ -8581,7 +8562,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
@@ -8708,7 +8689,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -9335,7 +9316,7 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
       "dev": true
     },
     "lpad-align": {
@@ -9369,7 +9350,7 @@
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
       "dev": true,
       "requires": {
         "pify": "^3.0.0"
@@ -9386,7 +9367,7 @@
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
-      "integrity": "sha1-KbM/MSqo9UfEpeSQ9Wr87JkTOtY=",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
         "kind-of": "^6.0.2"
@@ -9583,7 +9564,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
@@ -12735,7 +12716,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -13126,7 +13107,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "posix-character-classes": {
@@ -13812,7 +13793,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -14310,7 +14291,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "sax": {
@@ -14497,7 +14478,7 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "shebang-command": {
@@ -14775,7 +14756,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "dev": true,
       "requires": {
@@ -14920,7 +14901,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "optional": true,
@@ -15067,7 +15048,7 @@
     "stream-consume": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-      "integrity": "sha1-0721mMK9CugrjKx6xQsRB6eZbEg=",
+      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
       "dev": true
     },
     "stream-shift": {
@@ -15079,7 +15060,7 @@
     "streamroller": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
-      "integrity": "sha1-odG3z4PTmvsNYwSaWsv5NJO99ks=",
+      "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "dev": true,
       "requires": {
         "date-format": "^1.2.0",
@@ -15106,7 +15087,7 @@
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -15121,7 +15102,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -15138,7 +15119,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -15328,7 +15309,7 @@
     "strip-outer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
@@ -15488,7 +15469,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -15696,7 +15677,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
@@ -15731,7 +15712,7 @@
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
       "dev": true
     },
     "to-fast-properties": {
@@ -16064,13 +16045,13 @@
     "upath": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-      "integrity": "sha1-NSVll+RqWB20eT0M5H+prr/J+r0=",
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
       "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -937,7 +937,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
@@ -1104,6 +1104,7 @@
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
       "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
       "dev": true,
+      "optional": true,
       "requires": {
         "file-type": "^3.1.0"
       },
@@ -1112,7 +1113,8 @@
           "version": "3.9.0",
           "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1535,9 +1537,10 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -1547,13 +1550,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -1569,6 +1574,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -1757,7 +1763,8 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "buffer-fill": {
       "version": "1.0.0",
@@ -1776,6 +1783,7 @@
       "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
       "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "file-type": "^3.1.0",
         "readable-stream": "^2.0.2",
@@ -1787,19 +1795,22 @@
           "version": "3.9.0",
           "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -1815,6 +1826,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -1823,13 +1835,15 @@
           "version": "2.0.3",
           "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
           "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "vinyl": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
@@ -1950,7 +1964,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -1963,6 +1978,7 @@
       "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "get-proxy": "^1.0.1",
         "is-obj": "^1.0.0",
@@ -1974,7 +1990,8 @@
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2249,7 +2266,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
       "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "coa": {
       "version": "2.0.1",
@@ -2373,6 +2391,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-readlink": ">= 1.0.0"
       }
@@ -2585,6 +2604,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
+      "optional": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
       }
@@ -2839,6 +2859,7 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
       "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "buffer-to-vinyl": "^1.0.0",
         "concat-stream": "^1.4.6",
@@ -2856,6 +2877,7 @@
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.0.1"
           }
@@ -2864,13 +2886,15 @@
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "expand-range": "^1.8.1",
             "preserve": "^0.2.0",
@@ -2882,6 +2906,7 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-posix-bracket": "^0.1.0"
           }
@@ -2891,6 +2916,7 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -2900,6 +2926,7 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -2913,6 +2940,7 @@
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
+          "optional": true,
           "requires": {
             "extend": "^3.0.0",
             "glob": "^5.0.3",
@@ -2928,13 +2956,15 @@
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -2946,13 +2976,15 @@
               "version": "0.10.31",
               "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "through2": {
               "version": "0.6.5",
               "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "readable-stream": ">=1.0.33-1 <1.1.0-0",
                 "xtend": ">=4.0.0 <4.1.0-0"
@@ -2964,19 +2996,22 @@
           "version": "4.1.15",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -2985,13 +3020,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3001,6 +3038,7 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-diff": "^2.0.0",
             "array-unique": "^0.2.1",
@@ -3021,13 +3059,15 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ordered-read-streams": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-stream": "^1.0.1",
             "readable-stream": "^2.0.1"
@@ -3038,6 +3078,7 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3053,6 +3094,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -3062,6 +3104,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -3071,6 +3114,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
           "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
           "dev": true,
+          "optional": true,
           "requires": {
             "first-chunk-stream": "^1.0.0",
             "strip-bom": "^2.0.0"
@@ -3081,6 +3125,7 @@
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
           "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "json-stable-stringify-without-jsonify": "^1.0.1",
             "through2-filter": "^3.0.0"
@@ -3091,6 +3136,7 @@
               "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
               "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "through2": "~2.0.0",
                 "xtend": "~4.0.0"
@@ -3103,6 +3149,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
@@ -3114,6 +3161,7 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "duplexify": "^3.2.0",
             "glob-stream": "^5.3.2",
@@ -3141,6 +3189,7 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
       "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-tar": "^1.0.0",
         "object-assign": "^2.0.0",
@@ -3154,19 +3203,22 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -3179,6 +3231,7 @@
           "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "readable-stream": ">=1.0.33-1 <1.1.0-0",
             "xtend": ">=4.0.0 <4.1.0-0"
@@ -3189,6 +3242,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "clone": "^0.2.0",
             "clone-stats": "^0.0.1"
@@ -3201,6 +3255,7 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
       "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-bzip2": "^1.0.0",
         "object-assign": "^2.0.0",
@@ -3215,19 +3270,22 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -3240,6 +3298,7 @@
           "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "readable-stream": ">=1.0.33-1 <1.1.0-0",
             "xtend": ">=4.0.0 <4.1.0-0"
@@ -3250,6 +3309,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "clone": "^0.2.0",
             "clone-stats": "^0.0.1"
@@ -3262,6 +3322,7 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
       "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-gzip": "^1.0.0",
         "object-assign": "^2.0.0",
@@ -3275,19 +3336,22 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -3300,6 +3364,7 @@
           "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "readable-stream": ">=1.0.33-1 <1.1.0-0",
             "xtend": ">=4.0.0 <4.1.0-0"
@@ -3310,6 +3375,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "clone": "^0.2.0",
             "clone-stats": "^0.0.1"
@@ -3322,6 +3388,7 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
       "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-zip": "^1.0.0",
         "read-all-stream": "^3.0.0",
@@ -3337,6 +3404,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
@@ -3349,7 +3417,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3568,6 +3637,7 @@
       "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
       "dev": true,
+      "optional": true,
       "requires": {
         "caw": "^1.0.1",
         "concat-stream": "^1.4.7",
@@ -3591,6 +3661,7 @@
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.0.1"
           }
@@ -3599,13 +3670,15 @@
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "expand-range": "^1.8.1",
             "preserve": "^0.2.0",
@@ -3617,6 +3690,7 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-posix-bracket": "^0.1.0"
           }
@@ -3626,6 +3700,7 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -3635,6 +3710,7 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -3648,6 +3724,7 @@
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
+          "optional": true,
           "requires": {
             "extend": "^3.0.0",
             "glob": "^5.0.3",
@@ -3663,13 +3740,15 @@
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -3681,13 +3760,15 @@
               "version": "0.10.31",
               "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "through2": {
               "version": "0.6.5",
               "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "readable-stream": ">=1.0.33-1 <1.1.0-0",
                 "xtend": ">=4.0.0 <4.1.0-0"
@@ -3699,19 +3780,22 @@
           "version": "4.1.15",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -3720,13 +3804,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3736,6 +3822,7 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-diff": "^2.0.0",
             "array-unique": "^0.2.1",
@@ -3756,13 +3843,15 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ordered-read-streams": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-stream": "^1.0.1",
             "readable-stream": "^2.0.1"
@@ -3773,6 +3862,7 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3788,6 +3878,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -3797,6 +3888,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -3806,6 +3898,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
           "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
           "dev": true,
+          "optional": true,
           "requires": {
             "first-chunk-stream": "^1.0.0",
             "strip-bom": "^2.0.0"
@@ -3816,6 +3909,7 @@
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
           "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "json-stable-stringify-without-jsonify": "^1.0.1",
             "through2-filter": "^3.0.0"
@@ -3826,6 +3920,7 @@
               "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
               "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "through2": "~2.0.0",
                 "xtend": "~4.0.0"
@@ -3838,6 +3933,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
@@ -3849,6 +3945,7 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "duplexify": "^3.2.0",
             "glob-stream": "^5.3.2",
@@ -3891,6 +3988,7 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
       "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -3903,6 +4001,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.4.0"
           }
@@ -3911,13 +4010,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3927,6 +4028,7 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3942,6 +4044,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -3953,6 +4056,7 @@
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "onetime": "^1.0.0",
         "set-immediate-shim": "^1.0.0"
@@ -3962,7 +4066,8 @@
           "version": "1.1.0",
           "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4945,6 +5050,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -4992,13 +5098,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
       "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "filenamify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
       "dev": true,
+      "optional": true,
       "requires": {
         "filename-reserved-regex": "^1.0.0",
         "strip-outer": "^1.0.0",
@@ -5245,7 +5353,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fs-extra": {
       "version": "1.0.0",
@@ -5309,7 +5418,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5330,12 +5440,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5350,17 +5462,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5477,7 +5592,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5489,6 +5605,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5503,6 +5620,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5510,12 +5628,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5534,6 +5654,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5614,7 +5735,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5626,6 +5748,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5711,7 +5834,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5747,6 +5871,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5766,6 +5891,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5809,12 +5935,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5850,6 +5978,7 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
       "dev": true,
+      "optional": true,
       "requires": {
         "rc": "^1.1.2"
       }
@@ -6156,6 +6285,7 @@
       "resolved": "http://registry.npmjs.org/got/-/got-5.7.1.tgz",
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
       "dev": true,
+      "optional": true,
       "requires": {
         "create-error-class": "^3.0.1",
         "duplexer2": "^0.1.4",
@@ -6179,6 +6309,7 @@
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
+          "optional": true,
           "requires": {
             "readable-stream": "^2.0.2"
           }
@@ -6187,19 +6318,22 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "parse-json": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
+          "optional": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
@@ -6209,6 +6343,7 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -6224,6 +6359,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -6243,7 +6379,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "growly": {
       "version": "1.3.0",
@@ -6560,6 +6697,7 @@
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
       "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "archive-type": "^3.0.0",
         "decompress": "^3.0.0",
@@ -6571,13 +6709,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -6593,6 +6733,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -7210,6 +7351,7 @@
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
+      "optional": true,
       "requires": {
         "convert-source-map": "^1.1.1",
         "graceful-fs": "^4.1.2",
@@ -7222,13 +7364,15 @@
           "version": "4.1.15",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -7238,6 +7382,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
@@ -8120,7 +8265,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
       "integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -8255,7 +8401,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
       "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-jpg": {
       "version": "1.0.1",
@@ -8268,7 +8415,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
       "integrity": "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -8334,7 +8482,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -8364,7 +8513,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -8394,7 +8544,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
       "integrity": "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -8415,7 +8566,8 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -8427,7 +8579,8 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -8445,7 +8598,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
       "integrity": "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "isarray": {
       "version": "0.0.1",
@@ -8689,7 +8843,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -8785,6 +8939,7 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "readable-stream": "^2.0.5"
       },
@@ -8793,13 +8948,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -8815,6 +8972,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -9120,7 +9278,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lodash.isobject": {
       "version": "2.4.1",
@@ -9317,7 +9476,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lpad-align": {
       "version": "1.1.2",
@@ -9753,7 +9913,8 @@
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node.extend": {
       "version": "1.1.8",
@@ -12803,7 +12964,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "p-pipe": {
       "version": "1.2.0",
@@ -13514,7 +13676,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "preserve": {
       "version": "0.2.0",
@@ -13646,6 +13809,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -13658,6 +13822,7 @@
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "dev": true,
+      "optional": true,
       "requires": {
         "pinkie-promise": "^2.0.0",
         "readable-stream": "^2.0.0"
@@ -13667,13 +13832,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -13689,6 +13856,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -14305,6 +14473,7 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.8.1"
       }
@@ -14450,7 +14619,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "set-value": {
       "version": "2.0.0",
@@ -14955,7 +15125,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
       "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "static-extend": {
       "version": "0.1.2",
@@ -14999,6 +15170,7 @@
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
@@ -15009,6 +15181,7 @@
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
+          "optional": true,
           "requires": {
             "readable-stream": "^2.0.2"
           }
@@ -15017,13 +15190,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -15039,6 +15214,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -15055,7 +15231,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "streamroller": {
       "version": "0.7.0",
@@ -15233,6 +15410,7 @@
       "resolved": "http://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "chalk": "^1.0.0",
         "get-stdin": "^4.0.1",
@@ -15246,13 +15424,15 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -15266,6 +15446,7 @@
           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
           "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-relative": "^0.1.0"
           }
@@ -15274,13 +15455,15 @@
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
           "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -15311,6 +15494,7 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -15344,6 +15528,7 @@
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "chalk": "^1.0.0"
       },
@@ -15352,13 +15537,15 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -15371,7 +15558,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -15433,6 +15621,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -15448,6 +15637,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.4.0"
           }
@@ -15456,13 +15646,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -15472,6 +15664,7 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -15487,6 +15680,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -15591,6 +15785,7 @@
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
+      "optional": true,
       "requires": {
         "through2": "~2.0.0",
         "xtend": "~4.0.0"
@@ -15615,7 +15810,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
       "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "timers-ext": {
       "version": "0.1.7",
@@ -15688,6 +15884,7 @@
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
+      "optional": true,
       "requires": {
         "extend-shallow": "^2.0.1"
       },
@@ -15697,6 +15894,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -15713,7 +15911,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -15792,6 +15991,7 @@
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -16040,7 +16240,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
       "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "upath": {
       "version": "1.1.0",
@@ -16068,6 +16269,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "prepend-http": "^1.0.1"
       }
@@ -16153,7 +16355,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
       "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -16198,6 +16401,7 @@
       "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
       "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
       "dev": true,
+      "optional": true,
       "requires": {
         "object-assign": "^4.0.1",
         "readable-stream": "^2.0.0"
@@ -16207,19 +16411,22 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -16235,6 +16442,7 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -16374,6 +16582,7 @@
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "dev": true,
+      "optional": true,
       "requires": {
         "wrap-fn": "^0.1.0"
       }
@@ -16464,6 +16673,7 @@
       "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
       "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
       "dev": true,
+      "optional": true,
       "requires": {
         "co": "3.1.0"
       }
@@ -16567,6 +16777,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -628,7 +628,7 @@
                     $scope.page.buttonGroupState = "success";
                 }, function () {
                     $scope.page.buttonGroupState = "error";
-                });;
+                });
             }
         };
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -242,9 +242,13 @@
             }
 
             if (!$scope.content.isChildOfListView) {
-                navigationService.syncTree({ tree: $scope.treeAlias, path: path.split(","), forceReload: initialLoad !== true }).then(function (syncArgs) {
-                    $scope.page.menu.currentNode = syncArgs.node;
-                });
+                navigationService.syncTree({ tree: $scope.treeAlias, path: path.split(","), forceReload: initialLoad !== true })
+                    .then(function (syncArgs) {
+                        $scope.page.menu.currentNode = syncArgs.node;
+                    }, function () {
+                        //handle the rejection
+                        console.log("A problem occurred syncing the tree! A path is probably incorrect.")
+                    });
             }
             else if (initialLoad === true) {
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -329,6 +329,7 @@
                         loadAuditTrail();
                         loadRedirectUrls();
                         setNodePublishStatus();
+                        formatDatesToLocal();
                     } else {
                         isInfoTab = false;
                     }
@@ -345,6 +346,7 @@
                     loadAuditTrail(true);
                     loadRedirectUrls();
                     setNodePublishStatus();
+                    formatDatesToLocal();
                 }
                 updateCurrentUrls();
             });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -328,6 +328,7 @@
                         isInfoTab = true;
                         loadAuditTrail();
                         loadRedirectUrls();
+                        setNodePublishStatus();
                     } else {
                         isInfoTab = false;
                     }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
@@ -3,113 +3,113 @@
 **/
 angular.module('umbraco.directives')
 
-.directive('onDragEnter', function () {
-    return {
-        link: function (scope, elm, attrs) {
-            var f = function () {
-                scope.$apply(attrs.onDragEnter);
-            };
-            elm.on("dragenter", f);
-            scope.$on("$destroy", function(){ elm.off("dragenter", f);} );
-        }
-    };
-})
-
-.directive('onDragLeave', function () {
-    return function (scope, elm, attrs) {
-        var f = function (event) {
-            var rect = this.getBoundingClientRect();
-            var getXY = function getCursorPosition(event) {
-                var x, y;
-
-                if (typeof event.clientX === 'undefined') {
-                    // try touch screen
-                    x = event.pageX + document.documentElement.scrollLeft;
-                    y = event.pageY + document.documentElement.scrollTop;
-                } else {
-                    x = event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
-                    y = event.clientY + document.body.scrollTop + document.documentElement.scrollTop;
-                }
-
-                return { x: x, y : y };
-            };
-
-            var e = getXY(event.originalEvent);
-
-            // Check the mouseEvent coordinates are outside of the rectangle
-            if (e.x > rect.left + rect.width - 1 || e.x < rect.left || e.y > rect.top + rect.height - 1 || e.y < rect.top) {
-                scope.$apply(attrs.onDragLeave);
+    .directive('onDragEnter', function () {
+        return {
+            link: function (scope, elm, attrs) {
+                var f = function () {
+                    scope.$apply(attrs.onDragEnter);
+                };
+                elm.on("dragenter", f);
+                scope.$on("$destroy", function () { elm.off("dragenter", f); });
             }
         };
+    })
 
-        elm.on("dragleave", f);
-        scope.$on("$destroy", function(){ elm.off("dragleave", f);} );
-    };
-})
+    .directive('onDragLeave', function () {
+        return function (scope, elm, attrs) {
+            var f = function (event) {
+                var rect = this.getBoundingClientRect();
+                var getXY = function getCursorPosition(event) {
+                    var x, y;
 
-.directive('onDragOver', function () {
-    return {
-        link: function (scope, elm, attrs) {
-            var f = function () {
-                scope.$apply(attrs.onDragOver);
+                    if (typeof event.clientX === 'undefined') {
+                        // try touch screen
+                        x = event.pageX + document.documentElement.scrollLeft;
+                        y = event.pageY + document.documentElement.scrollTop;
+                    } else {
+                        x = event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
+                        y = event.clientY + document.body.scrollTop + document.documentElement.scrollTop;
+                    }
+
+                    return { x: x, y: y };
+                };
+
+                var e = getXY(event.originalEvent);
+
+                // Check the mouseEvent coordinates are outside of the rectangle
+                if (e.x > rect.left + rect.width - 1 || e.x < rect.left || e.y > rect.top + rect.height - 1 || e.y < rect.top) {
+                    scope.$apply(attrs.onDragLeave);
+                }
             };
-            elm.on("dragover", f);
-            scope.$on("$destroy", function(){ elm.off("dragover", f);} );
-        }
-    };
-})
 
-.directive('onDragStart', function () {
-    return {
-        link: function (scope, elm, attrs) {
-            var f = function () {
-                scope.$apply(attrs.onDragStart);
-            };
-            elm.on("dragstart", f);
-            scope.$on("$destroy", function(){ elm.off("dragstart", f);} );
-        }
-    };
-})
+            elm.on("dragleave", f);
+            scope.$on("$destroy", function () { elm.off("dragleave", f); });
+        };
+    })
 
-.directive('onDragEnd', function () {
-    return {
-        link: function (scope, elm, attrs) {
-            var f = function () {
-                scope.$apply(attrs.onDragEnd);
-            };
-            elm.on("dragend", f);
-            scope.$on("$destroy", function(){ elm.off("dragend", f);} );
-        }
-    };
-})
+    .directive('onDragOver', function () {
+        return {
+            link: function (scope, elm, attrs) {
+                var f = function () {
+                    scope.$apply(attrs.onDragOver);
+                };
+                elm.on("dragover", f);
+                scope.$on("$destroy", function () { elm.off("dragover", f); });
+            }
+        };
+    })
 
-.directive('onDrop', function () {
-    return {
-        link: function (scope, elm, attrs) {
-            var f = function () {
-                scope.$apply(attrs.onDrop);
-            };
-            elm.on("drop", f);
-            scope.$on("$destroy", function(){ elm.off("drop", f);} );
-        }
-    };
-})
+    .directive('onDragStart', function () {
+        return {
+            link: function (scope, elm, attrs) {
+                var f = function () {
+                    scope.$apply(attrs.onDragStart);
+                };
+                elm.on("dragstart", f);
+                scope.$on("$destroy", function () { elm.off("dragstart", f); });
+            }
+        };
+    })
 
-.directive('onOutsideClick', function ($timeout, angularHelper) {
-    return function (scope, element, attrs) {
+    .directive('onDragEnd', function () {
+        return {
+            link: function (scope, elm, attrs) {
+                var f = function () {
+                    scope.$apply(attrs.onDragEnd);
+                };
+                elm.on("dragend", f);
+                scope.$on("$destroy", function () { elm.off("dragend", f); });
+            }
+        };
+    })
 
-        var eventBindings = [];
+    .directive('onDrop', function () {
+        return {
+            link: function (scope, elm, attrs) {
+                var f = function () {
+                    scope.$apply(attrs.onDrop);
+                };
+                elm.on("drop", f);
+                scope.$on("$destroy", function () { elm.off("drop", f); });
+            }
+        };
+    })
 
-        function oneTimeClick(event) {
+    .directive('onOutsideClick', function ($timeout, angularHelper) {
+        return function (scope, element, attrs) {
+
+            var eventBindings = [];
+
+            function oneTimeClick(event) {
                 var el = event.target.nodeName;
 
                 //ignore link and button clicks
-                var els = ["INPUT","A","BUTTON"];
-                if(els.indexOf(el) >= 0){return;}
+                var els = ["INPUT", "A", "BUTTON"];
+                if (els.indexOf(el) >= 0) { return; }
 
                 // ignore clicks on new overlay
                 var parents = $(event.target).parents("a,button,.umb-overlay,.umb-tour");
-                if(parents.length > 0){
+                if (parents.length > 0) {
                     return;
                 }
 
@@ -132,70 +132,70 @@ angular.module('umbraco.directives')
                 }
 
                 //ignore clicks inside this element
-                if( $(element).has( $(event.target) ).length > 0 ){
+                if ($(element).has($(event.target)).length > 0) {
                     return;
                 }
 
-                scope.$apply(attrs.onOutsideClick);
-        }
-
-
-        $timeout(function(){
-
-            if ("bindClickOn" in attrs) {
-
-                eventBindings.push(scope.$watch(function() {
-                    return attrs.bindClickOn;
-                }, function(newValue) {
-                    if (newValue === "true") {
-                        $(document).on("click", oneTimeClick);
-                    } else {
-                        $(document).off("click", oneTimeClick);
-                    }
-                }));
-
-            } else {
-                $(document).on("click", oneTimeClick);
+                angularHelper.safeApply(scope, attrs.onOutsideClick);
             }
 
-            scope.$on("$destroy", function() {
-                $(document).off("click", oneTimeClick);
 
-                // unbind watchers
-                for (var e in eventBindings) {
-                    eventBindings[e]();
+            $timeout(function () {
+
+                if ("bindClickOn" in attrs) {
+
+                    eventBindings.push(scope.$watch(function () {
+                        return attrs.bindClickOn;
+                    }, function (newValue) {
+                        if (newValue === "true") {
+                            $(document).on("click", oneTimeClick);
+                        } else {
+                            $(document).off("click", oneTimeClick);
+                        }
+                    }));
+
+                } else {
+                    $(document).on("click", oneTimeClick);
                 }
 
+                scope.$on("$destroy", function () {
+                    $(document).off("click", oneTimeClick);
+
+                    // unbind watchers
+                    for (var e in eventBindings) {
+                        eventBindings[e]();
+                    }
+
+                });
+            }); // Temp removal of 1 sec timeout to prevent bug where overlay does not open. We need to find a better solution.
+
+        };
+    })
+
+    .directive('onRightClick', function ($parse) {
+
+        document.oncontextmenu = function (e) {
+            if (e.target.hasAttribute('on-right-click')) {
+                e.preventDefault();
+                e.stopPropagation();
+                return false;
+            }
+        };
+
+        return function (scope, el, attrs) {
+            el.on('contextmenu', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                var fn = $parse(attrs.onRightClick);
+                scope.$apply(function () {
+                    fn(scope, { $event: e });
+                });
+                return false;
             });
-        }); // Temp removal of 1 sec timeout to prevent bug where overlay does not open. We need to find a better solution.
+        };
+    })
 
-    };
-})
-
-.directive('onRightClick',function($parse){
-
-    document.oncontextmenu = function (e) {
-       if(e.target.hasAttribute('on-right-click')) {
-           e.preventDefault();
-           e.stopPropagation();
-           return false;
-       }
-    };
-
-    return function(scope,el,attrs){
-        el.on('contextmenu',function(e){
-            e.preventDefault();
-            e.stopPropagation();
-            var fn = $parse(attrs.onRightClick);
-            scope.$apply(function () {
-                fn(scope, { $event: e });
-            });
-            return false;
-        });
-    };
-})
-
-.directive('onDelayedMouseleave', function ($timeout, $parse) {
+    .directive('onDelayedMouseleave', function ($timeout, $parse) {
         return {
 
             restrict: 'A',
@@ -204,20 +204,20 @@ angular.module('umbraco.directives')
                 var active = false;
                 var fn = $parse(attrs.onDelayedMouseleave);
 
-                var leave_f = function(event) {
-                    var callback = function() {
-                        fn(scope, {$event:event});
+                var leave_f = function (event) {
+                    var callback = function () {
+                        fn(scope, { $event: event });
                     };
 
                     active = false;
-                    $timeout(function(){
-                        if(active === false){
+                    $timeout(function () {
+                        if (active === false) {
                             scope.$apply(callback);
                         }
                     }, 650);
                 };
 
-                var enter_f = function(event, args){
+                var enter_f = function (event, args) {
                     active = true;
                 };
 
@@ -226,7 +226,7 @@ angular.module('umbraco.directives')
                 element.on("mouseenter", enter_f);
 
                 //unsub events
-                scope.$on("$destroy", function(){
+                scope.$on("$destroy", function () {
                     element.off("mouseleave", leave_f);
                     element.off("mouseenter", enter_f);
                 });

--- a/src/Umbraco.Web.UI.Client/src/common/services/editorstate.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editorstate.service.js
@@ -13,7 +13,6 @@
 angular.module('umbraco.services').factory("editorState", function ($rootScope) {
 
     var current = null;
-    var preserveBetweenRoute = false;
 
     var state = {
 
@@ -66,22 +65,6 @@ angular.module('umbraco.services').factory("editorState", function ($rootScope) 
             return current;
         },
 
-        /**
-         * @ngdoc function
-         * @name umbraco.services.angularHelper#preserve
-         * @methodOf umbraco.services.editorState
-         * @function
-         *
-         * @description
-         * When called it will flag the state to be preserved after the next route. 
-         * Normally the editorState is cleared on each successful route but in some cases it should be preserved so calling this will preserve it.
-         *
-         * editorState.current can not be overwritten, you should only read values from it
-         * since modifying individual properties should be handled by the property editors
-         */
-        preserve: function () {
-            preserveBetweenRoute = true;
-        }
     };
 
     // TODO: This shouldn't be removed! use getCurrent() method instead of a hacked readonly property which is confusing.
@@ -99,13 +82,8 @@ angular.module('umbraco.services').factory("editorState", function ($rootScope) 
     //execute on each successful route (this is only bound once per application since a service is a singleton)
     $rootScope.$on('$routeChangeSuccess', function (event, current, previous) {
 
-        if (!preserveBetweenRoute) {
-            //reset the editorState on each successful route chage
-            state.reset();
-        }
-
-        //always reset this
-        preserveBetweenRoute = false;
+        //reset the editorState on each successful route chage
+        state.reset();
 
     });
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/filemanager.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/filemanager.service.js
@@ -8,11 +8,12 @@
  * that need to attach files.
  * When a route changes successfully, we ensure that the collection is cleared.
  */
-function fileManager() {
+function fileManager($rootScope) {
 
     var fileCollection = [];
 
-    return {
+
+    var mgr = {
         /**
          * @ngdoc function
          * @name umbraco.services.fileManager#addFiles
@@ -24,7 +25,7 @@ function fileManager() {
          *   for the files collection that effectively clears the files for the specified editor.
          */
         setFiles: function (args) {
-            
+
             //propertyAlias, files
             if (!angular.isString(args.propertyAlias)) {
                 throw "args.propertyAlias must be a non empty string";
@@ -52,7 +53,7 @@ function fileManager() {
                 fileCollection.push({ alias: args.propertyAlias, file: args.files[i], culture: args.culture, metaData: metaData });
             }
         },
-        
+
         /**
          * @ngdoc function
          * @name umbraco.services.fileManager#getFiles
@@ -62,10 +63,10 @@ function fileManager() {
          * @description
          *  Returns all of the files attached to the file manager
          */
-        getFiles: function() {
+        getFiles: function () {
             return fileCollection;
         },
-        
+
         /**
          * @ngdoc function
          * @name umbraco.services.fileManager#clearFiles
@@ -78,7 +79,17 @@ function fileManager() {
         clearFiles: function () {
             fileCollection = [];
         }
-};
+    };
+
+    //execute on each successful route (this is only bound once per application since a service is a singleton)
+    $rootScope.$on('$routeChangeSuccess', function (event, current, previous) {
+        //reset the file manager on each route change, the file collection is only relavent
+        // when working in an editor and submitting data to the server.
+        //This ensures that memory remains clear of any files and that the editors don't have to manually clear the files.
+        mgr.clearFiles();
+    });
+
+    return mgr;
 }
 
 angular.module('umbraco.services').factory('fileManager', fileManager);

--- a/src/Umbraco.Web.UI.Client/src/common/services/formhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/formhelper.service.js
@@ -105,6 +105,11 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
          * @param {object} err The error object returned from the http promise
          */
         handleError: function (err) {            
+
+            //TODO: Potentially add in the logic to showNotifications like the contentEditingHelper.handleSaveError does so that
+            // non content editors can just use this method instead of contentEditingHelper.handleSaveError which they should not use
+            // and they won't need to manually do it.
+
             //When the status is a 400 status with a custom header: X-Status-Reason: Validation failed, we have validation errors.
             //Otherwise the error is probably due to invalid data (i.e. someone mucking around with the ids or something).
             //Or, some strange server error

--- a/src/Umbraco.Web.UI.Client/src/common/services/formhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/formhelper.service.js
@@ -40,7 +40,7 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
             else {
                 currentForm = args.formCtrl;
             }
-            
+
             //the first thing any form must do is broadcast the formSubmitting event
             args.scope.$broadcast("formSubmitting", { scope: args.scope, action: args.action });
 
@@ -53,10 +53,10 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
 
             //reset the server validations
             serverValidationManager.reset();
-            
+
             return true;
         },
-        
+
         /**
          * @ngdoc function
          * @name umbraco.services.formHelper#submitForm
@@ -75,21 +75,21 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
             if (!args.scope) {
                 throw "args.scope cannot be null";
             }
-            
+
             args.scope.$broadcast("formSubmitted", { scope: args.scope });
         },
 
         showNotifications: function (args) {
-          if (!args || !args.notifications) {
-            return false;
-          }
-          if (angular.isArray(args.notifications)) {
-            for (var i = 0; i < args.notifications.length; i++) {
-              notificationsService.showNotification(args.notifications[i]);
+            if (!args || !args.notifications) {
+                return false;
             }
-            return true;
-          }
-          return false;
+            if (angular.isArray(args.notifications)) {
+                for (var i = 0; i < args.notifications.length; i++) {
+                    notificationsService.showNotification(args.notifications[i]);
+                }
+                return true;
+            }
+            return false;
         },
 
         /**
@@ -104,7 +104,7 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
          * 
          * @param {object} err The error object returned from the http promise
          */
-        handleError: function (err) {            
+        handleError: function (err) {
 
             //TODO: Potentially add in the logic to showNotifications like the contentEditingHelper.handleSaveError does so that
             // non content editors can just use this method instead of contentEditingHelper.handleSaveError which they should not use
@@ -121,7 +121,7 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
                     this.handleServerValidation(err.data.ModelState);
 
                     //execute all server validation events and subscribers
-                    serverValidationManager.notifyAndClearAllSubscriptions();                    
+                    serverValidationManager.notifyAndClearAllSubscriptions();
                 }
             }
             else {
@@ -129,7 +129,7 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
                 // TODO: All YSOD handling should be done with an interceptor
                 overlayService.ysod(err);
             }
-            
+
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -13,7 +13,7 @@
  * Section navigation and search, and maintain their state for the entire application lifetime
  *
  */
-function navigationService($routeParams, $location, $route, $q, $timeout, $injector, eventsService, umbModelMapper, treeService, appState) {
+function navigationService($routeParams, $location, $q, $injector, eventsService, umbModelMapper, treeService, appState) {
 
     //the promise that will be resolved when the navigation is ready
     var navReadyPromise = $q.defer();

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -32,7 +32,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
     var nonRoutingQueryStrings = ["mculture", "cculture", "lq"];
     var retainedQueryStrings = ["mculture"];
     //A list of trees that don't cause a route when creating new items (TODO: eventually all trees should do this!)
-    var nonRoutingTreesOnCreate = ["content"];
+    var nonRoutingTreesOnCreate = ["content", "contentblueprints"];
         
     function setMode(mode) {
         switch (mode) {

--- a/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js
@@ -12,6 +12,18 @@
 
         var currentOverlay = null;
 
+        function getCurrent() {
+            return currentOverlay;
+        }
+
+        function refresh(overlay) {
+            //extend the passed overlay on top of the current overlay and then re-assign to currentOverlay
+            var merged = angular.extend({}, currentOverlay, overlay);
+            currentOverlay = merged;
+
+            eventsService.emit("appState.overlay", currentOverlay);
+        }
+
         function open(newOverlay) {
 
             // prevent two open overlays at the same time
@@ -45,7 +57,7 @@
             overlay.show = true;
             backdropService.open(backdropOptions);
             currentOverlay = overlay;
-            eventsService.emit("appState.overlay", overlay);
+            eventsService.emit("appState.overlay", currentOverlay);
         }
 
         function close() {
@@ -68,7 +80,9 @@
         var service = {
             open: open,
             close: close,
-            ysod: ysod
+            ysod: ysod,
+            refresh: refresh,
+            getCurrent: getCurrent
         };
 
         return service;
@@ -76,5 +90,6 @@
     }
 
     angular.module("umbraco.services").factory("overlayService", overlayService);
+
 
 })();

--- a/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js
@@ -12,18 +12,6 @@
 
         var currentOverlay = null;
 
-        function getCurrent() {
-            return currentOverlay;
-        }
-
-        function refresh(overlay) {
-            //extend the passed overlay on top of the current overlay and then re-assign to currentOverlay
-            var merged = angular.extend({}, currentOverlay, overlay);
-            currentOverlay = merged;
-
-            eventsService.emit("appState.overlay", currentOverlay);
-        }
-
         function open(newOverlay) {
 
             // prevent two open overlays at the same time
@@ -57,7 +45,7 @@
             overlay.show = true;
             backdropService.open(backdropOptions);
             currentOverlay = overlay;
-            eventsService.emit("appState.overlay", currentOverlay);
+            eventsService.emit("appState.overlay", overlay);
         }
 
         function close() {
@@ -80,9 +68,7 @@
         var service = {
             open: open,
             close: close,
-            ysod: ysod,
-            refresh: refresh,
-            getCurrent: getCurrent
+            ysod: ysod
         };
 
         return service;

--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -1,6 +1,6 @@
 /** Executed when the application starts, binds to events and set global state */
-app.run(['userService', '$q', '$log', '$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 'appState', 'editorState', 'fileManager', 'assetsService', 'eventsService', '$cookies', '$templateCache', 'localStorageService', 'tourService', 'dashboardResource',
-    function (userService, $q, $log, $rootScope, $route, $location, urlHelper, navigationService, appState, editorState, fileManager, assetsService, eventsService, $cookies, $templateCache, localStorageService, tourService, dashboardResource) {
+app.run(['$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 'appState', 'assetsService', 'eventsService', '$cookies', 'tourService',
+    function ($rootScope, $route, $location, urlHelper, navigationService, appState, assetsService, eventsService, $cookies, tourService) {
 
         //This sets the default jquery ajax headers to include our csrf token, we
         // need to user the beforeSend method because our token changes per user/login so
@@ -91,13 +91,6 @@ app.run(['userService', '$q', '$log', '$rootScope', '$route', '$location', 'urlH
                 $rootScope.locationTitle = "Umbraco - " + $location.$$host;
             }
 
-            //reset the editorState on each successful route chage
-            editorState.reset();
-
-            //reset the file manager on each route change, the file collection is only relavent
-            // when working in an editor and submitting data to the server.
-            //This ensures that memory remains clear of any files and that the editors don't have to manually clear the files.
-            fileManager.clearFiles();
         });
 
         /** When the route change is rejected - based on checkAuth - we'll prevent the rejected route from executing including

--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -115,7 +115,7 @@ app.run(['$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 
         });
 
         //Bind to $routeUpdate which will execute anytime a location changes but the route is not triggered.
-        //This is the case when a route uses reloadOnSearch: false which is the case for many or our routes so that we are able to maintain
+        //This is the case when a route uses "reloadOnSearch: false" or "reloadOnUrl: false" which is the case for many or our routes so that we are able to maintain
         //global state query strings without force re-loading views.
         //We can then detect if it's a location change that should force a route or not programatically.
         $rootScope.$on('$routeUpdate', function (event, next) {

--- a/src/Umbraco.Web.UI.Client/src/routes.js
+++ b/src/Umbraco.Web.UI.Client/src/routes.js
@@ -228,6 +228,7 @@ app.config(function ($routeProvider) {
 
             },
             reloadOnSearch: false,
+            reloadOnUrl: false,
             resolve: canRoute(true)
         })
         .otherwise({ redirectTo: '/login' });

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-pagination.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-pagination.html
@@ -7,7 +7,7 @@
                 </a>
             </li>
 
-            <li ng-repeat="pgn in pagination track by pgn.val"
+            <li ng-repeat="pgn in pagination track by $index"
                 ng-class="{active:pgn.isActive}">
 
                 <a href="#" ng-click="goToPage(pgn.val - 1)" prevent-default

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.createblueprint.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.createblueprint.controller.js
@@ -36,7 +36,6 @@
             function(err) {
 
               contentEditingHelper.handleSaveError({
-                redirectOnFailure: false,
                 err: err
               });
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -24,13 +24,15 @@ function ContentEditController($scope, $rootScope, $routeParams, contentResource
     $scope.page = $routeParams.page;
     $scope.isNew = infiniteMode ? $scope.model.create : $routeParams.create;
     //load the default culture selected in the main tree if any
-    $scope.culture = $routeParams.cculture ? $routeParams.cculture : $routeParams.mculture;
+    $scope.culture = $routeParams.cculture ? $routeParams.cculture : ($routeParams.mculture === "true");
 
     //Bind to $routeUpdate which will execute anytime a location changes but the route is not triggered.
     //This is so we can listen to changes on the cculture parameter since that will not cause a route change
     // and then we can pass in the updated culture to the editor
     $scope.$on('$routeUpdate', function (event, next) {
         $scope.culture = next.params.cculture ? next.params.cculture : $routeParams.mculture;
+        $scope.isNew = next.params.create === "true";
+        $scope.contentId = infiniteMode ? $scope.model.id : $routeParams.id;
     });
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -28,7 +28,9 @@ function ContentEditController($scope, $rootScope, $routeParams, contentResource
 
     //Bind to $routeUpdate which will execute anytime a location changes but the route is not triggered.
     //This is so we can listen to changes on the cculture parameter since that will not cause a route change
-    // and then we can pass in the updated culture to the editor
+    //and then we can pass in the updated culture to the editor.
+    //This will also execute when we are redirecting from creating an item to a newly created item since that
+    //will not cause a route change and so we can update the isNew and contentId flags accordingly.
     $scope.$on('$routeUpdate', function (event, next) {
         $scope.culture = next.params.cculture ? next.params.cculture : $routeParams.mculture;
         $scope.isNew = next.params.create === "true";

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the content editor
  */
-function ContentEditController($scope, $rootScope, $routeParams, contentResource) {
+function ContentEditController($scope, $routeParams, contentResource) {
 
     var infiniteMode = $scope.model && $scope.model.infiniteMode;
 

--- a/src/Umbraco.Web.UI.Client/src/views/contentblueprints/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/contentblueprints/edit.controller.js
@@ -47,9 +47,13 @@ function ContentBlueprintEditController($scope, $routeParams, contentResource) {
 
     //Bind to $routeUpdate which will execute anytime a location changes but the route is not triggered.
     //This is so we can listen to changes on the cculture parameter since that will not cause a route change
-    // and then we can pass in the updated culture to the editor
+    //and then we can pass in the updated culture to the editor.
+    //This will also execute when we are redirecting from creating an item to a newly created item since that
+    //will not cause a route change and so we can update the isNew and contentId flags accordingly.
     $scope.$on('$routeUpdate', function (event, next) {
         $scope.culture = next.params.cculture ? next.params.cculture : $routeParams.mculture;
+        $scope.isNew = $routeParams.id === "-1";
+        $scope.contentId = $routeParams.id;
     });
 
 }

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.edit.controller.js
@@ -174,7 +174,6 @@ function DataTypeEditController($scope, $routeParams, appState, navigationServic
                     //NOTE: in the case of data type values we are setting the orig/new props
                     // to be the same thing since that only really matters for content/media.
                     contentEditingHelper.handleSaveError({
-                        redirectOnFailure: false,
                         err: err
                     });
 

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.edit.controller.js
@@ -91,7 +91,6 @@ function DictionaryEditController($scope, $routeParams, $location, dictionaryRes
                     function (err) {
 
                         contentEditingHelper.handleSaveError({
-                            redirectOnFailure: false,
                             err: err
                         });
                         

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -317,10 +317,6 @@
                     saveMethod: contentTypeResource.save,
                     scope: $scope,
                     content: vm.contentType,
-                    //We do not redirect on failure for doc types - this is because it is not possible to actually save the doc
-                    // type when server side validation fails - as opposed to content where we are capable of saving the content
-                    // item if server side validation fails
-                    redirectOnFailure: false,
                     // we need to rebind... the IDs that have been created!
                     rebindCallback: function (origContentType, savedContentType) {
                         vm.contentType.id = savedContentType.id;

--- a/src/Umbraco.Web.UI.Client/src/views/macros/macros.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/macros.edit.controller.js
@@ -35,7 +35,6 @@ function MacrosEditController($scope, $q, $routeParams, macroResource, editorSta
                 vm.page.saveButtonState = "success";
             }, function (error) {
                 contentEditingHelper.handleSaveError({
-                    redirectOnFailure: false,
                     err: error
                 });
 

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -184,7 +184,6 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
                     contentEditingHelper.handleSuccessfulSave({
                         scope: $scope,
                         savedContent: data,
-                        redirectOnSuccess: !infiniteMode,
                         rebindCallback: contentEditingHelper.reBindChangedProperties($scope.content, data)
                     });
 
@@ -206,7 +205,6 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
 
                     contentEditingHelper.handleSaveError({
                         err: err,
-                        redirectOnFailure: !infiniteMode,
                         rebindCallback: contentEditingHelper.reBindChangedProperties($scope.content, err.data)
                     });
                     

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
@@ -269,10 +269,6 @@
                     saveMethod: mediaTypeResource.save,
                     scope: $scope,
                     content: vm.contentType,
-                    //We do not redirect on failure for doc types - this is because it is not possible to actually save the doc
-                    // type when server side validation fails - as opposed to content where we are capable of saving the content
-                    // item if server side validation fails
-                    redirectOnFailure: false,
                     // we need to rebind... the IDs that have been created!
                     rebindCallback: function (origContentType, savedContentType) {
                         vm.contentType.id = savedContentType.id;

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -161,7 +161,6 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
             }, function (err) {
 
                     contentEditingHelper.handleSaveError({
-                        redirectOnFailure: false,
                         err: err,
                         rebindCallback: contentEditingHelper.reBindChangedProperties($scope.content, err.data)
                     });

--- a/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.controller.js
@@ -86,7 +86,6 @@ function MemberGroupsEditController($scope, $routeParams, appState, navigationSe
                 }, function (err) {
 
                     contentEditingHelper.handleSaveError({
-                        redirectOnFailure: false,
                         err: err
                     });
 

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
@@ -180,10 +180,6 @@
                     saveMethod: memberTypeResource.save,
                     scope: $scope,
                     content: vm.contentType,
-                    //We do not redirect on failure for doc types - this is because it is not possible to actually save the doc
-                    // type when server side validation fails - as opposed to content where we are capable of saving the content
-                    // item if server side validation fails
-                    redirectOnFailure: false,
                     // we need to rebind... the IDs that have been created!
                     rebindCallback: function (origContentType, savedContentType) {
                         vm.contentType.id = savedContentType.id;

--- a/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/edit.controller.js
@@ -65,10 +65,6 @@
                 saveMethod: codefileResource.save,
                 scope: $scope,
                 content: vm.partialViewMacro,
-                // We do not redirect on failure for partial view macros - this is because it is not possible to actually save the partial view
-                // when server side validation fails - as opposed to content where we are capable of saving the content
-                // item if server side validation fails
-                redirectOnFailure: false,
                 rebindCallback: function (orignal, saved) {}
             }).then(function (saved) {
                 // create macro if needed

--- a/src/Umbraco.Web.UI.Client/src/views/partialviews/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviews/edit.controller.js
@@ -83,10 +83,6 @@
                 saveMethod: codefileResource.save,
                 scope: $scope,
                 content: vm.partialView,
-                //We do not redirect on failure for partialviews - this is because it is not possible to actually save the partialviews
-                // type when server side validation fails - as opposed to content where we are capable of saving the content
-                // item if server side validation fails
-                redirectOnFailure: false,
                 rebindCallback: function (orignal, saved) {}
             }).then(function (saved) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
@@ -119,7 +119,6 @@ function RelationTypeEditController($scope, $routeParams, relationTypeResource, 
 
             }, function (error) {
                 contentEditingHelper.handleSaveError({
-                    redirectOnFailure: false,
                     err: error
                 });
 

--- a/src/Umbraco.Web.UI.Client/src/views/scripts/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/scripts/edit.controller.js
@@ -45,10 +45,6 @@
                 saveMethod: codefileResource.save,
                 scope: $scope,
                 content: vm.script,
-                // We do not redirect on failure for scripts - this is because it is not possible to actually save the script
-                // when server side validation fails - as opposed to content where we are capable of saving the content
-                // item if server side validation fails
-                redirectOnFailure: false,
                 rebindCallback: function (orignal, saved) {}
             }).then(function (saved) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/edit.controller.js
@@ -68,10 +68,6 @@
                 saveMethod: codefileResource.save,
                 scope: $scope,
                 content: vm.stylesheet,
-                // We do not redirect on failure for style sheets - this is because it is not possible to actually save the style sheet
-                // when server side validation fails - as opposed to content where we are capable of saving the content
-                // item if server side validation fails
-                redirectOnFailure: false,
                 rebindCallback: function (orignal, saved) {}
             }).then(function (saved) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -83,10 +83,6 @@
                 saveMethod: templateResource.save,
                 scope: $scope,
                 content: vm.template,
-                // We do not redirect on failure for templates - this is because it is not possible to actually save the template
-                // type when server side validation fails - as opposed to content where we are capable of saving the content
-                // item if server side validation fails
-                redirectOnFailure: false,
                 rebindCallback: function (orignal, saved) {}
             }).then(function (saved) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -81,10 +81,6 @@
                 saveMethod: userGroupsResource.saveUserGroup,
                 scope: $scope,
                 content: vm.userGroup,
-                // We do not redirect on failure for users - this is because it is not possible to actually save a user
-                // when server side validation fails - as opposed to content where we are capable of saving the content
-                // item if server side validation fails
-                redirectOnFailure: false,
                 rebindCallback: function (orignal, saved) { }
             }).then(function (saved) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -169,7 +169,6 @@
                     }, function (err) {
 
                         contentEditingHelper.handleSaveError({
-                            redirectOnFailure: false,
                             err: err,
                             showNotifications: true
                         });

--- a/src/Umbraco.Web.UI.Client/test/unit/common/services/content-editing-helper.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/services/content-editing-helper.spec.js
@@ -30,7 +30,6 @@ describe('contentEditingHelper tests', function () {
 
             //act
             var handled = contentEditingHelper.handleSaveError({
-                redirectOnFailure: true,
                 err: err,
                 allNewProps: contentEditingHelper.getAllProps(content),
                 allOrigProps: contentEditingHelper.getAllProps(content)
@@ -49,7 +48,6 @@ describe('contentEditingHelper tests', function () {
             
             //act
             var handled = contentEditingHelper.handleSaveError({
-                redirectOnFailure: true,
                 err: err,
                 allNewProps: [],
                 allOrigProps: []
@@ -70,7 +68,6 @@ describe('contentEditingHelper tests', function () {
 
             //act
             var handled = contentEditingHelper.handleSaveError({
-                redirectOnFailure: true,
                 err: err,
                 allNewProps: contentEditingHelper.getAllProps(content),
                 allOrigProps: contentEditingHelper.getAllProps(content)

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -2128,7 +2128,7 @@ namespace Umbraco.Web.Editors
                             {
                                 foreach (var c in successfulCultures)
                                 {
-                                    var names = string.Join(", ", status.Select(x => $"'{x.Content.GetCultureName(c)}'"));
+                                    var names = string.Join(", ", status.Select(x => $"'{(x.Content.ContentType.VariesByCulture() ? x.Content.GetCultureName(c) : x.Content.Name)}'"));
                                     display.AddWarningNotification(
                                         Services.TextService.Localize("publish"),
                                         Services.TextService.Localize("publish/contentPublishedFailedInvalid",

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -741,7 +741,7 @@ namespace Umbraco.Web.Editors
                         //global notifications
                         AddMessageForPublishStatus(publishStatus, globalNotifications, successfulCultures);
                         //variant specific notifications
-                        foreach (var c in successfulCultures)
+                        foreach (var c in successfulCultures ?? Array.Empty<string>())
                             AddMessageForPublishStatus(publishStatus, notifications.GetOrCreate(c), successfulCultures);
                     }
                     break;
@@ -762,7 +762,7 @@ namespace Umbraco.Web.Editors
                         //global notifications
                         AddMessageForPublishStatus(publishStatus, globalNotifications, successfulCultures);
                         //variant specific notifications
-                        foreach (var c in successfulCultures)
+                        foreach (var c in successfulCultures ?? Array.Empty<string>())
                             AddMessageForPublishStatus(publishStatus, notifications.GetOrCreate(c), successfulCultures);
                     }
                     break;
@@ -1143,7 +1143,7 @@ namespace Umbraco.Web.Editors
                 var publishStatus = Services.ContentService.SaveAndPublishBranch(contentItem.PersistedContent, force, userId: Security.CurrentUser.Id);
                 // TODO: Deal with multiple cancellations
                 wasCancelled = publishStatus.Any(x => x.Result == PublishResultType.FailedPublishCancelledByEvent);
-                successfulCultures = Array.Empty<string>();
+                successfulCultures = null; //must be null! this implies invariant
                 return publishStatus;
             }
 

--- a/src/Umbraco.Web/Editors/LanguageController.cs
+++ b/src/Umbraco.Web/Editors/LanguageController.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Web.Editors
         {
             var allLanguages = Services.LocalizationService.GetAllLanguages();
 
-            return Mapper.MapEnumerable<ILanguage, Language>(allLanguages);
+            return Mapper.Map<IEnumerable<ILanguage>, IEnumerable<Language>>(allLanguages);
         }
 
         [HttpGet]

--- a/src/Umbraco.Web/Models/ContentEditing/MessagesExtensions.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/MessagesExtensions.cs
@@ -1,10 +1,15 @@
 ﻿
+using System.Linq;
+using Umbraco.Core;
+
 namespace Umbraco.Web.Models.ContentEditing
 {
     public static class MessagesExtensions
     {
         public static void AddNotification(this INotificationModel model, string header, string msg, NotificationStyle type)
         {
+            if (model.Exists(header, msg, type)) return;
+
             model.Notifications.Add(new Notification()
                 {
                     Header = header,
@@ -15,6 +20,8 @@ namespace Umbraco.Web.Models.ContentEditing
 
         public static void AddSuccessNotification(this INotificationModel model, string header, string msg)
         {
+            if (model.Exists(header, msg, NotificationStyle.Success)) return;
+
             model.Notifications.Add(new Notification()
                 {
                     Header = header,
@@ -25,6 +32,8 @@ namespace Umbraco.Web.Models.ContentEditing
 
         public static void AddErrorNotification(this INotificationModel model, string header, string msg)
         {
+            if (model.Exists(header, msg, NotificationStyle.Error)) return;
+
             model.Notifications.Add(new Notification()
                 {
                     Header = header,
@@ -35,6 +44,8 @@ namespace Umbraco.Web.Models.ContentEditing
 
         public static void AddWarningNotification(this INotificationModel model, string header, string msg)
         {
+            if (model.Exists(header, msg, NotificationStyle.Warning)) return;
+
             model.Notifications.Add(new Notification()
                 {
                     Header = header,
@@ -45,6 +56,8 @@ namespace Umbraco.Web.Models.ContentEditing
 
         public static void AddInfoNotification(this INotificationModel model, string header, string msg)
         {
+            if (model.Exists(header, msg, NotificationStyle.Info)) return;
+
             model.Notifications.Add(new Notification()
                 {
                     Header = header,
@@ -52,5 +65,7 @@ namespace Umbraco.Web.Models.ContentEditing
                     NotificationType = NotificationStyle.Info
                 });
         }
+
+        private static bool Exists(this INotificationModel model, string header, string message, NotificationStyle notificationType) => model.Notifications.Any(x => x.Header.InvariantEquals(header) && x.Message.InvariantEquals(message) && x.NotificationType == notificationType);
     }
 }

--- a/src/Umbraco.Web/Models/Mapping/ContentVariantMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentVariantMapper.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Web.Models.Mapping
                 variants.Remove(defaultLang);
 
                 //Sort the remaining languages a-z
-                variants = variants.OrderBy(x => x.Language.IsoCode).ToList();
+                variants = variants.OrderBy(x => x.Language.Name).ToList();
 
                 //Insert the default language as the first item
                 variants.Insert(0, defaultLang);

--- a/src/Umbraco.Web/Models/Mapping/ContentVariantMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentVariantMapper.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Web.Models.Mapping
                 variants.Remove(defaultLang);
 
                 //Sort the remaining languages a-z
-                variants = variants.OrderBy(x => x.Name).ToList();
+                variants = variants.OrderBy(x => x.Language.IsoCode).ToList();
 
                 //Insert the default language as the first item
                 variants.Insert(0, defaultLang);


### PR DESCRIPTION
fixes #4988
fixes #5156

The details of what is done is here https://github.com/umbraco/Umbraco-CMS/issues/4988#issuecomment-499735437

## This PR has changes for:

### Whitespace

Sorry, there are a bunch of whitespace fixes here, so when viewing the diff, use this link to remove the whitespace comparison: 

### Main changes

* Adds `reloadOnUrl` to false for the "ID" routes - this means we can now control if a real route will execute when an editor route is changed. For example, /content/content/edit/1234 is this type of route (it's definition is `/{section}/{tree}/{method}/{id}`). We are already handling `reloadOnSearch` in this dynamic way for most routes and the same logic is used which is done in `navigationService.isRouteChangingNavigation` so this method is updated with some new logic. When a route that has `reloadOnSearch` or `reloadOnUrl` set to false and the route takes place, we deal with the route using an event `$routeUpdate` (which is handled in `init.js`) and we ask `navigationService.isRouteChangingNavigation` if we should proceed with the route or just let the URL change. In this case, we are explicitly checking if we're on the `content` tree and we are moving from creating a new item (with the ?create=true) parameter to a created item. In this case, we just allow the URL to change but don't cause the route to occur.
* Updates the content controller to listen for the route change and update it's `isNew` property accordingly since when transitioning from creating to created `isNew` will go from true -> false which affects some UI. 
* Updates the content editor directive - watch for isNew changes and if it changes from true -> false then we will render the breadcrumb, etc... Moves logic for rendering the breadcrumb and back button to where it should be to deal with not redirecting when creating new content. Let contentEditingHelper service handle editorState changes instead of doing that manually in the directive. 
* Updates contentEditingHelper  - removes the `redirectOnSuccess` and `redirectOnFailure` args which are legacy and completely not required at all (redirection will occur naturally if there's a valid ID in the new route). Adds a `softRedirect` arg which the content editor now uses so that a true redirect no longer occurs for this editor, just a URL change. Sets the `editorState` on success or failed save automatically. 

### Other bugs fixed

* Fixes issue with `SimilarNodeName` + unit tests for it (we weren't dealing with case sensitive naming)
* Fixes issue with content variant mapping - we weren't returning the content variants in the correct consistent order which was causing other problems relating to these notifications. Now variants are returned in order based on their human readable language name (i.e. French)
* Updates the language editor to return the languages in the order based on their human readable language name (i.e. French) and ensures that the correct language mapping logic is used (it wasn't before due to the usage of MapEnumerable)
* Fixes issue in the ContentController for not returning notification messages to the UI for invariant nodes (you wouldn't actually see the green notification bar on successful save)
* Updates the fileManager angular services to manage it's own clearing of files based on successful routes (makes it work standalone)
* Updates the editorState angular services to manage it's own clearing of state based on successful routes (makes it work standalone)
* Fixes creating blueprints when there are errors and mapping the blueprint object correctly so the tree syncs without an error.

## Testing

_Make sure all npm install, etc... is up to date and you do a new gulp build_

### General testing

_This is required because some changes have been made that affect all of these things_

* Test that creating a new data type, macro, doc type, media type, member type works and that notifications work
* Test that creating a new media item works and that notifications work, test that updating a media item 
works and that notifications work - try to break this with invalid data, etc...
* Test that creating a new member works and that notifications work, test that updating a media item 
works and that notifications work - try to break this with invalid data, etc...

### Content testing

To set this up: 

* Have 3x languages - none of them are mandatory
* Have an **invariant** doc type allowed as root and set to be a list view
* Have a **variant** doc type that has `title` as a text string property that is **invariant** and validates as a Number, ensure this doc type is allowed under the above invariant doc type

Then to test:

* Test that creating a new **invariant** content item works and that notifications work. The URL should also be updated to the correct path with a new ID. Without refreshing or navigating away, test that updating this content item works and that notifications work - try to break this with invalid data, etc...
* Test that creating a new **variant** content item works by filling in all required fields, all names in all 3 langs and be sure to enter a Number for the `title` so that all validation passes. Then Save/Publish and choose all 3 langs. Ensure notifications all work, ensure that after creation the back button is available and that the breadcrumb was created. The URL should also be updated to the correct path with a new ID. Without refreshing or navigating away, test that updating this content item works and that notifications work. 
* Test that creating a new invalid **variant** content item works by filling in the names in all 3 langs, enter an invalid value in the `title` field like `asdf` (which is not a Number). Then Save/Publish and choose all 3 langs. The dialog will remain open, you will get an error/warning for each language. `xyz could not be published because some properties did not pass validation rules` will appear for the non-default languages and `Validation failed for language 'xyz'` will appear for the default language. You should be able to press the `Save and publish` button again in this dialog and it will re-attempt to save it and you will no longer get JS errors in the console when doing so. Close this dialog and ensure you are not currently editing the default language, then you will see a circle with a "!" beside the lang drop down, click the lang drop down and you will see that the validation warning is for the default language, go to the default language and the validation message will be wired up to the `title` property. Change the `title` value to something valid like `1234`. Then Save and Publish again, selecting all 3 langs, this will now work and you'll get x3 green notification bars.  - try to break this with invalid data, etc...
* Test that creating a new invalid **variant** blueprint works by basically following the previous step, except do this by creating a blueprint