### PR TITLE
Remove last casting to LuceneIndex

### DIFF
--- a/src/Umbraco.Web/Editors/ExamineManagementController.cs
+++ b/src/Umbraco.Web/Editors/ExamineManagementController.cs
@@ -85,7 +85,7 @@ namespace Umbraco.Web.Editors
             };
         }
 
-       
+
 
         /// <summary>
         /// Check if the index has been rebuilt
@@ -250,7 +250,7 @@ namespace Umbraco.Web.Editors
 
         private void Indexer_IndexOperationComplete(object sender, EventArgs e)
         {
-            var indexer = (LuceneIndex)sender;
+            var indexer = (IIndex)sender;
 
             _logger.Debug<ExamineManagementController>("Logging operation completed for index {IndexName}", indexer.Name);
 
@@ -259,7 +259,7 @@ namespace Umbraco.Web.Editors
 
             _logger
                 .Info<ExamineManagementController
-                >($"Rebuilding index '{indexer.Name}' done, {indexer.CommitCount} items committed (can differ from the number of items in the index)");
+                >($"Rebuilding index '{indexer.Name}' done.");
 
             var cacheKey = "temp_indexing_op_" + indexer.Name;
             _runtimeCache.Clear(cacheKey);


### PR DESCRIPTION
### Description
It is really simple PR, which will allow to fully switch out all indexes from examine to any kind of provider.
As we discussed with @Shazwazza I switch to IIndex and remove CommitCount, because of not all type of indexer will use that.
