### PR TITLE
V8: Prevent markdown editor from stealing input focus on enter

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/markdown/markdown.editor.js
+++ b/src/Umbraco.Web.UI.Client/lib/markdown/markdown.editor.js
@@ -1239,6 +1239,11 @@
         // Perform the button's action.
         function doClick(button) {
 
+            // don't do anything if the editor input or button bar isn't the currently active element
+            if (document.activeElement !== panels.input && !panels.buttonBar.contains(document.activeElement)) {
+                return;
+            }
+
             inputBox.focus();
 
             if (button.textOp) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The markdown editor has a tendency to steal input focus if you hit Enter in an input field that doesn't support multiple lines (and thus doesn't explicitly handle the Enter keystroke). It's probably easier to understand with this GIF:

![markdown-editor-autofocus](https://user-images.githubusercontent.com/7405322/62158923-dec7de80-b310-11e9-9f2f-d6459372f4b6.gif)

It's got something to do with the way the markdown editor buttons are being built. However I can't seem to reliably disable the button focus, so this PR tackles the problem by ensuring that the button actions are only executed if the markdown editor is actually the currently active element on the page.

#### Testing this PR

1. Create a doctype with a markdown editor and a textbox property.
2. Create some content based on this doctype. Verify that the markdown editor does not automatically obtain focus when you:
   - Hit Enter in the content name input field.
   - Hit Enter in the textbox property editor.
3. Verify that you can still use the buttons when editing content within the markdown editor, including by using shortcuts (Ctrl+B, Ctrl+I etc.).