### PR TITLE
Added track by $index to ng-repeats for listing blueprints

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/create.html
@@ -42,7 +42,7 @@
             </ul>
             <ul class="umb-actions umb-actions-child" ng-if="selectBlueprint">
 
-                <li class="umb-action" ng-repeat="blueprint in selectableBlueprints | orderBy:'name':false">
+                <li class="umb-action" ng-repeat="blueprint in selectableBlueprints | orderBy:'name':false track by $index">
                     <button class="umb-action-link umb-outline btn-reset" ng-click="createFromBlueprint(blueprint.id)">
                         <i class="large icon {{docType.icon}}"></i>
                         <span class="menu-label">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -27,7 +27,7 @@
                        </a>
 
                        <umb-dropdown ng-if="page.createDropdownOpen" on-close="page.createDropdownOpen = false">
-                           <umb-dropdown-item ng-repeat="blueprint in listViewAllowedTypes[0].blueprints | orderBy:'name':false">
+                           <umb-dropdown-item ng-repeat="blueprint in listViewAllowedTypes[0].blueprints | orderBy:'name':false track by $index">
                                <a ng-click="createFromBlueprint(entityType, listViewAllowedTypes[0].alias, blueprint.id)">
                                    <i class="{{::listViewAllowedTypes[0].icon}}"></i>
                                    {{::blueprint.name}}


### PR DESCRIPTION
Fix for https://github.com/umbraco/Umbraco-CMS/issues/6155 
Adds tracking by index to ng-repeat when listing available blueprints.


