### PR TITLE
V8: Handle missing grid values in migration from 7.15

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
@@ -50,10 +50,10 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                         var obj = JsonConvert.DeserializeObject<JObject>(value);
                         var allControls = obj.SelectTokens("$.sections..rows..areas..controls");
 
-                        foreach (var control in allControls.SelectMany(c => c))
+                        foreach (var control in allControls.SelectMany(c => c).OfType<JObject>())
                         {
                             var controlValue = control["value"];
-                            if (controlValue.Type == JTokenType.String)
+                            if (controlValue?.Type == JTokenType.String)
                             {
                                 control["value"] = UpdateMediaUrls(mediaLinkPattern, controlValue.Value<string>());
                             }

--- a/src/Umbraco.Web/PropertyEditors/GridPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyIndexValueFactory.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Web.PropertyEditors
 
                             // TODO: If it's not a string, then it's a json formatted value -
                             // we cannot really index this in a smart way since it could be 'anything'
-                            if (controlVal.Type == JTokenType.String)
+                            if (controlVal?.Type == JTokenType.String)
                             {
                                 var str = controlVal.Value<string>();
                                 str = XmlHelper.CouldItBeXml(str) ? str.StripHtml() : str;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6060

### Description
The `ConvertTinyMceAndGridMediaUrlsToLocalLink` migration and `GridPropertyIndexValueFactory` fail if a grid control has no `value` property, stopping the upgrade.

Testing:
- Modify a grid value in a 7.15 database to include something like

```json
controls:[{
	"value": null,
	"editor": {
		"alias": "rte",
		"view": null
	},
	"styles": null,
	"config": null
}, {
	"editor": {
		"alias": "rte",
		"view": null
	},
	"styles": null,
	"config": null
}]
```

- Upgrade to v8 and confirm that the modified grid value has been indexed in Examine.