### PR TITLE
Fix #5335 - Multiple Media Picker not available as macro parameter

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -97,6 +97,11 @@ namespace Umbraco.Core
                 public const string MediaPicker = "Umbraco.MediaPicker";
 
                 /// <summary>
+                /// Multiple Media Picker.
+                /// </summary>
+                public const string MultipleMediaPicker = "Umbraco.MultipleMediaPicker";
+
+                /// <summary>
                 /// Member Picker.
                 /// </summary>
                 public const string MemberPicker = "Umbraco.MemberPicker";

--- a/src/Umbraco.Tests/Composing/TypeLoaderTests.cs
+++ b/src/Umbraco.Tests/Composing/TypeLoaderTests.cs
@@ -268,7 +268,7 @@ AnotherContentFinder
         public void GetDataEditors()
         {
             var types = _typeLoader.GetDataEditors();
-            Assert.AreEqual(38, types.Count());
+            Assert.AreEqual(39, types.Count());
         }
 
         /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultipleMediaPickerParameterEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultipleMediaPickerParameterEditor.cs
@@ -1,0 +1,27 @@
+﻿using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Web.PropertyEditors.ParameterEditors
+{
+    /// <summary>
+    /// Represents a multiple media picker macro parameter editor.
+    /// </summary>
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.MultipleMediaPicker,
+        EditorType.MacroParameter,
+        "Multiple Media Picker",
+        "mediapicker",
+        ValueType = ValueTypes.Text)]
+    public class MultipleMediaPickerParameterEditor : DataEditor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultipleMediaPickerParameterEditor"/> class.
+        /// </summary>
+        public MultipleMediaPickerParameterEditor(ILogger logger)
+            : base(logger)
+        {
+            DefaultConfiguration.Add("multiPicker", "1");
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Mvc\SurfaceControllerTypeCollectionBuilder.cs" />
     <Compile Include="Mvc\ValidateUmbracoFormRouteStringAttribute.cs" />
     <Compile Include="Profiling\WebProfilingController.cs" />
+    <Compile Include="PropertyEditors\ParameterEditors\MultipleMediaPickerParameterEditor.cs" />
     <Compile Include="PublishedCache\NuCache\PublishedSnapshotServiceOptions.cs" />
     <Compile Include="PublishedCache\NuCache\Snap\GenObj.cs" />
     <Compile Include="PublishedCache\NuCache\Snap\GenRef.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5335

### Description

Seemingly due to an oversight, multiple media picker was not available for macro parameters. This corrects that problem. 

Test steps:

- Add a Partial View Macro File from snippet "Gallery"
- Go to the macro this has created and enable it to be used in a RTE
- Go to the macro parameters and add a new parameter with the name "Media Picker", the alias `mediaIds` and of type "Multiple Media Picker"
- Add the "Gallery" macro in a RTE
- You get asked to pick one or more items, make sure you can pick multiple items
- When you're done picking, the macro preview should show you the picked items


