### PR TITLE
Make it possible to select styles on selected text in distraction free mode.

### DIFF
--- a/src/Umbraco.Web.UI/config/tinyMceConfig.Release.config
+++ b/src/Umbraco.Web.UI/config/tinyMceConfig.Release.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <tinymceConfig>
     <commands>
         <command alias="ace" name="Source code editor" mode="Insert" />
@@ -8,7 +8,7 @@
         <command alias="cut" name="Cut" mode="Selection"/>
         <command alias="copy" name="Copy" mode="Selection"/>
         <command alias="paste" name="Paste" mode="All" />
-        <command alias="styleselect" name="Style select" mode="Insert" />
+        <command alias="styleselect" name="Style select" mode="All" />
         <command alias="bold" name="Bold" mode="Selection" />
         <command alias="italic" name="Italic" mode="Selection" />
         <command alias="underline" name="Underline" mode="Selection" />

--- a/src/Umbraco.Web.UI/config/tinyMceConfig.config
+++ b/src/Umbraco.Web.UI/config/tinyMceConfig.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <tinymceConfig>
     <commands>
         <command alias="ace" name="Source code editor" mode="Insert" />
@@ -8,7 +8,7 @@
         <command alias="cut" name="Cut" mode="Selection"/>
         <command alias="copy" name="Copy" mode="Selection"/>
         <command alias="paste" name="Paste" mode="All" />
-        <command alias="styleselect" name="Style select" mode="Insert" />
+        <command alias="styleselect" name="Style select" mode="All" />
         <command alias="bold" name="Bold" mode="Selection" />
         <command alias="italic" name="Italic" mode="Selection" />
         <command alias="underline" name="Underline" mode="Selection" />


### PR DESCRIPTION
### Description
This changes the mode of the styleselect command in the Rich Text Editor to all, making it possible to select styles on selected text in distraction free mode.

To test:
Set a Rich Text Editor to distraction free mode, enable style select. Write some text in the editor, select it and notice the Formats dropdown.


![image](https://user-images.githubusercontent.com/3726467/62683922-d5e5a580-b9bf-11e9-8ef7-7b1980443537.png)
