### PR TITLE
V8: Fixes LogViewer Error Count search result click

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
@@ -42,7 +42,8 @@
         //functions
         vm.searchLogQuery = searchLogQuery;
         vm.findMessageTemplate = findMessageTemplate;
-        
+        vm.searchErrors = searchErrors;
+
         function preFlightCheck(){
             vm.loading = true;
             //Do our pre-flight check (to see if we can view logs)
@@ -132,6 +133,10 @@
             searchLogQuery(logQuery);
         }
 
+        function searchErrors(){
+            var logQuery = "@Level='Fatal' or @Level='Error' or Has(@Exception)";
+            searchLogQuery(logQuery);
+        }
 
 
 

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
@@ -84,7 +84,7 @@
 
                     <div ng-show=" vm.canLoadLogs">
                         <!-- No of Errors -->
-                        <umb-box ng-click="vm.searchLogQuery('Has(@Exception)')" style="cursor:pointer;">
+                        <umb-box ng-click="vm.searchErrors()" style="cursor:pointer;">
                             <umb-box-header title="Number of Errors"></umb-box-header>
                             <umb-box-content class="block-form" style="font-size: 40px; font-weight:900; text-align:center; color:#fe6561;">
                                 {{ vm.numberOfErrors }}


### PR DESCRIPTION
When clicking on the number of errors from the overview of the LogViewer which count
* Errors
* Fatal
* Log with Exceptions

Previously clicking through it would perform the search `Has(@Exception)` and not all Errors or Fatal log level messages would always include an exception & thus the count would be mismatched from clicking through from the overview page

---
_This item has been added to our backlog [AB#1705](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/1705)_