### PR TITLE
Adds PanicException with details instead of throwing "panic" strings

### DIFF
--- a/src/Umbraco.Core/Exceptions/PanicException.cs
+++ b/src/Umbraco.Core/Exceptions/PanicException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Umbraco.Core.Exceptions
+{
+    /// <summary>
+    /// Internal exception that in theory should never ben thrown, it is only thrown in circumstances that should never happen
+    /// </summary>
+    [Serializable]
+    internal class PanicException : Exception
+    {
+        public PanicException()
+        {
+        }
+
+        public PanicException(string message) : base(message)
+        {
+        }
+
+        public PanicException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected PanicException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Core/Mapping/UmbracoMapper.cs
+++ b/src/Umbraco.Core/Mapping/UmbracoMapper.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using Umbraco.Core.Exceptions;
 
 namespace Umbraco.Core.Mapping
 {
@@ -259,7 +260,7 @@ namespace Umbraco.Core.Mapping
             if (typeof(TTarget).IsArray)
             {
                 var elementType = typeof(TTarget).GetElementType();
-                if (elementType == null) throw new Exception("panic");
+                if (elementType == null) throw new PanicException("elementType == null which should never occur");
                 var targetArray = Array.CreateInstance(elementType, targetList.Count);
                 targetList.CopyTo(targetArray, 0);
                 target = targetArray;
@@ -382,7 +383,7 @@ namespace Umbraco.Core.Mapping
         {
             if (type.IsArray) return type.GetElementType();
             if (type.IsGenericType) return type.GenericTypeArguments[0];
-            throw new Exception("panic");
+            throw new PanicException($"Could not get enumerable or array type from {type}");
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/RenamingPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/RenamingPreValueMigrator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Umbraco.Core.Exceptions;
 
 namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
 {
@@ -20,7 +21,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
                 case "Umbraco.NoEdit":
                     return Constants.PropertyEditors.Aliases.Label;
                 default:
-                    throw new Exception("panic");
+                    throw new PanicException($"The alias {editorAlias} is not supported");
             }
         }
     }

--- a/src/Umbraco.Core/Models/PublishedContent/ModelType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/ModelType.cs
@@ -75,7 +75,7 @@ namespace Umbraco.Core.Models.PublishedContent
                 return type;
             var def = type.GetGenericTypeDefinition();
             if (def == null)
-                throw new InvalidOperationException("panic");
+                throw new PanicException($"The type {type} has not generic type definition");
 
             var args = type.GetGenericArguments().Select(x => Map(x, modelTypes, true)).ToArray();
             return def.MakeGenericType(args);
@@ -114,7 +114,7 @@ namespace Umbraco.Core.Models.PublishedContent
                 return type.FullName;
             var def = type.GetGenericTypeDefinition();
             if (def == null)
-                throw new InvalidOperationException("panic");
+                throw new PanicException($"The type {type} has not generic type definition");
 
             var args = type.GetGenericArguments().Select(x => MapToName(x, map, true)).ToArray();
             var defFullName = def.FullName.Substring(0, def.FullName.IndexOf('`'));

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NPoco;
 using Umbraco.Core.Cache;
+using Umbraco.Core.Exceptions;
 using Umbraco.Core.Models;
 using Umbraco.Core.Persistence.Dtos;
 using Umbraco.Core.Persistence.Factories;
@@ -90,7 +91,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                     contentType = ContentTypeFactory.BuildContentTypeEntity(contentTypeDto);
                 else if (contentTypeDto.NodeDto.NodeObjectType == Constants.ObjectTypes.MemberType)
                     contentType = ContentTypeFactory.BuildMemberTypeEntity(contentTypeDto);
-                else throw new Exception("panic");
+                else throw new PanicException($"The node object type {contentTypeDto.NodeDto.NodeObjectType} is not supported");
                 contentTypes.Add(contentType.Id, contentType);
 
                 // map allowed content types

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NPoco;
 using Umbraco.Core.Cache;
+using Umbraco.Core.Exceptions;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Entities;
@@ -56,7 +57,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         {
             // the cache policy will always want everything
             // even GetMany(ids) gets everything and filters afterwards
-            if (ids.Any()) throw new Exception("panic");
+            if (ids.Any()) throw new PanicException("There can be no ids specified");
             return CommonRepository.GetAllTypes().OfType<IContentType>();
         }
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MediaTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MediaTypeRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NPoco;
 using Umbraco.Core.Cache;
+using Umbraco.Core.Exceptions;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Entities;
@@ -50,7 +51,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         {
             // the cache policy will always want everything
             // even GetMany(ids) gets everything and filters afterwards
-            if (ids.Any()) throw new Exception("panic");
+            if (ids.Any()) throw new PanicException("There can be no ids specified");
             return CommonRepository.GetAllTypes().OfType<IMediaType>();
         }
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NPoco;
 using Umbraco.Core.Cache;
+using Umbraco.Core.Exceptions;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Entities;
@@ -57,7 +58,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         {
             // the cache policy will always want everything
             // even GetMany(ids) gets everything and filters afterwards
-            if (ids.Any()) throw new Exception("panic");
+            if (ids.Any()) throw new PanicException("There can be no ids specified");
             return CommonRepository.GetAllTypes().OfType<IMemberType>();
         }
 

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -204,6 +204,7 @@
     <Compile Include="CompositionExtensions_Essentials.cs" />
     <Compile Include="CompositionExtensions_FileSystems.cs" />
     <Compile Include="CompositionExtensions_Uniques.cs" />
+    <Compile Include="Exceptions\PanicException.cs" />
     <Compile Include="FactoryExtensions.cs" />
     <Compile Include="Composing\RegisterFactory.cs" />
     <Compile Include="Composing\Current.cs" />

--- a/src/Umbraco.Tests/Testing/TestOptionAttributeBase.cs
+++ b/src/Umbraco.Tests/Testing/TestOptionAttributeBase.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using Umbraco.Core.Exceptions;
 
 namespace Umbraco.Tests.Testing
 {
@@ -29,7 +30,7 @@ namespace Umbraco.Tests.Testing
             var methodName = test.MethodName;
             var type = Type.GetType(typeName, true);
             if (type == null)
-                throw new Exception("panic"); // makes no sense
+                throw new PanicException($"Could not resolve the type from type name {typeName}"); // makes no sense
             var methodInfo = type.GetMethod(methodName); // what about overloads?
             var options = GetTestOptions<TOptions>(methodInfo);
             return options;
@@ -53,7 +54,7 @@ namespace Umbraco.Tests.Testing
         {
             if (other == null) throw new ArgumentNullException(nameof(other));
             if (!(Merge((TestOptionAttributeBase) other) is TOptions merged))
-                throw new Exception("panic");
+                throw new PanicException("Could not merge test options");
             return merged;
         }
 

--- a/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
@@ -8,6 +8,7 @@ using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Web.Models.ContentEditing;
 using Umbraco.Core.Services;
+using Umbraco.Core.Exceptions;
 
 namespace Umbraco.Web.Models.Mapping
 {
@@ -577,7 +578,7 @@ namespace Umbraco.Web.Models.Mapping
                     udiType = Constants.UdiEntityType.DocumentType;
                     break;
                 default:
-                    throw new Exception("panic");
+                    throw new PanicException($"Source is of type {source.GetType()} which isn't supported here");
             }
 
             return Udi.Create(udiType, source.Key);

--- a/src/Umbraco.Web/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using Umbraco.Core;
+using Umbraco.Core.Exceptions;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Editors;
@@ -56,7 +57,7 @@ namespace Umbraco.Web.PropertyEditors
                 }
 
                 if (!(editorValue.DataTypeConfiguration is MultipleTextStringConfiguration config))
-                    throw new Exception("panic");
+                    throw new PanicException($"editorValue.DataTypeConfiguration is {editorValue.DataTypeConfiguration.GetType()} but must be {typeof(MultipleTextStringConfiguration)}");
                 var max = config.Maximum;
 
                 //The legacy property editor saved this data as new line delimited! strange but we have to maintain that.

--- a/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CSharpTest.Net.Collections;
 using Umbraco.Core;
+using Umbraco.Core.Exceptions;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Scoping;
@@ -1044,7 +1045,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     if (_genObj == null)
                         _genObjs.Enqueue(_genObj = new GenObj(snapGen));
                     else if (_genObj.Gen != snapGen)
-                        throw new Exception("panic");
+                        throw new PanicException($"The generation {_genObj.Gen} does not equal the snapshot generation {snapGen}");
                 }
                 else
                 {

--- a/src/Umbraco.Web/PublishedCache/NuCache/SnapDictionary.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/SnapDictionary.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Umbraco.Core.Exceptions;
 using Umbraco.Core.Scoping;
 using Umbraco.Web.PublishedCache.NuCache.Snap;
 
@@ -371,7 +372,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
                     // if we have one already, ensure it's consistent
                     else if (_genObj.Gen != snapGen)
-                        throw new Exception("panic");
+                        throw new PanicException($"The generation {_genObj.Gen} does not equal the snapshot generation {snapGen}");
                 }
                 else
                 {


### PR DESCRIPTION
Several places we are just throwing `new Exception("panic")` which indicates that this should __never__ happen, however in cases that it might, it is better to have a custom exception with some actual details, so this does that.