### PR TITLE
V8: Fix overflow for specific node permissions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-group-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-group-preview.less
@@ -34,9 +34,13 @@
     margin-top: 2px;
 }
 
-.umb-user-group-preview__permission {
+.umb-user-group-preview__permissions {
     font-size: 13px;
     color: @gray-3;
+
+    .umb-user-group-preview__permission:not(:last-child):after {
+        content: ', ';
+    }
 }
 
 .umb-user-group-preview__actions {

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
@@ -5,10 +5,10 @@
         <div class="umb-node-preview__name" ng-attr-title="{{alias}}">{{ name }}</div>
         <div class="umb-node-preview__description" ng-if="description">{{ description }}</div>
 
-        <div class="umb-user-group-preview__permission" ng-if="permissions">
+        <div class="umb-user-group-preview__permissions" ng-if="permissions">
             <span>
                 <span class="bold"><localize key="general_rights">Permissions</localize>:</span>
-                <span ng-repeat="permission in permissions">{{ permission.name }}<span ng-if="!$last">, </span></span>
+                <span ng-repeat="permission in permissions" class="umb-user-group-preview__permission">{{ permission.name }}</span>
             </span>
         </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/users/umb-user-group-preview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/users/umb-user-group-preview.html
@@ -5,15 +5,15 @@
     <div class="umb-user-group-preview__content">
         <div class="umb-user-group-preview__name">{{ name }}</div>
 
-        <div class="umb-user-group-preview__permission" ng-if="sections">
+        <div class="umb-user-group-preview__permissions" ng-if="sections">
             <span>
                 <span class="bold"><localize key="main_sections">Sections</localize>:</span>
-                <span ng-repeat="section in sections">{{ section.name }}<span ng-if="!$last">, </span></span>
+                <span ng-repeat="section in sections" class="umb-user-group-preview__permission">{{ section.name }}</span>
                 <span ng-if="sections.length === 0">All sections</span>
             </span>
         </div>
 
-        <div class="umb-user-group-preview__permission" ng-if="!hideContentStartNode">
+        <div class="umb-user-group-preview__permissions" ng-if="!hideContentStartNode">
             <span>
                 <span class="bold"><localize key="user_startnode">Content start node</localize>:</span>
                 <span ng-if="!contentStartNode"><localize key="user_noStartNode">No start node selected</localize></span>
@@ -21,7 +21,7 @@
             </span>
         </div>
         
-        <div class="umb-user-group-preview__permission" ng-if="!hideMediaStartNode">
+        <div class="umb-user-group-preview__permissions" ng-if="!hideMediaStartNode">
             <span>
                 <span class="bold"><localize key="user_mediastartnode">Media start node</localize>:</span>
                 <span ng-if="!mediaStartNode"><localize key="user_noStartNode">No start node selected</localize></span>
@@ -29,10 +29,10 @@
             </span>
         </div>
 
-        <div class="umb-user-group-preview__permission" ng-if="permissions">
+        <div class="umb-user-group-preview__permissions" ng-if="permissions">
             <span>
                 <span class="bold"><localize key="general_rights">Permissions</localize>:</span>
-                <span ng-repeat="permission in permissions">{{ permission.name }}<span ng-if="!$last">, </span></span>
+                <span ng-repeat="permission in permissions" class="umb-user-group-preview__permission">{{ permission.name }}</span>
             </span>
         </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When applying node specific permissions, the list of applied permissions fail to wrap around; for some reason the whitespaces between the individual permissions are ignored by the browser. This means that the Edit and Remove actions are pushed out of the dialog if the list of permissions is too long:

![image](https://user-images.githubusercontent.com/7405322/59740109-5f51e480-9267-11e9-868e-24fdc49933ae.png)

Less obvious, but equally faulty is the list of "Granular permissions" on group level:

![image](https://user-images.githubusercontent.com/7405322/59740059-3cbfcb80-9267-11e9-881c-d9acd37ba744.png)

This PR fixes it by applying the whitespace in CSS rather than in AngularJS rendering logic:

![image](https://user-images.githubusercontent.com/7405322/59739703-f87ffb80-9265-11e9-8c8e-731748d40f03.png)

..and on the group level:

![image](https://user-images.githubusercontent.com/7405322/59740167-945e3700-9267-11e9-9319-9925a60a3988.png)
