### PR TITLE
Fixes #5789 - PublishedContentQuery Search always searches on culture

### DIFF
--- a/src/Umbraco.Examine/ExamineExtensions.cs
+++ b/src/Umbraco.Examine/ExamineExtensions.cs
@@ -48,6 +48,31 @@ namespace Umbraco.Examine
             }
         }
 
+        /// <summary>
+        /// Returns all index fields that are culture specific (suffixed) or invariant
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="culture"></param>
+        /// <returns></returns>
+        public static IEnumerable<string> GetCultureAndInvariantFields(this IUmbracoIndex index, string culture)
+        {
+            var allFields = index.GetFields();
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            foreach (var field in allFields)
+            {
+                var match = CultureIsoCodeFieldNameMatchExpression.Match(field);
+                if (match.Success && match.Groups.Count == 3 && culture.InvariantEquals(match.Groups[2].Value))
+                {
+                    yield return field; //matches this culture field
+                }
+                else if (!match.Success)
+                {
+                    yield return field; //matches no culture field (invariant)
+                }
+                    
+            }
+        }
+
         internal static bool TryParseLuceneQuery(string query)
         {
             // TODO: I'd assume there would be a more strict way to parse the query but not that i can find yet, for now we'll

--- a/src/Umbraco.Tests/TestHelpers/RandomIdRamDirectory.cs
+++ b/src/Umbraco.Tests/TestHelpers/RandomIdRamDirectory.cs
@@ -1,0 +1,22 @@
+﻿using Lucene.Net.Store;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Tests.TestHelpers
+{
+
+    /// <summary>
+    /// Used for tests with Lucene so that each RAM directory is unique
+    /// </summary>
+    public class RandomIdRAMDirectory : RAMDirectory
+    {
+        private readonly string _lockId = Guid.NewGuid().ToString();
+        public override string GetLockId()
+        {
+            return _lockId;
+        }
+    }
+}

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Services\MemberGroupServiceTests.cs" />
     <Compile Include="Services\MediaTypeServiceTests.cs" />
     <Compile Include="Services\PropertyValidationServiceTests.cs" />
+    <Compile Include="TestHelpers\RandomIdRamDirectory.cs" />
     <Compile Include="Testing\Objects\TestDataSource.cs" />
     <Compile Include="Published\PublishedSnapshotTestObjects.cs" />
     <Compile Include="Published\ModelTypeTests.cs" />
@@ -268,6 +269,7 @@
     <Compile Include="Strings\StylesheetHelperTests.cs" />
     <Compile Include="Strings\StringValidationTests.cs" />
     <Compile Include="Web\Mvc\ValidateUmbracoFormRouteStringAttributeTests.cs" />
+    <Compile Include="Web\PublishedContentQueryTests.cs" />
     <Compile Include="Web\UmbracoHelperTests.cs" />
     <Compile Include="Membership\MembershipProviderBaseTests.cs" />
     <Compile Include="Membership\UmbracoServiceMembershipProviderTests.cs" />

--- a/src/Umbraco.Tests/Web/PublishedContentQueryTests.cs
+++ b/src/Umbraco.Tests/Web/PublishedContentQueryTests.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Examine;
+using Examine.LuceneEngine.Providers;
+using Lucene.Net.Store;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Examine;
+using Umbraco.Tests.TestHelpers;
+using Umbraco.Web;
+using Umbraco.Web.PublishedCache;
+
+namespace Umbraco.Tests.Web
+{
+    [TestFixture]
+    public class PublishedContentQueryTests
+    {
+
+        private class TestIndex : LuceneIndex, IUmbracoIndex
+        {
+            private readonly string[] _fieldNames;
+
+            public TestIndex(string name, Directory luceneDirectory, string[] fieldNames)
+                : base(name, luceneDirectory, null, null, null, null)
+            {
+                _fieldNames = fieldNames;
+            }
+            public bool EnableDefaultEventHandler => throw new NotImplementedException();
+            public bool PublishedValuesOnly => throw new NotImplementedException();
+            public IEnumerable<string> GetFields() => _fieldNames;
+        }
+
+        private TestIndex CreateTestIndex(Directory luceneDirectory, string[] fieldNames)
+        {
+            var indexer = new TestIndex("TestIndex", luceneDirectory, fieldNames);
+
+            //populate with some test data
+            indexer.IndexItem(new ValueSet("1", "content", new Dictionary<string, object>
+            {
+                [fieldNames[0]] = "Hello world, there are products here",
+                [UmbracoContentIndex.VariesByCultureFieldName] = "n"
+            }));
+            indexer.IndexItem(new ValueSet("2", "content", new Dictionary<string, object>
+            {
+                [fieldNames[1]] = "Hello world, there are products here",
+                [UmbracoContentIndex.VariesByCultureFieldName] = "y"
+            }));
+            indexer.IndexItem(new ValueSet("3", "content", new Dictionary<string, object>
+            {
+                [fieldNames[2]] = "Hello world, there are products here",
+                [UmbracoContentIndex.VariesByCultureFieldName] = "y"
+            }));
+            return indexer;
+        }
+
+        private PublishedContentQuery CreatePublishedContentQuery(IIndex indexer)
+        {
+            var examineManager = new Mock<IExamineManager>();
+            IIndex outarg = indexer;
+            examineManager.Setup(x => x.TryGetIndex("TestIndex", out outarg)).Returns(true);
+
+            var contentCache = new Mock<IPublishedContentCache>();
+            contentCache.Setup(x => x.GetById(It.IsAny<int>())).Returns((int intId) => Mock.Of<IPublishedContent>(x => x.Id == intId));
+            var snapshot = Mock.Of<IPublishedSnapshot>(x => x.Content == contentCache.Object);
+            var variationContext = new VariationContext();
+            var variationContextAccessor = Mock.Of<IVariationContextAccessor>(x => x.VariationContext == variationContext);
+
+            return new PublishedContentQuery(snapshot, variationContextAccessor, examineManager.Object);
+        }
+
+        [Test]
+        public void Search_Wildcard()
+        {
+            using (var luceneDir = new RandomIdRAMDirectory())
+            {
+                var fieldNames = new[] { "title", "title_en-us", "title_fr-fr" };
+                using (var indexer = CreateTestIndex(luceneDir, fieldNames))
+                {
+                    var pcq = CreatePublishedContentQuery(indexer);
+
+                    var results = pcq.Search("Products", "*", "TestIndex");
+
+                    var ids = results.Select(x => x.Content.Id).ToList();
+                    Assert.AreEqual(3, ids.Count);
+
+                    //returns results for all fields and document types
+                    Assert.IsTrue(ids.Contains(1) && ids.Contains(2) && ids.Contains(3));
+                }
+            }
+        }
+
+        [Test]
+        public void Search_Invariant()
+        {
+            using (var luceneDir = new RandomIdRAMDirectory())
+            {
+                var fieldNames = new[] { "title", "title_en-us", "title_fr-fr" };
+                using (var indexer = CreateTestIndex(luceneDir, fieldNames))
+                {
+                    var pcq = CreatePublishedContentQuery(indexer);
+
+                    var results = pcq.Search("Products", null, "TestIndex");
+
+                    var ids = results.Select(x => x.Content.Id).ToList();
+                    Assert.AreEqual(1, ids.Count);
+
+                    //returns results for only invariant fields and invariant documents
+                    Assert.IsTrue(ids.Contains(1) && !ids.Contains(2) && !ids.Contains(3));
+                }
+            }
+        }
+
+        [Test]
+        public void Search_Culture1()
+        {
+            using (var luceneDir = new RandomIdRAMDirectory())
+            {
+                var fieldNames = new[] { "title", "title_en-us", "title_fr-fr" };
+                using (var indexer = CreateTestIndex(luceneDir, fieldNames))
+                {
+                    var pcq = CreatePublishedContentQuery(indexer);
+
+                    var results = pcq.Search("Products", "en-us", "TestIndex");
+
+                    var ids = results.Select(x => x.Content.Id).ToList();
+                    Assert.AreEqual(2, ids.Count);
+
+                    //returns results for en-us fields and invariant fields for all document types
+                    Assert.IsTrue(ids.Contains(1) && ids.Contains(2) && !ids.Contains(3));
+                }
+            }
+        }
+
+        [Test]
+        public void Search_Culture2()
+        {
+            using (var luceneDir = new RandomIdRAMDirectory())
+            {
+                var fieldNames = new[] { "title", "title_en-us", "title_fr-fr" };
+                using (var indexer = CreateTestIndex(luceneDir, fieldNames))
+                {
+                    var pcq = CreatePublishedContentQuery(indexer);
+
+                    var results = pcq.Search("Products", "fr-fr", "TestIndex");
+
+                    var ids = results.Select(x => x.Content.Id).ToList();
+                    Assert.AreEqual(2, ids.Count);
+
+                    //returns results for fr-fr fields and invariant fields for all document types
+                    Assert.IsTrue(ids.Contains(1) && !ids.Contains(2) && ids.Contains(3));
+                }
+            }
+        }
+    }
+}

--- a/src/Umbraco.Tests/Web/PublishedContentQueryTests.cs
+++ b/src/Umbraco.Tests/Web/PublishedContentQueryTests.cs
@@ -36,22 +36,26 @@ namespace Umbraco.Tests.Web
         {
             var indexer = new TestIndex("TestIndex", luceneDirectory, fieldNames);
 
-            //populate with some test data
-            indexer.IndexItem(new ValueSet("1", "content", new Dictionary<string, object>
+            using (indexer.ProcessNonAsync())
             {
-                [fieldNames[0]] = "Hello world, there are products here",
-                [UmbracoContentIndex.VariesByCultureFieldName] = "n"
-            }));
-            indexer.IndexItem(new ValueSet("2", "content", new Dictionary<string, object>
-            {
-                [fieldNames[1]] = "Hello world, there are products here",
-                [UmbracoContentIndex.VariesByCultureFieldName] = "y"
-            }));
-            indexer.IndexItem(new ValueSet("3", "content", new Dictionary<string, object>
-            {
-                [fieldNames[2]] = "Hello world, there are products here",
-                [UmbracoContentIndex.VariesByCultureFieldName] = "y"
-            }));
+                //populate with some test data
+                indexer.IndexItem(new ValueSet("1", "content", new Dictionary<string, object>
+                {
+                    [fieldNames[0]] = "Hello world, there are products here",
+                    [UmbracoContentIndex.VariesByCultureFieldName] = "n"
+                }));
+                indexer.IndexItem(new ValueSet("2", "content", new Dictionary<string, object>
+                {
+                    [fieldNames[1]] = "Hello world, there are products here",
+                    [UmbracoContentIndex.VariesByCultureFieldName] = "y"
+                }));
+                indexer.IndexItem(new ValueSet("3", "content", new Dictionary<string, object>
+                {
+                    [fieldNames[2]] = "Hello world, there are products here",
+                    [UmbracoContentIndex.VariesByCultureFieldName] = "y"
+                }));
+            }
+            
             return indexer;
         }
 
@@ -80,7 +84,7 @@ namespace Umbraco.Tests.Web
             {
                 var fieldNames = new[] { "title", "title_en-us", "title_fr-fr" };
                 using (var indexer = CreateTestIndex(luceneDir, fieldNames))
-                {
+                {   
                     var pcq = CreatePublishedContentQuery(indexer);
 
                     var results = pcq.Search("Products", culture, "TestIndex");

--- a/src/Umbraco.Tests/Web/UmbracoHelperTests.cs
+++ b/src/Umbraco.Tests/Web/UmbracoHelperTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Text;
+using Examine.LuceneEngine;
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.Standard;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Core;
@@ -13,18 +16,19 @@ using Umbraco.Web;
 
 namespace Umbraco.Tests.Web
 {
+
     [TestFixture]
     public class UmbracoHelperTests
-    {   
+    {
 
         [TearDown]
         public void TearDown()
         {
             Current.Reset();
         }
-        
 
-        
+
+
         // ------- Int32 conversion tests
         [Test]
         public static void Converting_Boxed_34_To_An_Int_Returns_34()

--- a/src/Umbraco.Web/IPublishedContentQuery.cs
+++ b/src/Umbraco.Web/IPublishedContentQuery.cs
@@ -39,7 +39,11 @@ namespace Umbraco.Web
         /// <param name="culture">Optional culture.</param>
         /// <param name="indexName">Optional index name.</param>
         /// <remarks>
-        /// <para>When the <paramref name="culture"/> is not specified or is *, all cultures are searched. To search only invariant use null.</para>
+        /// <para>
+        /// When the <paramref name="culture"/> is not specified or is *, all cultures are searched.
+        /// To search for only invariant documents and fields use null.
+        /// When searching on a specific culture, all culture specific fields are searched for the provided culture and all invariant fields for all documents.
+        /// </para>
         /// <para>While enumerating results, the ambient culture is changed to be the searched culture.</para>
         /// </remarks>
         IEnumerable<PublishedSearchResult> Search(string term, string culture = "*", string indexName = null);
@@ -54,7 +58,11 @@ namespace Umbraco.Web
         /// <param name="culture">Optional culture.</param>
         /// <param name="indexName">Optional index name.</param>
         /// <remarks>
-        /// <para>When the <paramref name="culture"/> is not specified or is *, all cultures are searched. To search only invariant use null.</para>
+        /// <para>
+        /// When the <paramref name="culture"/> is not specified or is *, all cultures are searched.
+        /// To search for only invariant documents and fields use null.
+        /// When searching on a specific culture, all culture specific fields are searched for the provided culture and all invariant fields for all documents.
+        /// </para>
         /// <para>While enumerating results, the ambient culture is changed to be the searched culture.</para>
         /// </remarks>
         IEnumerable<PublishedSearchResult> Search(string term, int skip, int take, out long totalRecords, string culture = "*", string indexName = null);

--- a/src/Umbraco.Web/IPublishedContentQuery.cs
+++ b/src/Umbraco.Web/IPublishedContentQuery.cs
@@ -39,10 +39,10 @@ namespace Umbraco.Web
         /// <param name="culture">Optional culture.</param>
         /// <param name="indexName">Optional index name.</param>
         /// <remarks>
-        /// <para>When the <paramref name="culture"/> is not specified, all cultures are searched.</para>
+        /// <para>When the <paramref name="culture"/> is not specified or is *, all cultures are searched. To search only invariant use null.</para>
         /// <para>While enumerating results, the ambient culture is changed to be the searched culture.</para>
         /// </remarks>
-        IEnumerable<PublishedSearchResult> Search(string term, string culture = null, string indexName = null);
+        IEnumerable<PublishedSearchResult> Search(string term, string culture = "*", string indexName = null);
 
         /// <summary>
         /// Searches content.
@@ -54,10 +54,10 @@ namespace Umbraco.Web
         /// <param name="culture">Optional culture.</param>
         /// <param name="indexName">Optional index name.</param>
         /// <remarks>
-        /// <para>When the <paramref name="culture"/> is not specified, all cultures are searched.</para>
+        /// <para>When the <paramref name="culture"/> is not specified or is *, all cultures are searched. To search only invariant use null.</para>
         /// <para>While enumerating results, the ambient culture is changed to be the searched culture.</para>
         /// </remarks>
-        IEnumerable<PublishedSearchResult> Search(string term, int skip, int take, out long totalRecords, string culture = null, string indexName = null);
+        IEnumerable<PublishedSearchResult> Search(string term, int skip, int take, out long totalRecords, string culture = "*", string indexName = null);
 
         /// <summary>
         /// Executes the query and converts the results to PublishedSearchResult.

--- a/src/Umbraco.Web/PublishedContentQuery.cs
+++ b/src/Umbraco.Web/PublishedContentQuery.cs
@@ -216,7 +216,7 @@ namespace Umbraco.Web
 
                 //get all index fields suffixed with the culture name supplied
                 var cultureFields = umbIndex.GetCultureAndInvariantFields(culture).ToArray();
-                var qry = searcher.CreateQuery().Field(UmbracoContentIndex.VariesByCultureFieldName, "y"); //must vary by culture
+                var qry = searcher.CreateQuery();
                 qry = qry.And().ManagedQuery(term, cultureFields);
                 results = qry.Execute(count);
             }

--- a/src/Umbraco.Web/PublishedContentQuery.cs
+++ b/src/Umbraco.Web/PublishedContentQuery.cs
@@ -215,7 +215,7 @@ namespace Umbraco.Web
                 //search only the specified culture
 
                 //get all index fields suffixed with the culture name supplied
-                var cultureFields = umbIndex.GetCultureFields(culture).ToArray();
+                var cultureFields = umbIndex.GetCultureAndInvariantFields(culture).ToArray();
                 var qry = searcher.CreateQuery().Field(UmbracoContentIndex.VariesByCultureFieldName, "y"); //must vary by culture
                 qry = qry.And().ManagedQuery(term, cultureFields);
                 results = qry.Execute(count);

--- a/src/Umbraco.Web/PublishedContentQuery.cs
+++ b/src/Umbraco.Web/PublishedContentQuery.cs
@@ -217,7 +217,7 @@ namespace Umbraco.Web
                 //get all index fields suffixed with the culture name supplied
                 var cultureFields = umbIndex.GetCultureAndInvariantFields(culture).ToArray();
                 var qry = searcher.CreateQuery();
-                qry = qry.And().ManagedQuery(term, cultureFields);
+                qry = qry.ManagedQuery(term, cultureFields);
                 results = qry.Execute(count);
             }
 

--- a/src/Umbraco.Web/PublishedContentQuery.cs
+++ b/src/Umbraco.Web/PublishedContentQuery.cs
@@ -20,14 +20,22 @@ namespace Umbraco.Web
     {
         private readonly IPublishedSnapshot _publishedSnapshot;
         private readonly IVariationContextAccessor _variationContextAccessor;
+        private readonly IExamineManager _examineManager;
+
+        [Obsolete("Use the constructor with all parameters instead")]
+        public PublishedContentQuery(IPublishedSnapshot publishedSnapshot, IVariationContextAccessor variationContextAccessor)
+            : this (publishedSnapshot, variationContextAccessor, ExamineManager.Instance)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PublishedContentQuery"/> class.
         /// </summary>
-        public PublishedContentQuery(IPublishedSnapshot publishedSnapshot, IVariationContextAccessor variationContextAccessor)
+        public PublishedContentQuery(IPublishedSnapshot publishedSnapshot, IVariationContextAccessor variationContextAccessor, IExamineManager examineManager)
         {
             _publishedSnapshot = publishedSnapshot ?? throw new ArgumentNullException(nameof(publishedSnapshot));
             _variationContextAccessor = variationContextAccessor ?? throw new ArgumentNullException(nameof(variationContextAccessor));
+            _examineManager = examineManager ?? throw new ArgumentNullException(nameof(examineManager));
         }
 
         #region Content
@@ -187,7 +195,7 @@ namespace Umbraco.Web
                 ? Constants.UmbracoIndexes.ExternalIndexName
                 : indexName;
 
-            if (!ExamineManager.Instance.TryGetIndex(indexName, out var index) || !(index is IUmbracoIndex umbIndex))
+            if (!_examineManager.TryGetIndex(indexName, out var index) || !(index is IUmbracoIndex umbIndex))
                 throw new InvalidOperationException($"No index found by name {indexName} or is not of type {typeof(IUmbracoIndex)}");
 
             var searcher = umbIndex.GetSearcher();
@@ -216,8 +224,7 @@ namespace Umbraco.Web
 
                 //get all index fields suffixed with the culture name supplied
                 var cultureFields = umbIndex.GetCultureAndInvariantFields(culture).ToArray();
-                var qry = searcher.CreateQuery();
-                qry = qry.ManagedQuery(term, cultureFields);
+                var qry = searcher.CreateQuery().ManagedQuery(term, cultureFields);
                 results = qry.Execute(count);
             }
 
@@ -313,7 +320,7 @@ namespace Umbraco.Web
             }
         }
 
-        
+
 
 
         #endregion

--- a/src/Umbraco.Web/UmbracoContextFactory.cs
+++ b/src/Umbraco.Web/UmbracoContextFactory.cs
@@ -53,7 +53,15 @@ namespace Umbraco.Web
         {
             // make sure we have a variation context
             if (_variationContextAccessor.VariationContext == null)
+            {
+                // TODO: By using _defaultCultureAccessor.DefaultCulture this means that the VariationContext will always return a variant culture, it will never
+                // return an empty string signifying that the culture is invariant. But does this matter? Are we actually expecting this to return an empty string
+                // for invariant routes? From what i can tell throughout the codebase is that whenever we are checking against the VariationContext.Culture we are
+                // also checking if the content type varies by culture or not. This is fine, however the code in the ctor of VariationContext is then misleading
+                // since it's assuming that the Culture can be empty (invariant) when in reality of a website this will never be empty since a real culture is always set here.
                 _variationContextAccessor.VariationContext = new VariationContext(_defaultCultureAccessor.DefaultCulture);
+            }
+                
 
             var webSecurity = new WebSecurity(httpContext, _userService, _globalSettings);
 


### PR DESCRIPTION
See #5789 

To test follow the steps provided in the issue and make sure the expected results work.

Have a look at the code changes - the reason why this problem occurred is because passing in 'null' for a culture should mean it only searches invariant but this was defaulting to `_variationContextAccessor.VariationContext.Culture;` which always returns a culture. Further to that, the method's optional parameter value was incorrect. A "*" is what should be the default indicating that all cultures will be searched (this is consistent with our other culture methods in Umbraco APIs). Specifying an explicit null will be an invariant search or specifying a culture will only search that culture.

