### PR TITLE
V8: Fixes filter problem with minilistview when no filter is applied (#5744)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
@@ -71,7 +71,7 @@
                             }
                             // set published state for content
                             if (c.metaData) {
-                                c.hasChildren = c.metaData.HasChildren;
+                                c.hasChildren = c.metaData.hasChildren;
                                 if(scope.entityType === "Document") {
                                     c.published = c.metaData.IsPublished;
                                 }
@@ -79,7 +79,7 @@
                              
                             // filter items if there is a filter and it's not advanced
                             // ** ignores advanced filter at the moment
-                            if (scope.entityTypeFilter && !scope.entityTypeFilter.filterAdvanced) {
+                            if (scope.entityTypeFilter && scope.entityTypeFilter.filter && !scope.entityTypeFilter.filterAdvanced) {
                                 var a = scope.entityTypeFilter.filter.toLowerCase().replace(/\s/g, '').split(',');
                                 var found = a.indexOf(c.metaData.ContentTypeAlias.toLowerCase()) >= 0;
                                 


### PR DESCRIPTION
Leading on from @Shazwazza's fix in https://github.com/umbraco/Umbraco-CMS/commit/5c2b0647f3feaf23311bc26876a183bbb348bad5 I noticed two things:

1. The `umbminilistview.directive.js` has the incorrect case on `hasChildren` on line 74 though.

```
c.hasChildren = c.metaData.HasChildren;
```

2. When no doctype filter has been configured on the MNTP, the umbminilistview is still trying to use `scope.entityTypeFilter.filter` but it's undefined, resulting in this exception:

```
angular.js?cdv=1:15536 TypeError: Cannot read property 'toLowerCase' of null
    at umbraco.directives.js?cdv=1:13025
    at Function.h.each.h.forEach (underscore-min.js?cdv=1:5)
    at umbraco.directives.js?cdv=1:13008
    at processQueue (angular.js?cdv=1:17914)
    at angular.js?cdv=1:17962
    at Scope.$digest (angular.js?cdv=1:19075)
    at Scope.$apply (angular.js?cdv=1:19463)
    at done (angular.js?cdv=1:13312)
    at completeRequest (angular.js?cdv=1:13569)
    at XMLHttpRequest.requestLoaded (angular.js?cdv=1:13474) "Possibly unhandled rejection: {}"
```

The fix is to just check `scope.entityTypeFilter.filter` has been defined before filtering.

### To reproduce
* Install Starter Kit in 8.0.2.
* Create a MNTP datatype with no allowed items (everything is allowed).
* Add that datatype to the doctype, eg. the Home doctype.
* Edit the home node and use the picker to browse the tree. Note all regular nodes are selectable.
* Expand "People" which is enabled for list view. Exception seen in console.
