### PR TITLE
Improve error messages

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -757,11 +757,11 @@ namespace Umbraco.Core.Services.Implement
         {
             var publishedState = content.PublishedState;
             if (publishedState != PublishedState.Published && publishedState != PublishedState.Unpublished)
-                throw new InvalidOperationException("Cannot save (un)publishing content, use the dedicated SavePublished method.");
+                throw new InvalidOperationException($"Cannot save (un)publishing content with name: {content.Name} - and state: {content.PublishedState}, use the dedicated SavePublished method.");
 
             if (content.Name != null && content.Name.Length > 255)
             {
-                throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
+                throw new InvalidOperationException($"Content with the name "{content.Name}" cannot be more than 255 characters in length.");
             }
 
             var evtMsgs = EventMessagesFactory.Get();

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -761,7 +761,7 @@ namespace Umbraco.Core.Services.Implement
 
             if (content.Name != null && content.Name.Length > 255)
             {
-                throw new InvalidOperationException($"Content with the name "{content.Name}" cannot be more than 255 characters in length.");
+                throw new InvalidOperationException($"Content with the name {content.Name} cannot be more than 255 characters in length.");
             }
 
             var evtMsgs = EventMessagesFactory.Get();


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
When debugging deployments I ran into this error message, and I had to attach the Umbraco Core code to figure out which node had an issue being saved. 

Would be awesome to have more info on which specific content item it is that is failing for when you are looping through this call.

Not entirely sure how the site got into an error state where the content service couldn't save a node, so not sure on the steps to reproduce to get this error message. All this PR does is improve a bit on info in errors though.

<!-- Thanks for contributing to Umbraco CMS! -->
