### PR TITLE
v8 Changing public access settings affects parent and siblings.

### DIFF
--- a/src/Umbraco.Core/Services/IPublicAccessService.cs
+++ b/src/Umbraco.Core/Services/IPublicAccessService.cs
@@ -20,14 +20,14 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="content"></param>
         /// <returns>Returns null if no entry is found</returns>
-        PublicAccessEntry GetEntryForContent(IContent content);
+        PublicAccessEntry GetEntryForContent(IContent content, bool isPublicAccessEditor = false);
 
         /// <summary>
         /// Gets the entry defined for the content item based on a content path
         /// </summary>
         /// <param name="contentPath"></param>
         /// <returns>Returns null if no entry is found</returns>
-        PublicAccessEntry GetEntryForContent(string contentPath);
+        PublicAccessEntry GetEntryForContent(string contentPath, bool isPublicAccessEditor = false);
 
         /// <summary>
         /// Returns true if the content has an entry for it's path

--- a/src/Umbraco.Core/Services/IPublicAccessService.cs
+++ b/src/Umbraco.Core/Services/IPublicAccessService.cs
@@ -20,14 +20,14 @@ namespace Umbraco.Core.Services
         /// </summary>
         /// <param name="content"></param>
         /// <returns>Returns null if no entry is found</returns>
-        PublicAccessEntry GetEntryForContent(IContent content, bool isPublicAccessEditor = false);
+        PublicAccessEntry GetEntryForContent(IContent content);
 
         /// <summary>
         /// Gets the entry defined for the content item based on a content path
         /// </summary>
         /// <param name="contentPath"></param>
         /// <returns>Returns null if no entry is found</returns>
-        PublicAccessEntry GetEntryForContent(string contentPath, bool isPublicAccessEditor = false);
+        PublicAccessEntry GetEntryForContent(string contentPath);
 
         /// <summary>
         /// Returns true if the content has an entry for it's path

--- a/src/Umbraco.Core/Services/Implement/PublicAccessService.cs
+++ b/src/Umbraco.Core/Services/Implement/PublicAccessService.cs
@@ -37,9 +37,9 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="content"></param>
         /// <returns>Returns null if no entry is found</returns>
-        public PublicAccessEntry GetEntryForContent(IContent content)
+        public PublicAccessEntry GetEntryForContent(IContent content, bool isPublicAccessEditor = false)
         {
-            return GetEntryForContent(content.Path.EnsureEndsWith("," + content.Id));
+            return GetEntryForContent(content.Path.EnsureEndsWith("," + content.Id), isPublicAccessEditor);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Umbraco.Core.Services.Implement
         /// <remarks>
         /// NOTE: This method get's called *very* often! This will return the results from cache
         /// </remarks>
-        public PublicAccessEntry GetEntryForContent(string contentPath)
+        public PublicAccessEntry GetEntryForContent(string contentPath, bool isPublicAccessEditor = false)
         {
             //Get all ids in the path for the content item and ensure they all
             // parse to ints that are not -1.
@@ -68,6 +68,12 @@ namespace Umbraco.Core.Services.Implement
                 var entries = _publicAccessRepository.GetMany().ToArray();
 
                 scope.Complete();
+                if (isPublicAccessEditor)
+                {
+                    var found = entries.FirstOrDefault(x => x.ProtectedNodeId == ids[0]);
+                    if (found != null) {return found;}
+                     return null;
+                }
                 foreach (var id in ids)
                 {
                     var found = entries.FirstOrDefault(x => x.ProtectedNodeId == id);

--- a/src/Umbraco.Core/Services/Implement/PublicAccessService.cs
+++ b/src/Umbraco.Core/Services/Implement/PublicAccessService.cs
@@ -37,9 +37,9 @@ namespace Umbraco.Core.Services.Implement
         /// </summary>
         /// <param name="content"></param>
         /// <returns>Returns null if no entry is found</returns>
-        public PublicAccessEntry GetEntryForContent(IContent content, bool isPublicAccessEditor = false)
+        public PublicAccessEntry GetEntryForContent(IContent content)
         {
-            return GetEntryForContent(content.Path.EnsureEndsWith("," + content.Id), isPublicAccessEditor);
+            return GetEntryForContent(content.Path.EnsureEndsWith("," + content.Id));
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Umbraco.Core.Services.Implement
         /// <remarks>
         /// NOTE: This method get's called *very* often! This will return the results from cache
         /// </remarks>
-        public PublicAccessEntry GetEntryForContent(string contentPath, bool isPublicAccessEditor = false)
+        public PublicAccessEntry GetEntryForContent(string contentPath)
         {
             //Get all ids in the path for the content item and ensure they all
             // parse to ints that are not -1.
@@ -68,12 +68,7 @@ namespace Umbraco.Core.Services.Implement
                 var entries = _publicAccessRepository.GetMany().ToArray();
 
                 scope.Complete();
-                if (isPublicAccessEditor)
-                {
-                    var found = entries.FirstOrDefault(x => x.ProtectedNodeId == ids[0]);
-                    if (found != null) {return found;}
-                     return null;
-                }
+
                 foreach (var id in ids)
                 {
                     var found = entries.FirstOrDefault(x => x.ProtectedNodeId == id);

--- a/src/Umbraco.Web.UI.Client/src/common/mocks/services/localization.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/services/localization.mocks.js
@@ -468,6 +468,8 @@ angular.module('umbraco.mocks').
                   "publicAccess_paErrorPage": "Error Page",
                   "publicAccess_paErrorPageHelp": "Used when people are logged on, but do not have access",
                   "publicAccess_paHowWould": "Choose how to restict access to this page",
+                  "publicAccess_paInherit": "Edit inherited protection",
+                  "publicAccess_paInheritHelp": "If you wish to update the existing rules for Ancestor",
                   "publicAccess_paIsProtected": "%0% is now protected",
                   "publicAccess_paIsRemoved": "Protection removed from %0%",
                   "publicAccess_paLoginPage": "Login Page",

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -966,7 +966,8 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
             return umbRequestHelper.resourcePromise(
                 $http.get(
                     umbRequestHelper.getApiUrl("contentApiBaseUrl", "GetPublicAccess", {
-                        contentId: contentId
+                        contentId: contentId,
+                        isPublicAccessEditor: true
                     })
                 ),
                 "Failed to get public access for content item with id " + contentId

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.protect.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.protect.controller.js
@@ -40,6 +40,7 @@
                     vm.inherit.errorPage = publicAccess.inherit.errorPage;
                     vm.inherit.groups = publicAccess.inherit.groups || [];
                     vm.inherit.members = publicAccess.inherit.members || [];
+                    vm.inherit.nodeName = publicAccess.inherit.NodeName;
                     vm.inherit.Id = publicAccess.inherit.Id;
                     vm.groups = [];
                     vm.isInheriting = true;

--- a/src/Umbraco.Web.UI.Client/src/views/content/protect.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/protect.html
@@ -24,7 +24,7 @@
 
                             <label for="protectionTypeInherit">
                                 <h5 class="pa-access-header"><localize key="publicAccess_paInherit">Edit inherited protection</localize></h5>
-                                <p><localize key="publicAccess_paInheritHelp" >If you wish to update the existing rules for the ancestor</localize></p>
+                                <p><localize key="publicAccess_paInheritHelp"  tokens="[vm.inherit.nodeName]">If you wish to update the existing rules for the ancestor</localize></p>
                             </label>
                         </div>
                         <div class="pa-select-type">

--- a/src/Umbraco.Web.UI.Client/src/views/content/protect.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/protect.html
@@ -19,6 +19,14 @@
                     </p>
 
                     <umb-pane>
+                        <div class="pa-select-type" ng-if=" vm.isInheriting">
+                            <input id="protectionTypeInherit" type="radio" name="protectionType" value="inherit" ng-model="vm.type">
+
+                            <label for="protectionTypeInherit">
+                                <h5 class="pa-access-header"><localize key="publicAccess_paInherit">Edit inherited protection</localize></h5>
+                                <p><localize key="publicAccess_paInheritHelp" >If you wish to update the existing rules for the ancestor</localize></p>
+                            </label>
+                        </div>
                         <div class="pa-select-type">
                             <input id="protectionTypeMember" type="radio" name="protectionType" value="member" ng-model="vm.type">
 
@@ -59,7 +67,7 @@
                         <p><localize key="publicAccess_paGroupsNoGroups">You need to create a member group before you can use group based authentication</localize></p>
                     </div>
 
-                    <div ng-show="vm.step === 'group' && vm.hasGroups">
+                    <div ng-show="(vm.step === 'group' && vm.hasGroups) || (vm.step === 'inherit' && vm.hasGroups)">
                         <p><localize key="publicAccess_paSelectGroups" tokens="[currentNode.name]">Select the groups that should have access to this page</localize></p>
                         <umb-pane>
                             <umb-node-preview ng-repeat="group in vm.groups | orderBy:'name'"

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -976,6 +976,8 @@ Mange hilsner fra Umbraco robotten
     <key alias="paSelectMembers"><![CDATA[Vælg de medlemmer der har adgang til siden <strong>%0%</strong>]]></key>
     <key alias="paMembers">Adgang til enkelte medlemmer</key>
     <key alias="paMembersHelp">Hvis du ønsker at give adgang til enkelte medlemmer</key>
+    <key alias="paInherit">Edit inherited protection</key>
+    <key alias="paInheritHelp"><![CDATA[If you wish to update the existing rules for <strong>the ancestor</strong>]]></key>
   </area>
   <area alias="publish">
     <key alias="contentPublishedFailedAwaitingRelease">Udgivelsen kunne ikke udgives da publiceringsdato er sat</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -977,7 +977,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="paMembers">Adgang til enkelte medlemmer</key>
     <key alias="paMembersHelp">Hvis du ønsker at give adgang til enkelte medlemmer</key>
     <key alias="paInherit">Edit inherited protection</key>
-    <key alias="paInheritHelp"><![CDATA[If you wish to update the existing rules for <strong>the ancestor</strong>]]></key>
+    <key alias="paInheritHelp"><![CDATA[If you wish to update the existing rules for <strong>%0%</strong>]]></key>
   </area>
   <area alias="publish">
     <key alias="contentPublishedFailedAwaitingRelease">Udgivelsen kunne ikke udgives da publiceringsdato er sat</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1223,7 +1223,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="paMembers">Specific members protection</key>
     <key alias="paMembersHelp">If you wish to grant access to specific members</key>
     <key alias="paInherit">Edit inherited protection</key>
-    <key alias="paInheritHelp"><![CDATA[If you wish to update the existing rules for <strong>the ancestor</strong> (%0%)]]></key>
+    <key alias="paInheritHelp"><![CDATA[If you wish to update the existing rules for <strong>%0%</strong>]]></key>
   </area>
   <area alias="publish">
     <key alias="contentPublishedFailedAwaitingRelease"><![CDATA[

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1130,7 +1130,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="cancelAndUploadAnother">Cancel and upload another package</key>
     <key alias="accept">I accept</key>
     <key alias="termsOfUse">terms of use</key>
-    
+
     <key alias="pathToFile">Path to file</key>
     <key alias="pathToFileDescription">Absolute path to file (ie: /bin/umbraco.bin)</key>
     <key alias="installed">Installed</key>
@@ -1222,6 +1222,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="paSelectMembers"><![CDATA[Select the members who have access to the page <strong>%0%</strong>]]></key>
     <key alias="paMembers">Specific members protection</key>
     <key alias="paMembersHelp">If you wish to grant access to specific members</key>
+    <key alias="paInherit">Edit inherited protection</key>
+    <key alias="paInheritHelp"><![CDATA[If you wish to update the existing rules for <strong>the ancestor</strong> (%0%)]]></key>
   </area>
   <area alias="publish">
     <key alias="contentPublishedFailedAwaitingRelease"><![CDATA[

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1223,6 +1223,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="paSelectMembers"><![CDATA[Select the members who have access to the page <strong>%0%</strong>]]></key>
     <key alias="paMembers">Specific members protection</key>
     <key alias="paMembersHelp">If you wish to grant access to specific members</key>
+    <key alias="paInherit">Edit inherited protection</key>
+    <key alias="paInheritHelp"><![CDATA[If you wish to update the existing rules for <strong>the ancestor</strong>]]></key>
   </area>
   <area alias="publish">
     <key alias="invalidPublishBranchPermissions">Insufficient user permissions to publish all descendant documents</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1224,7 +1224,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="paMembers">Specific members protection</key>
     <key alias="paMembersHelp">If you wish to grant access to specific members</key>
     <key alias="paInherit">Edit inherited protection</key>
-    <key alias="paInheritHelp"><![CDATA[If you wish to update the existing rules for <strong>the ancestor</strong>]]></key>
+    <key alias="paInheritHelp"><![CDATA[If you wish to update the existing rules for <strong>%0%</strong>]]></key>
   </area>
   <area alias="publish">
     <key alias="invalidPublishBranchPermissions">Insufficient user permissions to publish all descendant documents</key>

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -813,7 +813,7 @@ namespace Umbraco.Web.Editors
         /// <returns></returns>
         /// <remarks>
         /// For invariant, the variants collection count will be 1 and this will check if that invariant item has the critical values for persistence (i.e. Name)
-        /// 
+        ///
         /// For variant, each variant will be checked for critical data for persistence and if it's not there then it's flags will be reset and it will not
         /// be persisted. However, we also need to deal with the case where all variants don't pass this check and then there is nothing to save. This also deals
         /// with removing the Name validation keys based on data annotations validation for items that haven't been marked to be saved.
@@ -869,7 +869,7 @@ namespace Umbraco.Web.Editors
             return true;
         }
 
-        
+
 
         /// <summary>
         /// Helper method to perform the saving of the content and add the notifications to the result
@@ -1161,14 +1161,14 @@ namespace Umbraco.Web.Editors
             //validate if we can publish based on the mandatory language requirements
             var canPublish = ValidatePublishingMandatoryLanguages(
                 cultureErrors,
-                contentItem, cultureVariants, mandatoryCultures, 
+                contentItem, cultureVariants, mandatoryCultures,
                 mandatoryVariant => mandatoryVariant.Publish);
 
             //Now check if there are validation errors on each variant.
             //If validation errors are detected on a variant and it's state is set to 'publish', then we
             //need to change it to 'save'.
             //It is a requirement that this is performed AFTER ValidatePublishingMandatoryLanguages.
-            
+
             foreach (var variant in contentItem.Variants)
             {
                 if (cultureErrors.Contains(variant.Culture))
@@ -1242,7 +1242,7 @@ namespace Umbraco.Web.Editors
             //Now check if there are validation errors on each variant.
             //If validation errors are detected on a variant and it's state is set to 'publish', then we
             //need to change it to 'save'.
-            //It is a requirement that this is performed AFTER ValidatePublishingMandatoryLanguages.            
+            //It is a requirement that this is performed AFTER ValidatePublishingMandatoryLanguages.
             foreach (var variant in contentItem.Variants)
             {
                 if (cultureErrors.Contains(variant.Culture))
@@ -1372,7 +1372,7 @@ namespace Umbraco.Web.Editors
         /// <param name="culture">Culture to assign the error to</param>
         /// <param name="localizationKey"></param>
         /// <param name="cultureToken">
-        /// The culture used in the localization message, null by default which means <see cref="culture"/> will be used. 
+        /// The culture used in the localization message, null by default which means <see cref="culture"/> will be used.
         /// </param>
         private void AddCultureValidationError(string culture, string localizationKey, string cultureToken = null)
         {
@@ -1663,7 +1663,7 @@ namespace Umbraco.Web.Editors
                     var uri = DomainUtilities.ParseUriFromDomainName(domain.Name, Request.RequestUri);
                 }
                 catch (UriFormatException)
-                {                    
+                {
                     var response = Request.CreateValidationErrorResponse(Services.TextService.Localize("assignDomain/invalidDomain"));
                     throw new HttpResponseException(response);
                 }
@@ -1829,7 +1829,7 @@ namespace Umbraco.Web.Editors
             base.HandleInvalidModelState(display);
 
         }
-        
+
         /// <summary>
         /// Maps the dto property values and names to the persisted model
         /// </summary>
@@ -2288,7 +2288,7 @@ namespace Umbraco.Web.Editors
 
         [EnsureUserPermissionForContent("contentId", ActionProtect.ActionLetter)]
         [HttpGet]
-        public HttpResponseMessage GetPublicAccess(int contentId)
+        public HttpResponseMessage GetPublicAccess(int contentId, bool isPublicAccessEditor)
         {
             var content = Services.ContentService.GetById(contentId);
             if (content == null)
@@ -2296,7 +2296,7 @@ namespace Umbraco.Web.Editors
                 throw new HttpResponseException(Request.CreateResponse(HttpStatusCode.NotFound));
             }
 
-            var entry = Services.PublicAccessService.GetEntryForContent(content);
+            var entry = Services.PublicAccessService.GetEntryForContent(content, isPublicAccessEditor);
             if (entry == null)
             {
                 return Request.CreateResponse(HttpStatusCode.OK);

--- a/src/Umbraco.Web/Models/ContentEditing/PublicAccess.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/PublicAccess.cs
@@ -5,6 +5,9 @@ namespace Umbraco.Web.Models.ContentEditing
     [DataContract(Name = "publicAccess", Namespace = "")]
     public class PublicAccess
     {
+        [DataMember(Name = "Id")]
+        public int Id { get; set; }
+
         [DataMember(Name = "groups")]
         public MemberGroupDisplay[] Groups { get; set; }
 

--- a/src/Umbraco.Web/Models/ContentEditing/PublicAccess.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/PublicAccess.cs
@@ -8,6 +8,9 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "Id")]
         public int Id { get; set; }
 
+        [DataMember(Name = "NodeName")]
+        public string NodeName { get; set; }
+
         [DataMember(Name = "groups")]
         public MemberGroupDisplay[] Groups { get; set; }
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->
#6057 

### Description
I looked at the problem from Lukasz and start working on allow 
In following to suggestions from @stevemegson I prepare changes in Public Access Service to allow to choose if we want to edit actual Node or Ancestor Public Access.

Before:
![image](https://user-images.githubusercontent.com/2244074/62534356-dc99de80-b840-11e9-90af-29a758079a3f.png)
Even if I choose children node I was editing ancestor Public access.

After:
![image](https://user-images.githubusercontent.com/2244074/62534408-f804e980-b840-11e9-8c14-7abe258c50e8.png)
Umbraco allows me to choose if I want to edit Ancestor or create new Public Access rules for children.
