### PR TITLE
Highlight when tabbing to umb-toggle

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -21,23 +21,23 @@
     background-color: @inputBorder;
     position: relative;
     transition: background-color 120ms;
-    
-    .umb-toggle:hover &, 
+
+    .umb-toggle:hover &,
     .umb-toggle:focus & {
         border-color: @inputBorderFocus;
     }
-    
+
     .umb-toggle.umb-toggle--checked & {
         border-color: @ui-btn;
         background-color: @ui-btn;
-        
+
         &:hover {
             background-color: @ui-btn-hover;
         }
     }
-    
-    .umb-toggle.umb-toggle--checked:focus & {
-        border-color: black;
+
+    .tabbing-active .umb-toggle:focus & {
+        box-shadow: 0 0 0 2px highlight;
     }
 }
 
@@ -54,12 +54,12 @@
     background-color: @white;
     border-radius: 8px;
     transition: transform 120ms ease-in-out, background-color 120ms;
-    
+
     .umb-toggle.umb-toggle--checked & {
         transform: translateX(20px);
         background-color: white;
     }
-    
+
 }
 
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5277 (Possibly part of)

### Description

It is very vague when tabbing to a toggle component (on/off) to see it was selected. Very contradictive to tab-outlines of other components.

Fixed by hooking in the same active-tabbing state as other components

![umbraco toggle highlight](https://user-images.githubusercontent.com/507992/60043385-3e065380-96c0-11e9-9be7-0031b2358100.gif)
