### PR TITLE
V8: Make log naming and colors consistent between Log Search and Log Overview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
@@ -43,14 +43,20 @@
         vm.searchLogQuery = searchLogQuery;
         vm.findMessageTemplate = findMessageTemplate;
         
-        function preFlightCheck(){
-            vm.loading = true;
+        function preFlightCheck(instance){
+            vm.loading = true;          
+
+            
             //Do our pre-flight check (to see if we can view logs)
             //IE the log file is NOT too big such as 1GB & crash the site
             logViewerResource.canViewLogs(vm.startDate, vm.endDate).then(function(result){
                 vm.loading = false;
                 vm.canLoadLogs = result;
 
+                if (instance) {
+                    instance.setDate(vm.period);
+                }
+                
                 if(result){
                     //Can view logs - so initalise
                     init();
@@ -117,7 +123,7 @@
             $q.all([savedSearches, numOfErrors, logCounts, commonMsgs]).then(function() {
                 vm.loading = false;
             });
-
+            
             $timeout(function () {
                 navigationService.syncTree({ tree: "logViewer", path: "-1" });
             });
@@ -146,9 +152,9 @@
             mode: "range",
             maxDate: "today",
             conjunction: " to "
-        };
-        
-        vm.dateRangeChange = function(selectedDates) {
+        };        
+            
+        vm.dateRangeChange = function(selectedDates, dateStr, instance) {
             
             if(selectedDates.length > 0){
                 vm.startDate = selectedDates[0].toIsoDateString();
@@ -158,9 +164,9 @@
                     vm.period = [vm.startDate];
                 }else{
                     vm.period = [vm.startDate, vm.endDate];
-                }
-                
-                preFlightCheck();
+                }                
+                                
+                preFlightCheck(instance);
             }
 
         }

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
@@ -112,7 +112,7 @@
 
                 for (let [key, value] of Object.entries(data)) {
                     const index = vm.logTypeLabels.findIndex(x => key.startsWith(x));
-                    if (index > -1 && index < vm.logTypeData.length) {
+                    if (index > -1) {
                         vm.logTypeData[index] = value;
                     }                
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
@@ -12,9 +12,9 @@
         vm.commonLogMessagesCount = 10;
 
         // ChartJS Options - for count/overview of log distribution
-        vm.logTypeLabels = ["Info", "Debug", "Warning", "Error", "Critical"];
+        vm.logTypeLabels = ["Debug", "Info", "Warning", "Error", "Fatal"];
         vm.logTypeData = [0, 0, 0, 0, 0];
-        vm.logTypeColors = [ '#dcdcdc', '#97bbcd', '#46bfbd', '#fdb45c', '#f7464a'];
+        vm.logTypeColors = ['#eaddd5', '#2bc37c', '#3544b1', '#ff9412', '#d42054'];
         vm.chartOptions = {
             legend: {
                 display: true,
@@ -74,7 +74,7 @@
                         "query": "Not(@Level='Verbose') and Not(@Level='Debug')"
                     },
                     {
-                        "name": "Find all logs that has an exception property (Warning, Error & Critical with Exceptions)",
+                        "name": "Find all logs that has an exception property (Warning, Error & Fatal with Exceptions)",
                         "query": "Has(@Exception)"
                     },
                     {
@@ -113,8 +113,8 @@
                 vm.commonLogMessages = data;
             });
 
-            //Set loading indicatior to false when these 3 queries complete
-            $q.all([savedSearches, numOfErrors, logCounts, commonMsgs]).then(function(data) {
+            //Set loading indicator to false when these 3 queries complete
+            $q.all([savedSearches, numOfErrors, logCounts, commonMsgs]).then(function() {
                 vm.loading = false;
             });
 
@@ -148,7 +148,7 @@
             conjunction: " to "
         };
         
-        vm.dateRangeChange = function(selectedDates, dateStr, instance) {
+        vm.dateRangeChange = function(selectedDates) {
             
             if(selectedDates.length > 0){
                 vm.startDate = selectedDates[0].toIsoDateString();

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
@@ -71,37 +71,37 @@
             vm.loading = true;
 
             var savedSearches = logViewerResource.getSavedSearches().then(function (data) {
-                vm.searches = data;
-            },
-            // fallback to some defaults if error from API response
-            function () {
-                vm.searches = [
-                    {
-                        "name": "Find all logs where the Level is NOT Verbose and NOT Debug",
-                        "query": "Not(@Level='Verbose') and Not(@Level='Debug')"
+                    vm.searches = data;
+                },
+                // fallback to some defaults if error from API response
+                function () {
+                    vm.searches = [
+                        {
+                            "name": "Find all logs where the Level is NOT Verbose and NOT Debug",
+                            "query": "Not(@Level='Verbose') and Not(@Level='Debug')"
                     },
-                    {
-                        "name": "Find all logs that has an exception property (Warning, Error & Fatal with Exceptions)",
-                        "query": "Has(@Exception)"
+                        {
+                            "name": "Find all logs that has an exception property (Warning, Error & Fatal with Exceptions)",
+                            "query": "Has(@Exception)"
                     },
-                    {
-                        "name": "Find all logs that have the property 'Duration'",
-                        "query": "Has(Duration)"
+                        {
+                            "name": "Find all logs that have the property 'Duration'",
+                            "query": "Has(Duration)"
                     },
-                    {
-                        "name": "Find all logs that have the property 'Duration' and the duration is greater than 1000ms",
-                        "query": "Has(Duration) and Duration > 1000"
+                        {
+                            "name": "Find all logs that have the property 'Duration' and the duration is greater than 1000ms",
+                            "query": "Has(Duration) and Duration > 1000"
                     },
-                    {
-                        "name": "Find all logs that are from the namespace 'Umbraco.Core'",
-                        "query": "StartsWith(SourceContext, 'Umbraco.Core')"
+                        {
+                            "name": "Find all logs that are from the namespace 'Umbraco.Core'",
+                            "query": "StartsWith(SourceContext, 'Umbraco.Core')"
                     },
-                    {
-                        "name": "Find all logs that use a specific log message template",
-                        "query": "@MessageTemplate = '[Timing {TimingId}] {EndMessage} ({TimingDuration}ms)'"
+                        {
+                            "name": "Find all logs that use a specific log message template",
+                            "query": "@MessageTemplate = '[Timing {TimingId}] {EndMessage} ({TimingDuration}ms)'"
                     }
                 ]
-            });
+                });
 
             var numOfErrors = logViewerResource.getNumberOfErrors(vm.startDate, vm.endDate).then(function (data) {
                 vm.numberOfErrors = data;
@@ -109,11 +109,13 @@
 
             var logCounts = logViewerResource.getLogLevelCounts(vm.startDate, vm.endDate).then(function (data) {
                 vm.logTypeData = [];
-                vm.logTypeData.push(data.Information);
-                vm.logTypeData.push(data.Debug);
-                vm.logTypeData.push(data.Warning);
-                vm.logTypeData.push(data.Error);
-                vm.logTypeData.push(data.Fatal);
+
+                for (let [key, value] of Object.entries(data)) {
+                    const index = vm.logTypeLabels.findIndex(x => key.startsWith(x));
+                    if (index > -1 && index < vm.logTypeData.length) {
+                        vm.logTypeData[index] = value;
+                    }                
+                }
             });
 
             var commonMsgs = logViewerResource.getMessageTemplates(vm.startDate, vm.endDate).then(function (data) {
@@ -121,17 +123,24 @@
             });
 
             //Set loading indicator to false when these 3 queries complete
-            $q.all([savedSearches, numOfErrors, logCounts, commonMsgs]).then(function() {
+            $q.all([savedSearches, numOfErrors, logCounts, commonMsgs]).then(function () {
                 vm.loading = false;
             });
-            
+
             $timeout(function () {
-                navigationService.syncTree({ tree: "logViewer", path: "-1" });
+                navigationService.syncTree({
+                    tree: "logViewer",
+                    path: "-1"
+                });
             });
         }
 
         function searchLogQuery(logQuery) {
-            $location.path("/settings/logViewer/search").search({ lq: logQuery, startDate: vm.startDate, endDate: vm.endDate });
+            $location.path("/settings/logViewer/search").search({
+                lq: logQuery,
+                startDate: vm.startDate,
+                endDate: vm.endDate
+            });
         }
 
         function findMessageTemplate(template) {
@@ -142,7 +151,7 @@
         function getDateRangeLabel(suffix) {
             return "Log Overview for " + suffix;
         }
-        
+
         preFlightCheck();
 
         /////////////////////
@@ -166,7 +175,10 @@
                 // is collapsed to a comma.
                 const startDate = selectedDates[0].toIsoDateString();
                 const endDate = selectedDates[selectedDates.length - 1].toIsoDateString(); // Take the last date as end
-                $location.path("/settings/logViewer/overview").search({ startDate: startDate, endDate: endDate });
+                $location.path("/settings/logViewer/overview").search({
+                    startDate: startDate,
+                    endDate: endDate
+                });
             }
 
         }

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
@@ -78,7 +78,7 @@
                             class="datepicker"
                             ng-model="vm.period"
                             options="vm.config"
-                            on-close="vm.dateRangeChange(selectedDates)">
+                            on-close="vm.dateRangeChange(selectedDates, dateStr, instance)">
                         </umb-flatpickr>
                     </umb-box>
 

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
@@ -78,7 +78,7 @@
                             class="datepicker"
                             ng-model="vm.period"
                             options="vm.config"
-                            on-close="vm.dateRangeChange(selectedDates, dateStr, instance)">
+                            on-close="vm.dateRangeChange(selectedDates)">
                         </umb-flatpickr>
                     </umb-box>
 

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
@@ -11,26 +11,28 @@
         vm.showBackButton = true;
         vm.page = {};
 
+        // this array is also used to map the logTypeColor param onto the log items
+        // in setLogTypeColors()
         vm.logLevels = [
             {
                 name: 'Verbose',
-                logTypeColor: 'gray'
+                logTypeColor: ''
             },
             {
                 name: 'Debug',
-                logTypeColor: 'secondary'
+                logTypeColor: 'gray'
             },
             {
                 name: 'Information',
-                logTypeColor: 'primary'
+                logTypeColor: 'success' 
             },
             {
                 name: 'Warning',
-                logTypeColor: 'warning'
+                logTypeColor: 'primary'
             },
             {
                 name: 'Error',
-                logTypeColor: 'danger'
+                logTypeColor: 'warning'
             },
             {
                 name: 'Fatal',
@@ -118,7 +120,7 @@
                         "query": "Not(@Level='Verbose') and Not(@Level='Debug')"
                     },
                     {
-                        "name": "Find all logs that has an exception property (Warning, Error & Critical with Exceptions)",
+                        "name": "Find all logs that has an exception property (Warning, Error & Fatal with Exceptions)",
                         "query": "Has(@Exception)"
                     },
                     {
@@ -173,25 +175,8 @@
         }
 
         function setLogTypeColor(logItems) {
-            angular.forEach(logItems, function (log) {
-                switch (log.Level) {
-                    case "Information":
-                        log.logTypeColor = "primary";
-                        break;
-                    case "Debug":
-                        log.logTypeColor = "secondary";
-                        break;
-                    case "Warning":
-                        log.logTypeColor = "warning";
-                        break;
-                    case "Fatal":
-                    case "Error":
-                        log.logTypeColor = "danger";
-                        break;
-                    default:
-                        log.logTypeColor = "gray";
-                }
-            });
+            logItems.forEach(logItem => 
+                logItem.logTypeColor = vm.logLevels.find(x => x.name === logItem.Level).logTypeColor);
         }
 
         function getFilterName(array) {

--- a/src/Umbraco.Web.UI/config/logviewer.searches.config.js
+++ b/src/Umbraco.Web.UI/config/logviewer.searches.config.js
@@ -4,7 +4,7 @@
     "query": "Not(@Level='Verbose') and Not(@Level='Debug')"
   },
   {
-    "name": "Find all logs that has an exception property (Warning, Error & Critical with Exceptions)",
+    "name": "Find all logs that has an exception property (Warning, Error & Fatal with Exceptions)",
     "query": "Has(@Exception)"
   },
   {

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Dashboards\HealthCheckDashboard.cs" />
     <Compile Include="Dashboards\MediaDashboard.cs" />
     <Compile Include="Dashboards\MembersDashboard.cs" />
+    <Compile Include="Dashboards\ProfilerDashboard.cs" />
     <Compile Include="Dashboards\PublishedStatusDashboard.cs" />
     <Compile Include="Dashboards\RedirectUrlDashboard.cs" />
     <Compile Include="Dashboards\SettingsDashboards.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5768

### Description

I've fixed up the verbiage between the chart and the search view to use Fatal in both locations, including in the saved searches.
 
Also tweaked the color palette a little as it was unclear using the same color for both Error and Fatal, since they mean different things. Palette now looks like this: 

![log-levels-chart](https://user-images.githubusercontent.com/3248070/60633463-1cd6fd00-9e4e-11e9-86f3-aa55082c7b2a.png)

![log-levels-dropdown](https://user-images.githubusercontent.com/3248070/60633509-4ee85f00-9e4e-11e9-99c3-33c7fd03782e.png)

Have stuck with the existing color options for badges, in ascending order of importance, hence green for info as everything logged to information should NOT be a warning, error or fatality.

Made some changes to the search controller to use the existing `logLevels` variable to map colors onto the logItems, where we previously had a switch statement - consolidating that means there's now only one place in the controller to define the log colors so should make future changes easier.

Addendum: The datepicker was doing strange things when setting a range. Rather than formatting the displayed date `2019-07-03 to 2019-07-04` as it does on page load, it was `2019-07-03,2019-07-04`. Thought it might have been related to unbinding the element in an ng-if, but nope. The call to `logViewerResource.canViewLogs` in the preflight check function is somehow responsible, so resetting the date value in the preflight callback fixes it - I've done that by passing the datepicker instance into `preflightCheck` when that function is called in the datepicker change function, then conditionally resetting the date only when the instance exists. Seems to do the trick.





---
_This item has been added to our backlog [AB#1689](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/1689)_