### PR TITLE
V8: Fix caching of macro results in RTE

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
@@ -11,6 +11,7 @@ using Umbraco.Core.Cache;
 using Umbraco.Core.Services;
 using Umbraco.Web.Composing;
 using Umbraco.Web.Macros;
+using System.Web;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
@@ -63,7 +64,19 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             }
         }
 
-        public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
+        public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        {
+            var converted = Convert(inter, preview);
+
+            return new HtmlString(converted == null ? string.Empty : converted);
+        }
+
+        public override object ConvertIntermediateToXPath(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        {
+            return Convert(inter, preview);
+        }
+
+        private string Convert(object source, bool preview)
         {
             if (source == null)
             {

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
@@ -71,11 +71,6 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             return new HtmlString(converted == null ? string.Empty : converted);
         }
 
-        public override object ConvertIntermediateToXPath(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
-        {
-            return Convert(inter, preview);
-        }
-
         private string Convert(object source, bool preview)
         {
             if (source == null)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5984, #5987, #6141

### Description
Macro results are being cached as part of RTE values even if the macro has all caching disabled.

`RteMacroRenderingValueConverter` sets its cache level to Snapshot, but that isn't actually doing what we want it to. That cache level is used when caching the ObjectValue and XPathValue, but the macro rendering is happening in `ConvertSourceToIntermediate`. The intermediate value is effectively always cached at the Element level.

This PR moves the processing into `ConvertIntermediateToObject` and `ConvertIntermediateToXPath`.

Testing:
- Create a Partial Macro with an @DateTime.Now.Ticks output
- Create a Macro which uses the Partial Macro and Use in rich text editor and the grid enabled, Cache Period 0, Cache by Page Disable, Cache personalized disabled.
- Create a Page with an TinyMCE Editor Field and use the Macro inside the Editor.
- Publish and show the page. Refresh and check that the time updates.