### PR TITLE
Change PropertyType.Alias to virtual

### DIFF
--- a/src/Umbraco.Core/Models/PropertyType.cs
+++ b/src/Umbraco.Core/Models/PropertyType.cs
@@ -114,7 +114,7 @@ namespace Umbraco.Core.Models
         /// Gets of sets the alias of the property type.
         /// </summary>
         [DataMember]
-        public string Alias
+        public virtual string Alias
         {
             get => _alias;
             set => SetPropertyValueAndDetectChanges(SanitizeAlias(value), ref _alias, nameof(Alias));


### PR DESCRIPTION
When unit testing PropertyType.Alias needs to be virtual to make it mockable. The underlying code on the set triggers IOC logic and makes it hard to test anything that uses Property Types.

This may have some security implications so I'll understand if you leave this as is.... 