### PR TITLE
V8: Fix YSOD when editing media types

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -1057,7 +1057,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
                 _mediaStore.UpdateContentTypes(removedIds, typesA, kits);
                 _mediaStore.UpdateContentTypes(CreateContentTypes(PublishedItemType.Media, otherIds.ToArray()).ToArray());
-                if(newIds != null && newIds.Any())
+                if(newIds.IsCollectionEmpty() == false)
                 {
                     _mediaStore.NewContentTypes(CreateContentTypes(PublishedItemType.Media, newIds.ToArray()).ToArray());
                 }

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -1057,7 +1057,10 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
                 _mediaStore.UpdateContentTypes(removedIds, typesA, kits);
                 _mediaStore.UpdateContentTypes(CreateContentTypes(PublishedItemType.Media, otherIds.ToArray()).ToArray());
-                _mediaStore.NewContentTypes(CreateContentTypes(PublishedItemType.Media, newIds.ToArray()).ToArray());
+                if(newIds != null && newIds.Any())
+                {
+                    _mediaStore.NewContentTypes(CreateContentTypes(PublishedItemType.Media, newIds.ToArray()).ToArray());
+                }
                 scope.Complete();
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5894

### Description

As described in #5894, a server error is displayed when you try editing a media type:

![image](https://user-images.githubusercontent.com/7405322/61209992-7ca98f80-a6fb-11e9-94bc-4e0bfff360dc.png)

This PR fixes it:

![add-media-type-property](https://user-images.githubusercontent.com/7405322/61210036-921eb980-a6fb-11e9-9fc3-9232e305685c.gif)

#### Testing this PR

1. Verify that you can add a new property (of any type) to an existing media type.
2. Verify that you can remote the property again.
