### PR TITLE
Fixes issue during upgrade where umbraco can't clear cdf log files

### DIFF
--- a/src/Umbraco.Web/JavaScript/ClientDependencyConfiguration.cs
+++ b/src/Umbraco.Web/JavaScript/ClientDependencyConfiguration.cs
@@ -106,8 +106,10 @@ namespace Umbraco.Web.JavaScript
             }
 
             try
-            {
-                var fullPath = currentHttpContext.Server.MapPath(XmlFileMapper.FileMapDefaultFolder);
+            {               
+                var fullPath = XmlFileMapper.FileMapDefaultFolder.StartsWith("~/")
+                    ? currentHttpContext.Server.MapPath(XmlFileMapper.FileMapDefaultFolder)
+                    : XmlFileMapper.FileMapDefaultFolder;
                 if (fullPath != null)
                 {
                     cdfTempDirectories.Add(fullPath);
@@ -122,13 +124,12 @@ namespace Umbraco.Web.JavaScript
             var success = true;
             foreach (var directory in cdfTempDirectories)
             {
-                var directoryInfo = new DirectoryInfo(directory);
-                if (directoryInfo.Exists == false)
-                    continue;
-
                 try
                 {
-                    directoryInfo.Delete(true);
+                    if (!Directory.Exists(directory))
+                        continue;
+
+                    Directory.Delete(directory, true);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
During the 8.0.x upgrade to 8.1 (it could also be from 8.0.1 -> 8.0.2) there's an operation during the upgrade where Umbraco tries to clear the CDF file cache but it fails because it's passing in a fully qualified path to MapPath which throws an exception. The exception is caught and logged but it means that the CDF files aren't cleared.

An example of the error is that is logged is:

```
Message:
Could not get path from ClientDependency.config

Exception:
System.Web.HttpException (0x80004005): 'C:/Sites/MySite/ClientDependency' is a physical path, but a virtual path was expected.
   at System.Web.Util.UrlPath.CheckValidVirtualPath(String path)
   at System.Web.Util.UrlPath.Combine(String appPath, String basepath, String relative)
   at System.Web.VirtualPath.Combine(VirtualPath relativePath)
   at System.Web.HttpRequest.MapPath(VirtualPath virtualPath, VirtualPath baseVirtualDir, Boolean allowCrossAppMapping)
   at System.Web.HttpRequest.MapPath(VirtualPath virtualPath)
   at System.Web.HttpServerUtility.MapPath(String path)
   at System.Web.HttpServerUtilityWrapper.MapPath(String path)
   at Umbraco.Web.JavaScript.ClientDependencyConfiguration.ClearTempFiles(HttpContextBase currentHttpContext)
```

### Testing

Test an upgrade with the build output from this PR - possibly put a break point into this method to make sure the files are cleared correctly

---
_This item has been added to our backlog [AB#1691](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/1691)_