### PR TITLE
v8: Use umbCheckbox in packager

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -29,7 +29,7 @@
 @param {string} serverValidationField Set the <code>val-server-field</code> of the checkbox.
 @param {boolean} disabled Set the checkbox to be disabled.
 @param {boolean} required Set the checkbox to be required.
-@param {string} onChange Callback when the value of the checkbox change by interaction.
+@param {callback} onChange Callback when the value of the checkbox change by interaction.
 
 **/
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -49,7 +49,6 @@
         
     }
     
-    
     var component = {
         templateUrl: 'views/components/forms/umb-checkbox.html',
         controller: UmbCheckboxController,
@@ -63,7 +62,7 @@
             serverValidationField: "@",
             disabled: "<",
             required: "<",
-            onChange: "&"
+            onChange: "&?"
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -22,14 +22,14 @@
 </pre>
 
 @param {boolean} model Set to <code>true</code> or <code>false</code> to set the checkbox to checked or unchecked.
-@param {string} input-id Set the <code>id</code> of the checkbox.
+@param {string} inputId Set the <code>id</code> of the checkbox.
 @param {string} value Set the value of the checkbox.
 @param {string} name Set the name of the checkbox.
 @param {string} text Set the text for the checkbox label.
-@param {string} server-validation-field Set the <code>val-server-field</code> of the checkbox.
+@param {string} serverValidationField Set the <code>val-server-field</code> of the checkbox.
 @param {boolean} disabled Set the checkbox to be disabled.
 @param {boolean} required Set the checkbox to be required.
-@param {string} on-change Callback when the value of the checkbox changed by interaction.
+@param {string} onChange Callback when the value of the checkbox changed by interaction.
 
 **/
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -29,7 +29,7 @@
 @param {string} serverValidationField Set the <code>val-server-field</code> of the checkbox.
 @param {boolean} disabled Set the checkbox to be disabled.
 @param {boolean} required Set the checkbox to be required.
-@param {string} onChange Callback when the value of the checkbox changed by interaction.
+@param {string} onChange Callback when the value of the checkbox change by interaction.
 
 **/
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -40,8 +40,8 @@
     function UmbCheckboxController($timeout) {
         
         var vm = this;
-        
-        vm.callOnChange = function() {
+
+        if (vm.onChange) {
             $timeout(function() {
                 vm.onChange({model:vm.model, value:vm.value});
             }, 0);

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -50,7 +50,7 @@
         templateUrl: 'views/components/forms/umb-radiobutton.html',
         controller: UmbRadiobuttonController,
         controllerAs: 'vm',
-        scope: {
+        bindings: {
             model: "=",
             value: "@",
             name: "@",

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -57,7 +57,7 @@
             text: "@",
             disabled: "=",
             required: "=",
-            onChange: "&"
+            onChange: "&?"
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -27,7 +27,7 @@
 @param {string} text Set the text for the radiobutton label.
 @param {boolean} disabled Set the radiobutton to be disabled.
 @param {boolean} required Set the radiobutton to be required.
-@param {string} onChange Callback when the value of the radiobutton change by interaction.
+@param {callback} onChange Callback when the value of the radiobutton change by interaction.
 
 **/
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -27,6 +27,7 @@
 @param {string} text Set the text for the radiobutton label.
 @param {boolean} disabled Set the radiobutton to be disabled.
 @param {boolean} required Set the radiobutton to be required.
+@param {string} onChange Callback when the value of the radiobutton change by interaction.
 
 **/
 
@@ -36,6 +37,12 @@
     function UmbRadiobuttonController() {
 
         var vm = this;
+
+        if (vm.onChange) {
+            $timeout(function () {
+                vm.onChange({ model: vm.model, value: vm.value });
+            }, 0);
+        }
         
     }
 
@@ -49,7 +56,8 @@
             name: "@",
             text: "@",
             disabled: "=",
-            required: "="
+            required: "=",
+            onChange: "&"
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -33,25 +33,26 @@
 (function () {
     'use strict';
 
-    function RadiobuttonDirective() {
-        var directive = {
-            restrict: 'E',
-            replace: true,
-            templateUrl: 'views/components/forms/umb-radiobutton.html',
-            scope: {
-                model: "=",
-                value: "@",
-                name: "@",
-                text: "@",
-                disabled: "=",
-                required: "="
-            }
-        };
+    function UmbRadiobuttonController() {
 
-        return directive;
-
+        var vm = this;
+        
     }
 
-    angular.module('umbraco.directives').directive('umbRadiobutton', RadiobuttonDirective);
+    var component = {
+        templateUrl: 'views/components/forms/umb-radiobutton.html',
+        controller: UmbRadiobuttonController,
+        controllerAs: 'vm',
+        scope: {
+            model: "=",
+            value: "@",
+            name: "@",
+            text: "@",
+            disabled: "=",
+            required: "="
+        }
+    };
+
+    angular.module('umbraco.directives').component('umbRadiobutton', component);
 
 })();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -34,7 +34,7 @@
 (function () {
     'use strict';
 
-    function UmbRadiobuttonController() {
+    function UmbRadiobuttonController($timeout) {
 
         var vm = this;
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -8,7 +8,7 @@
            ng-model="vm.model"
            ng-disabled="vm.disabled"
            ng-required="vm.required"
-           ng-change="vm.callOnChange()"/>
+           ng-change="vm.onChange()"/>
 
     <span class="umb-form-check__state" aria-hidden="true">
         <span class="umb-form-check__check">

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -1,4 +1,4 @@
-<label class="checkbox umb-form-check umb-form-check--checkbox" ng-class="{ 'umb-form-check--disabled': disabled }">
+<label class="checkbox umb-form-check umb-form-check--checkbox" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
     <input type="checkbox"
            id="{{vm.inputId}}"
            name="{{vm.name}}"

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -1,13 +1,13 @@
-<label class="radio umb-form-check umb-form-check--radiobutton" ng-class="{ 'umb-form-check--disabled': disabled }">
-    <input type="radio" name="{{name}}"
-        value="{{value}}"
+<label class="radio umb-form-check umb-form-check--radiobutton" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
+    <input type="radio" name="{{vm.name}}"
+        value="{{vm.value}}"
         class="umb-form-check__input"
-        ng-model="model"
-        ng-disabled="disabled"
-        ng-required="required" />
+        ng-model="vm.model"
+        ng-disabled="vm.disabled"
+        ng-required="vm.required" />
 
     <span class="umb-form-check__state" aria-hidden="true">
         <span class="umb-form-check__check"></span>
     </span>
-    <span class="umb-form-check__text">{{text}}</span>
+    <span class="umb-form-check__text">{{vm.text}}</span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -4,7 +4,8 @@
         class="umb-form-check__input"
         ng-model="vm.model"
         ng-disabled="vm.disabled"
-        ng-required="vm.required" />
+        ng-required="vm.required"
+        ng-change="vm.onChange()" />
 
     <span class="umb-form-check__state" aria-hidden="true">
         <span class="umb-form-check__check"></span>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -46,6 +46,8 @@
                 packageResource.getEmpty().then(scaffold => {
                     vm.package = scaffold;
 
+                    loadResources();
+
                     buildContributorsEditor(vm.package);
 
                     vm.loading = false;
@@ -59,12 +61,14 @@
                 packageResource.getCreatedById(packageId).then(createdPackage => {
                     vm.package = createdPackage;
 
+                    loadResources();
+
                     buildContributorsEditor(vm.package);
 
                     vm.loading = false;
 
                     // Get render model for content node
-                    if(vm.package.contentNodeId) {
+                    if (vm.package.contentNodeId) {
                         entityResource.getById(vm.package.contentNodeId, "Document")
                             .then((entity) => {
                                 vm.contentNodeDisplayModel = entity;
@@ -77,6 +81,9 @@
                     vm.buttonLabel = value;
                 });
             }
+        }
+
+        function loadResources() {
 
             // Get all document types
             entityResource.getAll("DocumentType").then(documentTypes => {
@@ -84,7 +91,7 @@
                 // need to convert all ids to string for comparison
                 documentTypes.forEach(documentType => {
                     documentType.id = documentType.id.toString();
-                    documentType.selected = vm.package.documentTypes.indexOf(documentType.id) >= 0;
+                    documentType.selected = vm.package.documentTypes.indexOf(documentType.id) !== -1;
                 });
                 vm.documentTypes = documentTypes;
             });
@@ -114,7 +121,7 @@
                 // need to convert all ids to string for comparison
                 macros.forEach(macro => {
                     macro.id = macro.id.toString();
-                    macro.selected = vm.package.macros.indexOf(macro.id) >= 0;
+                    macro.selected = vm.package.macros.indexOf(macro.id) !== -1;
                 });
                 vm.macros = macros;
             });
@@ -125,7 +132,7 @@
                 // need to convert all ids to string for comparison
                 languages.forEach(language => {
                     language.id = language.id.toString();
-                    language.selected = vm.package.languagues.indexOf(language.id) >= 0;
+                    language.selected = vm.package.languages.indexOf(language.id) !== -1;
                 });
                 vm.languages = languages;
             });
@@ -136,7 +143,7 @@
                 // need to convert all ids to string for comparison
                 dictionaryItems.forEach(dictionaryItem => {
                     dictionaryItem.id = dictionaryItem.id.toString();
-                    dictionaryItem.selected = vm.package.dictionaryItems.indexOf(dictionaryItem.id) >= 0;
+                    dictionaryItem.selected = vm.package.dictionaryItems.indexOf(dictionaryItem.id) !== -1;
                 });
                 vm.dictionaryItems = dictionaryItems;
             });
@@ -147,7 +154,7 @@
                 // need to convert all ids to string for comparison
                 dataTypes.forEach(dataType => {
                     dataType.id = dataType.id.toString();
-                    dataType.selected = vm.package.dataTypes.indexOf(dataType.id) >= 0;
+                    dataType.selected = vm.package.dataTypes.indexOf(dataType.id) !== -1;
                 });
                 vm.dataTypes = dataTypes;
             });

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -35,7 +35,7 @@
         vm.selectDictionaryItem = selectDictionaryItem;
         vm.selectDataType = selectDataType;
 
-        vm.buttonLabel = "";
+        vm.labels = {};
 
         vm.versionRegex = /^(\d+\.)(\d+\.)(\*|\d+)$/;  
 
@@ -53,8 +53,8 @@
                     vm.loading = false;
                 });
 
-                localizationService.localize("general_create").then(function(value) {
-                    vm.buttonLabel = value;
+                localizationService.localize("general_create").then(function (value) {
+                    vm.labels.button = value;
                 });
             } else {
                 // Load package
@@ -77,9 +77,11 @@
 
                 });
 
-                localizationService.localize("buttons_save").then(function (value) {
-                    vm.buttonLabel = value;
+                localizationService.localizeMany(["buttons_save", "packager_includeAllChildNodes"]).then(function (values) {
+                    vm.labels.button = values[0];
+                    vm.labels.includeAllChildNodes = values[1];
                 });
+
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -5,6 +5,9 @@
 
         const vm = this;
 
+        const packageId = $routeParams.id;
+        const create = $routeParams.create;
+
         vm.showBackButton = true;
 
         // open all expansion panels
@@ -24,12 +27,11 @@
         vm.downloadFile = downloadFile;
         vm.contributorsEditor = null;
 
+        vm.selectDocumentType = selectDocumentType;
+
         vm.buttonLabel = "";
 
-        vm.versionRegex = /^(\d+\.)(\d+\.)(\*|\d+)$/;
-
-        const packageId = $routeParams.id;
-        const create = $routeParams.create;
+        vm.versionRegex = /^(\d+\.)(\d+\.)(\*|\d+)$/;  
 
         function onInit() {
 
@@ -269,6 +271,18 @@
 
         function removePackageView() {
             vm.package.packageView = null;
+        }
+
+        function selectDocumentType(doctype) {
+
+            // Check if the document type is already selected.
+            var index = vm.package.documentTypes.indexOf(doctype.id);
+
+            if (index === -1) {
+                vm.package.documentTypes.push(doctype.id);
+            } else {
+                vm.package.documentTypes.splice(index, 1);
+            }
         }
 
         function buildContributorsEditor(pkg) {

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -28,6 +28,12 @@
         vm.contributorsEditor = null;
 
         vm.selectDocumentType = selectDocumentType;
+        vm.selectTemplate = selectTemplate;
+        vm.selectStyleSheet = selectStyleSheet;
+        vm.selectMacro = selectMacro;
+        vm.selectLanguage = selectLanguage;
+        vm.selectDictionaryItem = selectDictionaryItem;
+        vm.selectDataType = selectDataType;
 
         vm.buttonLabel = "";
 
@@ -36,7 +42,7 @@
         function onInit() {
 
             if (create) {
-                //pre populate package with some values
+                // Pre populate package with some values
                 packageResource.getEmpty().then(scaffold => {
                     vm.package = scaffold;
 
@@ -49,14 +55,15 @@
                     vm.buttonLabel = value;
                 });
             } else {
-                // load package
+                // Load package
                 packageResource.getCreatedById(packageId).then(createdPackage => {
                     vm.package = createdPackage;
 
                     buildContributorsEditor(vm.package);
 
                     vm.loading = false;
-                    // get render model for content node
+
+                    // Get render model for content node
                     if(vm.package.contentNodeId) {
                         entityResource.getById(vm.package.contentNodeId, "Document")
                             .then((entity) => {
@@ -71,66 +78,76 @@
                 });
             }
 
-            // get all doc types
+            // Get all document types
             entityResource.getAll("DocumentType").then(documentTypes => {
                 // a package stores the id as a string so we 
                 // need to convert all ids to string for comparison
                 documentTypes.forEach(documentType => {
                     documentType.id = documentType.id.toString();
+                    documentType.selected = vm.package.documentTypes.indexOf(documentType.id) >= 0;
                 });
                 vm.documentTypes = documentTypes;
             });
 
-            // get all templates
+            // Get all templates
             entityResource.getAll("Template").then(templates => {
                 // a package stores the id as a string so we 
                 // need to convert all ids to string for comparison
                 templates.forEach(template => {
                     template.id = template.id.toString();
+                    template.selected = vm.package.templates.indexOf(template.id) >= 0;
                 });
                 vm.templates = templates;
             });
 
-            // get all stylesheets
+            // Get all stylesheets
             entityResource.getAll("Stylesheet").then(stylesheets => {
+                stylesheets.forEach(stylesheet => {
+                    stylesheet.selected = vm.package.stylesheets.indexOf(stylesheet.name) >= 0;
+                });
                 vm.stylesheets = stylesheets;
             });
 
+            // Get all macros
             entityResource.getAll("Macro").then(macros => {
                 // a package stores the id as a string so we 
                 // need to convert all ids to string for comparison
                 macros.forEach(macro => {
                     macro.id = macro.id.toString();
+                    macro.selected = vm.package.macros.indexOf(macro.id) >= 0;
                 });
                 vm.macros = macros;
             });
 
-            // get all languages
+            // Get all languages
             entityResource.getAll("Language").then(languages => {
                 // a package stores the id as a string so we 
                 // need to convert all ids to string for comparison
                 languages.forEach(language => {
                     language.id = language.id.toString();
+                    language.selected = vm.package.languagues.indexOf(language.id) >= 0;
                 });
                 vm.languages = languages;
             });
 
-            // get all dictionary items
+            // Get all dictionary items
             entityResource.getAll("DictionaryItem").then(dictionaryItems => {
                 // a package stores the id as a string so we 
                 // need to convert all ids to string for comparison
                 dictionaryItems.forEach(dictionaryItem => {
                     dictionaryItem.id = dictionaryItem.id.toString();
+                    dictionaryItem.selected = vm.package.dictionaryItems.indexOf(dictionaryItem.id) >= 0;
                 });
                 vm.dictionaryItems = dictionaryItems;
             });
 
-            // get all data types items
+            // Get all data types
             entityResource.getAll("DataType").then(dataTypes => {
                 // a package stores the id as a string so we 
                 // need to convert all ids to string for comparison
                 dataTypes.forEach(dataType => {
                     dataType.id = dataType.id.toString();
+                    dataType.selected = vm.package.dataTypes.indexOf(dataType.id) >= 0;
                 });
                 vm.dataTypes = dataTypes;
             });
@@ -282,6 +299,78 @@
                 vm.package.documentTypes.push(doctype.id);
             } else {
                 vm.package.documentTypes.splice(index, 1);
+            }
+        }
+
+        function selectTemplate(template) {
+
+            // Check if the template is already selected.
+            var index = vm.package.templates.indexOf(template.id);
+
+            if (index === -1) {
+                vm.package.templates.push(template.id);
+            } else {
+                vm.package.templates.splice(index, 1);
+            }
+        }
+
+        function selectStyleSheet(stylesheet) {
+
+            // Check if the style sheet is already selected.
+            var index = vm.package.stylesheets.indexOf(stylesheet.name);
+
+            if (index === -1) {
+                vm.package.stylesheets.push(stylesheet.name);
+            } else {
+                vm.package.stylesheets.splice(index, 1);
+            }
+        }
+
+        function selectMacro(macro) {
+
+            // Check if the macro is already selected.
+            var index = vm.package.macros.indexOf(macro.id);
+
+            if (index === -1) {
+                vm.package.macros.push(macro.id);
+            } else {
+                vm.package.macros.splice(index, 1);
+            }
+        }
+
+        function selectLanguage(language) {
+
+            // Check if the language is already selected.
+            var index = vm.package.languages.indexOf(language.id);
+
+            if (index === -1) {
+                vm.package.languages.push(language.id);
+            } else {
+                vm.package.languages.splice(index, 1);
+            }
+        }
+
+        function selectDictionaryItem(dictionaryItem) {
+
+            // Check if the dictionary item is already selected.
+            var index = vm.package.dictionaryItems.indexOf(dictionaryItem.id);
+
+            if (index === -1) {
+                vm.package.dictionaryItems.push(dictionaryItem.id);
+            } else {
+                vm.package.dictionaryItems.splice(index, 1);
+            }
+        }
+
+        function selectDataType(dataType) {
+
+            // Check if the dictionary item is already selected.
+            var index = vm.package.dataTypes.indexOf(dataType.id);
+
+            if (index === -1) {
+                vm.package.dataTypes.push(dataType.id);
+            } else {
+                vm.package.dataTypes.splice(index, 1);
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -131,14 +131,11 @@
                                 <localize key="general_add">Add</localize>
                             </a>
 
-                            <div>
-                                <label>
-                                    <umb-checkbox model="vm.package.contentLoadChildNodes"
-                                                  disabled="!vm.package.contentNodeId"
-                                                  text="{{vm.labels.includeAllChildNodes}}" />
-                                </label>
-                            </div>
-
+                            <label style="padding-left: 0;">
+                                <umb-checkbox model="vm.package.contentLoadChildNodes"
+                                                disabled="!vm.package.contentNodeId"
+                                                text="{{vm.labels.includeAllChildNodes}}" />
+                            </label>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_documentTypes">

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -161,73 +161,102 @@
                         <umb-control-group label="@treeHeaders_templates">
                             <div ng-repeat="template in ::vm.templates | orderBy:'name'">
                                 <label>
-                                    <input
-                                        type="checkbox"
-                                        checklist-model="vm.package.templates"
-                                        checklist-value="template.id" />
+                                    <umb-checkbox model="template.selected"
+                                                  on-change="vm.selectTemplate(template)"
+                                                  text="{{template.name}}" />
+
+                                    <br />
+                                    <input type="checkbox"
+                                           checklist-model="vm.package.templates"
+                                           checklist-value="template.id" />
                                     {{template.name}}
                                 </label>
                             </div>
+                            <pre>{{vm.package.templates | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_stylesheets">
                             <div ng-repeat="stylesheet in ::vm.stylesheets | orderBy:'name'">
                                 <label>
-                                    <input
-                                        type="checkbox"
-                                        checklist-model="vm.package.stylesheets"
-                                        checklist-value="stylesheet.name" />
+                                    <umb-checkbox model="stylesheet.selected"
+                                                  on-change="vm.selectStyleSheet(stylesheet)"
+                                                  text="{{stylesheet.path}}" />
+
+                                    <input type="checkbox"
+                                           checklist-model="vm.package.stylesheets"
+                                           checklist-value="stylesheet.name" />
                                     {{stylesheet.path}}
                                 </label>
                             </div>
+                            <pre>{{vm.package.stylesheets | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_macros">
                             <div ng-repeat="macro in ::vm.macros | orderBy:'name'">
                                 <label>
+                                    <umb-checkbox model="macro.selected"
+                                                  on-change="vm.selectMacro(macro)"
+                                                  text="{{macro.name}}" />
+
+                                    <br />
                                     <input type="checkbox"
                                            checklist-model="vm.package.macros"
                                            checklist-value="macro.id" />
                                     {{macro.name}}
                                 </label>
                             </div>
-
+                            <pre>{{vm.package.macros | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_languages">
                             <div ng-repeat="language in ::vm.languages | orderBy:'name'">
                                 <label>
-                                    <input
-                                        type="checkbox"
-                                        checklist-model="vm.package.languages"
-                                        checklist-value="language.id" />
+                                    <umb-checkbox model="language.selected"
+                                                  on-change="vm.selectLanguage(language)"
+                                                  text="{{language.name}}" />
+
+                                    <br />
+
+                                    <input type="checkbox"
+                                           checklist-model="vm.package.languages"
+                                           checklist-value="language.id" />
                                     {{language.name}}
                                 </label>
                             </div>
+                            <pre>{{vm.package.languages | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_dictionary">
                             <div ng-repeat="dictionaryItem in ::vm.dictionaryItems | orderBy:'name'">
                                 <label>
-                                    <input
-                                        type="checkbox"
-                                        checklist-model="vm.package.dictionaryItems"
-                                        checklist-value="dictionaryItem.id" />
+                                    <umb-checkbox model="dictionaryItem.selected"
+                                                  on-change="vm.selectDictionaryItem(dictionaryItem)"
+                                                  text="{{dictionaryItem.name}}" />
+
+                                    <input type="checkbox"
+                                           checklist-model="vm.package.dictionaryItems"
+                                           checklist-value="dictionaryItem.id" />
                                     {{dictionaryItem.name}}
                                 </label>
                             </div>
+                            <pre>{{vm.package.dictionaryItems | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_dataTypes">
                             <div ng-repeat="dataType in ::vm.dataTypes | orderBy:'name'">
                                 <label>
-                                    <input
-                                        type="checkbox"
-                                        checklist-model="vm.package.dataTypes"
-                                        checklist-value="dataType.id" />
+                                    <umb-checkbox model="dataType.selected"
+                                                  on-change="vm.selectDataType(dataType)"
+                                                  text="{{dataType.name}}" />
+
+                                    <br />
+                                    <input type="checkbox"
+                                           checklist-model="vm.package.dataTypes"
+                                           checklist-value="dataType.id" />
                                     {{dataType.name}}
                                 </label>
                             </div>
+                            <pre>{{vm.package.dataTypes | json }}</pre>
                         </umb-control-group>
 
                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -141,6 +141,11 @@
                         <umb-control-group label="@treeHeaders_documentTypes">
                             <div ng-repeat="doctype in ::vm.documentTypes | orderBy:'name'">
                                 <label>
+                                    <umb-checkbox model="doctype.selected"
+                                                  on-change="vm.selectDocumentType(doctype)"
+                                                  text="{{doctype.name}}" />
+
+                                    <br />
                                     <input
                                         type="checkbox"
                                         ng-model="doctype.selected"
@@ -149,6 +154,8 @@
                                     {{doctype.name}}
                                 </label>
                             </div>
+
+                            <pre>{{vm.package.documentTypes | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_templates">

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -144,18 +144,8 @@
                                     <umb-checkbox model="doctype.selected"
                                                   on-change="vm.selectDocumentType(doctype)"
                                                   text="{{doctype.name}}" />
-
-                                    <br />
-                                    <input
-                                        type="checkbox"
-                                        ng-model="doctype.selected"
-                                        checklist-model="vm.package.documentTypes"
-                                        checklist-value="doctype.id" />
-                                    {{doctype.name}}
                                 </label>
                             </div>
-
-                            <pre>{{vm.package.documentTypes | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_templates">
@@ -164,15 +154,8 @@
                                     <umb-checkbox model="template.selected"
                                                   on-change="vm.selectTemplate(template)"
                                                   text="{{template.name}}" />
-
-                                    <br />
-                                    <input type="checkbox"
-                                           checklist-model="vm.package.templates"
-                                           checklist-value="template.id" />
-                                    {{template.name}}
                                 </label>
                             </div>
-                            <pre>{{vm.package.templates | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_stylesheets">
@@ -181,14 +164,8 @@
                                     <umb-checkbox model="stylesheet.selected"
                                                   on-change="vm.selectStyleSheet(stylesheet)"
                                                   text="{{stylesheet.path}}" />
-
-                                    <input type="checkbox"
-                                           checklist-model="vm.package.stylesheets"
-                                           checklist-value="stylesheet.name" />
-                                    {{stylesheet.path}}
                                 </label>
                             </div>
-                            <pre>{{vm.package.stylesheets | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_macros">
@@ -197,15 +174,8 @@
                                     <umb-checkbox model="macro.selected"
                                                   on-change="vm.selectMacro(macro)"
                                                   text="{{macro.name}}" />
-
-                                    <br />
-                                    <input type="checkbox"
-                                           checklist-model="vm.package.macros"
-                                           checklist-value="macro.id" />
-                                    {{macro.name}}
                                 </label>
                             </div>
-                            <pre>{{vm.package.macros | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_languages">
@@ -214,16 +184,8 @@
                                     <umb-checkbox model="language.selected"
                                                   on-change="vm.selectLanguage(language)"
                                                   text="{{language.name}}" />
-
-                                    <br />
-
-                                    <input type="checkbox"
-                                           checklist-model="vm.package.languages"
-                                           checklist-value="language.id" />
-                                    {{language.name}}
                                 </label>
                             </div>
-                            <pre>{{vm.package.languages | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_dictionary">
@@ -232,14 +194,8 @@
                                     <umb-checkbox model="dictionaryItem.selected"
                                                   on-change="vm.selectDictionaryItem(dictionaryItem)"
                                                   text="{{dictionaryItem.name}}" />
-
-                                    <input type="checkbox"
-                                           checklist-model="vm.package.dictionaryItems"
-                                           checklist-value="dictionaryItem.id" />
-                                    {{dictionaryItem.name}}
                                 </label>
                             </div>
-                            <pre>{{vm.package.dictionaryItems | json }}</pre>
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_dataTypes">
@@ -248,15 +204,8 @@
                                     <umb-checkbox model="dataType.selected"
                                                   on-change="vm.selectDataType(dataType)"
                                                   text="{{dataType.name}}" />
-
-                                    <br />
-                                    <input type="checkbox"
-                                           checklist-model="vm.package.dataTypes"
-                                           checklist-value="dataType.id" />
-                                    {{dataType.name}}
                                 </label>
                             </div>
-                            <pre>{{vm.package.dataTypes | json }}</pre>
                         </umb-control-group>
 
                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -131,18 +131,21 @@
                                 <localize key="general_add">Add</localize>
                             </a>
 
-                            <umb-checkbox model="vm.package.contentLoadChildNodes"
-                                            disabled="!vm.package.contentNodeId"
-                                            text="{{vm.labels.includeAllChildNodes}}" />
+                            <label>
+                                <umb-checkbox model="vm.package.contentLoadChildNodes"
+                                              disabled="!vm.package.contentNodeId"
+                                              text="{{vm.labels.includeAllChildNodes}}" />
+                            </label>
 
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_documentTypes">
                             <div ng-repeat="doctype in ::vm.documentTypes | orderBy:'name'">
-
-                                <umb-checkbox model="doctype.selected"
-                                                on-change="vm.selectDocumentType(doctype)"
-                                                text="{{doctype.name}}" />
+                                <label>
+                                    <umb-checkbox model="doctype.selected"
+                                                  on-change="vm.selectDocumentType(doctype)"
+                                                  text="{{doctype.name}}" />
+                                </label>
                             </div>
                         </umb-control-group>
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -131,20 +131,18 @@
                                 <localize key="general_add">Add</localize>
                             </a>
 
-                            <label style="padding-left: 0;">
-                                <input type="checkbox" ng-model="vm.package.contentLoadChildNodes" ng-disabled="!vm.package.contentNodeId" />
-                                <localize key="packager_includeAllChildNodes">Include all child nodes</localize>
-                            </label>
+                            <umb-checkbox model="vm.package.contentLoadChildNodes"
+                                            disabled="!vm.package.contentNodeId"
+                                            text="{{vm.labels.includeAllChildNodes}}" />
 
                         </umb-control-group>
 
                         <umb-control-group label="@treeHeaders_documentTypes">
                             <div ng-repeat="doctype in ::vm.documentTypes | orderBy:'name'">
-                                <label>
-                                    <umb-checkbox model="doctype.selected"
-                                                  on-change="vm.selectDocumentType(doctype)"
-                                                  text="{{doctype.name}}" />
-                                </label>
+
+                                <umb-checkbox model="doctype.selected"
+                                                on-change="vm.selectDocumentType(doctype)"
+                                                text="{{doctype.name}}" />
                             </div>
                         </umb-control-group>
 
@@ -310,7 +308,7 @@
                                 action="vm.createOrUpdatePackage(editPackageForm)"
                                 state="vm.buttonState"
                                 button-style="success"
-                                label="{{vm.buttonLabel}}"
+                                label="{{vm.labels.button}}"
                                 disabled="vm.loading">
                     </umb-button>
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -131,11 +131,13 @@
                                 <localize key="general_add">Add</localize>
                             </a>
 
-                            <label>
-                                <umb-checkbox model="vm.package.contentLoadChildNodes"
-                                              disabled="!vm.package.contentNodeId"
-                                              text="{{vm.labels.includeAllChildNodes}}" />
-                            </label>
+                            <div>
+                                <label>
+                                    <umb-checkbox model="vm.package.contentLoadChildNodes"
+                                                  disabled="!vm.package.contentNodeId"
+                                                  text="{{vm.labels.includeAllChildNodes}}" />
+                                </label>
+                            </div>
 
                         </umb-control-group>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR replaces the traditional checkboxes in the packager with `umb-checkbox` component used in many other parts of backoffice UI, e.g. in configuration of TinyMCE.
For some of the properties we might later re-consider if e.g. a tree picker is a better options for examples with many data types, templates etc... at the moment it could potentially be a very long list of checkboxes or we could consider if these should be collapsible?

For now I have re-placed these for `umb-checkbox` to be more consistent for the UI.

**Before**

![2019-09-02_00-26-32](https://user-images.githubusercontent.com/2919859/64083005-912c0080-cd18-11e9-8fe4-7ccb4316ac21.gif)

**After**

![2019-09-01_23-20-39](https://user-images.githubusercontent.com/2919859/64082448-891b9300-cd0f-11e9-9f6c-ab7fa5056748.gif)

Furthermore it seems `umb-checkbox` has been updated with scope properties, so e.g. disabled property is binded to `vm.disabled` while the ng-class evaluated `disabled`, so at the moment when setting `disabled="true"` on `umb-checkbox` it doesn't set the class `umb-form-check--disabled`.

This was broken in this commit https://github.com/umbraco/Umbraco-CMS/commit/320d2ae95356954e85ea671090833ba0544156a2 where ´umb-checkbox` it changed to a component and using `vm`, but it is missing to use `vm` as well in the ng-class expression for to set the disabled class.

Furthermore I think the radiobutton also should be changed to a component as very, as ´umb-radiobutton` and `umb-checkbox` component, should be as identical as possible.

I have fixes these issues in this PR as well.