### PR TITLE
V8: Support keyboard input in date/time picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -77,6 +77,11 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
         setDate(date);
         setDatePickerVal();
     };
+
+    $scope.inputChanged = function() {
+        setDate($scope.model.datetimePickerValue);
+        setDatePickerVal();
+    }
     
     //here we declare a special method which will be called whenever the value has changed from the server
     //this is instead of doing a watch on the model.value = faster

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.html
@@ -16,6 +16,7 @@
                         id="{{model.alias}}"
                         type="text"
                         ng-model="model.datetimePickerValue"
+                        ng-blur="inputChanged()"
                         ng-required="model.validation.mandatory"
                         val-server="value"
                         class="datepickerinput">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5584

### Description

This PR adds the ability to enter dates manually (or by copy/paste) in the date/time picker. When applied, the date/time picker behaves like this:

![datepicker-input](https://user-images.githubusercontent.com/7405322/59436051-2e009100-8def-11e9-93d3-f9eb5095b4a1.gif)

#### Testing this PR

1. Make sure you can still pick dates (with and without time) using the good ol' point-and-click approach.
2. Verify that you can enter a date explicitly using the keyboard.
3. Verify that you can paste a date.
4. Verify that invalid date entries are discarded.