### PR TITLE
V8: Fix "comma-dangle" gulp build error (editorstate.service.js)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editorstate.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editorstate.service.js
@@ -63,7 +63,7 @@ angular.module('umbraco.services').factory("editorState", function ($rootScope) 
          */
         getCurrent: function () {
             return current;
-        },
+        }
 
     };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

88d9e332 left behind a "dangling comma" in editorstate.service.js, which leads to the following gulp build error:

![image](https://user-images.githubusercontent.com/7405322/59784036-ce5c2700-92c1-11e9-9051-267159a608b6.png)

The build does seem to succeed, but the error isn't too pretty 😄 

This PR removes the offending comma. Possibly the smallest PR ever!