### PR TITLE
V8: Fix broken button to open content type from create dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -94,6 +94,11 @@ function contentCreateController($scope,
         navigationService.hideDialog(showMenu);
     };
 
+    $scope.editContentType = function() {
+        $location.path("/settings/documenttypes/edit/" + $scope.contentTypeId).search("view", "permissions");
+        close();
+    }
+
     $scope.createBlank = createBlank;
     $scope.createOrSelectBlueprintIfAny = createOrSelectBlueprintIfAny;
     $scope.createFromBlueprint = createFromBlueprint;

--- a/src/Umbraco.Web.UI.Client/src/views/content/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/create.html
@@ -10,7 +10,7 @@
                 <p class="abstract" ng-if="!hasSettingsAccess"><localize key="create_noDocumentTypesWithNoSettingsAccess"/></p>
                 <div ng-if="hasSettingsAccess">
                     <p class="abstract"><localize key="create_noDocumentTypes" /></p>
-                    <button class="btn umb-outline" href="#settings/documentTypes/edit/{{contentTypeId}}?view=permissions" ng-click="close()">
+                    <button class="btn umb-outline" ng-click="editContentType()">
                         <localize key="create_noDocumentTypesEditPermissions"/>
                     </button>
                 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The direct access to assign allowed child types to a content type from the "Create" dialog is currently broken:

![edit-content-type-from-create-before](https://user-images.githubusercontent.com/7405322/62361519-7e58bd00-b51b-11e9-9de2-60f4704a955e.gif)

Looks like this is caused by the changes in #5729 (swapping the link for a button, thus making the `href` attribute meaningless).

This PR amends it, so the button works again:

![edit-content-type-from-create-after](https://user-images.githubusercontent.com/7405322/62361578-9d574f00-b51b-11e9-86e2-79c60bece557.gif)
