### PR TITLE
Fix #6148 - Added data-property attribute to NestedContent Items for v8

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.editor.html
@@ -1,7 +1,7 @@
 ﻿<div class="umb-pane">
   <div ng-repeat="property in tab.properties" class="umb-nested-content-property-container">
 
-    <umb-property property="property" ng-class="{'umb-nested-content--not-supported': property.notSupported}">
+    <umb-property property="property" ng-class="{'umb-nested-content--not-supported': property.notSupported}" data-element="property-{{property.alias}}">
       <umb-property-editor model="property"></umb-property-editor>
     </umb-property>
 


### PR DESCRIPTION
Related issue - [#6148](https://github.com/umbraco/Umbraco-CMS/issues/6148) - That is for v7, this is for v8.

Same as [PR #6150](https://github.com/umbraco/Umbraco-CMS/pull/6150) except this is for v8.