### PR TITLE
DocType Editor sorting - vertical direction

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -47,6 +47,7 @@
       function setSortingOptions() {
 
         scope.sortableOptionsGroup = {
+          axis: 'y',
           distance: 10,
           tolerance: "pointer",
           opacity: 0.7,
@@ -65,6 +66,7 @@
         };
 
         scope.sortableOptionsProperty = {
+          axis: 'y',
           distance: 10,
           tolerance: "pointer",
           connectWith: ".umb-group-builder__properties",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In the DocType Editor, when sorting the groups and properties, the draggable direction is freeform (horizontal, vertical or even diagonal).

We can restrict the direction, by setting the `axis` property in the sort options.

---

To test, in the DocType Editor, press "Reorder", then drag the groups and/or properties, the direction will be restricted to the vertical axis.