### PR TITLE
V8: Migration of MarkdownEditor prevalues

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/MarkdownEditorPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/MarkdownEditorPreValueMigrator.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
+{
+    class MarkdownEditorPreValueMigrator : DefaultPreValueMigrator //PreValueMigratorBase
+    {
+        public override bool CanMigrate(string editorAlias)
+            => editorAlias == Constants.PropertyEditors.Aliases.MarkdownEditor;
+        
+        protected override object GetPreValueValue(PreValueDto preValue)
+        {
+            if (preValue.Alias == "preview")
+                return preValue.Value == "1";
+
+            return base.GetPreValueValue(preValue);
+        }
+    }
+}

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/PreValueMigratorComposer.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/PreValueMigratorComposer.cs
@@ -20,7 +20,8 @@ public class PreValueMigratorComposer : ICoreComposer
             .Append<DecimalPreValueMigrator>()
             .Append<ListViewPreValueMigrator>()
             .Append<DropDownFlexiblePreValueMigrator>()
-            .Append<ValueListPreValueMigrator>();
+            .Append<ValueListPreValueMigrator>()
+            .Append<MarkdownEditorPreValueMigrator>();
     }
 }
 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -235,6 +235,7 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\IPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\ListViewPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\MediaPickerPreValueMigrator.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\MarkdownEditorPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\NestedContentPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\PreValueMigratorCollection.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\PreValueMigratorCollectionBuilder.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes  #6194 

### Description
Adds a PreValueMigrator for the markdown editor, converting the `preview` value to a bool,

Testing:
- In 7.15, create a Markdown data type, and upgrade to 8.1
- Check that the config for the migrated data type has `preview:true` or `preview:false`, rather than the original string value.