### PR TITLE
V7: Change the priority of the tree node annotations for containers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -348,7 +348,6 @@ div.is-container:before{
 	bottom: 0;
 }
 
-
 div.locked:before{
 	content:"\e0a7";
 	font-family: 'icomoon';

--- a/src/Umbraco.Web.UI.Client/src/less/tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/tree.less
@@ -327,27 +327,6 @@ li.root > div > a.umb-options {
 div.not-published > i.icon,div.not-published > a{
 	opacity: 0.6;
 }
-div.protected:before{
-	content:"\e256";
-	font-family: 'icomoon';
-	color: @red;
-	position: absolute;
-	font-size: 20px;
-	padding-left: 7px;
-	padding-top: 7px;
-	bottom: 0;
-}
-
-div.has-unpublished-version:before{
-	content:"\e25a";
-	font-family: 'icomoon';
-	color: @green;
-	position: absolute;
-	font-size: 20px;
-	padding-left: 7px;
-	padding-top: 7px;
-	bottom: 0;
-}
 
 div.not-allowed > i.icon,div.not-allowed > a{
 	cursor: not-allowed;
@@ -369,6 +348,7 @@ div.is-container:before{
 	bottom: 0;
 }
 
+
 div.locked:before{
 	content:"\e0a7";
 	font-family: 'icomoon';
@@ -378,6 +358,29 @@ div.locked:before{
 	padding-left: 7px;
 	padding-top: 7px;
 	bottom: 0;
+}
+
+
+div.has-unpublished-version:before {
+    content: "\e25a";
+    font-family: 'icomoon';
+    color: @green;
+    position: absolute;
+    font-size: 20px;
+    padding-left: 7px;
+    padding-top: 7px;
+    bottom: 0;
+}
+
+div.protected:before {
+    content: "\e256";
+    font-family: 'icomoon';
+    color: @red;
+    position: absolute;
+    font-size: 20px;
+    padding-left: 7px;
+    padding-top: 7px;
+    bottom: 0;
 }
 
 .umb-tree li div.no-access .umb-tree-icon,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6079

### Description

As described in #6079 you can't tell if a node is protected if it's a container (list view) node. As it turns out, the same thing applies to nodes with pending changes:

![image](https://user-images.githubusercontent.com/7405322/62736179-17f90080-ba2d-11e9-86e9-62d16f92f9ad.png)

This PR changes the priority of the tree node annotations to be:

1. Is protected
2. Has pending changes
3. Is container (list view)

When the PR is applied, the same nodes will look like this:

![image](https://user-images.githubusercontent.com/7405322/62736065-d9634600-ba2c-11e9-8ac5-230e3c641f0d.png)
