### PR TITLE
V8: Don't reuse previously used content templates when creating new content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -51,7 +51,10 @@ function contentCreateController($scope,
             .search("create", "true")
             /* when we create a new node we want to make sure it uses the same 
             language as what is selected in the tree */
-            .search("cculture", mainCulture);
+            .search("cculture", mainCulture)
+            /* when we create a new node we must make sure that any previously 
+            used blueprint is reset */
+            .search("blueprintId", null);
         close();
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Slightly odd scenario here:

1. Start creating content based on a content template. Don't save.
2. Now create content of another type that does *not* use a content template.
3. The editor still attempts to create content of the other type based on the previously selected content template.

![content-template-reuse-before](https://user-images.githubusercontent.com/7405322/63050234-e5db1900-beda-11e9-9db9-5e4145f692fa.gif)

Similar (and slightly less odd) scenario:

1. Start creating content based on a content template. Don't save.
2. Now create content of the same content type but _not_ based on a content template.
3. The previously selected content template data still lingers in the editor.

![content-template-reuse-before-2](https://user-images.githubusercontent.com/7405322/63050476-829db680-bedb-11e9-92f1-045d14ad1ed5.gif)

This PR fixes both of these scenarios - here's how it works when the PR is applied:

![content-template-reuse-after](https://user-images.githubusercontent.com/7405322/63050506-9812e080-bedb-11e9-9720-61522810cf73.gif)
