### PR TITLE
Content migration - Include CheckBoxList in ValueListPreValueMigrator

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/ValueListPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/ValueListPreValueMigrator.cs
@@ -9,6 +9,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
         private readonly string[] _editors =
         {
             "Umbraco.RadioButtonList",
+            "Umbraco.CheckBoxList",
             "Umbraco.DropDown",
             "Umbraco.DropdownlistPublishingKeys",
             "Umbraco.DropDownMultiple",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
ValueListPreValueMigrator converts the items config for RadioButtonList and the various dropdowns, but not CheckBoxList. It needs the same conversion.

Testing:
- In 7.15.0, create a CheckBoxList property and add some items. Create a document with some items selected.
- Upgrade to 8.1.0
- Check that the items are still listed, and that the previously selected items are still selected.

---
_This item has been added to our backlog [AB#1872](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/1872)_