### PR TITLE
V8: Make user group sections mandatory

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.html
@@ -29,7 +29,7 @@
 
                                 <umb-box-content class="block-form">
 
-                                    <umb-control-group style="margin-bottom: 20px;" label="@main_sections" description="@user_sectionsHelp">
+                                    <umb-control-group style="margin-bottom: 20px;" label="@main_sections" description="@user_sectionsHelp" required="true">
                                         <umb-node-preview
                                             style="max-width: 100%;"
                                             ng-repeat="section in vm.userGroup.sections"
@@ -46,6 +46,8 @@
                                             prevent-default>
                                             <localize key="general_add">Add</localize>
                                         </a>
+
+                                        <input type="hidden" ng-model="_sectionsValidation" ng-required="!vm.userGroup.sections.length" />
                                     </umb-control-group>
 
                                     <umb-control-group style="margin-bottom: 20px;" label="@user_startnode" description="@user_startnodehelp">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I believe it makes no sense to have a user group without access to any sections, but this might not be entirely apparent for newcomers. So this PR makes it mandatory to grant user groups access to at least one section.

When applied it works like this:

![group-sections-mandatory](https://user-images.githubusercontent.com/7405322/61289150-f65b7f00-a7c8-11e9-8289-1adf572c1bc2.gif)
