### PR TITLE
Show the list view paging component even when there are less than 10 pages

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbpagination.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbpagination.directive.js
@@ -140,10 +140,9 @@ Use this directive to generate a pagination.
                         tempPagination.push({ val: "...", isActive: false }, { name: lastLabel, val: scope.totalPages, isActive: false });
                     });
                 }
-
-                scope.pagination = tempPagination;
             }
 
+            scope.pagination = tempPagination;
          }
 
          scope.next = function () {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Looks like d52f6b58 introduced a slight bug; list views with less than 10 result pages no longer have the paging component displayed 😄 

![image](https://user-images.githubusercontent.com/7405322/60043891-70648080-96c1-11e9-8b03-32378dac8d2a.png)

This PR fixes it; when applied the list view paging works as you'd expect for both large and small result sets:

![image](https://user-images.githubusercontent.com/7405322/60043733-0a77f900-96c1-11e9-83b8-e1c183bafc5a.png)
