### PR TITLE
[V7] Added the ability to copy nested content items 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -84,6 +84,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
         $scope.editIconTitle = '';
         $scope.moveIconTitle = '';
         $scope.deleteIconTitle = '';
+        $scope.copyIconTitle = '';
 
         // localize the edit icon title
         localizationService.localize('general_edit').then(function (value) {
@@ -98,6 +99,11 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
         // localize the move icon title
         localizationService.localize('actions_move').then(function (value) {
             $scope.moveIconTitle = value;
+        });
+
+        // localize the copy icon title
+        localizationService.localize('actions_copy').then(function (value) {
+            $scope.copyIconTitle = value;
         });
 
         $scope.nodes = [];
@@ -203,6 +209,19 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
                     $scope.setDirty();
                     updateModel();
                 }
+            }
+        };
+
+        $scope.copyNode = function (idx) {
+            if ($scope.nodes.length > $scope.model.config.minItems) {
+                var nodeToCopy = $scope.nodes[idx];
+
+                var clonedNode = angular.copy(nodeToCopy);
+                clonedNode.key = UUID.generate();
+
+                $scope.nodes.push(clonedNode);
+                $scope.setDirty();
+                updateModel();
             }
         };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -18,6 +18,9 @@
                         <a class="umb-nested-content__icon umb-nested-content__icon--move" title="{{moveIconTitle}}" ng-click="$event.stopPropagation();" ng-show="$parent.nodes.length > 1" prevent-default>
                             <i class="icon icon-navigation"></i>
                         </a>
+                        <a class="umb-nested-content__icon umb-nested-content__icon--delete" title="{{copyIconTitle}}" ng-class="{ 'umb-nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.copyNode($index); $event.stopPropagation();" prevent-default>
+                            <i class="icon icon-split"></i>
+                        </a>
                         <a class="umb-nested-content__icon umb-nested-content__icon--delete" title="{{deleteIconTitle}}" ng-class="{ 'umb-nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.deleteNode($index); $event.stopPropagation();" prevent-default>
                             <i class="icon icon-trash"></i>
                         </a>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -18,7 +18,7 @@
                         <a class="umb-nested-content__icon umb-nested-content__icon--move" title="{{moveIconTitle}}" ng-click="$event.stopPropagation();" ng-show="$parent.nodes.length > 1" prevent-default>
                             <i class="icon icon-navigation"></i>
                         </a>
-                        <a class="umb-nested-content__icon umb-nested-content__icon--delete" title="{{copyIconTitle}}" ng-class="{ 'umb-nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.copyNode($index); $event.stopPropagation();" prevent-default>
+                        <a class="umb-nested-content__icon umb-nested-content__icon--copy" title="{{copyIconTitle}}" ng-click="$parent.copyNode($index); $event.stopPropagation();" prevent-default>
                             <i class="icon icon-split"></i>
                         </a>
                         <a class="umb-nested-content__icon umb-nested-content__icon--delete" title="{{deleteIconTitle}}" ng-class="{ 'umb-nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.deleteNode($index); $event.stopPropagation();" prevent-default>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

I have added the ability to copy/clone a nested content item to the Umbraco Backoffice UI. I added this feature because it would greatly improve workflows where a nested content item would need to be duplicated. Without this PR, content editors/backoffice users would need to create a new nested content item and fill in all properties manually which can take some time.

In order to test this PR:
1. Create a document type to be used as Nested Content. 
2. Create a Nested Content data type, with the document type created in step 1 as a blueprint
3. Create a document type to use the Nested Content data type created in step 2.
4. In the content tab of backoffice, create an instance of the document type created in step 3. 
5. In the nested content editor, add a content item - select the doc type created in step 1.
6. If you hover over the controls area of the opened nested content item, the new Copy button will appear, next to the delete and move buttons.
7. Clicking the Copy button will copy the nested content item and place it at the end of the nested content list. All properties will be set to the same values as the original nested content item.

<!-- Thanks for contributing to Umbraco CMS! -->
