### PR TITLE
Fixed returntype of IPublishedContent.Siblings<T> to be IEnumerable<T…

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1067,7 +1067,7 @@ namespace Umbraco.Web
         /// <remarks>
         ///   <para>Note that in V7 this method also return the content node self.</para>
         /// </remarks>
-        public static IEnumerable<IPublishedContent> Siblings<T>(this IPublishedContent content, string culture = null)
+        public static IEnumerable<T> Siblings<T>(this IPublishedContent content, string culture = null)
             where T : class, IPublishedContent
         {
             return SiblingsAndSelf<T>(content, culture).Where(x => x.Id != content.Id);


### PR DESCRIPTION
…> rather than IEnumerable<IPublishedContent>

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6240

### Description

`IPublishedContent.Siblings<T>` should return `IEnumerable<T>`, but was returning `IEnumerable<IPublishedContent>`.

Pull request simply changes the return type, the actual data returned was already of type `IEnumerable<T>`

Steps to test:

* Install Umbraco with starter kit.
* Add the following snippet to the Product template:
```
    @foreach(var p in Model.Siblings<Product>()){
        <p>@p.ProductName</p>
    }
```
* Browse to a product page and see other products listed. ProductName is a specific property on the type Product, so we know the returned objects are actually of type Product
