### PR TITLE
V8: Import and export of document type and property variations setting in packages (5993)

### DIFF
--- a/src/Umbraco.Core/Services/Implement/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/Implement/EntityXmlSerializer.cs
@@ -437,7 +437,8 @@ namespace Umbraco.Core.Services.Implement
                                     new XElement("Description", contentType.Description),
                                     new XElement("AllowAtRoot", contentType.AllowedAsRoot.ToString()),
                                     new XElement("IsListView", contentType.IsContainer.ToString()),
-                                    new XElement("IsElement", contentType.IsElement.ToString()));
+                                    new XElement("IsElement", contentType.IsElement.ToString()),
+                                    new XElement("Variations", contentType.Variations.ToString()));
 
             var masterContentType = contentType.ContentTypeComposition.FirstOrDefault(x => x.Id == contentType.ParentId);
             if(masterContentType != null)
@@ -487,7 +488,8 @@ namespace Umbraco.Core.Services.Implement
                                                    new XElement("SortOrder", propertyType.SortOrder),
                                                    new XElement("Mandatory", propertyType.Mandatory.ToString()),
                                                    propertyType.ValidationRegExp != null ? new XElement("Validation", propertyType.ValidationRegExp) : null,
-                                                   propertyType.Description != null ? new XElement("Description", new XCData(propertyType.Description)) : null);
+                                                   propertyType.Description != null ? new XElement("Description", new XCData(propertyType.Description)) : null,
+                                                   new XElement("Variations", propertyType.Variations.ToString()));
 
                 genericProperties.Add(genericProperty);
             }


### PR DESCRIPTION
This PR writes and reads XML elements for the "allow varying by culture" field into the package definition, so this information can be saved and restored by the creation and installation of packages.

Reported in issue #5993.