### PR TITLE
temp-5612: Being able to add your own roles/startnodes etc

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -71,12 +71,10 @@
                                             sections="userGroup.sections"
                                             content-start-node="userGroup.contentStartNode"
                                             media-start-node="userGroup.mediaStartNode"
-                                            allow-remove="!model.user.isCurrentUser"
                                             on-remove="model.removeSelectedItem($index, model.user.userGroups)">
                     </umb-user-group-preview>
 
                     <a href=""
-                       ng-if="!model.user.isCurrentUser"
                        style="max-width: 100%;"
                        class="umb-node-preview-add"
                        ng-click="model.openUserGroupPicker()"
@@ -92,7 +90,6 @@
                                       ng-repeat="node in model.user.startContentIds"
                                       icon="node.icon"
                                       name="node.name"
-                                      allow-remove="!model.user.isCurrentUser"
                                       on-remove="model.removeSelectedItem($index, model.user.startContentIds)">
                     </umb-node-preview>
 
@@ -102,7 +99,6 @@
                     </umb-node-preview>
 
                     <a href=""
-                       ng-if="!model.user.isCurrentUser"
                        class="umb-node-preview-add"
                        id="content-start-add"
                        ng-click="model.openContentPicker()"
@@ -118,7 +114,6 @@
                                       ng-repeat="node in model.user.startMediaIds"
                                       icon="node.icon"
                                       name="node.name"
-                                      allow-remove="!model.user.isCurrentUser"
                                       on-remove="model.removeSelectedItem($index, model.user.startMediaIds)">
                     </umb-node-preview>
 
@@ -128,7 +123,6 @@
                     </umb-node-preview>
 
                     <a href=""
-                       ng-if="!model.user.isCurrentUser"
                        class="umb-node-preview-add"
                        ng-click="model.openMediaPicker()"
                        id="media-start-add"


### PR DESCRIPTION
Issue: https://github.com/umbraco/Umbraco-CMS/issues/5612

Currently you aren't able to change your own groups meaning you need another account to do it for you if you are the first one in the system. This was because there was a check to see if you are the same user as the one you are currently editing. However you were still able to go to groups and add yourself to the groups there. Meaning the check was unneeded, so I removed it.

