### PR TITLE
V8: Fix broken on-outside-click for context menus and dialogs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
@@ -136,7 +136,8 @@ angular.module('umbraco.directives')
                     return;
                 }
 
-                angularHelper.safeApply(scope, attrs.onOutsideClick);
+                // please to not use angularHelper.safeApply here, it won't work
+                scope.$apply(attrs.onOutsideClick);
             }
 
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Looks like fd5b5b67 broke the ability to close context menus and dialogs by clicking outside them:

![outside-click-before](https://user-images.githubusercontent.com/7405322/60261150-7a61cb80-98db-11e9-91af-f304a1490111.gif)

As is stands, the only way to close them is to pick another node or hit escape.

Not sure if the change to `events.directive.js` was founded in another issue or just good ol' housekeeping - @Shazwazza might have input here?

Anyway... this PR reverts the change, and this makes the context menus and dialogs close as expected when clicking outside them:

![outside-click-after](https://user-images.githubusercontent.com/7405322/60261249-b301a500-98db-11e9-91a9-9ce9353f53f0.gif)
