### PR TITLE
use SystemDirectories.Media instead of hardcoded string media

### DIFF
--- a/src/Umbraco.Core/Persistence/Factories/MediaFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/MediaFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Umbraco.Core.IO;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Rdbms;
 
@@ -130,7 +131,7 @@ namespace Umbraco.Core.Persistence.Factories
             return nodeDto;
         }
 
-        private static readonly Regex MediaPathPattern = new Regex(@"(/media/.+?)(?:['""]|$)", RegexOptions.Compiled);
+        private static readonly Regex MediaPathPattern = new Regex($@"({SystemDirectories.Media.TrimStart("~")}/.+?)(?:['""]|$)", RegexOptions.Compiled);
 
         /// <summary>
         /// Try getting a media path out of the string being stored for media


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6202

### Description

Replaced hard-coded media string and used the SystemDirectories.Media path.
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
