### PR TITLE
Typo in umb-grid-selector

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-grid-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-grid-selector.html
@@ -32,7 +32,7 @@
     </div>
 
     <div class="text-center" ng-if="(availableItems | compareArrays:selectedItems:'alias').length === 0">
-        <small><localize key="general_all">Akk</localize> {{itemLabel}}s <localize key="grid_areAdded">are added</localize></small>
+        <small><localize key="general_all">All</localize> {{itemLabel}}s <localize key="grid_areAdded">are added</localize></small>
     </div>
 
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

It's a typo correction, doesn't really need steps to test it.

### Description

The `umb-grid-selector` view template says "Akk" instead of "All".

The localization would automatically replace it.
But for languages where there is no direct translation, it would display incorrectly.
