### PR TITLE
V8: Make sure treepicker URLs are displayed for the current editor culture

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -104,13 +104,18 @@ function entityResource($q, $http, umbRequestHelper) {
          *
          * @param {Int} id Id of node to return the public url to
          * @param {string} type Object type name
+         * @param {string} culture Culture
          * @returns {Promise} resourcePromise object containing the url.
          *
          */
-        getUrl: function (id, type) {
+        getUrl: function (id, type, culture) {
 
             if (id === -1 || id === "-1") {
                 return "";
+            }
+
+            if (!culture) {
+                culture = "";
             }
 
             return umbRequestHelper.resourcePromise(
@@ -118,7 +123,7 @@ function entityResource($q, $http, umbRequestHelper) {
                    umbRequestHelper.getApiUrl(
                        "entityApiBaseUrl",
                        "GetUrl",
-                       [{ id: id }, {type: type }])),
+                       [{ id: id }, {type: type }, {culture: culture }])),
                'Failed to retrieve url for id:' + id);
         },
 

--- a/src/Umbraco.Web/Editors/EntityController.cs
+++ b/src/Umbraco.Web/Editors/EntityController.cs
@@ -211,17 +211,20 @@ namespace Umbraco.Web.Editors
         /// </summary>
         /// <param name="id">Int id of the entity to fetch URL for</param>
         /// <param name="type">The type of entity such as Document, Media, Member</param>
+        /// <param name="culture">The culture to fetch the URL for</param>
         /// <returns>The URL or path to the item</returns>
         /// <remarks>
         /// We are not restricting this with security because there is no sensitive data
         /// </remarks>
-        public HttpResponseMessage GetUrl(int id, UmbracoEntityTypes type)
+        public HttpResponseMessage GetUrl(int id, UmbracoEntityTypes type, string culture = null)
         {
+            culture = culture ?? ClientCulture();
+
             var returnUrl = string.Empty;
 
             if (type == UmbracoEntityTypes.Document)
             {
-                var foundUrl = UmbracoContext.Url(id);
+                var foundUrl = UmbracoContext.Url(id, culture);
                 if (string.IsNullOrEmpty(foundUrl) == false && foundUrl != "#")
                 {
                     returnUrl = foundUrl;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6100

### Description

When selecting content using either a Content Picker or a Multinode Treepicker, the URLs of the picked content are shown for the default culture - not (necessarily) the current editor culture. See #6100 for details.

This PR ensures that the URLs returned by `entityResource.getUrl()` are always for the current editor culture unless it is explicitly overridden in the method. When the PR is applied, URLs are rendered like this:

![treepicker-urls-culture](https://user-images.githubusercontent.com/7405322/62893953-00cb5300-bd4c-11e9-9581-aff3fa97b48f.gif)

#### Testing this PR

For properties of both Content Picker and Multinode Treepicker (configured for picking content), verify that the URLs of the picked items are always rendered in the current editor culture for:

1. Culture variant properties.
2. Culture invariant properties on culture variant content types.
3. Properties on culture invariant content types.
