### PR TITLE
V8: Don't explicitly allow deleting the current editor's own content

### DIFF
--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -411,18 +411,7 @@ namespace Umbraco.Web.Trees
         internal IEnumerable<MenuItem> GetAllowedUserMenuItemsForNode(IUmbracoEntity dd)
         {
             var permission = Services.UserService.GetPermissions(Security.CurrentUser, dd.Path);
-            // TODO: inject
-            var actions = Current.Actions.FromEntityPermission(permission)
-                .ToList();
-
-            var actionDelete = Current.Actions.GetAction<ActionDelete>();
-
-            // A user is allowed to delete their own stuff
-            var tryGetCurrentUserId = Security.GetUserId();
-            if (tryGetCurrentUserId && dd.CreatorId == tryGetCurrentUserId.Result && actions.Contains(actionDelete) == false)
-                actions.Add(actionDelete);
-
-            return actions.Select(x => new MenuItem(x));
+            return Current.Actions.FromEntityPermission(permission).Select(x => new MenuItem(x));
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5675

### Description

#5675 explains the issue in detail; basically UI currently *always* give the editors the "Delete" option for content they have created, despite what permissions are set on said content. The "Delete" option doesn't work, though, if the editor is not allowed to delete the content.

This PR ensures that the "Delete" option is only present if the current editor is actually allowed to delete the content; when applied it looks like this:

![do-not-delete-own-content](https://user-images.githubusercontent.com/7405322/59712610-dce90680-920d-11e9-8339-02d3c1b3805e.gif)

#### Testing this PR

1. Create some content.
2. Make sure you're allowed to delete it (but don't!).
3. Using the permissions dialog, remove "Delete" permissions for your current user group on the content.
4. Verify that the content is no longer delete-able.

*Note:* There seems to be a UI glitch in the permissions dialog for assigned permissions; you can't really edit or remove them I'm working on it 😄 there will be a separate PR for it.