### PR TITLE
Accessibility: Unable to navigate to close 'X' icon with keyboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-tour.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-tour.html
@@ -4,22 +4,22 @@
     <div class="umb-tour__pulse"></div>
 
     <div class="umb-tour__popover shadow-depth-2" ng-class="{'umb-tour__popover--l': model.currentStep.type === 'intro' || model.currentStepIndex === model.steps.length}">
-        
+
         <div ng-if="!configuredView && !elementNotFound">
 
             <!-- Regular steps -->
             <umb-tour-step ng-if="model.currentStepIndex < model.steps.length" on-close="model.endTour()">
-                    
+
                 <umb-tour-step-header
                     title="model.currentStep.title">
                 </umb-tour-step-header>
-    
+
                 <umb-tour-step-content
                     content="model.currentStep.content">
                 </umb-tour-step-content>
-    
+
                 <umb-tour-step-footer>
-                    
+
                     <div class="flex justify-between items-center">
 
                         <div>
@@ -27,9 +27,11 @@
                                 current-step="model.currentStepIndex + 1"
                                 total-steps="model.steps.length">
                             </umb-tour-step-counter>
-                            <div ng-if="model.allowDisable && model.currentStep.type === 'intro'" style="font-size: 13px;"><a href="" class="underline" ng-click="model.disableTour()">Don't show this tour again</a></div>
+                            <div ng-if="model.allowDisable && model.currentStep.type === 'intro'">
+                                <button type="button" class="underline" ng-click="model.disableTour()" style="font-size: 13px; background: transparent; border: none; padding: 0;" prevent-default>Don't show this tour again</button>
+                            </div>
                         </div>
-                        
+
                         <div ng-if="model.currentStep.type !== 'intro'">
                             <umb-button size="xs" ng-if="!model.currentStep.event" button-style="action" type="button" action="model.nextStep()" label="Next"></umb-button>
                         </div>
@@ -40,7 +42,7 @@
                     </div>
 
                 </umb-tour-step-footer>
-        
+
             </umb-tour-step>
 
             <!-- Outro step -->
@@ -64,7 +66,7 @@
 
         <!-- Custom step view -->
         <div ng-if="configuredView && !loadingStep && !elementNotFound" ng-include="configuredView"></div>
-        
+
         <!-- Dom element not found error -->
         <div ng-if="elementNotFound && !loadingStep">
             <umb-tour-step class="tc">

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umbtour/umb-tour-step.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umbtour/umb-tour-step.html
@@ -2,7 +2,11 @@
 
 
     <div ng-if="hideClose !== true">
-        <button class="icon-wrong umb-tour-step__close" ng-click="close()"></button>
+        <button class="icon-wrong umb-tour-step__close" ng-click="close()">
+            <span class="sr-only">
+                <localize key="general_close">Close</localize>
+            </span>
+        </button>
     </div>
 
     <div ng-transclude></div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes issue 11 from #5277 

### Description
It appears to me that the "X" is possible to tab to using the keyboard - However I noticed that the "Don't show this tour again" was not, so I have been fixing that.

I have also added a sr-only text to the close button so "Close" is read out to screen readers.

**Before**
![welcome-modal-before](https://user-images.githubusercontent.com/1932158/61584317-d5d35200-ab45-11e9-9451-f6f1337763a6.gif)

**After**
![welcome-modal-after](https://user-images.githubusercontent.com/1932158/61584321-f9969800-ab45-11e9-96ff-8f7621a9b891.gif)
