### PR TITLE
Fixes DI Lifetime.Request works per thread. #6044

### DIFF
--- a/src/Umbraco.Core/Composing/Lifetime.cs
+++ b/src/Umbraco.Core/Composing/Lifetime.cs
@@ -1,4 +1,6 @@
-﻿namespace Umbraco.Core.Composing
+﻿using System;
+
+namespace Umbraco.Core.Composing
 {
     /// <summary>
     /// Specifies the lifetime of a registered instance.
@@ -12,13 +14,6 @@
         /// or MS.DI, PerDependency in Autofac.</remarks>
         Transient,
 
-        // TODO: We need to fix this up, currently LightInject is the only one that behaves differently from all other containers.
-        //  ... the simple fix would be to map this to PerScopeLifetime in LI but need to wait on a response here https://github.com/seesharper/LightInject/issues/494#issuecomment-518942625
-        //
-        // we use it for controllers, httpContextBase and other request scoped objects: MembershpHelper, TagQuery, UmbracoTreeSearcher and ISearchableTree
-        // - so that they are automatically disposed at the end of the scope (ie request)
-        // - not sure they should not be simply 'scoped'?
-        
         /// <summary>
         /// One unique instance per request.
         /// </summary>
@@ -28,7 +23,9 @@
         /// </para>
         /// Corresponds to
         /// <para>
-        /// PerRequestLifeTime in LightInject - means transient but disposed at the end of the current web request.
+        /// PerScopeLifetime in LightInject.
+        /// Although it would seem that this should map to PerRequestLifeTime in LightInject,
+        /// that is actually misleading since PerRequestLifeTime in LightInject means transient but disposed at the end of the current web request.
         /// see: https://github.com/seesharper/LightInject/issues/494#issuecomment-518493262
         /// </para>
         /// <para>

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -71,7 +71,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="LightInject" Version="5.4.0" />
+    <PackageReference Include="LightInject" Version="5.5.0" />
     <PackageReference Include="LightInject.Annotation" Version="1.1.0" />
     <PackageReference Include="LightInject.Web" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNet.Identity.Core">

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -83,7 +83,7 @@
     <PackageReference Include="HtmlAgilityPack">
       <Version>1.8.14</Version>
     </PackageReference>
-    <PackageReference Include="LightInject" Version="5.4.0" />
+    <PackageReference Include="LightInject" Version="5.5.0" />
     <PackageReference Include="LightInject.Annotation" Version="1.1.0" />
     <PackageReference Include="Lucene.Net" Version="3.0.3" />
     <PackageReference Include="Lucene.Net.Contrib" Version="3.0.3" />

--- a/src/Umbraco.Web/Composing/LightInject/LightInjectContainer.cs
+++ b/src/Umbraco.Web/Composing/LightInject/LightInjectContainer.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Mvc;
 using LightInject;
+using Umbraco.Core;
+using Umbraco.Core.Composing;
 using Umbraco.Core.Composing.LightInject;
 
 namespace Umbraco.Web.Composing.LightInject
@@ -33,6 +37,33 @@ namespace Umbraco.Web.Composing.LightInject
             Container.EnableMvc(); // does container.EnablePerWebRequestScope()
             Container.ScopeManagerProvider = smp; // reverts - we will do it last (in WebRuntime)
             Container.EnableWebApi(GlobalConfiguration.Configuration);
+        }
+
+        protected override ILifetime GetLifetime(Lifetime lifetime, Type type)
+        {
+            switch (lifetime)
+            {
+                case Lifetime.Transient:
+                    return null;
+                case Lifetime.Request:
+                    //LightInject behaves slightly differently than all containers and based on feedback from the LightInject authors
+                    //it seems best to use PerRequestLifeTime for controllers even though controllers will work
+                    //just fine with PerScopeLifetime but this is just being 'safe'.
+                    //See: https://github.com/seesharper/LightInject/issues/494#issuecomment-519273614
+                    //Normally this will return PerScopeLifetime because in LightInject that means "one per request".
+                    //See: base class comments
+                    //See: https://github.com/umbraco/Umbraco-CMS/issues/6044#issuecomment-518949758
+
+                    return type.Inherits<IController>() || type.Inherits<IHttpController>()
+                        ? (ILifetime)new PerRequestLifeTime()
+                        : new PerScopeLifetime();
+                case Lifetime.Scope:
+                    return new PerScopeLifetime();
+                case Lifetime.Singleton:
+                    return new PerContainerLifetime();
+                default:
+                    throw new NotSupportedException($"Lifetime {lifetime} is not supported.");
+            }
         }
     }
 }

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="ImageProcessor">
       <Version>2.7.0.100</Version>
     </PackageReference>
-    <PackageReference Include="LightInject" Version="5.4.0" />
+    <PackageReference Include="LightInject" Version="5.5.0" />
     <PackageReference Include="LightInject.Annotation" Version="1.1.0" />
     <PackageReference Include="LightInject.Mvc" Version="2.0.0" />
     <PackageReference Include="LightInject.WebApi" Version="2.0.0" />


### PR DESCRIPTION
Fixes DI Lifetime.Request works per thread. #6044

There's a long discussion on #6044 as well as on the LightInject repo https://github.com/seesharper/LightInject/issues/494 about this but it comes down to the fact that Lifetime.Request maps to LightInjects PerRequestLifeTime which is incorrect since Lifetime.Request means "one per request" and that's not what LI does for PerRequestLifeTime - which is just transient per request and disposing at the end of the request. 

This changes the mapping so that Lifetime.Request maps to PerScopeLifetime which in LI is "one per request".

However, there's a catch. LightInject wants to have controllers registered as PerRequestLifeTime, so in the `Umbraco.Web.Composing.LightInject.LightInjectContainer` we need to check for that.

There was discussion on #6044 to obsolete `Lifetime.Scope` however i don't think we should do this anymore since every container natively supports this and there will be some cases where a user actually wants to use Lifetime.Scope over Lifetime.Request for some scenarios (i.e. custom scopes). 

