### PR TITLE
V7: Fix the disabled upload button in media picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -267,7 +267,7 @@ angular.module("umbraco")
 
                 // also make sure the node is not trashed
                 if (nodePath.indexOf($scope.startNodeId.toString()) !== -1 && node.trashed === false) {
-                    $scope.gotoFolder({ id: $scope.lastOpenedNode, name: "Media", icon: "icon-folder" });
+                    $scope.gotoFolder({ id: $scope.lastOpenedNode, name: "Media", icon: "icon-folder", path: node.path });
                     return true;
                 } else {
                     $scope.gotoFolder({ id: $scope.startNodeId, name: "Media", icon: "icon-folder" });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6075

### Description

If Umbraco can figure out which media folder you last visited, the "Upload" button in the media picker is disabled. If you browse around within the media picker, the "Upload" button immediately becomes enabled, even for the folder where it was initially disabled:

![media-picker-upload-before](https://user-images.githubusercontent.com/7405322/62734425-4ecd1780-ba29-11e9-8281-8a0b053642b3.gif)

The issue was introduced with 1dd2c1cb. Basically it's due to a missing `path` property in the starting node of the media picker, whichever node that might be (except the root).

This PR fixes the issue; when it's applied the "Upload" button works as expected:

![media-picker-upload-after](https://user-images.githubusercontent.com/7405322/62734578-a23f6580-ba29-11e9-83d7-0f646a683c37.gif)
