### PR TITLE
v8: Highlight of old password in change password form

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -24,10 +24,9 @@
             alias="changePassword"
             type="button"
             action="togglePasswordFields()"
-            button-style="action"
+            button-style="success"
             label="Change password"
-            label-key="general_changePassword"
-            button-style="success">
+            label-key="general_changePassword">
        </umb-button>
 
         <umb-button

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -49,8 +49,7 @@
 
         <div ng-repeat="login in externalLoginProviders">
 
-			<form ng-if="login.linkedProviderKey == undefined" method="POST" name="externalLoginForm"
-				  action="{{externalLinkLoginFormAction}}" id="oauthloginform" name="oauthloginform">
+			<form ng-if="login.linkedProviderKey == undefined" method="POST" action="{{externalLinkLoginFormAction}}" id="oauthloginform" name="oauthloginform">
 				<input type="hidden" name="provider" value="{{login.authType}}" />
                 <button class="btn btn-block btn-social"
                         ng-class="login.properties.SocialStyle"

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -24,7 +24,7 @@
             alias="changePassword"
             type="button"
             action="togglePasswordFields()"
-            button-style="success"
+            button-style="action"
             label="Change password"
             label-key="general_changePassword">
        </umb-button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
@@ -19,8 +19,8 @@
                            val-server-field="resetPassword"
                            no-dirty-check
                            ng-change="vm.showReset = !vm.showReset" />
-                    <span ng-messages="vm.passwordForm.resetPassword.$error" show-validation-on-submit>
-                        <span class="help-inline" ng-message="valServerField">{{vm.passwordForm.resetPassword.errorMsg}}</span>
+                    <span ng-messages="changePasswordForm.resetPassword.$error" show-validation-on-submit>
+                        <span class="help-inline" ng-message="valServerField">{{changePasswordForm.resetPassword.errorMsg}}</span>
                     </span>
 
                 </umb-control-group> 
@@ -32,9 +32,9 @@
                            required
                            val-server-field="oldPassword"
                            no-dirty-check />
-                    <span ng-messages="vm.passwordForm.oldPassword.$error" show-validation-on-submit>
+                    <span ng-messages="changePasswordForm.oldPassword.$error" show-validation-on-submit>
                         <span class="help-inline" ng-message="required">Required</span>
-                        <span class="help-inline" ng-message="valServerField">{{vm.passwordForm.oldPassword.errorMsg}}</span>
+                        <span class="help-inline" ng-message="valServerField">{{changePasswordForm.oldPassword.errorMsg}}</span>
                     </span>
                 </umb-control-group>
 
@@ -45,19 +45,19 @@
                            val-server-field="password"
                            ng-minlength="{{vm.config.minPasswordLength}}"
                            no-dirty-check />
-                    <span ng-messages="vm.passwordForm.password.$error" show-validation-on-submit>
+                    <span ng-messages="changePasswordForm.password.$error" show-validation-on-submit>
                         <span class="help-inline" ng-message="required">Required</span>
                         <span class="help-inline" ng-message="minlength">Minimum {{vm.config.minPasswordLength}} characters</span>
-                        <span class="help-inline" ng-message="valServerField">{{vm.passwordForm.password.errorMsg}}</span>
+                        <span class="help-inline" ng-message="valServerField">{{changePasswordForm.password.errorMsg}}</span>
                     </span>
                 </umb-control-group>
 
-                <umb-control-group alias="confirmpassword" label="@user_confirmNewPassword" ng-if="!vm.showReset" required="true">
-                    <input type="password" name="confirmpassword" ng-model="vm.passwordValues.confirm"
+                <umb-control-group alias="confirmPassword" label="@user_confirmNewPassword" ng-if="!vm.showReset" required="true">
+                    <input type="password" name="confirmPassword" ng-model="vm.passwordValues.confirm"
                            class="input-block-level umb-textstring textstring"
                            val-compare="password"
                            no-dirty-check />
-                    <span ng-messages="vm.passwordForm.confirmpassword.$error" show-validation-on-submit>
+                    <span ng-messages="changePasswordForm.confirmPassword.$error" show-validation-on-submit>
                         <span class="help-inline" ng-message="valCompare"><localize key="user_passwordMismatch">The confirmed password doesn't match the new password!</localize></span>
                     </span>
                 </umb-control-group>

--- a/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
@@ -12,7 +12,7 @@
         </div>
         <div ng-switch-when="true">
 
-            <ng-form name="passwordForm">
+            <ng-form name="changePasswordForm">
                 <umb-control-group alias="resetPassword" label="@user_resetPassword" ng-show="vm.config.enableReset">
                     <input type="checkbox" ng-model="vm.passwordValues.reset"
                            name="resetPassword"

--- a/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
@@ -15,7 +15,6 @@
             <ng-form name="vm.passwordForm">
                 <umb-control-group alias="resetPassword" label="@user_resetPassword" ng-show="vm.config.enableReset">
                     <input type="checkbox" ng-model="vm.passwordValues.reset"
-                           id="Checkbox1"
                            name="resetPassword"
                            val-server-field="resetPassword"
                            no-dirty-check

--- a/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
@@ -12,7 +12,7 @@
         </div>
         <div ng-switch-when="true">
 
-            <ng-form name="vm.passwordForm">
+            <ng-form name="passwordForm">
                 <umb-control-group alias="resetPassword" label="@user_resetPassword" ng-show="vm.config.enableReset">
                     <input type="checkbox" ng-model="vm.passwordValues.reset"
                            name="resetPassword"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/4678

### Description
This PR fixes an issue where the old password field in change password form was not highlighted, because of the name of the form which returned `vm.passwordForm` and not the interpolated value `{{vm.passwordForm}}`, but `vm.passwordForm` is an object anyway. It seems this was changed here https://github.com/umbraco/Umbraco-CMS/blame/d2be30a228af13e34967e89fe11010749b1bad1b/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html#L19

I have changed this name to `changePasswordForm` since the parent regular form has the name `passwordForm` here: https://github.com/umbraco/Umbraco-CMS/blob/db6714d3b8f8e04dceb607c3a25117331f6b525d/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html#L98-L107

It seems the oldPassword field sometimes in highlighted and other times not. In user section on a user it seems always to be highlighted when invalid.