### PR TITLE
V8: Use a pointer cursor for selectable items in mini listviews

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-table.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-table.less
@@ -295,7 +295,11 @@ input.umb-table__input {
 .umb-table__row-expand {
     font-size: 12px;
     text-decoration: none;
-    color: @black;
+    color: @gray-4;
+
+    &:hover {
+        color: @black;
+    }
 }
 
 .umb-table__row-expand--hidden {

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
@@ -60,7 +60,7 @@
                 </div>
 
                 <!-- Items -->
-                <div class="umb-table-row"
+                <div class="umb-table-row cursor-pointer"
                     ng-repeat="child in miniListView.children"
                     ng-click="selectNode(child)"
                     ng-class="{'-selected':child.selected, 'not-allowed':!child.allowed}">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It's not immediately obvious that items in a mini listview can be picked, since the cursor isn't of type `pointer` when the items are hovered:

![mini-listview-cursor-before](https://user-images.githubusercontent.com/7405322/63806419-dc5ea180-c91b-11e9-81be-52bf4a9ec69f.gif)

With this PR applied it becomes marginally more obvious that the items are selectable 😄 

![mini-listview-cursor-after](https://user-images.githubusercontent.com/7405322/63806450-f304f880-c91b-11e9-92f5-0cb758fe3ec2.gif)

Note that the "expand" arrow has been dimmed down a little until it's hovered, to provide a hint that clicking it will expand the item, not select it.