### PR TITLE
V8: Allow localization of the backoffice using parent cultures to the editor culture

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/LanguageRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/LanguageRepository.cs
@@ -250,7 +250,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             lock (_codeIdMap)
             {
                 if (_codeIdMap.TryGetValue(isoCode, out var id)) return id;
-                if (isoCode.Contains('-') && _codeIdMap.TryGetValue(isoCode.Split('-').First(), out var invariantId)) return invariantId;
             }
             if (throwOnNotFound)
                 throw new ArgumentException($"Code {isoCode} does not correspond to an existing language.", nameof(isoCode));

--- a/src/Umbraco.Tests/Persistence/Repositories/LanguageRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/LanguageRepositoryTest.cs
@@ -80,39 +80,6 @@ namespace Umbraco.Tests.Persistence.Repositories
         }
 
         [Test]
-        public void Can_Perform_Get_By_Invariant_Code_On_LanguageRepository()
-        {
-            var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
-            {
-                var repository = CreateRepository(provider);
-
-                var es = new CultureInfo("es");
-                var esSpecific = new CultureInfo("es-ES");
-
-                var language = (ILanguage)new Language(es.Name)
-                {
-                    CultureName = es.DisplayName,
-                    FallbackLanguageId = 1
-                };
-                repository.Save(language);
-
-                language = repository.GetByIsoCode(es.Name);
-                var languageSpecific = repository.GetByIsoCode(esSpecific.Name);
-                
-                // Assert
-                Assert.That(language, Is.Not.Null);
-                Assert.That(language.HasIdentity, Is.True);
-                Assert.That(language.IsoCode, Is.EqualTo(es.Name));
-
-                Assert.That(languageSpecific, Is.Not.Null);
-                Assert.That(languageSpecific.HasIdentity, Is.True);
-                Assert.That(languageSpecific.Id, Is.EqualTo(language.Id));
-                Assert.That(language.IsoCode, Is.EqualTo(language.IsoCode));
-            }
-        }
-        
-        [Test]
         public void Get_When_Id_Doesnt_Exist_Returns_Null()
         {
             // Arrange

--- a/src/Umbraco.Web/Dictionary/UmbracoCultureDictionary.cs
+++ b/src/Umbraco.Web/Dictionary/UmbracoCultureDictionary.cs
@@ -122,7 +122,20 @@ namespace Umbraco.Web.Dictionary
                 //ensure it's stored/retrieved from request cache
                 //NOTE: This is no longer necessary since these are cached at the runtime level, but we can leave it here for now.
                 return _requestCache.GetCacheItem<ILanguage>(typeof (DefaultCultureDictionary).Name + "Culture" + Culture.Name,
-                    () => _localizationService.GetLanguageByIsoCode(Culture.Name));
+                    () => {
+                        // find a language that matches the current culture or any of its parent cultures
+                        var culture = Culture;
+                        while(culture != CultureInfo.InvariantCulture)
+                        {
+                            var language = _localizationService.GetLanguageByIsoCode(culture.Name);
+                            if(language != null)
+                            {
+                                return language;
+                            }
+                            culture = culture.Parent;
+                        }
+                        return null;
+                    });
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5959

### Description

This is a new take on the issue outlined in #4519. The PR reverts the changes from #4519 and handles dictionary based localization via region-less languages in a different way.

#### Setup for testing this PR

First and foremost make sure you have created both a region specific and a region-less language - e.g. add "da" if you still have the default "en-US":

![image](https://user-images.githubusercontent.com/7405322/62820273-4298a580-bb62-11e9-9c60-773080a4f68a.png)

Create a doctype that localizes both its name and a property label via the dictionary (using the "#" notation):

![image](https://user-images.githubusercontent.com/7405322/62820295-8be8f500-bb62-11e9-9263-8d1291ce5192.png)

Add two dictionary entries, one for the name of the doctype and one for the name property label:

![image](https://user-images.githubusercontent.com/7405322/62820235-9ce53680-bb61-11e9-8259-efa306fd46ed.png)

![image](https://user-images.githubusercontent.com/7405322/62820239-a8d0f880-bb61-11e9-9937-61af481034ac.png)

#### Testing this PR

Set your user language to match the region-less language you created above - e.g. use "da-DK" as your user language if you created "da". 

Verify that the localization works by testing the following:

1. The doctype name in create dialog:
![image](https://user-images.githubusercontent.com/7405322/62820219-57c10480-bb61-11e9-9eb2-914bfc62237c.png)

2. The property label in the doctype editor:
![image](https://user-images.githubusercontent.com/7405322/62820221-65768a00-bb61-11e9-8b7d-f1e0fa9ef289.png)

3. The doctype name in the "Info" section:
![image](https://user-images.githubusercontent.com/7405322/62820227-72937900-bb61-11e9-8582-9e7f4fa1b8d7.png)

Now change your user language to match the region specific language you created above and redo the verification of localization for this language. 

