### PR TITLE
Fix FIPS compliance, add FIPS tests

### DIFF
--- a/src/Umbraco.Tests/TestHelpers/ControllerTesting/TestRunner.cs
+++ b/src/Umbraco.Tests/TestHelpers/ControllerTesting/TestRunner.cs
@@ -25,11 +25,15 @@ namespace Umbraco.Tests.TestHelpers.ControllerTesting
         public async Task<Tuple<HttpResponseMessage, string>> Execute(string controllerName, string actionName, HttpMethod method,
             HttpContent content = null,
             MediaTypeWithQualityHeaderValue mediaTypeHeader = null,
-            bool assertOkResponse = true)
+            bool assertOkResponse = true, object routeDefaults = null, string url = null)
         {
             if (mediaTypeHeader == null)
             {
                 mediaTypeHeader = new MediaTypeWithQualityHeaderValue("application/json");
+            }
+            if (routeDefaults == null)
+            {
+                routeDefaults = new { controller = controllerName, action = actionName, id = RouteParameter.Optional };
             }
 
             var startup = new TestStartup(
@@ -37,7 +41,7 @@ namespace Umbraco.Tests.TestHelpers.ControllerTesting
                 {
                     configuration.Routes.MapHttpRoute("Default",
                         routeTemplate: "{controller}/{action}/{id}",
-                        defaults: new { controller = controllerName, action = actionName, id = RouteParameter.Optional });
+                        defaults: routeDefaults);
                 },
                 _controllerFactory);
 
@@ -45,7 +49,7 @@ namespace Umbraco.Tests.TestHelpers.ControllerTesting
             {
                 var request = new HttpRequestMessage
                 {
-                    RequestUri = new Uri("https://testserver/"),
+                    RequestUri = new Uri("https://testserver/" + (url ?? "")),
                     Method = method
                 };
 

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -242,6 +242,7 @@
     <Compile Include="Cache\FullDataSetCachePolicyTests.cs" />
     <Compile Include="Cache\SingleItemsOnlyCachePolicyTests.cs" />
     <Compile Include="Collections\DeepCloneableListTests.cs" />
+    <Compile Include="Web\Controllers\AuthenticationControllerTests.cs" />
     <Compile Include="Web\Controllers\BackOfficeControllerUnitTests.cs" />
     <Compile Include="CoreThings\DelegateExtensionsTests.cs" />
     <Compile Include="Web\Controllers\ContentControllerTests.cs" />

--- a/src/Umbraco.Tests/Web/Controllers/AuthenticationControllerTests.cs
+++ b/src/Umbraco.Tests/Web/Controllers/AuthenticationControllerTests.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Web;
+using System.Web.Hosting;
+using System.Web.Http;
+using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Umbraco.Core;
+using Umbraco.Core.Cache;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.IO;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Mappers;
+using Umbraco.Core.Persistence.Querying;
+using Umbraco.Core.Persistence.SqlSyntax;
+using Umbraco.Core.Services;
+using Umbraco.Tests.TestHelpers;
+using Umbraco.Tests.TestHelpers.ControllerTesting;
+using Umbraco.Tests.Testing;
+using Umbraco.Web;
+using Umbraco.Web.Editors;
+using Umbraco.Web.Features;
+using Umbraco.Web.Models.ContentEditing;
+using IUser = Umbraco.Core.Models.Membership.IUser;
+
+namespace Umbraco.Tests.Web.Controllers
+{
+    [TestFixture]
+    [UmbracoTest(Database = UmbracoTestOptions.Database.None)]
+    public class AuthenticationControllerTests : TestWithDatabaseBase
+    {
+        protected override void ComposeApplication(bool withApplication)
+        {
+            base.ComposeApplication(withApplication);
+            //if (!withApplication) return;
+
+            // replace the true IUserService implementation with a mock
+            // so that each test can configure the service to their liking
+            Composition.RegisterUnique(f => Mock.Of<IUserService>());
+
+            // kill the true IEntityService too
+            Composition.RegisterUnique(f => Mock.Of<IEntityService>());
+
+            Composition.RegisterUnique<UmbracoFeatures>();
+        }
+
+
+        [Test]
+        public async System.Threading.Tasks.Task GetCurrentUser_Fips()
+        {
+            ApiController CtrlFactory(HttpRequestMessage message, IUmbracoContextAccessor umbracoContextAccessor, UmbracoHelper helper)
+            {
+                //setup some mocks
+                var userServiceMock = Mock.Get(Current.Services.UserService);
+                userServiceMock.Setup(service => service.GetUserById(It.IsAny<int>()))
+                    .Returns(() => null);
+
+                var baseDir = IOHelper.MapPath("", false).TrimEnd(IOHelper.DirSepChar);
+                HttpContext.Current = new HttpContext(new SimpleWorkerRequest("/", baseDir, "", "", new StringWriter()));
+                IOHelper.ForceNotHosted = true;
+                var usersController = new AuthenticationController(
+                    Factory.GetInstance<IGlobalSettings>(),
+                    umbracoContextAccessor,
+                    Factory.GetInstance<ISqlContext>(),
+                    Factory.GetInstance<ServiceContext>(),
+                    Factory.GetInstance<AppCaches>(),
+                    Factory.GetInstance<IProfilingLogger>(),
+                    Factory.GetInstance<IRuntimeState>(),
+                    helper);
+                return usersController;
+            }
+
+            Mock.Get(Current.SqlContext)
+                .Setup(x => x.Query<IUser>())
+                .Returns(new Query<IUser>(Current.SqlContext));
+
+            var syntax = new SqlCeSyntaxProvider();
+
+            Mock.Get(Current.SqlContext)
+                .Setup(x => x.SqlSyntax)
+                .Returns(syntax);
+
+            var mappers = new MapperCollection(new[]
+            {
+                new UserMapper(new Lazy<ISqlContext>(() => Current.SqlContext), new ConcurrentDictionary<Type, ConcurrentDictionary<string, string>>())
+            });
+
+            Mock.Get(Current.SqlContext)
+                .Setup(x => x.Mappers)
+                .Returns(mappers);
+
+            // Testing what happens if the system were configured to only use FIPS-compliant algorithms
+            var typ = typeof(CryptoConfig);
+            var flds = typ.GetFields(BindingFlags.Static | BindingFlags.NonPublic);
+            var haveFld = flds.FirstOrDefault(f => f.Name == "s_haveFipsAlgorithmPolicy");
+            var isFld = flds.FirstOrDefault(f => f.Name == "s_fipsAlgorithmPolicy");
+            var originalFipsValue = CryptoConfig.AllowOnlyFipsAlgorithms;
+
+            try
+            {
+                if (!originalFipsValue)
+                {
+                    haveFld.SetValue(null, true);
+                    isFld.SetValue(null, true);
+                }
+
+                var runner = new TestRunner(CtrlFactory);
+                var response = await runner.Execute("Authentication", "GetCurrentUser", HttpMethod.Get);
+
+                var obj = JsonConvert.DeserializeObject<UserDetail>(response.Item2);
+                Assert.AreEqual(-1, obj.UserId);
+            }
+            finally
+            {
+                if (!originalFipsValue)
+                {
+                    haveFld.SetValue(null, false);
+                    isFld.SetValue(null, false);
+                }
+            }
+        }
+    }
+}

--- a/src/Umbraco.Tests/Web/Controllers/AuthenticationControllerTests.cs
+++ b/src/Umbraco.Tests/Web/Controllers/AuthenticationControllerTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Security.Cryptography;
+using System.Threading;
 using System.Web;
 using System.Web.Hosting;
 using System.Web.Http;
@@ -63,8 +64,15 @@ namespace Umbraco.Tests.Web.Controllers
                 userServiceMock.Setup(service => service.GetUserById(It.IsAny<int>()))
                     .Returns(() => null);
 
-                var baseDir = IOHelper.MapPath("", false).TrimEnd(IOHelper.DirSepChar);
-                HttpContext.Current = new HttpContext(new SimpleWorkerRequest("/", baseDir, "", "", new StringWriter()));
+                if (Thread.GetDomain().GetData(".appPath") != null)
+                {
+                    HttpContext.Current = new HttpContext(new SimpleWorkerRequest("", "", new StringWriter()));
+                }
+                else
+                {
+                    var baseDir = IOHelper.MapPath("", false).TrimEnd(IOHelper.DirSepChar);
+                    HttpContext.Current = new HttpContext(new SimpleWorkerRequest("/", baseDir, "", "", new StringWriter()));
+                }
                 IOHelper.ForceNotHosted = true;
                 var usersController = new AuthenticationController(
                     Factory.GetInstance<IGlobalSettings>(),

--- a/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
@@ -301,7 +301,7 @@ namespace Umbraco.Web.Models.Mapping
             target.Avatars = source.GetUserAvatarUrls(_appCaches.RuntimeCache);
             target.Culture = source.GetUserCulture(_textService, _globalSettings).ToString();
             target.Email = source.Email;
-            target.EmailHash = source.Email.ToLowerInvariant().Trim().ToMd5();
+            target.EmailHash = source.Email.ToLowerInvariant().Trim().GenerateHash();
             target.Id = source.Id;
             target.Key = source.Key;
             target.LastLoginDate = source.LastLoginDate == default ? null : (DateTime?) source.LastLoginDate;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

This fixes #5976

### Description

This fixes #5976 and allows for viewing the User list in the back-office when FIPS is enabled.  It also includes unit tests to verify that user mapping (the most common FIPS-breaking change) is FIPS compliant.

To verify this fix:

1. Follow the directions at https://our.umbraco.com/documentation/Reference/Security/Setup-Umbraco-for-a-Fips-Server/ to install Umbraco v8.1 on a FIPS-enabled server.
2. Go through the install wizard
3. Log in to the back office, and navigate to the Users section
4. You should not see any error in the users list, but should see a list of currently active users (see attached screenshot ![FIPS_Enabled_User_List](https://user-images.githubusercontent.com/702500/61664328-6a919900-ac87-11e9-8845-92ac3df953b7.png))