### PR TITLE
Fixes #6255: Don't replace maps for existing keys

### DIFF
--- a/src/Umbraco.Core/Mapping/UmbracoMapper.cs
+++ b/src/Umbraco.Core/Mapping/UmbracoMapper.cs
@@ -343,7 +343,12 @@ namespace Umbraco.Core.Mapping
 
             if (ctor == null) return null;
 
-            _ctors[sourceType] = sourceCtor;
+            if (_ctors.ContainsKey(sourceType))
+                foreach (var c in sourceCtor)
+                    _ctors[sourceType].Add(c.Key, c.Value);
+            else
+                _ctors[sourceType] = sourceCtor;
+            
             return ctor;
         }
 
@@ -368,7 +373,12 @@ namespace Umbraco.Core.Mapping
 
             if (map == null) return null;
 
-            _maps[sourceType] = sourceMap;
+            if (_maps.ContainsKey(sourceType))
+                foreach(var m in sourceMap)
+                    _maps[sourceType].Add(m.Key, m.Value);
+            else
+                _maps[sourceType] = sourceMap;
+            
             return map;
         }
 


### PR DESCRIPTION
UmbracoMapper has an issue whereby if you have some explicit maps for a type, but then also have some base class maps, when you trigger the base class map functions, the explicit maps gets replaced.

With this update, when resolving the base class maps, it now merges any maps for the source type, rather than replacing them.