### PR TITLE
v8: Fix toggle change password in user dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js
@@ -95,7 +95,7 @@ angular.module('umbraco.directives')
         };
     })
 
-    .directive('onOutsideClick', function ($timeout, angularHelper) {
+    .directive('onOutsideClick', function ($timeout) {
         return function (scope, element, attrs) {
 
             var eventBindings = [];

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.controller.js
@@ -167,8 +167,9 @@ angular.module("umbraco")
 
         };
 
-        $scope.togglePasswordFields = function() {
+        $scope.togglePasswordFields = function($event) {
            clearPasswordFields();
+           $event.stopPropagation();
            $scope.showPasswordFields = !$scope.showPasswordFields;
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -23,9 +23,10 @@
         <umb-button
             alias="changePassword"
             type="button"
-            action="togglePasswordFields()"
+            action="togglePasswordFields($event)"
             button-style="action"
             label="Change password"
+            label-key="general_changePassword">
        </umb-button>
 
         <umb-button
@@ -106,7 +107,7 @@
 
            <umb-button
                type="button"
-               action="togglePasswordFields()"
+               action="togglePasswordFields($event)"
                label="Back"
                label-key="general_back"
                button-style="cancel">

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -26,8 +26,6 @@
             action="togglePasswordFields()"
             button-style="action"
             label="Change password"
-            label-key="general_changePassword"
-            button-style="success">
        </umb-button>
 
         <umb-button


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5808

### Description
When clicking the change password button this parent `.umb-overlay` wasn't found, but it was found when clicking the whitespace in the dialog outside the button.
https://github.com/umbraco/Umbraco-CMS/blob/1a437c1c6abe77ef5edd337bbbdb169edde5f41e/src/Umbraco.Web.UI.Client/src/common/directives/components/events/events.directive.js#L111

I guess it in some way conflict with the `umbButton` event.
https://github.com/umbraco/Umbraco-CMS/blob/040ebfe9dd7d7053ccf4393f8a83c11fc3866b69/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js#L193

To fix this issue and without changing too much in `umbButton` component, I have stopped event bubbling when clicking the change password button, which toggle the change password fields.

![2019-07-09_22-10-51](https://user-images.githubusercontent.com/2919859/60919601-7ac47400-a296-11e9-9d83-13c6c75ee7fa.gif)
