### PR TITLE
V8: Selecting text in context menu closes the dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/events/onOutsideClick.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/events/onOutsideClick.directive.js
@@ -56,18 +56,18 @@
                         return attrs.bindClickOn;
                     }, function (newValue) {
                         if (newValue === "true") {
-                            $(document).on("click", oneTimeClick);
+                            $(document).on("mousedown", oneTimeClick);
                         } else {
-                            $(document).off("click", oneTimeClick);
+                            $(document).off("mousedown", oneTimeClick);
                         }
                     }));
 
                 } else {
-                    $(document).on("click", oneTimeClick);
+                    $(document).on("mousedown", oneTimeClick);
                 }
 
                 scope.$on("$destroy", function () {
-                    $(document).off("click", oneTimeClick);
+                    $(document).off("mousedown", oneTimeClick);
 
                     // unbind watchers
                     for (var e in eventBindings) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #4934

### Description
`on-outside-click` can trigger and close a dialog if you mouse down inside the dialog, then drag and mouse up outside the dialog. To avoid that, this PR triggers `on-outside-click` on the mousedown event.

Testing:
- Open the Culture and Hostnames dialog
- Click and drag from inside the dialog to somewhere outside it, this should not close the dialog
- Click outside the dialog, and the dialog should still close

---
_This item has been added to our backlog [AB#4336](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/4336)_