### PR TITLE
Feature/6024 application event handler default weight

### DIFF
--- a/src/Umbraco.Core/ObjectResolution/ApplicationEventsResolver.cs
+++ b/src/Umbraco.Core/ObjectResolution/ApplicationEventsResolver.cs
@@ -94,11 +94,12 @@ namespace Umbraco.Core.ObjectResolution
             var type = o.GetType();
             var attr = type.GetCustomAttribute<WeightAttribute>(true);
             if (attr != null) return attr.Weight;
-            var name = type.Assembly.FullName;
+            var assemblyName = type.Assembly.GetName();
+            var fullName = assemblyName.FullName;
 
             // we should really attribute all our Core handlers, so this is temp
-            var core = name.InvariantStartsWith("Umbraco.") || name.InvariantStartsWith("Concorde.");
-            return core ? -DefaultPluginWeight : DefaultPluginWeight;
+            var isCore = assemblyName.Name.Equals("umbraco", StringComparison.InvariantCultureIgnoreCase) || fullName.InvariantStartsWith("umbraco.") || fullName.InvariantStartsWith("concorde.");
+            return isCore ? -DefaultPluginWeight : DefaultPluginWeight;
         }
 
         /// <summary>

--- a/src/Umbraco.Web/BatchedDatabaseServerMessengerStartup.cs
+++ b/src/Umbraco.Web/BatchedDatabaseServerMessengerStartup.cs
@@ -1,5 +1,5 @@
 using Umbraco.Core;
-using Umbraco.Core.Logging;
+using Umbraco.Core.ObjectResolution;
 using Umbraco.Core.Sync;
 
 namespace Umbraco.Web
@@ -7,6 +7,7 @@ namespace Umbraco.Web
     /// <summary>
     /// Used to boot up the server messenger once the application succesfully starts
     /// </summary>
+    [Weight(-100)]
     internal class BatchedDatabaseServerMessengerStartup : ApplicationEventHandler
     {
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)

--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -1,17 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Examine;
 using Lucene.Net.Documents;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Core;
-using Umbraco.Core.Logging;
-using Umbraco.Core.Models;
+using Umbraco.Core.ObjectResolution;
 using Umbraco.Core.PropertyEditors;
-using Umbraco.Core.Services;
 using UmbracoExamine;
 
 namespace Umbraco.Web.PropertyEditors
@@ -148,6 +144,7 @@ namespace Umbraco.Web.PropertyEditors
         /// <summary>
         /// we're using a sub -class because this has the logic to prevent it from executing if the application is not configured
         /// </summary>
+        [Weight(-100)]
         private class GridPropertyEditorApplicationStartup : ApplicationEventHandler
         {
             /// <summary>

--- a/src/Umbraco.Web/Routing/RedirectTrackingEventHandler.cs
+++ b/src/Umbraco.Web/Routing/RedirectTrackingEventHandler.cs
@@ -7,6 +7,7 @@ using Umbraco.Core.Configuration;
 using Umbraco.Core.Events;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.ObjectResolution;
 using Umbraco.Core.Publishing;
 using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
@@ -24,6 +25,7 @@ namespace Umbraco.Web.Routing
     /// <para>not managing domains because we don't know how to do it - changing domains => must create a higher level strategy using rewriting rules probably</para>
     /// <para>recycle bin = moving to and from does nothing: to = the node is gone, where would we redirect? from = same</para>
     /// </remarks>
+    [Weight(-100)]
     public class RedirectTrackingEventHandler : ApplicationEventHandler
     {
         private const string ContextKey1 = "Umbraco.Web.Routing.RedirectTrackingEventHandler.1";

--- a/src/Umbraco.Web/Scheduling/Scheduler.cs
+++ b/src/Umbraco.Web/Scheduling/Scheduler.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Threading;
 using Umbraco.Core;
 using Umbraco.Core.Configuration;
-using Umbraco.Core.Configuration.HealthChecks;
 using Umbraco.Core.Logging;
-using Umbraco.Web.HealthCheck;
+using Umbraco.Core.ObjectResolution;
 using Umbraco.Web.Routing;
 
 namespace Umbraco.Web.Scheduling
@@ -18,6 +16,7 @@ namespace Umbraco.Web.Scheduling
     /// All tasks are run in a background task runner which is web aware and will wind down the task correctly instead of killing it completely when
     /// the app domain shuts down.
     /// </remarks>
+    [Weight(-100)]
     internal sealed class Scheduler : ApplicationEventHandler
     {
         private BackgroundTaskRunner<IBackgroundTask> _keepAliveRunner;

--- a/src/Umbraco.Web/Search/ExamineEvents.cs
+++ b/src/Umbraco.Web/Search/ExamineEvents.cs
@@ -11,6 +11,7 @@ using Umbraco.Core;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
+using Umbraco.Core.ObjectResolution;
 using Umbraco.Core.Scoping;
 using Umbraco.Core.Sync;
 using Umbraco.Web.Cache;
@@ -20,10 +21,11 @@ using Document = umbraco.cms.businesslogic.web.Document;
 
 namespace Umbraco.Web.Search
 {
-	/// <summary>
-	/// Used to wire up events for Examine
-	/// </summary>
-	public sealed class ExamineEvents : ApplicationEventHandler
+    /// <summary>
+    /// Used to wire up events for Examine
+    /// </summary>
+    [Weight(-100)]
+    public sealed class ExamineEvents : ApplicationEventHandler
 	{
 	    // the default enlist priority is 100
 	    // enlist with a lower priority to ensure that anything "default" runs after us

--- a/src/Umbraco.Web/Strategies/DataTypes/LegacyUploadFieldWorkaround.cs
+++ b/src/Umbraco.Web/Strategies/DataTypes/LegacyUploadFieldWorkaround.cs
@@ -2,22 +2,22 @@
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
-using System.Xml;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.IO;
-using umbraco.interfaces;
 using Umbraco.Core;
+using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Web.Strategies.DataTypes
 {
-	/// <summary>
-	/// Before Save Content/Media subscriber that checks for Upload fields and updates related fields accordingly.
-	/// </summary>
-	/// <remarks>
-	/// This is an intermediate fix for the legacy DataTypeUploadField and the FileHandlerData, so that properties
-	/// are saved correctly when using the Upload field on a (legacy) Document or Media class.
-	/// </remarks>
-	public class LegacyUploadFieldWorkaround : ApplicationEventHandler
+    /// <summary>
+    /// Before Save Content/Media subscriber that checks for Upload fields and updates related fields accordingly.
+    /// </summary>
+    /// <remarks>
+    /// This is an intermediate fix for the legacy DataTypeUploadField and the FileHandlerData, so that properties
+    /// are saved correctly when using the Upload field on a (legacy) Document or Media class.
+    /// </remarks>
+    [Weight(-100)]
+    public class LegacyUploadFieldWorkaround : ApplicationEventHandler
 	{
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
         {

--- a/src/Umbraco.Web/Strategies/LegacyClasses.cs
+++ b/src/Umbraco.Web/Strategies/LegacyClasses.cs
@@ -1,21 +1,17 @@
 ﻿using System;
-using System.Linq;
 using Umbraco.Core;
-using Umbraco.Core.Configuration;
-using Umbraco.Core.Events;
-using Umbraco.Core.Models;
-using Umbraco.Core.Publishing;
-using Umbraco.Web.Cache;
-
+using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Web.Strategies.Publishing
 {
     [Obsolete("This is not used and will be removed from the codebase in future versions")]
+    [Weight(-100)]
     public class UpdateCacheAfterPublish : ApplicationEventHandler
     {
     }
 
     [Obsolete("This is not used and will be removed from the codebase in future versions")]
+    [Weight(-100)]
     public class UpdateCacheAfterUnPublish : ApplicationEventHandler
     {
     }

--- a/src/Umbraco.Web/Strategies/Migrations/ClearCsrfCookiesAfterUpgrade.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/ClearCsrfCookiesAfterUpgrade.cs
@@ -1,17 +1,16 @@
-﻿using System.Linq;
-using System.Web;
+﻿using System.Web;
 using Umbraco.Core.Events;
 using Umbraco.Core.Persistence.Migrations;
 using Umbraco.Web.WebApi.Filters;
-using umbraco.interfaces;
 using Umbraco.Core;
-using Umbraco.Core.Configuration;
+using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Web.Strategies.Migrations
 {
     /// <summary>
     /// After upgrade we clear out the csrf tokens
     /// </summary>
+    [Weight(-100)]
     public class ClearCsrfCookiesAfterUpgrade : MigrationStartupHander
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)

--- a/src/Umbraco.Web/Strategies/Migrations/ClearMediaXmlCacheForDeletedItemsAfterUpgrade.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/ClearMediaXmlCacheForDeletedItemsAfterUpgrade.cs
@@ -4,8 +4,7 @@ using Umbraco.Core.Events;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence.Migrations;
 using Umbraco.Core.Persistence.SqlSyntax;
-using umbraco.interfaces;
-using Umbraco.Core.Configuration;
+using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Web.Strategies.Migrations
 {
@@ -17,6 +16,7 @@ namespace Umbraco.Web.Strategies.Migrations
     ///
     /// * If current is less than or equal to 7.0.0
     /// </remarks>
+    [Weight(-100)]
     public class ClearMediaXmlCacheForDeletedItemsAfterUpgrade : MigrationStartupHander
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)

--- a/src/Umbraco.Web/Strategies/Migrations/EnsureAppsTreesUpdatedOnUpgrade.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/EnsureAppsTreesUpdatedOnUpgrade.cs
@@ -1,7 +1,7 @@
 ﻿using Umbraco.Core;
 using Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSix;
 using umbraco.BusinessLogic;
-using umbraco.interfaces;
+using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Web.Strategies.Migrations
 {
@@ -9,6 +9,7 @@ namespace Umbraco.Web.Strategies.Migrations
     /// This is kind of a hack to ensure that Apps and Trees that might still reside in the db is
     /// written to the 'new' applications.config and trees.config files upon upgrade to version 6.0
     /// </summary>
+    [Weight(-100)]
     public class EnsureAppsTreesUpdatedOnUpgrade : ApplicationEventHandler
     {
         /// <summary>

--- a/src/Umbraco.Web/Strategies/Migrations/EnsureListViewDataTypeIsCreated.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/EnsureListViewDataTypeIsCreated.cs
@@ -1,22 +1,18 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Events;
-using Umbraco.Core.Models;
 using Umbraco.Core.Models.Rdbms;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Migrations;
 using Umbraco.Core.Persistence.SqlSyntax;
-using Umbraco.Core.Persistence.UnitOfWork;
-using umbraco.interfaces;
-using Umbraco.Core.Configuration;
+using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Web.Strategies.Migrations
 {
     /// <summary>
     /// Creates the built in list view data types
     /// </summary>
+    [Weight(-100)]
     public class EnsureDefaultListViewDataTypesCreated : MigrationStartupHander
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)

--- a/src/Umbraco.Web/Strategies/Migrations/OverwriteStylesheetFilesFromTempFiles.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/OverwriteStylesheetFilesFromTempFiles.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Umbraco.Core.Events;
 using Umbraco.Core;
-using Umbraco.Core.Configuration;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
+using Umbraco.Core.ObjectResolution;
 using Umbraco.Core.Persistence.Migrations;
 
 namespace Umbraco.Web.Strategies.Migrations
@@ -19,6 +15,7 @@ namespace Umbraco.Web.Strategies.Migrations
     /// files during the migration since other parts of the migration might fail. So once the migration is complete, we'll then copy over the temp
     /// files that this migration created over top of the developer's files. We'll also create a backup of their files.
     /// </summary>
+    [Weight(-100)]
     public sealed class OverwriteStylesheetFilesFromTempFiles : MigrationStartupHander
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)

--- a/src/Umbraco.Web/Strategies/Migrations/PublishAfterUpgradeToVersionSixth.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/PublishAfterUpgradeToVersionSixth.cs
@@ -5,10 +5,8 @@ using Umbraco.Core.Events;
 using Umbraco.Core.Models.Rdbms;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Migrations;
-using Umbraco.Core.Persistence.UnitOfWork;
-using umbraco.interfaces;
 using Umbraco.Core;
-using Umbraco.Core.Configuration;
+using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Web.Strategies.Migrations
 {
@@ -16,6 +14,7 @@ namespace Umbraco.Web.Strategies.Migrations
     /// This event ensures that upgrades from (configured) versions lower then 6.0.0
     /// have their publish state updated after the database schema has been migrated.
     /// </summary>
+    [Weight(-100)]
     public class PublishAfterUpgradeToVersionSixth : MigrationStartupHander
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)

--- a/src/Umbraco.Web/Strategies/Migrations/RebuildXmlCachesAfterUpgrade.cs
+++ b/src/Umbraco.Web/Strategies/Migrations/RebuildXmlCachesAfterUpgrade.cs
@@ -2,9 +2,9 @@
 using umbraco;
 using Umbraco.Core;
 using Umbraco.Core.Events;
+using Umbraco.Core.ObjectResolution;
 using Umbraco.Core.Persistence.Migrations;
 using Umbraco.Core.Services;
-using GlobalSettings = Umbraco.Core.Configuration.GlobalSettings;
 
 namespace Umbraco.Web.Strategies.Migrations
 {
@@ -19,6 +19,7 @@ namespace Umbraco.Web.Strategies.Migrations
     /// - Media & Content Xml : if current is less than, or equal to, 7.3.0 - because 7.3.0 adds .Key to cached items
     /// </para>
     /// </remarks>
+    [Weight(-100)]
     public class RebuildXmlCachesAfterUpgrade : MigrationStartupHander
     {
         protected override void AfterMigration(MigrationRunner sender, MigrationEventArgs e)

--- a/src/Umbraco.Web/Strategies/NotificationsHandler.cs
+++ b/src/Umbraco.Web/Strategies/NotificationsHandler.cs
@@ -1,21 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Umbraco.Core;
-using Umbraco.Core.Configuration;
 using Umbraco.Core.Models.EntityBase;
 using Umbraco.Core.Services;
-using umbraco;
 using umbraco.BusinessLogic.Actions;
 using Umbraco.Core.Models;
+using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Web.Strategies
 {
     /// <summary>
     /// Subscribes to the relavent events in order to send out notifications
     /// </summary>
+    [Weight(-100)]
     public sealed class NotificationsHandler : ApplicationEventHandler
     {
 

--- a/src/Umbraco.Web/Strategies/PublicAccessEventHandler.cs
+++ b/src/Umbraco.Web/Strategies/PublicAccessEventHandler.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using umbraco.cms.businesslogic.web;
-using Umbraco.Core;
-using Umbraco.Core.Models.EntityBase;
+﻿using Umbraco.Core;
+using Umbraco.Core.ObjectResolution;
 using Umbraco.Core.Services;
 
 namespace Umbraco.Web.Strategies
@@ -12,6 +7,7 @@ namespace Umbraco.Web.Strategies
     /// <summary>
     /// Used to ensure that the public access data file is kept up to date properly
     /// </summary>
+    [Weight(-100)]
     public sealed class PublicAccessEventHandler : ApplicationEventHandler
     {
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)

--- a/src/Umbraco.Web/Strategies/RelateOnCopyHandler.cs
+++ b/src/Umbraco.Web/Strategies/RelateOnCopyHandler.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.Linq;
 using Umbraco.Core;
-using Umbraco.Core.Auditing;
-using Umbraco.Core.Models;
-using Umbraco.Core.Services;
+using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Web.Strategies
 {
     [Obsolete("This class is no longer used and will be removed from the codebase in future versions")]
+    [Weight(-100)]
     public sealed class RelateOnCopyHandler : ApplicationEventHandler
     {
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)

--- a/src/Umbraco.Web/Strategies/ServerRegistrationEventHandler.cs
+++ b/src/Umbraco.Web/Strategies/ServerRegistrationEventHandler.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Threading;
-using System.Threading.Tasks;
-using System.Web;
-using Newtonsoft.Json;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
+using Umbraco.Core.ObjectResolution;
 using Umbraco.Core.Services;
 using Umbraco.Core.Sync;
 using Umbraco.Web.Routing;
@@ -23,6 +21,7 @@ namespace Umbraco.Web.Strategies
     /// out the "server address" ie the address to which server-to-server requests should be sent - because it
     /// probably is not the "current request address" - especially in multi-domains configurations.</para>
     /// </remarks>
+    [Weight(-100)]
     public sealed class ServerRegistrationEventHandler : ApplicationEventHandler
     {
         private DatabaseServerRegistrar _registrar;

--- a/src/Umbraco.Web/Trees/ApplicationTreeRegistrar.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeRegistrar.cs
@@ -2,11 +2,10 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Xml.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Models;
 using umbraco.businesslogic;
-using Umbraco.Core.Services;
+using Umbraco.Core.ObjectResolution;
 
 namespace Umbraco.Web.Trees
 {
@@ -17,6 +16,7 @@ namespace Umbraco.Web.Trees
     /// TODO: This is really not a very ideal process but the code is found here because tree plugins are in the Web project or the legacy business logic project.
     /// Moving forward we can put the base tree plugin classes in the core and then this can all just be taken care of normally within the service.
     /// </remarks>
+    [Weight(-100)]
     public sealed class ApplicationTreeRegistrar : ApplicationEventHandler
     {
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)

--- a/src/Umbraco.Web/umbraco.presentation/EnsureSystemPathsApplicationStartupHandler.cs
+++ b/src/Umbraco.Web/umbraco.presentation/EnsureSystemPathsApplicationStartupHandler.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Web;
-using Umbraco.Core;
+﻿using Umbraco.Core;
 using Umbraco.Core.IO;
-using umbraco.businesslogic;
-using umbraco.interfaces;
+using Umbraco.Core.ObjectResolution;
 
 namespace umbraco.presentation
 {
+    [Weight(-100)]
     public class EnsureSystemPathsApplicationStartupHandler : ApplicationEventHandler
     {
         protected override void ApplicationInitialized(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)


### PR DESCRIPTION
This is a pull request for issue #6024.

Previously, all of the ApplicationEventHandlers in the `Umbraco.Web` project were being assigned a default weight of 100 instead of -100. This was because the `.FullName` of the `umbraco.dll` assembly did not start with `Umbraco.`.

This pull request includes:
1. Fixing the logic of the `GetObjectWeight` method in the `ApplicationEventsResolver` to recognize the `umbraco.dll` assembly as a core assembly.
1. Adding the `[Weight(-100)]` attribute to all `ApplicationEventHandler` classes in the `Umbraco.Web` project.

