### PR TITLE
V8: Accessibility Changes For Title On Content Section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
@@ -18,18 +18,22 @@
 
             localizationService.localizeMany([
                     scope.isNew ? "placeholders_a11yCreateItem" : "placeholders_a11yEdit",
-                    "placeholders_a11yName"]
+                "placeholders_a11yName",
+                    scope.isNew?"general_new":"general_edit"]
             ).then(function (data) {
                 scope.a11yMessage = data[0];
                 scope.a11yName = data[1];
+                var title = data[2] +":";
                 if (!scope.isNew) {
                     scope.a11yMessage += " " + scope.content.name;
-
+                    title += scope.content.name;
                 } else {
                     var name = editorState.current.contentTypeName;
                     scope.a11yMessage += " " + name;
                     scope.a11yName = name + " " + scope.a11yName;
+                    title += name;
                 }
+                scope.$root.locationTitle = title + " - " + scope.$root.locationTitle ;
             });
             scope.vm = {};
             scope.vm.dropdownOpen = false;


### PR DESCRIPTION
This PR sets the page title when the user is in the content section and builds on the work in #5888 

The aim is to help screen reader users and also content editors which have multiple tabs open determine what they are doing in the content section.

The logic for the title being set is in umbeditorcontentheader.directive.js as opposed to init.js to prevent multiple hits on the database to retrieve the content name/ content type being edited.