### PR TITLE
AB 2440 - Enable Paste & Drag n Drop of images into RTE editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -233,17 +233,22 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
                     //this would be for a theme other than inlite
                     toolbar: args.toolbar.join(" "),
+
                     //these are for the inlite theme to work
                     insert_toolbar: toolbars.insertToolbar,
                     selection_toolbar: toolbars.selectionToolbar,
 
                     body_class: 'umb-rte',
+
                     //see http://archive.tinymce.com/wiki.php/Configuration:cache_suffix
                     cache_suffix: "?umb__rnd=" + Umbraco.Sys.ServerVariables.application.cacheBuster,
 
                     //this is used to style the inline macro bits, sorry hard coding this form now since we don't have a standalone
                     //stylesheet to load in for this with only these styles (the color is @pinkLight)
-                    content_style: ".mce-content-body .umb-macro-holder { border: 3px dotted #f5c1bc; padding: 7px; display: block; margin: 3px; } .umb-rte .mce-content-body .umb-macro-holder.loading {background: url(assets/img/loader.gif) right no-repeat; background-size: 18px; background-position-x: 99%;}"
+                    content_style: ".mce-content-body .umb-macro-holder { border: 3px dotted #f5c1bc; padding: 7px; display: block; margin: 3px; } .umb-rte .mce-content-body .umb-macro-holder.loading {background: url(assets/img/loader.gif) right no-repeat; background-size: 18px; background-position-x: 99%;}",
+
+                    // This allows images to be pasted in & stored as Base64 until they get uploaded to server
+                    paste_data_images: true
                 };
 
                 if (tinyMceConfig.customConfig) {


### PR DESCRIPTION
## Notes
The paste plugin was already enabled as it comes from the legacy XML `config/tinymceconfig.config` file so we only needed the additional property `paste_data_images` in the config of every RTE editor init code.

This first step of adding support for pasting images in will put them in as base64 images in the HTML source code - further follow up PRs will make these upload to the media section & be replaced by the real URL as opposed to base64 images.

## Testing
- Create a doctype with a RTE
- Take a screenshot or similar and copy to your clipboard
- Paste image into RTE
- Find an image on your machine and drag and drop this into the RTE

- Repeat: For a RTE inside a Grid & Nested Content or anything similar

Fixes [AB#2240](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/2240)
