### PR TITLE
fix the left margin which causes a space in the help drawer article titles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-drawer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-drawer.less
@@ -194,7 +194,6 @@
 .umb-help-list-item__title {
     font-size: 14px;
     display: block;
-    margin-left: 26px;
 }
 
 .umb-help-list-item__description {


### PR DESCRIPTION
- [x ] I have added steps to test this contribution in the description below

If you look at the help drawer you can see a space (left margin) by the article title and the tour step names.

**Before**
![image](https://user-images.githubusercontent.com/3941753/64055759-76298700-cb86-11e9-8c94-42f24c7dd08b.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/64055761-7b86d180-cb86-11e9-82ea-a6e810e2a84f.png)
