### PR TITLE
V8: Allow plugin "Lang" folders to reside in nested directories

### DIFF
--- a/src/Umbraco.Core/Composing/CompositionExtensions/Services.cs
+++ b/src/Umbraco.Core/Composing/CompositionExtensions/Services.cs
@@ -96,7 +96,7 @@ namespace Umbraco.Core.Composing.CompositionExtensions
             var pluginLangFolders = appPlugins.Exists == false
                 ? Enumerable.Empty<LocalizedTextServiceSupplementaryFileSource>()
                 : appPlugins.GetDirectories()
-                    .SelectMany(x => x.GetDirectories("Lang"))
+                    .SelectMany(x => x.GetDirectories("Lang", SearchOption.AllDirectories))
                     .SelectMany(x => x.GetFiles("*.xml", SearchOption.TopDirectoryOnly))
                     .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, false));
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6097

### Description

This PR allows plugins to place their localization files anywhere in the plugin folder sub structure, as long as they reside within a folder called `Lang`.

To test this PR:

1. Unzip the attached plugin in `App_Plugins`
2. Log in with a user in `en-US` backoffice locale
3. Verify that the "Language test dashboard" is localized correctly. It'll use the localization files in `~/App_Plugins/LanguageTest/Some/Another/Lang/`, and it should look something like this:
![image](https://user-images.githubusercontent.com/7405322/63333745-379bfd00-c33a-11e9-96e0-67ad97ba50e5.png)

The test plugin is here: 
[LanguageTest.zip](https://github.com/umbraco/Umbraco-CMS/files/3519659/LanguageTest.zip)




