### PR TITLE
Ability to distinguish document types with same name in Nested Content config

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -15,6 +15,10 @@
             });
         }
 
+        $scope.canAdd = function () {
+            return !$scope.model.docTypes || !$scope.model.value || $scope.model.value.length < $scope.model.docTypes.length;
+        }
+
         $scope.remove = function (index) {
             $scope.model.value.splice(index, 1);
         }
@@ -60,7 +64,6 @@
 
             // Count doctype name occurrences
             var docTypeNameOccurrences = _.countBy(docTypes, 'name');
-            console.info(docTypeNameOccurrences);
             
             // Populate document type tab dictionary
             // And append alias to name if multiple doctypes have the same name

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -57,10 +57,21 @@
 
         ncResources.getContentTypes().then(function (docTypes) {
             $scope.model.docTypes = docTypes;
+
+            // Count doctype name occurrences
+            var docTypeNameOccurrences = _.countBy(docTypes, 'name');
+            console.info(docTypeNameOccurrences);
             
             // Populate document type tab dictionary
+            // And append alias to name if multiple doctypes have the same name
             docTypes.forEach(function (value) {
                 $scope.docTypeTabs[value.alias] = value.tabs;
+
+                value.displayName = value.name;
+
+                if (docTypeNameOccurrences[value.name] > 1) {
+                    value.displayName += " (" + value.alias + ")";
+                }
             });
         });
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -35,17 +35,17 @@
                         <input type="text" ng-model="config.nameTemplate" />
                     </td>
                     <td>
-                        <a class="btn btn-danger" ng-click="remove($index)">
+                        <button type="button" class="btn btn-danger" ng-click="remove($index)">
                             <localize key="general_delete">Delete</localize>
-                        </a>
+                        </button>
                     </td>
                 </tr>
             </tbody>
         </table>
         <div>
-            <a class="btn" ng-click="add()">
+            <button type="button" class="btn" ng-click="add()">
                 <localize key="general_add">Add</localize>
-            </a>
+            </button>
             <i class="icon icon-help-alt medium umb-nested-content__help-icon" ng-click="showHelpText = !showHelpText"></i>
         </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -43,7 +43,7 @@
             </tbody>
         </table>
         <div>
-            <button type="button" class="btn" ng-click="add()">
+            <button type="button" class="btn" ng-click="add()" ng-disabled="!canAdd()">
                 <localize key="general_add">Add</localize>
             </button>
             <i class="icon icon-help-alt medium umb-nested-content__help-icon" ng-click="showHelpText = !showHelpText"></i>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -23,7 +23,7 @@
                     </td>
                     <td>
                         <select id="{{model.alias}}_doctype_select"
-                            ng-options="dt.alias as dt.name for dt in selectableDocTypesFor(config) | orderBy: 'name'"
+                            ng-options="dt.alias as dt.displayName for dt in selectableDocTypesFor(config) | orderBy: 'name'"
                             ng-model="config.ncAlias" required></select>
                     </td>
                     <td>


### PR DESCRIPTION
### Description

This pull request updates the **Nested Content** property editor so you can distinguish document types which have the same name by appending the alias.

It also disables the "Add" button in case no available document types are left.


### Before

![image](https://user-images.githubusercontent.com/445092/62833786-9c719c00-bc44-11e9-965b-aecdff9a826d.png)

### After

![image](https://user-images.githubusercontent.com/445092/62833791-adbaa880-bc44-11e9-82bd-5dd5eb6fa86d.png)

