### PR TITLE
Fixed GetCurrentLoginStatus() summary

### DIFF
--- a/src/Umbraco.Web/Security/MembershipHelper.cs
+++ b/src/Umbraco.Web/Security/MembershipHelper.cs
@@ -542,7 +542,7 @@ namespace Umbraco.Web.Security
         }
 
         /// <summary>
-        /// Returns the login status model of the currently logged in member, if no member is logged in it returns null;
+        /// Returns the login status model of the currently logged in member.
         /// </summary>
         /// <returns></returns>
         public virtual LoginStatusModel GetCurrentLoginStatus()


### PR DESCRIPTION
Small change but it saves some debugging.

In the summary of MembershipHelper.GetCurrentLoginStatus() it states that null will be returned when no member is logged in but that isn't the case (anymore?).
