### PR TITLE
Disable Mini Profiler

### DIFF
--- a/src/Umbraco.Web/Profiling/WebProfilerProvider.cs
+++ b/src/Umbraco.Web/Profiling/WebProfilerProvider.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Web;
+using System.Web.Routing;
 using StackExchange.Profiling;
+using Umbraco.Core.Configuration;
 
 namespace Umbraco.Web.Profiling
 {
@@ -24,6 +27,19 @@ namespace Umbraco.Web.Profiling
         {
             // booting...
             _bootPhase = BootPhase.Boot;
+
+            // Remove Mini Profiler routes when not in debug mode
+            if (GlobalSettings.DebugMode == false)
+            {
+                var prefix = MiniProfiler.Settings.RouteBasePath.Replace("~/", string.Empty);
+
+                using (RouteTable.Routes.GetWriteLock())
+                {
+                    var routes = RouteTable.Routes.Where(x => x is Route r && r.Url.StartsWith(prefix)).ToList();
+                    foreach(var r in routes)
+                        RouteTable.Routes.Remove(r);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Profiling/WebProfilerProvider.cs
+++ b/src/Umbraco.Web/Profiling/WebProfilerProvider.cs
@@ -31,7 +31,8 @@ namespace Umbraco.Web.Profiling
             // Remove Mini Profiler routes when not in debug mode
             if (GlobalSettings.DebugMode == false)
             {
-                var prefix = MiniProfiler.Settings.RouteBasePath.Replace("~/", string.Empty);
+                //NOTE: Keep the global fully qualified name, for some reason without it I was getting null refs
+                var prefix = global::StackExchange.Profiling.MiniProfiler.Settings.RouteBasePath.Replace("~/", string.Empty);
 
                 using (RouteTable.Routes.GetWriteLock())
                 {


### PR DESCRIPTION
Mini Profiler will be disabled when a solution is not in a debug mode, therefore Mini Profiler Startup Profiler won't be accessible.

Fixes: [AB#2178](https://umbraco.visualstudio.com/D-Team%20Tracker/_workitems/edit/2178)