### PR TITLE
Fixes: v8.1 migration from v7 results in an error due to a unique index on cmsContent #5804

### DIFF
--- a/src/Umbraco.Core/Migrations/Expressions/Delete/KeysAndIndexes/DeleteKeysAndIndexesBuilder.cs
+++ b/src/Umbraco.Core/Migrations/Expressions/Delete/KeysAndIndexes/DeleteKeysAndIndexesBuilder.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NPoco;
+using Umbraco.Core;
 using Umbraco.Core.Migrations.Expressions.Common;
 using Umbraco.Core.Persistence.SqlSyntax;
 
@@ -27,31 +29,57 @@ namespace Umbraco.Core.Migrations.Expressions.Delete.KeysAndIndexes
         {
             _context.BuildingExpression = false;
 
+            //get a list of all constraints - this will include all PK, FK and unique constraints
+            var tableConstraints = _context.SqlContext.SqlSyntax.GetConstraintsPerTable(_context.Database).DistinctBy(x => x.Item2).ToList();
+
+            //get a list of defined indexes - this will include all indexes, unique indexes and unique constraint indexes
+            var indexes = _context.SqlContext.SqlSyntax.GetDefinedIndexesDefinitions(_context.Database).DistinctBy(x => x.IndexName).ToList();
+
+            var uniqueConstraintNames = tableConstraints.Where(x => !x.Item2.InvariantStartsWith("PK_") && !x.Item2.InvariantStartsWith("FK_")).Select(x => x.Item2);
+            var indexNames = indexes.Select(x => x.IndexName).ToList();
+
             // drop keys
             if (DeleteLocal || DeleteForeign)
             {
                 // table, constraint
-                var tableKeys = _context.SqlContext.SqlSyntax.GetConstraintsPerTable(_context.Database).DistinctBy(x => x.Item2).ToList();
+                
                 if (DeleteForeign)
                 {
-                    foreach (var key in tableKeys.Where(x => x.Item1 == TableName && x.Item2.StartsWith("FK_")))
+                    //In some cases not all FK's are prefixed with "FK" :/ mostly with old upgraded databases so we need to check if it's either:
+                    // * starts with FK OR
+                    // * doesn't start with PK_ and doesn't exist in the list of indexes
+
+                    foreach (var key in tableConstraints.Where(x => x.Item1 == TableName
+                        && (x.Item2.InvariantStartsWith("FK_") || (!x.Item2.InvariantStartsWith("PK_") && !indexNames.InvariantContains(x.Item2)))))
+                    {
                         Delete.ForeignKey(key.Item2).OnTable(key.Item1).Do();
+                    }
+                        
                 }
                 if (DeleteLocal)
                 {
-                    foreach (var key in tableKeys.Where(x => x.Item1 == TableName && x.Item2.StartsWith("PK_")))
+                    foreach (var key in tableConstraints.Where(x => x.Item1 == TableName && x.Item2.InvariantStartsWith("PK_")))
                         Delete.PrimaryKey(key.Item2).FromTable(key.Item1).Do();
 
-                    // note: we do *not* delete the DEFAULT constraints
+                    // note: we do *not* delete the DEFAULT constraints and if we wanted to we'd have to deal with that in interesting ways
+                    // since SQL server has a specific way to handle that, see SqlServerSyntaxProvider.GetDefaultConstraintsPerColumn
                 }
             }
 
             // drop indexes
             if (DeleteLocal)
-            {
-                var indexes = _context.SqlContext.SqlSyntax.GetDefinedIndexesDefinitions(_context.Database).DistinctBy(x => x.IndexName).ToList();
+            {   
                 foreach (var index in indexes.Where(x => x.TableName == TableName))
-                    Delete.Index(index.IndexName).OnTable(index.TableName).Do();
+                {
+                    //if this is a unique constraint we need to drop the constraint, else drop the index
+                    //to figure this out, the index must be tagged as unique and it must exist in the tableConstraints
+
+                    if (index.IsUnique && uniqueConstraintNames.InvariantContains(index.IndexName))
+                        Delete.UniqueConstraint(index.IndexName).FromTable(index.TableName).Do();
+                    else
+                        Delete.Index(index.IndexName).OnTable(index.TableName).Do();
+                }
+                    
             }
         }
 


### PR DESCRIPTION
Fixes: v8.1 migration from v7 results in an error due to a unique index on cmsContent #5804

A couple of issues:

* The code was trying to drop unique constraints as if they were normal indexes which is not allowed
* Some older DBs have very oddly named things so this deals with oddly named FKs by checking firstly if the name is prefixed with FK, otherwise if its not prefixed with PK and it doesn't exist in our index list, then we can only assume it's an FK

