### PR TITLE
V8: Make sure the empty search result is visible for list views

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -5,7 +5,6 @@
 // --------------------------------------------------
 .umb-property-editor {
     width: 100%;
-    position:relative;
 }
 
 .umb-property-editor-tiny {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If no results are found when searching for items in list views, the label that should tell you so is rather hidden behind the sticky header bar:

![image](https://user-images.githubusercontent.com/7405322/63649335-91d2fe80-c73c-11e9-82a7-994f689a7f35.png)

With this PR applied, the label displays as expected:

![image](https://user-images.githubusercontent.com/7405322/63649320-71a33f80-c73c-11e9-8def-739fe4f19799.png)

The offending line of CSS was added in d17022d8 to solve something sticky header bar related. However, I haven't been able to find any sticky header bar related issues when removing the CSS, neither in the grid nor in list views.

