### PR TITLE
V7: Fix media file icon in search results

### DIFF
--- a/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
+++ b/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
@@ -301,19 +301,7 @@ namespace Umbraco.Web.Search
         /// <param name="results"></param>
         /// <returns></returns>
         private IEnumerable<SearchResultItem> MediaFromSearchResults(IEnumerable<SearchResult> results)
-        {
-            var mapped = Mapper.Map<IEnumerable<SearchResultItem>>(results).ToArray();
-            //add additional data
-            foreach (var m in mapped)
-            {
-                //if no icon could be mapped, it will be set to document, so change it to picture
-                if (m.Icon == "icon-document")
-                {
-                    m.Icon = "icon-picture";
-                }
-            }
-            return mapped;
-        }
+            => Mapper.Map<IEnumerable<SearchResultItem>>(results).ToArray();
 
         /// <summary>
         /// Returns a collection of entities for content based on search results


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5771

### Description

See #5771 for steps to reproduce/test. 

The issue happens because the tree searcher assumes that the icon "icon-document" in a media search result means a bad mapping from the search result; it's the default icon used by the mapper. However, "icon-document" is also used for the default file media type, so it doesn't have to be a mapping error.

With this PR applied, the search feature in the tree picker works as expected for file results:

![mntp-search-file-icon-changes](https://user-images.githubusercontent.com/7405322/60752699-39e40b00-9fc9-11e9-92b4-1175267681bd.gif)
