### PR TITLE
V8: Can't save members without resetting their password

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -139,7 +139,7 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
 
             //anytime a user is changing a member's password without the oldPassword, we are in effect resetting it so we need to set that flag here
             var passwordProp = _.find(contentEditingHelper.getAllProps($scope.content), function (e) { return e.alias === '_umb_password' });
-            if (!passwordProp.value.reset) {
+            if (passwordProp && passwordProp.value && !passwordProp.value.reset) {
                 //so if the admin is not explicitly resetting the password, flag it for resetting if a new password is being entered
                 passwordProp.value.reset = !passwordProp.value.oldPassword && passwordProp.config.allowManuallyChangingPassword;
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5691 (for V8)

### Description

There's a JS error that prevents saving a member if you're not resetting the member password in the same operation:

![save-member-before](https://user-images.githubusercontent.com/7405322/60766399-8868d680-a0a9-11e9-8c33-9ac26814f651.gif)

This PR fixes it:

![save-member-after](https://user-images.githubusercontent.com/7405322/60766404-961e5c00-a0a9-11e9-8c76-9c04aa7dd74f.gif)
