### PR TITLE
V8: Make searched media pickable in linkpicker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -373,20 +373,32 @@ angular.module("umbraco")
                 mediaItem.thumbnail = mediaHelper.resolveFileFromEntity(mediaItem, true);
                 mediaItem.image = mediaHelper.resolveFileFromEntity(mediaItem, false);
                 // set properties to match a media object
-                if (mediaItem.metaData &&
-                    mediaItem.metaData.umbracoWidth &&
-                    mediaItem.metaData.umbracoHeight) {
-
-                    mediaItem.properties = [
-                        {
-                            alias: "umbracoWidth",
-                            value: mediaItem.metaData.umbracoWidth.Value
-                        },
-                        {
-                            alias: "umbracoHeight",
-                            value: mediaItem.metaData.umbracoHeight.Value
-                        }
-                    ];
+                if (mediaItem.metaData) {
+                    mediaItem.properties = [];
+                    if (mediaItem.metaData.umbracoWidth && mediaItem.metaData.umbracoHeight) {
+                        mediaItem.properties.push(
+                            {
+                                alias: "umbracoWidth",
+                                editor: mediaItem.metaData.umbracoWidth.PropertyEditorAlias,
+                                value: mediaItem.metaData.umbracoWidth.Value
+                            },
+                            {
+                                alias: "umbracoHeight",
+                                editor: mediaItem.metaData.umbracoHeight.PropertyEditorAlias,
+                                value: mediaItem.metaData.umbracoHeight.Value
+                            }
+                        );
+                    }
+                    if (mediaItem.metaData.umbracoFile) {
+                        // this is required for resolving files through the mediahelper
+                        mediaItem.properties.push(
+                            {
+                                alias: "umbracoFile",
+                                editor: mediaItem.metaData.umbracoFile.PropertyEditorAlias,
+                                value: mediaItem.metaData.umbracoFile.Value
+                            }
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5659

### Description

As described in #5659, when you search for media in the linkpicker, you can't apply any of the search results as link target. See #5659 for further details (and a lovely gif).

This PR fixes the issue. When applied, media search in the linkpicker works as you'd expect:

![link-picker-search-media](https://user-images.githubusercontent.com/7405322/59502027-1b449580-8e9d-11e9-8c09-0ab19075785a.gif)
