### PR TITLE
Removing legacyAjaxCalls.ValidateUser method

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/umbraco/webservices/legacyAjaxCalls.asmx.cs
+++ b/src/Umbraco.Web/umbraco.presentation/umbraco/webservices/legacyAjaxCalls.asmx.cs
@@ -36,19 +36,7 @@ namespace umbraco.presentation.webservices
     public class legacyAjaxCalls : UmbracoAuthorizedWebService
     {
         private User _currentUser;
-
-        [WebMethod]
-        public bool ValidateUser(string username, string password)
-        {
-            if (ValidateCredentials(username, password))
-            {
-                var u = new BusinessLogic.User(username);
-                BasePage.doLogin(u);
-                return true;
-            }
-            return false;
-        }
-
+       
         /// <summary>
         /// method to accept a string value for the node id. Used for tree's such as python
         /// and xslt since the file names are the node IDs


### PR DESCRIPTION
Removes an old web service endpoint which that can be used to bypass account lockout when validating credentials.

## Workaround

A work around can be put in place to prevent access to this endpoint using an IIS Rewrite rule.

In the Web.config, inside `<rewrite><rules>` tags:

```xml
<rule name="Fail bad requests" patternSyntax="ECMAScript">
  <match url="umbraco/webservices/legacyajaxcalls\.asmx"/>
    <conditions>
      <add input="{QUERY_STRING}" pattern="op=ValidateUser" />
    </conditions>
    <action type="CustomResponse" statusCode="403" statusReason="Forbidden: Access is denied." statusDescription="You do not have permission to view this directory or page." />
</rule>
```

And with the CustomResponse you can put response of your choice.

Any doubts about IIS Rewrite Rules setup -> https://our.umbraco.com/documentation/reference/Routing/IISRewriteRules/