### PR TITLE
V8: Hard coded "image" type in media picker value converter causes YSOD

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
@@ -37,14 +37,8 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
         {
             var isMultiple = IsMultipleDataType(propertyType.DataType);
-            var isOnlyImages = IsOnlyImagesDataType(propertyType.DataType);
-
             return isMultiple
-                ? isOnlyImages
-                    ? typeof(IEnumerable<>).MakeGenericType(ModelType.For(ImageTypeAlias))
-                    : typeof(IEnumerable<IPublishedContent>)
-                : isOnlyImages
-                    ? ModelType.For(ImageTypeAlias)
+                    ? typeof(IEnumerable<IPublishedContent>)
                     : typeof(IPublishedContent);
         }
 
@@ -55,12 +49,6 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         {
             var config = ConfigurationEditor.ConfigurationAs<MediaPickerConfiguration>(dataType.Configuration);
             return config.Multiple;
-        }
-
-        private bool IsOnlyImagesDataType(PublishedDataType dataType)
-        {
-            var config = ConfigurationEditor.ConfigurationAs<MediaPickerConfiguration>(dataType.Configuration);
-            return config.OnlyImages;
         }
 
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType,
@@ -79,12 +67,9 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             PropertyCacheLevel cacheLevel, object source, bool preview)
         {
             var isMultiple = IsMultipleDataType(propertyType.DataType);
-            var isOnlyImages = IsOnlyImagesDataType(propertyType.DataType);
 
             var udis = (Udi[]) source;
-            var mediaItems = isOnlyImages
-                ? _publishedModelFactory.CreateModelList(ImageTypeAlias)
-                : new List<IPublishedContent>();
+            var mediaItems = new List<IPublishedContent>();
 
             if (source == null) return isMultiple ? mediaItems : null;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6033

### Description

If you configure a media picker to pick only images, the media picker value converter assumes that all picked elements in the media picker are of a content type with the alias `Image` (which is the default "Image" media type).

![image](https://user-images.githubusercontent.com/7405322/62242524-a3dead00-b3db-11e9-8c34-04b0ddcc2fee.png)

![image](https://user-images.githubusercontent.com/7405322/62242755-25363f80-b3dc-11e9-87e2-45628e54b33a.png)

This is handy as you can access the built-in image properties of `Image` like `UmbracoHeight` and `UmbracoWidth` directly without having to cast it or use e.g. `.Value<int>("umbracoHeight")`.

Unfortunately this hard coded content type alias also results in a YSOD when rendering, if an editor has picked another "image" media type - e.g. if you have a custom "image" media type alongside the built-in one. Here's a GIF that demonstrates it:

![media-picker-value-conversion-before](https://user-images.githubusercontent.com/7405322/62243143-f40a3f00-b3dc-11e9-939e-efac4e83f951.gif)

Clearly the media picker doesn't prevent the user from selecting other media types, as long as they have a thumbnail (which qualifies them as "images") - and nor should it. However... this needs to be mirrored in the media value converter; it can't assume that the value is made up solely by `Image` items when it's in "only images" mode.

This PR removes this assumption from the value converter. When it's applied you're able to pick _and_ render different "image" media types:

![media-picker-value-conversion-after](https://user-images.githubusercontent.com/7405322/62243452-97f3ea80-b3dd-11e9-9c3e-377940f3a67c.gif)

The value converter now always returns `IEnumerable<IPublishedContent>` if the media picker is configured to allow multiple selected items, or `IPublishedContent` if it is only allowed to pick one - just like the rest of the content pickers. 

This both fixes #6033 and ensures that the media picker works the way it is [documented](https://our.umbraco.com/documentation/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Media-Picker/).

#### Breaking change?

This isn't strictly a breaking change from a code perspective. But it probably qualifies as a behavioral breaking change, as it may break implementations that access the `Image` content type properties (`UmbracoHeight`, `UmbracoWidth` etc.) directly on the picked items of a media picker in "only images" mode.

#### Testing this PR

1. Create a new media type  by copying the built-in "Image" media type
2. Create a new image of the new media type.
3. Add a media picker configured as shown above to a content type.
4. Create content of this type and pick items of both the built-in "Image" media type and the new media type.
5. Render the content with a template that fetches the value of the media picker. You can use the sample template below, if your media picker has the alias `imagePicker`.
6. If things do not blow up, this PR works 😄 

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@{
	Layout = null;
	var images = Model.Value<IEnumerable<IPublishedElement>>("imagePicker").ToArray();
}
<!DOCTYPE html>
<html>
    <body>
        <p>
            Image picker contains <b>@(images.Count())</b> images of the following types:
        </p>
        <ul>
            @foreach(var image in images) {
                <li>@image.ContentType.Alias</li>
            }
        </ul>
    </body>
</html>
```
