### PR TITLE
V8: Don't allow selecting non-element types when composing element types

### DIFF
--- a/src/Umbraco.Core/Services/ContentTypeServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceExtensions.cs
@@ -22,12 +22,14 @@ namespace Umbraco.Core.Services
         /// This is required because in the case of creating/modifying a content type because new property types being added to it are not yet persisted so cannot
         /// be looked up via the db, they need to be passed in.
         /// </param>
+        /// <param name="isElement">Wether the composite content types should be applicable for an element type</param>
         /// <returns></returns>
         internal static ContentTypeAvailableCompositionsResults GetAvailableCompositeContentTypes(this IContentTypeService ctService,
             IContentTypeComposition source,
             IContentTypeComposition[] allContentTypes,
             string[] filterContentTypes = null,
-            string[] filterPropertyTypes = null)
+            string[] filterPropertyTypes = null,
+            bool isElement = false)
         {
             filterContentTypes = filterContentTypes == null
                 ? Array.Empty<string>()
@@ -46,7 +48,7 @@ namespace Umbraco.Core.Services
                     .Select(c => c.Alias)
                     .Union(filterPropertyTypes)
                     .ToArray();
-
+            
             var sourceId = source?.Id ?? 0;
 
             // find out if any content type uses this content type
@@ -64,8 +66,9 @@ namespace Umbraco.Core.Services
                 x => x.Id));
 
             // usable types are those that are top-level
+            // do not allow element types to be composed by non-element types as this will break the model generation in ModelsBuilder
             var usableContentTypes = allContentTypes
-                .Where(x => x.ContentTypeComposition.Any() == false).ToArray();
+                .Where(x => x.ContentTypeComposition.Any() == false && (isElement == false || x.IsElement)).ToArray();
             foreach (var x in usableContentTypes)
                 list.Add(x);
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -256,7 +256,7 @@
             view: "views/common/infiniteeditors/compositions/compositions.html",
             size: "small",
             submit: function() {
-              
+
               // make sure that all tabs has an init property
               if (scope.model.groups.length !== 0) {
                 angular.forEach(scope.model.groups, function(group) {
@@ -339,7 +339,7 @@
         });
         $q.all([
             //get available composite types
-            availableContentTypeResource(scope.model.id, [], propAliasesExisting).then(function (result) {
+            availableContentTypeResource(scope.model.id, [], propAliasesExisting, scope.model.isElement).then(function (result) {
                 setupAvailableContentTypesModel(result); 
             }),
                 //get where used document types

--- a/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
@@ -16,7 +16,7 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter, loca
                 'Failed to retrieve count');
         },
 
-        getAvailableCompositeContentTypes: function (contentTypeId, filterContentTypes, filterPropertyTypes) {
+        getAvailableCompositeContentTypes: function (contentTypeId, filterContentTypes, filterPropertyTypes, isElement) {
             if (!filterContentTypes) {
                 filterContentTypes = [];
             }
@@ -27,7 +27,8 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter, loca
             var query = {
                 contentTypeId: contentTypeId,
                 filterContentTypes: filterContentTypes,
-                filterPropertyTypes: filterPropertyTypes
+                filterPropertyTypes: filterPropertyTypes,
+                isElement: isElement
             };
 
             return umbRequestHelper.resourcePromise(

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -132,7 +132,7 @@ namespace Umbraco.Web.Editors
         [HttpPost]
         public HttpResponseMessage GetAvailableCompositeContentTypes(GetAvailableCompositionsFilter filter)
         {
-            var result = PerformGetAvailableCompositeContentTypes(filter.ContentTypeId, UmbracoObjectTypes.DocumentType, filter.FilterContentTypes, filter.FilterPropertyTypes)
+            var result = PerformGetAvailableCompositeContentTypes(filter.ContentTypeId, UmbracoObjectTypes.DocumentType, filter.FilterContentTypes, filter.FilterPropertyTypes, filter.IsElement)
                 .Select(x => new
                 {
                     contentType = x.Item1,

--- a/src/Umbraco.Web/Editors/ContentTypeControllerBase.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeControllerBase.cs
@@ -53,11 +53,13 @@ namespace Umbraco.Web.Editors
         /// be looked up via the db, they need to be passed in.
         /// </param>
         /// <param name="contentTypeId"></param>
+        /// <param name="isElement">Wether the composite content types should be applicable for an element type</param>
         /// <returns></returns>
         protected IEnumerable<Tuple<EntityBasic, bool>> PerformGetAvailableCompositeContentTypes(int contentTypeId,
             UmbracoObjectTypes type,
             string[] filterContentTypes,
-            string[] filterPropertyTypes)
+            string[] filterPropertyTypes,
+            bool isElement)
         {
             IContentTypeComposition source = null;
 
@@ -98,7 +100,7 @@ namespace Umbraco.Web.Editors
                     throw new ArgumentOutOfRangeException("The entity type was not a content type");
             }
 
-            var availableCompositions = Services.ContentTypeService.GetAvailableCompositeContentTypes(source, allContentTypes, filterContentTypes, filterPropertyTypes);
+            var availableCompositions = Services.ContentTypeService.GetAvailableCompositeContentTypes(source, allContentTypes, filterContentTypes, filterPropertyTypes, isElement);
 
 
 

--- a/src/Umbraco.Web/Editors/MediaTypeController.cs
+++ b/src/Umbraco.Web/Editors/MediaTypeController.cs
@@ -110,7 +110,7 @@ namespace Umbraco.Web.Editors
         [HttpPost]
         public HttpResponseMessage GetAvailableCompositeMediaTypes(GetAvailableCompositionsFilter filter)
         {
-            var result = PerformGetAvailableCompositeContentTypes(filter.ContentTypeId, UmbracoObjectTypes.MediaType, filter.FilterContentTypes, filter.FilterPropertyTypes)
+            var result = PerformGetAvailableCompositeContentTypes(filter.ContentTypeId, UmbracoObjectTypes.MediaType, filter.FilterContentTypes, filter.FilterPropertyTypes, filter.IsElement)
                 .Select(x => new
                 {
                     contentType = x.Item1,

--- a/src/Umbraco.Web/Editors/MemberTypeController.cs
+++ b/src/Umbraco.Web/Editors/MemberTypeController.cs
@@ -89,7 +89,7 @@ namespace Umbraco.Web.Editors
             [FromUri]string[] filterContentTypes,
             [FromUri]string[] filterPropertyTypes)
         {
-            var result = PerformGetAvailableCompositeContentTypes(contentTypeId, UmbracoObjectTypes.MemberType, filterContentTypes, filterPropertyTypes)
+            var result = PerformGetAvailableCompositeContentTypes(contentTypeId, UmbracoObjectTypes.MemberType, filterContentTypes, filterPropertyTypes, false)
                 .Select(x => new
                 {
                     contentType = x.Item1,

--- a/src/Umbraco.Web/Models/ContentEditing/GetAvailableCompositionsFilter.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/GetAvailableCompositionsFilter.cs
@@ -16,5 +16,10 @@
         /// along with any content types that have matching property types that are included in the filtered content types
         /// </summary>
         public string[] FilterContentTypes { get; set; }
+
+        /// <summary>
+        /// Wether the content type is currently marked as an element type
+        /// </summary>
+        public bool IsElement { get; set; }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4863 (in part)

### Description

If you pick a non-element type when composing an element type, ModelsBuilder throws up because the resulting content type cannot be expressed in code:

![element-composition-before](https://user-images.githubusercontent.com/7405322/63164223-0d8bc780-c028-11e9-881e-2f72a8623c14.gif)

This PR filters out any non-element types in the compositions picker when you compose element types:

![element-composition-after](https://user-images.githubusercontent.com/7405322/63164257-28f6d280-c028-11e9-842e-c5107b27749e.gif)

Kudos to @callumbwhyte for raising awareness on this issue (https://twitter.com/callumbwhyte/status/1161956628759007232)

#### Not a complete solution to the problem

This fix is by no means a complete solution to the issue described in #4863. This is only a first step (albeit an important one).

Later on the following should be implemented to improve on things:

1. It should not be possible to turn a non-element type into an element type if it is composed by or inherits non-element types.
2. It should not be possible to turn an element type into a non-element type if it is used as a composition for another element type, or if another element type inherits from it.

