### PR TITLE
v8: Fix missing checkmark selection in section picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/utilities/_flexbox.less
+++ b/src/Umbraco.Web.UI.Client/src/less/utilities/_flexbox.less
@@ -1,7 +1,5 @@
 /*
-
     Flexbox
-
 */
 
 .flex { display: flex; }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/sectionpicker/sectionpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/sectionpicker/sectionpicker.html
@@ -19,10 +19,10 @@
             <umb-box ng-if="!vm.loading">
                 <umb-box-content>
                     <ul class="umb-tree">
-                        <li ng-repeat="section in vm.sections" class="umb-tree-item">
-                            <div style="padding: 5px 10px;" ng-class="{'umb-tree-node-checked': section.selected }">
-                                <a href="" ng-click="vm.selectSection(section)">
-                                    <i class="icon umb-tree-icon {{section.icon}}"></i>
+                        <li ng-repeat="section in vm.sections" class="umb-tree-item" ng-class="{'umb-tree-node-checked': section.selected }">
+                            <div class="umb-tree-item__inner cursor-pointer" ng-click="vm.selectSection(section)" style="padding: 5px 10px;">
+                                <i class="icon umb-tree-icon {{section.icon}}"></i>
+                                <a class="flex-auto" href="" prevent-default>
                                     <span>{{ section.name }}</span>
                                 </a>
                             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed the section picker in users section > group no longer was showing checkmark of the selected sections of when toggle selection of any of these.

**Before**

![2019-09-03_00-06-03](https://user-images.githubusercontent.com/2919859/64134504-b6834200-cdde-11e9-871e-d46ed0fade12.gif)


**After**

![2019-09-03_00-03-52](https://user-images.githubusercontent.com/2919859/64134469-6efcb600-cdde-11e9-8799-8b1446c6675a.gif)

