### PR TITLE
Improve consistency around some buttons in the backoffice

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
@@ -38,8 +38,8 @@
                                         <span ng-class="{'strike': tour.completed}" class="umb-help-list-item__title">{{ tour.name }}</span>
                                     </div>
                                     <div>
-                                        <umb-button ng-if="!tour.completed && vm.showTourButton($index, tourGroup)" button-style="primary" size="xxs" type="button" label="Start" action="vm.startTour(tour)"></umb-button>
-                                        <umb-button ng-if="tour.completed" size="xxs" type="button" label="Rerun" action="vm.startTour(tour)"></umb-button>
+                                        <umb-button ng-if="!tour.completed && vm.showTourButton($index, tourGroup)" button-style="primary" type="button" label="Start" action="vm.startTour(tour)"></umb-button>
+                                        <umb-button ng-if="tour.completed" type="button" label="Rerun" action="vm.startTour(tour)"></umb-button>
                                     </div>
                                 </div>
                             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/created.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/created.html
@@ -32,7 +32,6 @@
                 <td style="text-align: right;">
                     <umb-button
                         type="button"
-                        size="xxs"
                         button-style="danger"
                         state="createdPackage.deleteButtonState"
                         label-key="general_delete"

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/installed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/installed.html
@@ -33,7 +33,6 @@
 
                             <umb-button type="button"
                                         button-style="danger"
-                                        size="xxs"
                                         label-key="packager_packageUninstallHeader"
                                         action="vm.confirmUninstall(installedPackage)">
                             </umb-button>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

I have tried to improve consistency around buttons in the backoffice in the following places. The following buttons have a `size="xxs"` on the directive making it look tiny and inconsistent from the rest of the application

- Packages section -> Installed Packages -> **Uninstall Package** button
- Packages section -> Created Packages -> **Delete** button
- Help drawer -> **Start** button on completed tours
- Help drawer -> **Rerun** button on tours

**Before**
![button-original](https://user-images.githubusercontent.com/3941753/64121351-831cc500-cd96-11e9-8082-dd45fb24f881.gif)

**After**
![button-fix](https://user-images.githubusercontent.com/3941753/64121348-7c8e4d80-cd96-11e9-9a33-9ad39402c559.gif)


Any clarification you need, let me know.

Poornima


