### PR TITLE
V8: Fix the overflow wrapping for repeatable textstrings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
@@ -1,14 +1,19 @@
 ﻿.umb-multiple-textbox{
     &__confirm{
         position: relative;
+        display: inline-block;
 
         &-action{
-            margin: 0;
+            margin: -2px 0 0 0;
             padding: 2px;
             background: transparent;
             border: 0 none;
         }
     }
+}
+
+.umb-multiple-textbox .icon-wrapper {
+    width: 50px;
 }
 
 .umb-multiple-textbox .textbox-wrapper {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
@@ -2,23 +2,24 @@
 
   <div ui-sortable="sortableOptions" ng-model="model.value">
     <div class="flex flex-wrap textbox-wrapper" ng-repeat="item in model.value track by $index">
-      <input type="text" name="item_{{$index}}" ng-model="item.value" class="umb-property-editor umb-textstring textstring"
-             ng-keyup="addRemoveOnKeyDown($event, $index)" focus-when="{{item.hasFocus}}"/>
-      <i class="icon icon-navigation handle" localize="title" title="@general_move"></i>
+        <input type="text" name="item_{{$index}}" ng-model="item.value" class="umb-property-editor umb-textstring textstring flx-i"
+               ng-keyup="addRemoveOnKeyDown($event, $index)" focus-when="{{item.hasFocus}}"/>
+        <div class="icon-wrapper">
+            <i class="icon icon-navigation handle" localize="title" title="@general_move"></i>
 
-    <div class="umb-multiple-textbox__confirm" ng-show="model.value.length > model.config.min">
-        <button class="umb-multiple-textbox__confirm-action" type="button" prevet-default ng-click="showPrompt($index, item)" localize="title" title="@content_removeTextBox">
-            <i class="icon-trash"></i>
-        </button>
+            <div class="umb-multiple-textbox__confirm" ng-show="model.value.length > model.config.min">
+                <button class="umb-multiple-textbox__confirm-action" type="button" prevet-default ng-click="showPrompt($index, item)" localize="title" title="@content_removeTextBox">
+                    <i class="icon-trash"></i>
+                </button>
 
-        <umb-confirm-action
-            ng-if="promptIsVisible === $index"
-            direction="left"
-            on-confirm="remove($index)"
-            on-cancel="hidePrompt()">
-        </umb-confirm-action>
-    </div>
-
+                <umb-confirm-action
+                    ng-if="promptIsVisible === $index"
+                    direction="left"
+                    on-confirm="remove($index)"
+                    on-cancel="hidePrompt()">
+                </umb-confirm-action>
+            </div>
+        </div>
     </div>
   </div>
   <a prevent-default href="" class="add-link" localize="title" title="@content_addTextBox"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Repeatable textstrings have a rather bad overflow handling for smaller screens; the action icons simply wrap below the textboxes:

![image](https://user-images.githubusercontent.com/7405322/59330575-27402400-8cf2-11e9-88ab-a0ab04c31e13.png)

This PR ensures that the textboxes shrink with the screen width, so the action icons remain on the same line as the textboxes:

![image](https://user-images.githubusercontent.com/7405322/59330479-de886b00-8cf1-11e9-9f95-f77d33c60ad3.png)

On larger screens the the textboxes still align with the max width of other controls:

![image](https://user-images.githubusercontent.com/7405322/59330710-81d98000-8cf2-11e9-82ed-8c10bf16acaf.png)
