### PR TITLE
V8: Indexing of grid values containing JSON

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/GridPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyIndexValueFactory.cs
@@ -41,9 +41,7 @@ namespace Umbraco.Web.PropertyEditors
                         {
                             var controlVal = control.Value;
 
-                            // TODO: If it's not a string, then it's a json formatted value -
-                            // we cannot really index this in a smart way since it could be 'anything'
-                            if (controlVal.Type == JTokenType.String)
+                            if (controlVal?.Type == JTokenType.String)
                             {
                                 var str = controlVal.Value<string>();
                                 str = XmlHelper.CouldItBeXml(str) ? str.StripHtml() : str;
@@ -52,6 +50,14 @@ namespace Umbraco.Web.PropertyEditors
 
                                 //add the row name as an individual field
                                 result.Add(new KeyValuePair<string, IEnumerable<object>>($"{property.Alias}.{rowName}", new[] { str }));
+                            }
+                            else if (controlVal is JContainer jc)
+                            {
+                                foreach (var s in jc.Descendants().Where(t => t.Type == JTokenType.String))
+                                {
+                                    sb.Append(s.Value<string>());
+                                    sb.Append(" ");
+                                }
                             }
                         }
                     }

--- a/src/Umbraco.Web/PropertyEditors/GridPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyIndexValueFactory.cs
@@ -56,11 +56,11 @@ namespace Umbraco.Web.PropertyEditors
                         }
                     }
 
+                    //First save the raw value to a raw field
+                    result.Add(new KeyValuePair<string, IEnumerable<object>>($"{UmbracoExamineIndex.RawFieldPrefix}{property.Alias}", new[] { rawVal }));
+
                     if (sb.Length > 0)
                     {
-                        //First save the raw value to a raw field
-                        result.Add(new KeyValuePair<string, IEnumerable<object>>($"{UmbracoExamineIndex.RawFieldPrefix}{property.Alias}", new[] { rawVal }));
-
                         //index the property with the combined/cleaned value
                         result.Add(new KeyValuePair<string, IEnumerable<object>>(property.Alias, new[] { sb.ToString() }));
                     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6164

### Description
If a grid control stores a JSON value rather than a string, the value is not indexed by Examine. This PR indexes any string values found within the JSON.

Testing:
- Add a macro control to a grid, with a unique value in a macro parameter.
- Search for the unique value in the Examine dashboard, the document should be found.