### PR TITLE
V8: Bugfix - Redirects future v7 versions into v7.14 initial migration state

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -74,8 +74,9 @@ namespace Umbraco.Core.Migrations.Upgrade
                     throw new InvalidOperationException($"Version {currentVersion} cannot be migrated to {UmbracoVersion.SemanticVersion}."
                                                         + $" Please upgrade first to at least {minVersion}.");
 
-                // Force newer versions of 7, into 7.14, when migrating
-                if (currentVersion.Major == 7)
+                // Force versions between 7.14.*-7.15.* into into 7.14 initial state. Because there is no db-changes,
+                // and we don't want users to workaround my putting in version 7.14.0 them self.
+                if (minVersion <= currentVersion && currentVersion < new SemVersion(7, 16))
                     return GetInitState(minVersion);
 
                 // initial state is eg "{init-7.14.0}"

--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -74,6 +74,10 @@ namespace Umbraco.Core.Migrations.Upgrade
                     throw new InvalidOperationException($"Version {currentVersion} cannot be migrated to {UmbracoVersion.SemanticVersion}."
                                                         + $" Please upgrade first to at least {minVersion}.");
 
+                // Force newer versions of 7, into 7.14, when migrating
+                if (currentVersion.Major == 7)
+                    return GetInitState(minVersion);
+
                 // initial state is eg "{init-7.14.0}"
                 return GetInitState(currentVersion);
             }


### PR DESCRIPTION
Forces the initial migration state of V7 sites that are allowed to be migrated into v7.14 state.
