### PR TITLE
Fix JS error that arises when you select any node with the link picker 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -81,7 +81,7 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
 
                     contentResource.getById(id, options).then(function (resp) {
                         $scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
-                        $scope.model.target.url = resp.urls[0].text;
+                        $scope.model.target.url = resp.urls.filter(item => item.culture === $scope.$parent.selectedLanguage.culture)[0].text;
                     });
                 }
             } else if ($scope.model.target.url.length) {
@@ -135,7 +135,7 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
 
                 contentResource.getById(args.node.id, options).then(function (resp) {
                     $scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
-                    $scope.model.target.url = resp.urls[0].text;
+                    $scope.model.target.url = resp.urls.filter(item => item.culture === $scope.$parent.selectedLanguage.culture)[0].text;
                 });
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -1,7 +1,7 @@
 //used for the media picker dialog
 angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
-    function ($scope, eventsService, entityResource, contentResource, mediaHelper, userService, localizationService, tinyMceService, editorService) {
-        
+    function ($routeParams, $scope, eventsService, entityResource, contentResource, mediaHelper, userService, localizationService, tinyMceService, editorService) {
+        var currentCulture = $routeParams.cculture ? $routeParams.cculture : null;
         var vm = this;
         var dialogOptions = $scope.model;
 
@@ -81,7 +81,18 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
 
                     contentResource.getById(id, options).then(function (resp) {
                         $scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
-                        $scope.model.target.url = resp.urls.filter(item => item.culture === $scope.$parent.selectedLanguage.culture)[0].text;
+                        if (currentCulture != null) {
+                            if (resp.urls.filter(item => item.culture === currentCulture).length != 0) {
+                                $scope.model.target.url = resp.urls.filter(item => item.culture === currentCulture)[0].text;
+                            }
+                            else {
+                                // this node does not exist in the current language - should be handled in the search box
+                                $scope.model.target.url = "#";
+                            }
+                        }
+                        else {
+                            $scope.model.target.url = resp.urls[0].text;
+                        }
                     });
                 }
             } else if ($scope.model.target.url.length) {
@@ -135,7 +146,18 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
 
                 contentResource.getById(args.node.id, options).then(function (resp) {
                     $scope.anchorValues = tinyMceService.getAnchorNames(JSON.stringify(resp.properties));
-                    $scope.model.target.url = resp.urls.filter(item => item.culture === $scope.$parent.selectedLanguage.culture)[0].text;
+                    if (currentCulture != null) {
+                        if (resp.urls.filter(item => item.culture === currentCulture).length != 0) {
+                            $scope.model.target.url = resp.urls.filter(item => item.culture === currentCulture)[0].text;
+                        }
+                        else {
+                            // this node does not exist in the current language - should be handled in the search box
+                            $scope.model.target.url = "#";
+                        }
+                    }
+                    else {
+                        $scope.model.target.url = resp.urls[0].text;
+                    }
                 });
             }
 


### PR DESCRIPTION
Hi,

This is a bugfix regarding the following issue: https://github.com/umbraco/Umbraco-CMS/issues/5689
It fixes a previous PR I have made which was causing JS error when you use the search box of the Link Picker.

With this code the user can select any node with the link picker and we should not get any JS error.
The selected node link should also be displayed in the right language.

The only problem is when the user type something in the search box of the link picker.
The result of the searchbox is always displayed in the main culture.

For example, my website has fr-CH as main culture and I am editing an EN page:
![image](https://user-images.githubusercontent.com/44721265/59771270-a95bba00-92a9-11e9-98a7-81587c4e76db.png)

In the search result we have the fr-CH nodes displayed instead of the EN: 
![image](https://user-images.githubusercontent.com/44721265/59771312-c09aa780-92a9-11e9-9c14-192076c34a6e.png)

With this fix the selected node is right one:
![image](https://user-images.githubusercontent.com/44721265/59771363-d6a86800-92a9-11e9-9359-b15dfad469cd.png)

If this node is not available in the current language (EN in this example), a dash is set for the link:
![image](https://user-images.githubusercontent.com/44721265/59771474-0e171480-92aa-11e9-8a9e-97f36e85b28f.png)

I am not very happy with this solution, it works fine if you do not use the search.

It would be better to display the right language in the search result.
Unfortunately I did not find how to change the search mechanic, I am not an Umbraco expert ;)

