### PR TITLE
Documentation link on edit packages open up in the same window

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -298,7 +298,7 @@
                             description="Here you can add custom installer / uninstaller events to perform certain tasks during installation and uninstallation.
                             All actions are formed as a xml node, containing data for the action to be performed.">
                             <div>
-                                <a ng-href="https://our.umbraco.com/documentation/Reference/Packaging/">Documentation</a>
+                                <a target="_blank" ng-href="https://our.umbraco.com/documentation/Reference/Packaging/">Documentation</a>
                                 <div>
                                     <textarea class="umb-property-editor" rows="10" ng-model="vm.package.actions"></textarea>
                                 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

- Go to Packages -> Created Packages -> Click Create Package
- Scroll down to the bottom of the form, the _documentation_ link opens up in the same window

Before
![package-documentation](https://user-images.githubusercontent.com/3941753/64054060-3c07b780-cb7d-11e9-8cb6-35e80544893d.gif)

After
![package-documentation-fix](https://user-images.githubusercontent.com/3941753/64054063-40cc6b80-cb7d-11e9-983d-ee8796bbfd70.gif)

