### PR TITLE
V8 - missing media folders after migration

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
@@ -404,7 +404,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             if (isMedia)
             {
                 sql
-                    .InnerJoin<MediaVersionDto>().On<ContentVersionDto, MediaVersionDto>((left, right) => left.Id == right.Id);
+                    .LeftJoin<MediaVersionDto>().On<ContentVersionDto, MediaVersionDto>((left, right) => left.Id == right.Id);
             }
 
             //Any LeftJoin statements need to come last


### PR DESCRIPTION
### Prerequisites
If there's an existing issue for this PR then this fixes #6158

### Description
The upgrade to 7.8.0 would not create rows in `cmsMedia` for folders (or any media type without an `umbracoFile` property). From 7.15 the media tree used an inner join to `cmsMedia`, so folders created before the upgrade to 7.8.0 disappeared.

The problem was fixed for 7.15 in PR #5865., but v8 has a similar issue with those media folders (except that the table is now `umbracoMediaVersion`). This PR applies the equivalent fix for v8.