### PR TITLE
5724: Unable to add multiple property groups

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -576,17 +576,6 @@
         // remove property
         tab.properties.splice(propertyIndex, 1);
 
-        // if the last property in group is an placeholder - remove add new tab placeholder
-        if(tab.properties.length === 1 && tab.properties[0].propertyState === "init") {
-
-          angular.forEach(scope.model.groups, function(group, index, groups){
-            if(group === tab) {
-              groups.splice(index, 1);
-            }
-            });
-
-        }
-
         notifyChanged();
       };
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -381,6 +381,8 @@
         // activate group
         scope.activateGroup(group);
 
+        // push new init tab to the scope
+        addInitGroup(scope.model.groups);
       };
 
       scope.activateGroup = function(selectedGroup) {
@@ -399,7 +401,6 @@
 
       scope.removeGroup = function(groupIndex) {
         scope.model.groups.splice(groupIndex, 1);
-        addInitGroup(scope.model.groups);
       };
 
       scope.updateGroupTitle = function(group) {
@@ -528,9 +529,6 @@
               // set focus on init property
               var numberOfProperties = group.properties.length;
               group.properties[numberOfProperties - 1].focus = true;
-  
-              // push new init tab to the scope
-              addInitGroup(scope.model.groups);
 
               notifyChanged();
             },
@@ -582,10 +580,10 @@
         if(tab.properties.length === 1 && tab.properties[0].propertyState === "init") {
 
           angular.forEach(scope.model.groups, function(group, index, groups){
-            if(group.tabState === 'init') {
+            if(group === tab) {
               groups.splice(index, 1);
             }
-          });
+            });
 
         }
 


### PR DESCRIPTION
Issue: #5724 (Unable to add multiple property groups in membertype/doctype editor)

Moved initGroup to the addGroup function so that it'll create a new initial group every time a new group is added.

Also changed the deleteProperty function so that it doesn't remove the init group when the last property is removed, because there should always be an init group.