### PR TITLE
V8: Don't prompt to discard changes when there are none

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -474,6 +474,11 @@
         if (!property.inherited) {
 
           var oldPropertyModel = angular.copy(property);
+          if (oldPropertyModel.allowCultureVariant === undefined) {
+            // this is necessary for comparison when detecting changes to the property
+            oldPropertyModel.allowCultureVariant = scope.model.allowCultureVariant;
+            oldPropertyModel.alias = "";
+          }
           var propertyModel = angular.copy(property);
 
           var propertySettings = {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Someone (ahem... yours truly) rewrote something at some point, which introduced a prompt to keep or discard changes when editing properties. Apparently said someone didn't test what happens if you click to add a new property, and then close the property settings dialog it without making any changes:

![create-new-property-warning-before](https://user-images.githubusercontent.com/7405322/59940957-668e1380-945c-11e9-9816-c2552d40c01c.gif)

This PR fixes it right up:

![create-new-property-warning-after](https://user-images.githubusercontent.com/7405322/59941022-8cb3b380-945c-11e9-8c03-5b8bac19f739.gif)
