### PR TITLE
Handle null/empty values in RefactorMacroColumns migration

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/RefactorMacroColumns.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/RefactorMacroColumns.cs
@@ -15,21 +15,17 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
             {
                 //special trick to add the column without constraints and return the sql to add them later
                 AddColumn<MacroDto>("macroType", out var sqls1);
-                //now we need to update the new column with some values because this column doesn't allow NULL values
-                Update.Table(Constants.DatabaseSchema.Tables.Macro).Set(new { macroType = (int)MacroTypes.Unknown}).AllRows().Do();
-                //now apply constraints (NOT NULL) to new table
-                foreach (var sql in sqls1) Execute.Sql(sql).Do();
-
-                //special trick to add the column without constraints and return the sql to add them later
                 AddColumn<MacroDto>("macroSource", out var sqls2);
 
-                //populate the new macroSource column with legacy data
-                Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.Macro} SET macroSource = macroXSLT, macroType = {(int)MacroTypes.Unknown} WHERE macroXSLT IS NOT NULL").Do();
-                Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.Macro} SET macroSource = macroScriptAssembly, macroType = {(int)MacroTypes.Unknown} WHERE macroScriptAssembly IS NOT NULL").Do();
-                Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.Macro} SET macroSource = macroScriptType, macroType = {(int)MacroTypes.Unknown} WHERE macroScriptType IS NOT NULL").Do();
-                Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.Macro} SET macroSource = macroPython, macroType = {(int)MacroTypes.PartialView} WHERE macroPython IS NOT NULL").Do();
+                //populate the new columns with legacy data
+                Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.Macro} SET macroSource = '', macroType = {(int)MacroTypes.Unknown}").Do();
+                Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.Macro} SET macroSource = macroXSLT, macroType = {(int)MacroTypes.Unknown} WHERE macroXSLT != '' AND macroXSLT IS NOT NULL").Do();
+                Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.Macro} SET macroSource = macroScriptAssembly, macroType = {(int)MacroTypes.Unknown} WHERE macroScriptAssembly != '' AND macroScriptAssembly IS NOT NULL").Do();
+                Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.Macro} SET macroSource = macroScriptType, macroType = {(int)MacroTypes.Unknown} WHERE macroScriptType != '' AND macroScriptType IS NOT NULL").Do();
+                Execute.Sql($"UPDATE {Constants.DatabaseSchema.Tables.Macro} SET macroSource = macroPython, macroType = {(int)MacroTypes.PartialView} WHERE macroPython != '' AND macroPython IS NOT NULL").Do();
 
                 //now apply constraints (NOT NULL) to new table
+                foreach (var sql in sqls1) Execute.Sql(sql).Do();
                 foreach (var sql in sqls2) Execute.Sql(sql).Do();
 
                 //now remove these old columns


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5827 

### Description
The RefactorMacroColumns migration assumes that unused columns in `cmsMacro` will be NULL. This is true when a macro is first created while adding a partial view file, but they'll be empty strings if the macro has then been edited. It also assumes that at least one column will be non-NULL (which should be true, but apparently not always).

Testing:
- In 7.15, create a macro but don't save it. The row in `cmsMacro` should have NULL in `macroPython`, `macroScriptType`, `macroScriptAssembly`, `macroXSLT`.
- Create an XSLT macro and save it. The row in `cmsMacro` should have empty strings in `macroPython`, `macroScriptType`, `macroScriptAssembly`.
- Upgrade to 8.1.
- Both macros should be `macroType` 4. The ex-XSLT macro should have the XSLT filename in macroSource, not an empty string.