### PR TITLE
Improve JS Asset load of TinyMCE Editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/main.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/main.controller.js
@@ -10,7 +10,7 @@
  */
 function MainController($scope, $location, appState, treeService, notificationsService, 
     userService, historyService, updateChecker, navigationService, eventsService, 
-    tmhDynamicLocale, localStorageService, editorService, overlayService) {
+    tmhDynamicLocale, localStorageService, editorService, overlayService, assetsService, tinyMceAssets) {
 
     //the null is important because we do an explicit bool check on this in the view
     $scope.authenticated = null;
@@ -21,6 +21,13 @@ function MainController($scope, $location, appState, treeService, notificationsS
     $scope.search = {};
     $scope.login = {};
     $scope.tabbingActive = false;
+
+    // Load TinyMCE Assets ahead of time in the background for the user
+    // To help woth first load of the RTE
+    tinyMceAssets.forEach(function (tinyJsAsset) {
+        assetsService.loadJs(tinyJsAsset, $scope);
+    });
+
     
     // There are a number of ways to detect when a focus state should be shown when using the tab key and this seems to be the simplest solution. 
     // For more information about this approach, see https://hackernoon.com/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -1,6 +1,6 @@
 angular.module("umbraco")
     .controller("Umbraco.PropertyEditors.RTEController",
-        function ($scope, $q, assetsService, $timeout, tinyMceService, angularHelper) {
+        function ($scope, $q, assetsService, $timeout, tinyMceService, angularHelper, tinyMceAssets) {
 
             // TODO: A lot of the code below should be shared between the grid rte and the normal rte
 
@@ -30,9 +30,9 @@ angular.module("umbraco")
             var promises = [];
 
             //queue file loading
-            if (typeof tinymce === "undefined") { // Don't reload tinymce if already loaded
-                promises.push(assetsService.loadJs("lib/tinymce/tinymce.min.js", $scope));
-            }
+            tinyMceAssets.forEach(function (tinyJsAsset) {
+                promises.push(assetsService.loadJs(tinyJsAsset, $scope));
+            });
 
             //stores a reference to the editor
             var tinyMceEditor = null;

--- a/src/Umbraco.Web.UI.Client/test/unit/app/propertyeditors/rte-controller.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/app/propertyeditors/rte-controller.spec.js
@@ -1,7 +1,9 @@
 describe('RTE controller tests', function () {
     var scope, controllerFactory;
     
-    beforeEach(module('umbraco'));
+    beforeEach(module('umbraco', function ($provide) {
+        $provide.value('tinyMceAssets', []);
+    }));
 
     beforeEach(inject(function ($rootScope, $controller) {
         controllerFactory = $controller;
@@ -21,3 +23,4 @@ describe('RTE controller tests', function () {
         
     });
 });
+

--- a/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
@@ -128,7 +128,6 @@
 
     <script src="lib/lazyload-js/lazyload.min.js"></script>
     <script src="@Url.GetUrlWithCacheBust("Application", "BackOffice")"></script>
-    <script src="@Url.Action("TinyMceEditor", "BackOffice")" async defer></script>
 
     @if (isDebug)
     {

--- a/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
@@ -119,6 +119,8 @@
         document.angularReady = function(app) {
             @Html.AngularValueExternalLoginInfoScript(ViewData.GetExternalSignInError())
             @Html.AngularValueResetPasswordCodeInfoScript(ViewData["PasswordResetCode"])
+            @Html.AngularValueTinyMceAssets()
+
             //required for the noscript trick
             document.getElementById("mainwrapper").style.display = "inherit";
         }
@@ -126,6 +128,7 @@
 
     <script src="lib/lazyload-js/lazyload.min.js"></script>
     <script src="@Url.GetUrlWithCacheBust("Application", "BackOffice")"></script>
+    <script src="@Url.Action("TinyMceEditor", "BackOffice")" async defer></script>
 
     @if (isDebug)
     {

--- a/src/Umbraco.Web.UI/Umbraco/js/main.controller.js
+++ b/src/Umbraco.Web.UI/Umbraco/js/main.controller.js
@@ -10,7 +10,7 @@
  */
 function MainController($scope, $location, appState, treeService, notificationsService, 
     userService, historyService, updateChecker, navigationService, eventsService, 
-    tmhDynamicLocale, localStorageService, editorService, overlayService) {
+    tmhDynamicLocale, localStorageService, editorService, overlayService, assetsService, tinyMceAssets) {
 
     //the null is important because we do an explicit bool check on this in the view
     $scope.authenticated = null;
@@ -21,6 +21,13 @@ function MainController($scope, $location, appState, treeService, notificationsS
     $scope.search = {};
     $scope.login = {};
     $scope.tabbingActive = false;
+
+    // Load TinyMCE Assets ahead of time in the background for the user
+    // To help woth first load of the RTE
+    tinyMceAssets.forEach(function (tinyJsAsset) {
+        assetsService.loadJs(tinyJsAsset, $scope);
+    });
+
     
     // There are a number of ways to detect when a focus state should be shown when using the tab key and this seems to be the simplest solution. 
     // For more information about this approach, see https://hackernoon.com/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -211,28 +211,6 @@ namespace Umbraco.Web.Editors
             return JavaScript(result);
         }
 
-        [MinifyJavaScriptResult(Order = 0)]
-        [OutputCache(Order = 1, VaryByParam = "none", Location = OutputCacheLocation.Server, Duration = 5000)]
-        public JavaScriptResult TinyMceEditor()
-        {
-            var files = JsInitialization.OptimizeTinyMceScriptFiles(HttpContext);
-
-            var rawJS = new StringBuilder();
-            rawJS.AppendLine("LazyLoad.js([");
-            var first = true;
-            foreach (var file in files)
-            {
-                if (first) first = false;
-                else rawJS.AppendLine(",");
-                rawJS.Append("\"");
-                rawJS.Append(file);
-                rawJS.Append("\"");
-
-            }
-            rawJS.Append("]);");
-            return JavaScript(rawJS.ToString());
-        }
-
         /// <summary>
         /// Returns a js array of all of the manifest assets
         /// </summary>

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -28,6 +28,7 @@ using Umbraco.Web.JavaScript;
 using Umbraco.Web.Security;
 using Constants = Umbraco.Core.Constants;
 using JArray = Newtonsoft.Json.Linq.JArray;
+using System.Text;
 
 namespace Umbraco.Web.Editors
 {
@@ -208,6 +209,28 @@ namespace Umbraco.Web.Editors
             result += initCss.GetStylesheetInitialization(HttpContext);
 
             return JavaScript(result);
+        }
+
+        [MinifyJavaScriptResult(Order = 0)]
+        [OutputCache(Order = 1, VaryByParam = "none", Location = OutputCacheLocation.Server, Duration = 5000)]
+        public JavaScriptResult TinyMceEditor()
+        {
+            var files = JsInitialization.OptimizeTinyMceScriptFiles(HttpContext);
+
+            var rawJS = new StringBuilder();
+            rawJS.AppendLine("LazyLoad.js([");
+            var first = true;
+            foreach (var file in files)
+            {
+                if (first) first = false;
+                else rawJS.AppendLine(",");
+                rawJS.Append("\"");
+                rawJS.Append(file);
+                rawJS.Append("\"");
+
+            }
+            rawJS.Append("]);");
+            return JavaScript(rawJS.ToString());
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -28,7 +28,6 @@ using Umbraco.Web.JavaScript;
 using Umbraco.Web.Security;
 using Constants = Umbraco.Core.Constants;
 using JArray = Newtonsoft.Json.Linq.JArray;
-using System.Text;
 
 namespace Umbraco.Web.Editors
 {

--- a/src/Umbraco.Web/HtmlHelperBackOfficeExtensions.cs
+++ b/src/Umbraco.Web/HtmlHelperBackOfficeExtensions.cs
@@ -13,6 +13,7 @@ using Umbraco.Web.Models;
 namespace Umbraco.Web
 {
     using Core.Configuration;
+    using Umbraco.Web.JavaScript;
 
     /// <summary>
     /// HtmlHelper extensions for the back office
@@ -117,6 +118,21 @@ namespace Umbraco.Web
             sb.Append(@"resetCodeModel: ");
             sb.AppendLine(JsonConvert.SerializeObject(resetCodeModel));
             sb.AppendLine(@"});");
+
+            return html.Raw(sb.ToString());
+        }
+
+        public static IHtmlString AngularValueTinyMceAssets(this HtmlHelper html)
+        {
+            var ctx = new HttpContextWrapper(HttpContext.Current);
+            var files = JsInitialization.OptimizeTinyMceScriptFiles(ctx);
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine(@"app.value(""tinyMceAssets"",");
+            sb.AppendLine(JsonConvert.SerializeObject(files));
+            sb.AppendLine(@");");
+
 
             return html.Raw(sb.ToString());
         }

--- a/src/Umbraco.Web/JavaScript/JsInitialization.cs
+++ b/src/Umbraco.Web/JavaScript/JsInitialization.cs
@@ -60,6 +60,26 @@ namespace Umbraco.Web.JavaScript
             return WriteScript(jarray.ToString(), IOHelper.ResolveUrl(SystemDirectories.Umbraco), angularModule);
         }
 
+        public static string GetTinyJavascriptInitialization(HttpContextBase httpContext, IEnumerable<string> scripts)
+        {
+            var rawJs = new StringBuilder();
+            rawJs.AppendLine("LazyLoad.js([");
+
+            var first = true;
+            foreach (var file in scripts)
+            {
+                if (first) first = false;
+                else rawJs.AppendLine(",");
+                rawJs.Append("\"");
+                rawJs.Append(file);
+                rawJs.Append("\"");
+
+            }
+            rawJs.Append("]);");
+
+            return rawJs.ToString();
+        }
+
         /// <summary>
         /// Returns a list of optimized script paths for the back office
         /// </summary>
@@ -129,6 +149,17 @@ namespace Umbraco.Web.JavaScript
         {
             var resources = JsonConvert.DeserializeObject<JArray>(Resources.PreviewInitialize);
             return resources.Where(x => x.Type == JTokenType.String).Select(x => x.ToString());
+        }
+
+        internal static IEnumerable<string> GetTinyMceInitialization()
+        {
+            var resources = JsonConvert.DeserializeObject<JArray>(Resources.TinyMceInitialize);
+            return resources.Where(x => x.Type == JTokenType.String).Select(x => x.ToString());
+        }
+
+        internal static IEnumerable<string> OptimizeTinyMceScriptFiles(HttpContextBase httpContext)
+        {
+            return OptimizeScriptFiles(httpContext, GetTinyMceInitialization());
         }
 
         /// <summary>

--- a/src/Umbraco.Web/JavaScript/JsInitialization.cs
+++ b/src/Umbraco.Web/JavaScript/JsInitialization.cs
@@ -60,26 +60,6 @@ namespace Umbraco.Web.JavaScript
             return WriteScript(jarray.ToString(), IOHelper.ResolveUrl(SystemDirectories.Umbraco), angularModule);
         }
 
-        public static string GetTinyJavascriptInitialization(HttpContextBase httpContext, IEnumerable<string> scripts)
-        {
-            var rawJs = new StringBuilder();
-            rawJs.AppendLine("LazyLoad.js([");
-
-            var first = true;
-            foreach (var file in scripts)
-            {
-                if (first) first = false;
-                else rawJs.AppendLine(",");
-                rawJs.Append("\"");
-                rawJs.Append(file);
-                rawJs.Append("\"");
-
-            }
-            rawJs.Append("]);");
-
-            return rawJs.ToString();
-        }
-
         /// <summary>
         /// Returns a list of optimized script paths for the back office
         /// </summary>

--- a/src/Umbraco.Web/JavaScript/Resources.Designer.cs
+++ b/src/Umbraco.Web/JavaScript/Resources.Designer.cs
@@ -146,5 +146,17 @@ namespace Umbraco.Web.JavaScript {
                 return ResourceManager.GetString("ServerVariables", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [
+        ///    &apos;../lib/tinymce/tinymce.min.js&apos;,
+        ///]
+        ///.
+        /// </summary>
+        internal static string TinyMceInitialize {
+            get {
+                return ResourceManager.GetString("TinyMceInitialize", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Umbraco.Web/JavaScript/Resources.resx
+++ b/src/Umbraco.Web/JavaScript/Resources.resx
@@ -130,4 +130,7 @@
   <data name="ServerVariables" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>servervariables.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="TinyMceInitialize" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>TinyMceInitialize.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/src/Umbraco.Web/JavaScript/TinyMceInitialize.js
+++ b/src/Umbraco.Web/JavaScript/TinyMceInitialize.js
@@ -1,8 +1,6 @@
 ﻿[
     'lib/tinymce/tinymce.min.js',
 
-    'lib/tinymce/langs/en_us.js',
-
     'lib/tinymce/plugins/paste/plugin.min.js',
     'lib/tinymce/plugins/anchor/plugin.min.js',
     'lib/tinymce/plugins/charmap/plugin.min.js',

--- a/src/Umbraco.Web/JavaScript/TinyMceInitialize.js
+++ b/src/Umbraco.Web/JavaScript/TinyMceInitialize.js
@@ -1,0 +1,19 @@
+﻿[
+    'lib/tinymce/tinymce.min.js',
+
+    'lib/tinymce/langs/en_us.js',
+
+    'lib/tinymce/plugins/paste/plugin.min.js',
+    'lib/tinymce/plugins/anchor/plugin.min.js',
+    'lib/tinymce/plugins/charmap/plugin.min.js',
+    'lib/tinymce/plugins/table/plugin.min.js',
+    'lib/tinymce/plugins/lists/plugin.min.js',
+    'lib/tinymce/plugins/advlist/plugin.min.js',
+    'lib/tinymce/plugins/hr/plugin.min.js',
+    'lib/tinymce/plugins/autolink/plugin.min.js',
+    'lib/tinymce/plugins/directionality/plugin.min.js',
+    'lib/tinymce/plugins/tabfocus/plugin.min.js',
+    'lib/tinymce/plugins/searchreplace/plugin.min.js',
+    'lib/tinymce/plugins/fullscreen/plugin.min.js',
+    'lib/tinymce/plugins/noneditable/plugin.min.js'
+]

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -1205,6 +1205,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="JavaScript\PreviewInitialize.js" />
+    <None Include="JavaScript\TinyMceInitialize.js" />
     <!--<Content Include="umbraco.presentation\umbraco\users\PermissionEditor.aspx" />-->
     <Content Include="PublishedCache\NuCache\notes.txt" />
   </ItemGroup>


### PR DESCRIPTION
Adds TinyMCE JS assets into init page load via script in default.cshtml view for Umbraco backoffice ng-app

* Add TinyMCE JS assets array via NG app.value & uses assetsService to load (if not loaded in time by main init script above)

Fixes [AB#2196](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/2196)