### PR TITLE
V8/bug/5708

### DIFF
--- a/src/Umbraco.Web/Services/DashboardService.cs
+++ b/src/Umbraco.Web/Services/DashboardService.cs
@@ -104,8 +104,9 @@ namespace Umbraco.Web.Services
                 }
             }
 
-            if (hasAccess || denyRules.Length == 0)
-                return true;
+            // No need to check denyRules if there aren't any, just return current state
+            if (denyRules.Length == 0)
+                return hasAccess;
 
             // check if this item has any deny arguments, if so check if the user is in one of the denied user groups, if so they will
             // be denied to see it no matter what

--- a/src/Umbraco.Web/Services/DashboardService.cs
+++ b/src/Umbraco.Web/Services/DashboardService.cs
@@ -104,7 +104,7 @@ namespace Umbraco.Web.Services
                 }
             }
 
-            if (!hasAccess || denyRules.Length == 0)
+            if (hasAccess || denyRules.Length == 0)
                 return true;
 
             // check if this item has any deny arguments, if so check if the user is in one of the denied user groups, if so they will


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5708

### Description
The access rules for dashboards contained a logical error.

To test, make sure to create a new dashboard from code:

```
using System;
using Umbraco.Core.Composing;
using Umbraco.Core.Dashboards;

namespace My.Website
{
    [Weight(-10)]
    public class MyDashboard : IDashboard
    {
        public string Alias => "Dashing";

        public string[] Sections => new[] { "content", "settings" };

        public string View => "/App_Plugins/dashing/dashboard.html";

        public IAccessRule[] AccessRules
        {
            get
            {
                var rules = new IAccessRule[]
                {
                    new AccessRule() {Type = AccessRuleType.Grant, Value = Umbraco.Core.Constants.Security.AdminGroupAlias},
                    new AccessRule() {Type = AccessRuleType.Grant, Value = "hrAdmin"},
                    new AccessRule() {Type = AccessRuleType.Deny, Value = "aBRIManager"},
                    new AccessRule() {Type = AccessRuleType.Deny, Value = Umbraco.Core.Constants.Security.SensitiveDataGroupAlias},
                    new AccessRule() {Type = AccessRuleType.Deny, Value = Umbraco.Core.Constants.Security.TranslatorGroupAlias},
                    new AccessRule() {Type = AccessRuleType.Deny, Value = "editor"}
                };

                return rules;
            }
        }
    }
}

```

Make sure to have an html file with "Hello World" or something in `~/App_Plugins/Dashing/dashboard.html`.

Create two new usergroups with the aliases `aBRIManager` and `hrAdmin` - make sure they at least have access to the content section.  Then create a user in each group.

Before applying this fix, note that both users will see our `Dashing` "hello world" dashboard, afterwards only `hrAdmin` users can see it, `aBRIManager` is not allowed. You can also test that admins can see it and editors can not.


<!-- Thanks for contributing to Umbraco CMS! -->
