### PR TITLE
v8: Add margin before value in listview grid layout

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-content-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-content-grid.less
@@ -105,6 +105,7 @@
 .umb-content-grid__details-value {
    display: inline-block;
    word-break: break-word;
+   margin-left: 3px;
 }
 
 .umb-content-grid__checkmark {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5813

### Description
This PR add a bit margin before the value in the listview grid layout, so there is some space between the label and value.

**Before**
![image](https://user-images.githubusercontent.com/2919859/60914107-1f3fb980-a289-11e9-9ec9-f25d0521f3d5.png)

**After**
![image](https://user-images.githubusercontent.com/2919859/60914155-367ea700-a289-11e9-87d7-f4cebe4b91fb.png)
