### PR TITLE
Cleanup to the published status dashboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/nucache.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/nucache.html
@@ -4,13 +4,13 @@
         <umb-load-indicator></umb-load-indicator>
     </div>
 
-    <p style="min-height: 120px; background: #f8f8f8; padding: 10px; margin-bottom: 4px;">
+    <p>
         <span ng-show="vm.working">(wait)</span>
         <span ng-show="!vm.working">{{vm.status}}</span>
     </p>
 
     <div>
-        <button type="button" ng-click="vm.verify($event)" class="btn btn-warning">Refresh status</button>
+        <button type="button" ng-click="vm.verify($event)" class="btn btn-danger">Refresh status</button>
     </div>
 
     <h4 class="mt4">Memory Cache</h4>
@@ -24,7 +24,7 @@
     </p>
 
     <div>
-        <button type="button" ng-click="vm.reload($event)" class="btn btn-warning">Reload</button>
+        <button type="button" ng-click="vm.reload($event)" class="btn btn-danger">Reload</button>
     </div>
 
     <h4 class="mt4">Database Cache</h4>
@@ -37,7 +37,7 @@
     </p>
 
     <div>
-        <button type="button" ng-click="vm.rebuild($event)" class="btn btn-warning">Rebuild</button>
+        <button type="button" ng-click="vm.rebuild($event)" class="btn btn-danger">Rebuild</button>
     </div>
 
     <h4 class="mt4">Internals</h4>
@@ -48,7 +48,7 @@
     </p>
 
     <div>
-        <button type="button" ng-click="vm.collect($event)" class="btn btn-warning">Collect</button>
+        <button type="button" ng-click="vm.collect($event)" class="btn btn-danger">Collect</button>
     </div>
 
 </div>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <https://github.com/umbraco/Umbraco-CMS/issues/4253>

The above issue points out some inconsistencies to the modelsbuilder and the published status dashboards. While the modelsbuilder dashboard looks consistent now, the published status dashboard could do with some tweaks. I have got rid of the massive textarea and changed the orange colour buttons to red(similar to modelsbuilder dashboard). I was wondering whether it should be made to look like the Examine Management dashboard, with each title having the blue background, with the text and button within but decided against it as the styling seems to be used for panels. This also raises another question in my head - Should the rebuild indexes button on Examine Management dashboard be red - in line with Modelsbuilder dashboard? Dont know whether I am overthinking it here.

Any changes let me know. :-)

**Before**
![image](https://user-images.githubusercontent.com/3941753/63898954-f1f2ca80-c9f2-11e9-95a3-af607065c220.png)

After
![image](https://user-images.githubusercontent.com/3941753/63934600-a3c1e380-ca53-11e9-9f62-da33f2262d61.png)

Poornima
