### PR TITLE
V8: Accessibility Changes For Title On Login Page

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -13,7 +13,7 @@
             }
         });
 
-    function UmbLoginController($scope, $location, currentUserResource, formHelper, mediaHelper, umbRequestHelper, Upload, localizationService, userService, externalLoginInfo, resetPasswordCodeInfo, $timeout, authResource, $q) {
+    function UmbLoginController($scope, $location, currentUserResource, formHelper, mediaHelper, umbRequestHelper, Upload, localizationService, userService, externalLoginInfo, resetPasswordCodeInfo, $timeout, authResource, $q, $route) {
 
         const vm = this;
 
@@ -60,7 +60,6 @@
         vm.loginSubmit = loginSubmit;
         vm.requestPasswordResetSubmit = requestPasswordResetSubmit;
         vm.setPasswordSubmit = setPasswordSubmit;
-
         vm.labels = {};
         localizationService.localizeMany([
             vm.usernameIsEmail ? "general_email" : "general_username", 
@@ -76,6 +75,8 @@
 
             // Check if it is a new user
             const inviteVal = $location.search().invite;
+
+            vm.baseTitle = $scope.$root.locationTitle;
             //1 = enter password, 2 = password set, 3 = invalid token
             if (inviteVal && (inviteVal === "1" || inviteVal === "2")) {
 
@@ -122,6 +123,7 @@
                 vm.showLogin();
             }
 
+            SetTitle();
         }
 
         function togglePassword() {
@@ -173,6 +175,7 @@
             vm.errorMsg = "";
             resetInputValidation();
             vm.view = "login";
+            SetTitle();
         }
 
         function showRequestPasswordReset() {
@@ -180,12 +183,14 @@
             resetInputValidation();
             vm.view = "request-password-reset";
             vm.showEmailResetConfirmation = false;
+            SetTitle();
         }
 
         function showSetPassword() {
             vm.errorMsg = "";
             resetInputValidation();
             vm.view = "set-password";
+            SetTitle();
         }
 
         function loginSubmit() {
@@ -413,6 +418,7 @@
             }
             vm.twoFactor.view = viewPath;
             vm.view = "2fa-login";
+            SetTitle();
         }
 
         function resetInputValidation() {
@@ -433,7 +439,28 @@
         }
 
 
+        function SetTitle() {
+            var title = null;
+            switch (vm.view.toLowerCase()) {
+                case "login":
+                    title = "Login";
+                    break;
+                case "password-reset-code-expired":
+                case "request-password-reset":
+                    title = "Password Reset";
+                    break;
+                case "set-password":
+                    title = "Change Password";
+                    break;
+                case "2fa-login":
+                    title = "Two Factor Authentication";
+                    break;
+            } 
 
+            if (title != null) {
+                $scope.$root.locationTitle = title + " - " + vm.baseTitle;
+            }
+        }
 
     }
 


### PR DESCRIPTION
This PR aims to give the user more context as to what the page is displaying by setting the `<title>` element

I have made this a draft PR because whilst is solves the issue on the login page, it isn't generic enough.

Ideally a `SetTitle` method based on this `init.js` routine should be created:

`$rootScope.$on('$routeChangeSuccess', function (event, current, previous) {..}`

Currently it relies  on a `.params` property which doesn't exist in the context of the login page.

A refactored "`SetTitle`" routine could then be reused once logged into Umbraco to provide more context as to what action the user is performing (currently on the section the user is in is displayed in the title, not what area within that section/ or if the user is creating/ editing something).  More information would help:

-  screen reader uses have context as to what the page is for
-  all users who in 2 or more browsers with the same Umbraco site open