### PR TITLE
ConfigurationFields - `Add` extension method

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ConfigurationFieldsExtensions.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationFieldsExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+
+namespace Umbraco.Core.PropertyEditors
+{
+    public static partial class ConfigurationFieldsExtensions
+    {
+        /// <summary>
+        /// Adds a configuration field.
+        /// </summary>
+        /// <param name="fields">The list of configuration fields.</param>
+        /// <param name="key">The key (alias) of the field.</param>
+        /// <param name="name">The name (label) of the field.</param>
+        /// <param name="description">The description for the field.</param>
+        /// <param name="view">The path to the editor view to be used for the field.</param>
+        /// <param name="config">Optional configuration used for field's editor.</param>
+        public static void Add(
+            this List<ConfigurationField> fields,
+            string key,
+            string name,
+            string description,
+            string view,
+            IDictionary<string, object> config = null)
+        {
+            fields.Add(new ConfigurationField
+            {
+                Key = key,
+                Name = name,
+                Description = description,
+                View = view,
+                Config = config,
+            });
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -267,6 +267,7 @@
     <Compile Include="Models\PublishedContent\ILivePublishedModelFactory.cs" />
     <Compile Include="Models\PublishedContent\IPublishedContentType.cs" />
     <Compile Include="Models\PublishedContent\IPublishedPropertyType.cs" />
+    <Compile Include="PropertyEditors\ConfigurationFieldsExtensions.cs" />
     <Compile Include="PropertyEditors\IIgnoreUserStartNodesConfig.cs" />
     <Compile Include="PublishedContentExtensions.cs" />
     <Compile Include="Models\PublishedContent\UrlMode.cs" />


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

### Description

Added an extension method for `List<ConfigurationField>` to simplify adding fields.

Currently on a `ConfigurationEditor` implementation, you can either have a strongly-typed class for the fields, or manually each of the fields, _(the latter is my personal preference)._ Adding manually it can become quite verbose...

e.g. 
```csharp
Fields.Add(new ConfigurationField() {
    Key = "myFieldAlias",
    Name = "My Field Name",
    Description = "This is description for my field.",
    View = "textstring"
});
```

For my package dev, I do this a lot ... so wrote an extension method to reduce my keystrokes...

```csharp
Fields.Add("myFieldAlias", "My Field Name", "This is description for my field.", "textstring");
```

> Here's my original code from my own package. 
> https://github.com/leekelleher/umbraco-contentment/blob/001571ebe6e864063e5576e62602176751616267/src/Umbraco.Community.Contentment/DataEditors/_/ConfigurationFieldExtensions.cs#L14-L30

I haven't added any unit-tests for this. I can do, but I haven't spent too much time on this yet.
Just thought it would be useful to share.

