### PR TITLE
V8: Make user group start nodes mandatory

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.html
@@ -48,7 +48,7 @@
                                         </a>
                                     </umb-control-group>
 
-                                    <umb-control-group style="margin-bottom: 20px;" label="@user_startnode" description="@user_startnodehelp">
+                                    <umb-control-group style="margin-bottom: 20px;" label="@user_startnode" description="@user_startnodehelp" required="true">
                                         <umb-node-preview
                                             ng-if="vm.userGroup.contentStartNode.id"
                                             style="max-width: 100%;"
@@ -69,9 +69,10 @@
                                             <localize key="general_add">Add</localize>
                                         </a>
 
+                                        <input type="hidden" ng-model="_contentStartNodeValidation" ng-required="!vm.userGroup.contentStartNode" />
                                     </umb-control-group>
 
-                                    <umb-control-group label="@user_mediastartnode" description="@user_mediastartnodehelp">
+                                    <umb-control-group label="@user_mediastartnode" description="@user_mediastartnodehelp" required="true">
                                         
                                         <umb-node-preview
                                             ng-if="vm.userGroup.mediaStartNode.id"
@@ -93,6 +94,7 @@
                                             <localize key="general_add">Add</localize>
                                         </a>
 
+                                        <input type="hidden" ng-model="_mediaStartNodeValidation" ng-required="!vm.userGroup.mediaStartNode" />
                                     </umb-control-group>
 
                                 </umb-box-content>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5641

### Description

As @AndyButland points out on #5641, user groups with no content/media start nodes configured cause a bit of havoc when users assigned to these groups log into the back office. The users are actually logged in successfully, but due to the [back office identity claim types](https://github.com/umbraco/Umbraco-CMS/blob/853087a75044b814df458457dc9a1f778cc89749/src/Umbraco.Core/Security/UmbracoBackOfficeIdentity.cs#L118), any subsequent calls to back office resources end up as 401 unauthorized.

I do believe it makes sense to make both content and media start nodes mandatory for user groups for a few reasons:

1. Even if the user group does not allow access to content and/or media, the users may implicitly encounter those sections via pickers etc. - having been forced to consider the start nodes for these users would be beneficial.
2. It would of course solve #5641 😄 

With this PR applied, group editing behaves like this:

![group-start-nodes-mandatory](https://user-images.githubusercontent.com/7405322/61290241-b5b13500-a7cb-11e9-8709-a5055f42919f.gif)

See also #5910 
