### PR TITLE
Fix #6148 - added data element to NestedContent - V7

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.editor.html
@@ -1,7 +1,7 @@
 ﻿<div class="umb-pane">
   <div ng-repeat="property in tab.properties" style="position: relative;">
 
-    <umb-property property="property" ng-class="{'umb-nested-content--not-supported': property.notSupported}" data-element="{{property.alias}}">
+    <umb-property property="property" ng-class="{'umb-nested-content--not-supported': property.notSupported}" data-element="property-{{property.alias}}">
       <umb-editor model="property"></umb-editor>
     </umb-property>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.editor.html
@@ -1,7 +1,7 @@
 ﻿<div class="umb-pane">
   <div ng-repeat="property in tab.properties" style="position: relative;">
 
-    <umb-property property="property" ng-class="{'umb-nested-content--not-supported': property.notSupported}">
+    <umb-property property="property" ng-class="{'umb-nested-content--not-supported': property.notSupported}" data-element="{{property.alias}}">
       <umb-editor model="property"></umb-editor>
     </umb-property>
 


### PR DESCRIPTION
Related issue: [#6148 ](https://github.com/umbraco/Umbraco-CMS/issues/6148)

NestedContent items are missing a data-attribute that is added to property editors by default.

I added that data-attribute (data-property), tested it and everything works just the way it should work.

Here's a screenshot of the NestedContent item with the data-attribute added to it:

![nc-not-missing-attribute](https://user-images.githubusercontent.com/2563119/63273614-d4ed2780-c28d-11e9-9808-2057ea57aa72.jpg)


