### PR TITLE
Handle CSV values in TagsPropertyEditor (#5855)

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TagsPropertyEditor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Newtonsoft.Json.Linq;
@@ -38,9 +39,15 @@ namespace Umbraco.Web.PropertyEditors
             /// <inheritdoc />
             public override object FromEditor(ContentPropertyData editorValue, object currentValue)
             {
-                return editorValue.Value is JArray json
-                    ? json.Select(x => x.Value<string>())
-                    : null;
+                if (editorValue.Value is JArray json)
+                {
+                    return json.Select(x => x.Value<string>());
+                }
+                else if ( editorValue.Value is string stringValue && !String.IsNullOrWhiteSpace(stringValue))
+                {
+                    return stringValue.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+                }
+                return null;
             }
 
             /// <inheritdoc />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5855
### Description

Handles CSV values being returned from the tags editor, which happens when the data type is configured for CSV storage and the page is saved without modifying the tags,

To test:
- Create a Tags property with storage type set to CSV
- Create and save a document with some tags populated
- Reopen the document and save it without making any changes to the tags
- Reopen the document again and confirm that the tags are not blank