### PR TITLE
V8: Use an Umbraco confirm dialog when deleting groups

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.controller.js
@@ -2,7 +2,7 @@
     "use strict";
 
     function UserGroupsController($scope, $timeout, $location, $filter, userService, userGroupsResource, 
-        formHelper, localizationService, listViewHelper) {
+        formHelper, localizationService, listViewHelper, overlayService) {
 
         var vm = this;
 
@@ -95,18 +95,26 @@
 
             if(vm.selection.length > 0) {
 
-                localizationService.localize("defaultdialogs_confirmdelete")
-                    .then(function(value) {
-
-                        var confirmResponse = confirm(value);
-
-                        if (confirmResponse === true) {
-                            userGroupsResource.deleteUserGroups(_.pluck(vm.selection, "id")).then(function (data) {
-                                clearSelection();
-                                onInit();
-                            }, angular.noop);
-                        }
-
+                localizationService.localizeMany(["general_delete", "defaultdialogs_confirmdelete", "general_cancel", "contentTypeEditor_yesDelete"])
+                    .then(function (data) {
+                        const overlay = {
+                            title: data[0],
+                            content: data[1] + "?",
+                            closeButtonLabel: data[2],
+                            submitButtonLabel: data[3],
+                            submitButtonStyle: "danger",
+                            close: function () {
+                                overlayService.close();
+                            },
+                            submit: function () {
+                                userGroupsResource.deleteUserGroups(_.pluck(vm.selection, "id")).then(function (data) {
+                                    clearSelection();
+                                    onInit();
+                                }, angular.noop);
+                                overlayService.close();
+                            }
+                        };
+                        overlayService.open(overlay);
                     });
 
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

A default browser confirm modal is still used when deleting user groups:

![image](https://user-images.githubusercontent.com/7405322/63000136-b7c0ef00-be70-11e9-9760-3f3143b03d6c.png)

This PR changes it to use an Umbraco confirm dialog:

![image](https://user-images.githubusercontent.com/7405322/63000183-d4f5bd80-be70-11e9-8f15-bfd330eef0af.png)
