### PR TITLE
V8: Make sure save options are up to date with the content state

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -94,6 +94,10 @@
                 content.apps[0].active = true;
                 $scope.appChanged(content.apps[0]);
             }
+            // otherwise make sure the save options are up to date with the current content state
+            else {
+                createButtons($scope.content);
+            }
 
             editorState.set(content);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5845

### Description

As described in #5845, the save options aren't updated when you publish or unpublish the current content, making it impossible to unpublish content after it's been published without forcing a page reload.

This PR ensures that the save options are always up to date with the state of the current content after save/publish/unpublish:

![update-save-publish-button-group-on-save](https://user-images.githubusercontent.com/7405322/61146577-ab94eb00-a4da-11e9-9757-780800ce1ce4.gif)

#### Testing this PR

1. Create some new content and save it. Verify that "Unpublish" is not an option.
2. Publish the content. Verify that "Unpublish" is now available as an option.
3. Unpublish the content. Veify that "Unpublish" is no longer an option.
