### PR TITLE
V8: Always open the selected content template in infinite editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    function ContentNodeInfoDirective($timeout, logResource, eventsService, userService, localizationService, dateHelper, editorService, redirectUrlsResource, overlayService) {
+    function ContentNodeInfoDirective($timeout, logResource, eventsService, userService, localizationService, dateHelper, editorService, redirectUrlsResource, overlayService, entityResource) {
 
         function link(scope) {
 
@@ -16,8 +16,12 @@
             scope.disableTemplates = Umbraco.Sys.ServerVariables.features.disabledFeatures.disableTemplates;
             scope.allowChangeDocumentType = false;
             scope.allowChangeTemplate = false;
+            scope.allTemplates = [];
 
             function onInit() {
+                entityResource.getAll("Template").then(function (templates) {
+                    scope.allTemplates = templates;
+                });
 
                 // set currentVariant
                 scope.currentVariant = _.find(scope.node.variants, (v) => v.active);
@@ -158,8 +162,12 @@
             }
 
             scope.openTemplate = function () {
+                var template = _.findWhere(scope.allTemplates, {alias: scope.node.template})
+                if (!template) {
+                    return;
+                }
                 var templateEditor = {
-                    id: scope.node.templateId,
+                    id: template.id,
                     submit: function (model) {
                         editorService.close();
                     },


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6006 (in part)

### Description

When opening the content template from the content "info" section, the currently assigned template is always opened no matter if you selected another one (assuming you have multiple templates allowed):

![open-template-before](https://user-images.githubusercontent.com/7405322/61998591-8f847280-b0b2-11e9-8961-15ef2f560beb.gif)

The same issue is the root cause of a slightly more annoying (and rather less likely to happen) error, which can be produced by the following steps:

1. Create a content type without a template.
2. Create a content item based on this content type.
3. Assign a template to the content type.
4. Open the content item and switch to the "info" section. The template will list as being already assigned to the content item because it will be once the content item is saved.
5. Open the template in infinite editing. 404 error happens:

![image](https://user-images.githubusercontent.com/7405322/61998685-e2aaf500-b0b3-11e9-9efa-009160b398f5.png)

This PR solves both of these issues by ensuring we always open the currently selected template (by template alias) in infinite editing. 

Here's how things work with the PR applied:

![open-template-after](https://user-images.githubusercontent.com/7405322/61998699-0bcb8580-b0b4-11e9-9007-d0f8ef1ca3fc.gif)
