### PR TITLE
use modifiable media path in file system composition

### DIFF
--- a/src/Umbraco.Core/Composing/CompositionExtensions/FileSystems.cs
+++ b/src/Umbraco.Core/Composing/CompositionExtensions/FileSystems.cs
@@ -90,7 +90,7 @@ namespace Umbraco.Core.Composing.CompositionExtensions
             // register the IFileSystem supporting the IMediaFileSystem
             // THIS IS THE ONLY THING THAT NEEDS TO CHANGE, IN ORDER TO REPLACE THE UNDERLYING FILESYSTEM
             // and, SupportingFileSystem.For<IMediaFileSystem>() returns the underlying filesystem
-            composition.SetMediaFileSystem(() => new PhysicalFileSystem("~/media"));
+            composition.SetMediaFileSystem(() => new PhysicalFileSystem(SystemDirectories.Media));
 
             return composition;
         }


### PR DESCRIPTION
### Problem

It was not possible to change the media path without using a custom composer like this:

```
public class CoreComposer : IUserComposer
{
  public void Compose(Composition composition)
  {
    composition.SetMediaFileSystem(() => new PhysicalFileSystem(SystemDirectories.Media));
  }
}
```

That's because the FileSystems composer uses a hard-coded folder `~/media` for the `PhysicalFileSystem` and ignores the `SystemDirectories.Media` path which can be changed via the appSettings configuration.

`composition.SetMediaFileSystem(() => new PhysicalFileSystem("~/media"));`

### Description

It's basically a one liner which replaces the mentioned hard-coded string with:

`composition.SetMediaFileSystem(() => new PhysicalFileSystem(SystemDirectories.Media));`