### PR TITLE
Move CreateRoutes from WebFinalComponent to WebInitialComponent

### DIFF
--- a/src/Umbraco.Tests/Routing/RenderRouteHandlerTests.cs
+++ b/src/Umbraco.Tests/Routing/RenderRouteHandlerTests.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Tests.Routing
         {
             base.SetUp();
 
-            WebFinalComponent.CreateRoutes(
+            WebInitialComponent.CreateRoutes(
                 new TestUmbracoContextAccessor(),
                 TestObjects.GetGlobalSettings(),
                 new SurfaceControllerTypeCollection(Enumerable.Empty<Type>()),

--- a/src/Umbraco.Web/Runtime/WebFinalComponent.cs
+++ b/src/Umbraco.Web/Runtime/WebFinalComponent.cs
@@ -1,39 +1,18 @@
 ﻿using System;
-using System.Linq;
-using System.Web.Helpers;
 using System.Web.Http;
-using System.Web.Mvc;
-using System.Web.Routing;
-using Umbraco.Core;
 using Umbraco.Core.Composing;
-using Umbraco.Core.Configuration;
-using Umbraco.Web.Install;
-using Umbraco.Web.Mvc;
-using Umbraco.Web.Security;
-using Umbraco.Web.WebApi;
 
 namespace Umbraco.Web.Runtime
 {
     public class WebFinalComponent : IComponent
     {
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
-        private readonly SurfaceControllerTypeCollection _surfaceControllerTypes;
-        private readonly UmbracoApiControllerTypeCollection _apiControllerTypes;
-        private readonly IGlobalSettings _globalSettings;
 
-        public WebFinalComponent(IUmbracoContextAccessor umbracoContextAccessor, SurfaceControllerTypeCollection surfaceControllerTypes, UmbracoApiControllerTypeCollection apiControllerTypes, IGlobalSettings globalSettings)
+        public WebFinalComponent()
         {
-            _umbracoContextAccessor = umbracoContextAccessor;
-            _surfaceControllerTypes = surfaceControllerTypes;
-            _apiControllerTypes = apiControllerTypes;
-            _globalSettings = globalSettings;
         }
 
         public void Initialize()
         {
-            // set routes
-            CreateRoutes(_umbracoContextAccessor, _globalSettings, _surfaceControllerTypes, _apiControllerTypes);
-
             // ensure WebAPI is initialized, after everything
             GlobalConfiguration.Configuration.EnsureInitialized();
         }
@@ -41,92 +20,5 @@ namespace Umbraco.Web.Runtime
         public void Terminate()
         { }
 
-        // internal for tests
-        internal static void CreateRoutes(
-            IUmbracoContextAccessor umbracoContextAccessor,
-            IGlobalSettings globalSettings,
-            SurfaceControllerTypeCollection surfaceControllerTypes,
-            UmbracoApiControllerTypeCollection apiControllerTypes)
-        {
-            var umbracoPath = globalSettings.GetUmbracoMvcArea();
-
-            // create the front-end route
-            var defaultRoute = RouteTable.Routes.MapRoute(
-                "Umbraco_default",
-                umbracoPath + "/RenderMvc/{action}/{id}",
-                new { controller = "RenderMvc", action = "Index", id = UrlParameter.Optional }
-            );
-            defaultRoute.RouteHandler = new RenderRouteHandler(umbracoContextAccessor, ControllerBuilder.Current.GetControllerFactory());
-
-            // register install routes
-            RouteTable.Routes.RegisterArea<UmbracoInstallArea>();
-
-            // register all back office routes
-            RouteTable.Routes.RegisterArea(new BackOfficeArea(globalSettings));
-
-            // plugin controllers must come first because the next route will catch many things
-            RoutePluginControllers(globalSettings, surfaceControllerTypes, apiControllerTypes);
-        }
-
-        private static void RoutePluginControllers(
-            IGlobalSettings globalSettings,
-            SurfaceControllerTypeCollection surfaceControllerTypes,
-            UmbracoApiControllerTypeCollection apiControllerTypes)
-        {
-            var umbracoPath = globalSettings.GetUmbracoMvcArea();
-
-            // need to find the plugin controllers and route them
-            var pluginControllers = surfaceControllerTypes.Concat(apiControllerTypes).ToArray();
-
-            // local controllers do not contain the attribute
-            var localControllers = pluginControllers.Where(x => PluginController.GetMetadata(x).AreaName.IsNullOrWhiteSpace());
-            foreach (var s in localControllers)
-            {
-                if (TypeHelper.IsTypeAssignableFrom<SurfaceController>(s))
-                    RouteLocalSurfaceController(s, umbracoPath);
-                else if (TypeHelper.IsTypeAssignableFrom<UmbracoApiController>(s))
-                    RouteLocalApiController(s, umbracoPath);
-            }
-
-            // get the plugin controllers that are unique to each area (group by)
-            var pluginSurfaceControlleres = pluginControllers.Where(x => PluginController.GetMetadata(x).AreaName.IsNullOrWhiteSpace() == false);
-            var groupedAreas = pluginSurfaceControlleres.GroupBy(controller => PluginController.GetMetadata(controller).AreaName);
-            // loop through each area defined amongst the controllers
-            foreach (var g in groupedAreas)
-            {
-                // create & register an area for the controllers (this will throw an exception if all controllers are not in the same area)
-                var pluginControllerArea = new PluginControllerArea(globalSettings, g.Select(PluginController.GetMetadata));
-                RouteTable.Routes.RegisterArea(pluginControllerArea);
-            }
-        }
-
-        private static void RouteLocalApiController(Type controller, string umbracoPath)
-        {
-            var meta = PluginController.GetMetadata(controller);
-            var url = umbracoPath + (meta.IsBackOffice ? "/BackOffice" : "") + "/Api/" + meta.ControllerName + "/{action}/{id}";
-            var route = RouteTable.Routes.MapHttpRoute(
-                $"umbraco-api-{meta.ControllerName}",
-                url, // url to match
-                new { controller = meta.ControllerName, id = UrlParameter.Optional },
-                new[] { meta.ControllerNamespace });
-            if (route.DataTokens == null) // web api routes don't set the data tokens object
-                route.DataTokens = new RouteValueDictionary();
-            route.DataTokens.Add(Core.Constants.Web.UmbracoDataToken, "api"); //ensure the umbraco token is set
-        }
-
-        private static void RouteLocalSurfaceController(Type controller, string umbracoPath)
-        {
-            var meta = PluginController.GetMetadata(controller);
-            var url = umbracoPath + "/Surface/" + meta.ControllerName + "/{action}/{id}";
-            var route = RouteTable.Routes.MapRoute(
-                $"umbraco-surface-{meta.ControllerName}",
-                url, // url to match
-                new { controller = meta.ControllerName, action = "Index", id = UrlParameter.Optional },
-                new[] { meta.ControllerNamespace }); // look in this namespace to create the controller
-            route.DataTokens.Add(Core.Constants.Web.UmbracoDataToken, "surface"); // ensure the umbraco token is set
-            route.DataTokens.Add("UseNamespaceFallback", false); // don't look anywhere else except this namespace!
-            // make it use our custom/special SurfaceMvcHandler
-            route.RouteHandler = new SurfaceRouteHandler();
-        }
     }
 }

--- a/src/Umbraco.Web/Runtime/WebInitialComponent.cs
+++ b/src/Umbraco.Web/Runtime/WebInitialComponent.cs
@@ -8,12 +8,14 @@ using System.Web.Configuration;
 using System.Web.Http;
 using System.Web.Http.Dispatcher;
 using System.Web.Mvc;
+using System.Web.Routing;
 using ClientDependency.Core.CompositeFiles.Providers;
 using ClientDependency.Core.Config;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.IO;
+using Umbraco.Web.Install;
 using Umbraco.Web.JavaScript;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
@@ -24,10 +26,16 @@ namespace Umbraco.Web.Runtime
 {
     public sealed class WebInitialComponent : IComponent
     {
+        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly SurfaceControllerTypeCollection _surfaceControllerTypes;
+        private readonly UmbracoApiControllerTypeCollection _apiControllerTypes;
         private readonly IGlobalSettings _globalSettings;
 
-        public WebInitialComponent(IGlobalSettings globalSettings)
+        public WebInitialComponent(IUmbracoContextAccessor umbracoContextAccessor, SurfaceControllerTypeCollection surfaceControllerTypes, UmbracoApiControllerTypeCollection apiControllerTypes, IGlobalSettings globalSettings)
         {
+            _umbracoContextAccessor = umbracoContextAccessor;
+            _surfaceControllerTypes = surfaceControllerTypes;
+            _apiControllerTypes = apiControllerTypes;
             _globalSettings = globalSettings;
         }
 
@@ -51,6 +59,9 @@ namespace Umbraco.Web.Runtime
 
             // add global filters
             ConfigureGlobalFilters();
+
+            // set routes
+            CreateRoutes(_umbracoContextAccessor, _globalSettings, _surfaceControllerTypes, _apiControllerTypes);
         }
 
         public void Terminate()
@@ -131,5 +142,94 @@ namespace Umbraco.Web.Runtime
 
             ClientDependencySettings.Instance.MvcRendererCollection.Add(renderer);
         }
+
+        // internal for tests
+        internal static void CreateRoutes(
+            IUmbracoContextAccessor umbracoContextAccessor,
+            IGlobalSettings globalSettings,
+            SurfaceControllerTypeCollection surfaceControllerTypes,
+            UmbracoApiControllerTypeCollection apiControllerTypes)
+        {
+            var umbracoPath = globalSettings.GetUmbracoMvcArea();
+
+            // create the front-end route
+            var defaultRoute = RouteTable.Routes.MapRoute(
+                "Umbraco_default",
+                umbracoPath + "/RenderMvc/{action}/{id}",
+                new { controller = "RenderMvc", action = "Index", id = UrlParameter.Optional }
+            );
+            defaultRoute.RouteHandler = new RenderRouteHandler(umbracoContextAccessor, ControllerBuilder.Current.GetControllerFactory());
+
+            // register install routes
+            RouteTable.Routes.RegisterArea<UmbracoInstallArea>();
+
+            // register all back office routes
+            RouteTable.Routes.RegisterArea(new BackOfficeArea(globalSettings));
+
+            // plugin controllers must come first because the next route will catch many things
+            RoutePluginControllers(globalSettings, surfaceControllerTypes, apiControllerTypes);
+        }
+
+        private static void RoutePluginControllers(
+            IGlobalSettings globalSettings,
+            SurfaceControllerTypeCollection surfaceControllerTypes,
+            UmbracoApiControllerTypeCollection apiControllerTypes)
+        {
+            var umbracoPath = globalSettings.GetUmbracoMvcArea();
+
+            // need to find the plugin controllers and route them
+            var pluginControllers = surfaceControllerTypes.Concat(apiControllerTypes).ToArray();
+
+            // local controllers do not contain the attribute
+            var localControllers = pluginControllers.Where(x => PluginController.GetMetadata(x).AreaName.IsNullOrWhiteSpace());
+            foreach (var s in localControllers)
+            {
+                if (TypeHelper.IsTypeAssignableFrom<SurfaceController>(s))
+                    RouteLocalSurfaceController(s, umbracoPath);
+                else if (TypeHelper.IsTypeAssignableFrom<UmbracoApiController>(s))
+                    RouteLocalApiController(s, umbracoPath);
+            }
+
+            // get the plugin controllers that are unique to each area (group by)
+            var pluginSurfaceControlleres = pluginControllers.Where(x => PluginController.GetMetadata(x).AreaName.IsNullOrWhiteSpace() == false);
+            var groupedAreas = pluginSurfaceControlleres.GroupBy(controller => PluginController.GetMetadata(controller).AreaName);
+            // loop through each area defined amongst the controllers
+            foreach (var g in groupedAreas)
+            {
+                // create & register an area for the controllers (this will throw an exception if all controllers are not in the same area)
+                var pluginControllerArea = new PluginControllerArea(globalSettings, g.Select(PluginController.GetMetadata));
+                RouteTable.Routes.RegisterArea(pluginControllerArea);
+            }
+        }
+
+        private static void RouteLocalApiController(Type controller, string umbracoPath)
+        {
+            var meta = PluginController.GetMetadata(controller);
+            var url = umbracoPath + (meta.IsBackOffice ? "/BackOffice" : "") + "/Api/" + meta.ControllerName + "/{action}/{id}";
+            var route = RouteTable.Routes.MapHttpRoute(
+                $"umbraco-api-{meta.ControllerName}",
+                url, // url to match
+                new { controller = meta.ControllerName, id = UrlParameter.Optional },
+                new[] { meta.ControllerNamespace });
+            if (route.DataTokens == null) // web api routes don't set the data tokens object
+                route.DataTokens = new RouteValueDictionary();
+            route.DataTokens.Add(Core.Constants.Web.UmbracoDataToken, "api"); //ensure the umbraco token is set
+        }
+
+        private static void RouteLocalSurfaceController(Type controller, string umbracoPath)
+        {
+            var meta = PluginController.GetMetadata(controller);
+            var url = umbracoPath + "/Surface/" + meta.ControllerName + "/{action}/{id}";
+            var route = RouteTable.Routes.MapRoute(
+                $"umbraco-surface-{meta.ControllerName}",
+                url, // url to match
+                new { controller = meta.ControllerName, action = "Index", id = UrlParameter.Optional },
+                new[] { meta.ControllerNamespace }); // look in this namespace to create the controller
+            route.DataTokens.Add(Core.Constants.Web.UmbracoDataToken, "surface"); // ensure the umbraco token is set
+            route.DataTokens.Add("UseNamespaceFallback", false); // don't look anywhere else except this namespace!
+            // make it use our custom/special SurfaceMvcHandler
+            route.RouteHandler = new SurfaceRouteHandler();
+        }
+
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6045

### Description
This implements Solution 1 discussed in #6045, moving the registration of Umbraco's routes into WebInitialComponent so that custom routes can more easily be placed after Umbraco's routes.

To test:
- Create an IUserComposer and IComponent registering a very general custom route, such as the standard `{controller}/{action}`.
- Check that the route doesn't take priority over more specific routes needed by Umbraco.