### PR TITLE
V8: Allow removing user start nodes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -90,6 +90,7 @@
                                       ng-repeat="node in model.user.startContentIds"
                                       icon="node.icon"
                                       name="node.name"
+                                      allow-remove="true"
                                       on-remove="model.removeSelectedItem($index, model.user.startContentIds)">
                     </umb-node-preview>
 
@@ -114,6 +115,7 @@
                                       ng-repeat="node in model.user.startMediaIds"
                                       icon="node.icon"
                                       name="node.name"
+                                      allow-remove="true"
                                       on-remove="model.removeSelectedItem($index, model.user.startMediaIds)">
                     </umb-node-preview>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5995

### Description

See #5995 for details.

As it turns out, the user editing implementation already supports removal of user start nodes - it's just not been enabled in the view. So... this PR just does that.

When this PR is applied, user start nodes can be removed for both content and media:

![remove-user-start-nodes](https://user-images.githubusercontent.com/7405322/61858898-5045fe00-aec7-11e9-9aa2-6a9f3fbadd5a.gif)
