### PR TITLE
Remove comparison in ApplicationUrlHelper.GetApplicationUrlFromCurrentRequest that is always false

### DIFF
--- a/src/Umbraco.Core/Sync/ApplicationUrlHelper.cs
+++ b/src/Umbraco.Core/Sync/ApplicationUrlHelper.cs
@@ -97,8 +97,7 @@ namespace Umbraco.Core.Sync
                 ? ":" + request.ServerVariables["SERVER_PORT"]
                 : "";
 
-            var useSsl = globalSettings.UseHttps || port == "443";
-            var ssl = useSsl ? "s" : ""; // force, whatever the first request
+            var ssl = globalSettings.UseHttps ? "s" : ""; // force, whatever the first request
             var url = "http" + ssl + "://" + request.ServerVariables["SERVER_NAME"] + port + IOHelper.ResolveUrl(SystemDirectories.Umbraco);
 
             return url.TrimEnd('/');


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

**Note**: I've left the above unchecked, I do not believe a new test is appropriate for this change

### Description

When deciding whether to use SSL, ApplicationUrlHelper.GetApplicationUrlFromCurrentRequest() has an expression `port == "443"` which is always `false`. The variable `port` is set to to either `""` or `":" + request.ServerVariables["SERVER_PORT"]`, so it might sometimes be ":443" but it will _never_ be just "443". 

This code has been this way for at least a year, and I don't know if the situation it tried to handle makes any sense (using port 443 over plain HTTP, for some reason??) so I've just removed it. 