### PR TITLE
Friendly exception message when datatype with name more than 255 char…

### DIFF
--- a/src/Umbraco.Core/Services/Implement/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/Implement/DataTypeService.cs
@@ -349,6 +349,11 @@ namespace Umbraco.Core.Services.Implement
                     throw new ArgumentException("Cannot save datatype with empty name.");
                 }
 
+                if (dataType.Name != null && dataType.Name.Length > 255)
+                {
+                    throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
+                }
+
                 _dataTypeRepository.Save(dataType);
 
                 saveEventArgs.CanCancel = false;


### PR DESCRIPTION
The issue [4633](https://github.com/umbraco/Umbraco-CMS/issues/4633) mentions how exception occurs on various parts of the CMS when the name exceeds 255 characters. I have added better exception on the DataType Service. I havent added maxlength attribute to the input field as that would be a sweeping change. It can be introduced once all the entities have this check in place

Before
![image](https://user-images.githubusercontent.com/3941753/63957343-1ba60300-ca80-11e9-95a5-9e805adc95da.png)

After
![image](https://user-images.githubusercontent.com/3941753/63956990-7723c100-ca7f-11e9-9a34-2331301f521d.png)

Let me know if anything more is needed
Poornima
