### PR TITLE
better exception message on content type save

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -390,6 +390,11 @@ namespace Umbraco.Core.Services.Implement
                 if (string.IsNullOrWhiteSpace(item.Name))
                     throw new ArgumentException("Cannot save item with empty name.");
 
+                if (item.Name != null && item.Name.Length > 255)
+                {
+                    throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
+                }
+
                 scope.WriteLock(WriteLockIds);
 
                 // validate the DAG transform, within the lock

--- a/src/Umbraco.Core/Services/Implement/FileService.cs
+++ b/src/Umbraco.Core/Services/Implement/FileService.cs
@@ -358,6 +358,11 @@ namespace Umbraco.Core.Services.Implement
                 { "ContentTypeAlias", contentTypeAlias },
             };
 
+            if (contentTypeAlias != null && contentTypeAlias.Length > 255)
+            {
+                throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
+            }
+
             // check that the template hasn't been created on disk before creating the content type
             // if it exists, set the new template content to the existing file content
             string content = GetViewContent(contentTypeAlias);
@@ -365,7 +370,10 @@ namespace Umbraco.Core.Services.Implement
             {
                 template.Content = content;
             }
+
             
+
+
             using (var scope = ScopeProvider.CreateScope())
             {
                 var saveEventArgs = new SaveEventArgs<ITemplate>(template, true, evtMsgs, additionalData);


### PR DESCRIPTION
The issue [4633 ](https://github.com/umbraco/Umbraco-CMS/issues/4633) mentions how an exception occurs on various parts of the CMS when the name exceeds 255 characters. I have added better exception upon saving on content types. A check has been put in place before the content type is saved as well as template creation. I havent added maxlength attribute to the input field as that would be a sweeping change. It can be introduced once all the entities have this check in place. This should also fix the same issue on MemberType save

Before
![image](https://user-images.githubusercontent.com/3941753/63959733-bdc7ea00-ca84-11e9-8139-9fbbbb705a7e.png)

After
![image](https://user-images.githubusercontent.com/3941753/63959724-b86a9f80-ca84-11e9-959f-167e9857aaad.png)

Regards,
Poornima