### PR TITLE
V8: Value Set builder shouldn't stop indexing when one field is empty in …

### DIFF
--- a/src/Umbraco.Examine/BaseValueSetBuilder.cs
+++ b/src/Umbraco.Examine/BaseValueSetBuilder.cs
@@ -45,7 +45,7 @@ namespace Umbraco.Examine
                             continue;
                         case string strVal:
                             {
-                                if (strVal.IsNullOrWhiteSpace()) return;
+                                if (strVal.IsNullOrWhiteSpace()) continue;
                                 var key = $"{keyVal.Key}{cultureSuffix}";
                                 if (values.TryGetValue(key, out var v))
                                     values[key] = new List<object>(v) { val }.ToArray();


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Based on the discussion in that subject
https://github.com/umbraco/Umbraco-CMS/issues/5994,
I start digging in Umbraco and I found one line, which was causing my problem with not all fields were indexed. 

