### PR TITLE
V8: Fix the disabled upload button in media picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -268,7 +268,7 @@ angular.module("umbraco")
 
                 // also make sure the node is not trashed
                 if (nodePath.indexOf($scope.startNodeId.toString()) !== -1 && node.trashed === false) {
-                    $scope.gotoFolder({ id: $scope.lastOpenedNode, name: "Media", icon: "icon-folder" });
+                    $scope.gotoFolder({ id: $scope.lastOpenedNode, name: "Media", icon: "icon-folder", path: node.path });
                     return true;
                 } else {
                     $scope.gotoFolder({ id: $scope.startNodeId, name: "Media", icon: "icon-folder" });


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

_This is the V8-ification of #6081_

If Umbraco can figure out which media folder you last visited, the "Upload" button in the media picker is disabled. If you browse around within the media picker, the "Upload" button immediately becomes enabled, even for the folder where it was initially disabled:

![media-picker-upload-before](https://user-images.githubusercontent.com/7405322/62735350-48d83600-ba2b-11e9-9f85-0221bb3eb849.gif)

This PR fixes the issue; when it's applied the "Upload" button works as expected:

![media-picker-upload-after](https://user-images.githubusercontent.com/7405322/62735374-52fa3480-ba2b-11e9-9005-8a0c622c4bce.gif)
