### PR TITLE
PR fixes 7 -> 8 migration bugs for #5852 and #5864

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/DropDownFlexiblePreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/DropDownFlexiblePreValueMigrator.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
+{
+    class DropDownFlexiblePreValueMigrator : IPreValueMigrator
+    {
+        public bool CanMigrate(string editorAlias)
+            => editorAlias == "Umbraco.DropDown.Flexible";
+
+        public virtual string GetNewAlias(string editorAlias)
+            => null;
+
+        public object GetConfiguration(int dataTypeId, string editorAlias, Dictionary<string, PreValueDto> preValues)
+        {
+            var config = new DropDownFlexibleConfiguration();
+            foreach (var preValue in preValues.Values)
+            {
+                if (preValue.Alias == "multiple")
+                {
+                    config.Multiple = (preValue.Value == "1");
+                }
+                else
+                {
+                    config.Items.Add(new ValueListConfiguration.ValueListItem { Id = preValue.Id, Value = preValue.Value });
+                }
+            }
+            return config;
+        }
+    }
+}

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/PreValueMigratorComposer.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/PreValueMigratorComposer.cs
@@ -19,6 +19,7 @@ public class PreValueMigratorComposer : ICoreComposer
             .Append<NestedContentPreValueMigrator>()
             .Append<DecimalPreValueMigrator>()
             .Append<ListViewPreValueMigrator>()
+            .Append<DropDownFlexiblePreValueMigrator>()
             .Append<ValueListPreValueMigrator>();
     }
 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -241,6 +241,7 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\DefaultPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\RenamingPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\RichTextPreValueMigrator.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\DropDownFlexiblePreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\MergeDateAndDateTimePropertyEditor.cs" />
     <Compile Include="Models\Entities\EntityExtensions.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\PreValueMigratorBase.cs" />


### PR DESCRIPTION
Fixes for #5852 and #5864

TablesForScheduledPublishing requests release and expiry dates in two separate  queries, and populates the id when creating new rows.

Adds a DropDownFlexiblePreValueMigrator based on ValueListPreValueMigrator.

---
_This item has been added to our backlog [AB#1719](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/1719)_