### PR TITLE
V8: Don't change parent protection when editing child protection

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -2297,7 +2297,7 @@ namespace Umbraco.Web.Editors
             }
 
             var entry = Services.PublicAccessService.GetEntryForContent(content);
-            if (entry == null)
+            if (entry == null || entry.ProtectedNodeId != content.Id)
             {
                 return Request.CreateResponse(HttpStatusCode.OK);
             }
@@ -2379,7 +2379,7 @@ namespace Umbraco.Web.Editors
 
             var entry = Services.PublicAccessService.GetEntryForContent(content);
 
-            if (entry == null)
+            if (entry == null || entry.ProtectedNodeId != content.Id)
             {
                 entry = new PublicAccessEntry(content, loginPage, errorPage, new List<PublicAccessRule>());
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6057

### Description

This PR updates the public access functionality of V8 so it behaves like V7 when configuring public access for children of a protected parent. See #6057 (specifically https://github.com/umbraco/Umbraco-CMS/issues/6057#issuecomment-520720833) for additional details.

With this PR applied, you no longer change the parent protection by accident when editing the public access settings for a child. Here's a GIF demonstrating it:

![public-access-children](https://user-images.githubusercontent.com/7405322/62970534-07230300-be10-11e9-9c5b-d42940bf7509.gif)

#### Testing this PR

1. Assign protection to a node with multiple children.
2. Assign protection to one of the children; verify that you're tasked with setting public access up all over again, _not_ editing the settings of the protected parent.
3. Once assigned, verify that the protection settings are saved on the child.
4. Verify that the changes to the child protection settings do not affect the parent or any of the other children.