### PR TITLE
V8: Use a standard confirm dialog when removing content type compositions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -376,14 +376,3 @@ a.umb-variant-switcher__toggle {
 	margin-right: auto;
 	padding-right: 10px;
 }
-
-/* Confirm */
-.umb-editor-confirm {
-	background-color: @white;
-	padding: 20px;
-	position: absolute;
-	left: 0;
-	bottom: 0;
-	z-index: 10;
-	box-shadow: 0 -3px 12px 0px rgba(0,0,0,0.16);
-}

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function CompositionsController($scope, $location, $filter) {
+    function CompositionsController($scope, $location, $filter, overlayService) {
 
         var vm = this;
         var oldModel = null;
@@ -56,19 +56,35 @@
             if ($scope.model && $scope.model.submit) {
 
                 // check if any compositions has been removed
-                vm.compositionRemoved = false;
+                var compositionRemoved = false;
                 for (var i = 0; oldModel.compositeContentTypes.length > i; i++) {
                     var oldComposition = oldModel.compositeContentTypes[i];
                     if (_.contains($scope.model.compositeContentTypes, oldComposition) === false) {
-                        vm.compositionRemoved = true;
+                        compositionRemoved = true;
                     }
                 }
 
                 /* submit the form if there havne't been removed any composition
                 or the confirm checkbox has been checked */
-                if (!vm.compositionRemoved || vm.allowSubmit) {
-                    $scope.model.submit($scope.model);
+                if (compositionRemoved) {
+                    vm.allowSubmit = false;
+                    const dialog = {
+                        view: "views/common/infiniteeditors/compositions/overlays/confirmremove.html",
+                        submitButtonLabelKey: "general_ok",
+                        closeButtonLabelKey: "general_cancel",
+                        submit: function (model) {
+                            $scope.model.submit($scope.model);
+                            overlayService.close();
+                        },
+                        close: function () {
+                            overlayService.close();
+                        }
+                    };
+                    overlayService.open(dialog);
+                    return;
                 }
+
+                $scope.model.submit($scope.model);
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -92,16 +92,6 @@
 
                 </umb-box-content>
             </umb-box>
-
-            <div ng-if="vm.compositionRemoved" class="umb-editor-confirm">
-                <h5 class="red"><i class="icon-alert"></i>Warning</h5>
-                <p>Removing a composition will delete all the associated property data. Once you save the document type there's no way back, are you sure?</p>
-                <label class="checkbox no-indent">
-                    <input type="checkbox" ng-model="vm.allowSubmit" />
-                    <strong>I know what I'm doing</strong>
-                </label>
-            </div>
-
         </umb-editor-container>
 
         <umb-editor-footer>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/overlays/confirmremove.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/overlays/confirmremove.html
@@ -1,0 +1,6 @@
+<div>
+
+    <h5 class="red"><i class="icon-alert"></i>Warning</h5>
+    <p>Removing a composition will delete all the associated property data. Once you save the document type there's no way back, are you sure?</p>
+
+</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When you remove an existing composition from a content type, the confirmation dialog that pops up is rather unlike any other place in the backoffice. It is also kinda broken, as you can scroll it out of view:

![remove-composition-before](https://user-images.githubusercontent.com/7405322/63805219-3c077d80-c919-11e9-960c-d248fd2a969b.gif)

This PR moves the confirmation to a default dialog (overlay), which is first and foremost in line with the other dialogs, and as an added bonus you can't scroll it out of view 😆 

Here's how things work with this PR applied:

![remove-composition-after](https://user-images.githubusercontent.com/7405322/63805320-75d88400-c919-11e9-8a53-b8f470a2c525.gif)
