### PR TITLE
Fix for #5484 - V8 : Back office freeze when opening multiple content nodes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
@@ -69,12 +69,14 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
                 if (childPath.startsWith(p + ",")) {
                     //this means that the node's path supercedes this path stored so we can remove the current 'p' and replace it with node.path
                     expandedPaths.splice(expandedPaths.indexOf(p), 1); //remove it
-                    expandedPaths.push(childPath); //replace it
+                    if (expandedPaths.indexOf(childPath) === -1) {
+                        expandedPaths.push(childPath); //replace it
+                    }
                 }
                 else if (p.startsWith(childPath + ",")) {
                     //this means we've already tracked a deeper node so we shouldn't track this one
                 }
-                else {
+                else if (expandedPaths.indexOf(childPath) === -1) {
                     expandedPaths.push(childPath); //track it
                 }
             });


### PR DESCRIPTION
This PR fixes the issue where the expandedPaths array grows out of control (adding duplicate paths)   [#5484 ](https://github.com/umbraco/Umbraco-CMS/issues/5484)