### PR TITLE
V8: Make sure to mark the current form as dirty when altering content types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -530,6 +530,7 @@
               // push new init tab to the scope
               addInitGroup(scope.model.groups);
 
+              notifyChanged();
             },
             close: function() {
               if(_.isEqual(oldPropertyModel, propertyModel) === false) {
@@ -586,7 +587,12 @@
 
         }
 
+        notifyChanged();
       };
+
+      function notifyChanged() {
+        eventsService.emit("editors.groupsBuilder.changed");
+      }
 
       function addInitProperty(group) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -506,6 +506,10 @@
             }
         }));
 
+        evts.push(eventsService.on("editors.groupsBuilder.changed", function(name, args) {
+            angularHelper.getCurrentForm($scope).$setDirty();
+        }));
+
         //ensure to unregister from all events!
         $scope.$on('$destroy', function () {
             for (var e in evts) {

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
@@ -431,6 +431,10 @@
             loadMediaType();
         }));
 
+        evts.push(eventsService.on("editors.groupsBuilder.changed", function(name, args) {
+            angularHelper.getCurrentForm($scope).$setDirty();
+        }));
+
         //ensure to unregister from all events!
         $scope.$on('$destroy', function () {
             for (var e in evts) {

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
@@ -311,7 +311,6 @@
 
         //ensure to unregister from all events!
         $scope.$on('$destroy', function () {
-            console.log("I am unregistering", evts.length)
             for (var e in evts) {
                 eventsService.unsubscribe(evts[e]);
             }

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
@@ -9,8 +9,9 @@
 (function () {
     "use strict";
 
-    function MemberTypesEditController($scope, $rootScope, $routeParams, $log, $filter, memberTypeResource, dataTypeResource, editorState, iconHelper, formHelper, navigationService, contentEditingHelper, notificationsService, $q, localizationService, overlayHelper, contentTypeHelper) {
+    function MemberTypesEditController($scope, $rootScope, $routeParams, $log, $filter, memberTypeResource, dataTypeResource, editorState, iconHelper, formHelper, navigationService, contentEditingHelper, notificationsService, $q, localizationService, overlayHelper, contentTypeHelper, angularHelper, eventsService) {
 
+        var evts = [];
         var vm = this;
 
         vm.save = save;
@@ -304,7 +305,17 @@
 
         }
 
+        evts.push(eventsService.on("editors.groupsBuilder.changed", function(name, args) {
+            angularHelper.getCurrentForm($scope).$setDirty();
+        }));
 
+        //ensure to unregister from all events!
+        $scope.$on('$destroy', function () {
+            console.log("I am unregistering", evts.length)
+            for (var e in evts) {
+                eventsService.unsubscribe(evts[e]);
+            }
+        });
     }
 
     angular.module("umbraco").controller("Umbraco.Editors.MemberTypes.EditController", MemberTypesEditController);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6098

### Description

There is no warning to discard changes if you navigate away from a content type after making changes to its properties (add, remove or edit property).

This applies to both document types, media types and member types.

With this PR applied, the warning shows as you'd expect:

![groups-builder-set-dirty](https://user-images.githubusercontent.com/7405322/62891164-4a646f80-bd45-11e9-9b11-d9aff8edba7e.gif)

#### Testing this PR

Verify for document types, media types and member types that a warning appears when you navigate away after:

- Adding a new property
- Removing an existing property
- Editing an existing property