### PR TITLE
V8: Display current log level in log viewer sidebar

### DIFF
--- a/src/Umbraco.Core/Logging/Viewer/ILogViewer.cs
+++ b/src/Umbraco.Core/Logging/Viewer/ILogViewer.cs
@@ -43,6 +43,12 @@ namespace Umbraco.Core.Logging.Viewer
         bool CheckCanOpenLogs(LogTimePeriod logTimePeriod);
 
         /// <summary>
+        /// Gets the current Serilog minimum log level
+        /// </summary>
+        /// <returns></returns>
+        string GetLogLevel();
+
+        /// <summary>
         /// Returns the collection of logs
         /// </summary>
         PagedResult<LogMessage> GetLogs(LogTimePeriod logTimePeriod,

--- a/src/Umbraco.Web.UI.Client/src/common/resources/logviewer.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/logviewer.resource.js
@@ -7,64 +7,44 @@
  **/
 function logViewerResource($q, $http, umbRequestHelper) {
 
+    /**
+     * verb => 'get', 'post',
+     * method => API method to call
+     * params => additional data to send
+     * error => error message when things go wrong...
+     */
+    const request = (verb, method, params, error) =>
+        umbRequestHelper.resourcePromise(
+            (verb === 'GET' ?
+            $http.get(umbRequestHelper.getApiUrl("logViewerApiBaseUrl", method) + (params ? params : '')) : 
+            $http.post(umbRequestHelper.getApiUrl("logViewerApiBaseUrl", method), params)),
+        error); 
+
     //the factory object returned
     return {
 
-        getNumberOfErrors: function (startDate, endDate) {
-            return umbRequestHelper.resourcePromise(
-                $http.get(
-                    umbRequestHelper.getApiUrl(
-                        "logViewerApiBaseUrl",
-                        "GetNumberOfErrors")+ '?startDate='+startDate+ '&endDate='+  endDate ),
-                'Failed to retrieve number of errors in logs');
-        },
+        getNumberOfErrors: (startDate, endDate) => 
+            request('GET', 'GetNumberOfErrors', '?startDate=' + startDate + '&endDate=' + endDate, 'Failed to retrieve number of errors in logs'),    
 
-        getLogLevelCounts: function (startDate, endDate) {
-            return umbRequestHelper.resourcePromise(
-                $http.get(
-                    umbRequestHelper.getApiUrl(
-                        "logViewerApiBaseUrl",
-                        "GetLogLevelCounts")+ '?startDate='+startDate+ '&endDate='+  endDate ),
-                'Failed to retrieve log level counts');
-        },
+        getLogLevel: () =>
+            request('GET', 'GetLogLevel', null, 'Failed to retrieve log level'),        
 
-        getMessageTemplates: function (startDate, endDate) {
-            return umbRequestHelper.resourcePromise(
-                $http.get(
-                    umbRequestHelper.getApiUrl(
-                        "logViewerApiBaseUrl",
-                        "GetMessageTemplates")+ '?startDate='+startDate+ '&endDate='+  endDate ),
-                'Failed to retrieve log templates');
-        },
+        getLogLevelCounts: (startDate, endDate) =>
+            request('GET', 'GetLogLevelCounts', '?startDate=' + startDate + '&endDate=' + endDate, 'Failed to retrieve log level counts'),  
 
-        getSavedSearches: function () {
-            return umbRequestHelper.resourcePromise(
-                $http.get(
-                    umbRequestHelper.getApiUrl(
-                        "logViewerApiBaseUrl",
-                        "GetSavedSearches")),
-                'Failed to retrieve saved searches');
-        },
+        getMessageTemplates: (startDate, endDate) => 
+            request('GET', 'GetMessageTemplates', '?startDate=' + startDate + '&endDate=' + endDate, 'Failed to retrieve log templates'), 
 
-        postSavedSearch: function (name, query) {
-            return umbRequestHelper.resourcePromise(
-                $http.post(
-                    umbRequestHelper.getApiUrl(
-                        "logViewerApiBaseUrl",
-                        "PostSavedSearch"), { 'name': name, 'query': query }),
-                'Failed to add new saved search');
-        },
+        getSavedSearches: () =>
+            request('GET', 'GetSavedSearches', null, 'Failed to retrieve saved searches'),      
 
-        deleteSavedSearch: function (name, query) {
-            return umbRequestHelper.resourcePromise(
-                $http.post(
-                    umbRequestHelper.getApiUrl(
-                        "logViewerApiBaseUrl",
-                        "DeleteSavedSearch"), { 'name': name, 'query': query }),
-                'Failed to delete saved search');
-        },
+        postSavedSearch: (name, query) =>
+            request('POST', 'PostSavedSearch', { 'name': name, 'query': query }, 'Failed to add new saved search'),
 
-        getLogs: function (options) {
+        deleteSavedSearch: (name, query) =>
+            request('POST', 'DeleteSavedSearch', { 'name': name, 'query': query }, 'Failed to delete saved search'),
+
+        getLogs: options => {
 
             var defaults = {
                 pageSize: 100,
@@ -83,7 +63,6 @@ function logViewerResource($q, $http, umbRequestHelper) {
             //now copy back to the options we will use
             options = defaults;
 
-
             return umbRequestHelper.resourcePromise(
                 $http.get(
                     umbRequestHelper.getApiUrl(
@@ -93,15 +72,8 @@ function logViewerResource($q, $http, umbRequestHelper) {
                 'Failed to retrieve common log messages');
         },
 
-        canViewLogs: function (startDate, endDate) {
-            return umbRequestHelper.resourcePromise(
-                $http.get(
-                    umbRequestHelper.getApiUrl(
-                        "logViewerApiBaseUrl",
-                        "GetCanViewLogs") + '?startDate='+startDate+ '&endDate='+  endDate ),
-                'Failed to retrieve state if logs can be viewed');
-        }
-
+        canViewLogs: (startDate, endDate) => 
+            request('GET', 'GetCanViewLogs', '?startDate=' + startDate + '&endDate=' + endDate, 'Failed to retrieve state if logs can be viewed')    
     };
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-box.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-box.less
@@ -1,12 +1,14 @@
+@boxUnit: 10px;
+
 .umb-box {
     background: @white;
     border-radius: 3px;
-    margin-bottom: 20px;
+    margin-bottom: @boxUnit * 2;
     box-shadow: 0 1px 1px 0 rgba(0,0,0,.16);
 }
 
 .umb-box-header {
-    padding: 10px 20px;
+    padding: @boxUnit @boxUnit * 2;
     border-bottom: 1px solid @gray-9;
     display: flex;
     align-items: center;
@@ -27,5 +29,19 @@
 }
 
 .umb-box-content {
-    padding: 20px;
+    padding: @boxUnit * 2;
+}
+
+// allow side-by-side boxes
+.umb-box-row {
+    margin-left:-@boxUnit;
+    margin-right:-@boxUnit;
+    display:flex;
+    justify-content: space-around;
+    
+    .umb-box {
+        margin-left:@boxUnit;
+        margin-right:@boxUnit;
+        flex:1;
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
@@ -22,7 +22,7 @@
                 position: 'left'
             }
         };
-
+        
         let querystring = $location.search();
         if (querystring.startDate) {
             vm.startDate = querystring.startDate;
@@ -122,9 +122,15 @@
             var commonMsgs = logViewerResource.getMessageTemplates(vm.startDate, vm.endDate).then(function (data) {
                 vm.commonLogMessages = data;
             });
+            
+            var logLevel = logViewerResource.getLogLevel().then(function(data) {
+                vm.logLevel = data; 
+                const index = vm.logTypeLabels.findIndex(x => vm.logLevel.startsWith(x));
+                vm.logLevelColor = index > -1 ? vm.logTypeColors[index] : '#000';
+            });
 
             //Set loading indicator to false when these 3 queries complete
-            $q.all([savedSearches, numOfErrors, logCounts, commonMsgs]).then(function () {
+            $q.all([savedSearches, numOfErrors, logCounts, commonMsgs, logLevel]).then(function () {
                 vm.loading = false;
             });
 

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
@@ -82,13 +82,22 @@
                     </umb-box>
 
                     <div ng-show=" vm.canLoadLogs">
-                        <!-- No of Errors -->
-                        <umb-box ng-click="vm.searchErrors()" style="cursor:pointer;">
-                            <umb-box-header title="Number of Errors"></umb-box-header>
-                            <umb-box-content class="block-form" style="font-size: 40px; font-weight:900; text-align:center; color:#fe6561;">
-                                {{ vm.numberOfErrors }}
-                            </umb-box-content>
-                        </umb-box>
+                        <div class="umb-box-row">
+                        <!-- No of Errors -->                        
+                            <umb-box ng-click="vm.searchErrors()" style="cursor:pointer;">
+                                <umb-box-header title="Number of Errors"></umb-box-header>
+                                <umb-box-content class="block-form" style="font-size: 40px; font-weight:900; text-align:center; color:#fe6561;">
+                                    {{ vm.numberOfErrors }}
+                                </umb-box-content>
+                            </umb-box>     
+                            
+                            <umb-box>
+                                <umb-box-header title="Log level"></umb-box-header>
+                                <umb-box-content class="block-form" style="font-weight:900; text-align:center; color: {{ vm.logLevelColor }}">
+                                    {{ vm.logLevel }}
+                                </umb-box-content>
+                            </umb-box>                                                                            
+                        </div>
 
                         <!-- Chart of diff log types -->
                         <umb-box>
@@ -103,7 +112,8 @@
                                 </canvas>
 
                             </umb-box-content>
-                        </umb-box>
+                        </umb-box>                        
+                      
                     </div>
                 </div>
             </div>

--- a/src/Umbraco.Web/Editors/LogViewerController.cs
+++ b/src/Umbraco.Web/Editors/LogViewerController.cs
@@ -130,5 +130,11 @@ namespace Umbraco.Web.Editors
         {
             return _logViewer.DeleteSavedSearch(item.Name, item.Query);
         }
+
+        [HttpGet]
+        public string GetLogLevel()
+        {
+            return _logViewer.GetLogLevel();
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6055 

### Description
Changes here display the current log level in the sidebar of the log viewer dashboard. Will look like this:

![log-level](https://user-images.githubusercontent.com/3248070/62503353-27165d80-b837-11e9-8aa8-56877b711a48.png)

What's changed?

- updated LogViewerSourceBase.cs to add a method for fetching the current Serilog level.
- added endpoint to LogViewerController.cs to call into that new method
- updated logViewerResource.js to add a client-side function. Also tidied up to remove a heap of duplication (refactors call to umbRequestHelper into a separate function)
- updated overview.controller.js to request the log level, and uses the returned value to set the display color for the level to match the pie chart colors
- updates UI to display the new bit - I've added a variation for the `umb-box` directive to display these inline, by wrapping a set of boxes in an element with class `.umb-box-row`.

Verified by changing the log level in serilog.config, UI updates accordingly.