### PR TITLE
V8: Fix "infinityMode" typo

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
@@ -16,9 +16,7 @@
                 editor.moveRight = true;
                 editor.level = 0;
                 editor.styleIndex = 0;
-                
-                editor.infinityMode = true;
-                
+                                
                 // push the new editor to the dom
                 scope.editors.push(editor);
                 

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
@@ -17,7 +17,7 @@
     z-index: @zIndexEditor;
 }
 
-.umb-editor--infinityMode {
+.umb-editor--infiniteMode {
     transform: none;
     will-change: transform;
     transition: transform 400ms ease-in-out;

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editors.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editors.html
@@ -5,7 +5,7 @@
         ng-class="{'umb-editor--small': model.size === 'small',
         'umb-editor--animating': model.animating,
         '--notInFront': model.inFront !== true,
-        'umb-editor--infinityMode': model.infinityMode,
+        'umb-editor--infiniteMode': model.infiniteMode,
         'moveRight': model.moveRight,
         'umb-editor--n0': model.styleIndex === 0,
         'umb-editor--n1': model.styleIndex === 1,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6058

### Description

This PR fixes the "infinityMode" typo originating from the `umbEditors` directive.

As it turns out, `umbEditors` attempts to dictate infinite mode - only it kinda fails as it's setting `infinityMode`, not `infiniteMode` which is used throughout the app. But `umbEditors` really shouldn't be messing with infinite mode. This is determined and handled by `editorService` [here](https://github.com/umbraco/Umbraco-CMS/blob/a398881fa1e7eebda4ad74d505a592d4178bfa64/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js#L265).

Bottom line: We can safely remove the `infinityMode` assignment from `umbEditors` and rely on the `infiniteMode` assignment from `editorService`. That's what this PR does 😄 

#### Testing this PR

Browse around the backoffice and open things in infinite editing (both single level and multilevel infinite editing) and make sure the infinite editing dialogs look and behave as expected.