### PR TITLE
Fixes how examine starts up to make it easier for custom index developers

### DIFF
--- a/src/Umbraco.Examine/ContentValueSetBuilder.cs
+++ b/src/Umbraco.Examine/ContentValueSetBuilder.cs
@@ -54,7 +54,7 @@ namespace Umbraco.Examine
                     {"updateDate", new object[] {c.UpdateDate}},    //Always add invariant updateDate
                     {"nodeName", (PublishedValuesOnly               //Always add invariant nodeName
                         ? c.PublishName?.Yield()
-                        : c?.Name.Yield()) ?? Enumerable.Empty<string>()},
+                        : c.Name?.Yield()) ?? Enumerable.Empty<string>()},
                     {"urlName", urlValue?.Yield() ?? Enumerable.Empty<string>()},                  //Always add invariant urlName
                     {"path", c.Path?.Yield() ?? Enumerable.Empty<string>()},
                     {"nodeType", c.ContentType.Id.ToString().Yield() ?? Enumerable.Empty<string>()},

--- a/src/Umbraco.Examine/IndexRebuilder.cs
+++ b/src/Umbraco.Examine/IndexRebuilder.cs
@@ -5,7 +5,8 @@ using System.Threading.Tasks;
 using Examine;
 
 namespace Umbraco.Examine
-{
+{   
+
     /// <summary>
     /// Utility to rebuild all indexes ensuring minimal data queries
     /// </summary>

--- a/src/Umbraco.Examine/LuceneIndexDiagnostics.cs
+++ b/src/Umbraco.Examine/LuceneIndexDiagnostics.cs
@@ -4,6 +4,7 @@ using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Lucene.Net.Store;
 using Umbraco.Core.IO;
+using System.Linq;
 
 namespace Umbraco.Examine
 {
@@ -60,16 +61,18 @@ namespace Umbraco.Examine
         {
             get
             {
+                var luceneDir = Index.GetLuceneDirectory();
                 var d = new Dictionary<string, object>
                 {
                     [nameof(UmbracoExamineIndex.CommitCount)] = Index.CommitCount,
                     [nameof(UmbracoExamineIndex.DefaultAnalyzer)] = Index.DefaultAnalyzer.GetType().Name,
-                    ["LuceneDirectory"] = Index.GetLuceneDirectory().GetType().Name,
-                    [nameof(UmbracoExamineIndex.LuceneIndexFolder)] =
-                        Index.LuceneIndexFolder == null
-                            ? string.Empty
-                            : Index.LuceneIndexFolder.ToString().ToLowerInvariant().TrimStart(IOHelper.MapPath(SystemDirectories.Root).ToLowerInvariant()).Replace("\\", "/").EnsureStartsWith('/'),
+                    ["LuceneDirectory"] = luceneDir.GetType().Name                    
                 };
+
+                if (luceneDir is FSDirectory fsDir)
+                {
+                    d[nameof(UmbracoExamineIndex.LuceneIndexFolder)] = fsDir.Directory.ToString().ToLowerInvariant().TrimStart(IOHelper.MapPath(SystemDirectories.Root).ToLowerInvariant()).Replace("\\", "/").EnsureStartsWith('/');
+                }
 
                 return d;
             }

--- a/src/Umbraco.Examine/LuceneIndexDiagnostics.cs
+++ b/src/Umbraco.Examine/LuceneIndexDiagnostics.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using Examine.LuceneEngine.Providers;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Lucene.Net.Store;
+using Umbraco.Core.IO;
+
+namespace Umbraco.Examine
+{
+    public class LuceneIndexDiagnostics : IIndexDiagnostics
+    {
+        public LuceneIndexDiagnostics(LuceneIndex index, ILogger logger)
+        {
+            Index = index;
+            Logger = logger;
+        }
+
+        public LuceneIndex Index { get; }
+        public ILogger Logger { get; }
+
+        public int DocumentCount
+        {
+            get
+            {
+                try
+                {
+                    return Index.GetIndexDocumentCount();
+                }
+                catch (AlreadyClosedException)
+                {
+                    Logger.Warn(typeof(UmbracoContentIndex), "Cannot get GetIndexDocumentCount, the writer is already closed");
+                    return 0;
+                }
+            }
+        }
+
+        public int FieldCount
+        {
+            get
+            {
+                try
+                {
+                    return Index.GetIndexFieldCount();
+                }
+                catch (AlreadyClosedException)
+                {
+                    Logger.Warn(typeof(UmbracoContentIndex), "Cannot get GetIndexFieldCount, the writer is already closed");
+                    return 0;
+                }
+            }
+        }
+
+        public Attempt<string> IsHealthy()
+        {
+            var isHealthy = Index.IsHealthy(out var indexError);
+            return isHealthy ? Attempt<string>.Succeed() : Attempt.Fail(indexError.Message);
+        }
+
+        public virtual IReadOnlyDictionary<string, object> Metadata
+        {
+            get
+            {
+                var d = new Dictionary<string, object>
+                {
+                    [nameof(UmbracoExamineIndex.CommitCount)] = Index.CommitCount,
+                    [nameof(UmbracoExamineIndex.DefaultAnalyzer)] = Index.DefaultAnalyzer.GetType().Name,
+                    ["LuceneDirectory"] = Index.GetLuceneDirectory().GetType().Name,
+                    [nameof(UmbracoExamineIndex.LuceneIndexFolder)] =
+                        Index.LuceneIndexFolder == null
+                            ? string.Empty
+                            : Index.LuceneIndexFolder.ToString().ToLowerInvariant().TrimStart(IOHelper.MapPath(SystemDirectories.Root).ToLowerInvariant()).Replace("\\", "/").EnsureStartsWith('/'),
+                };
+
+                return d;
+            }
+        }
+
+        
+    }
+}

--- a/src/Umbraco.Examine/Umbraco.Examine.csproj
+++ b/src/Umbraco.Examine/Umbraco.Examine.csproj
@@ -72,6 +72,7 @@
     <Compile Include="IPublishedContentValueSetBuilder.cs" />
     <Compile Include="IUmbracoIndex.cs" />
     <Compile Include="IValueSetBuilder.cs" />
+    <Compile Include="LuceneIndexDiagnostics.cs" />
     <Compile Include="MediaIndexPopulator.cs" />
     <Compile Include="MediaValueSetBuilder.cs" />
     <Compile Include="MemberIndexPopulator.cs" />

--- a/src/Umbraco.Examine/UmbracoExamineIndexDiagnostics.cs
+++ b/src/Umbraco.Examine/UmbracoExamineIndexDiagnostics.cs
@@ -14,6 +14,7 @@ namespace Umbraco.Examine
         public UmbracoExamineIndexDiagnostics(UmbracoExamineIndex index, ILogger logger)
             : base(index, logger)
         {
+            _index = index;
         }
 
         public override IReadOnlyDictionary<string, object> Metadata

--- a/src/Umbraco.Examine/UmbracoExamineIndexDiagnostics.cs
+++ b/src/Umbraco.Examine/UmbracoExamineIndexDiagnostics.cs
@@ -7,73 +7,23 @@ using Umbraco.Core.Logging;
 
 namespace Umbraco.Examine
 {
-    public class UmbracoExamineIndexDiagnostics : IIndexDiagnostics
+    public class UmbracoExamineIndexDiagnostics : LuceneIndexDiagnostics
     {
         private readonly UmbracoExamineIndex _index;
-        private readonly ILogger _logger;
 
         public UmbracoExamineIndexDiagnostics(UmbracoExamineIndex index, ILogger logger)
+            : base(index, logger)
         {
-            _index = index;
-            _logger = logger;
         }
 
-        public int DocumentCount
+        public override IReadOnlyDictionary<string, object> Metadata
         {
             get
             {
-                try
-                {
-                    return _index.GetIndexDocumentCount();
-                }
-                catch (AlreadyClosedException)
-                {
-                    _logger.Warn(typeof(UmbracoContentIndex), "Cannot get GetIndexDocumentCount, the writer is already closed");
-                    return 0;
-                }
-            }
-        }
+                var d = base.Metadata.ToDictionary(x => x.Key, x => x.Value);
 
-        public int FieldCount
-        {
-            get
-            {
-                try
-                {
-                    return _index.GetIndexFieldCount();
-                }
-                catch (AlreadyClosedException)
-                {
-                    _logger.Warn(typeof(UmbracoContentIndex), "Cannot get GetIndexFieldCount, the writer is already closed");
-                    return 0;
-                }
-            }
-        }
-
-        public Attempt<string> IsHealthy()
-        {
-            var isHealthy = _index.IsHealthy(out var indexError);
-            return isHealthy ? Attempt<string>.Succeed() : Attempt.Fail(indexError.Message);
-        }
-
-        public virtual IReadOnlyDictionary<string, object> Metadata
-        {
-            get
-            {
-                var d = new Dictionary<string, object>
-                {
-                    [nameof(UmbracoExamineIndex.CommitCount)] = _index.CommitCount,
-                    [nameof(UmbracoExamineIndex.DefaultAnalyzer)] = _index.DefaultAnalyzer.GetType().Name,
-                    ["LuceneDirectory"] = _index.GetLuceneDirectory().GetType().Name,
-                    [nameof(UmbracoExamineIndex.EnableDefaultEventHandler)] = _index.EnableDefaultEventHandler,
-                    [nameof(UmbracoExamineIndex.LuceneIndexFolder)] =
-                        _index.LuceneIndexFolder == null
-                            ? string.Empty
-                            : _index.LuceneIndexFolder.ToString().ToLowerInvariant().TrimStart(IOHelper.MapPath(SystemDirectories.Root).ToLowerInvariant()).Replace("\\", "/").EnsureStartsWith('/'),
-                    [nameof(UmbracoExamineIndex.PublishedValuesOnly)] = _index.PublishedValuesOnly,
-                    //There's too much info here
-                    //[nameof(UmbracoExamineIndexer.FieldDefinitionCollection)] = _index.FieldDefinitionCollection,
-                };
+                d[nameof(UmbracoExamineIndex.EnableDefaultEventHandler)] = _index.EnableDefaultEventHandler;
+                d[nameof(UmbracoExamineIndex.PublishedValuesOnly)] = _index.PublishedValuesOnly;
 
                 if (_index.ValueSetValidator is ValueSetValidator vsv)
                 {

--- a/src/Umbraco.Web/Search/BackgroundIndexRebuilder.cs
+++ b/src/Umbraco.Web/Search/BackgroundIndexRebuilder.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Threading;
+using Umbraco.Core.Logging;
+using Umbraco.Examine;
+using System.Threading.Tasks;
+using Umbraco.Core;
+using Umbraco.Web.Scheduling;
+
+namespace Umbraco.Web.Search
+{
+    /// <summary>
+    /// Utility to rebuild all indexes on a background thread
+    /// </summary>
+    public sealed class BackgroundIndexRebuilder
+    {
+        private static readonly object RebuildLocker = new object();
+        private readonly IndexRebuilder _indexRebuilder;
+        private readonly IMainDom _mainDom;
+        private readonly IProfilingLogger _logger;
+        private static BackgroundTaskRunner<IBackgroundTask> _rebuildOnStartupRunner;
+
+        public BackgroundIndexRebuilder(IMainDom mainDom, IProfilingLogger logger, IndexRebuilder indexRebuilder)
+        {
+            _mainDom = mainDom;
+            _logger = logger;
+            _indexRebuilder = indexRebuilder;
+        }
+
+        /// <summary>
+        /// Called to rebuild empty indexes on startup
+        /// </summary>
+        /// <param name="indexRebuilder"></param>
+        /// <param name="logger"></param>
+        /// <param name="onlyEmptyIndexes"></param>
+        /// <param name="waitMilliseconds"></param>
+        public void RebuildIndexes(bool onlyEmptyIndexes, int waitMilliseconds = 0)
+        {
+            // TODO: need a way to disable rebuilding on startup
+
+            lock (RebuildLocker)
+            {
+                if (_rebuildOnStartupRunner != null && _rebuildOnStartupRunner.IsRunning)
+                {
+                    _logger.Warn<BackgroundIndexRebuilder>("Call was made to RebuildIndexes but the task runner for rebuilding is already running");
+                    return;
+                }
+
+                _logger.Info<BackgroundIndexRebuilder>("Starting initialize async background thread.");
+                //do the rebuild on a managed background thread
+                var task = new RebuildOnStartupTask(_mainDom, _indexRebuilder, _logger, onlyEmptyIndexes, waitMilliseconds);
+
+                _rebuildOnStartupRunner = new BackgroundTaskRunner<IBackgroundTask>(
+                    "RebuildIndexesOnStartup",
+                    _logger);
+
+                _rebuildOnStartupRunner.TryAdd(task);
+            }
+        }
+
+        /// <summary>
+        /// Background task used to rebuild empty indexes on startup
+        /// </summary>
+        private class RebuildOnStartupTask : IBackgroundTask
+        {
+            private readonly IMainDom _mainDom;
+
+            private readonly IndexRebuilder _indexRebuilder;
+            private readonly ILogger _logger;
+            private readonly bool _onlyEmptyIndexes;
+            private readonly int _waitMilliseconds;
+
+            public RebuildOnStartupTask(IMainDom mainDom,
+                IndexRebuilder indexRebuilder, ILogger logger, bool onlyEmptyIndexes, int waitMilliseconds = 0)
+            {
+                _mainDom = mainDom;
+                _indexRebuilder = indexRebuilder ?? throw new ArgumentNullException(nameof(indexRebuilder));
+                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+                _onlyEmptyIndexes = onlyEmptyIndexes;
+                _waitMilliseconds = waitMilliseconds;
+            }
+
+            public bool IsAsync => false;
+
+            public void Dispose()
+            {
+            }
+
+            public void Run()
+            {
+                try
+                {
+                    // rebuilds indexes
+                    RebuildIndexes();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error<RebuildOnStartupTask>(ex, "Failed to rebuild empty indexes.");
+                }
+            }
+
+            public Task RunAsync(CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <summary>
+            /// Used to rebuild indexes on startup or cold boot
+            /// </summary>
+            private void RebuildIndexes()
+            {
+                //do not attempt to do this if this has been disabled since we are not the main dom.
+                //this can be called during a cold boot
+                if (!_mainDom.IsMainDom) return;
+
+                if (_waitMilliseconds > 0)
+                    Thread.Sleep(_waitMilliseconds);
+
+                _indexRebuilder.ExamineManager.EnsureUnlocked(_mainDom, _logger);
+                _indexRebuilder.RebuildIndexes(_onlyEmptyIndexes);
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/Search/ExamineComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineComponent.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using Examine;
 using Umbraco.Core;
 using Umbraco.Core.Cache;
@@ -15,13 +14,12 @@ using Umbraco.Core.Sync;
 using Umbraco.Web.Cache;
 using Umbraco.Examine;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
-using Umbraco.Web.Scheduling;
-using System.Threading.Tasks;
 using Examine.LuceneEngine.Directories;
 using Umbraco.Core.Composing;
 
 namespace Umbraco.Web.Search
 {
+
     public sealed class ExamineComponent : IComponent
     {
         private readonly IExamineManager _examineManager;
@@ -30,26 +28,31 @@ namespace Umbraco.Web.Search
         private readonly IValueSetBuilder<IMedia> _mediaValueSetBuilder;
         private readonly IValueSetBuilder<IMember> _memberValueSetBuilder;
         private static bool _disableExamineIndexing = false;
-        private static volatile bool _isConfigured = false;
-        private static readonly object IsConfiguredLocker = new object();
         private readonly IScopeProvider _scopeProvider;
-        private readonly ServiceContext _services;
-        private static BackgroundTaskRunner<IBackgroundTask> _rebuildOnStartupRunner;
-        private static readonly object RebuildLocker = new object();
+        private readonly ServiceContext _services;        
         private readonly IMainDom _mainDom;
         private readonly IProfilingLogger _logger;
         private readonly IUmbracoIndexesCreator _indexCreator;
-        private readonly IndexRebuilder _indexRebuilder;
+        
 
         // the default enlist priority is 100
         // enlist with a lower priority to ensure that anything "default" runs after us
         // but greater that SafeXmlReaderWriter priority which is 60
         private const int EnlistPriority = 80;
 
+        /// <summary>
+        /// Returns true if Examine is enabled for this AppDomain
+        /// </summary>
+        /// <remarks>
+        /// This flag should be used by custom Examine index implementors to determine if they should
+        /// execute. This value is true if this component successfully registered with <see cref="IMainDom"/>
+        /// </remarks>
+        public static bool ExamineEnabled => !_disableExamineIndexing;
+
         public ExamineComponent(IMainDom mainDom,
             IExamineManager examineManager, IProfilingLogger profilingLogger,
             IScopeProvider scopeProvider, IUmbracoIndexesCreator indexCreator,
-            IndexRebuilder indexRebuilder, ServiceContext services,
+            ServiceContext services,
             IContentValueSetBuilder contentValueSetBuilder,
             IPublishedContentValueSetBuilder publishedContentValueSetBuilder,
             IValueSetBuilder<IMedia> mediaValueSetBuilder,
@@ -66,7 +69,6 @@ namespace Umbraco.Web.Search
             _mainDom = mainDom;
             _logger = profilingLogger;
             _indexCreator = indexCreator;
-            _indexRebuilder = indexRebuilder;
         }
 
         public void Initialize()
@@ -119,11 +121,6 @@ namespace Umbraco.Web.Search
             ContentTypeCacheRefresher.CacheUpdated += ContentTypeCacheRefresherUpdated; ;
             MediaCacheRefresher.CacheUpdated += MediaCacheRefresherUpdated;
             MemberCacheRefresher.CacheUpdated += MemberCacheRefresherUpdated;
-
-            EnsureUnlocked(_logger, _examineManager);
-
-            // TODO: Instead of waiting 5000 ms, we could add an event handler on to fulfilling the first request, then start?
-            RebuildIndexes(_indexRebuilder, _logger, true, 5000);
         }
 
         public void Terminate()
@@ -136,51 +133,7 @@ namespace Umbraco.Web.Search
         /// <param name="logger"></param>
         /// <param name="onlyEmptyIndexes"></param>
         /// <param name="waitMilliseconds"></param>
-        public static void RebuildIndexes(IndexRebuilder indexRebuilder, ILogger logger, bool onlyEmptyIndexes, int waitMilliseconds = 0)
-        {
-            // TODO: need a way to disable rebuilding on startup
-
-            lock(RebuildLocker)
-            {
-                if (_rebuildOnStartupRunner != null && _rebuildOnStartupRunner.IsRunning)
-                {
-                    logger.Warn<ExamineComponent>("Call was made to RebuildIndexes but the task runner for rebuilding is already running");
-                    return;
-                }
-
-                logger.Info<ExamineComponent>("Starting initialize async background thread.");
-                //do the rebuild on a managed background thread
-                var task = new RebuildOnStartupTask(indexRebuilder, logger, onlyEmptyIndexes, waitMilliseconds);
-
-                _rebuildOnStartupRunner = new BackgroundTaskRunner<IBackgroundTask>(
-                    "RebuildIndexesOnStartup",
-                    logger);
-
-                _rebuildOnStartupRunner.TryAdd(task);
-            }
-        }
-
-        /// <summary>
-        /// Must be called to each index is unlocked before any indexing occurs
-        /// </summary>
-        /// <remarks>
-        /// Indexing rebuilding can occur on a normal boot if the indexes are empty or on a cold boot by the database server messenger. Before
-        /// either of these happens, we need to configure the indexes.
-        /// </remarks>
-        private static void EnsureUnlocked(ILogger logger, IExamineManager examineManager)
-        {
-            if (_disableExamineIndexing) return;
-            if (_isConfigured) return;
-
-            lock (IsConfiguredLocker)
-            {
-                //double check
-                if (_isConfigured) return;
-
-                _isConfigured = true;
-                examineManager.UnlockLuceneIndexes(logger);
-            }
-        }
+        public static void RebuildIndexes(IndexRebuilder indexRebuilder, ILogger logger, bool onlyEmptyIndexes, int waitMilliseconds = 0) => ExamineFinalComponent.RebuildIndexes(indexRebuilder, logger, onlyEmptyIndexes, waitMilliseconds);
 
         #region Cache refresher updated event handlers
 
@@ -746,63 +699,6 @@ namespace Umbraco.Web.Search
         }
         #endregion
 
-        /// <summary>
-        /// Background task used to rebuild empty indexes on startup
-        /// </summary>
-        private class RebuildOnStartupTask : IBackgroundTask
-        {
-            private readonly IndexRebuilder _indexRebuilder;
-            private readonly ILogger _logger;
-            private readonly bool _onlyEmptyIndexes;
-            private readonly int _waitMilliseconds;
-
-            public RebuildOnStartupTask(IndexRebuilder indexRebuilder, ILogger logger, bool onlyEmptyIndexes, int waitMilliseconds = 0)
-            {
-                _indexRebuilder = indexRebuilder ?? throw new ArgumentNullException(nameof(indexRebuilder));
-                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-                _onlyEmptyIndexes = onlyEmptyIndexes;
-                _waitMilliseconds = waitMilliseconds;
-            }
-
-            public bool IsAsync => false;
-
-            public void Dispose()
-            {
-            }
-
-            public void Run()
-            {
-                try
-                {
-                    // rebuilds indexes
-                    RebuildIndexes();
-                }
-                catch (Exception ex)
-                {
-                    _logger.Error<ExamineComponent>(ex, "Failed to rebuild empty indexes.");
-                }
-            }
-
-            public Task RunAsync(CancellationToken token)
-            {
-                throw new NotImplementedException();
-            }
-
-            /// <summary>
-            /// Used to rebuild indexes on startup or cold boot
-            /// </summary>
-            private void RebuildIndexes()
-            {
-                //do not attempt to do this if this has been disabled since we are not the main dom.
-                //this can be called during a cold boot
-                if (_disableExamineIndexing) return;
-
-                if (_waitMilliseconds > 0)
-                    Thread.Sleep(_waitMilliseconds);
-
-                EnsureUnlocked(_logger, _indexRebuilder.ExamineManager);
-                _indexRebuilder.RebuildIndexes(_onlyEmptyIndexes);
-            }
-        }
+        
     }
 }

--- a/src/Umbraco.Web/Search/ExamineComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineComponent.cs
@@ -118,7 +118,7 @@ namespace Umbraco.Web.Search
             // bind to distributed cache events - this ensures that this logic occurs on ALL servers
             // that are taking part in a load balanced environment.
             ContentCacheRefresher.CacheUpdated += ContentCacheRefresherUpdated;
-            ContentTypeCacheRefresher.CacheUpdated += ContentTypeCacheRefresherUpdated; ;
+            ContentTypeCacheRefresher.CacheUpdated += ContentTypeCacheRefresherUpdated;
             MediaCacheRefresher.CacheUpdated += MediaCacheRefresherUpdated;
             MemberCacheRefresher.CacheUpdated += MemberCacheRefresherUpdated;
         }

--- a/src/Umbraco.Web/Search/ExamineComposer.cs
+++ b/src/Umbraco.Web/Search/ExamineComposer.cs
@@ -44,6 +44,7 @@ namespace Umbraco.Web.Search
                     false));
             composition.RegisterUnique<IValueSetBuilder<IMedia>, MediaValueSetBuilder>();
             composition.RegisterUnique<IValueSetBuilder<IMember>, MemberValueSetBuilder>();
+            composition.RegisterUnique<BackgroundIndexRebuilder>();
 
             //We want to manage Examine's AppDomain shutdown sequence ourselves so first we'll disable Examine's default behavior
             //and then we'll use MainDom to control Examine's shutdown - this MUST be done in Compose ie before ExamineManager

--- a/src/Umbraco.Web/Search/ExamineComposer.cs
+++ b/src/Umbraco.Web/Search/ExamineComposer.cs
@@ -10,6 +10,7 @@ using Umbraco.Examine;
 
 namespace Umbraco.Web.Search
 {
+
     /// <summary>
     /// Configures and installs Examine.
     /// </summary>

--- a/src/Umbraco.Web/Search/ExamineFinalComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineFinalComponent.cs
@@ -1,159 +1,42 @@
-﻿using System;
-using System.Threading;
-using Examine;
+﻿using Examine;
 using Umbraco.Core.Logging;
 using Umbraco.Examine;
-using Umbraco.Web.Scheduling;
-using System.Threading.Tasks;
 using Umbraco.Core.Composing;
+using Umbraco.Core;
 
 namespace Umbraco.Web.Search
 {
+
     /// <summary>
     /// Executes after all other examine components have executed
     /// </summary>
     public sealed class ExamineFinalComponent : IComponent
-    {
-
-        private static volatile bool _isConfigured = false;
-        private static readonly object IsConfiguredLocker = new object();
+    {   
         private readonly IProfilingLogger _logger;
         private readonly IExamineManager _examineManager;
-        private static readonly object RebuildLocker = new object();
-        private readonly IndexRebuilder _indexRebuilder;
-        private static BackgroundTaskRunner<IBackgroundTask> _rebuildOnStartupRunner;
-
-        public ExamineFinalComponent(IProfilingLogger logger, IExamineManager examineManager, IndexRebuilder indexRebuilder)
+        BackgroundIndexRebuilder _indexRebuilder;
+        private readonly IMainDom _mainDom;
+        
+        public ExamineFinalComponent(IProfilingLogger logger, IExamineManager examineManager, BackgroundIndexRebuilder indexRebuilder, IMainDom mainDom)
         {
             _logger = logger;
             _examineManager = examineManager;
             _indexRebuilder = indexRebuilder;
+            _mainDom = mainDom;
         }
 
         public void Initialize()
         {
-            if (!ExamineComponent.ExamineEnabled) return;
+            if (!_mainDom.IsMainDom) return;
 
-            EnsureUnlocked(_logger, _examineManager);
+            _examineManager.EnsureUnlocked(_mainDom, _logger);
 
             // TODO: Instead of waiting 5000 ms, we could add an event handler on to fulfilling the first request, then start?
-            ExamineComponent.RebuildIndexes(_indexRebuilder, _logger, true, 5000);
+            _indexRebuilder.RebuildIndexes(true, 5000);
         }
 
         public void Terminate()
         {
-        }
-
-        /// <summary>
-        /// Called to rebuild empty indexes on startup
-        /// </summary>
-        /// <param name="indexRebuilder"></param>
-        /// <param name="logger"></param>
-        /// <param name="onlyEmptyIndexes"></param>
-        /// <param name="waitMilliseconds"></param>
-        internal static void RebuildIndexes(IndexRebuilder indexRebuilder, ILogger logger, bool onlyEmptyIndexes, int waitMilliseconds = 0)
-        {
-            // TODO: need a way to disable rebuilding on startup
-
-            lock (RebuildLocker)
-            {
-                if (_rebuildOnStartupRunner != null && _rebuildOnStartupRunner.IsRunning)
-                {
-                    logger.Warn<ExamineComponent>("Call was made to RebuildIndexes but the task runner for rebuilding is already running");
-                    return;
-                }
-
-                logger.Info<ExamineComponent>("Starting initialize async background thread.");
-                //do the rebuild on a managed background thread
-                var task = new RebuildOnStartupTask(indexRebuilder, logger, onlyEmptyIndexes, waitMilliseconds);
-
-                _rebuildOnStartupRunner = new BackgroundTaskRunner<IBackgroundTask>(
-                    "RebuildIndexesOnStartup",
-                    logger);
-
-                _rebuildOnStartupRunner.TryAdd(task);
-            }
-        }
-
-        /// <summary>
-        /// Must be called to each index is unlocked before any indexing occurs
-        /// </summary>
-        /// <remarks>
-        /// Indexing rebuilding can occur on a normal boot if the indexes are empty or on a cold boot by the database server messenger. Before
-        /// either of these happens, we need to configure the indexes.
-        /// </remarks>
-        internal static void EnsureUnlocked(ILogger logger, IExamineManager examineManager)
-        {
-            if (!ExamineComponent.ExamineEnabled) return;
-            if (_isConfigured) return;
-
-            lock (IsConfiguredLocker)
-            {
-                //double check
-                if (_isConfigured) return;
-
-                _isConfigured = true;
-                examineManager.UnlockLuceneIndexes(logger);
-            }
-        }
-
-        /// <summary>
-        /// Background task used to rebuild empty indexes on startup
-        /// </summary>
-        private class RebuildOnStartupTask : IBackgroundTask
-        {
-            private readonly IndexRebuilder _indexRebuilder;
-            private readonly ILogger _logger;
-            private readonly bool _onlyEmptyIndexes;
-            private readonly int _waitMilliseconds;
-
-            public RebuildOnStartupTask(IndexRebuilder indexRebuilder, ILogger logger, bool onlyEmptyIndexes, int waitMilliseconds = 0)
-            {
-                _indexRebuilder = indexRebuilder ?? throw new ArgumentNullException(nameof(indexRebuilder));
-                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-                _onlyEmptyIndexes = onlyEmptyIndexes;
-                _waitMilliseconds = waitMilliseconds;
-            }
-
-            public bool IsAsync => false;
-
-            public void Dispose()
-            {
-            }
-
-            public void Run()
-            {
-                try
-                {
-                    // rebuilds indexes
-                    RebuildIndexes();
-                }
-                catch (Exception ex)
-                {
-                    _logger.Error<ExamineComponent>(ex, "Failed to rebuild empty indexes.");
-                }
-            }
-
-            public Task RunAsync(CancellationToken token)
-            {
-                throw new NotImplementedException();
-            }
-
-            /// <summary>
-            /// Used to rebuild indexes on startup or cold boot
-            /// </summary>
-            private void RebuildIndexes()
-            {
-                //do not attempt to do this if this has been disabled since we are not the main dom.
-                //this can be called during a cold boot
-                if (!ExamineComponent.ExamineEnabled) return;
-
-                if (_waitMilliseconds > 0)
-                    Thread.Sleep(_waitMilliseconds);
-
-                EnsureUnlocked(_logger, _indexRebuilder.ExamineManager);
-                _indexRebuilder.RebuildIndexes(_onlyEmptyIndexes);
-            }
         }
     }
 }

--- a/src/Umbraco.Web/Search/ExamineFinalComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineFinalComponent.cs
@@ -14,6 +14,7 @@ namespace Umbraco.Web.Search
     /// </summary>
     public sealed class ExamineFinalComponent : IComponent
     {
+
         private static volatile bool _isConfigured = false;
         private static readonly object IsConfiguredLocker = new object();
         private readonly IProfilingLogger _logger;
@@ -21,6 +22,13 @@ namespace Umbraco.Web.Search
         private static readonly object RebuildLocker = new object();
         private readonly IndexRebuilder _indexRebuilder;
         private static BackgroundTaskRunner<IBackgroundTask> _rebuildOnStartupRunner;
+
+        public ExamineFinalComponent(IProfilingLogger logger, IExamineManager examineManager, IndexRebuilder indexRebuilder)
+        {
+            _logger = logger;
+            _examineManager = examineManager;
+            _indexRebuilder = indexRebuilder;
+        }
 
         public void Initialize()
         {

--- a/src/Umbraco.Web/Search/ExamineFinalComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineFinalComponent.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Threading;
+using Examine;
+using Umbraco.Core.Logging;
+using Umbraco.Examine;
+using Umbraco.Web.Scheduling;
+using System.Threading.Tasks;
+using Umbraco.Core.Composing;
+
+namespace Umbraco.Web.Search
+{
+    /// <summary>
+    /// Executes after all other examine components have executed
+    /// </summary>
+    public sealed class ExamineFinalComponent : IComponent
+    {
+        private static volatile bool _isConfigured = false;
+        private static readonly object IsConfiguredLocker = new object();
+        private readonly IProfilingLogger _logger;
+        private readonly IExamineManager _examineManager;
+        private static readonly object RebuildLocker = new object();
+        private readonly IndexRebuilder _indexRebuilder;
+        private static BackgroundTaskRunner<IBackgroundTask> _rebuildOnStartupRunner;
+
+        public void Initialize()
+        {
+            if (!ExamineComponent.ExamineEnabled) return;
+
+            EnsureUnlocked(_logger, _examineManager);
+
+            // TODO: Instead of waiting 5000 ms, we could add an event handler on to fulfilling the first request, then start?
+            ExamineComponent.RebuildIndexes(_indexRebuilder, _logger, true, 5000);
+        }
+
+        public void Terminate()
+        {
+        }
+
+        /// <summary>
+        /// Called to rebuild empty indexes on startup
+        /// </summary>
+        /// <param name="indexRebuilder"></param>
+        /// <param name="logger"></param>
+        /// <param name="onlyEmptyIndexes"></param>
+        /// <param name="waitMilliseconds"></param>
+        internal static void RebuildIndexes(IndexRebuilder indexRebuilder, ILogger logger, bool onlyEmptyIndexes, int waitMilliseconds = 0)
+        {
+            // TODO: need a way to disable rebuilding on startup
+
+            lock (RebuildLocker)
+            {
+                if (_rebuildOnStartupRunner != null && _rebuildOnStartupRunner.IsRunning)
+                {
+                    logger.Warn<ExamineComponent>("Call was made to RebuildIndexes but the task runner for rebuilding is already running");
+                    return;
+                }
+
+                logger.Info<ExamineComponent>("Starting initialize async background thread.");
+                //do the rebuild on a managed background thread
+                var task = new RebuildOnStartupTask(indexRebuilder, logger, onlyEmptyIndexes, waitMilliseconds);
+
+                _rebuildOnStartupRunner = new BackgroundTaskRunner<IBackgroundTask>(
+                    "RebuildIndexesOnStartup",
+                    logger);
+
+                _rebuildOnStartupRunner.TryAdd(task);
+            }
+        }
+
+        /// <summary>
+        /// Must be called to each index is unlocked before any indexing occurs
+        /// </summary>
+        /// <remarks>
+        /// Indexing rebuilding can occur on a normal boot if the indexes are empty or on a cold boot by the database server messenger. Before
+        /// either of these happens, we need to configure the indexes.
+        /// </remarks>
+        internal static void EnsureUnlocked(ILogger logger, IExamineManager examineManager)
+        {
+            if (!ExamineComponent.ExamineEnabled) return;
+            if (_isConfigured) return;
+
+            lock (IsConfiguredLocker)
+            {
+                //double check
+                if (_isConfigured) return;
+
+                _isConfigured = true;
+                examineManager.UnlockLuceneIndexes(logger);
+            }
+        }
+
+        /// <summary>
+        /// Background task used to rebuild empty indexes on startup
+        /// </summary>
+        private class RebuildOnStartupTask : IBackgroundTask
+        {
+            private readonly IndexRebuilder _indexRebuilder;
+            private readonly ILogger _logger;
+            private readonly bool _onlyEmptyIndexes;
+            private readonly int _waitMilliseconds;
+
+            public RebuildOnStartupTask(IndexRebuilder indexRebuilder, ILogger logger, bool onlyEmptyIndexes, int waitMilliseconds = 0)
+            {
+                _indexRebuilder = indexRebuilder ?? throw new ArgumentNullException(nameof(indexRebuilder));
+                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+                _onlyEmptyIndexes = onlyEmptyIndexes;
+                _waitMilliseconds = waitMilliseconds;
+            }
+
+            public bool IsAsync => false;
+
+            public void Dispose()
+            {
+            }
+
+            public void Run()
+            {
+                try
+                {
+                    // rebuilds indexes
+                    RebuildIndexes();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error<ExamineComponent>(ex, "Failed to rebuild empty indexes.");
+                }
+            }
+
+            public Task RunAsync(CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <summary>
+            /// Used to rebuild indexes on startup or cold boot
+            /// </summary>
+            private void RebuildIndexes()
+            {
+                //do not attempt to do this if this has been disabled since we are not the main dom.
+                //this can be called during a cold boot
+                if (!ExamineComponent.ExamineEnabled) return;
+
+                if (_waitMilliseconds > 0)
+                    Thread.Sleep(_waitMilliseconds);
+
+                EnsureUnlocked(_logger, _indexRebuilder.ExamineManager);
+                _indexRebuilder.RebuildIndexes(_onlyEmptyIndexes);
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/Search/ExamineFinalComposer.cs
+++ b/src/Umbraco.Web/Search/ExamineFinalComposer.cs
@@ -1,0 +1,11 @@
+﻿using Umbraco.Core.Composing;
+
+namespace Umbraco.Web.Search
+{
+    // examine's final composer composes after all user composers
+    // and *also* after ICoreComposer (in case IUserComposer is disabled)
+    [ComposeAfter(typeof(IUserComposer))]
+    [ComposeAfter(typeof(ICoreComposer))]
+    public class ExamineFinalComposer : ComponentComposer<ExamineFinalComponent>
+    { }
+}

--- a/src/Umbraco.Web/Search/ExamineFinalComposer.cs
+++ b/src/Umbraco.Web/Search/ExamineFinalComposer.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.Composing;
+﻿using Umbraco.Core;
+using Umbraco.Core.Composing;
 
 namespace Umbraco.Web.Search
 {
@@ -6,6 +7,7 @@ namespace Umbraco.Web.Search
     // and *also* after ICoreComposer (in case IUserComposer is disabled)
     [ComposeAfter(typeof(IUserComposer))]
     [ComposeAfter(typeof(ICoreComposer))]
+    [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
     public class ExamineFinalComposer : ComponentComposer<ExamineFinalComponent>
     { }
 }

--- a/src/Umbraco.Web/Search/ExamineUserComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineUserComponent.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.Composing;
+﻿using Umbraco.Core;
+using Umbraco.Core.Composing;
 
 namespace Umbraco.Web.Search
 {
@@ -7,12 +8,19 @@ namespace Umbraco.Web.Search
     /// </summary>
     public abstract class ExamineUserComponent : IComponent
     {
+        private readonly IMainDom _mainDom;
+
+        public ExamineUserComponent(IMainDom mainDom)
+        {
+            _mainDom = mainDom;
+        }
+
         /// <summary>
         /// Initialize the component, eagerly exits if ExamineComponent.ExamineEnabled == false
         /// </summary>
         public void Initialize()
         {
-            if (!ExamineComponent.ExamineEnabled) return;
+            if (!_mainDom.IsMainDom) return;
 
             InitializeComponent();
         }

--- a/src/Umbraco.Web/Search/ExamineUserComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineUserComponent.cs
@@ -1,0 +1,29 @@
+﻿using Umbraco.Core.Composing;
+
+namespace Umbraco.Web.Search
+{
+    /// <summary>
+    /// An abstract class for custom index authors to inherit from
+    /// </summary>
+    public abstract class ExamineUserComponent : IComponent
+    {
+        /// <summary>
+        /// Initialize the component, eagerly exits if ExamineComponent.ExamineEnabled == false
+        /// </summary>
+        public void Initialize()
+        {
+            if (!ExamineComponent.ExamineEnabled) return;
+
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Abstract method which executes to initialize this component if ExamineComponent.ExamineEnabled == true
+        /// </summary>
+        protected abstract void InitializeComponent();
+
+        public virtual void Terminate()
+        {
+        }
+    }
+}

--- a/src/Umbraco.Web/Search/GenericIndexDiagnostics.cs
+++ b/src/Umbraco.Web/Search/GenericIndexDiagnostics.cs
@@ -8,6 +8,7 @@ using Umbraco.Examine;
 
 namespace Umbraco.Web.Search
 {
+
     /// <summary>
     /// Used to return diagnostic data for any index
     /// </summary>

--- a/src/Umbraco.Web/Suspendable.cs
+++ b/src/Umbraco.Web/Suspendable.cs
@@ -50,6 +50,8 @@ namespace Umbraco.Web
             }
         }
 
+        //This is really needed at all since the only place this is used is in ExamineComponent and that already maintains a flag of whether it suspsended or not
+        // AHH... but Deploy probably uses this?
         public static class ExamineEvents
         {
             private static bool _tried, _suspended;

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -233,6 +233,7 @@
     <Compile Include="Routing\IPublishedRouter.cs" />
     <Compile Include="Routing\MediaUrlProviderCollection.cs" />
     <Compile Include="Routing\MediaUrlProviderCollectionBuilder.cs" />
+    <Compile Include="Search\BackgroundIndexRebuilder.cs" />
     <Compile Include="Search\ExamineFinalComponent.cs" />
     <Compile Include="Search\ExamineFinalComposer.cs" />
     <Compile Include="Search\ExamineUserComponent.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -233,6 +233,9 @@
     <Compile Include="Routing\IPublishedRouter.cs" />
     <Compile Include="Routing\MediaUrlProviderCollection.cs" />
     <Compile Include="Routing\MediaUrlProviderCollectionBuilder.cs" />
+    <Compile Include="Search\ExamineFinalComponent.cs" />
+    <Compile Include="Search\ExamineFinalComposer.cs" />
+    <Compile Include="Search\ExamineUserComponent.cs" />
     <Compile Include="Services\DashboardService.cs" />
     <Compile Include="Services\IDashboardService.cs" />
     <Compile Include="Models\Link.cs" />


### PR DESCRIPTION
There's an issue currently for developers creating custom lucene based indexes that most times requires that the index be manually unlocked on startup in their custom IComponent. This was never the intention and the reason is because Umbraco unlocks all of the indexes at startup but unfortunately this was happening before the developers component was executing.

This solves a couple of problems:

* Ensures the indexes are unlocked and the rebuild logic for empty indexes is queued AFTER all user components
* Creates a base class for custom index developers `ExamineUserComponent` so that developers can inherit from this instead of just `IComponent` and this will also ensure that no initialization is done if MainDom was not acquired. This is very important for Lucene and by inheriting from this means that devs don't need to worry about this check
