### PR TITLE
V8: Use mculture in content editor for multilingual content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.edit.controller.js
@@ -24,7 +24,7 @@ function ContentEditController($scope, $routeParams, contentResource) {
     $scope.page = $routeParams.page;
     $scope.isNew = infiniteMode ? $scope.model.create : $routeParams.create;
     //load the default culture selected in the main tree if any
-    $scope.culture = $routeParams.cculture ? $routeParams.cculture : ($routeParams.mculture === "true");
+    $scope.culture = $routeParams.cculture ? $routeParams.cculture : $routeParams.mculture;
 
     //Bind to $routeUpdate which will execute anytime a location changes but the route is not triggered.
     //This is so we can listen to changes on the cculture parameter since that will not cause a route change


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6022

### Description

Looks like 88d9e332 introduced a bit of weird behavior for multilingual content; the selected main culture (`mculture`) is never applied to content when browsing around, thus unless `cculture` is explicitly specified, content is by default displayed in the default language no matter what is selected as main culture.

Here's a GIF that demonstrates the problem:

![mculture-editor-before](https://user-images.githubusercontent.com/7405322/62155243-a3291680-b308-11e9-98e4-1d9e736e78d5.gif)

This PR fixes it by reverting [this change](https://github.com/umbraco/Umbraco-CMS/commit/88d9e3321c4dce97dc6122c919ee3c6226631dd4#diff-aa230801fb161647c66f06257a18665bR27) from 88d9e332. When the PR is applied, the content editor once again conforms to the selected main culture:

![mculture-editor-after](https://user-images.githubusercontent.com/7405322/62155362-eedbc000-b308-11e9-9977-c30766c0a6c1.gif)

#### Stuff to test

1. Verify that the selected main culture is displayed by default when browsing content - both when using the default and a non-default culture.
2. Verify that you can override the displayed culture on a per-content basis by selecting another culture in the language dropdown next to the content name.
