### PR TITLE
V8: Accessibility improvements for textbox validation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -81,6 +81,7 @@
 @import "forms/umb-validation-label.less";
 
 // Umbraco Components
+@import "components/application/umb-app-a11y.less"; 
 @import "components/application/umb-app-header.less";
 @import "components/application/umb-app-content.less";
 @import "components/application/umb-tour.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-a11y.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-a11y.less
@@ -1,0 +1,10 @@
+﻿.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+}

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -26,6 +26,8 @@
                             umb-auto-focus
                             val-server-field="{{serverValidationNameField}}"
                             required
+                            aria-required="true"
+                            aria-invalid="{{contentForm.headerNameForm.headerName.$invalid ? true : false}}"
                             autocomplete="off" maxlength="255" />
                     </ng-form>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
@@ -4,19 +4,24 @@
                class="umb-property-editor umb-textstring textstring"
                val-server="value"
                ng-required="model.validation.mandatory"
+               aria-required="model.validation.mandatory"
+               aria-invalid="False"
                ng-trim="false"
                ng-keyup="model.change()" />
-
-        <span ng-messages="textboxFieldForm.textbox.$error" show-validation-on-submit >
-            <span class="help-inline" ng-message="valServer">{{textboxFieldForm.textbox.errorMsg}}</span>
-            <span class="help-inline" ng-message="required"><localize key="general_required">Required</localize></span>
-        </span>
+        
+        <div ng-messages="textboxFieldForm.textbox.$error" show-validation-on-submit>
+            <p class="sr-only" ng-message="valServer" tabindex="0">{{model.label}} {{textboxFieldForm.textbox.errorMsg}}</p>
+            <p class="help-inline" ng-message="valServer" tabindex="0" aria-hidden="true">{{textboxFieldForm.textbox.errorMsg}}</p>
+            <p class="help-inline" ng-message="required"><localize key="general_required">Required</localize></p>
+        </div>
 
         <div class="help" ng-if="model.count >= (model.config.maxChars*.8) && model.count <= model.config.maxChars">
-            <localize key="textbox_characters_left" tokens="[model.config.maxChars - model.count]" watch-tokens="true">%0% characters left.</localize>
+            <p class="sr-only" tabindex="0">{{model.label}} <localize key="textbox_characters_left" tokens="[model.config.maxChars - model.count]" watch-tokens="true">%0% characters left.</localize></p>
+            <p aria-hidden="True"><localize key="textbox_characters_left" tokens="[model.config.maxChars - model.count]" watch-tokens="true">%0% characters left.</localize></p>
         </div>
         <div class="help text-error" ng-if="model.count > model.config.maxChars">
-            <localize key="textbox_characters_exceed" tokens="[model.config.maxChars, model.count - model.config.maxChars]" watch-tokens="true">Maximum %0% characters, <strong>%1%</strong> too many.</localize>
+            <p class="sr-only" tabindex="0">{{model.label}} <localize key="textbox_characters_exceed" tokens="[model.config.maxChars, model.count - model.config.maxChars]" watch-tokens="true">Maximum %0% characters, <strong>%1%</strong> too many.</localize></p>
+            <p aria-hidden="true"><localize key="textbox_characters_exceed" tokens="[model.config.maxChars, model.count - model.config.maxChars]" watch-tokens="true">Maximum %0% characters, <strong>%1%</strong> too many.</localize></p>
         </div>
 
     </ng-form>


### PR DESCRIPTION
A bug in Angular is triggering "invalid" prompt to be played when a user tabs into an empty text box prior to entering any information, this PR removes that prompt.

On reviewing error messages after saving, it's not possible for a screen reader user to determine what the errors are.  So  this PR also continues to use the sr-only class first introduced in https://github.com/umbraco/Umbraco-CMS/pull/5585 to allow error messages to be styled for users of both screenreaders and browsers.  

Note the sr-only class is deliberately  missing from the required error message, as screen readers hear a textbox is required when they tab into it