### PR TITLE
V8: Speed up content migration

### DIFF
--- a/src/Umbraco.Core/Migrations/MigrationBase_Extra.cs
+++ b/src/Umbraco.Core/Migrations/MigrationBase_Extra.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.SqlSyntax;
 
@@ -84,10 +85,17 @@ namespace Umbraco.Core.Migrations
 
         protected void ReplaceColumn<T>(string tableName, string currentName, string newName)
         {
-            AddColumn<T>(tableName, newName, out var sqls);
-            Execute.Sql($"UPDATE {SqlSyntax.GetQuotedTableName(tableName)} SET {SqlSyntax.GetQuotedColumnName(newName)}={SqlSyntax.GetQuotedColumnName(currentName)}").Do();
-            foreach (var sql in sqls) Execute.Sql(sql).Do();
-            Delete.Column(currentName).FromTable(tableName).Do();
+            if (DatabaseType.IsSqlCe())
+            {
+                AddColumn<T>(tableName, newName, out var sqls);
+                Execute.Sql($"UPDATE {SqlSyntax.GetQuotedTableName(tableName)} SET {SqlSyntax.GetQuotedColumnName(newName)}={SqlSyntax.GetQuotedColumnName(currentName)}").Do();
+                foreach (var sql in sqls) Execute.Sql(sql).Do();
+                Delete.Column(currentName).FromTable(tableName).Do();
+            }
+            else
+            {
+                Execute.Sql(SqlSyntax.FormatColumnRename(tableName, currentName, newName)).Do();
+            }
         }
 
         protected bool TableExists(string tableName)

--- a/src/Umbraco.Core/Migrations/MigrationBase_Extra.cs
+++ b/src/Umbraco.Core/Migrations/MigrationBase_Extra.cs
@@ -95,6 +95,7 @@ namespace Umbraco.Core.Migrations
             else
             {
                 Execute.Sql(SqlSyntax.FormatColumnRename(tableName, currentName, newName)).Do();
+                AlterColumn<T>(tableName, newName);
             }
         }
 

--- a/src/Umbraco.Core/Migrations/Upgrade/Common/CreateKeysAndIndexes.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/Common/CreateKeysAndIndexes.cs
@@ -12,6 +12,7 @@ namespace Umbraco.Core.Migrations.Upgrade.Common
         {
             // remove those that may already have keys
             Delete.KeysAndIndexes(Constants.DatabaseSchema.Tables.KeyValue).Do();
+            Delete.KeysAndIndexes(Constants.DatabaseSchema.Tables.PropertyData).Do();
 
             // re-create *all* keys and indexes
             foreach (var x in DatabaseSchemaCreator.OrderedTables)

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/AddTypedLabels.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/AddTypedLabels.cs
@@ -89,16 +89,18 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
             foreach (var value in values)
                 Database.Execute(Sql()
                     .Update<PropertyDataDto>(u => u
-                        .Set(x => x.IntegerValue, string.IsNullOrWhiteSpace(value.VarcharValue) ? (int?) null :  int.Parse(value.VarcharValue, NumberStyles.Any, CultureInfo.InvariantCulture))
-                        .Set(x => x.TextValue, null))
+                        .Set(x => x.IntegerValue, string.IsNullOrWhiteSpace(value.VarcharValue) ? (int?)null : int.Parse(value.VarcharValue, NumberStyles.Any, CultureInfo.InvariantCulture))
+                        .Set(x => x.TextValue, null)
+                        .Set(x => x.VarcharValue, null))
                     .Where<PropertyDataDto>(x => x.Id == value.Id));
 
             values = Database.Fetch<PropertyDataValue>(Sql().Select<PropertyDataDto>(x => x.Id, x => x.VarcharValue).From<PropertyDataDto>().WhereIn<PropertyDataDto>(x => x.PropertyTypeId, dtPropertyTypes));
             foreach (var value in values)
                 Database.Execute(Sql()
                     .Update<PropertyDataDto>(u => u
-                        .Set(x => x.DateValue, string.IsNullOrWhiteSpace(value.VarcharValue) ? (DateTime?) null : DateTime.Parse(value.VarcharValue, CultureInfo.InvariantCulture, DateTimeStyles.None))
-                        .Set(x => x.TextValue, null))
+                        .Set(x => x.DateValue, string.IsNullOrWhiteSpace(value.VarcharValue) ? (DateTime?)null : DateTime.Parse(value.VarcharValue, CultureInfo.InvariantCulture, DateTimeStyles.None))
+                        .Set(x => x.TextValue, null)
+                        .Set(x => x.VarcharValue, null))
                     .Where<PropertyDataDto>(x => x.Id == value.Id));
 
             // anything that's custom... ppl will have to figure it out manually, there isn't much we can do about it

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/RenameMediaVersionTable.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/RenameMediaVersionTable.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.Persistence.Dtos;
+﻿using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
 
 namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
 {
@@ -17,13 +18,24 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
 
             AddColumn<MediaVersionDto>("id", out var sqls);
 
-            // SQLCE does not support UPDATE...FROM
-            var temp2 = Database.Fetch<dynamic>($@"SELECT v.versionId, v.id
+            if (Database.DatabaseType.IsSqlCe())
+            {
+                // SQLCE does not support UPDATE...FROM
+                var temp2 = Database.Fetch<dynamic>($@"SELECT v.versionId, v.id
 FROM cmsContentVersion v
 JOIN umbracoNode n on v.contentId=n.id
 WHERE n.nodeObjectType='{Constants.ObjectTypes.Media}'");
-            foreach (var t in temp2)
-                Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.MediaVersion} SET id={t.id} WHERE versionId='{t.versionId}'").Do();
+                foreach (var t in temp2)
+                    Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.MediaVersion} SET id={t.id} WHERE versionId='{t.versionId}'").Do();
+            }
+            else
+            {
+                Database.Execute($@"UPDATE {Constants.DatabaseSchema.Tables.MediaVersion} SET id=v.id
+FROM {Constants.DatabaseSchema.Tables.MediaVersion} m
+JOIN cmsContentVersion v on m.versionId = v.versionId
+JOIN umbracoNode n on v.contentId=n.id
+WHERE n.nodeObjectType='{Constants.ObjectTypes.Media}'");
+            }
 
             foreach (var sql in sqls)
                 Execute.Sql(sql).Do();

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/VariantsMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/VariantsMigration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Umbraco.Core.Migrations.Install;
@@ -19,6 +20,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
         public override void Migrate()
         {
             MigratePropertyData();
+            CreatePropertyDataIndexes();
             MigrateContentAndPropertyTypes();
             MigrateContent();
             MigrateVersions();
@@ -75,9 +77,17 @@ HAVING COUNT(v2.id) <> 1").Any())
                 Alter.Table(PreTables.PropertyData).AddColumn("versionId2").AsInt32().Nullable().Do();
 
                 // SQLCE does not support UPDATE...FROM
-                var temp = Database.Fetch<dynamic>($"SELECT id, versionId FROM {PreTables.ContentVersion}");
-                foreach (var t in temp)
-                    Database.Execute($"UPDATE {PreTables.PropertyData} SET versionId2=@v2 WHERE versionId=@v1", new { v1 = t.versionId, v2 = t.id });
+                if (Database.DatabaseType.IsSqlCe())
+                {
+                    var temp = Database.Fetch<dynamic>($"SELECT id, versionId FROM {PreTables.ContentVersion}");
+                    foreach (var t in temp)
+                        Database.Execute($"UPDATE {PreTables.PropertyData} SET versionId2=@v2 WHERE versionId=@v1", new { v1 = t.versionId, v2 = t.id });
+                }
+                else
+                {
+                    Database.Execute($"UPDATE {PreTables.PropertyData} SET versionId2={PreTables.ContentVersion}.id FROM {PreTables.ContentVersion} INNER JOIN {PreTables.PropertyData} ON {PreTables.ContentVersion}.versionId = {PreTables.PropertyData}.versionId");
+                }
+
                 Delete.Column("versionId").FromTable(PreTables.PropertyData).Do();
                 ReplaceColumn<PropertyDataDto>(PreTables.PropertyData, "versionId2", "versionId");
             }
@@ -88,6 +98,13 @@ HAVING COUNT(v2.id) <> 1").Any())
 
             // rename table
             Rename.Table(PreTables.PropertyData).To(Constants.DatabaseSchema.Tables.PropertyData).Do();
+        }
+
+        private void CreatePropertyDataIndexes()
+        {
+            var tableDefinition = Persistence.DatabaseModelDefinitions.DefinitionFactory.GetTableDefinition(typeof(PropertyDataDto), SqlSyntax);
+            Execute.Sql(SqlSyntax.FormatPrimaryKey(tableDefinition)).Do();
+            Execute.Sql("CREATE UNIQUE NONCLUSTERED INDEX[IX_umbracoPropertyData_VersionId] ON [umbracoPropertyData]([versionId],[propertyTypeId],[languageId],[segment])").Do();
         }
 
         private void MigrateContentAndPropertyTypes()
@@ -153,22 +170,40 @@ HAVING COUNT(v2.id) <> 1").Any())
                 ReplaceColumn<ContentVersionDto>(PreTables.ContentVersion, "ContentId", "nodeId");
 
             // populate contentVersion text, current and userId columns for documents
-            // SQLCE does not support UPDATE...FROM
-            var temp1 = Database.Fetch<dynamic>($"SELECT versionId, text, newest, documentUser FROM {PreTables.Document}");
-            foreach (var t in temp1)
-                Database.Execute($@"UPDATE {PreTables.ContentVersion} SET text=@text, {SqlSyntax.GetQuotedColumnName("current")}=@current, userId=@userId WHERE versionId=@versionId",
-                    new { text = t.text, current = t.newest, userId=t.documentUser, versionId=t.versionId });
+            if (Database.DatabaseType.IsSqlCe())
+            {
+                // SQLCE does not support UPDATE...FROM
+                var temp1 = Database.Fetch<dynamic>($"SELECT versionId, text, published, newest, documentUser FROM {PreTables.Document}");
+                foreach (var t in temp1)
+                    Database.Execute($@"UPDATE {PreTables.ContentVersion} SET text=@text, {SqlSyntax.GetQuotedColumnName("current")}=@current, userId=@userId WHERE versionId=@versionId",
+                        new { text = t.text, current = t.newest && !t.published, userId = t.documentUser, versionId = t.versionId });
+            }
+            else
+            {
+                Database.Execute($@"UPDATE {PreTables.ContentVersion} SET text=d.text, {SqlSyntax.GetQuotedColumnName("current")}=(d.newest & ~d.published), userId=d.documentUser
+FROM {PreTables.ContentVersion} v INNER JOIN {PreTables.Document} d ON d.versionId = v.versionId");
+            }
 
             // populate contentVersion text and current columns for non-documents, userId is default
-            // SQLCE does not support UPDATE...FROM
-            var temp2 = Database.Fetch<dynamic>($@"SELECT cver.versionId, n.text
+            if (Database.DatabaseType.IsSqlCe())
+            {
+                // SQLCE does not support UPDATE...FROM
+                var temp2 = Database.Fetch<dynamic>($@"SELECT cver.versionId, n.text
 FROM {PreTables.ContentVersion} cver
 JOIN {SqlSyntax.GetQuotedTableName(Constants.DatabaseSchema.Tables.Node)} n ON cver.nodeId=n.id
 WHERE cver.versionId NOT IN (SELECT versionId FROM {SqlSyntax.GetQuotedTableName(PreTables.Document)})");
 
-            foreach (var t in temp2)
-                Database.Execute($@"UPDATE {PreTables.ContentVersion} SET text=@text, {SqlSyntax.GetQuotedColumnName("current")}=1, userId=0 WHERE versionId=@versionId",
-                    new { text = t.text, versionId=t.versionId });
+                foreach (var t in temp2)
+                    Database.Execute($@"UPDATE {PreTables.ContentVersion} SET text=@text, {SqlSyntax.GetQuotedColumnName("current")}=1, userId=0 WHERE versionId=@versionId",
+                        new { text = t.text, versionId = t.versionId });
+            }
+            else
+            {
+                Database.Execute($@"UPDATE {PreTables.ContentVersion} SET text=n.text, {SqlSyntax.GetQuotedColumnName("current")}=1, userId=0
+FROM {PreTables.ContentVersion} cver
+JOIN {SqlSyntax.GetQuotedTableName(Constants.DatabaseSchema.Tables.Node)} n ON cver.nodeId=n.id
+WHERE cver.versionId NOT IN (SELECT versionId FROM {SqlSyntax.GetQuotedTableName(PreTables.Document)})");
+            }
 
             // create table
             Create.Table<DocumentVersionDto>(withoutKeysAndIndexes: true).Do();
@@ -179,51 +214,11 @@ SELECT cver.id, doc.templateId, doc.published
 FROM {SqlSyntax.GetQuotedTableName(PreTables.ContentVersion)} cver
 JOIN {SqlSyntax.GetQuotedTableName(PreTables.Document)} doc ON doc.nodeId=cver.nodeId AND doc.versionId=cver.versionId");
 
-            // need to add extra rows for where published=newest
-            // 'cos INSERT above has inserted the 'published' document version
-            // and v8 always has a 'edited' document version too
-            var temp3 = Database.Fetch<dynamic>($@"SELECT doc.nodeId, doc.updateDate, doc.documentUser, doc.text, doc.templateId, cver.id versionId
-FROM {SqlSyntax.GetQuotedTableName(PreTables.Document)} doc
-JOIN {SqlSyntax.GetQuotedTableName(PreTables.ContentVersion)} cver ON doc.nodeId=cver.nodeId AND doc.versionId=cver.versionId
-WHERE doc.newest=1 AND doc.published=1");
-            var getIdentity = "@@@@IDENTITY";
-            foreach (var t in temp3)
-            {
-                Database.Execute($@"INSERT INTO {SqlSyntax.GetQuotedTableName(PreTables.ContentVersion)} (nodeId, versionId, versionDate, userId, {SqlSyntax.GetQuotedColumnName("current")}, text)
-VALUES (@nodeId, @versionId, @versionDate, @userId, 1, @text)", new { nodeId=t.nodeId, versionId=Guid.NewGuid(), versionDate=t.updateDate, userId=t.documentUser, text=t.text });
-                var id = Database.ExecuteScalar<int>("SELECT " + getIdentity);
-                Database.Execute($"UPDATE {SqlSyntax.GetQuotedTableName(PreTables.ContentVersion)} SET {SqlSyntax.GetQuotedColumnName("current")}=0 WHERE nodeId=@0 AND id<>@1", (int) t.nodeId, id);
-                Database.Execute($@"INSERT INTO {SqlSyntax.GetQuotedTableName(Constants.DatabaseSchema.Tables.DocumentVersion)} (id, templateId, published)
-VALUES (@id, @templateId, 0)", new { id=id, templateId=t.templateId });
-
-                var versionId = (int) t.versionId;
-                var pdatas = Database.Fetch<PropertyDataDto>(Sql().Select<PropertyDataDto>().From<PropertyDataDto>().Where<PropertyDataDto>(x => x.VersionId == versionId));
-                foreach (var pdata in pdatas)
-                {
-                    pdata.VersionId = id;
-                    Database.Insert(pdata);
-                }
-            }
-
-            // reduce document to 1 row per content
-            Database.Execute($@"DELETE FROM {PreTables.Document}
-WHERE versionId NOT IN (SELECT (versionId) FROM {PreTables.ContentVersion} WHERE {SqlSyntax.GetQuotedColumnName("current")} = 1) AND (published<>1 OR newest<>1)");
-
-            // drop some document columns
-            Delete.Column("text").FromTable(PreTables.Document).Do();
-            Delete.Column("templateId").FromTable(PreTables.Document).Do();
-            Delete.Column("documentUser").FromTable(PreTables.Document).Do();
-            Delete.DefaultConstraint().OnTable(PreTables.Document).OnColumn("updateDate").Do();
-            Delete.Column("updateDate").FromTable(PreTables.Document).Do();
-            Delete.Column("versionId").FromTable(PreTables.Document).Do();
-            Delete.DefaultConstraint().OnTable(PreTables.Document).OnColumn("newest").Do();
-            Delete.Column("newest").FromTable(PreTables.Document).Do();
-
             // add and populate edited column
             if (!ColumnExists(PreTables.Document, "edited"))
             {
                 AddColumn<DocumentDto>(PreTables.Document, "edited", out var sqls);
-                Database.Execute($"UPDATE {SqlSyntax.GetQuotedTableName(PreTables.Document)} SET edited=0");
+                Database.Execute($"UPDATE {SqlSyntax.GetQuotedTableName(PreTables.Document)} SET edited=~published");
                 foreach (var sql in sqls) Database.Execute(sql);
             }
 
@@ -240,11 +235,59 @@ JOIN {Constants.DatabaseSchema.Tables.PropertyData} v1 ON cv1.id=v1.versionId
 JOIN {PreTables.ContentVersion} cv2 ON n.id=cv2.nodeId
 JOIN {Constants.DatabaseSchema.Tables.DocumentVersion} dv ON cv2.id=dv.id AND dv.published=1
 JOIN {Constants.DatabaseSchema.Tables.PropertyData} v2 ON cv2.id=v2.versionId
-WHERE v1.propertyTypeId=v2.propertyTypeId AND v1.languageId=v2.languageId AND v1.segment=v2.segment");
+WHERE v1.propertyTypeId=v2.propertyTypeId
+AND (v1.languageId=v2.languageId OR (v1.languageId IS NULL AND v2.languageId IS NULL))
+AND (v1.segment=v2.segment OR (v1.segment IS NULL AND v2.segment IS NULL))");
 
+            var updatedIds = new HashSet<int>();
             foreach (var t in temp)
                 if (t.intValue1 != t.intValue2 || t.decimalValue1 != t.decimalValue2 || t.dateValue1 != t.dateValue2 || t.varcharValue1 != t.varcharValue2 || t.textValue1 != t.textValue2)
-                    Database.Execute("UPDATE {SqlSyntax.GetQuotedTableName(PreTables.Document)} SET edited=1 WHERE nodeId=@nodeIdd", new { t.id });
+                    if (updatedIds.Add((int)t.id))
+                        Database.Execute($"UPDATE {SqlSyntax.GetQuotedTableName(PreTables.Document)} SET edited=1 WHERE nodeId=@nodeId", new { nodeId = t.id });
+
+
+            // need to add extra rows for where published=newest
+            // 'cos INSERT above has inserted the 'published' document version
+            // and v8 always has a 'edited' document version too
+            Database.Execute($@"
+INSERT INTO [cmsContentVersion] (nodeId, versionId, versionDate, userId, [current], text)
+SELECT doc.nodeId, NEWID(), doc.updateDate, doc.documentUser, 1, doc.[text]
+FROM [cmsDocument] doc
+JOIN [cmsContentVersion] cver ON doc.nodeId=cver.nodeId AND doc.versionId=cver.versionId
+WHERE doc.newest=1 AND doc.published=1");
+
+            Database.Execute($@"
+INSERT INTO [umbracoDocumentVersion] (id, templateId, published)
+SELECT cverNew.id, doc.templateId, 0
+FROM [cmsDocument] doc
+JOIN [cmsContentVersion] cverNew ON doc.nodeId = cverNew.nodeId
+WHERE doc.newest=1 AND doc.published=1 AND cverNew.[current] = 1");
+
+            Database.Execute($@"
+INSERT INTO [umbracoPropertyData] ([propertytypeid],[languageId],[segment],[textValue],[varcharValue],[decimalValue],[intValue],[dateValue],[versionId])
+SELECT [propertytypeid],[languageId],[segment],[textValue],[varcharValue],[decimalValue],[intValue],[dateValue],cverNew.id
+FROM [cmsDocument] doc
+JOIN [cmsContentVersion] cver ON doc.nodeId=cver.nodeId AND doc.versionId=cver.versionId
+JOIN [cmsContentVersion] cverNew ON doc.nodeId = cverNew.nodeId
+JOIN [umbracoPropertyData] pd ON pd.versionId=cver.id
+WHERE doc.newest=1 AND doc.published=1 AND cverNew.[current] = 1");
+
+            // reduce document to 1 row per content
+            Database.Execute($@"DELETE FROM {PreTables.Document}
+WHERE versionId NOT IN (SELECT (versionId) FROM {PreTables.ContentVersion} WHERE {SqlSyntax.GetQuotedColumnName("current")} = 1) AND (published<>1 OR newest<>1)");
+
+            Database.Execute($@"UPDATE {PreTables.Document} SET published=1 WHERE nodeId IN (
+SELECT nodeId FROM {PreTables.ContentVersion} cv INNER JOIN {Constants.DatabaseSchema.Tables.DocumentVersion} dv ON dv.id = cv.id WHERE dv.published=1)");
+
+            // drop some document columns
+            Delete.Column("text").FromTable(PreTables.Document).Do();
+            Delete.Column("templateId").FromTable(PreTables.Document).Do();
+            Delete.Column("documentUser").FromTable(PreTables.Document).Do();
+            Delete.DefaultConstraint().OnTable(PreTables.Document).OnColumn("updateDate").Do();
+            Delete.Column("updateDate").FromTable(PreTables.Document).Do();
+            Delete.Column("versionId").FromTable(PreTables.Document).Do();
+            Delete.DefaultConstraint().OnTable(PreTables.Document).OnColumn("newest").Do();
+            Delete.Column("newest").FromTable(PreTables.Document).Do();
 
             // drop more columns
             Delete.Column("versionId").FromTable(PreTables.ContentVersion).Do();

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
@@ -43,6 +43,8 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                 var value = property.TextValue;
                 if (string.IsNullOrWhiteSpace(value)) continue;
 
+
+                bool propertyChanged = false;
                 if (property.PropertyTypeDto.DataTypeDto.EditorAlias == Constants.PropertyEditors.Aliases.Grid)
                 {
                     try
@@ -55,7 +57,8 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                             var controlValue = control["value"];
                             if (controlValue?.Type == JTokenType.String)
                             {
-                                control["value"] = UpdateMediaUrls(mediaLinkPattern, controlValue.Value<string>());
+                                control["value"] = UpdateMediaUrls(mediaLinkPattern, controlValue.Value<string>(), out var controlChanged);
+                                propertyChanged |= controlChanged;
                             }
                         }
 
@@ -76,10 +79,11 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                 }
                 else
                 {
-                    property.TextValue = UpdateMediaUrls(mediaLinkPattern, value);
+                    property.TextValue = UpdateMediaUrls(mediaLinkPattern, value, out propertyChanged);
                 }
 
-                Database.Update(property);
+                if (propertyChanged)
+                    Database.Update(property);
             }
 
 
@@ -91,10 +95,14 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
             Context.AddPostMigration<RebuildPublishedSnapshot>();
         }
 
-        private string UpdateMediaUrls(Regex mediaLinkPattern, string value)
+        private string UpdateMediaUrls(Regex mediaLinkPattern, string value, out bool changed)
         {
-            return mediaLinkPattern.Replace(value, match =>
+            bool matched = false;
+
+            var result = mediaLinkPattern.Replace(value, match =>
             {
+                matched = true;
+
                 // match groups:
                 // - 1 = from the beginning of the a tag until href attribute value begins
                 // - 2 = the href attribute value excluding the querystring (if present)
@@ -106,6 +114,10 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                     ? match.Value
                     : $"{match.Groups[1].Value}/{{localLink:{media.GetUdi()}}}{match.Groups[3].Value}";
             });
+
+            changed = matched;
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
Some work on #5803.

### Speed improvements

- Create indexes on `umbracoPropertyData` to speed up updates in later migrations
- Use `sp_rename` for columns on SQL Server (mainly for umbracoPropertyData.textValue)
- Use UPDATE...FROM for `umbracoPropertyData`, `umbracoContentVersion`, `umbracoMediaVersion`  on SQL Server
- VariantsMigration: Check for edited property data before copying versions where "published=newest" - we know that the copied versions won't be edited
- VariantsMigration: Create extra versions for "published=newest" with a few large queries rather than a foreach loop
- ConvertTinyMceAndGridMediaUrlsToLocalLink: only update if value changed

### Other fixes
- VariantsMigration: Unpublished documents should have `edited`=1 (fixes warnings "Skip item id=x, both draft and published data are null.")
- VariantsMigration: Handle NULL `languageId` and `segment` when checking for edited property data
- VariantsMigration: Published documents with unpublished changes were left in an unpublished state (added update of `published` column after "reduce document to 1 row per content")
- AddTypedLabels: clear varcharValue when setting int/date value


---
_This item has been added to our backlog [AB#4555](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/4555)_