### PR TITLE
Reduce size of LocalizedText output.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -14,6 +14,12 @@
  */
 function contentPickerController($scope, entityResource, editorState, iconHelper, $routeParams, angularHelper, navigationService, $location, localizationService, editorService, $q) {
 
+    var vm = {
+        labels: {
+            general_recycleBin: ""
+        }
+    };
+
     var unsubscribe;
 
     function subscribe() {
@@ -405,7 +411,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
                 angular.forEach($scope.renderModel, function (item) {
                     if (item.id === entity.id) {
                         if (entity.trashed) {
-                            item.url = localizationService.dictionary.general_recycleBin;
+                            item.url = vm.labels.general_recycleBin;
                         } else {
                             item.url = data;
                         }
@@ -463,12 +469,17 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     }
 
     function init() {
-        syncRenderModel(false).then(function () {
-            //everything is loaded, start the watch on the model
-            startWatch();
-            subscribe();
-            validate();
-        });
+        localizationService.localizeMany(["general_recycleBin"])
+            .then(function(data) {
+                vm.labels.general_recycleBin = data[0];
+
+                syncRenderModel(false).then(function () {
+                    //everything is loaded, start the watch on the model
+                    startWatch();
+                    subscribe();
+                    validate();
+                });
+            });
     }
 
     init();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -920,11 +920,9 @@ angular.module("umbraco")
                 //Localize the grid editor names
                 angular.forEach($scope.availableEditors, function (value, key) {
                     //If no translation is provided, keep using the editor name from the manifest
-                    if (localizationService.dictionary.hasOwnProperty("grid_" + value.alias)) {
-                        localizationService.localize("grid_" + value.alias).then(function (v) {
-                            value.name = v;
-                        });
-                    }
+                    localizationService.localize("grid_" + value.alias, undefined, value.name).then(function (v) {
+                        value.name = v;
+                    });
                 });
 
                 $scope.contentReady = true;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -3,6 +3,12 @@
 angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerController",
     function ($scope, entityResource, mediaHelper, $timeout, userService, localizationService, editorService) {
 
+        var vm = {
+            labels: {
+                 mediaPicker_deletedItem: ""
+            }
+        }
+
         //check the pre-values for multi-picker
         var multiPicker = $scope.model.config.multiPicker && $scope.model.config.multiPicker !== '0' ? true : false;
         var onlyImages = $scope.model.config.onlyImages && $scope.model.config.onlyImages !== '0' ? true : false;
@@ -50,7 +56,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                                 return found;
                             } else {
                                 return {
-                                    name: localizationService.dictionary.mediaPicker_deletedItem,
+                                    name: vm.labels.mediaPicker_deletedItem,
                                     id: $scope.model.config.idType !== "udi" ? id : null,
                                     udi: $scope.model.config.idType === "udi" ? id : null,
                                     icon: "icon-picture",
@@ -106,27 +112,31 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
 
         function init() {
 
-            userService.getCurrentUser().then(function (userData) {
-                if (!$scope.model.config.startNodeId) {
-                    $scope.model.config.startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
-                    $scope.model.config.startNodeIsVirtual = userData.startMediaIds.length !== 1;
-                }
-                // only allow users to add and edit media if they have access to the media section
-                var hasAccessToMedia = userData.allowedSections.indexOf("media") !== -1;
-                $scope.allowEditMedia = hasAccessToMedia;
-                $scope.allowAddMedia = hasAccessToMedia;
+            localizationService.localizeMany(["mediaPicker_deletedItem"])
+                .then(function(data) {
+                    vm.labels.mediaPicker_deletedItem = data[0];
 
-                setupViewModel();
-
-                //When the model value changes sync the view model
-                $scope.$watch("model.value",
-                    function (newVal, oldVal) {
-                        if (newVal !== oldVal) {
-                            setupViewModel();
+                    userService.getCurrentUser().then(function (userData) {
+                        if (!$scope.model.config.startNodeId) {
+                            $scope.model.config.startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
+                            $scope.model.config.startNodeIsVirtual = userData.startMediaIds.length !== 1;
                         }
-                    });
-            });
+                        // only allow users to add and edit media if they have access to the media section
+                        var hasAccessToMedia = userData.allowedSections.indexOf("media") !== -1;
+                        $scope.allowEditMedia = hasAccessToMedia;
+                        $scope.allowAddMedia = hasAccessToMedia;
 
+                        setupViewModel();
+
+                        //When the model value changes sync the view model
+                        $scope.$watch("model.value",
+                            function (newVal, oldVal) {
+                                if (newVal !== oldVal) {
+                                    setupViewModel();
+                                }
+                            });
+                    });
+                });
         }
 
         $scope.remove = function (index) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -1,5 +1,11 @@
 function multiUrlPickerController($scope, angularHelper, localizationService, entityResource, iconHelper, editorService) {
 
+    var vm = {
+        labels: {
+            general_recycleBin: ""
+        }
+    };
+
     $scope.renderModel = [];
 
     if ($scope.preview) {
@@ -102,7 +108,7 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
                             link.published = (data.metaData && data.metaData.IsPublished === false && entityType === "Document") ? false : true;
                             link.trashed = data.trashed;
                             if (link.trashed) {
-                                item.url = localizationService.dictionary.general_recycleBin;
+                                item.url = vm.labels.general_recycleBin;
                             }
                         });
                     } else {
@@ -120,6 +126,15 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
         };
         editorService.linkPicker(linkPicker);
     };
+
+    function init() {
+        localizationService.localizeMany(["general_recycleBin"])
+            .then(function (data) {
+                vm.labels.general_recycleBin = data[0];
+            });
+    }
+
+    init();
 }
 
 angular.module("umbraco").controller("Umbraco.PropertyEditors.MultiUrlPickerController", multiUrlPickerController);

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -170,12 +170,26 @@ namespace Umbraco.Web.Editors
                     : CultureInfo.GetCultureInfo(GlobalSettings.DefaultUILanguage)
                 : CultureInfo.GetCultureInfo(culture);
 
-            var textForCulture = Services.TextService.GetAllStoredValues(cultureInfo)
-                //the dictionary returned is fine but the delimiter between an 'area' and a 'value' is a '/' but the javascript
-                // in the back office requires the delimiter to be a '_' so we'll just replace it
-                .ToDictionary(key => key.Key.Replace("/", "_"), val => val.Value);
+            var allValues = Services.TextService.GetAllStoredValues(cultureInfo);
+            var pathedValues = allValues.Select(kv =>
+            {
+                var slashIndex = kv.Key.IndexOf('/');
+                var areaAlias = kv.Key.Substring(0, slashIndex);
+                var valueAlias = kv.Key.Substring(slashIndex+1);
+                return new
+                {
+                    areaAlias,
+                    valueAlias,
+                    value = kv.Value
+                };
+            });
 
-            return new JsonNetResult { Data = textForCulture, Formatting = Formatting.Indented };
+            Dictionary<string, Dictionary<string, string>> nestedDictionary = pathedValues
+                .GroupBy(pv => pv.areaAlias)
+                .ToDictionary(pv => pv.Key, pv =>
+                    pv.ToDictionary(pve => pve.valueAlias, pve => pve.value));
+
+            return new JsonNetResult { Data = nestedDictionary, Formatting = Formatting.Indented };
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes https://github.com/umbraco/Umbraco-CMS/issues/4759

### Description
Refactored the json format returned in order to save some bytes, and adapted the frontend code that did not use the correct method for labels.

### Possible breaking changes
There is no more `localizationService.dictionary`. The data has changed, and I don't think it was supposed to be available to begin with.

The data in `eventsService.emit("localizationService.updated", response.data);` has changed. I cannot find any consumers of this event. I left it because some might want to be notified, but maybe the data should just not be included since the format is internal?

Does there need to be any cachebusting for when people upgrade, in case they have cached the localizations? Or does the upgrade already bust those?

I added a parameter to the `localize` method. Will the docs automatically update? https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.services.localizationService