### PR TITLE
v8: Add keyboard support to slider

### DIFF
--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -35,7 +35,7 @@
     "lazyload-js": "1.0.0",
     "moment": "2.22.2",
     "ng-file-upload": "12.2.13",
-    "nouislider": "12.1.0",
+    "nouislider": "13.1.5",
     "npm": "^6.4.1",
     "signalr": "2.4.0",
     "spectrum-colorpicker": "1.8.0",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -35,7 +35,7 @@
     "lazyload-js": "1.0.0",
     "moment": "2.22.2",
     "ng-file-upload": "12.2.13",
-    "nouislider": "13.1.5",
+    "nouislider": "14.0.1",
     "npm": "^6.4.1",
     "signalr": "2.4.0",
     "spectrum-colorpicker": "1.8.0",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/3957

### Description
This updates noUiSlider used as slider plugin in Umbraco to use version 13.0.0+ which has keyboard support build in.

There are no breaking changes from the current used noUiSlider version only enhancement and bug fixes.

The keyboard support might not be ideal for the slider in image cropper, because the step size in very small (a lot of steps in the range). I have suggested on the noUiSlider issue tracker to be able to set a specific step size when using keyboard in this specific case. https://github.com/leongersen/noUiSlider/issues/992

Furthermore it is only possible the disable keyboard support on noUiSlider (enabled by default), but the `umb-range-slider` doesn't handle this at the moment. I think it is fine for now the always keep it enabled.

![2019-06-12_12-10-47](https://user-images.githubusercontent.com/2919859/59343450-3633d000-8d0c-11e9-8f91-18d2d3cb150f.gif)