### PR TITLE
V8: Prevent double click errors when editing compositions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -17,6 +17,7 @@
       scope.sortableOptionsGroup = {};
       scope.sortableOptionsProperty = {};
       scope.sortingButtonKey = "general_reorder";
+      scope.compositionsButtonState = "init";
 
       function activate() {
 
@@ -337,6 +338,7 @@
         })), function(f) {
             return f !== null && f !== undefined;
         });
+        scope.compositionsButtonState = "busy";
         $q.all([
             //get available composite types
             availableContentTypeResource(scope.model.id, [], propAliasesExisting).then(function (result) {
@@ -356,6 +358,7 @@
         ]).then(function() {
             //resolves when both other promises are done, now show it
             editorService.open(scope.compositionsDialogModel);
+            scope.compositionsButtonState = "init";
         });
 
       };

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -14,7 +14,8 @@
                 icon="icon-merge"
                 action="openCompositionsDialog()"
                 size="xs"
-                add-ellipsis="true">
+                add-ellipsis="true"
+                state="compositionsButtonState">
             </umb-button>
 
             <umb-button


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Originally described by @pgregorynz here: https://twitter.com/pgregorynz/status/1161947910050725893

It can take a bit of time from you click the "Compositions..." button until the compositions dialog is shown. But if you click the button again before the dialog is shown, things go very wrong and you're stuck; you need to reload the browser, and thus any unsaved changes are lost:

![compositions-double-click-before](https://user-images.githubusercontent.com/7405322/63229948-8e081f00-c206-11e9-97cf-c13f3c249c17.gif)

Ideally the dialog should be displayed immediately in a loading state when the button is clicked. However that's not at all feasible with the current code structure, so this PR fixes the problem by adding a loading spinner to the button instead:

![compositions-double-click-after](https://user-images.githubusercontent.com/7405322/63230016-8b59f980-c207-11e9-8035-2f591fee92d3.gif)
