### PR TITLE
V8: Minor log viewer improvements

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
@@ -3,7 +3,7 @@
     <umb-editor-view footer="false">
 
         <umb-editor-header
-            name="'Log Overview for Today'"
+            name="vm.dateRangeLabel"
             name-locked="true"
             hide-icon="true"
             hide-description="true"
@@ -74,11 +74,10 @@
                     <umb-box>
                         <umb-box-header title="Time Period"></umb-box-header>
 
-                        <umb-flatpickr
-                            class="datepicker"
-                            ng-model="vm.period"
-                            options="vm.config"
-                            on-close="vm.dateRangeChange(selectedDates, dateStr, instance)">
+                        <umb-flatpickr class="datepicker"
+                                       ng-model="vm.period"
+                                       options="vm.config"
+                                       on-close="vm.dateRangeChange(selectedDates, dateStr, instance)">
                         </umb-flatpickr>
                     </umb-box>
 

--- a/src/Umbraco.Web/Editors/LogViewerController.cs
+++ b/src/Umbraco.Web/Editors/LogViewerController.cs
@@ -15,11 +15,11 @@ namespace Umbraco.Web.Editors
     [PluginController("UmbracoApi")]
     public class LogViewerController : UmbracoAuthorizedJsonController
     {
-        private ILogViewer _logViewer;
+        private readonly ILogViewer _logViewer;
 
         public LogViewerController(ILogViewer logViewer)
         {
-            _logViewer = logViewer;
+            _logViewer = logViewer ?? throw new ArgumentNullException(nameof(logViewer));
         }
 
         private bool CanViewLogs(LogTimePeriod logTimePeriod)
@@ -90,8 +90,6 @@ namespace Umbraco.Web.Editors
             }
 
             var direction = orderDirection == "Descending" ? Direction.Descending : Direction.Ascending;
-
-
 
             return _logViewer.GetLogs(logTimePeriod, filterExpression: filterExpression, pageNumber: pageNumber, orderDirection: direction, logLevels: logLevels);
         }


### PR DESCRIPTION
This PR contains a few minor improvements to the log viewer:

- Fixes issue #5768 (wrong label for "Fatal" errors on the pie chart).
 - Made the title variable so it either says "Log Overview For Today", "Log Overview For Selected Date" or "Log Overview For Selected Time Period" as appropriate (previously it said the former even if you'd adjusted the dates you were looking at.
- Fixed up the selected date period display so the conjunction "to" is used between the dates when the selected time period is changed, and the query-string is updated to match the current search.
- Made some minor code tidying updates.