### PR TITLE
V8/bugfix/3498 entity service updates

### DIFF
--- a/src/Umbraco.Core/Models/Entities/DocumentEntitySlim.cs
+++ b/src/Umbraco.Core/Models/Entities/DocumentEntitySlim.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 namespace Umbraco.Core.Models.Entities
 {
+
     /// <summary>
     /// Implements <see cref="IDocumentEntitySlim"/>.
     /// </summary>

--- a/src/Umbraco.Core/Models/Entities/EntitySlim.cs
+++ b/src/Umbraco.Core/Models/Entities/EntitySlim.cs
@@ -111,52 +111,6 @@ namespace Umbraco.Core.Models.Entities
         public virtual bool IsContainer { get; set; }
 
 
-        /// <summary>
-        /// Represents a lightweight property.
-        /// </summary>
-        public class PropertySlim
-        {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="PropertySlim"/> class.
-            /// </summary>
-            public PropertySlim(string editorAlias, object value)
-            {
-                PropertyEditorAlias = editorAlias;
-                Value = value;
-            }
-
-            /// <summary>
-            /// Gets the property editor alias.
-            /// </summary>
-            public string PropertyEditorAlias { get; }
-
-            /// <summary>
-            /// Gets the property value.
-            /// </summary>
-            public object Value { get; }
-
-            protected bool Equals(PropertySlim other)
-            {
-                return PropertyEditorAlias.Equals(other.PropertyEditorAlias) && Equals(Value, other.Value);
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != GetType()) return false;
-                return Equals((PropertySlim) obj);
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    return (PropertyEditorAlias.GetHashCode() * 397) ^ (Value != null ? Value.GetHashCode() : 0);
-                }
-            }
-        }
-
         #region IDeepCloneable
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/Models/Entities/IDocumentEntitySlim.cs
+++ b/src/Umbraco.Core/Models/Entities/IDocumentEntitySlim.cs
@@ -2,6 +2,7 @@
 
 namespace Umbraco.Core.Models.Entities
 {
+
     /// <summary>
     /// Represents a lightweight document entity, managed by the entity service.
     /// </summary>

--- a/src/Umbraco.Core/Models/Entities/IMediaEntitySlim.cs
+++ b/src/Umbraco.Core/Models/Entities/IMediaEntitySlim.cs
@@ -1,0 +1,14 @@
+﻿namespace Umbraco.Core.Models.Entities
+{
+    /// <summary>
+    /// Represents a lightweight media entity, managed by the entity service.
+    /// </summary>
+    public interface IMediaEntitySlim : IContentEntitySlim
+    {
+
+        /// <summary>
+        /// The media file's path/url
+        /// </summary>
+        string MediaPath { get; }
+    }
+}

--- a/src/Umbraco.Core/Models/Entities/MediaEntitySlim.cs
+++ b/src/Umbraco.Core/Models/Entities/MediaEntitySlim.cs
@@ -1,0 +1,10 @@
+﻿namespace Umbraco.Core.Models.Entities
+{
+    /// <summary>
+    /// Implements <see cref="IMediaEntitySlim"/>.
+    /// </summary>
+    public class MediaEntitySlim : ContentEntitySlim, IMediaEntitySlim
+    {
+        public string MediaPath { get; set; }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
@@ -87,9 +87,9 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             if (isContent)
                 BuildVariants(entities.Cast<DocumentEntitySlim>());
 
-            // TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-            if (isMedia)
-                BuildProperties(entities, dtos.ToList());
+            //// TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
+            //if (isMedia)
+            //    BuildProperties(entities, dtos.ToList());
 
             return entities;
         }
@@ -117,8 +117,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             var entity = BuildEntity(false, isMedia, dto);
 
-            if (isMedia)
-                BuildProperties(entity, dto);
+            //if (isMedia)
+            //    BuildProperties(entity, dto);
 
             return entity;
         }
@@ -162,7 +162,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 : PerformGetAll(objectType);
         }
 
-        private IEnumerable<IEntitySlim> GetEntities(Sql<ISqlContext> sql, bool isContent, bool isMedia, bool loadMediaProperties)
+        private IEnumerable<IEntitySlim> GetEntities(Sql<ISqlContext> sql, bool isContent, bool isMedia)
         {
             //isContent is going to return a 1:M result now with the variants so we need to do different things
             if (isContent)
@@ -179,9 +179,9 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             var entities = dtos.Select(x => BuildEntity(false, isMedia, x)).ToArray();
 
-            // TODO: See https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-            if (isMedia && loadMediaProperties)
-                BuildProperties(entities, dtos);
+            //// TODO: See https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
+            //if (isMedia && loadMediaProperties)
+            //    BuildProperties(entities, dtos);
 
             return entities;
         }
@@ -192,7 +192,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var isMedia = objectType == Constants.ObjectTypes.Media;
 
             var sql = GetFullSqlForEntityType(isContent, isMedia, objectType, filter);
-            return GetEntities(sql, isContent, isMedia, true);
+            return GetEntities(sql, isContent, isMedia);
         }
 
         public IEnumerable<TreeEntityPath> GetAllPaths(Guid objectType, params int[] ids)
@@ -238,23 +238,23 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             sql = translator.Translate();
             sql = AddGroupBy(isContent, isMedia, sql, true);
 
-            return GetEntities(sql, isContent, isMedia, true);
+            return GetEntities(sql, isContent, isMedia);
         }
 
-        // TODO: See https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-        internal IEnumerable<IEntitySlim> GetMediaByQueryWithoutPropertyData(IQuery<IUmbracoEntity> query)
-        {
-            var isContent = false;
-            var isMedia = true;
+        //// TODO: See https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
+        //internal IEnumerable<IEntitySlim> GetMediaByQueryWithoutPropertyData(IQuery<IUmbracoEntity> query)
+        //{
+        //    var isContent = false;
+        //    var isMedia = true;
 
-            var sql = GetBaseWhere(isContent, isMedia, false, null, Constants.ObjectTypes.Media);
+        //    var sql = GetBaseWhere(isContent, isMedia, false, null, Constants.ObjectTypes.Media);
 
-            var translator = new SqlTranslator<IUmbracoEntity>(sql, query);
-            sql = translator.Translate();
-            sql = AddGroupBy(isContent, isMedia, sql, true);
+        //    var translator = new SqlTranslator<IUmbracoEntity>(sql, query);
+        //    sql = translator.Translate();
+        //    sql = AddGroupBy(isContent, isMedia, sql, true);
 
-            return GetEntities(sql, isContent, isMedia, false);
-        }
+        //    return GetEntities(sql, isContent, isMedia, false);
+        //}
 
         public UmbracoObjectTypes GetObjectType(int id)
         {
@@ -280,40 +280,40 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             return Database.ExecuteScalar<int>(sql) > 0;
         }
 
-        // TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-        private void BuildProperties(EntitySlim entity, BaseDto dto)
-        {
-            var pdtos = Database.Fetch<PropertyDataDto>(GetPropertyData(dto.VersionId));
-            foreach (var pdto in pdtos)
-                BuildProperty(entity, pdto);
-        }
+        //// TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
+        //private void BuildProperties(EntitySlim entity, BaseDto dto)
+        //{
+        //    var pdtos = Database.Fetch<PropertyDataDto>(GetPropertyData(dto.VersionId));
+        //    foreach (var pdto in pdtos)
+        //        BuildProperty(entity, pdto);
+        //}
 
-        // TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-        private void BuildProperties(EntitySlim[] entities, List<BaseDto> dtos)
-        {
-            var versionIds = dtos.Select(x => x.VersionId).Distinct().ToList();
-            var pdtos = Database.FetchByGroups<PropertyDataDto, int>(versionIds, 2000, GetPropertyData);
+        //// TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
+        //private void BuildProperties(EntitySlim[] entities, List<BaseDto> dtos)
+        //{
+        //    var versionIds = dtos.Select(x => x.VersionId).Distinct().ToList();
+        //    var pdtos = Database.FetchByGroups<PropertyDataDto, int>(versionIds, 2000, GetPropertyData);
 
-            var xentity = entities.ToDictionary(x => x.Id, x => x); // nodeId -> entity
-            var xdto = dtos.ToDictionary(x => x.VersionId, x => x.NodeId); // versionId -> nodeId
-            foreach (var pdto in pdtos)
-            {
-                var nodeId = xdto[pdto.VersionId];
-                var entity = xentity[nodeId];
-                BuildProperty(entity, pdto);
-            }
-        }
+        //    var xentity = entities.ToDictionary(x => x.Id, x => x); // nodeId -> entity
+        //    var xdto = dtos.ToDictionary(x => x.VersionId, x => x.NodeId); // versionId -> nodeId
+        //    foreach (var pdto in pdtos)
+        //    {
+        //        var nodeId = xdto[pdto.VersionId];
+        //        var entity = xentity[nodeId];
+        //        BuildProperty(entity, pdto);
+        //    }
+        //}
 
-        // TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-        private void BuildProperty(EntitySlim entity, PropertyDataDto pdto)
-        {
-            // explain ?!
-            var value = string.IsNullOrWhiteSpace(pdto.TextValue)
-                ? pdto.VarcharValue
-                : pdto.TextValue.ConvertToJsonIfPossible();
+        //// TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
+        //private void BuildProperty(EntitySlim entity, PropertyDataDto pdto)
+        //{
+        //    // explain ?!
+        //    var value = string.IsNullOrWhiteSpace(pdto.TextValue)
+        //        ? pdto.VarcharValue
+        //        : pdto.TextValue.ConvertToJsonIfPossible();
 
-            entity.AdditionalData[pdto.PropertyTypeDto.Alias] = new EntitySlim.PropertySlim(pdto.PropertyTypeDto.DataTypeDto.EditorAlias, value);
-        }
+        //    entity.AdditionalData[pdto.PropertyTypeDto.Alias] = new EntitySlim.PropertySlim(pdto.PropertyTypeDto.DataTypeDto.EditorAlias, value);
+        //}
 
         private DocumentEntitySlim BuildVariants(DocumentEntitySlim entity)
             => BuildVariants(new[] { entity }).First();
@@ -400,26 +400,26 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             return AddGroupBy(isContent, isMedia, sql, true);
         }
 
-        private Sql<ISqlContext> GetPropertyData(int versionId)
-        {
-            return Sql()
-                .Select<PropertyDataDto>(r => r.Select(x => x.PropertyTypeDto, r1 => r1.Select(x => x.DataTypeDto)))
-                .From<PropertyDataDto>()
-                .InnerJoin<PropertyTypeDto>().On<PropertyDataDto, PropertyTypeDto>((left, right) => left.PropertyTypeId == right.Id)
-                .InnerJoin<DataTypeDto>().On<PropertyTypeDto, DataTypeDto>((left, right) => left.DataTypeId == right.NodeId)
-                .Where<PropertyDataDto>(x => x.VersionId == versionId);
-        }
+        //private Sql<ISqlContext> GetPropertyData(int versionId)
+        //{
+        //    return Sql()
+        //        .Select<PropertyDataDto>(r => r.Select(x => x.PropertyTypeDto, r1 => r1.Select(x => x.DataTypeDto)))
+        //        .From<PropertyDataDto>()
+        //        .InnerJoin<PropertyTypeDto>().On<PropertyDataDto, PropertyTypeDto>((left, right) => left.PropertyTypeId == right.Id)
+        //        .InnerJoin<DataTypeDto>().On<PropertyTypeDto, DataTypeDto>((left, right) => left.DataTypeId == right.NodeId)
+        //        .Where<PropertyDataDto>(x => x.VersionId == versionId);
+        //}
 
-        private Sql<ISqlContext> GetPropertyData(IEnumerable<int> versionIds)
-        {
-            return Sql()
-                .Select<PropertyDataDto>(r => r.Select(x => x.PropertyTypeDto, r1 => r1.Select(x => x.DataTypeDto)))
-                .From<PropertyDataDto>()
-                .InnerJoin<PropertyTypeDto>().On<PropertyDataDto, PropertyTypeDto>((left, right) => left.PropertyTypeId == right.Id)
-                .InnerJoin<DataTypeDto>().On<PropertyTypeDto, DataTypeDto>((left, right) => left.DataTypeId == right.NodeId)
-                .WhereIn<PropertyDataDto>(x => x.VersionId, versionIds)
-                .OrderBy<PropertyDataDto>(x => x.VersionId);
-        }
+        //private Sql<ISqlContext> GetPropertyData(IEnumerable<int> versionIds)
+        //{
+        //    return Sql()
+        //        .Select<PropertyDataDto>(r => r.Select(x => x.PropertyTypeDto, r1 => r1.Select(x => x.DataTypeDto)))
+        //        .From<PropertyDataDto>()
+        //        .InnerJoin<PropertyTypeDto>().On<PropertyDataDto, PropertyTypeDto>((left, right) => left.PropertyTypeId == right.Id)
+        //        .InnerJoin<DataTypeDto>().On<PropertyTypeDto, DataTypeDto>((left, right) => left.DataTypeId == right.NodeId)
+        //        .WhereIn<PropertyDataDto>(x => x.VersionId, versionIds)
+        //        .OrderBy<PropertyDataDto>(x => x.VersionId);
+        //}
 
         // gets the base SELECT + FROM [+ filter] sql
         // always from the 'current' content version
@@ -566,21 +566,21 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         #region Classes
 
-        [ExplicitColumns]
-        internal class UmbracoPropertyDto
-        {
-            [Column("propertyEditorAlias")]
-            public string PropertyEditorAlias { get; set; }
+        //[ExplicitColumns]
+        //internal class UmbracoPropertyDto
+        //{
+        //    [Column("propertyEditorAlias")]
+        //    public string PropertyEditorAlias { get; set; }
 
-            [Column("propertyTypeAlias")]
-            public string PropertyAlias { get; set; }
+        //    [Column("propertyTypeAlias")]
+        //    public string PropertyAlias { get; set; }
 
-            [Column("varcharValue")]
-            public string VarcharValue { get; set; }
+        //    [Column("varcharValue")]
+        //    public string VarcharValue { get; set; }
 
-            [Column("textValue")]
-            public string TextValue { get; set; }
-        }
+        //    [Column("textValue")]
+        //    public string TextValue { get; set; }
+        //}
 
 
         /// <summary>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
@@ -240,21 +240,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             return GetEntities(sql, isContent, isMedia);
         }
 
-        //// TODO: See https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-        //internal IEnumerable<IEntitySlim> GetMediaByQueryWithoutPropertyData(IQuery<IUmbracoEntity> query)
-        //{
-        //    var isContent = false;
-        //    var isMedia = true;
-
-        //    var sql = GetBaseWhere(isContent, isMedia, false, null, Constants.ObjectTypes.Media);
-
-        //    var translator = new SqlTranslator<IUmbracoEntity>(sql, query);
-        //    sql = translator.Translate();
-        //    sql = AddGroupBy(isContent, isMedia, sql, true);
-
-        //    return GetEntities(sql, isContent, isMedia, false);
-        //}
-
         public UmbracoObjectTypes GetObjectType(int id)
         {
             var sql = Sql().Select<NodeDto>(x => x.NodeObjectType).From<NodeDto>().Where<NodeDto>(x => x.NodeId == id);
@@ -278,41 +263,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var sql = Sql().SelectCount().From<NodeDto>().Where<NodeDto>(x => x.NodeId == id);
             return Database.ExecuteScalar<int>(sql) > 0;
         }
-
-        //// TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-        //private void BuildProperties(EntitySlim entity, BaseDto dto)
-        //{
-        //    var pdtos = Database.Fetch<PropertyDataDto>(GetPropertyData(dto.VersionId));
-        //    foreach (var pdto in pdtos)
-        //        BuildProperty(entity, pdto);
-        //}
-
-        //// TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-        //private void BuildProperties(EntitySlim[] entities, List<BaseDto> dtos)
-        //{
-        //    var versionIds = dtos.Select(x => x.VersionId).Distinct().ToList();
-        //    var pdtos = Database.FetchByGroups<PropertyDataDto, int>(versionIds, 2000, GetPropertyData);
-
-        //    var xentity = entities.ToDictionary(x => x.Id, x => x); // nodeId -> entity
-        //    var xdto = dtos.ToDictionary(x => x.VersionId, x => x.NodeId); // versionId -> nodeId
-        //    foreach (var pdto in pdtos)
-        //    {
-        //        var nodeId = xdto[pdto.VersionId];
-        //        var entity = xentity[nodeId];
-        //        BuildProperty(entity, pdto);
-        //    }
-        //}
-
-        //// TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-        //private void BuildProperty(EntitySlim entity, PropertyDataDto pdto)
-        //{
-        //    // explain ?!
-        //    var value = string.IsNullOrWhiteSpace(pdto.TextValue)
-        //        ? pdto.VarcharValue
-        //        : pdto.TextValue.ConvertToJsonIfPossible();
-
-        //    entity.AdditionalData[pdto.PropertyTypeDto.Alias] = new EntitySlim.PropertySlim(pdto.PropertyTypeDto.DataTypeDto.EditorAlias, value);
-        //}
 
         private DocumentEntitySlim BuildVariants(DocumentEntitySlim entity)
             => BuildVariants(new[] { entity }).First();
@@ -398,27 +348,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var sql = GetBaseWhere(isContent, isMedia, false, filter, objectType);
             return AddGroupBy(isContent, isMedia, sql, true);
         }
-
-        //private Sql<ISqlContext> GetPropertyData(int versionId)
-        //{
-        //    return Sql()
-        //        .Select<PropertyDataDto>(r => r.Select(x => x.PropertyTypeDto, r1 => r1.Select(x => x.DataTypeDto)))
-        //        .From<PropertyDataDto>()
-        //        .InnerJoin<PropertyTypeDto>().On<PropertyDataDto, PropertyTypeDto>((left, right) => left.PropertyTypeId == right.Id)
-        //        .InnerJoin<DataTypeDto>().On<PropertyTypeDto, DataTypeDto>((left, right) => left.DataTypeId == right.NodeId)
-        //        .Where<PropertyDataDto>(x => x.VersionId == versionId);
-        //}
-
-        //private Sql<ISqlContext> GetPropertyData(IEnumerable<int> versionIds)
-        //{
-        //    return Sql()
-        //        .Select<PropertyDataDto>(r => r.Select(x => x.PropertyTypeDto, r1 => r1.Select(x => x.DataTypeDto)))
-        //        .From<PropertyDataDto>()
-        //        .InnerJoin<PropertyTypeDto>().On<PropertyDataDto, PropertyTypeDto>((left, right) => left.PropertyTypeId == right.Id)
-        //        .InnerJoin<DataTypeDto>().On<PropertyTypeDto, DataTypeDto>((left, right) => left.DataTypeId == right.NodeId)
-        //        .WhereIn<PropertyDataDto>(x => x.VersionId, versionIds)
-        //        .OrderBy<PropertyDataDto>(x => x.VersionId);
-        //}
 
         // gets the base SELECT + FROM [+ filter] sql
         // always from the 'current' content version
@@ -582,23 +511,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         #endregion
 
         #region Classes
-
-        //[ExplicitColumns]
-        //internal class UmbracoPropertyDto
-        //{
-        //    [Column("propertyEditorAlias")]
-        //    public string PropertyEditorAlias { get; set; }
-
-        //    [Column("propertyTypeAlias")]
-        //    public string PropertyAlias { get; set; }
-
-        //    [Column("varcharValue")]
-        //    public string VarcharValue { get; set; }
-
-        //    [Column("textValue")]
-        //    public string TextValue { get; set; }
-        //}
-
 
         /// <summary>
         /// The DTO used to fetch results for a content item with its variation info

--- a/src/Umbraco.Core/Services/IEntityService.cs
+++ b/src/Umbraco.Core/Services/IEntityService.cs
@@ -18,24 +18,8 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Gets an entity.
         /// </summary>
-        /// <param name="id">The identifier of the entity.</param>
-        /// <param name="full">A value indicating whether to load a light entity, or the full entity.</param>
-        /// <remarks>Returns either a <see cref="IEntitySlim"/>, or an actual entity, depending on <paramref name="full"/>.</remarks>
-        IUmbracoEntity Get(int id, bool full);
-
-        /// <summary>
-        /// Gets an entity.
-        /// </summary>
         /// <param name="key">The unique key of the entity.</param>
         IEntitySlim Get(Guid key);
-
-        /// <summary>
-        /// Gets an entity.
-        /// </summary>
-        /// <param name="key">The unique key of the entity.</param>
-        /// <param name="full">A value indicating whether to load a light entity, or the full entity.</param>
-        /// <remarks>Returns either a <see cref="IEntitySlim"/>, or an actual entity, depending on <paramref name="full"/>.</remarks>
-        IUmbracoEntity Get(Guid key, bool full);
 
         /// <summary>
         /// Gets an entity.
@@ -43,64 +27,28 @@ namespace Umbraco.Core.Services
         /// <param name="id">The identifier of the entity.</param>
         /// <param name="objectType">The object type of the entity.</param>
         IEntitySlim Get(int id, UmbracoObjectTypes objectType);
-
-        /// <summary>
-        /// Gets an entity.
-        /// </summary>
-        /// <param name="id">The identifier of the entity.</param>
-        /// <param name="objectType">The object type of the entity.</param>
-        /// <param name="full">A value indicating whether to load a light entity, or the full entity.</param>
-        /// <remarks>Returns either a <see cref="IEntitySlim"/>, or an actual entity, depending on <paramref name="full"/>.</remarks>
-        IUmbracoEntity Get(int id, UmbracoObjectTypes objectType, bool full);
-
+        
         /// <summary>
         /// Gets an entity.
         /// </summary>
         /// <param name="key">The unique key of the entity.</param>
         /// <param name="objectType">The object type of the entity.</param>
         IEntitySlim Get(Guid key, UmbracoObjectTypes objectType);
-
-        /// <summary>
-        /// Gets an entity.
-        /// </summary>
-        /// <param name="key">The unique key of the entity.</param>
-        /// <param name="objectType">The object type of the entity.</param>
-        /// <param name="full">A value indicating whether to load a light entity, or the full entity.</param>
-        /// <remarks>Returns either a <see cref="IEntitySlim"/>, or an actual entity, depending on <paramref name="full"/>.</remarks>
-        IUmbracoEntity Get(Guid key, UmbracoObjectTypes objectType, bool full);
-
+        
         /// <summary>
         /// Gets an entity.
         /// </summary>
         /// <typeparam name="T">The type used to determine the object type of the entity.</typeparam>
         /// <param name="id">The identifier of the entity.</param>
         IEntitySlim Get<T>(int id) where T : IUmbracoEntity;
-
-        /// <summary>
-        /// Gets an entity.
-        /// </summary>
-        /// <typeparam name="T">The type used to determine the object type of the entity.</typeparam>
-        /// <param name="id">The identifier of the entity.</param>
-        /// <param name="full">A value indicating whether to load a light entity, or the full entity.</param>
-        /// <remarks>Returns either a <see cref="IEntitySlim"/>, or an actual entity, depending on <paramref name="full"/>.</remarks>
-        IUmbracoEntity Get<T>(int id, bool full) where T : IUmbracoEntity;
-
+        
         /// <summary>
         /// Gets an entity.
         /// </summary>
         /// <typeparam name="T">The type used to determine the object type of the entity.</typeparam>
         /// <param name="key">The unique key of the entity.</param>
         IEntitySlim Get<T>(Guid key) where T : IUmbracoEntity;
-
-        /// <summary>
-        /// Gets an entity.
-        /// </summary>
-        /// <typeparam name="T">The type used to determine the object type of the entity.</typeparam>
-        /// <param name="key">The unique key of the entity.</param>
-        /// <param name="full">A value indicating whether to load a light entity, or the full entity.</param>
-        /// <remarks>Returns either a <see cref="IEntitySlim"/>, or an actual entity, depending on <paramref name="full"/>.</remarks>
-        IUmbracoEntity Get<T>(Guid key, bool full) where T : IUmbracoEntity;
-
+        
         /// <summary>
         /// Determines whether an entity exists.
         /// </summary>

--- a/src/Umbraco.Core/Services/IRelationService.cs
+++ b/src/Umbraco.Core/Services/IRelationService.cs
@@ -142,52 +142,43 @@ namespace Umbraco.Core.Services
         /// Gets the Child object from a Relation as an <see cref="IUmbracoEntity"/>
         /// </summary>
         /// <param name="relation">Relation to retrieve child object from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>An <see cref="IUmbracoEntity"/></returns>
-        IUmbracoEntity GetChildEntityFromRelation(IRelation relation, bool loadBaseType = false);
+        IUmbracoEntity GetChildEntityFromRelation(IRelation relation);
 
         /// <summary>
         /// Gets the Parent object from a Relation as an <see cref="IUmbracoEntity"/>
         /// </summary>
         /// <param name="relation">Relation to retrieve parent object from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>An <see cref="IUmbracoEntity"/></returns>
-        IUmbracoEntity GetParentEntityFromRelation(IRelation relation, bool loadBaseType = false);
+        IUmbracoEntity GetParentEntityFromRelation(IRelation relation);
 
         /// <summary>
         /// Gets the Parent and Child objects from a Relation as a <see cref="Tuple"/>"/> with <see cref="IUmbracoEntity"/>.
         /// </summary>
         /// <param name="relation">Relation to retrieve parent and child object from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>Returns a Tuple with Parent (item1) and Child (item2)</returns>
-        Tuple<IUmbracoEntity, IUmbracoEntity> GetEntitiesFromRelation(IRelation relation, bool loadBaseType = false);
+        Tuple<IUmbracoEntity, IUmbracoEntity> GetEntitiesFromRelation(IRelation relation);
 
         /// <summary>
         /// Gets the Child objects from a list of Relations as a list of <see cref="IUmbracoEntity"/> objects.
         /// </summary>
         /// <param name="relations">List of relations to retrieve child objects from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>An enumerable list of <see cref="IUmbracoEntity"/></returns>
-        IEnumerable<IUmbracoEntity> GetChildEntitiesFromRelations(IEnumerable<IRelation> relations, bool loadBaseType = false);
+        IEnumerable<IUmbracoEntity> GetChildEntitiesFromRelations(IEnumerable<IRelation> relations);
 
         /// <summary>
         /// Gets the Parent objects from a list of Relations as a list of <see cref="IUmbracoEntity"/> objects.
         /// </summary>
         /// <param name="relations">List of relations to retrieve parent objects from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>An enumerable list of <see cref="IUmbracoEntity"/></returns>
-        IEnumerable<IUmbracoEntity> GetParentEntitiesFromRelations(IEnumerable<IRelation> relations,
-                                                                   bool loadBaseType = false);
+        IEnumerable<IUmbracoEntity> GetParentEntitiesFromRelations(IEnumerable<IRelation> relations);
 
         /// <summary>
         /// Gets the Parent and Child objects from a list of Relations as a list of <see cref="IUmbracoEntity"/> objects.
         /// </summary>
         /// <param name="relations">List of relations to retrieve parent and child objects from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>An enumerable list of <see cref="Tuple"/> with <see cref="IUmbracoEntity"/></returns>
-        IEnumerable<Tuple<IUmbracoEntity, IUmbracoEntity>> GetEntitiesFromRelations(
-            IEnumerable<IRelation> relations,
-            bool loadBaseType = false);
+        IEnumerable<Tuple<IUmbracoEntity, IUmbracoEntity>> GetEntitiesFromRelations(IEnumerable<IRelation> relations);
 
         /// <summary>
         /// Relates two objects by their entity Ids.

--- a/src/Umbraco.Core/Services/Implement/EntityService.cs
+++ b/src/Umbraco.Core/Services/Implement/EntityService.cs
@@ -7,11 +7,9 @@ using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Entities;
 using Umbraco.Core.Persistence;
-using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.Dtos;
 using Umbraco.Core.Persistence.Querying;
 using Umbraco.Core.Persistence.Repositories;
-using Umbraco.Core.Persistence.Repositories.Implement;
 using Umbraco.Core.Scoping;
 
 namespace Umbraco.Core.Services.Implement
@@ -275,22 +273,6 @@ namespace Umbraco.Core.Services.Implement
                 return _entityRepository.GetByQuery(query, objectType.GetGuid());
             }
         }
-
-        ///// <summary>
-        ///// Gets a collection of children by the parent's Id and UmbracoObjectType without adding property data
-        ///// </summary>
-        ///// <param name="parentId">Id of the parent to retrieve children for</param>
-        ///// <returns>An enumerable list of <see cref="IUmbracoEntity"/> objects</returns>
-        //internal IEnumerable<IEntitySlim> GetMediaChildrenWithoutPropertyData(int parentId)
-        //{
-        //    using (ScopeProvider.CreateScope(autoComplete: true))
-        //    {
-        //        var query = Query<IUmbracoEntity>().Where(x => x.ParentId == parentId);
-
-        //        // TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-        //        return ((EntityRepository)_entityRepository).GetMediaByQueryWithoutPropertyData(query);
-        //    }
-        //}
 
         /// <inheritdoc />
         public virtual IEnumerable<IEntitySlim> GetDescendants(int id)

--- a/src/Umbraco.Core/Services/Implement/EntityService.cs
+++ b/src/Umbraco.Core/Services/Implement/EntityService.cs
@@ -19,30 +19,25 @@ namespace Umbraco.Core.Services.Implement
     public class EntityService : ScopeRepositoryService, IEntityService
     {
         private readonly IEntityRepository _entityRepository;
-        private readonly Dictionary<string, (UmbracoObjectTypes ObjectType, Func<int, IUmbracoEntity> GetById, Func<Guid, IUmbracoEntity> GetByKey)> _objectTypes;
+        private readonly Dictionary<string, UmbracoObjectTypes> _objectTypes;
         private IQuery<IUmbracoEntity> _queryRootEntity;
         private readonly IdkMap _idkMap;
 
-        public EntityService(IScopeProvider provider, ILogger logger, IEventMessagesFactory eventMessagesFactory,
-           IContentService contentService, IContentTypeService contentTypeService,
-           IMediaService mediaService, IMediaTypeService mediaTypeService,
-           IDataTypeService dataTypeService,
-           IMemberService memberService, IMemberTypeService memberTypeService, IdkMap idkMap,
-           IEntityRepository entityRepository)
+        public EntityService(IScopeProvider provider, ILogger logger, IEventMessagesFactory eventMessagesFactory, IdkMap idkMap, IEntityRepository entityRepository)
             : base(provider, logger, eventMessagesFactory)
         {
             _idkMap = idkMap;
             _entityRepository = entityRepository;
 
-            _objectTypes = new Dictionary<string, (UmbracoObjectTypes, Func<int, IUmbracoEntity>, Func<Guid, IUmbracoEntity>)>
+            _objectTypes = new Dictionary<string, UmbracoObjectTypes>
             {
-                { typeof (IDataType).FullName, (UmbracoObjectTypes.DataType, dataTypeService.GetDataType, dataTypeService.GetDataType) },
-                { typeof (IContent).FullName, (UmbracoObjectTypes.Document, contentService.GetById, contentService.GetById) },
-                { typeof (IContentType).FullName, (UmbracoObjectTypes.DocumentType, contentTypeService.Get, contentTypeService.Get) },
-                { typeof (IMedia).FullName, (UmbracoObjectTypes.Media, mediaService.GetById, mediaService.GetById) },
-                { typeof (IMediaType).FullName, (UmbracoObjectTypes.MediaType, mediaTypeService.Get, mediaTypeService.Get) },
-                { typeof (IMember).FullName, (UmbracoObjectTypes.Member, memberService.GetById, memberService.GetByKey) },
-                { typeof (IMemberType).FullName, (UmbracoObjectTypes.MemberType, memberTypeService.Get, memberTypeService.Get) },
+                { typeof (IDataType).FullName, UmbracoObjectTypes.DataType },
+                { typeof (IContent).FullName, UmbracoObjectTypes.Document },
+                { typeof (IContentType).FullName, UmbracoObjectTypes.DocumentType },
+                { typeof (IMedia).FullName, UmbracoObjectTypes.Media },
+                { typeof (IMediaType).FullName, UmbracoObjectTypes.MediaType },
+                { typeof (IMember).FullName, UmbracoObjectTypes.Member },
+                { typeof (IMemberType).FullName, UmbracoObjectTypes.MemberType },
             };
         }
 
@@ -54,162 +49,68 @@ namespace Umbraco.Core.Services.Implement
 
         #endregion
 
-        // gets the getters, throws if not supported
-        private (UmbracoObjectTypes ObjectType, Func<int, IUmbracoEntity> GetById, Func<Guid, IUmbracoEntity> GetByKey) GetGetters(Type type)
+        // gets the object type, throws if not supported
+        private UmbracoObjectTypes GetObjectType(Type type)
         {
-            if (type?.FullName == null || !_objectTypes.TryGetValue(type.FullName, out var getters))
+            if (type?.FullName == null || !_objectTypes.TryGetValue(type.FullName, out var objType))
                 throw new NotSupportedException($"Type \"{type?.FullName ?? "<null>"}\" is not supported here.");
-            return getters;
+            return objType;
         }
 
         /// <inheritdoc />
         public IEntitySlim Get(int id)
         {
-            return (IEntitySlim) Get(id, false);
-        }
-
-        /// <inheritdoc />
-        public IUmbracoEntity Get(int id, bool full)
-        {
-            if (!full)
+            using (ScopeProvider.CreateScope(autoComplete: true))
             {
-                // get the light entity
-                using (ScopeProvider.CreateScope(autoComplete: true))
-                {
-                    return _entityRepository.Get(id);
-                }
+                return _entityRepository.Get(id);
             }
-
-            // get the full entity
-            var objectType = GetObjectType(id);
-            var entityType = objectType.GetClrType();
-            var getters = GetGetters(entityType);
-            return getters.GetById(id);
         }
 
         /// <inheritdoc />
         public IEntitySlim Get(Guid key)
         {
-            return (IEntitySlim) Get(key, false);
-        }
-
-        /// <inheritdoc />
-        public IUmbracoEntity Get(Guid key, bool full)
-        {
-            if (!full)
+            using (ScopeProvider.CreateScope(autoComplete: true))
             {
-                // get the light entity
-                using (ScopeProvider.CreateScope(autoComplete: true))
-                {
-                    return _entityRepository.Get(key);
-                }
+                return _entityRepository.Get(key);
             }
-
-            // get the full entity
-            var objectType = GetObjectType(key);
-            var entityType = objectType.GetClrType();
-            var getters = GetGetters(entityType);
-            return getters.GetByKey(key);
         }
 
         /// <inheritdoc />
         public virtual IEntitySlim Get(int id, UmbracoObjectTypes objectType)
         {
-            return (IEntitySlim) Get(id, objectType, false);
-        }
-
-        /// <inheritdoc />
-        public virtual IUmbracoEntity Get(int id, UmbracoObjectTypes objectType, bool full)
-        {
-            if (!full)
+            using (ScopeProvider.CreateScope(autoComplete: true))
             {
-                // get the light entity
-                using (ScopeProvider.CreateScope(autoComplete: true))
-                {
-                    return _entityRepository.Get(id, objectType.GetGuid());
-                }
+                return _entityRepository.Get(id, objectType.GetGuid());
             }
-
-            // get the full entity
-            var entityType = objectType.GetClrType();
-            var getters = GetGetters(entityType);
-            return getters.GetById(id);
         }
 
         /// <inheritdoc />
         public IEntitySlim Get(Guid key, UmbracoObjectTypes objectType)
         {
-            return (IEntitySlim) Get(key, objectType, false);
-        }
-
-        /// <inheritdoc />
-        public IUmbracoEntity Get(Guid key, UmbracoObjectTypes objectType, bool full)
-        {
-            if (!full)
+            using (ScopeProvider.CreateScope(autoComplete: true))
             {
-                // get the light entity
-                using (ScopeProvider.CreateScope(autoComplete: true))
-                {
-                    return _entityRepository.Get(key, objectType.GetGuid());
-                }
+                return _entityRepository.Get(key, objectType.GetGuid());
             }
-
-            // get the full entity
-            var entityType = objectType.GetClrType();
-            var getters = GetGetters(entityType);
-            return getters.GetByKey(key);
         }
 
         /// <inheritdoc />
         public virtual IEntitySlim Get<T>(int id)
             where T : IUmbracoEntity
         {
-            return (IEntitySlim) Get<T>(id, false);
-        }
-
-        /// <inheritdoc />
-        public virtual IUmbracoEntity Get<T>(int id, bool full)
-            where T : IUmbracoEntity
-        {
-            if (!full)
+            using (ScopeProvider.CreateScope(autoComplete: true))
             {
-                // get the light entity
-                using (ScopeProvider.CreateScope(autoComplete: true))
-                {
-                    return _entityRepository.Get(id);
-                }
+                return _entityRepository.Get(id);
             }
-
-            // get the full entity
-            var entityType = typeof (T);
-            var getters = GetGetters(entityType);
-            return getters.GetById(id);
         }
 
         /// <inheritdoc />
         public virtual IEntitySlim Get<T>(Guid key)
             where T : IUmbracoEntity
         {
-            return (IEntitySlim) Get<T>(key, false);
-        }
-
-        /// <inheritdoc />
-        public IUmbracoEntity Get<T>(Guid key, bool full)
-            where T : IUmbracoEntity
-        {
-            if (!full)
+            using (ScopeProvider.CreateScope(autoComplete: true))
             {
-                // get the light entity
-                using (ScopeProvider.CreateScope(autoComplete: true))
-                {
-                    return _entityRepository.Get(key);
-                }
+                return _entityRepository.Get(key);
             }
-
-            // get the full entity
-            var entityType = typeof (T);
-            var getters = GetGetters(entityType);
-            return getters.GetByKey(key);
         }
 
         /// <inheritdoc />
@@ -240,8 +141,7 @@ namespace Umbraco.Core.Services.Implement
             where T : IUmbracoEntity
         {
             var entityType = typeof (T);
-            var getters = GetGetters(entityType);
-            var objectType = getters.ObjectType;
+            var objectType = GetObjectType(entityType);
             var objectTypeId = objectType.GetGuid();
 
             using (ScopeProvider.CreateScope(autoComplete: true))
@@ -261,7 +161,7 @@ namespace Umbraco.Core.Services.Implement
             if (entityType == null)
                 throw new NotSupportedException($"Type \"{objectType}\" is not supported here.");
 
-            GetGetters(entityType);
+            GetObjectType(entityType);
 
             using (ScopeProvider.CreateScope(autoComplete: true))
             {
@@ -277,7 +177,7 @@ namespace Umbraco.Core.Services.Implement
         public virtual IEnumerable<IEntitySlim> GetAll(Guid objectType, params int[] ids)
         {
             var entityType = ObjectTypes.GetClrType(objectType);
-            GetGetters(entityType);
+            GetObjectType(entityType);
 
             using (ScopeProvider.CreateScope(autoComplete: true))
             {
@@ -290,8 +190,7 @@ namespace Umbraco.Core.Services.Implement
             where T : IUmbracoEntity
         {
             var entityType = typeof (T);
-            var getters = GetGetters(entityType);
-            var objectType = getters.ObjectType;
+            var objectType = GetObjectType(entityType);
             var objectTypeId = objectType.GetGuid();
 
             using (ScopeProvider.CreateScope(autoComplete: true))
@@ -304,7 +203,7 @@ namespace Umbraco.Core.Services.Implement
         public IEnumerable<IEntitySlim> GetAll(UmbracoObjectTypes objectType, Guid[] keys)
         {
             var entityType = objectType.GetClrType();
-            GetGetters(entityType);
+            GetObjectType(entityType);
 
             using (ScopeProvider.CreateScope(autoComplete: true))
             {
@@ -316,7 +215,7 @@ namespace Umbraco.Core.Services.Implement
         public virtual IEnumerable<IEntitySlim> GetAll(Guid objectType, params Guid[] keys)
         {
             var entityType = ObjectTypes.GetClrType(objectType);
-            GetGetters(entityType);
+            GetObjectType(entityType);
 
             using (ScopeProvider.CreateScope(autoComplete: true))
             {
@@ -377,21 +276,21 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        /// <summary>
-        /// Gets a collection of children by the parent's Id and UmbracoObjectType without adding property data
-        /// </summary>
-        /// <param name="parentId">Id of the parent to retrieve children for</param>
-        /// <returns>An enumerable list of <see cref="IUmbracoEntity"/> objects</returns>
-        internal IEnumerable<IEntitySlim> GetMediaChildrenWithoutPropertyData(int parentId)
-        {
-            using (ScopeProvider.CreateScope(autoComplete: true))
-            {
-                var query = Query<IUmbracoEntity>().Where(x => x.ParentId == parentId);
+        ///// <summary>
+        ///// Gets a collection of children by the parent's Id and UmbracoObjectType without adding property data
+        ///// </summary>
+        ///// <param name="parentId">Id of the parent to retrieve children for</param>
+        ///// <returns>An enumerable list of <see cref="IUmbracoEntity"/> objects</returns>
+        //internal IEnumerable<IEntitySlim> GetMediaChildrenWithoutPropertyData(int parentId)
+        //{
+        //    using (ScopeProvider.CreateScope(autoComplete: true))
+        //    {
+        //        var query = Query<IUmbracoEntity>().Where(x => x.ParentId == parentId);
 
-                // TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
-                return ((EntityRepository)_entityRepository).GetMediaByQueryWithoutPropertyData(query);
-            }
-        }
+        //        // TODO: see https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930 we need to not load any property data at all for media
+        //        return ((EntityRepository)_entityRepository).GetMediaByQueryWithoutPropertyData(query);
+        //    }
+        //}
 
         /// <inheritdoc />
         public virtual IEnumerable<IEntitySlim> GetDescendants(int id)
@@ -578,7 +477,7 @@ namespace Umbraco.Core.Services.Implement
         public virtual IEnumerable<TreeEntityPath> GetAllPaths(UmbracoObjectTypes objectType, params int[] ids)
         {
             var entityType = objectType.GetClrType();
-            GetGetters(entityType);
+            GetObjectType(entityType);
 
             using (ScopeProvider.CreateScope(autoComplete: true))
             {
@@ -590,7 +489,7 @@ namespace Umbraco.Core.Services.Implement
         public virtual IEnumerable<TreeEntityPath> GetAllPaths(UmbracoObjectTypes objectType, params Guid[] keys)
         {
             var entityType = objectType.GetClrType();
-            GetGetters(entityType);
+            GetObjectType(entityType);
 
             using (ScopeProvider.CreateScope(autoComplete: true))
             {

--- a/src/Umbraco.Core/Services/Implement/RelationService.cs
+++ b/src/Umbraco.Core/Services/Implement/RelationService.cs
@@ -285,39 +285,36 @@ namespace Umbraco.Core.Services.Implement
         /// Gets the Child object from a Relation as an <see cref="IUmbracoEntity"/>
         /// </summary>
         /// <param name="relation">Relation to retrieve child object from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>An <see cref="IUmbracoEntity"/></returns>
-        public IUmbracoEntity GetChildEntityFromRelation(IRelation relation, bool loadBaseType = false)
+        public IUmbracoEntity GetChildEntityFromRelation(IRelation relation)
         {
             var objectType = ObjectTypes.GetUmbracoObjectType(relation.RelationType.ChildObjectType);
-            return _entityService.Get(relation.ChildId, objectType, loadBaseType);
+            return _entityService.Get(relation.ChildId, objectType);
         }
 
         /// <summary>
         /// Gets the Parent object from a Relation as an <see cref="IUmbracoEntity"/>
         /// </summary>
         /// <param name="relation">Relation to retrieve parent object from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>An <see cref="IUmbracoEntity"/></returns>
-        public IUmbracoEntity GetParentEntityFromRelation(IRelation relation, bool loadBaseType = false)
+        public IUmbracoEntity GetParentEntityFromRelation(IRelation relation)
         {
             var objectType = ObjectTypes.GetUmbracoObjectType(relation.RelationType.ParentObjectType);
-            return _entityService.Get(relation.ParentId, objectType, loadBaseType);
+            return _entityService.Get(relation.ParentId, objectType);
         }
 
         /// <summary>
         /// Gets the Parent and Child objects from a Relation as a <see cref="Tuple"/>"/> with <see cref="IUmbracoEntity"/>.
         /// </summary>
         /// <param name="relation">Relation to retrieve parent and child object from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>Returns a Tuple with Parent (item1) and Child (item2)</returns>
-        public Tuple<IUmbracoEntity, IUmbracoEntity> GetEntitiesFromRelation(IRelation relation, bool loadBaseType = false)
+        public Tuple<IUmbracoEntity, IUmbracoEntity> GetEntitiesFromRelation(IRelation relation)
         {
             var childObjectType = ObjectTypes.GetUmbracoObjectType(relation.RelationType.ChildObjectType);
             var parentObjectType = ObjectTypes.GetUmbracoObjectType(relation.RelationType.ParentObjectType);
 
-            var child = _entityService.Get(relation.ChildId, childObjectType, loadBaseType);
-            var parent = _entityService.Get(relation.ParentId, parentObjectType, loadBaseType);
+            var child = _entityService.Get(relation.ChildId, childObjectType);
+            var parent = _entityService.Get(relation.ParentId, parentObjectType);
 
             return new Tuple<IUmbracoEntity, IUmbracoEntity>(parent, child);
         }
@@ -326,14 +323,13 @@ namespace Umbraco.Core.Services.Implement
         /// Gets the Child objects from a list of Relations as a list of <see cref="IUmbracoEntity"/> objects.
         /// </summary>
         /// <param name="relations">List of relations to retrieve child objects from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>An enumerable list of <see cref="IUmbracoEntity"/></returns>
-        public IEnumerable<IUmbracoEntity> GetChildEntitiesFromRelations(IEnumerable<IRelation> relations, bool loadBaseType = false)
+        public IEnumerable<IUmbracoEntity> GetChildEntitiesFromRelations(IEnumerable<IRelation> relations)
         {
             foreach (var relation in relations)
             {
                 var objectType = ObjectTypes.GetUmbracoObjectType(relation.RelationType.ChildObjectType);
-                yield return _entityService.Get(relation.ChildId, objectType, loadBaseType);
+                yield return _entityService.Get(relation.ChildId, objectType);
             }
         }
 
@@ -341,14 +337,13 @@ namespace Umbraco.Core.Services.Implement
         /// Gets the Parent objects from a list of Relations as a list of <see cref="IUmbracoEntity"/> objects.
         /// </summary>
         /// <param name="relations">List of relations to retrieve parent objects from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>An enumerable list of <see cref="IUmbracoEntity"/></returns>
-        public IEnumerable<IUmbracoEntity> GetParentEntitiesFromRelations(IEnumerable<IRelation> relations, bool loadBaseType = false)
+        public IEnumerable<IUmbracoEntity> GetParentEntitiesFromRelations(IEnumerable<IRelation> relations)
         {
             foreach (var relation in relations)
             {
                 var objectType = ObjectTypes.GetUmbracoObjectType(relation.RelationType.ParentObjectType);
-                yield return _entityService.Get(relation.ParentId, objectType, loadBaseType);
+                yield return _entityService.Get(relation.ParentId, objectType);
             }
         }
 
@@ -356,17 +351,16 @@ namespace Umbraco.Core.Services.Implement
         /// Gets the Parent and Child objects from a list of Relations as a list of <see cref="IUmbracoEntity"/> objects.
         /// </summary>
         /// <param name="relations">List of relations to retrieve parent and child objects from</param>
-        /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         /// <returns>An enumerable list of <see cref="Tuple"/> with <see cref="IUmbracoEntity"/></returns>
-        public IEnumerable<Tuple<IUmbracoEntity, IUmbracoEntity>> GetEntitiesFromRelations(IEnumerable<IRelation> relations, bool loadBaseType = false)
+        public IEnumerable<Tuple<IUmbracoEntity, IUmbracoEntity>> GetEntitiesFromRelations(IEnumerable<IRelation> relations)
         {
             foreach (var relation in relations)
             {
                 var childObjectType = ObjectTypes.GetUmbracoObjectType(relation.RelationType.ChildObjectType);
                 var parentObjectType = ObjectTypes.GetUmbracoObjectType(relation.RelationType.ParentObjectType);
 
-                var child = _entityService.Get(relation.ChildId, childObjectType, loadBaseType);
-                var parent = _entityService.Get(relation.ParentId, parentObjectType, loadBaseType);
+                var child = _entityService.Get(relation.ChildId, childObjectType);
+                var parent = _entityService.Get(relation.ParentId, parentObjectType);
 
                 yield return new Tuple<IUmbracoEntity, IUmbracoEntity>(parent, child);
             }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -249,6 +249,8 @@
     <Compile Include="Migrations\Upgrade\V_8_1_0\ConvertTinyMceAndGridMediaUrlsToLocalLink.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\FixLanguageIsoCodeLength.cs" />
     <Compile Include="Models\CultureImpact.cs" />
+    <Compile Include="Models\Entities\IMediaEntitySlim.cs" />
+    <Compile Include="Models\Entities\MediaEntitySlim.cs" />
     <Compile Include="Models\PublishedContent\ILivePublishedModelFactory.cs" />
     <Compile Include="Persistence\Dtos\PropertyTypeCommonDto.cs" />
     <Compile Include="Persistence\Repositories\Implement\ContentTypeCommonRepository.cs" />

--- a/src/Umbraco.Tests/Models/LightEntityTest.cs
+++ b/src/Umbraco.Tests/Models/LightEntityTest.cs
@@ -37,9 +37,7 @@ namespace Umbraco.Tests.Models
             };
             item.AdditionalData.Add("test1", 3);
             item.AdditionalData.Add("test2", "valuie");
-            item.AdditionalData.Add("test3", new EntitySlim.PropertySlim("TestPropertyEditor", "test"));
-            item.AdditionalData.Add("test4", new EntitySlim.PropertySlim("TestPropertyEditor2", "test2"));
-
+            
             var result = ss.ToStream(item);
             var json = result.ResultStream.ToJsonString();
             Debug.Print(json); // FIXME: compare with v7

--- a/src/Umbraco.Tests/Services/EntityServiceTests.cs
+++ b/src/Umbraco.Tests/Services/EntityServiceTests.cs
@@ -675,15 +675,10 @@ namespace Umbraco.Tests.Services
 
             foreach (var entity in entities)
             {
-                Console.WriteLine();
-                foreach (var data in entity.AdditionalData)
-                {
-                    Console.WriteLine($"{entity.Id} {data.Key} {data.Value} {(data.Value is EntitySlim.PropertySlim p ? p.PropertyEditorAlias : "")}");
-                }
+                Assert.IsTrue(entity.GetType().Implements<IMediaEntitySlim>());
+                Console.WriteLine(((IMediaEntitySlim)entity).MediaPath);
+                Assert.IsNotEmpty(((IMediaEntitySlim)entity).MediaPath);
             }
-
-            Assert.That(entities.Any(x =>
-                x.AdditionalData.Any(y => y.Value is EntitySlim.PropertySlim && ((EntitySlim.PropertySlim)y.Value).PropertyEditorAlias == Constants.PropertyEditors.Aliases.UploadField)), Is.True);
         }
 
         [Test]

--- a/src/Umbraco.Tests/TestHelpers/TestObjects.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestObjects.cs
@@ -164,11 +164,7 @@ namespace Umbraco.Tests.TestHelpers
             var fileService = GetLazyService<IFileService>(factory, c => new FileService(scopeProvider, logger, eventMessagesFactory, GetRepo<IStylesheetRepository>(c), GetRepo<IScriptRepository>(c), GetRepo<ITemplateRepository>(c), GetRepo<IPartialViewRepository>(c), GetRepo<IPartialViewMacroRepository>(c), GetRepo<IAuditRepository>(c)));
 
             var memberTypeService = GetLazyService<IMemberTypeService>(factory, c => new MemberTypeService(scopeProvider, logger, eventMessagesFactory, memberService.Value, GetRepo<IMemberTypeRepository>(c), GetRepo<IAuditRepository>(c), GetRepo<IEntityRepository>(c)));
-            var entityService = GetLazyService<IEntityService>(factory, c => new EntityService(
-                scopeProvider, logger, eventMessagesFactory,
-                    contentService.Value, contentTypeService.Value, mediaService.Value, mediaTypeService.Value, dataTypeService.Value, memberService.Value, memberTypeService.Value,
-                    idkMap,
-                    GetRepo<IEntityRepository>(c)));
+            var entityService = GetLazyService<IEntityService>(factory, c => new EntityService(scopeProvider, logger, eventMessagesFactory, idkMap, GetRepo<IEntityRepository>(c)));
 
             var macroService = GetLazyService<IMacroService>(factory, c => new MacroService(scopeProvider, logger, eventMessagesFactory, GetRepo<IMacroRepository>(c), GetRepo<IAuditRepository>(c)));
             var packagingService = GetLazyService<IPackagingService>(factory, c =>

--- a/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
@@ -143,27 +143,21 @@ function mediaHelper(umbRequestHelper) {
          */
         resolveFileFromEntity: function (mediaEntity, thumbnail) {
 
-            if (!angular.isObject(mediaEntity.metaData)) {
+            if (!angular.isObject(mediaEntity.metaData) || !mediaEntity.metaData.MediaPath) {
                 throw "Cannot resolve the file url from the mediaEntity, it does not contain the required metaData";
             }
 
-            var values = _.values(mediaEntity.metaData);
-            for (var i = 0; i < values.length; i++) {
-                var val = values[i];
-                if (angular.isObject(val) && val.PropertyEditorAlias) {
-                    for (var resolver in _mediaFileResolvers) {
-                        if (val.PropertyEditorAlias === resolver) {
-                            //we need to format a property variable that coincides with how the property would be structured
-                            // if it came from the mediaResource just to keep things slightly easier for the file resolvers.
-                            var property = { value: val.Value };
-
-                            return _mediaFileResolvers[resolver](property, mediaEntity, thumbnail);
-                        }
-                    }
+            if (thumbnail) {
+                if (this.detectIfImageByExtension(mediaEntity.metaData.MediaPath)) {
+                    return this.getThumbnailFromPath(mediaEntity.metaData.MediaPath);
+                }
+                else {
+                    return null;
                 }
             }
-
-            return "";
+            else {
+                return mediaEntity.metaData.MediaPath;
+            }            
         },
 
         /**

--- a/src/Umbraco.Web/Editors/ImagesController.cs
+++ b/src/Umbraco.Web/Editors/ImagesController.cs
@@ -61,7 +61,7 @@ namespace Umbraco.Web.Editors
             //redirect to ImageProcessor thumbnail with rnd generated from last modified time of original media file
             var response = Request.CreateResponse(HttpStatusCode.Found);
             var imageLastModified = _mediaFileSystem.GetLastModified(imagePath);
-            response.Headers.Location = new Uri($"{imagePath}?rnd={imageLastModified:yyyyMMddHHmmss}&upscale=false&width={width}", UriKind.Relative);
+            response.Headers.Location = new Uri($"{imagePath}?rnd={imageLastModified:yyyyMMddHHmmss}&upscale=false&width={width}&animationprocessmode=first&mode=max", UriKind.Relative);
             return response;
         }
         

--- a/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
@@ -45,6 +45,12 @@ namespace Umbraco.Web.Models.Mapping
             if (source.NodeObjectType == Constants.ObjectTypes.Member && target.Icon.IsNullOrWhiteSpace())
                 target.Icon = "icon-user";
 
+            if (source.NodeObjectType == Constants.ObjectTypes.Media && source is IContentEntitySlim contentSlim)
+                source.AdditionalData["ContentTypeAlias"] = contentSlim.ContentTypeAlias;
+
+            if (source.NodeObjectType == Constants.ObjectTypes.Media && source is IMediaEntitySlim mediaSlim)
+                source.AdditionalData["MediaPath"] = mediaSlim.MediaPath;
+
             // NOTE: we're mapping the objects in AdditionalData by object reference here.
             // it works fine for now, but it's something to keep in mind in the future
             foreach(var kvp in source.AdditionalData)

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -201,9 +201,6 @@ namespace Umbraco.Web.Trees
             return HasPathAccess(entity, queryStrings);
         }
 
-        //internal override IEnumerable<IEntitySlim> GetChildrenFromEntityService(int entityId)
-        //    => Services.EntityService.GetChildren(entityId, UmbracoObjectType).ToList();
-
         protected override IEnumerable<IEntitySlim> GetChildEntities(string id, FormDataCollection queryStrings)
         {
             var result = base.GetChildEntities(id, queryStrings);
@@ -327,7 +324,7 @@ namespace Umbraco.Web.Trees
 
         public IEnumerable<SearchResultEntity> Search(string query, int pageSize, long pageIndex, out long totalFound, string searchFrom = null)
         {
-            return _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Document, pageSize, pageIndex, out totalFound, false, searchFrom);
+            return _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Document, pageSize, pageIndex, out totalFound, searchFrom);
         }
     }
 }

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -201,8 +201,8 @@ namespace Umbraco.Web.Trees
             return HasPathAccess(entity, queryStrings);
         }
 
-        internal override IEnumerable<IEntitySlim> GetChildrenFromEntityService(int entityId)
-            => Services.EntityService.GetChildren(entityId, UmbracoObjectType).ToList();
+        //internal override IEnumerable<IEntitySlim> GetChildrenFromEntityService(int entityId)
+        //    => Services.EntityService.GetChildren(entityId, UmbracoObjectType).ToList();
 
         protected override IEnumerable<IEntitySlim> GetChildEntities(string id, FormDataCollection queryStrings)
         {
@@ -327,7 +327,7 @@ namespace Umbraco.Web.Trees
 
         public IEnumerable<SearchResultEntity> Search(string query, int pageSize, long pageIndex, out long totalFound, string searchFrom = null)
         {
-            return _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Document, pageSize, pageIndex, out totalFound, searchFrom);
+            return _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Document, pageSize, pageIndex, out totalFound, false, searchFrom);
         }
     }
 }

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -214,12 +214,8 @@ namespace Umbraco.Web.Trees
             return result;
         }
 
-        /// <summary>
-        /// Abstract method to fetch the entities from the entity service
-        /// </summary>
-        /// <param name="entityId"></param>
-        /// <returns></returns>
-        internal abstract IEnumerable<IEntitySlim> GetChildrenFromEntityService(int entityId);
+        internal virtual IEnumerable<IEntitySlim> GetChildrenFromEntityService(int entityId)
+            => Services.EntityService.GetChildren(entityId, UmbracoObjectType).ToList();
 
         /// <summary>
         /// Returns true or false if the current user has access to the node based on the user's allowed start node (path) access

--- a/src/Umbraco.Web/Trees/MediaTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTreeController.cs
@@ -164,17 +164,8 @@ namespace Umbraco.Web.Trees
 
         public IEnumerable<SearchResultEntity> Search(string query, int pageSize, long pageIndex, out long totalFound, string searchFrom = null)
         {
-            return _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Media, pageSize, pageIndex, out totalFound, false, searchFrom);
+            return _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Media, pageSize, pageIndex, out totalFound, searchFrom);
         }
 
-        //internal override IEnumerable<IEntitySlim> GetChildrenFromEntityService(int entityId)
-        //    => Services.EntityService.GetChildren(entityId, UmbracoObjectType).ToList();
-
-        //internal override IEnumerable<IEntitySlim> GetChildrenFromEntityService(int entityId)
-        //    // Not pretty having to cast the service, but it is the only way to get to use an internal method that we
-        //    // do not want to make public on the interface. Unfortunately also prevents this from being unit tested.
-        //    // See this issue for details on why we need this:
-        //    // https://github.com/umbraco/Umbraco-CMS/issues/3457
-        //    => ((EntityService)Services.EntityService).GetMediaChildrenWithoutPropertyData(entityId).ToList();        
     }
 }

--- a/src/Umbraco.Web/Trees/MediaTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTreeController.cs
@@ -164,14 +164,17 @@ namespace Umbraco.Web.Trees
 
         public IEnumerable<SearchResultEntity> Search(string query, int pageSize, long pageIndex, out long totalFound, string searchFrom = null)
         {
-            return _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Media, pageSize, pageIndex, out totalFound, searchFrom);
+            return _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Media, pageSize, pageIndex, out totalFound, false, searchFrom);
         }
 
-        internal override IEnumerable<IEntitySlim> GetChildrenFromEntityService(int entityId)
-            // Not pretty having to cast the service, but it is the only way to get to use an internal method that we
-            // do not want to make public on the interface. Unfortunately also prevents this from being unit tested.
-            // See this issue for details on why we need this:
-            // https://github.com/umbraco/Umbraco-CMS/issues/3457
-            => ((EntityService)Services.EntityService).GetMediaChildrenWithoutPropertyData(entityId).ToList();        
+        //internal override IEnumerable<IEntitySlim> GetChildrenFromEntityService(int entityId)
+        //    => Services.EntityService.GetChildren(entityId, UmbracoObjectType).ToList();
+
+        //internal override IEnumerable<IEntitySlim> GetChildrenFromEntityService(int entityId)
+        //    // Not pretty having to cast the service, but it is the only way to get to use an internal method that we
+        //    // do not want to make public on the interface. Unfortunately also prevents this from being unit tested.
+        //    // See this issue for details on why we need this:
+        //    // https://github.com/umbraco/Umbraco-CMS/issues/3457
+        //    => ((EntityService)Services.EntityService).GetMediaChildrenWithoutPropertyData(entityId).ToList();        
     }
 }


### PR DESCRIPTION
Fixes #3498 

Please read notes in the tasks and related links.

The gist is: 

* The EntityService for media was querying all media properties which is slow and shouldn't be done (here's a description of why it was loading in all props: https://github.com/umbraco/Umbraco-CMS/pull/3460#issuecomment-434903930)
* It did this in order to get the media's file path, but we can do this a nicer way by joining the `umbracoMediaVersion` table which contains the media path

So this is all done and tons of code is cleaned up/removed. I'd wager that nobody was ever using the code that was removed. There would be no reason why anyone was using these services and passing in a true value for `loadBaseType` (or `full`). 

The `_mediaFileResolvers` stuff that was mentioned in one of those links still remains and that is fine, they are still used to resolve a media's path based on a full media item (i.e. when you click on a media folder in the media section... that said ... it would be much much faster and better performance to load in all media items and thumbnails when you click on a folder to use the EntityService, something to consider in the future since now it uses the MediaService which is loading in all property data!)

### Testing

* Make sure that the media picker still works and shows a thumbnail
* Make sure that the media grid works and shows thumbnails when you click on a folder in the media tree that contains images
* Make sure unit tests are all passing
* review code