### PR TITLE
V8: Accessibility improvements: Screen Reader Prerequisites

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/accessibility/sr-only.less
+++ b/src/Umbraco.Web.UI.Client/src/less/accessibility/sr-only.less
@@ -1,0 +1,12 @@
+﻿// sr-only - based on the boot strap naming conventions used to remove an element from the view, whilst retaining accessibily for screen readers. More info available at https://getbootstrap.com/docs/4.0/utilities/screenreaders/
+// --------------------------------------------------
+sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+}

--- a/src/Umbraco.Web.UI.Client/src/less/accessibility/visually-hidden.less
+++ b/src/Umbraco.Web.UI.Client/src/less/accessibility/visually-hidden.less
@@ -1,0 +1,9 @@
+﻿// Visually Hidden - used to remove an element from the view, whilst retaining accessibily for screen readers. More info available at https://a11yproject.com/posts/how-to-hide-content/
+// --------------------------------------------------
+.visually-hidden {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
+}

--- a/src/Umbraco.Web.UI.Client/src/less/accessibility/visually-hidden.less
+++ b/src/Umbraco.Web.UI.Client/src/less/accessibility/visually-hidden.less
@@ -1,9 +1,0 @@
-﻿// Visually Hidden - used to remove an element from the view, whilst retaining accessibily for screen readers. More info available at https://a11yproject.com/posts/how-to-hide-content/
-// --------------------------------------------------
-.visually-hidden {
-    position: absolute !important;
-    height: 1px;
-    width: 1px;
-    overflow: hidden;
-    clip: rect(1px, 1px, 1px, 1px);
-}

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -80,6 +80,9 @@
 
 @import "forms/umb-validation-label.less";
 
+// Umbraco Accessibility
+@import "accessibility/visually-hidden.less";
+
 // Umbraco Components
 @import "components/application/umb-app-header.less";
 @import "components/application/umb-app-content.less";

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -81,7 +81,7 @@
 @import "forms/umb-validation-label.less";
 
 // Umbraco Accessibility
-@import "accessibility/visually-hidden.less";
+@import "accessibility/sr-only.less";
 
 // Umbraco Components
 @import "components/application/umb-app-header.less";


### PR DESCRIPTION
A number of accessibility issues have been identified in  #5277.  
Many of the fixes require a class which supports hidden text for screen readers.

The aim of this PR is to start to build the css elements which the screen readers will require.

A number of PRs have already been submitted which require a screen reader only class #5544, #5585 and #5664

Following a review of #5664 we identified the need to submit an individual PR for a screen reader only class.  The aim of this PR is to allow the class to be pulled into `belle.less`  independently of the other PRs allowing the accessibility work to continue whilst the other PRs are reviewed.