### PR TITLE
Fix for #6047 - Ensure a media type correctly inherits it's selected parent

### DIFF
--- a/src/Umbraco.Web/Editors/MediaTypeController.cs
+++ b/src/Umbraco.Web/Editors/MediaTypeController.cs
@@ -145,9 +145,18 @@ namespace Umbraco.Web.Editors
         }
         public MediaTypeDisplay GetEmpty(int parentId)
         {
-            var ct = new MediaType(parentId) {Icon = "icon-picture"};
+            IMediaType mt;
+            if (parentId != Constants.System.Root)
+            {
+                var parent = Services.ContentTypeService.GetMediaType(parentId);
+                mt = parent != null ? new MediaType(parent, string.Empty) : new MediaType(parentId);
+            }
+            else
+                mt = new MediaType(parentId);
 
-            var dto = Mapper.Map<IMediaType, MediaTypeDisplay>(ct);
+            mt.Icon = "icon-picture";
+
+            var dto = Mapper.Map<IMediaType, MediaTypeDisplay>(mt);
             return dto;
         }
 


### PR DESCRIPTION
When creating a new MediaType beneath an existing MediaType, the composition is not set correctly, and any properties from the parent MediaType are not inherited by the child MediaType.

This PR fixes #6047 