### PR TITLE
Maxlength attribute on macro name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/macros/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/create.html
@@ -19,7 +19,8 @@
                 </div>
 
                 <umb-control-group label="@macro_enterMacroName" hide-label="false">
-                    <input type="text" name="itemKey" ng-model="vm.itemKey" class="umb-textstring textstring input-block-level" umb-auto-focus required />
+                    <input type="text" name="itemKey" ng-model="vm.itemKey" class="umb-textstring textstring input-block-level"
+                           umb-auto-focus required maxlength="255" />
                 </umb-control-group>
 
                 <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>

--- a/src/Umbraco.Web/Editors/MacrosController.cs
+++ b/src/Umbraco.Web/Editors/MacrosController.cs
@@ -62,6 +62,11 @@ namespace Umbraco.Web.Editors
                 return this.ReturnErrorResponse("Macro with this alias already exists");
             }
 
+            if (name == null || name.Length > 255)
+            {
+                return this.ReturnErrorResponse("Name cannnot be more than 255 characters in length.");
+            }
+
             try
             {
                 var macro = new Macro
@@ -147,6 +152,11 @@ namespace Umbraco.Web.Editors
             if (macroDisplay == null)
             {
                 return this.ReturnErrorResponse($"No macro data found in request");
+            }
+
+            if (macroDisplay.Name == null || macroDisplay.Name.Length > 255)
+            {
+                return this.ReturnErrorResponse("Name cannnot be more than 255 characters in length.");
             }
 
             var macro = _macroService.GetById(int.Parse(macroDisplay.Id.ToString()));


### PR DESCRIPTION
The issue [4633 ](https://github.com/umbraco/Umbraco-CMS/issues/4633) mentions how an exception occurs on various parts of the CMS when the name exceeds 255 characters. I have added better exception upon saving on macros. I havent added maxlength attribute to the input field on the right hand panel as that would be a sweeping change. It can be introduced once all the entities have this check in place. I have not added the validation to the `EntityBasic `class either as that would be a sweeping change as well

**Before**
![image](https://user-images.githubusercontent.com/3941753/63976889-45741f80-caaa-11e9-8ec4-4d2eaa4235e7.png)

![image](https://user-images.githubusercontent.com/3941753/63976930-5d4ba380-caaa-11e9-99e0-997e628bae45.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/63979990-398c5b80-cab2-11e9-9e01-f299d6ed86fa.png)

You should not be able to create a macro with more than 255 characters in the name to begin with. Even if you manually edit the name in the right hand panel name input field, it should give a friendly error message rather than the generic error message.
