### PR TITLE
V8: Date pickers - parsing non-standard formats

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -78,9 +78,20 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
         setDatePickerVal();
     };
 
-    $scope.inputChanged = function() {
-        setDate($scope.model.datetimePickerValue);
-        setDatePickerVal();
+    $scope.inputChanged = function () {        
+        if ($scope.model.datetimePickerValue == "" && $scope.hasDatetimePickerValue) {
+                $scope.clearDate();
+        } else if ($scope.model.datetimePickerValue) {
+            var momentDate = moment($scope.model.datetimePickerValue, $scope.model.config.format, true);
+            if (!momentDate || !momentDate.isValid()) {
+                momentDate = moment(new Date($scope.model.datetimePickerValue));
+            }
+            if (momentDate && momentDate.isValid()) {
+                setDate(momentDate.format("YYYY-MM-DD HH:mm:ss"));
+            }
+            setDatePickerVal();
+            flatPickr.setDate($scope.model.value, false);
+        }
     }
     
     //here we declare a special method which will be called whenever the value has changed from the server

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -74,20 +74,23 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
     };
 
     $scope.datePickerChange = function(date) {
-        setDate(date);
+        const momentDate = moment(date);
+        setDate(momentDate);
         setDatePickerVal();
     };
 
     $scope.inputChanged = function () {        
-        if ($scope.model.datetimePickerValue == "" && $scope.hasDatetimePickerValue) {
-                $scope.clearDate();
+        if ($scope.model.datetimePickerValue === "" && $scope.hasDatetimePickerValue) {
+            // $scope.hasDatetimePickerValue indicates that we had a value before the input was changed,
+            // but now the input is empty.
+            $scope.clearDate();
         } else if ($scope.model.datetimePickerValue) {
             var momentDate = moment($scope.model.datetimePickerValue, $scope.model.config.format, true);
             if (!momentDate || !momentDate.isValid()) {
                 momentDate = moment(new Date($scope.model.datetimePickerValue));
             }
             if (momentDate && momentDate.isValid()) {
-                setDate(momentDate.format("YYYY-MM-DD HH:mm:ss"));
+                setDate(momentDate);
             }
             setDatePickerVal();
             flatPickr.setDate($scope.model.value, false);
@@ -103,15 +106,14 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
             var newDate = moment(newVal);
 
             if (newDate.isAfter(minDate)) {
-                setDate(newVal);
+                setDate(newDate);
             } else {
                 $scope.clearDate();
             }
         }
     };
 
-    function setDate(date) {
-        const momentDate = moment(date);
+    function setDate(momentDate) {        
         angularHelper.safeApply($scope, function() {
             // when a date is changed, update the model
             if (momentDate && momentDate.isValid()) {
@@ -123,12 +125,11 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
                 $scope.hasDatetimePickerValue = false;
                 $scope.model.datetimePickerValue = null;
             }
-            updateModelValue(date);
+            updateModelValue(momentDate);
         });
     }
 
-    function updateModelValue(date) {
-        const momentDate = moment(date);
+    function updateModelValue(momentDate) {
         if ($scope.hasDatetimePickerValue) {
             if ($scope.model.config.pickTime) {
                 //check if we are supposed to offset the time


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5968

### Description
Date pickers cause issues if a non-default format like DD-MM-YYYY is configured. Moment.js is asked to parse the formatted value, which at best causes a javascript warning and at worst leaves the field back or with the wrong date. In a future version, Moment.js will remove support for the fallback parsing which currently triggers the warning, causing further problems.

This change passes the configured format string to Moment.js so that the value can be parsed properly. Since the user could still type a date in another format, it falls back to the browser's date parsing in a way which keeps Moment.js happy.

To test:
- Configure the date picker with a non-default format, such as DD-MM-YYYY.
- Open the picker by clicking in the text box, rather than on the button next to it.
- Pick 25 July 2019 (to cause a problem if 25-07-2019 is parsed as MM-DD-YYYY) and move focus to another property.
- There should be no javascript warning from moment, and the date should appear as expected.
- Type "1 Jan 2000" in the date picker's text box, and move focus to another field.
- The value should change to "01-01-2000", again with no javascript warning.
- Open the date picker again, and 1 January 2000 should be pre-selected.