### PR TITLE
V8: Don't crash the Multi URL Picker if only an anchor has been entered

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -93,7 +93,7 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
                     });
 
                 }
-            } else if ($scope.model.target.url.length) {
+            } else if ($scope.model.target.url && $scope.model.target.url.length) {
                 // a url but no id/udi indicates an external link - trim the url to remove the anchor/qs
                 // only do the substring if there's a # or a ?
                 var indexOfAnchor = $scope.model.target.url.search(/(#|\?)/);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6172

### Description

If you add a link with only an anchor or a query string value in a Multi URL Picker property and then go to edit the link again *without saving the content first*, the Multi URL Picker editor crashes with a JS error:

![url-picker-anchor-only-before](https://user-images.githubusercontent.com/7405322/63540847-2fe87e00-c51d-11e9-9a09-beebf097bcd1.gif)

This PR fixes it:

![url-picker-anchor-only-after](https://user-images.githubusercontent.com/7405322/63540856-370f8c00-c51d-11e9-98dc-ad2ae6e82547.gif)
