### PR TITLE
Enable removal of unpublished content from ExternalIndex (#5218)

### DIFF
--- a/src/Umbraco.Web/Search/ExamineComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineComponent.cs
@@ -737,7 +737,7 @@ namespace Umbraco.Web.Search
             {
                 var strId = id.ToString(CultureInfo.InvariantCulture);
                 foreach (var index in examineComponent._examineManager.Indexes.OfType<IUmbracoIndex>()
-                    .Where(x => (keepIfUnpublished && !x.PublishedValuesOnly) || !keepIfUnpublished)
+                    .Where(x => x.PublishedValuesOnly || !keepIfUnpublished)
                     .Where(x => x.EnableDefaultEventHandler))
                 {
                     index.DeleteFromIndex(strId);


### PR DESCRIPTION
DeferedDeleteIndex.Execute should delete entries in indexes with PublishedValuesOnly

### Prerequisites

- [ x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5218

### Description
As described in the issue; Content isn't removed from the ExternalIndex when you Unpublish content. You have to Rebuild the ExternalIndex to remove the Unpublished content.
A change to the logic in DeferedDeleteIndex.Execute that determines which Indexes should be affected fixes the issue.
To test: See #5218. 