### PR TITLE
Fixes N+1 Issues caused by the new bypass start nodes changes

### DIFF
--- a/src/Umbraco.Core/Models/PropertyType.cs
+++ b/src/Umbraco.Core/Models/PropertyType.cs
@@ -21,6 +21,7 @@ namespace Umbraco.Core.Models
         private string _alias;
         private string _description;
         private int _dataTypeId;
+        private Guid _dataTypeKey;
         private Lazy<int> _propertyGroupId;
         private string _propertyEditorAlias;
         private ValueStorageType _valueStorageType;
@@ -137,6 +138,13 @@ namespace Umbraco.Core.Models
         {
             get => _dataTypeId;
             set => SetPropertyValueAndDetectChanges(value, ref _dataTypeId, nameof(DataTypeId));
+        }
+
+        [DataMember]
+        public Guid DataTypeKey
+        {
+            get => _dataTypeKey;
+            set => SetPropertyValueAndDetectChanges(value, ref _dataTypeKey, nameof(DataTypeKey));
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Persistence/Factories/PropertyGroupFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/PropertyGroupFactory.cs
@@ -54,6 +54,7 @@ namespace Umbraco.Core.Persistence.Factories
 
                             propertyType.Alias = typeDto.Alias;
                             propertyType.DataTypeId = typeDto.DataTypeId;
+                            propertyType.DataTypeKey = typeDto.DataTypeDto.NodeDto.UniqueId;
                             propertyType.Description = typeDto.Description;
                             propertyType.Id = typeDto.Id;
                             propertyType.Key = typeDto.UniqueId;

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
@@ -189,27 +189,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var groupDtos = Database.Fetch<PropertyTypeGroupDto>(sql1);
 
             var sql2 = Sql()
-                .Select<PropertyTypeDto>(r => r.Select(x => x.DataTypeDto))
-
-                //TODO: Why doesn't this overload have the ability to auto alias columns like the inner select above, instead we need to manually apply all aliases
-                //QUESTION: Why doesn't this work? but the below `.AndSelect<NodeDto>()` works? The problem now is that the output SQL has duplicate column names.
-                // NPoco seems to be able to map this correctly but it would be better to have aliased columns like below. These alias names seem to follow some sort
-                // of convention with the double underscore and these columns are in the exact same order as the auto-produced ones, however NPoco does not map these
-                // columns? 
-                //.AndSelect<NodeDto>(
-                //    x => Alias(x.NodeId, "NodeDto__NodeId"),
-                //    x => Alias(x.UniqueId, "NodeDto__UniqueId"),
-                //    x => Alias(x.ParentId, "NodeDto__ParentId"),
-                //    x => Alias(x.Level, "NodeDto__Level"),
-                //    x => Alias(x.Path, "NodeDto__Path"),
-                //    x => Alias(x.SortOrder, "NodeDto__SortOrder"),
-                //    x => Alias(x.Trashed, "NodeDto__Trashed"),
-                //    x => Alias(x.UserId, "NodeDto__UserId"),
-                //    x => Alias(x.Text, "NodeDto__Text"),
-                //    x => Alias(x.NodeObjectType, "NodeDto__NodeObjectType"),
-                //    x => Alias(x.CreateDate, "NodeDto__CreateDate"))
-                .AndSelect<NodeDto>()
-
+                .Select<PropertyTypeDto>(r => r.Select(x => x.DataTypeDto, r1 => r1.Select(x => x.NodeDto)))
                 .AndSelect<MemberPropertyTypeDto>()
                 .From<PropertyTypeDto>()
                 .InnerJoin<DataTypeDto>().On<PropertyTypeDto, DataTypeDto>((pt, dt) => pt.DataTypeId == dt.NodeId)

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -1013,8 +1013,9 @@ AND umbracoNode.id <> @id",
             if (propertyType.PropertyEditorAlias.IsNullOrWhiteSpace() == false)
             {
                 var sql = Sql()
-                    .SelectAll()
+                    .Select<DataTypeDto>(dt => dt.Select(x => x.NodeDto))
                     .From<DataTypeDto>()
+                    .InnerJoin<NodeDto>().On<DataTypeDto, NodeDto>((dt, n) => dt.NodeId == n.NodeId)
                     .Where("propertyEditorAlias = @propertyEditorAlias", new { propertyEditorAlias = propertyType.PropertyEditorAlias })
                     .OrderBy<DataTypeDto>(typeDto => typeDto.NodeId);
                 var datatype = Database.FirstOrDefault<DataTypeDto>(sql);
@@ -1022,6 +1023,7 @@ AND umbracoNode.id <> @id",
                 if (datatype != null)
                 {
                     propertyType.DataTypeId = datatype.NodeId;
+                    propertyType.DataTypeKey = datatype.NodeDto.UniqueId;
                 }
                 else
                 {

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -225,6 +225,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 {
                     //this reset's its current data type reference which will be re-assigned based on the property editor assigned on the next line
                     propertyType.DataTypeId = 0;
+                    propertyType.DataTypeKey = default;
                 }
             }
         }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
@@ -5,7 +5,7 @@ angular.module("umbraco.directives")
                 uniqueId: '=',
                 value: '=',
                 configuration: "=", //this is the RTE configuration
-                datatypeId: '@',
+                datatypeKey: '@',
                 ignoreUserStartNodes: '@'
             },
             templateUrl: 'views/components/grid/grid-rte.html',
@@ -43,7 +43,7 @@ angular.module("umbraco.directives")
                 scope.config = {
                     ignoreUserStartNodes: scope.ignoreUserStartNodes === "true"
                 }
-                scope.dataTypeId = scope.datatypeId; //Yes - this casing is rediculous, but it's because the var starts with `data` so it can't be `data-type-id` :/
+                scope.dataTypeKey = scope.datatypeKey; //Yes - this casing is rediculous, but it's because the var starts with `data` so it can't be `data-type-id` :/
 
                 //stores a reference to the editor
                 var tinyMceEditor = null;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreesearchbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreesearchbox.directive.js
@@ -12,7 +12,7 @@ function treeSearchBox(localizationService, searchService, $q) {
             searchFromName: "@",
             showSearch: "@",
             section: "@",
-            datatypeId: "@",
+            datatypeKey: "@",
             hideSearchCallback: "=",
             searchCallback: "="
         },
@@ -63,8 +63,8 @@ function treeSearchBox(localizationService, searchService, $q) {
                     }
 
                     //append dataTypeId value if there is one
-                    if (scope.datatypeId) {
-                        searchArgs["dataTypeId"] = scope.datatypeId;
+                    if (scope.datatypeKey) {
+                        searchArgs["dataTypeKey"] = scope.datatypeKey;
                     }
 
                     searcher(searchArgs).then(function (data) {

--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -327,8 +327,8 @@ function entityResource($q, $http, umbRequestHelper) {
                 { type: type },
                 { culture: culture}
             ];
-            if (options && options.dataTypeId) {
-                args.push({ dataTypeId: options.dataTypeId });
+            if (options && options.dataTypeKey) {
+                args.push({ dataTypeKey: options.dataTypeKey });
             }
 
             return umbRequestHelper.resourcePromise(
@@ -356,8 +356,8 @@ function entityResource($q, $http, umbRequestHelper) {
         getChildren: function (id, type, options) {
 
             var args = [{ id: id }, { type: type }];
-            if (options && options.dataTypeId) {
-                args.push({ dataTypeId: options.dataTypeId });
+            if (options && options.dataTypeKey) {
+                args.push({ dataTypeKey: options.dataTypeKey });
             }
 
             return umbRequestHelper.resourcePromise(
@@ -434,7 +434,7 @@ function entityResource($q, $http, umbRequestHelper) {
                             orderBy: options.orderBy,
                             orderDirection: options.orderDirection,
                             filter: encodeURIComponent(options.filter),
-                            dataTypeId: options.dataTypeId
+                            dataTypeKey: options.dataTypeKey
                         }
                     )),
                 'Failed to retrieve child data for id ' + parentId);
@@ -476,7 +476,7 @@ function entityResource($q, $http, umbRequestHelper) {
                 filter: '',
                 orderDirection: "Ascending",
                 orderBy: "SortOrder",
-                dataTypeId: null
+                dataTypeKey: null
             };
             if (options === undefined) {
                 options = {};
@@ -506,7 +506,7 @@ function entityResource($q, $http, umbRequestHelper) {
                             orderBy: options.orderBy,
                             orderDirection: options.orderDirection,
                             filter: encodeURIComponent(options.filter),
-                            dataTypeId: options.dataTypeId
+                            dataTypeKey: options.dataTypeKey
                         }
                     )),
                 'Failed to retrieve child data for id ' + parentId);
@@ -535,15 +535,15 @@ function entityResource($q, $http, umbRequestHelper) {
          * @returns {Promise} resourcePromise object containing the entity array.
          *
          */
-        search: function (query, type, searchFrom, canceler, dataTypeId) {
+        search: function (query, type, searchFrom, canceler, dataTypeKey) {
 
             var args = [{ query: query }, { type: type }];
             if (searchFrom) {
                 args.push({ searchFrom: searchFrom });
             }
 
-            if (dataTypeId) {
-                args.push({ dataTypeId: dataTypeId });
+            if (dataTypeKey) {
+                args.push({ dataTypeKey: dataTypeKey });
             }
 
             var httpConfig = {};

--- a/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
@@ -67,7 +67,7 @@ angular.module('umbraco.services')
                     throw "args.term is required";
                 }
 
-                return entityResource.search(args.term, "Document", args.searchFrom, args.canceler, args.dataTypeId).then(function (data) {
+                return entityResource.search(args.term, "Document", args.searchFrom, args.canceler, args.dataTypeKey).then(function (data) {
                     _.each(data, function (item) {
                         searchResultFormatter.configureContentResult(item);
                     });
@@ -92,7 +92,7 @@ angular.module('umbraco.services')
                     throw "args.term is required";
                 }
 
-                return entityResource.search(args.term, "Media", args.searchFrom, args.canceler, args.dataTypeId).then(function (data) {
+                return entityResource.search(args.term, "Media", args.searchFrom, args.canceler, args.dataTypeKey).then(function (data) {
                     _.each(data, function (item) {
                         searchResultFormatter.configureMediaResult(item);
                     });

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1121,7 +1121,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 entityResource.getAnchors(args.model.value).then(function (anchorValues) {
                     var linkPicker = {
                         currentTarget: currentTarget,
-                        dataTypeId: args.model.dataTypeId,
+                        dataTypeKey: args.model.dataTypeKey,
                         ignoreUserStartNodes: args.model.config.ignoreUserStartNodes,
                         anchors: anchorValues,
                         submit: function (model) {
@@ -1159,7 +1159,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                     disableFolderSelect: true,
                     startNodeId: startNodeId,
                     startNodeIsVirtual: startNodeIsVirtual,
-                    dataTypeId: args.model.dataTypeId,
+                    dataTypeKey: args.model.dataTypeKey,
                     submit: function (model) {
                         self.insertMediaInEditor(args.editor, model.selection[0]);
                         editorService.close();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -20,14 +20,14 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
                     $scope.model.title = value;
                 });
         }
-        $scope.customTreeParams = dialogOptions.dataTypeId ? "dataTypeId=" + dialogOptions.dataTypeId : "";
+        $scope.customTreeParams = dialogOptions.dataTypeKey ? "dataTypeKey=" + dialogOptions.dataTypeKey : "";
         $scope.dialogTreeApi = {};
         $scope.model.target = {};
         $scope.searchInfo = {
             searchFromId: null,
             searchFromName: null,
             showSearch: false,
-            dataTypeId: dialogOptions.dataTypeId,
+            dataTypeKey: dialogOptions.dataTypeKey,
             results: [],
             selectedSearchResults: []
         };
@@ -175,7 +175,7 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
                 var mediaPicker = {
                     startNodeId: startNodeId,
                     startNodeIsVirtual: startNodeIsVirtual,
-                    dataTypeId: dialogOptions.dataTypeId,
+                    dataTypeKey: dialogOptions.dataTypeKey,
                     submit: function (model) {
                         var media = model.selection[0];
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
@@ -25,7 +25,7 @@
                                     ng-model="model.target.url"
                                     ng-disabled="model.target.id || model.target.udi" />
                         </umb-control-group>
-                
+
                         <umb-control-group label="@defaultdialogs_anchorLinkPicker">
                             <input type="text"
                                     list="anchors"
@@ -33,13 +33,13 @@
                                     placeholder="@placeholders_anchor"
                                     class="umb-property-editor umb-textstring"
                                     ng-model="model.target.anchor" />
-                    
+
                             <datalist id="anchors">
                                 <option value="{{a}}" ng-repeat="a in anchorValues"></option>
                             </datalist>
                         </umb-control-group>
                     </div>
-                
+
                     <umb-control-group label="@defaultdialogs_nodeNameLinkPicker">
                         <input type="text"
                                 localize="placeholder"
@@ -47,7 +47,7 @@
                                 class="umb-property-editor umb-textstring"
                                 ng-model="model.target.name" />
                     </umb-control-group>
-                
+
                     <umb-control-group ng-if="showTarget" label="@content_target">
                         <umb-checkbox
                                       model="vm.openInNewWindow"
@@ -58,28 +58,28 @@
 
                     <div class="umb-control-group">
                         <h5><localize key="defaultdialogs_linkToPage">Link to page</localize></h5>
-                
+
                         <div ng-hide="miniListView">
-                            <umb-tree-search-box 
+                            <umb-tree-search-box
                                 hide-search-callback="hideSearch"
                                 search-callback="onSearchResults"
                                 search-from-id="{{searchInfo.searchFromId}}"
                                 search-from-name="{{searchInfo.searchFromName}}"
-                                datatype-id="{{searchInfo.dataTypeId}}"
+                                datatype-key="{{searchInfo.dataTypeKey}}"
                                 show-search="{{searchInfo.showSearch}}"
                                 section="{{section}}">
                             </umb-tree-search-box>
-                
+
                             <br />
-                
-                            <umb-tree-search-results 
+
+                            <umb-tree-search-results
                                 ng-if="searchInfo.showSearch"
                                 results="searchInfo.results"
                                 select-result-callback="selectResult">
                             </umb-tree-search-results>
-                
+
                             <div ng-hide="searchInfo.showSearch">
-                                <umb-tree 
+                                <umb-tree
                                     section="content"
                                     hideheader="true"
                                     hideoptions="true"
@@ -92,17 +92,17 @@
                                 </umb-tree>
                             </div>
                         </div>
-                
-                        <umb-mini-list-view 
+
+                        <umb-mini-list-view
                             ng-if="miniListView"
                             node="miniListView"
                             entity-type="Document"
                             on-select="selectListViewNode(node)"
                             on-close="closeMiniListView()">
                         </umb-mini-list-view>
-                
+
                     </div>
-                
+
                     <div class="umb-control-group">
                         <h5><localize key="defaultdialogs_linkToMedia">Link to media</localize></h5>
                         <a href ng-click="switchToMediaPicker()" class="btn">

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -57,7 +57,7 @@ angular.module("umbraco")
                 totalItems: 0,
                 totalPages: 0,
                 filter: '',
-                dataTypeId: $scope.model.dataTypeId
+                dataTypeKey: $scope.model.dataTypeKey
             };
 
             //preload selected item
@@ -160,7 +160,7 @@ angular.module("umbraco")
                 }
 
                 if (folder.id > 0) {
-                    entityResource.getAncestors(folder.id, "media", null, { dataTypeId: $scope.model.dataTypeId })
+                    entityResource.getAncestors(folder.id, "media", null, { dataTypeKey: $scope.model.dataTypeKey })
                         .then(function (anc) {
                             $scope.path = _.filter(anc,
                                 function (f) {
@@ -318,7 +318,7 @@ angular.module("umbraco")
                             totalItems: 0,
                             totalPages: 0,
                             filter: '',
-                            dataTypeId: $scope.model.dataTypeId
+                            dataTypeKey: $scope.model.dataTypeKey
                         };
                         getChildren($scope.currentFolder.id);
                     }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -28,12 +28,12 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
         vm.treeAlias = $scope.model.treeAlias;
         vm.multiPicker = $scope.model.multiPicker;
         vm.hideHeader = (typeof $scope.model.hideHeader) === "boolean" ? $scope.model.hideHeader : true;
-        vm.dataTypeId = $scope.model.dataTypeId;
+        vm.dataTypeKey = $scope.model.dataTypeKey;
         vm.searchInfo = {
             searchFromId: $scope.model.startNodeId,
             searchFromName: null,
             showSearch: false,
-            dataTypeId: vm.dataTypeId,
+            dataTypeKey: vm.dataTypeKey,
             results: [],
             selectedSearchResults: []
         }
@@ -192,8 +192,8 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
             if (vm.selectedLanguage && vm.selectedLanguage.id) {
                 queryParams["culture"] = vm.selectedLanguage.culture;
             }
-            if (vm.dataTypeId) {
-                queryParams["dataTypeId"] = vm.dataTypeId;
+            if (vm.dataTypeKey) {
+                queryParams["dataTypeKey"] = vm.dataTypeKey;
             }
                 
             var queryString = $.param(queryParams); //create the query string from the params object

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
@@ -27,7 +27,7 @@
                                         <a ng-click="vm.selectLanguage(language)" ng-repeat="language in vm.languages" href="">{{language.name}}</a>
                                     </div>
                                 </div>
-                        
+
                                 <div class="umb-control-group">
                                     <umb-tree-search-box
                                         ng-if="vm.enableSearh"
@@ -36,22 +36,22 @@
                                         search-from-id="{{vm.searchInfo.searchFromId}}"
                                         search-from-name="{{vm.searchInfo.searchFromName}}"
                                         show-search="{{vm.searchInfo.showSearch}}"
-                                        datatype-id="{{vm.searchInfo.dataTypeId}}"
+                                        datatype-key="{{vm.searchInfo.dataTypeKey}}"
                                         section="{{vm.section}}">
                                     </umb-tree-search-box>
                                 </div>
-                        
+
                                 <umb-tree-search-results ng-if="vm.searchInfo.showSearch"
                                                             results="vm.searchInfo.results"
                                                             select-result-callback="vm.selectResult">
                                 </umb-tree-search-results>
-                        
+
                                 <umb-empty-state ng-if="!vm.hasItems && vm.emptyStateMessage" position="center">
                                     {{ vm.emptyStateMessage }}
                                 </umb-empty-state>
-                        
+
                                 <div ng-if="vm.treeReady" ng-hide="vm.searchInfo.showSearch" ng-animate="'tree-fade-out'">
-                                    <umb-tree 
+                                    <umb-tree
                                         section="{{vm.section}}"
                                         treealias="{{vm.treeAlias}}"
                                         hideheader="{{vm.hideHeader}}"
@@ -65,10 +65,10 @@
                                         api="vm.dialogTreeApi">
                                     </umb-tree>
                                 </div>
-                        
+
                             </div>
-                        
-                            <umb-mini-list-view 
+
+                            <umb-mini-list-view
                                 ng-if="vm.miniListView"
                                 node="vm.miniListView"
                                 entity-type="{{vm.entityType}}"
@@ -93,7 +93,7 @@
                         shortcut="esc"
                         action="vm.close()">
                     </umb-button>
-    
+
                     <umb-button
                         ng-if="vm.multiPicker"
                         type="button"
@@ -101,7 +101,7 @@
                         label-key="general_submit"
                         action="vm.submit(model)">
                     </umb-button>
-            
+
                 </umb-editor-footer-content-right>
 
             </umb-editor-footer>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -86,7 +86,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         showOpenButton: false,
         showEditButton: false,
         showPathOnHover: false,
-        dataTypeId: null,
+        dataTypeKey: null,
         maxNumber: 1,
         minNumber: 0,
         startNode: {
@@ -140,7 +140,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         entityType: entityType,
         filterCssClass: "not-allowed not-published",
         startNodeId: null,
-        dataTypeId: $scope.model.dataTypeId,
+        dataTypeKey: $scope.model.dataTypeKey,
         currentNode: editorState ? editorState.current : null,
         callback: function (data) {
             if (angular.isArray(data)) {
@@ -162,7 +162,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     // pre-value config on to the dialog options
     angular.extend(dialogOptions, $scope.model.config);
 
-    dialogOptions.dataTypeId = $scope.model.dataTypeId;
+    dialogOptions.dataTypeKey = $scope.model.dataTypeKey;
 
     // if we can't pick more than one item, explicitly disable multiPicker in the dialog options
     if ($scope.model.config.maxNumber && parseInt($scope.model.config.maxNumber) === 1) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
@@ -30,7 +30,7 @@ angular.module("umbraco")
                 showDetails: true,
                 disableFolderSelect: true,
                 onlyImages: true,
-                dataTypeId: $scope.model.dataTypeId,
+                dataTypeKey: $scope.model.dataTypeKey,
                 submit: function(model) {
                     var selectedImage = model.selection[0];
                    

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/rte.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/rte.html
@@ -4,7 +4,7 @@
 		configuration="model.config.rte"
 		value="control.value"
 		unique-id="control.$uniqueId"
-        datatype-id="{{model.dataTypeId}}"
+        datatype-key="{{model.dataTypeKey}}"
         ignore-user-start-nodes="{{model.config.ignoreUserStartNodes}}">
 	</grid-rte>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -187,7 +187,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
             var mediaPicker = {
                 startNodeId: $scope.model.config.startNodeId,
                 startNodeIsVirtual: $scope.model.config.startNodeIsVirtual,
-                dataTypeId: $scope.model.dataTypeId,
+                dataTypeKey: $scope.model.dataTypeKey,
                 multiPicker: multiPicker,
                 onlyImages: onlyImages,
                 disableFolderSelect: disableFolderSelect,

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -77,7 +77,7 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
 
         var linkPicker = {
             currentTarget: target,
-            dataTypeId: $scope.model.dataTypeId,
+            dataTypeKey: $scope.model.dataTypeKey,
             ignoreUserStartNodes : $scope.model.config.ignoreUserStartNodes,
             submit: function (model) {
                 if (model.target.url || model.target.anchor) {

--- a/src/Umbraco.Web/Editors/EntityController.cs
+++ b/src/Umbraco.Web/Editors/EntityController.cs
@@ -104,10 +104,10 @@ namespace Umbraco.Web.Editors
         /// <param name="searchFrom">
         /// A starting point for the search, generally a node id, but for members this is a member type alias
         /// </param>
-        /// <param name="dataTypeId">If set used to look up whether user and group start node permissions will be ignored.</param>
+        /// <param name="dataTypeKey">If set used to look up whether user and group start node permissions will be ignored.</param>
         /// <returns></returns>
         [HttpGet]
-        public IEnumerable<EntityBasic> Search(string query, UmbracoEntityTypes type, string searchFrom = null, Guid? dataTypeId = null)
+        public IEnumerable<EntityBasic> Search(string query, UmbracoEntityTypes type, string searchFrom = null, Guid? dataTypeKey = null)
         {
             // NOTE: Theoretically you shouldn't be able to see member data if you don't have access to members right? ... but there is a member picker, so can't really do that
 
@@ -116,7 +116,7 @@ namespace Umbraco.Web.Editors
 
             //TODO: This uses the internal UmbracoTreeSearcher, this instead should delgate to the ISearchableTree implementation for the type
 
-            var ignoreUserStartNodes = dataTypeId.HasValue && Services.DataTypeService.IsDataTypeIgnoringUserStartNodes(dataTypeId.Value);
+            var ignoreUserStartNodes = dataTypeKey.HasValue && Services.DataTypeService.IsDataTypeIgnoringUserStartNodes(dataTypeKey.Value);
             return ExamineSearch(query, type, searchFrom, ignoreUserStartNodes);
         }
 
@@ -424,7 +424,7 @@ namespace Umbraco.Web.Editors
         }
         #endregion
 
-        public IEnumerable<EntityBasic> GetChildren(int id, UmbracoEntityTypes type, Guid? dataTypeId = null)
+        public IEnumerable<EntityBasic> GetChildren(int id, UmbracoEntityTypes type, Guid? dataTypeKey = null)
         {
             var objectType = ConvertToObjectType(type);
             if (objectType.HasValue)
@@ -433,7 +433,7 @@ namespace Umbraco.Web.Editors
 
                 var startNodes = GetStartNodes(type);
 
-                var ignoreUserStartNodes = IsDataTypeIgnoringUserStartNodes(dataTypeId);
+                var ignoreUserStartNodes = IsDataTypeIgnoringUserStartNodes(dataTypeKey);
 
                 // root is special: we reduce it to start nodes if the user's start node is not the default, then we need to return their start nodes
                 if (id == Constants.System.Root && startNodes.Length > 0 && startNodes.Contains(Constants.System.Root) == false && !ignoreUserStartNodes)
@@ -482,7 +482,7 @@ namespace Umbraco.Web.Editors
             string orderBy = "SortOrder",
             Direction orderDirection = Direction.Ascending,
             string filter = "",
-            Guid? dataTypeId = null)
+            Guid? dataTypeKey = null)
         {
             if (int.TryParse(id, out var intId))
             {
@@ -507,7 +507,7 @@ namespace Umbraco.Web.Editors
                 //the EntityService can search paged members from the root
 
                 intId = -1;
-                return GetPagedChildren(intId, type, pageNumber, pageSize, orderBy, orderDirection, filter, dataTypeId);
+                return GetPagedChildren(intId, type, pageNumber, pageSize, orderBy, orderDirection, filter, dataTypeKey);
             }
 
             //the EntityService cannot search members of a certain type, this is currently not supported and would require
@@ -543,7 +543,7 @@ namespace Umbraco.Web.Editors
             string orderBy = "SortOrder",
             Direction orderDirection = Direction.Ascending,
             string filter = "",
-            Guid? dataTypeId = null)
+            Guid? dataTypeKey = null)
         {
             if (pageNumber <= 0)
                 throw new HttpResponseException(HttpStatusCode.NotFound);
@@ -558,7 +558,7 @@ namespace Umbraco.Web.Editors
 
                 var startNodes = GetStartNodes(type);
 
-                var ignoreUserStartNodes = IsDataTypeIgnoringUserStartNodes(dataTypeId);
+                var ignoreUserStartNodes = IsDataTypeIgnoringUserStartNodes(dataTypeKey);
 
                 // root is special: we reduce it to start nodes if the user's start node is not the default, then we need to return their start nodes
                 if (id == Constants.System.Root && startNodes.Length > 0 && startNodes.Contains(Constants.System.Root) == false && !ignoreUserStartNodes)
@@ -642,7 +642,7 @@ namespace Umbraco.Web.Editors
             string orderBy = "SortOrder",
             Direction orderDirection = Direction.Ascending,
             string filter = "",
-            Guid? dataTypeId = null)
+            Guid? dataTypeKey = null)
         {
             if (pageNumber <= 0)
                 throw new HttpResponseException(HttpStatusCode.NotFound);
@@ -661,7 +661,7 @@ namespace Umbraco.Web.Editors
 
                     int[] aids = GetStartNodes(type);
 
-                    var ignoreUserStartNodes = IsDataTypeIgnoringUserStartNodes(dataTypeId);
+                    var ignoreUserStartNodes = IsDataTypeIgnoringUserStartNodes(dataTypeKey);
                     entities = aids == null || aids.Contains(Constants.System.Root) || ignoreUserStartNodes
                         ? Services.EntityService.GetPagedDescendants(objectType.Value, pageNumber - 1, pageSize, out totalRecords,
                             SqlContext.Query<IUmbracoEntity>().Where(x => x.Name.Contains(filter)),
@@ -704,7 +704,7 @@ namespace Umbraco.Web.Editors
             }
         }
 
-        private bool IsDataTypeIgnoringUserStartNodes(Guid? dataTypeId) => dataTypeId.HasValue && Services.DataTypeService.IsDataTypeIgnoringUserStartNodes(dataTypeId.Value);
+        private bool IsDataTypeIgnoringUserStartNodes(Guid? dataTypeKey) => dataTypeKey.HasValue && Services.DataTypeService.IsDataTypeIgnoringUserStartNodes(dataTypeKey.Value);
 
         public IEnumerable<EntityBasic> GetAncestors(int id, UmbracoEntityTypes type, [ModelBinder(typeof(HttpQueryStringModelBinder))]FormDataCollection queryStrings)
         {

--- a/src/Umbraco.Web/Models/ContentEditing/ContentPropertyBasic.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentPropertyBasic.cs
@@ -22,8 +22,7 @@ namespace Umbraco.Web.Models.ContentEditing
         [Required]
         public int Id { get; set; }
 
-        //fixme: This name dataTypeId is inconsistent, but requires us to change it everywhere in angular
-        [DataMember(Name = "dataTypeId", IsRequired = false)] 
+        [DataMember(Name = "dataTypeKey", IsRequired = false)]
         [ReadOnly(true)]
         public Guid DataTypeKey { get; set; }
 

--- a/src/Umbraco.Web/Models/ContentEditing/ContentPropertyBasic.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentPropertyBasic.cs
@@ -22,8 +22,10 @@ namespace Umbraco.Web.Models.ContentEditing
         [Required]
         public int Id { get; set; }
 
-        [DataMember(Name = "dataTypeId", IsRequired = false)]
-        public Guid? DataTypeId { get; set; }
+        //fixme: This name dataTypeId is inconsistent, but requires us to change it everywhere in angular
+        [DataMember(Name = "dataTypeId", IsRequired = false)] 
+        [ReadOnly(true)]
+        public Guid DataTypeKey { get; set; }
 
         [DataMember(Name = "value")]
         public object Value { get; set; }

--- a/src/Umbraco.Web/Models/ContentEditing/PropertyTypeBasic.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/PropertyTypeBasic.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 
@@ -42,6 +43,10 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "dataTypeId")]
         [Required]
         public int DataTypeId { get; set; }
+
+        [DataMember(Name = "dataTypeKey")]
+        [ReadOnly(true)]
+        public Guid DataTypeKey { get; set; }
 
         //SD: Is this really needed ?
         [DataMember(Name = "groupId")]

--- a/src/Umbraco.Web/Models/Mapping/ContentPropertyBasicMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentPropertyBasicMapper.cs
@@ -50,13 +50,7 @@ namespace Umbraco.Web.Models.Mapping
             dest.Alias = property.Alias;
             dest.PropertyEditor = editor;
             dest.Editor = editor.Alias;
-
-            //fixme: although this might get cached, if a content item has 100 properties of different data types, then this means this is going to be 100 extra DB queries :( :( :(
-            // - ideally, we'd just have the DataTypeKey alongside the DataTypeId which is loaded in the single sql statement which should be relatively easy.
-            var dataTypeKey = _entityService.GetKey(property.PropertyType.DataTypeId, UmbracoObjectTypes.DataType);
-            if (!dataTypeKey.Success)
-                throw new InvalidOperationException("Can't get the unique key from the id: " + property.PropertyType.DataTypeId);
-            dest.DataTypeId = dataTypeKey.Result;
+            dest.DataTypeKey = property.PropertyType.DataTypeKey;
 
             // if there's a set of property aliases specified, we will check if the current property's value should be mapped.
             // if it isn't one of the ones specified in 'includeProperties', we will just return the result without mapping the Value.

--- a/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
@@ -219,6 +219,7 @@ namespace Umbraco.Web.Models.Mapping
         {
             target.Name = source.Label;
             target.DataTypeId = source.DataTypeId;
+            target.DataTypeKey = source.DataTypeKey;
             target.Mandatory = source.Validation.Mandatory;
             target.ValidationRegExp = source.Validation.Pattern;
             target.Variations = source.AllowCultureVariant ? ContentVariation.Culture : ContentVariation.Nothing;
@@ -334,6 +335,7 @@ namespace Umbraco.Web.Models.Mapping
             target.Alias = source.Alias;
             target.AllowCultureVariant = source.AllowCultureVariant;
             target.DataTypeId = source.DataTypeId;
+            target.DataTypeKey = source.DataTypeKey;
             target.Description = source.Description;
             target.GroupId = source.GroupId;
             target.Id = source.Id;
@@ -349,6 +351,7 @@ namespace Umbraco.Web.Models.Mapping
             target.Alias = source.Alias;
             target.AllowCultureVariant = source.AllowCultureVariant;
             target.DataTypeId = source.DataTypeId;
+            target.DataTypeKey = source.DataTypeKey;
             target.Description = source.Description;
             target.GroupId = source.GroupId;
             target.Id = source.Id;

--- a/src/Umbraco.Web/Models/Mapping/PropertyTypeGroupMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/PropertyTypeGroupMapper.cs
@@ -231,6 +231,7 @@ namespace Umbraco.Web.Models.Mapping
                     GroupId = groupId,
                     Inherited = inherited,
                     DataTypeId = p.DataTypeId,
+                    DataTypeKey = p.DataTypeKey,
                     SortOrder = p.SortOrder,
                     ContentTypeId = contentType.Id,
                     ContentTypeName = contentType.Name,

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -338,7 +338,7 @@ namespace Umbraco.Web.Trees
             //Here we need to figure out if the node is a container and if so check if the user has a custom start node, then check if that start node is a child
             // of this container node. If that is true, the HasChildren must be true so that the tree node still renders even though this current node is a container/list view.
             if (isContainer && UserStartNodes.Length > 0 && UserStartNodes.Contains(Constants.System.Root) == false)
-            {                    
+            {
                 var startNodes = Services.EntityService.GetAll(UmbracoObjectType, UserStartNodes);
                 //if any of these start nodes' parent is current, then we need to render children normally so we need to switch some logic and tell
                 // the UI that this node does have children and that it isn't a container
@@ -396,7 +396,7 @@ namespace Umbraco.Web.Trees
                 }
 
                 var menu = new MenuItemCollection();
-                // only add empty recycle bin if the current user is allowed to delete by default 
+                // only add empty recycle bin if the current user is allowed to delete by default
                 if (deleteAllowed)
                 {
 	                menu.Items.Add(new MenuItem("emptyRecycleBin", Services.TextService)
@@ -538,8 +538,8 @@ namespace Umbraco.Web.Trees
         {
             if (_ignoreUserStartNodes.HasValue) return _ignoreUserStartNodes.Value;
 
-            var dataTypeId = queryStrings.GetValue<Guid?>(TreeQueryStringParameters.DataTypeId);
-            _ignoreUserStartNodes = dataTypeId.HasValue ? Services.DataTypeService.IsDataTypeIgnoringUserStartNodes(dataTypeId.Value) : false;
+            var dataTypeKey = queryStrings.GetValue<Guid?>(TreeQueryStringParameters.DataTypeKey);
+            _ignoreUserStartNodes = dataTypeKey.HasValue && Services.DataTypeService.IsDataTypeIgnoringUserStartNodes(dataTypeKey.Value);
 
             return _ignoreUserStartNodes.Value;
         }

--- a/src/Umbraco.Web/Trees/TreeQueryStringParameters.cs
+++ b/src/Umbraco.Web/Trees/TreeQueryStringParameters.cs
@@ -8,7 +8,7 @@
         public const string Use = "use";
         public const string Application = "application";
         public const string StartNodeId = "startNodeId";
-        public const string DataTypeId = "dataTypeId";
+        public const string DataTypeKey = "dataTypeKey";
         //public const string OnNodeClick = "OnNodeClick";
         //public const string RenderParent = "RenderParent";
     }


### PR DESCRIPTION
With the bypass user start nodes for pickers changes, we introduced an N+1 SQL problem which can be seen here: https://github.com/umbraco/Umbraco-CMS/blob/4134dd16df02151ced2bb566c284b87b9ec8ec15/src/Umbraco.Web/Models/Mapping/ContentPropertyBasicMapper.cs#L54

This issue also exists in 7.15 in the `ContentPropertyBasicConverter` and could in theory be fixed in a similar way to this.

The real problem here is when a content item with a lot of properties and different data types is loaded, especially after a site restart. This could cause a vast amount of SQL queries to execute. These will be cached but it's not ideal when the initial SQL to get a property type should just include the data type GUID in the first place.

This is exactly what this PR does:

* Populates the data in `DataTypeDto.NodeDto` - turns out this POCO was never populated except when executing queries to edit a Data Type but it's relatively easy to populate this to get the required data
* This means we have access to the DataTypeDto.NodeDto.UniqueId` which is what we want and now we can assign this accordingly to the models

There are questions however: 

 * ~@zpqrtbnk would love to know about the question I've posted in the code, i'm unsure why the npoco column mappings don't work with aliases and since the `.Select<PropertyTypeDto>(r => r.Select(x => x.DataTypeDto))` doesn't support nested selects to populate the DataTypeDto.NodeDto, i don't know the best way to do this~ ... figured it out and pushed a change
* @bergmania I've left a comment in there about naming inconsistency with the `dataTypeId` going to angular, this should really be `dataTypeKey` but would require a lot of the angular files to be updated - it's either now or never ... in 7.15 we can just leave this as-is

