### PR TITLE
Added constants for Property Editor Groups

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -186,6 +186,24 @@ namespace Umbraco.Core
                 /// <remarks>Must be a valid <see cref="ValueTypes"/> value.</remarks>
                 public const string DataValueType = "umbracoDataValueType";
             }
+
+            /// <summary>
+            /// Defines Umbraco's built-in property editor groups.
+            /// </summary>
+            public static class Groups
+            {
+                public const string Common = "Common";
+
+                public const string Lists = "Lists";
+
+                public const string Media = "Media";
+
+                public const string People = "People";
+
+                public const string Pickers = "Pickers";
+
+                public const string RichContent = "Rich Content";
+            }
         }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/DataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditor.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Core.PropertyEditors
             // defaults
             Type = type;
             Icon = Constants.Icons.PropertyEditor;
-            Group = "common";
+            Group = Constants.PropertyEditors.Groups.Common;
 
             // assign properties based on the attribute, if it is found
             Attribute = GetType().GetCustomAttribute<DataEditorAttribute>(false);

--- a/src/Umbraco.Core/PropertyEditors/DataEditorAttribute.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditorAttribute.cs
@@ -121,7 +121,7 @@ namespace Umbraco.Core.PropertyEditors
         /// Gets or sets an optional group.
         /// </summary>
         /// <remarks>The group can be used for example to group the editors by category.</remarks>
-        public string Group { get; set; } = "common";
+        public string Group { get; set; } = Constants.PropertyEditors.Groups.Common;
 
         /// <summary>
         /// Gets or sets a value indicating whether the value editor is deprecated.

--- a/src/Umbraco.Core/PropertyEditors/LabelPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/LabelPropertyEditor.cs
@@ -5,7 +5,11 @@ namespace Umbraco.Core.PropertyEditors
     /// <summary>
     /// Represents a property editor for label properties.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.Label, "Label", "readonlyvalue", Icon = "icon-readonly")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.Label,
+        "Label",
+        "readonlyvalue",
+        Icon = "icon-readonly")]
     public class LabelPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/CheckBoxListPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/CheckBoxListPropertyEditor.cs
@@ -8,7 +8,12 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// A property editor to allow multiple checkbox selection of pre-defined items.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.CheckBoxList, "Checkbox list", "checkboxlist", Icon="icon-bulleted-list", Group="lists")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.CheckBoxList,
+        "Checkbox list",
+        "checkboxlist",
+        Icon = "icon-bulleted-list",
+        Group = Constants.PropertyEditors.Groups.Lists)]
     public class CheckBoxListPropertyEditor : DataEditor
     {
         private readonly ILocalizedTextService _textService;

--- a/src/Umbraco.Web/PropertyEditors/ColorPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ColorPickerPropertyEditor.cs
@@ -4,7 +4,12 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.ColorPicker, "Color Picker", "colorpicker", Icon="icon-colorpicker", Group="Pickers")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.ColorPicker,
+        "Color Picker",
+        "colorpicker",
+        Icon = "icon-colorpicker",
+        Group = Constants.PropertyEditors.Groups.Pickers)]
     public class ColorPickerPropertyEditor : DataEditor
     {
         public ColorPickerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/ContentPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ContentPickerPropertyEditor.cs
@@ -8,7 +8,13 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Content property editor that stores UDI
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.ContentPicker, EditorType.PropertyValue | EditorType.MacroParameter, "Content Picker", "contentpicker", ValueType = ValueTypes.String, Group = "Pickers")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.ContentPicker,
+        EditorType.PropertyValue | EditorType.MacroParameter,
+        "Content Picker",
+        "contentpicker",
+        ValueType = ValueTypes.String,
+        Group = Constants.PropertyEditors.Groups.Pickers)]
     public class ContentPickerPropertyEditor : DataEditor
     {
         public ContentPickerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/DateTimePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DateTimePropertyEditor.cs
@@ -7,7 +7,12 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a date and time property editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.DateTime, "Date/Time", "datepicker", ValueType = ValueTypes.DateTime, Icon="icon-time")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.DateTime,
+        "Date/Time",
+        "datepicker",
+        ValueType = ValueTypes.DateTime,
+        Icon = "icon-time")]
     public class DateTimePropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/DecimalPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DecimalPropertyEditor.cs
@@ -8,7 +8,12 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a decimal property and parameter editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.Decimal, EditorType.PropertyValue | EditorType.MacroParameter, "Decimal", "decimal", ValueType = ValueTypes.Decimal)]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.Decimal,
+        EditorType.PropertyValue | EditorType.MacroParameter,
+        "Decimal",
+        "decimal",
+        ValueType = ValueTypes.Decimal)]
     public class DecimalPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/DropDownFlexiblePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DropDownFlexiblePropertyEditor.cs
@@ -5,7 +5,12 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.DropDownListFlexible, "Dropdown", "dropdownFlexible", Group = "lists", Icon = "icon-indent")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.DropDownListFlexible,
+        "Dropdown",
+        "dropdownFlexible",
+        Group = Constants.PropertyEditors.Groups.Lists,
+        Icon = "icon-indent")]
     public class DropDownFlexiblePropertyEditor : DataEditor
     {
         private readonly ILocalizedTextService _textService;

--- a/src/Umbraco.Web/PropertyEditors/EmailAddressPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/EmailAddressPropertyEditor.cs
@@ -5,7 +5,12 @@ using Umbraco.Core.PropertyEditors.Validators;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.EmailAddress, EditorType.PropertyValue | EditorType.MacroParameter, "Email address", "email", Icon="icon-message")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.EmailAddress,
+        EditorType.PropertyValue | EditorType.MacroParameter,
+        "Email address",
+        "email",
+        Icon = "icon-message")]
     public class EmailAddressPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/FileUploadPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/FileUploadPropertyEditor.cs
@@ -12,7 +12,12 @@ using Umbraco.Web.Media;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.UploadField, "File upload", "fileupload", Icon = "icon-download-alt", Group = "media")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.UploadField,
+        "File upload",
+        "fileupload",
+        Group = Constants.PropertyEditors.Groups.Media,
+        Icon = "icon-download-alt")]
     public class FileUploadPropertyEditor : DataEditor
     {
         private readonly IMediaFileSystem _mediaFileSystem;

--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -12,7 +12,14 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a grid property and parameter editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.Grid, "Grid layout", "grid", HideLabel = true, ValueType = ValueTypes.Json, Group="rich content", Icon="icon-layout")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.Grid,
+        "Grid layout",
+        "grid",
+        HideLabel = true,
+        ValueType = ValueTypes.Json,
+        Icon = "icon-layout",
+        Group = Constants.PropertyEditors.Groups.RichContent)]
     public class GridPropertyEditor : DataEditor
     {
         public GridPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -19,7 +19,14 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents an image cropper property editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.ImageCropper, "Image Cropper", "imagecropper", ValueType = ValueTypes.Json, HideLabel = false, Group="media", Icon="icon-crop")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.ImageCropper,
+        "Image Cropper",
+        "imagecropper",
+        ValueType = ValueTypes.Json,
+        HideLabel = false,
+        Group = Constants.PropertyEditors.Groups.Media,
+        Icon = "icon-crop")]
     public class ImageCropperPropertyEditor : DataEditor
     {
         private readonly IMediaFileSystem _mediaFileSystem;

--- a/src/Umbraco.Web/PropertyEditors/IntegerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/IntegerPropertyEditor.cs
@@ -8,7 +8,12 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents an integer property and parameter editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.Integer, EditorType.PropertyValue | EditorType.MacroParameter, "Numeric", "integer", ValueType = ValueTypes.Integer)]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.Integer,
+        EditorType.PropertyValue | EditorType.MacroParameter,
+        "Numeric",
+        "integer",
+        ValueType = ValueTypes.Integer)]
     public class IntegerPropertyEditor : DataEditor
     {
         public IntegerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
@@ -8,7 +8,13 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a list-view editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.ListView, "List view", "listview", HideLabel = true, Group = "lists", Icon = Constants.Icons.ListView)]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.ListView,
+        "List view",
+        "listview",
+        HideLabel = true,
+        Group = Constants.PropertyEditors.Groups.Lists,
+        Icon = Constants.Icons.ListView)]
     public class ListViewPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/MacroContainerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MacroContainerPropertyEditor.cs
@@ -5,7 +5,14 @@ using Umbraco.Core.PropertyEditors;
 namespace Umbraco.Web.PropertyEditors
 {
     // TODO: MacroContainerPropertyEditor is deprecated, but what's the alternative?
-    [DataEditor(Constants.PropertyEditors.Aliases.MacroContainer, "(Obsolete) Macro Picker", "macrocontainer", ValueType = ValueTypes.Text, Group = "rich content", Icon = Constants.Icons.Macro, IsDeprecated = true)]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.MacroContainer,
+        "(Obsolete) Macro Picker",
+        "macrocontainer",
+        ValueType = ValueTypes.Text,
+        Group = Constants.PropertyEditors.Groups.RichContent,
+        Icon = Constants.Icons.Macro,
+        IsDeprecated = true)]
     public class MacroContainerPropertyEditor : DataEditor
     {
         public MacroContainerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/MarkdownPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MarkdownPropertyEditor.cs
@@ -7,7 +7,13 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a markdown editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.MarkdownEditor, "Markdown editor", "markdowneditor", ValueType = ValueTypes.Text, Icon="icon-code", Group="rich content")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.MarkdownEditor,
+        "Markdown editor",
+        "markdowneditor",
+        ValueType = ValueTypes.Text,
+        Group = Constants.PropertyEditors.Groups.RichContent,
+        Icon = "icon-code")]
     public class MarkdownPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/MediaPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPickerPropertyEditor.cs
@@ -7,8 +7,14 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a media picker property editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.MediaPicker, EditorType.PropertyValue | EditorType.MacroParameter,
-        "Media Picker", "mediapicker", ValueType = ValueTypes.Text, Group = "media", Icon = Constants.Icons.MediaImage)]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.MediaPicker,
+        EditorType.PropertyValue | EditorType.MacroParameter,
+        "Media Picker",
+        "mediapicker",
+        ValueType = ValueTypes.Text,
+        Group = Constants.PropertyEditors.Groups.Media,
+        Icon = Constants.Icons.MediaImage)]
     public class MediaPickerPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/MemberGroupPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MemberGroupPickerPropertyEditor.cs
@@ -4,7 +4,13 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.MemberGroupPicker, "Member Group Picker", "membergrouppicker", ValueType = ValueTypes.Text, Group = "People", Icon = Constants.Icons.MemberGroup)]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.MemberGroupPicker,
+        "Member Group Picker",
+        "membergrouppicker",
+        ValueType = ValueTypes.Text,
+        Group = Constants.PropertyEditors.Groups.People,
+        Icon = Constants.Icons.MemberGroup)]
     public class MemberGroupPickerPropertyEditor : DataEditor
     {
          public MemberGroupPickerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/MemberPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MemberPickerPropertyEditor.cs
@@ -4,7 +4,13 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.MemberPicker, "Member Picker", "memberpicker", ValueType = ValueTypes.String, Group = "People", Icon = Constants.Icons.Member)]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.MemberPicker,
+        "Member Picker",
+        "memberpicker",
+        ValueType = ValueTypes.String,
+        Group = Constants.PropertyEditors.Groups.People,
+        Icon = Constants.Icons.Member)]
     public class MemberPickerPropertyEditor : DataEditor
     {
         public MemberPickerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
@@ -4,7 +4,13 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.MultiNodeTreePicker, "Multinode Treepicker", "contentpicker", ValueType = ValueTypes.Text, Group = "pickers", Icon = "icon-page-add")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.MultiNodeTreePicker,
+        "Multinode Treepicker",
+        "contentpicker",
+        ValueType = ValueTypes.Text,
+        Group = Constants.PropertyEditors.Groups.Pickers,
+        Icon = "icon-page-add")]
     public class MultiNodeTreePickerPropertyEditor : DataEditor
     {
         public MultiNodeTreePickerPropertyEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerPropertyEditor.cs
@@ -7,7 +7,14 @@ using Umbraco.Web.PublishedCache;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.MultiUrlPicker, EditorType.PropertyValue, "Multi Url Picker", "multiurlpicker", ValueType = ValueTypes.Json, Group = "pickers", Icon = "icon-link")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.MultiUrlPicker,
+        EditorType.PropertyValue,
+        "Multi Url Picker",
+        "multiurlpicker",
+        ValueType = ValueTypes.Json,
+        Group = Constants.PropertyEditors.Groups.Pickers,
+        Icon = "icon-link")]
     public class MultiUrlPickerPropertyEditor : DataEditor
     {
         private readonly IEntityService _entityService;

--- a/src/Umbraco.Web/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -13,7 +13,13 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a multiple text string property editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.MultipleTextstring, "Repeatable textstrings", "multipletextbox", ValueType = ValueTypes.Text, Icon="icon-ordered-list", Group="lists")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.MultipleTextstring,
+        "Repeatable textstrings",
+        "multipletextbox",
+        ValueType = ValueTypes.Text,
+        Group = Constants.PropertyEditors.Groups.Lists,
+        Icon = "icon-ordered-list")]
     public class MultipleTextStringPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -18,7 +18,13 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a nested content property editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.NestedContent, "Nested Content", "nestedcontent", ValueType = "JSON", Group = "lists", Icon = "icon-thumbnail-list")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.NestedContent,
+        "Nested Content",
+        "nestedcontent",
+        ValueType = ValueTypes.Json,
+        Group = Constants.PropertyEditors.Groups.Lists,
+        Icon = "icon-thumbnail-list")]
     public class NestedContentPropertyEditor : DataEditor
     {
         private readonly Lazy<PropertyEditorCollection> _propertyEditors;

--- a/src/Umbraco.Web/PropertyEditors/ParameterEditors/ContentTypeParameterEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ParameterEditors/ContentTypeParameterEditor.cs
@@ -6,7 +6,11 @@ namespace Umbraco.Web.PropertyEditors.ParameterEditors
     /// <summary>
     /// Represents a content type parameter editor.
     /// </summary>
-    [DataEditor("contentType", EditorType.MacroParameter, "Content Type Picker", "entitypicker")]
+    [DataEditor(
+        "contentType",
+        EditorType.MacroParameter,
+        "Content Type Picker",
+        "entitypicker")]
     public class ContentTypeParameterEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultipleContentPickerParameterEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultipleContentPickerParameterEditor.cs
@@ -7,7 +7,11 @@ namespace Umbraco.Web.PropertyEditors.ParameterEditors
     /// <summary>
     /// Represents a parameter editor of some sort.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.MultiNodeTreePicker, EditorType.MacroParameter, "Multiple Content Picker", "contentpicker")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.MultiNodeTreePicker,
+        EditorType.MacroParameter,
+        "Multiple Content Picker",
+        "contentpicker")]
     public class MultipleContentPickerParameterEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultipleContentTypeParameterEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultipleContentTypeParameterEditor.cs
@@ -3,7 +3,11 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors.ParameterEditors
 {
-    [DataEditor("contentTypeMultiple", EditorType.MacroParameter, "Multiple Content Type Picker", "entitypicker")]
+    [DataEditor(
+        "contentTypeMultiple",
+        EditorType.MacroParameter,
+        "Multiple Content Type Picker",
+        "entitypicker")]
     public class MultipleContentTypeParameterEditor : DataEditor
     {
         public MultipleContentTypeParameterEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultiplePropertyGroupParameterEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultiplePropertyGroupParameterEditor.cs
@@ -3,7 +3,11 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors.ParameterEditors
 {
-    [DataEditor("tabPickerMultiple", EditorType.MacroParameter, "Multiple Tab Picker", "entitypicker")]
+    [DataEditor(
+        "tabPickerMultiple",
+        EditorType.MacroParameter,
+        "Multiple Tab Picker",
+        "entitypicker")]
     public class MultiplePropertyGroupParameterEditor : DataEditor
     {
         public MultiplePropertyGroupParameterEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultiplePropertyTypeParameterEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultiplePropertyTypeParameterEditor.cs
@@ -3,7 +3,11 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors.ParameterEditors
 {
-    [DataEditor("propertyTypePickerMultiple", EditorType.MacroParameter, "Multiple Property Type Picker", "entitypicker")]
+    [DataEditor(
+        "propertyTypePickerMultiple",
+        EditorType.MacroParameter,
+        "Multiple Property Type Picker",
+        "entitypicker")]
     public class MultiplePropertyTypeParameterEditor : DataEditor
     {
         public MultiplePropertyTypeParameterEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/ParameterEditors/PropertyGroupParameterEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ParameterEditors/PropertyGroupParameterEditor.cs
@@ -3,7 +3,11 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors.ParameterEditors
 {
-    [DataEditor("tabPicker", EditorType.MacroParameter, "Tab Picker", "entitypicker")]
+    [DataEditor(
+        "tabPicker",
+        EditorType.MacroParameter,
+        "Tab Picker",
+        "entitypicker")]
     public class PropertyGroupParameterEditor : DataEditor
     {
         public PropertyGroupParameterEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/ParameterEditors/PropertyTypeParameterEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ParameterEditors/PropertyTypeParameterEditor.cs
@@ -3,7 +3,11 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors.ParameterEditors
 {
-    [DataEditor("propertyTypePicker", EditorType.MacroParameter, "Property Type Picker", "entitypicker")]
+    [DataEditor(
+        "propertyTypePicker",
+        EditorType.MacroParameter,
+        "Property Type Picker",
+        "entitypicker")]
     public class PropertyTypeParameterEditor : DataEditor
     {
         public PropertyTypeParameterEditor(ILogger logger)

--- a/src/Umbraco.Web/PropertyEditors/RadioButtonsPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RadioButtonsPropertyEditor.cs
@@ -8,7 +8,13 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// A property editor to allow the individual selection of pre-defined items.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.RadioButtonList, "Radio button list", "radiobuttons", ValueType = ValueTypes.String, Group="lists", Icon="icon-target")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.RadioButtonList,
+        "Radio button list",
+        "radiobuttons",
+        ValueType = ValueTypes.String,
+        Group = Constants.PropertyEditors.Groups.Lists,
+        Icon = "icon-target")]
     public class RadioButtonsPropertyEditor : DataEditor
     {
         private readonly ILocalizedTextService _textService;

--- a/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
@@ -15,7 +15,14 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a rich text property editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.TinyMce, "Rich Text Editor", "rte", ValueType = ValueTypes.Text,  HideLabel = false, Group="Rich Content", Icon="icon-browser-window")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.TinyMce,
+        "Rich Text Editor",
+        "rte",
+        ValueType = ValueTypes.Text,
+        HideLabel = false,
+        Group = Constants.PropertyEditors.Groups.RichContent,
+        Icon = "icon-browser-window")]
     public class RichTextPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/SliderPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/SliderPropertyEditor.cs
@@ -7,7 +7,11 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a slider editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.Slider, "Slider", "slider", Icon = "icon-navigation-horizontal")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.Slider,
+        "Slider",
+        "slider",
+        Icon = "icon-navigation-horizontal")]
     public class SliderPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TagsPropertyEditor.cs
@@ -14,7 +14,11 @@ namespace Umbraco.Web.PropertyEditors
     /// Represents a tags property editor.
     /// </summary>
     [TagsPropertyEditor]
-    [DataEditor(Constants.PropertyEditors.Aliases.Tags, "Tags", "tags", Icon="icon-tags")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.Tags,
+        "Tags",
+        "tags",
+        Icon = "icon-tags")]
     public class TagsPropertyEditor : DataEditor
     {
         private readonly ManifestValueValidatorCollection _validators;

--- a/src/Umbraco.Web/PropertyEditors/TextAreaPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TextAreaPropertyEditor.cs
@@ -7,7 +7,13 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a textarea property and parameter editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.TextArea, EditorType.PropertyValue | EditorType.MacroParameter, "Textarea", "textarea", ValueType = ValueTypes.Text, Icon="icon-application-window-alt")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.TextArea,
+        EditorType.PropertyValue | EditorType.MacroParameter,
+        "Textarea",
+        "textarea",
+        ValueType = ValueTypes.Text,
+        Icon = "icon-application-window-alt")]
     public class TextAreaPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/TextboxPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TextboxPropertyEditor.cs
@@ -7,7 +7,12 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a textbox property and parameter editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.TextBox, EditorType.PropertyValue | EditorType.MacroParameter, "Textbox", "textbox", Group = "Common")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.TextBox,
+        EditorType.PropertyValue | EditorType.MacroParameter,
+        "Textbox",
+        "textbox",
+        Group = Constants.PropertyEditors.Groups.Common)]
     public class TextboxPropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/TrueFalsePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalsePropertyEditor.cs
@@ -7,7 +7,14 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents a checkbox property and parameter editor.
     /// </summary>
-    [DataEditor(Constants.PropertyEditors.Aliases.Boolean, EditorType.PropertyValue | EditorType.MacroParameter, "Checkbox", "boolean", ValueType = ValueTypes.Integer, Group = "Common", Icon="icon-checkbox")]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.Boolean,
+        EditorType.PropertyValue | EditorType.MacroParameter,
+        "Checkbox",
+        "boolean",
+        ValueType = ValueTypes.Integer,
+        Group = Constants.PropertyEditors.Groups.Common,
+        Icon = "icon-checkbox")]
     public class TrueFalsePropertyEditor : DataEditor
     {
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/UserPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/UserPickerPropertyEditor.cs
@@ -6,7 +6,13 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-    [DataEditor(Constants.PropertyEditors.Aliases.UserPicker, "User picker", "entitypicker", ValueType = ValueTypes.Integer, Group = "People", Icon = Constants.Icons.User)]
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.UserPicker,
+        "User picker",
+        "entitypicker",
+        ValueType = ValueTypes.Integer,
+        Group = Constants.PropertyEditors.Groups.People,
+        Icon = Constants.Icons.User)]
     public class UserPickerPropertyEditor : DataEditor
     {
         public UserPickerPropertyEditor(ILogger logger)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I've added a constants class for Property Editor groups. Mostly for consistency - and also as a package developer, I can know which group names are used for Umbraco core editors.

I've marked this pull request as a draft, as I got carried away with re-formatting the `DataEditor` attributes - breaking each parameter onto a newline, for readability purposes.

If you don't like this style, I can rework the pull request to put them all back on a single line.

---

In terms of testing, it'd be a case of going into the DocType Editor and checking that the various Data Types appear in the correct Property Editor group.