### PR TITLE
Small fixes for backoffice under load.

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -1695,12 +1695,11 @@ namespace Umbraco.Core.Services.Implement
             }
 
             const int pageSize = 500;
-            var page = 0;
             var total = long.MaxValue;
-            while (page * pageSize < total)
+            while (total > 0)
             {
                 //get descendants - ordered from deepest to shallowest
-                var descendants = GetPagedDescendants(content.Id, page, pageSize, out total, ordering: Ordering.By("Path", Direction.Descending));
+                var descendants = GetPagedDescendants(content.Id, 0, pageSize, out total, ordering: Ordering.By("Path", Direction.Descending));
                 foreach (var c in descendants)
                     DoDelete(c);
             }
@@ -1926,11 +1925,10 @@ namespace Umbraco.Core.Services.Implement
             paths[content.Id] = (parent == null ? (parentId == Constants.System.RecycleBinContent ? "-1,-20" : Constants.System.RootString) : parent.Path) + "," + content.Id;
 
             const int pageSize = 500;
-            var page = 0;
             var total = long.MaxValue;
-            while (page * pageSize < total)
+            while (total > 0)
             {
-                var descendants = GetPagedDescendantsLocked(originalPath, page, pageSize, out total, null, Ordering.By("Path", Direction.Ascending));
+                var descendants = GetPagedDescendantsLocked(originalPath, 0, pageSize, out total, null, Ordering.By("Path", Direction.Ascending));
                 foreach (var descendant in descendants)
                 {
                     moves.Add(Tuple.Create(descendant, descendant.Path)); // capture original path

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -1930,7 +1930,7 @@ namespace Umbraco.Core.Services.Implement
             var total = long.MaxValue;
             while (page * pageSize < total)
             {
-                var descendants = GetPagedDescendantsLocked(originalPath, page++, pageSize, out total, null, Ordering.By("Path", Direction.Ascending));
+                var descendants = GetPagedDescendantsLocked(originalPath, page, pageSize, out total, null, Ordering.By("Path", Direction.Ascending));
                 foreach (var descendant in descendants)
                 {
                     moves.Add(Tuple.Create(descendant, descendant.Path)); // capture original path

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -229,11 +229,9 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
             }
 
             /** Method to load in the tree data */
-
             function loadTree() {
-                if (!$scope.loading && $scope.section) {
-                    $scope.loading = true;
-                    
+                if ($scope.section) {
+
                     //default args
                     var args = { section: $scope.section, tree: $scope.treealias, cacheKey: $scope.cachekey, isDialog: $scope.isdialog ? $scope.isdialog : false };
 
@@ -244,20 +242,22 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
 
                     return treeService.getTree(args)
                         .then(function (data) {
-
+                            //Only use the tree data, if we are still on the correct section
+                            if(data.alias !==  $scope.section){
+                                return $q.reject();
+                            }
+                            
                             //set the data once we have it
                             $scope.tree = data;
-
-                            $scope.loading = false;
 
                             //set the root as the current active tree
                             $scope.activeTree = $scope.tree.root;
 
                             emitEvent("treeLoaded", { tree: $scope.tree });
                             emitEvent("treeNodeExpanded", { tree: $scope.tree, node: $scope.tree.root, children: $scope.tree.root.children });
+                         
                             return $q.when(data);
                         }, function (reason) {
-                            $scope.loading = false;
                             notificationsService.error("Tree Error", reason);
                             return $q.reject(reason);
                         });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -243,7 +243,7 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
                     return treeService.getTree(args)
                         .then(function (data) {
                             //Only use the tree data, if we are still on the correct section
-                            if(data.alias !==  $scope.section){
+                            if(data.alias !== $scope.section){
                                 return $q.reject();
                             }
                             


### PR DESCRIPTION
Bugfix: When trashing an content with more than 500 descendants, there was a leak of non-trashed items. This lead to a issue when trying to delete this item from the recycle-bin, because of `Same Table References`

Fixes: https://umbraco.visualstudio.com/D-Team%20Tracker/_workitems/edit/1362

UI improvement: When navigating the sections faster then the response of then tree, the user could end up in a situation where the wrong tree was loaded for the section.

Fixes: https://umbraco.visualstudio.com/D-Team%20Tracker/_workitems/edit/1357
