### PR TITLE
Style nested content item for umbracoNaviHide

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -109,6 +109,15 @@
     }
 }
 
+.umb-nested-content__item--disabled:not(.umb-nested-content__item--active) {
+    & > .umb-nested-content__header-bar {
+        .umb-nested-content__heading {
+            &, &:hover {
+                color: @grayLight;
+            }
+        }
+    }
+}
 
 
 .umb-nested-content__header-bar:hover .umb-nested-content__icons,

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -87,14 +87,13 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
     "$scope",
     "$interpolate",
     "$filter",
-    "$timeout",
     "contentResource",
     "localizationService",
     "iconHelper",
     "clipboardService",
     "eventsService",
     
-    function ($scope, $interpolate, $filter, $timeout, contentResource, localizationService, iconHelper, clipboardService, eventsService) {
+    function ($scope, $interpolate, $filter, contentResource, localizationService, iconHelper, clipboardService, eventsService) {
         
         var contentTypeAliases = [];
         _.each($scope.model.config.contentTypes, function (contentType) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -249,6 +249,14 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             }
         };
 
+        $scope.isVisible = function (idx) {
+
+            var umbNaviHide = "umbracoNaviHide";
+            var item = $scope.model.value[idx];
+
+            return item && item.hasOwnProperty(umbNaviHide) && item[umbNaviHide] === "1";
+        };
+
         $scope.getName = function (idx) {
 
             var name = "";
@@ -301,7 +309,8 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
         $scope.getIcon = function (idx) {
             var scaffold = $scope.getScaffold($scope.model.value[idx].ncContentTypeAlias);
             return scaffold && scaffold.icon ? iconHelper.convertFromLegacyIcon(scaffold.icon) : "icon-folder";
-        }
+        };
+
         $scope.sortableOptions = {
             axis: "y",
             cursor: "move",
@@ -340,13 +349,13 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             return _.find($scope.scaffolds, function (scaffold) {
                 return scaffold.contentTypeAlias === alias;
             });
-        }
+        };
 
         $scope.getContentTypeConfig = function (alias) {
             return _.find($scope.model.config.contentTypes, function (contentType) {
                 return contentType.ncAlias === alias;
             });
-        }
+        };
         
         $scope.showCopy = clipboardService.isSupported();
         
@@ -360,21 +369,21 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             $event.stopPropagation();
         }
         
-        $scope.pasteFromClipboard = function(newNode) {
-            
+        $scope.pasteFromClipboard = function (newNode) {
+
             if (newNode === undefined) {
                 return;
             }
-            
+
             // generate a new key.
             newNode.key = String.CreateGuid();
-            
+
             $scope.nodes.push(newNode);
             $scope.setDirty();
             //updateModel();// done by setting current node...
-            
+
             $scope.currentNode = newNode;
-        }
+        };
         
         function checkAbilityToPasteContent() {
             $scope.showPaste = clipboardService.hasEntriesOfType("elementType", contentTypeAliases);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -8,7 +8,7 @@
 
         <div class="umb-nested-content__items" ng-hide="nodes.length === 0" ui-sortable="sortableOptions" ng-model="nodes">
 
-            <div class="umb-nested-content__item" ng-repeat="node in nodes" ng-class="{ 'umb-nested-content__item--active' : $parent.realCurrentNode.key === node.key, 'umb-nested-content__item--single' : $parent.singleMode }">
+            <div class="umb-nested-content__item" ng-repeat="node in nodes" ng-class="{ 'umb-nested-content__item--active' : $parent.realCurrentNode.key === node.key, 'umb-nested-content__item--single' : $parent.singleMode, 'umb-nested-content__item--disabled' : $parent.isVisible($index) }">
 
                 <div class="umb-nested-content__header-bar" ng-click="$parent.editNode($index)" ng-hide="$parent.singleMode">
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add a class to nested content item, when the nested content element has a property `umbracoNaviHide` and the value is "1" (true).

It makes it easier for editors to see when nested content items is disabled (similar to when nodes are unpublished).

In starterkit check this on features for a product, e.g. "Biker Jacket".

![2019-06-20_00-37-06](https://user-images.githubusercontent.com/2919859/59806182-ca48fd00-92f3-11e9-9b70-5982a700bf35.gif)
