### PR TITLE
V8: Restored indication of unpublished content in content picker display

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
@@ -46,10 +46,19 @@ namespace Umbraco.Web.Models.Mapping
                 target.Icon = Constants.Icons.Member;
 
             if (source is IContentEntitySlim contentSlim)
+            {
                 source.AdditionalData["ContentTypeAlias"] = contentSlim.ContentTypeAlias;
+            }
+
+            if (source is IDocumentEntitySlim documentSlim)
+            {
+                source.AdditionalData["IsPublished"] = documentSlim.Published;
+            }
 
             if (source is IMediaEntitySlim mediaSlim)
+            {
                 source.AdditionalData["MediaPath"] = mediaSlim.MediaPath;
+            }
 
             // NOTE: we're mapping the objects in AdditionalData by object reference here.
             // it works fine for now, but it's something to keep in mind in the future


### PR DESCRIPTION
Fixes #6143.

Without this additional field, the greyed out display you see below on the second item isn't seen, so you can't distinguish published and unpublished items.

![image](https://user-images.githubusercontent.com/1993459/63273978-471a3800-c29f-11e9-81ce-751d9df841f2.png)
