### PR TITLE
Fixes Change to Entity Service GetByKey isn't breaking in 7.15 #5822

### DIFF
--- a/src/Umbraco.Core/Services/EntityService.cs
+++ b/src/Umbraco.Core/Services/EntityService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using Umbraco.Core.CodeAnnotations;
@@ -717,5 +718,32 @@ namespace Umbraco.Core.Services
             }
             return node.NodeId;
         }
+
+        #region Obsolete - only here for compat
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IUmbracoEntity GetByKey(Guid key, bool loadBaseType = true) => GetByKey(key);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IUmbracoEntity Get(int id, bool loadBaseType = true) => Get(id);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IUmbracoEntity GetByKey(Guid key, UmbracoObjectTypes umbracoObjectType, bool loadBaseType = true) => GetByKey(key, umbracoObjectType);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IUmbracoEntity GetByKey<T>(Guid key, bool loadBaseType = true) where T : IUmbracoEntity => GetByKey<T>(key);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IUmbracoEntity Get(int id, UmbracoObjectTypes umbracoObjectType, bool loadBaseType = true) => Get(id, umbracoObjectType);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IUmbracoEntity Get<T>(int id, bool loadBaseType = true) where T : IUmbracoEntity => Get<T>(id);
+        #endregion
     }
 }

--- a/src/Umbraco.Core/Services/IEntityService.cs
+++ b/src/Umbraco.Core/Services/IEntityService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.EntityBase;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
@@ -55,6 +56,10 @@ namespace Umbraco.Core.Services
         /// <returns>An <see cref="IUmbracoEntity"/></returns>
         IUmbracoEntity GetByKey(Guid key);
 
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IUmbracoEntity GetByKey(Guid key, bool loadBaseType = true);
+
         /// <summary>
         /// Gets an UmbracoEntity by its Id, and optionally loads the complete object graph.
         /// </summary>
@@ -62,8 +67,12 @@ namespace Umbraco.Core.Services
         /// By default this will load the base type <see cref="IUmbracoEntity"/> with a minimum set of properties.
         /// </returns>
         /// <param name="id">Id of the object to retrieve</param>
-       /// <returns>An <see cref="IUmbracoEntity"/></returns>
+        /// <returns>An <see cref="IUmbracoEntity"/></returns>
         IUmbracoEntity Get(int id);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IUmbracoEntity Get(int id, bool loadBaseType = true);
 
         /// <summary>
         /// Gets an UmbracoEntity by its Id and UmbracoObjectType, and optionally loads the complete object graph.
@@ -76,6 +85,14 @@ namespace Umbraco.Core.Services
         /// <returns>An <see cref="IUmbracoEntity"/></returns>
         IUmbracoEntity GetByKey(Guid key, UmbracoObjectTypes umbracoObjectType);
 
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IUmbracoEntity GetByKey(Guid key, UmbracoObjectTypes umbracoObjectType, bool loadBaseType = true);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IUmbracoEntity GetByKey<T>(Guid key, bool loadBaseType = true) where T : IUmbracoEntity;
+
         /// <summary>
         /// Gets an UmbracoEntity by its Id and UmbracoObjectType, and optionally loads the complete object graph.
         /// </summary>
@@ -87,6 +104,9 @@ namespace Umbraco.Core.Services
         /// <returns>An <see cref="IUmbracoEntity"/></returns>
         IUmbracoEntity Get(int id, UmbracoObjectTypes umbracoObjectType);
 
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IUmbracoEntity Get(int id, UmbracoObjectTypes umbracoObjectType, bool loadBaseType = true);
 
         /// <summary>
         /// Gets an UmbracoEntity by its Id and specified Type. Optionally loads the complete object graph.
@@ -98,6 +118,10 @@ namespace Umbraco.Core.Services
         /// <param name="id">Id of the object to retrieve</param>
         /// <returns>An <see cref="IUmbracoEntity"/></returns>
         IUmbracoEntity Get<T>(int id) where T : IUmbracoEntity;
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IUmbracoEntity Get<T>(int id, bool loadBaseType = true) where T : IUmbracoEntity;
 
         /// <summary>
         /// Gets the parent of entity by its id

--- a/src/Umbraco.Core/Services/IRelationService.cs
+++ b/src/Umbraco.Core/Services/IRelationService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.EntityBase;
 
@@ -145,12 +146,20 @@ namespace Umbraco.Core.Services
         /// <returns>An <see cref="IUmbracoEntity"/></returns>
         IUmbracoEntity GetChildEntityFromRelation(IRelation relation);
 
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IUmbracoEntity GetChildEntityFromRelation(IRelation relation, bool loadBaseType = false);
+
         /// <summary>
         /// Gets the Parent object from a Relation as an <see cref="IUmbracoEntity"/>
         /// </summary>
         /// <param name="relation">Relation to retrieve parent object from</param>
         /// <returns>An <see cref="IUmbracoEntity"/></returns>
         IUmbracoEntity GetParentEntityFromRelation(IRelation relation);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IUmbracoEntity GetParentEntityFromRelation(IRelation relation, bool loadBaseType = false);
 
         /// <summary>
         /// Gets the Parent and Child objects from a Relation as a <see cref="Tuple"/>"/> with <see cref="IUmbracoEntity"/>.
@@ -159,12 +168,20 @@ namespace Umbraco.Core.Services
         /// <returns>Returns a Tuple with Parent (item1) and Child (item2)</returns>
         Tuple<IUmbracoEntity, IUmbracoEntity> GetEntitiesFromRelation(IRelation relation);
 
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Tuple<IUmbracoEntity, IUmbracoEntity> GetEntitiesFromRelation(IRelation relation, bool loadBaseType = false);
+
         /// <summary>
         /// Gets the Child objects from a list of Relations as a list of <see cref="IUmbracoEntity"/> objects.
         /// </summary>
         /// <param name="relations">List of relations to retrieve child objects from</param>
         /// <returns>An enumerable list of <see cref="IUmbracoEntity"/></returns>
         IEnumerable<IUmbracoEntity> GetChildEntitiesFromRelations(IEnumerable<IRelation> relations);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IEnumerable<IUmbracoEntity> GetChildEntitiesFromRelations(IEnumerable<IRelation> relations, bool loadBaseType = false);
 
         /// <summary>
         /// Gets the Parent objects from a list of Relations as a list of <see cref="IUmbracoEntity"/> objects.
@@ -173,6 +190,10 @@ namespace Umbraco.Core.Services
         /// <returns>An enumerable list of <see cref="IUmbracoEntity"/></returns>
         IEnumerable<IUmbracoEntity> GetParentEntitiesFromRelations(IEnumerable<IRelation> relations);
 
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IEnumerable<IUmbracoEntity> GetParentEntitiesFromRelations(IEnumerable<IRelation> relations, bool loadBaseType = false);
+
         /// <summary>
         /// Gets the Parent and Child objects from a list of Relations as a list of <see cref="IUmbracoEntity"/> objects.
         /// </summary>
@@ -180,6 +201,12 @@ namespace Umbraco.Core.Services
         /// <param name="loadBaseType">Optional bool to load the complete object graph when set to <c>False</c></param>
         IEnumerable<Tuple<IUmbracoEntity, IUmbracoEntity>> GetEntitiesFromRelations(
             IEnumerable<IRelation> relations);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IEnumerable<Tuple<IUmbracoEntity, IUmbracoEntity>> GetEntitiesFromRelations(
+            IEnumerable<IRelation> relations,
+            bool loadBaseType = false);
 
         /// <summary>
         /// Relates two objects by their entity Ids.

--- a/src/Umbraco.Core/Services/RelationService.cs
+++ b/src/Umbraco.Core/Services/RelationService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Umbraco.Core.Events;
 using Umbraco.Core.Logging;
@@ -735,6 +736,32 @@ namespace Umbraco.Core.Services
         /// Occurs after a RelationType is Saved
         /// </summary>
         public static event TypedEventHandler<IRelationService, SaveEventArgs<IRelationType>> SavedRelationType;
+        #endregion
+
+        #region Obsolete - only here for compat
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IUmbracoEntity GetChildEntityFromRelation(IRelation relation, bool loadBaseType = false) => GetChildEntityFromRelation(relation);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IUmbracoEntity GetParentEntityFromRelation(IRelation relation, bool loadBaseType = false) => GetParentEntityFromRelation(relation);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Tuple<IUmbracoEntity, IUmbracoEntity> GetEntitiesFromRelation(IRelation relation, bool loadBaseType = false) => GetEntitiesFromRelation(relation);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IEnumerable<IUmbracoEntity> GetChildEntitiesFromRelations(IEnumerable<IRelation> relations, bool loadBaseType = false) => GetChildEntitiesFromRelations(relations);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IEnumerable<IUmbracoEntity> GetParentEntitiesFromRelations(IEnumerable<IRelation> relations, bool loadBaseType = false) => GetParentEntitiesFromRelations(relations);
+
+        [Obsolete("Use the overload that doesn't specify loadBaseType instead, loadBaseType will not affect any results")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IEnumerable<Tuple<IUmbracoEntity, IUmbracoEntity>> GetEntitiesFromRelations(IEnumerable<IRelation> relations, bool loadBaseType = false) => GetEntitiesFromRelations(relations);
         #endregion
     }
 }


### PR DESCRIPTION
Fixes ##5822 This reinstates the method overloads that were removed purely for backwards compat API surface area. The overloads don't do anything different and all `loadBaseType` parameters are just ignored.