### PR TITLE
v8: Propagate default Searchers

### DIFF
--- a/src/Umbraco.Web/Search/ExamineComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineComponent.cs
@@ -101,8 +101,12 @@ namespace Umbraco.Web.Search
             }
 
             //create the indexes and register them with the manager
-            foreach(var index in _indexCreator.Create())
+            foreach (var index in _indexCreator.Create())
+            {
                 _examineManager.AddIndex(index);
+                _examineManager.AddSearcher(index.GetSearcher());
+            }
+
 
             _logger.Debug<ExamineComponent>("Examine shutdown registered with MainDom");
 


### PR DESCRIPTION
### Prerequisites
I notice Umbraco v8 doesn't propagate basic searchers for Indexes, and from my perspective, it is not correct behavior. As some API could use a list of searchers and they will be not able to access default index searchers.

### Description
Actual behavior, when you will go to back-office Umbraco will display empty section of searchers as default searchers for Indexes are not propagate:
![image](https://user-images.githubusercontent.com/2244074/62835199-3a696480-bc4d-11e9-8193-a19b8b45993f.png)
After applied my PR:
![image](https://user-images.githubusercontent.com/2244074/62835204-51a85200-bc4d-11e9-859b-d2b3a2008163.png)
As you could see now on the list of Searchers is containing default searchers for indexes. 
@Shazwazza it was any reason behind not propagating default searchers?
<!-- Thanks for contributing to Umbraco CMS! -->
