### PR TITLE
V8: Don't prompt to discard changes in public access when a picker is active

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.protect.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.protect.controller.js
@@ -123,6 +123,8 @@
 
         function pickGroup() {
             navigationService.allowHideDialog(false);
+            var previousConfirmDiscardChanges = $scope.dialog.confirmDiscardChanges;
+            $scope.dialog.confirmDiscardChanges = false;
             editorService.memberGroupPicker({
                 multiPicker: true,
                 submit: function(model) {
@@ -144,6 +146,7 @@
                 close: function() {
                     editorService.close();
                     navigationService.allowHideDialog(true);
+                    $scope.dialog.confirmDiscardChanges = previousConfirmDiscardChanges;
                 }
             });
         }
@@ -155,6 +158,8 @@
 
         function pickMember() {
             navigationService.allowHideDialog(false);
+            var previousConfirmDiscardChanges = $scope.dialog.confirmDiscardChanges;
+            $scope.dialog.confirmDiscardChanges = false;
             // TODO: once editorService has a memberPicker method, use that instead
             editorService.treePicker({
                 multiPicker: true,
@@ -196,6 +201,7 @@
                 close: function () {
                     editorService.close();
                     navigationService.allowHideDialog(true);
+                    $scope.dialog.confirmDiscardChanges = previousConfirmDiscardChanges;
                 }
             });
         }
@@ -214,6 +220,8 @@
 
         function pickPage(page) {
             navigationService.allowHideDialog(false);
+            var previousConfirmDiscardChanges = $scope.dialog.confirmDiscardChanges;
+            $scope.dialog.confirmDiscardChanges = false;
             editorService.contentPicker({
                 submit: function (model) {
                     if (page === vm.loginPage) {
@@ -229,6 +237,7 @@
                 close: function () {
                     editorService.close();
                     navigationService.allowHideDialog(true);
+                    $scope.dialog.confirmDiscardChanges = previousConfirmDiscardChanges;
                 }
             });
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5844

### Description

See #5844 for details. 

The confirm dialog obviously shouldn't appear when a picker (member/group/content) is active. This PR ensures that:

![public-access-confirm-after](https://user-images.githubusercontent.com/7405322/61125770-fb5bbe00-a4aa-11e9-9a6a-100fd2c422fb.gif)
