### PR TITLE
V8: Enforce max width on numeric inputs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -162,6 +162,7 @@
 @import "components/umb-textarea.less";
 @import "components/umb-dropdown.less";
 @import "components/umb-range-slider.less";
+@import "components/umb-number.less";
 
 @import "components/buttons/umb-button.less";
 @import "components/buttons/umb-button-group.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-number.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-number.less
@@ -1,0 +1,3 @@
+.umb-number {
+    .umb-property-editor--limit-width();
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description

For some odd reason, the property editor max-width of 800px isn't enforced on numeric inputs:

![image](https://user-images.githubusercontent.com/7405322/59331135-6f137b00-8cf3-11e9-80f8-c61adebe9a6e.png)

This PR adds that, so the numeric inputs align nicely with the other property editors:

![image](https://user-images.githubusercontent.com/7405322/59331068-4b503500-8cf3-11e9-8f42-67a2dc929640.png)
