### PR TITLE
V8: Sorting of images in multiple media picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -229,7 +229,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
 
 
         $scope.sortableOptions = {
-            disabled: !$scope.isMultiPicker,
+            disabled: !multiPicker,
             items: "li:not(.add-wrapper)",
             cancel: ".unsortable",
             update: function (e, ui) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5504

### Description
The order of execution when setting up a media picker has changed in v8, so that `$scope.isMultiPicker` is read before it has been initialized. This leads to sorting being disabled, because sortableOptions is always set up as though it's a single media picker.

Testing:
 - Add some items to a multiple media picker property editor
- Check that you can sort them by dragging