### PR TITLE
Better exception message on media type save

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -390,6 +390,11 @@ namespace Umbraco.Core.Services.Implement
                 if (string.IsNullOrWhiteSpace(item.Name))
                     throw new ArgumentException("Cannot save item with empty name.");
 
+                if (item.Name != null && item.Name.Length > 255)
+                {
+                    throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
+                }
+
                 scope.WriteLock(WriteLockIds);
 
                 // validate the DAG transform, within the lock


### PR DESCRIPTION
The issue [4633 ](https://github.com/umbraco/Umbraco-CMS/issues/4633) mentions how an exception occurs on various parts of the CMS when the name exceeds 255 characters. I have added better exception on the MediaTypeService. I havent added maxlength attribute to the input field as that would be a sweeping change. It can be introduced once all the entities have this check in place

Before
![image](https://user-images.githubusercontent.com/3941753/63958356-18137b80-ca82-11e9-83aa-e6130abb0734.png)

After
![image](https://user-images.githubusercontent.com/3941753/63958336-1053d700-ca82-11e9-8f52-6fed2328e71b.png)

Let me know if anything is needed.
Poornima