### PR TITLE
V8: Fix confirmation for permissions dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.rights.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.rights.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function ContentRightsController($scope, $timeout, contentResource, localizationService, angularHelper, navigationService) {
+    function ContentRightsController($scope, $timeout, contentResource, localizationService, angularHelper, navigationService, overlayService) {
 
         var vm = this;
         var currentForm;
@@ -11,7 +11,6 @@
         vm.removedUserGroups = [];
         vm.viewState = "manageGroups";
         vm.labels = {};
-        vm.showNotification = false;
         
         vm.setViewSate = setViewSate;
         vm.editPermissions = editPermissions;
@@ -20,7 +19,6 @@
         vm.removePermissions = removePermissions;
         vm.cancelManagePermissions = cancelManagePermissions;
         vm.closeDialog = closeDialog;
-        vm.stay = stay;
         vm.discardChanges = discardChanges;
 
         function onInit() {
@@ -164,14 +162,31 @@
             });
         }
 
-        function stay() {
-          vm.showNotification = false;
-        }
-
         function closeDialog() {
           // check if form has been changed. If it has show discard changes notification
           if (currentForm && currentForm.$dirty) {
-            vm.showNotification = true;
+              localizationService.localizeMany(["prompt_unsavedChanges", "prompt_unsavedChangesWarning", "prompt_discardChanges", "prompt_stay"]).then(
+                  function(values) {
+                      var overlay = {
+                          "view": "default",
+                          "title": values[0],
+                          "content": values[1],
+                          "disableBackdropClick": true,
+                          "disableEscKey": true,
+                          "submitButtonLabel": values[2],
+                          "closeButtonLabel": values[3],
+                          submit: function () {
+                              overlayService.close();
+                              navigationService.hideDialog();
+                          },
+                          close: function () {
+                              overlayService.close();
+                          }
+                      };
+
+                      overlayService.open(overlay);
+                  }
+              );
           } else {
             navigationService.hideDialog();
           }

--- a/src/Umbraco.Web.UI.Client/src/views/content/rights.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/rights.html
@@ -62,24 +62,6 @@
                         </umb-user-group-preview>
                     </div>
         
-                    <div class="umb-notifications" style="bottom: 0;" ng-if="vm.showNotification">
-                        <div class="umb-notification alert alert-block alert-form umb-notifications__notification animated -half-second fadeIn -no-border -extra-padding">
-                            <h4 style="font-size: 16px;"><localize key="prompt_unsavedChanges"></localize></h4>
-                            <p style="line-height: 1.6em; margin-bottom: 10px;"><localize key="prompt_unsavedChangesWarning"></localize></p>
-                            <umb-button
-                                label-key="prompt_discardChanges"
-                                action="vm.discardChanges();"
-                                type="button">
-                            </umb-button>
-                            <umb-button
-                                label-key="prompt_stay"
-                                action="vm.stay()"
-                                type="button"
-                                button-style="action">
-                            </umb-button>
-                        </div>
-                    </div>
-
                 </form>
 
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The content permissions dialog has an "unsaved changes" confirmation feature, if you navigate away without saving the configured permissions. It's a bit unorthodox for dialogs, but I guess it makes sense as there is (potentially) a lot of configuration involved.

However... the confirmation looks really really funny 🤣 

![set-permission-confirmation-before](https://user-images.githubusercontent.com/7405322/59757175-773b5f80-928b-11e9-96c2-dfd1b4fc6e9c.gif)

This PR fixes the confirmation dialog. When applied it looks like this:

![set-permission-confirmation-after](https://user-images.githubusercontent.com/7405322/59757193-83bfb800-928b-11e9-8aed-0e8197b8c698.gif)
