### PR TITLE
Content migration - nested content

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -130,6 +130,8 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<DataTypeMigration>("{8640C9E4-A1C0-4C59-99BB-609B4E604981}");
             To<TagsMigration>("{DD1B99AF-8106-4E00-BAC7-A43003EA07F8}");
             To<SuperZero>("{9DF05B77-11D1-475C-A00A-B656AF7E0908}");
+            To<AddContentTypeIsElementColumn>("{0009109C-A0B8-4F3F-8FEB-C137BBDDA268}");
+            To<NestedContentPropertyEditorsMigration>("{a730b327-300b-4b60-bd18-9a4f05b8e931}");
             To<PropertyEditorsMigration>("{6FE3EF34-44A0-4992-B379-B40BC4EF1C4D}");
             To<LanguageColumns>("{7F59355A-0EC9-4438-8157-EB517E6D2727}");
             ToWithReplace<AddVariationTables2, AddVariationTables1A>("{941B2ABA-2D06-4E04-81F5-74224F1DB037}", "{76DF5CD7-A884-41A5-8DC6-7860D95B1DF5}"); // kill AddVariationTable1
@@ -154,7 +156,6 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<TablesForScheduledPublishing>("{7EB0254C-CB8B-4C75-B15B-D48C55B449EB}");
             To<MakeTagsVariant>("{C39BF2A7-1454-4047-BBFE-89E40F66ED63}");
             To<MakeRedirectUrlVariant>("{64EBCE53-E1F0-463A-B40B-E98EFCCA8AE2}");
-            To<AddContentTypeIsElementColumn>("{0009109C-A0B8-4F3F-8FEB-C137BBDDA268}");
             To<ConvertRelatedLinksToMultiUrlPicker>("{ED28B66A-E248-4D94-8CDB-9BDF574023F0}");
             To<UpdatePickerIntegerValuesToUdi>("{38C809D5-6C34-426B-9BEA-EFD39162595C}");
             To<RenameUmbracoDomainsTable>("{6017F044-8E70-4E10-B2A3-336949692ADD}");

--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -7,6 +7,7 @@ using Umbraco.Core.Migrations.Upgrade.V_8_0_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_0_1;
 using Umbraco.Core.Migrations.Upgrade.V_8_1_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_6_0;
+using Umbraco.Core.Migrations.Upgrade.V_8_7_0;
 
 namespace Umbraco.Core.Migrations.Upgrade
 {
@@ -130,8 +131,6 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<DataTypeMigration>("{8640C9E4-A1C0-4C59-99BB-609B4E604981}");
             To<TagsMigration>("{DD1B99AF-8106-4E00-BAC7-A43003EA07F8}");
             To<SuperZero>("{9DF05B77-11D1-475C-A00A-B656AF7E0908}");
-            To<AddContentTypeIsElementColumn>("{0009109C-A0B8-4F3F-8FEB-C137BBDDA268}");
-            To<NestedContentPropertyEditorsMigration>("{a730b327-300b-4b60-bd18-9a4f05b8e931}");
             To<PropertyEditorsMigration>("{6FE3EF34-44A0-4992-B379-B40BC4EF1C4D}");
             To<LanguageColumns>("{7F59355A-0EC9-4438-8157-EB517E6D2727}");
             ToWithReplace<AddVariationTables2, AddVariationTables1A>("{941B2ABA-2D06-4E04-81F5-74224F1DB037}", "{76DF5CD7-A884-41A5-8DC6-7860D95B1DF5}"); // kill AddVariationTable1
@@ -156,6 +155,7 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<TablesForScheduledPublishing>("{7EB0254C-CB8B-4C75-B15B-D48C55B449EB}");
             To<MakeTagsVariant>("{C39BF2A7-1454-4047-BBFE-89E40F66ED63}");
             To<MakeRedirectUrlVariant>("{64EBCE53-E1F0-463A-B40B-E98EFCCA8AE2}");
+            To<AddContentTypeIsElementColumn>("{0009109C-A0B8-4F3F-8FEB-C137BBDDA268}");
             To<ConvertRelatedLinksToMultiUrlPicker>("{ED28B66A-E248-4D94-8CDB-9BDF574023F0}");
             To<UpdatePickerIntegerValuesToUdi>("{38C809D5-6C34-426B-9BEA-EFD39162595C}");
             To<RenameUmbracoDomainsTable>("{6017F044-8E70-4E10-B2A3-336949692ADD}");
@@ -194,6 +194,9 @@ namespace Umbraco.Core.Migrations.Upgrade
 
 
             To<MissingDictionaryIndex>("{a78e3369-8ea3-40ec-ad3f-5f76929d2b20}");
+
+            // to 8.7.0...
+            To<NestedContentPropertyEditorsMigration>("{a730b327-300b-4b60-bd18-9a4f05b8e931}");
 
             //FINAL
         }

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/NestedContentPropertyEditorsMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/NestedContentPropertyEditorsMigration.cs
@@ -124,6 +124,13 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
             _elementTypesInUse.Add(elementTypeId);
 
             var propertyValues = element.ToObject<Dictionary<string, string>>();
+            if (!propertyValues.TryGetValue("key", out var keyo)
+                || !Guid.TryParse(keyo.ToString(), out var key))
+            {
+                changed = true;
+                element["key"] = Guid.NewGuid();
+            }
+
             var propertyTypes = GetPropertyTypes(elementTypeId);
 
             foreach (var pt in propertyTypes)

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/NestedContentPropertyEditorsMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/NestedContentPropertyEditorsMigration.cs
@@ -1,0 +1,139 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Migrations.PostMigrations;
+using Umbraco.Core.Models;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
+{
+    public class NestedContentPropertyEditorsMigration : PropertyEditorsMigrationBase
+    {
+        private Dictionary<string, int> _elementTypeIds;
+        private ConfigurationEditor _configEditor;
+
+        public NestedContentPropertyEditorsMigration(IMigrationContext context)
+            : base(context)
+        { }
+
+        public override void Migrate()
+        {
+            _elementTypeIds = Database.Fetch<ContentTypeDto>(Sql()
+                .Select<ContentTypeDto>(x => x.NodeId, x => x.Alias)
+                .From<ContentTypeDto>()
+                .InnerJoin<NodeDto>().On<ContentTypeDto, NodeDto>(left => left.NodeId, right => right.NodeId)
+                .Where<NodeDto>(node => node.NodeObjectType == Constants.ObjectTypes.DocumentType))
+                .ToDictionary(ct => ct.Alias, ct => ct.NodeId);
+
+            _configEditor = new DropDownFlexibleConfigurationEditor();
+
+            var dataTypes = GetDataTypes(Constants.PropertyEditors.Aliases.NestedContent);            
+
+            var refreshCache = false;
+            //ConfigurationEditor configurationEditor = null;
+
+            foreach (var dataType in dataTypes)
+            {
+                // get property data dtos
+                var propertyDataDtos = Database.Fetch<PropertyDataDto>(Sql()
+                    .Select<PropertyDataDto>()
+                    .From<PropertyDataDto>()
+                    .InnerJoin<PropertyTypeDto>().On<PropertyTypeDto, PropertyDataDto>((pt, pd) => pt.Id == pd.PropertyTypeId)
+                    .InnerJoin<DataTypeDto>().On<DataTypeDto, PropertyTypeDto>((dt, pt) => dt.NodeId == pt.DataTypeId)
+                    .Where<PropertyTypeDto>(x => x.DataTypeId == dataType.NodeId));
+
+                // update dtos
+                var updatedDtos = propertyDataDtos.Where(x => UpdateNestedPropertyDataDto(x)).ToArray();
+
+                // persist changes
+                foreach (var propertyDataDto in updatedDtos)
+                {
+                    Database.Update(propertyDataDto);
+                    refreshCache = true;
+                }
+            }
+
+            // if some data types have been updated directly in the database (editing DataTypeDto and/or PropertyDataDto),
+            // bypassing the services, then we need to rebuild the cache entirely, including the umbracoContentNu table
+            if (refreshCache)
+                Context.AddPostMigration<RebuildPublishedSnapshot>();
+        }
+
+        private bool UpdateNestedPropertyDataDto(PropertyDataDto pd)
+        {
+            if (String.IsNullOrWhiteSpace(pd.TextValue))
+                return false;
+
+            bool changed = false;
+
+            var objects = JsonConvert.DeserializeObject<List<JObject>>(pd.TextValue);
+            foreach(var sourceObject in objects)
+            {
+                var elementTypeAlias = sourceObject["ncContentTypeAlias"]?.ToObject<string>();
+                if (string.IsNullOrEmpty(elementTypeAlias))
+                    continue;
+
+                var propertyValues = sourceObject.ToObject<Dictionary<string, string>>();
+
+                var elementTypeId = _elementTypeIds[elementTypeAlias];
+
+                var propertyTypes = Database.Fetch<PropertyTypeDto>(Sql()
+                        .Select<PropertyTypeDto>(r => r.Select(x => x.DataTypeDto))
+                        .From<PropertyTypeDto>()
+                        .InnerJoin<DataTypeDto>().On<PropertyTypeDto, DataTypeDto>((pt, dt) => pt.DataTypeId == dt.NodeId)
+                        .Where<PropertyTypeDto>(pt => pt.ContentTypeId == elementTypeId)
+                        );
+
+                foreach(var pt in propertyTypes.Where(pt => propertyValues.ContainsKey(pt.Alias)))
+                {
+                    DropDownFlexibleConfiguration config;
+                    switch(pt.DataTypeDto.EditorAlias)
+                    {
+                        case Constants.PropertyEditors.Aliases.RadioButtonList:
+                            config = (DropDownFlexibleConfiguration)_configEditor.FromDatabase(pt.DataTypeDto.Configuration);
+                            config.Multiple = false;
+                            changed = UpdateValueList(sourceObject, propertyValues, pt, config);
+                            break;
+                        case Constants.PropertyEditors.Aliases.CheckBoxList:
+                            config = (DropDownFlexibleConfiguration)_configEditor.FromDatabase(pt.DataTypeDto.Configuration);
+                            config.Multiple = true;
+                            changed = UpdateValueList(sourceObject, propertyValues, pt, config);
+                            break;
+                        case Constants.PropertyEditors.Aliases.DropDownListFlexible:
+                            config = (DropDownFlexibleConfiguration)_configEditor.FromDatabase(pt.DataTypeDto.Configuration);
+                            changed = UpdateValueList(sourceObject, propertyValues, pt, config);
+                            break;
+                    }
+                }
+            }
+
+            if (changed)
+                pd.TextValue = JsonConvert.SerializeObject(objects);
+
+            return changed;
+        }
+
+        private bool UpdateValueList(JObject sourceObject, Dictionary<string, string> propertyValues, PropertyTypeDto pt, DropDownFlexibleConfiguration config)
+        {
+            var propData = new PropertyDataDto { VarcharValue = propertyValues[pt.Alias] };
+            
+            if (UpdatePropertyDataDto(propData, config, isMultiple: true))
+            {
+                sourceObject[pt.Alias] = propData.VarcharValue;
+                return true;
+            }
+
+            return false;
+        }
+
+
+        // dummy editor for deserialization
+        protected class DropDownFlexibleConfigurationEditor : ConfigurationEditor<DropDownFlexibleConfiguration>
+        { }
+    }
+}

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/NestedContentPropertyEditorsMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/NestedContentPropertyEditorsMigration.cs
@@ -123,7 +123,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
             var elementTypeId = _elementTypeIds[elementTypeAlias];
             _elementTypesInUse.Add(elementTypeId);
 
-            var propertyValues = element.ToObject<Dictionary<string, string>>();
+            var propertyValues = element.Properties().ToDictionary(p => p.Name, p => p.Value.ToString());
             if (!propertyValues.TryGetValue("key", out var keyo)
                 || !Guid.TryParse(keyo.ToString(), out var key))
             {
@@ -161,7 +161,8 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
                         }
                         break;
 
-                    case Constants.PropertyEditors.Aliases.MultiUrlPicker:                        
+                    case Constants.PropertyEditors.Legacy.Aliases.RelatedLinks:
+                    case Constants.PropertyEditors.Legacy.Aliases.RelatedLinks2:
                         if (string.IsNullOrWhiteSpace(propertyValue))
                             continue;
                         element[pt.Alias] = ConvertRelatedLinksToMultiUrlPicker(propertyValue);

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/NestedContentPropertyEditorsMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/NestedContentPropertyEditorsMigration.cs
@@ -6,12 +6,13 @@ using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Migrations.PostMigrations;
+using Umbraco.Core.Migrations.Upgrade.V_8_0_0;
 using Umbraco.Core.Models;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Dtos;
 using Umbraco.Core.PropertyEditors;
 
-namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
+namespace Umbraco.Core.Migrations.Upgrade.V_8_7_0
 {
     public class NestedContentPropertyEditorsMigration : PropertyEditorsMigrationBase
     {

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -282,7 +282,7 @@
     <Compile Include="Models\Editors\UmbracoEntityReference.cs" />
     <Compile Include="Models\ContentEditing\ContentAppBadge.cs" />
     <Compile Include="Models\ContentEditing\ContentAppBadgeType.cs" />
-    <Compile Include="Migrations\Upgrade\V_8_0_0\NestedContentPropertyEditorsMigration.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_7_0\NestedContentPropertyEditorsMigration.cs" />
     <Compile Include="Models\Entities\EntityExtensions.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\PreValueMigratorBase.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\PreValueDto.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -282,6 +282,7 @@
     <Compile Include="Models\Editors\UmbracoEntityReference.cs" />
     <Compile Include="Models\ContentEditing\ContentAppBadge.cs" />
     <Compile Include="Models\ContentEditing\ContentAppBadgeType.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_0_0\NestedContentPropertyEditorsMigration.cs" />
     <Compile Include="Models\Entities\EntityExtensions.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\PreValueMigratorBase.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\PreValueDto.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5889

This PR creates `NestedContentPropertyEditorsMigration`, but adding it to the migration plan is left as an exercise for the reader.

### Description
Property values within nested content are currently untouched during content migration. This PR applies the conversions currently applied to top-level properties:

- DropDownFlexible (or other dropdowns which have been converted)
- RadioButtonList
- CheckBoxList
- MultiUrlPicker (converted from RelatedLinks)
- further levels of nested content

Also, any content types used within nested content must currently be manually changed to element types. This PR makes the change automatically in simple cases. It will set a content type as an element type if it:

- is used in a nested item
- is not used by any existing content
- uses no compositions

Warnings are generated for any content type which is used in nested content but was not set as an element type.

This step could be made more thorough, but I think this handles enough common cases to be useful. Where a content type uses compositions, we could in some cases still safely set all the necessary types as element types. We could also consider content types which are selected in nested content configuration but are not currently used anywhere.

Testing:
- In 7.15.0, create nested content containing dropdowns, related links, and other nested content.
- Migrate to 8.1.0 and check that nested elements are visible and have the expected values.

---
_This item has been added to our backlog [AB#4935](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/4935)_