### PR TITLE
V8: Resolved issue where adding non-admin user group editor to group already exists

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserGroupRepository.cs
@@ -411,8 +411,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                     return;
 
                 //now the user association
-                RemoveAllUsersFromGroup(entity.UserGroup.Id);
-                AddUsersToGroup(entity.UserGroup.Id, entity.UserIds);
+                RefreshUsersInGroup(entity.UserGroup.Id, entity.UserIds);
             }
 
             protected override void PersistUpdatedItem(UserGroupWithUsers entity)
@@ -424,8 +423,18 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                     return;
 
                 //now the user association
-                RemoveAllUsersFromGroup(entity.UserGroup.Id);
-                AddUsersToGroup(entity.UserGroup.Id, entity.UserIds);
+                RefreshUsersInGroup(entity.UserGroup.Id, entity.UserIds);
+            }
+
+            /// <summary>
+            /// Adds a set of users to a group, first removing any that exist
+            /// </summary>
+            /// <param name="groupId">Id of group</param>
+            /// <param name="userIds">Ids of users</param>
+            private void RefreshUsersInGroup(int groupId, int[] userIds)
+            {
+                RemoveAllUsersFromGroup(groupId);
+                AddUsersToGroup(groupId, userIds);
             }
 
             /// <summary>
@@ -444,7 +453,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             /// <param name="userIds">Ids of users</param>
             private void AddUsersToGroup(int groupId, int[] userIds)
             {
-                // TODO: Check if the user exists?
                 foreach (var userId in userIds)
                 {
                     var dto = new User2UserGroupDto

--- a/src/Umbraco.Web/Editors/UserGroupsController.cs
+++ b/src/Umbraco.Web/Editors/UserGroupsController.cs
@@ -50,13 +50,8 @@ namespace Umbraco.Web.Editors
             if (isAuthorized == false)
                 throw new HttpResponseException(Request.CreateResponse(HttpStatusCode.Unauthorized, isAuthorized.Result));
 
-            //current user needs to be added to a new group if not an admin (possibly only if no other users are added?) to avoid a 401
-            if(!Security.CurrentUser.IsAdmin() && (userGroupSave.Id == null || Convert.ToInt32(userGroupSave.Id) >= 0)/* && !userGroupSave.Users.Any() */)
-            {
-                var userIds = userGroupSave.Users.ToList();
-                userIds.Add(Security.CurrentUser.Id);
-                userGroupSave.Users = userIds;
-            }
+            //need to ensure current user is in a group if not an admin to avoid a 401
+            EnsureNonAdminUserIsInSavedUserGroup(userGroupSave);
 
             //save the group
             Services.UserService.Save(userGroupSave.PersistedUserGroup, userGroupSave.Users.ToArray());
@@ -85,6 +80,23 @@ namespace Umbraco.Web.Editors
 
             display.AddSuccessNotification(Services.TextService.Localize("speechBubbles/operationSavedHeader"), Services.TextService.Localize("speechBubbles/editUserGroupSaved"));
             return display;
+        }
+
+        private void EnsureNonAdminUserIsInSavedUserGroup(UserGroupSave userGroupSave)
+        {
+            if (Security.CurrentUser.IsAdmin())
+            {
+                return;
+            }
+
+            var userIds = userGroupSave.Users.ToList();
+            if (userIds.Contains(Security.CurrentUser.Id))
+            {
+                return;
+            }
+
+            userIds.Add(Security.CurrentUser.Id);
+            userGroupSave.Users = userIds;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #5665 

This issue was relatively easily fixed - there's a step to add the current user into the group but not check that they aren't already there, which then means an attempt is made to save a duplicate to the database that violates the primary key.

Worth a look at these two lines from the original though when reviewing - it didn't quite make sense in that the comment didn't look to match the code in terms of only being an issue for newly created groups, and there was part commented out.  So I've simplified the conditional to only what seems to be necessary:

```
//current user needs to be added to a new group if not an admin (possibly only if no other users are added?) to avoid a 401
if(!Security.CurrentUser.IsAdmin() && (userGroupSave.Id == null || Convert.ToInt32(userGroupSave.Id) >= 0)/* && !userGroupSave.Users.Any() */)
```

Also made a little tidy up to `UserGroupRepository.cs` to remove an unnecessary `TODO` once the methods were refactored to ensure user group/user records were deleted before the new collection added.
