### PR TITLE
#5750 - make actions like create folder work again

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
@@ -131,6 +131,12 @@ angular.module('umbraco.directives')
                     return;
                 }
 
+                // ignore clicks on dialog actions
+                var actions = $(event.target).parents(".umb-action");
+                if (actions.length === 1) {
+                    return;
+                }
+
                 //ignore clicks inside this element
                 if ($(element).has($(event.target)).length > 0) {
                     return;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5750 

### Description
Before this fix it was not possible to create folders for documenttypes, datatypes, etc... see related issue.

This PR fixes this. Maybe @kjac can do a review because it was caused by a PR by him last week. As far as I can see the things fixed in his PR are still working
