### PR TITLE
v7: Fix link picker url and anchors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -172,7 +172,7 @@ function entityResource($q, $http, umbRequestHelper) {
                     umbRequestHelper.getApiUrl(
                         "entityApiBaseUrl",
                         "GetUrlAndAnchors",
-                        { id: id })),
+                        [{ id: id }])),
                 'Failed to retrieve url and anchors data for id ' + id);
         },
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.controller.js
@@ -28,23 +28,22 @@ angular.module("umbraco").controller("Umbraco.Overlays.LinkPickerController",
         if (dialogOptions.currentTarget) {
             // clone the current target so we don't accidentally update the caller's model while manipulating $scope.model.target
             $scope.model.target = angular.copy(dialogOptions.currentTarget);
-            //if we have a node ID, we fetch the current node to build the form data
+            // if we have a node ID, we fetch the current node to build the form data
             if ($scope.model.target.id || $scope.model.target.udi) {
 
-                //will be either a udi or an int
+                // will be either a udi or an int
                 var id = $scope.model.target.udi ? $scope.model.target.udi : $scope.model.target.id;
 
                 // is it a content link?
                 if (!$scope.model.target.isMedia) {
                     // get the content path
                     entityResource.getPath(id, "Document").then(function (path) {
-                        //now sync the tree to this path
+                        // now sync the tree to this path
                         $scope.dialogTreeEventHandler.syncTree({
                             path: path,
                             tree: "content"
                         });
                     });
-
 
                     entityResource.getUrlAndAnchors(id).then(function(resp){
                         $scope.anchorValues = resp.anchorValues;

--- a/src/Umbraco.Web/Editors/EntityController.cs
+++ b/src/Umbraco.Web/Editors/EntityController.cs
@@ -56,6 +56,7 @@ namespace Umbraco.Web.Editors
                     //id is passed in eventually we'll probably want to support GUID + Udi too
                     new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetPagedChildren", "id", typeof(int), typeof(string)),
                     new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetPath", "id", typeof(int), typeof(Guid), typeof(Udi)),
+                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetUrlAndAnchors", "id", typeof(int), typeof(Guid), typeof(Udi)),
                     new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetById", "id", typeof(int), typeof(Guid), typeof(Udi)),
                     new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetByIds", "ids", typeof(int[]), typeof(Guid[]), typeof(Udi[]))));
             }
@@ -281,9 +282,17 @@ namespace Umbraco.Web.Editors
                 publishedContentExists: i => Umbraco.TypedContent(i) != null);
         }
 
+        [HttpGet]
+        public UrlAndAnchors GetUrlAndAnchors(Udi id)
+        {
+            var nodeId = Umbraco.GetIdForUdi(id);
+            var url = Umbraco.Url(nodeId);
+            var anchorValues = Services.ContentService.GetAnchorValuesFromRTEs(nodeId);
+            return new UrlAndAnchors(url, anchorValues);
+        }
 
         [HttpGet]
-        public UrlAndAnchors GetUrlAndAnchors([FromUri]int id)
+        public UrlAndAnchors GetUrlAndAnchors(int id)
         {
             var url = Umbraco.Url(id);
             var anchorValues = Services.ContentService.GetAnchorValuesFromRTEs(id);

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -503,6 +503,16 @@ namespace Umbraco.Web
         }
 
         /// <summary>
+        /// Gets the url of a content identified by its identifier.
+        /// </summary>
+        /// <param name="contentGuid">The content identifier.</param>
+        /// <returns>The url for the content.</returns>
+        public string Url(Guid contentGuid)
+        {
+            return UrlProvider.GetUrl(contentGuid);
+        }
+
+        /// <summary>
         /// Gets the url of a content identified by its identifier, in a specified mode.
         /// </summary>
         /// <param name="contentId">The content identifier.</param>
@@ -511,6 +521,17 @@ namespace Umbraco.Web
         public string Url(int contentId, UrlProviderMode mode)
         {
             return UrlProvider.GetUrl(contentId, mode);
+        }
+
+        /// <summary>
+        /// Gets the url of a content identified by its identifier, in a specified mode.
+        /// </summary>
+        /// <param name="contentGuid">The content identifier.</param>
+        /// <param name="mode">The mode.</param>
+        /// <returns>The url for the content.</returns>
+        public string Url(Guid contentGuid, UrlProviderMode mode)
+        {
+            return UrlProvider.GetUrl(contentGuid, mode);
         }
 
         /// <summary>

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -493,6 +493,18 @@ namespace Umbraco.Web
         }
 
         /// <summary>
+        /// Returns a string with a friendly url from a node.
+        /// IE.: Instead of having /482 (id) as an url, you can have
+        /// /screenshots/developer/macros (spoken url)
+        /// </summary>
+        /// <param name="guid">Identifier for the node that should be returned</param>
+        /// <returns>String with a friendly url from a node</returns>
+        public string NiceUrl(Guid guid)
+        {
+            return Url(guid);
+        }
+
+        /// <summary>
         /// Gets the url of a content identified by its identifier.
         /// </summary>
         /// <param name="contentId">The content identifier.</param>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5849

### Description
This PR fixes the issue, where it returned `417 Missing token` in console, when edit an existing link in RTE.
I noticed when inserting a link first time it was using `id`, but on edit it use the existing `udi`. However it didn't seems to hit the method with the signature `int id`.

I had a look at the other method, e.g. `GetPath` and it seems the params need to be an array. After I made this change in `entityResource.getUrlAndAnchors` it hit the method with signature `Udi id` when editing the link.
https://github.com/umbraco/Umbraco-CMS/blob/v7/dev/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js#L85
This might has something to do about these special `ParameterSwapControllerActionSelector` https://github.com/umbraco/Umbraco-CMS/blob/de9241bcf592ca9994810d43232545844fc06848/src/Umbraco.Web/Editors/EntityController.cs#L57-L61 , but now it is similar with get e.g. the `GetPath` method.

We could also have an overload method for `Guid id`, but it doesn't seem we need this at the moment. I have however added two overload method the `UmbracoHelper` to get Url from `Guid` as well.

Also note when edit the link the "Link" property field in the dialog no longer shows `localLink`, but the actual link to the page.

![2019-07-13_15-07-23](https://user-images.githubusercontent.com/2919859/61172076-12201480-a580-11e9-9caf-084e7a300e10.gif)

![devenv_2019-07-13_14-45-52](https://user-images.githubusercontent.com/2919859/61171979-0aac3b80-a57f-11e9-90dc-63e118e4b027.png)

![devenv_2019-07-13_14-46-18](https://user-images.githubusercontent.com/2919859/61171980-0aac3b80-a57f-11e9-8926-eb11bb5f9520.png)

We should probably also merge this to v8 - the only difference is that v8 also have a parameter with culture in this method. https://github.com/umbraco/Umbraco-CMS/blob/4733256ca1bfb49d4fe946110e734db1351f81d9/src/Umbraco.Web/Editors/EntityController.cs#L290-L296
Let me know if I should submit a separate PR for v8 or you can merge in to v8 and adjust it a bit.
