### PR TITLE
v7 Change z-index for notification

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
@@ -1,5 +1,5 @@
 .umb-notifications {
-   z-index: 1000;
+   z-index: 1100;
    position: absolute;
    bottom: 52px;
    left: 0;


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes #6065

As described in issue step to test that:
Steps to reproduce
Create a custom tree in BackOffice.
Add a menu alternative that opens a dialog and trigger either success, error or warning in notificationsService.

Expected result
You can see the full notification, and read the text