### PR TITLE
V8: Fix preview with multiple cultures + highlight the current culture

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
@@ -266,7 +266,6 @@ a, a:hover{
 ul.sections {
     display: block;
     background: #1b264f;
-    height: 100%;
     position:absolute;
     top: 90px;
     width: 80px;
@@ -275,12 +274,21 @@ ul.sections {
     margin:0;
     padding:0;
     margin-left: -80px;
+    overflow: scroll;
+    overflow-x: hidden;
+    height: calc(100% - 91px);
+
+    &::-webkit-scrollbar {
+        width: 0px;
+        background: transparent; 
+    }
 }
 
 ul.sections li {
     display: block;
     border-left: 4px #1b264f solid;
     transition: all .3s linear;
+    cursor: pointer;
 }
 
 .fix-left-menu ul.sections li a span,

--- a/src/Umbraco.Web.UI.Client/src/preview/preview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/preview/preview.controller.js
@@ -143,7 +143,10 @@ var app = angular.module("umbraco.preview", ['umbraco.resources', 'umbraco.servi
                 setPageUrl();
             }
         };
-        
+
+        $scope.isCurrentCulture = function(culture) {
+            return $location.search().culture === culture;
+        }
     })
 
 

--- a/src/Umbraco.Web.UI/Umbraco/Views/Preview/Index.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Preview/Index.cshtml
@@ -44,21 +44,21 @@
             </div>
             <ul class="sections" ng-class="{selected: showDevicesPreview && showDevices}">
                 <li ng-repeat="device in devices" ng-class="{ current:previewDevice==device }">
-                    <a href="" ng-click="updatePreviewDevice(device)"><i class="icon {{device.icon}}" title="{{device.title}}"></i><span></span></a>
+                    <a ng-click="updatePreviewDevice(device)"><i class="icon {{device.icon}}" title="{{device.title}}"></i><span></span></a>
                 </li>
 
                 @if (Model.Languages != null && Model.Languages.Count() > 1)
                 {
                     foreach (var previewLink in Model.Languages)
                      {
-                         <li>
-                             <a href="" ng-click="changeCulture('@previewLink.IsoCode')" title="Preview in @previewLink.CultureName"><i class="icon icon-globe-europe---africa"></i><span>@previewLink.CultureName</span></a>
+                         <li ng-class="{ current:isCurrentCulture('@previewLink.IsoCode') }">
+                             <a ng-click="changeCulture('@previewLink.IsoCode')" title="Preview in @previewLink.CultureName"><i class="icon icon-globe-europe---africa"></i><span>@previewLink.CultureName</span></a>
                          </li>
                      }
                 }
 
                 <li>
-                    <a href="" ng-click="exitPreview()" title="Exit Preview"><i class="icon icon-wrong"></i><span> </span></a>
+                    <a ng-click="exitPreview()" title="Exit Preview"><i class="icon icon-wrong"></i><span> </span></a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The preview sidebar doesn't handle multiple cultures very gracefully:

1. You can't scroll the sidebar downwards, leaving you unable to see all cultures (let alone close the preview).
2. The currently active culture isn't highlighted like the currently active device is.

Here, have a GIF:

![preview-cultures-before](https://user-images.githubusercontent.com/7405322/63874747-68c39f80-c9c2-11e9-86ca-c964378ec72b.gif)

This PR fixes both of these issues; here's how the sidebar works when the PR is applied:

![preview-cultures-after](https://user-images.githubusercontent.com/7405322/63874879-a294a600-c9c2-11e9-92a0-38a7023bb591.gif)

...and for a site with only a few cultures:

![preview-cultures-after-2](https://user-images.githubusercontent.com/7405322/63874999-dec80680-c9c2-11e9-889b-9be6cf2a2aea.gif)

### Not a perfect solution

This isn't necessarily a perfect solution to the scrolling issue, since hiding the scrollbar is pretty bad practice. But I can't think of any better way to handle it for the time being... at least not a way that handles both multiple devices (if you expand beyond the default ones) and multiple cultures. 
