### PR TITLE
Secure svg media files preview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
@@ -1,25 +1,29 @@
 (function () {
     'use strict';
 
-    function MediaNodeInfoDirective($timeout, $location, eventsService, userService, dateHelper) {
+    function MediaNodeInfoDirective($timeout, $location, eventsService, userService, dateHelper, mediaHelper) {
 
         function link(scope, element, attrs, ctrl) {
 
             var evts = [];
-
+            
             function onInit() {
                 // If logged in user has access to the settings section
                 // show the open anchors - if the user doesn't have 
                 // access, contentType is null, see MediaModelMapper
                 scope.allowOpen = scope.node.contentType !== null;
-                
+
                 // get document type details
                 scope.mediaType = scope.node.contentType;
 
                 // set the media link initially
                 setMediaLink();
+
                 // make sure dates are formatted to the user's locale
                 formatDatesToLocal();
+
+                // set media file extension initially
+                setMediaExtension();
             }
 
             function formatDatesToLocal() {
@@ -30,8 +34,12 @@
                 });
             }
 
-            function setMediaLink(){
+            function setMediaLink() {
                 scope.nodeUrl = scope.node.mediaLink;
+            }
+
+            function setMediaExtension() {
+                scope.node.extension = mediaHelper.getFileExtension(scope.nodeUrl);
             }
 
             scope.openMediaType = function (mediaType) {
@@ -40,16 +48,29 @@
                 $location.path(url);
             };
 
+            scope.openSVG = function () {
+                var popup = window.open('', '_blank');
+                var html = '<!DOCTYPE html><body><img src="' + scope.nodeUrl + '"/>' +
+                    '<script>history.pushState(null, null,"' + $location.$$absUrl + '");</script></body>';
+
+                popup.document.open();
+                popup.document.write(html);
+                popup.document.close();
+            }
+
             // watch for content updates - reload content when node is saved, published etc.
-            scope.$watch('node.updateDate', function(newValue, oldValue){
-                if(!newValue) { return; }
-                if(newValue === oldValue) { return; }
+            scope.$watch('node.updateDate', function (newValue, oldValue) {
+                if (!newValue) { return; }
+                if (newValue === oldValue) { return; }
 
                 // Update the media link
                 setMediaLink();
 
                 // Update the create and update dates
                 formatDatesToLocal();
+
+                //Update the media file format
+                setMediaExtension();
             });
 
             //ensure to unregister from all events!

--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
@@ -12,9 +12,15 @@
 
                 <ul ng-if="nodeUrl" class="nav nav-stacked" style="margin-bottom: 0;">
                     <li>
-                        <a href="{{nodeUrl}}" target="_blank">
+                        <ng-conainer ng-if="node.extension != 'svg'">
+                            <a href="{{nodeUrl}}" target="_blank">
+                                <i class="icon icon-window-popin"></i>
+                                <span>{{nodeUrl}}</span>
+                            </a>
+                        </ng-conainer>
+                        <a ng-if="node.extension == 'svg'">
                             <i class="icon icon-window-popin"></i>
-                            <span>{{nodeUrl}}</span>
+                            <span ng-click="openSVG()">{{nodeUrl}}</span>
                         </a>
                     </li>
                 </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
@@ -12,12 +12,12 @@
 
                 <ul ng-if="nodeUrl" class="nav nav-stacked" style="margin-bottom: 0;">
                     <li>
-                        <ng-conainer ng-if="node.extension != 'svg'">
+                        <ng-container ng-if="node.extension != 'svg'">
                             <a href="{{nodeUrl}}" target="_blank">
                                 <i class="icon icon-window-popin"></i>
                                 <span>{{nodeUrl}}</span>
                             </a>
-                        </ng-conainer>
+                        </ng-container>
                         <a ng-if="node.extension == 'svg'">
                             <i class="icon icon-window-popin"></i>
                             <span ng-click="openSVG()">{{nodeUrl}}</span>


### PR DESCRIPTION
Prevent malicious JS content from .svg media files to be running inside of the back office.

Fixes: [AB#2180](https://umbraco.visualstudio.com/D-Team%20Tracker/_workitems/edit/2180)