### PR TITLE
V7: Can't save members without resetting their password

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -133,7 +133,7 @@ function MemberEditController($scope, $routeParams, $location, $q, $window, appS
 
             //anytime a user is changing a member's password without the oldPassword, we are in effect resetting it so we need to set that flag here
             var passwordProp = _.find(contentEditingHelper.getAllProps($scope.content), function (e) { return e.alias === '_umb_password' });
-            if (!passwordProp.value.reset) {
+            if (passwordProp && passwordProp.value && !passwordProp.value.reset) {
                 //so if the admin is not explicitly resetting the password, flag it for resetting if a new password is being entered
                 passwordProp.value.reset = !passwordProp.value.oldPassword && passwordProp.config.allowManuallyChangingPassword;
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5691

### Description

As described in #5691 there's a JS error on the edit member page; you can't save an existing member without changing the member password:

![save-member-before](https://user-images.githubusercontent.com/7405322/60766590-fd3d1000-a0ab-11e9-8040-b991842bc589.gif)

This PR fixes it:

![save-member-after](https://user-images.githubusercontent.com/7405322/60766591-0201c400-a0ac-11e9-9bf0-714c67946a0e.gif)

_Note: This is the V7 equivalent of #5798_
