### PR TITLE
V7: Add confirmation when deleting content and media

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -50,7 +50,7 @@ function ContentDeleteController($scope, contentResource, treeService, navigatio
                 $location.path(location);
             }
 
-            navigationService.hideMenu();
+            $scope.success = true;
         }, function(err) {
 
             $scope.currentNode.loading = false;

--- a/src/Umbraco.Web.UI.Client/src/views/content/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/delete.html
@@ -1,12 +1,22 @@
 <div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.Content.DeleteController">
     <div class="umb-dialog-body" auto-scale="90">
-        
-        <p class="umb-abstract">
-            <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong> ?
-        </p>
 
-        <umb-confirm on-confirm="performDelete" on-cancel="cancel">    
-        </umb-confirm>
+        <div ng-show="success">
+            <div class="alert alert-success">
+                <strong>{{currentNode.name}}</strong>
+                <localize key="actions_wasDeleted">was deleted</localize>
+            </div>
+            <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
+        </div>
+
+        <div ng-hide="success">
+            <p class="umb-abstract">
+                <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong> ?
+            </p>
+
+            <umb-confirm on-confirm="performDelete" on-cancel="cancel">    
+            </umb-confirm>
+        </div>
 
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/delete.html
@@ -1,10 +1,21 @@
 <div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.Media.DeleteController">
     <div class="umb-dialog-body" auto-scale="90">
-        
-        <p class="umb-abstract">
-            <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong> ?
-        </p>
 
-        <umb-confirm on-confirm="performDelete" on-cancel="cancel"></umb-confirm>
+        <div ng-show="success">
+            <div class="alert alert-success">
+                <strong>{{currentNode.name}}</strong>
+                <localize key="actions_wasDeleted">was deleted</localize>
+            </div>
+            <button class="btn btn-primary" ng-click="nav.hideDialog()">Ok</button>
+        </div>
+
+        <div ng-hide="success">
+            <p class="umb-abstract">
+                <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong> ?
+            </p>
+
+            <umb-confirm on-confirm="performDelete" on-cancel="cancel"></umb-confirm>
+        </div>
+
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
@@ -50,8 +50,7 @@ function MediaDeleteController($scope, mediaResource, treeService, navigationSer
                 $location.path(location);
             }
 
-            navigationService.hideMenu();
-
+            $scope.success = true;
         }, function (err) {
 
             $scope.currentNode.loading = false;

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -37,6 +37,7 @@
     <key alias="toInTheTreeStructureBelow">til i træstrukturen nedenfor</key>
     <key alias="wasMovedTo">blev flyttet til</key>
     <key alias="wasCopiedTo">blev kopieret til</key>
+    <key alias="wasDeleted">blev slettet</key>
     <key alias="rights">Rettigheder</key>
     <key alias="rollback">Fortryd ændringer</key>
     <key alias="sendtopublish">Send til udgivelse</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -38,6 +38,7 @@
         <key alias="toInTheTreeStructureBelow">to in the tree structure below</key>
         <key alias="wasMovedTo">was moved to</key>
         <key alias="wasCopiedTo">was copied to</key>
+        <key alias="wasDeleted">was deleted</key>
         <key alias="rights">Permissions</key>
         <key alias="rollback">Rollback</key>
         <key alias="sendtopublish">Send To Publish</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -38,6 +38,7 @@
         <key alias="toInTheTreeStructureBelow">to in the tree structure below</key>
         <key alias="wasMovedTo">was moved to</key>
         <key alias="wasCopiedTo">was copied to</key>
+        <key alias="wasDeleted">was deleted</key>
         <key alias="rights">Permissions</key>
         <key alias="rollback">Rollback</key>
         <key alias="sendtopublish">Send To Publish</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5975

### Description

There is no confirmation when deleting items in the content and media sections; all you get is that little node animation as it "jumps" out of the tree.

This PR adds a confirmation in the same style that applies to the move, copy and restore actions. See #5975 for more info.

Here are previews of this PR in action:

#### Content deletion

![delete-confirmation-after-content](https://user-images.githubusercontent.com/7405322/61955978-76999580-afbc-11e9-9c5c-03dd597e2c55.gif)

#### Media deletion

![delete-confirmation-after-media](https://user-images.githubusercontent.com/7405322/61955984-7b5e4980-afbc-11e9-8590-6b102bfef32d.gif)
