### PR TITLE
V8: Set focus on "Mandatory" after picking a property type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -91,6 +91,7 @@
                             <umb-toggle data-element="validation_mandatory"
                                         checked="model.property.validation.mandatory"
                                         on-click="vm.toggleValidation()"
+                                        focus-when="{{vm.focusOnMandatoryField}}"
                             >
                             </umb-toggle>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It used to be so you tab your way through property creation on the content type builder. Somewhere along the line this got broken; the "property settings" dialog looses tab focus after picking the property datatype. Leftovers of the original focus handling remains in the code, though, so this PR simply re-applies the old solution from V7.

Here's how it all works when the PR is applied: 

![create-property-focus-after-datatype-select](https://user-images.githubusercontent.com/7405322/59939893-807a2700-9459-11e9-881c-0e18b6056727.gif)
