### PR TITLE
Unpublished multilingual page has PublishedState of Published

### DIFF
--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -239,7 +239,7 @@ namespace Umbraco.Core.Models
             foreach (var property in content.Properties)
                 property.UnpublishValues(culture);
 
-            content.PublishedState = PublishedState.Publishing;
+            content.PublishedState = PublishedState.Unpublishing;
         }
 
         public static void ClearPublishInfos(this IContent content)


### PR DESCRIPTION
This fixes: #5554

The `UnpublishCulture` method would set `PublishedState.Publishing` instead of `PublishedState.Unpublishing`, I assume this was copy/pasted from the `PublishCulture` method.

This fixes 5554 already but I saw further weird behavior in the `ContentService` where the variables `culturesPublishing` and `culturesUnpublishing` would only be populated when jumping into the `if(publishing)` method. In other words: in the `if(unpublishing)` path the line `if (culturesUnpublishing != null)` would always be `false`(!).

I was hoping that would fix #5218 but unfortunately that's still an issue. I don't know how items in the ExternalIndex get updated, so I'm not sure what the problem is here.

In any case, the `culturesPublishing` and `culturesUnpublishing` variables definitely need to be populated outside of the `if(publishing)` statement.