### PR TITLE
V8: Include sort and filter in list view back link

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -62,11 +62,13 @@
         function init() {
 
             var content = $scope.content;
-
             if (content.id && content.isChildOfListView && content.trashed === false) {
-                $scope.page.listViewPath = ($routeParams.page) ?
-                    "/content/content/edit/" + content.parentId + "?page=" + $routeParams.page :
-                    "/content/content/edit/" + content.parentId;
+                $scope.page.listViewPath = "/content/content/edit/" + content.parentId
+                    + "?list=" + $routeParams.list
+                    + "&page=" + $routeParams.page 
+                    + "&filter=" + $routeParams.filter
+                    + "&orderBy=" + $routeParams.orderBy
+                    + "&orderDirection=" + $routeParams.orderDirection;
             }
 
             // we need to check wether an app is present in the current data, if not we will present the default app.

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -44,7 +44,9 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
             return selected.id;
         };
         createEditUrlCallback = function (item) {
-            return "/" + $scope.entityType + "/" + $scope.entityType + "/edit/" + item.id + "?page=" + $scope.options.pageNumber;
+            return "/" + $scope.entityType + "/" + $scope.entityType + "/edit/" + item.id 
+                + "?list=" + $routeParams.id + "&page=" + $scope.options.pageNumber + "&filter=" + $scope.options.filter 
+                + "&orderBy=" + $scope.options.orderBy + "&orderDirection=" + $scope.options.orderDirection;
         };
     }
 
@@ -141,12 +143,13 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
 
     }
 
+    var listParamsForCurrent = $routeParams.id == $routeParams.list;
     $scope.options = {
         pageSize: $scope.model.config.pageSize ? $scope.model.config.pageSize : 10,
-        pageNumber: ($routeParams.page && Number($routeParams.page) != NaN && Number($routeParams.page) > 0) ? $routeParams.page : 1,
-        filter: '',
-        orderBy: ($scope.model.config.orderBy ? $scope.model.config.orderBy : 'VersionDate').trim(),
-        orderDirection: $scope.model.config.orderDirection ? $scope.model.config.orderDirection.trim() : "desc",
+        pageNumber: (listParamsForCurrent && $routeParams.page && Number($routeParams.page) != NaN && Number($routeParams.page) > 0) ? $routeParams.page : 1,
+        filter: (listParamsForCurrent && $routeParams.filter ? $routeParams.filter : '').trim(),
+        orderBy: (listParamsForCurrent && $routeParams.orderBy ? $routeParams.orderBy : $scope.model.config.orderBy ? $scope.model.config.orderBy : 'VersionDate').trim(),
+        orderDirection: (listParamsForCurrent && $routeParams.orderDirection ? $routeParams.orderDirection : $scope.model.config.orderDirection ? $scope.model.config.orderDirection : "desc").trim(),
         orderBySystemField: true,
         includeProperties: $scope.model.config.includeProperties ? $scope.model.config.includeProperties : [
             { alias: 'updateDate', header: 'Last edited', isSystem: 1 },


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6175 and #6176 

### Description

Sort and filter (search) state is not applied when going back to a list view from a list view item. See #6175 and #6176 for details on the issue.

When this PR is applied, sorting and filtering will be re-applied when the editor goes back to the list view:

![list-view-sort-filter-after](https://user-images.githubusercontent.com/7405322/63641392-d5caf280-c6ad-11e9-8a52-47553a7a0df6.gif)

While fixing this I uncovered another issue which this PR also implicitly handles. When you navigate to a child of a list view, and said child also is list view enabled, the pagination of the parent list view is applied to the child list view:

![list-view-pagination-inheritance-before](https://user-images.githubusercontent.com/7405322/63641419-42de8800-c6ae-11e9-9942-096d71845256.gif)

Here's the same operation with this PR applied:

![list-view-pagination-inheritance-after](https://user-images.githubusercontent.com/7405322/63641427-6acdeb80-c6ae-11e9-88c9-b36100dd9109.gif)

#### Testing notes

When testing multiple levels of list views, remember that the "Back to list view" functionality only remembers the state of the parent. If you work your way downwards in a structure using list views, the current parent list view state will always overwrite the previous one. This may be a bug but it's definitively beyond the scope of this PR to fix it 😄 
