### PR TITLE
Added GetAllElementTypes extension method to ContentTypeService

### DIFF
--- a/src/Umbraco.Core/Services/ContentTypeServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceExtensions.cs
@@ -8,6 +8,21 @@ namespace Umbraco.Core.Services
     public static class ContentTypeServiceExtensions
     {
         /// <summary>
+        /// Gets all of the element types (e.g. content types that have been marked as an element type).
+        /// </summary>
+        /// <param name="contentTypeService">The content type service.</param>
+        /// <returns>Returns all the element types.</returns>
+        public static IEnumerable<IContentType> GetAllElementTypes(this IContentTypeService contentTypeService)
+        {
+            if (contentTypeService == null)
+            {
+                return Enumerable.Empty<IContentType>();
+            }
+
+            return contentTypeService.GetAll().Where(x => x.IsElement);
+        }
+
+        /// <summary>
         /// Returns the available composite content types for a given content type
         /// </summary>
         /// <param name="allContentTypes"></param>

--- a/src/Umbraco.Web/PropertyEditors/NestedContentController.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Umbraco.Core.Services;
 using Umbraco.Web.Editors;
 using Umbraco.Web.Mvc;
 
@@ -11,8 +12,8 @@ namespace Umbraco.Web.PropertyEditors
         [System.Web.Http.HttpGet]
         public IEnumerable<object> GetContentTypes()
         {
-            return Services.ContentTypeService.GetAll()
-                .Where(x => x.IsElement)
+            return Services.ContentTypeService
+                .GetAllElementTypes()
                 .OrderBy(x => x.SortOrder)
                 .Select(x => new
                 {


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

### Description

Added an extension method for `ContentTypeService` to get all the Element Types.

> This is something I've developed for my own package. Thought it would be useful to share.
> https://github.com/leekelleher/umbraco-contentment/blob/6938fba139b45fab6d353027a6e2e3964cb12690/src/Umbraco.Community.Contentment/DataEditors/_/ContentTypeServiceExtensions.cs#L16-L19

I've done this as an extension method, as I wasn't sure whether adding to the concrete implementation would be considered a breaking-change or not?

This PR also updates NestedContent's controller for getting the Element Types.

I haven't added any unit-tests, etc.
_(To be honest, I haven't spent that much time on this - was more of a "I've coded this already, it could be useful in core?" - I could add unit-tests, etc - if it's deemed worthy enough 😄)_




