### PR TITLE
V8: Clear the content type "common" cache when deleting templates

### DIFF
--- a/src/Umbraco.Web/Cache/TemplateCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/TemplateCacheRefresher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Models;
+using Umbraco.Core.Persistence.Repositories;
 using Umbraco.Core.Services;
 
 namespace Umbraco.Web.Cache
@@ -8,11 +9,13 @@ namespace Umbraco.Web.Cache
     public sealed class TemplateCacheRefresher : CacheRefresherBase<TemplateCacheRefresher>
     {
         private readonly IdkMap _idkMap;
+        private readonly IContentTypeCommonRepository _contentTypeCommonRepository;
 
-        public TemplateCacheRefresher(AppCaches appCaches, IdkMap idkMap)
+        public TemplateCacheRefresher(AppCaches appCaches, IdkMap idkMap, IContentTypeCommonRepository contentTypeCommonRepository)
             : base(appCaches)
         {
             _idkMap = idkMap;
+            _contentTypeCommonRepository = contentTypeCommonRepository;
         }
 
         #region Define
@@ -45,6 +48,7 @@ namespace Umbraco.Web.Cache
             // it has an associated template.
             ClearAllIsolatedCacheByEntityType<IContent>();
             ClearAllIsolatedCacheByEntityType<IContentType>();
+            _contentTypeCommonRepository.ClearCache();
 
             base.Remove(id);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

_Original source for this issue here: https://github.com/umbraco/Umbraco-CMS/issues/6006#issuecomment-515677337_ 

### Description

When you delete a template that's assigned to a content type, the content type remains in the cache with the template assigned:

![delete-template-reload-content-type-cache-before](https://user-images.githubusercontent.com/7405322/62026675-f5204e00-b1db-11e9-89d9-a1ae47f26d61.gif)

Turns out the template cache refresher doesn't clear the "common" cache for content types, only the isolated content type cache. This PR amends that, and thus deleting a template also forces a content type cache refresh:

![delete-template-reload-content-type-cache-after](https://user-images.githubusercontent.com/7405322/62026746-2ac53700-b1dc-11e9-957c-5b046a7adb56.gif)

#### Steps to test

1. Create a content type with a template assigned.
2. Delete the template.
3. Verify that the content type does not list the (now deleted) template in its "Templates" section.

