### PR TITLE
Fixed @name label in filemanager.service.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/filemanager.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/filemanager.service.js
@@ -16,7 +16,7 @@ function fileManager($rootScope) {
     var mgr = {
         /**
          * @ngdoc function
-         * @name umbraco.services.fileManager#addFiles
+         * @name umbraco.services.fileManager#setFiles
          * @methodOf umbraco.services.fileManager
          * @function
          *


### PR DESCRIPTION
Just a small fix to inline documentation. Corrected the @name documentation of the setFiles method in filemanager.service.js, from "addFiles" to "setFiles".