### PR TITLE
Apply focus to URL input on embed overlay open. Issue #6276

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/embed/embed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/embed/embed.html
@@ -1,7 +1,7 @@
 <form ng-controller="Umbraco.Overlays.EmbedOverlay as vm">
 
    <umb-control-group label="@general_url">
-       <input id="url" class="umb-editor input-block-level" type="text" style="margin-bottom: 10px;" ng-model="model.embed.url" ng-keyup="$event.keyCode == 13 ? vm.showPreview() : null" required />
+       <input id="url" class="umb-editor input-block-level" type="text" style="margin-bottom: 10px;" ng-model="model.embed.url" ng-keyup="$event.keyCode == 13 ? vm.showPreview() : null" focus-when="{{true}}" required />
        <input type="button" ng-click="vm.showPreview()" class="btn" value="@general_retrieve" localize="value" />
    </umb-control-group>
 


### PR DESCRIPTION
This is a patch for [Issue 6276](https://github.com/umbraco/Umbraco-CMS/issues/6276).

## Description of problem
When Umbraco's RTE Embed dialog is opened, the URL input does not automatically get focus. If a user tries to paste an embed url without first clicking on the URL input, they will unknowingly be pasting the embed url into the RTE behind the dialog. This could result in the url being rendered directly on the front end next to the embed iframe.

This is the RTE embed that I patched:
![rte_embed_toolbar](https://user-images.githubusercontent.com/1404230/64215072-ecb8d400-ce67-11e9-8be9-8861d4ddce22.png)

This is the input that should automatically be getting focus
![rte_embed_overlay_dialog](https://user-images.githubusercontent.com/1404230/64215081-efb3c480-ce67-11e9-9ccf-16d58aea50de.png)


## Description of solution
I saw that the `focus-when` directive was used to solve this problem for other overlays like the `Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html`. I applied the same `focus-when` directive to the embed overlay at `Umbraco.Web.UI.Client/src/views/common/overlays/embed/embed.html`

## Steps to reproduce
1. Ensure that the Richtext editor datatype has the Embed toolbar option enabled
1. Open a content node with the Richtext editor datatype on it.
1. Copy a youtube url into your clipboard
1. Click on the Embed icon in the RTE's toolbar. When the dialog opens, do not click anywhere.
1. Paste from your clipboard.

### Expected result
When you open the dialog, the URL field should automatically get focus. When you paste, you should see the youtube url in your clipboard pasted into the URL input. You should be able to successfully retrieve the embed iframe and submit it.

### Actual result
When you open the embed dialog, the URL field does not have focus. When you paste, it looks like nothing happens. If you click on the URL to give it focus before pasting, you should see the youtube url in your clipboard pasted into the URL input. You should then be able to successfully retrieve the embed iframe and submit it. When you do, you should see the raw embed url from your original and failed paste in the rich text editor.