### PR TITLE
V8: Make "reset password" for members work again

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/users/changepassword.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/users/changepassword.directive.js
@@ -17,8 +17,6 @@
       }
       */
 
-      $scope.showReset = false;
-
       //set defaults if they are not available
       if ($scope.config.disableToggle === undefined) {
         $scope.config.disableToggle = false;
@@ -132,7 +130,7 @@
     $scope.showOldPass = function () {
       return $scope.config.hasPassword &&
         !$scope.config.allowManuallyChangingPassword &&
-        !$scope.config.enablePasswordRetrieval && !$scope.showReset;
+        !$scope.config.enablePasswordRetrieval && !$scope.passwordValues.reset;
     };
       
     // TODO: I don't think we need this or the cancel button, this can be up to the editor rendering this directive

--- a/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
@@ -17,8 +17,7 @@
                            id="Checkbox1"
                            name="resetPassword"
                            val-server-field="resetPassword"
-                           no-dirty-check
-                           ng-change="showReset = !showReset" />
+                           no-dirty-check />
                     <span ng-messages="passwordForm.resetPassword.$error" show-validation-on-submit >
                         <span class="help-inline" ng-message="valServerField">{{passwordForm.resetPassword.errorMsg}}</span>
                     </span>
@@ -38,7 +37,7 @@
                     </span>
                 </umb-control-group>
 
-                <umb-control-group alias="password" label="@user_newPassword" ng-if="!showReset" required="true">
+                <umb-control-group alias="password" label="@user_newPassword" ng-if="!passwordValues.reset" required="true">
                     <input type="password" name="password" ng-model="passwordValues.newPassword"
                            class="input-block-level umb-textstring textstring"
                            required
@@ -52,7 +51,7 @@
                     </span>
                 </umb-control-group>
 
-                <umb-control-group alias="confirmpassword" label="@user_confirmNewPassword" ng-if="!showReset" required="true">
+                <umb-control-group alias="confirmpassword" label="@user_confirmNewPassword" ng-if="!passwordValues.reset" required="true">
                     <input type="password" name="confirmpassword" ng-model="passwordValues.confirm"
                            class="input-block-level umb-textstring textstring"
                            val-compare="password"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6099

### Description

See #6099 for details.

The "reset password" checkbox is supposed to let admins reset a member's password without supplying old and new passwords. In 8.1.2 the checkbox does nothing:

![reset-password-before](https://user-images.githubusercontent.com/7405322/62976806-b7e3cf00-be1d-11e9-94ac-c0b2dd639368.gif)

This PR fixes it; when applied, here's how the checkbox works:

![reset-password-after](https://user-images.githubusercontent.com/7405322/62976936-05603c00-be1e-11e9-8849-814534b06595.gif)
