### PR TITLE
V8: Migration should not warn about build in data types that is handled correct but renamed

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -14,6 +14,23 @@ namespace Umbraco.Core
             /// </summary>
             public const string InternalGenericPropertiesPrefix = "_umb_";
 
+            public static class Legacy
+            {
+                public static class Aliases
+                {
+                    public const string Textbox = "Umbraco.Textbox";
+                    public const string Date = "Umbraco.Date";
+                    public const string ContentPicker2 = "Umbraco.ContentPicker2";
+                    public const string MediaPicker2 = "Umbraco.MediaPicker2";
+                    public const string MemberPicker2 = "Umbraco.MemberPicker2";
+                    public const string MultiNodeTreePicker2 = "Umbraco.MultiNodeTreePicker2";
+                    public const string TextboxMultiple = "Umbraco.TextboxMultiple";
+                    public const string RelatedLinks2 = "Umbraco.RelatedLinks2";
+                    public const string RelatedLinks = "Umbraco.RelatedLinks";
+
+                }
+            }
+
             /// <summary>
             /// Defines Umbraco built-in property editor aliases.
             /// </summary>

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/ConvertRelatedLinksToMultiUrlPicker.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/ConvertRelatedLinksToMultiUrlPicker.cs
@@ -19,8 +19,8 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
             var sqlDataTypes = Sql()
                 .Select<DataTypeDto>()
                 .From<DataTypeDto>()
-                .Where<DataTypeDto>(x => x.EditorAlias == "Umbraco.RelatedLinks"
-                                         || x.EditorAlias == "Umbraco.RelatedLinks2");
+                .Where<DataTypeDto>(x => x.EditorAlias == Constants.PropertyEditors.Legacy.Aliases.RelatedLinks
+                                         || x.EditorAlias == Constants.PropertyEditors.Legacy.Aliases.RelatedLinks2);
 
             var dataTypes = Database.Fetch<DataTypeDto>(sqlDataTypes);
             var dataTypeIds = dataTypes.Select(x => x.NodeId).ToList();

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/ContentPickerPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/ContentPickerPreValueMigrator.cs
@@ -3,7 +3,7 @@
     class ContentPickerPreValueMigrator : DefaultPreValueMigrator
     {
         public override bool CanMigrate(string editorAlias)
-            => editorAlias == "Umbraco.ContentPicker2";
+            => editorAlias == Constants.PropertyEditors.Legacy.Aliases.ContentPicker2;
 
         public override string GetNewAlias(string editorAlias)
             => null;

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/MediaPickerPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/MediaPickerPreValueMigrator.cs
@@ -6,15 +6,15 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
     {
         private readonly string[] _editors =
         {
-            "Umbraco.MediaPicker2",
-            "Umbraco.MediaPicker"
+            Constants.PropertyEditors.Legacy.Aliases.MediaPicker2,
+            Constants.PropertyEditors.Aliases.MediaPicker
         };
 
         public override bool CanMigrate(string editorAlias)
             => _editors.Contains(editorAlias);
 
         public override string GetNewAlias(string editorAlias)
-            => "Umbraco.MediaPicker";
+            => Constants.PropertyEditors.Aliases.MediaPicker;
 
         // you wish - but MediaPickerConfiguration lives in Umbraco.Web
         /*

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/MergeDateAndDateTimePropertyEditor.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/MergeDateAndDateTimePropertyEditor.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
 
         public override void Migrate()
         {
-            var dataTypes = GetDataTypes("Umbraco.Date");
+            var dataTypes = GetDataTypes(Constants.PropertyEditors.Legacy.Aliases.Date);
 
             foreach (var dataType in dataTypes)
             {
@@ -25,6 +25,14 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
                 {
                     config = (DateTimeConfiguration) new CustomDateTimeConfigurationEditor().FromDatabase(
                         dataType.Configuration);
+
+                    // If the Umbraco.Date type is the default from V7 and it has never been updated, then the
+                    // configuration is empty, and the format stuff is handled by in JS by moment.js. - We can't do that
+                    // after the migration, so we force the format to the default from V7.
+                    if (string.IsNullOrEmpty(dataType.Configuration))
+                    {
+                        config.Format = "YYYY-MM-DD";
+                    };
                 }
                 catch (Exception ex)
                 {

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/PropertyEditorsMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/PropertyEditorsMigration.cs
@@ -12,12 +12,12 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
 
         public override void Migrate()
         {
-            RenameDataType(Constants.PropertyEditors.Aliases.ContentPicker + "2", Constants.PropertyEditors.Aliases.ContentPicker);
-            RenameDataType(Constants.PropertyEditors.Aliases.MediaPicker + "2", Constants.PropertyEditors.Aliases.MediaPicker);
-            RenameDataType(Constants.PropertyEditors.Aliases.MemberPicker + "2", Constants.PropertyEditors.Aliases.MemberPicker);
-            RenameDataType(Constants.PropertyEditors.Aliases.MultiNodeTreePicker + "2", Constants.PropertyEditors.Aliases.MultiNodeTreePicker);
-            RenameDataType("Umbraco.TextboxMultiple", Constants.PropertyEditors.Aliases.TextArea, false);
-            RenameDataType("Umbraco.Textbox", Constants.PropertyEditors.Aliases.TextBox, false);
+            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.ContentPicker2, Constants.PropertyEditors.Aliases.ContentPicker);
+            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.MediaPicker2, Constants.PropertyEditors.Aliases.MediaPicker);
+            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.MemberPicker2, Constants.PropertyEditors.Aliases.MemberPicker);
+            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.MultiNodeTreePicker2, Constants.PropertyEditors.Aliases.MultiNodeTreePicker);
+            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.TextboxMultiple, Constants.PropertyEditors.Aliases.TextArea, false);
+            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.Textbox, Constants.PropertyEditors.Aliases.TextBox, false);
         }
 
         private void RenameDataType(string fromAlias, string toAlias, bool checkCollision = true)
@@ -43,7 +43,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
                         $"Property Editors. Before upgrading to v8, any Data Types using property editors that are named with the prefix '(Obsolete)' must be migrated " +
                         $"to the non-obsolete v7 property editors of the same type.");
                 }
-                    
+
             }
 
             Database.Execute(Sql()


### PR DESCRIPTION
https://github.com/umbraco/Umbraco-CMS/issues/5902
- Fixed issue with migration of Umbraco.Date if it was never saved in v7, the default format was added the time-part.
- Fixed issue with warnings of migrations of build in types, that was renamed between v7 and v8. These are handled correct.
- Added constants for some of the legacy property editor aliases.
