### PR TITLE
V7: Selecting text in context menu closes the dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/angular/1.1.5/angular-mobile.js
+++ b/src/Umbraco.Web.UI.Client/lib/angular/1.1.5/angular-mobile.js
@@ -293,7 +293,7 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
  * A leftward swipe is a quick, right-to-left slide of the finger.
  * Though ngSwipeLeft is designed for touch-based devices, it will work with a mouse click and drag too.
  *
- *                      [well, it did until we disabled that feature to avoid problems with selecting text]
+ *                  [well, it did until we disabled that feature to avoid problems with selecting text]
  *
  * @element ANY
  * @param {expression} ngSwipeLeft {@link guide/expression Expression} to evaluate

--- a/src/Umbraco.Web.UI.Client/lib/angular/1.1.5/angular-mobile.js
+++ b/src/Umbraco.Web.UI.Client/lib/angular/1.1.5/angular-mobile.js
@@ -293,6 +293,8 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
  * A leftward swipe is a quick, right-to-left slide of the finger.
  * Though ngSwipeLeft is designed for touch-based devices, it will work with a mouse click and drag too.
  *
+ *                      [well, it did until we disabled that feature to avoid problems with selecting text]
+ *
  * @element ANY
  * @param {expression} ngSwipeLeft {@link guide/expression Expression} to evaluate
  * upon left swipe. (Event object is available as `$event`)
@@ -388,7 +390,7 @@ function makeSwipeDirective(directiveName, direction) {
             deltaY / deltaX < MAX_VERTICAL_RATIO;
       }
 
-      element.bind('touchstart mousedown', function(event) {
+      element.bind('touchstart', function(event) {
         startCoords = getCoordinates(event);
         valid = true;
         totalX = 0;
@@ -401,7 +403,7 @@ function makeSwipeDirective(directiveName, direction) {
         valid = false;
       });
 
-      element.bind('touchmove mousemove', function(event) {
+      element.bind('touchmove', function(event) {
         if (!valid) return;
 
         // Android will send a touchcancel if it thinks we're starting to scroll.
@@ -440,7 +442,7 @@ function makeSwipeDirective(directiveName, direction) {
         }
       });
 
-      element.bind('touchend mouseup', function(event) {
+      element.bind('touchend', function(event) {
         if (validSwipe(event)) {
           // Prevent this swipe from bubbling up to any other elements with ngSwipes.
           event.stopPropagation();

--- a/src/Umbraco.Web.UI.Client/src/index.html
+++ b/src/Umbraco.Web.UI.Client/src/index.html
@@ -10,7 +10,7 @@
 </head>
 
 <body ng-class="{touch:touchDevice,emptySection:emptySection}" ng-controller="Umbraco.MainController" id="umbracoMainPageBody">
-    <div ng-hide="!authenticated" ng-cloak id="mainwrapper" class="clearfix" ng-click="closeDialogs($event)">
+    <div ng-hide="!authenticated" ng-cloak id="mainwrapper" class="clearfix" ng-mousedown="closeDialogs($event)">
         <umb-navigation></umb-navigation>
 
         <section id="contentwrapper">

--- a/src/Umbraco.Web.UI/umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/umbraco/Views/Default.cshtml
@@ -47,7 +47,7 @@
         <!-- help dialog controller by the help button - this also forces the backoffice UI to shift 400px  -->
         <umb-drawer data-element="drawer" ng-if="drawer.show" model="drawer.model" view="drawer.view"></umb-drawer>
 
-        <div id="mainwrapper" class="clearfix" ng-click="closeDialogs($event)">
+        <div id="mainwrapper" class="clearfix" ng-mousedown="closeDialogs($event)">
 
             <umb-navigation></umb-navigation>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #4934, #6023

### Description
V7 version of PR #6203.

Additionally, stops swipe events triggering from mouse events. This can also trigger unexpected dialog closes, and can make it impossible to select text when mousemove events are intercepted.

Testing:
- As for PR #6203
- Also, check that you can select text on the login screen.