### PR TITLE
V7: Make sure Nested Content blueprints are listed in defined sort order

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.controller.js
@@ -4,6 +4,11 @@ function ItemPickerOverlay($scope, localizationService) {
         $scope.model.title = localizationService.localize("defaultdialogs_selectItem");
     }
 
+    
+    if (!$scope.model.orderBy) {
+        $scope.model.orderBy = "name";
+    }
+
     $scope.model.hideSubmitButton = true;
 
     $scope.selectItem = function(item) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
@@ -12,7 +12,7 @@
     </div>
 
     <ul class="umb-card-grid">
-        <li ng-repeat="availableItem in model.availableItems | compareArrays:model.selectedItems:'alias' | orderBy:'name' | filter:searchTerm"
+        <li ng-repeat="availableItem in model.availableItems | compareArrays:model.selectedItems:'alias' | orderBy:model.orderBy | filter:searchTerm"
             ng-click="selectItem(availableItem)"
             class="-three-in-row">
             <a class="umb-card-grid-item" href="" title="{{ availableItem.name }}">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -142,6 +142,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
                 show: false,
                 style: {},
                 filter: $scope.scaffolds.length > 15 ? true : false,
+                orderBy: "$index",
                 view: "itempicker",
                 event: $event,
                 submit: function(model) {                    


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5769

### Description

See #5769 for details on the issue. 

This is pretty much just a backport of the same bugfix for V8 (#5213).

When this PR is applied, the items in the blueprint selection dialog are listed in the order in which they're defined in the Nested Content configuration:

![nested-content-blueprint-sortorder](https://user-images.githubusercontent.com/7405322/60585037-10d83600-9d8f-11e9-9a2e-a0b0c48122c6.gif)
