### PR TITLE
V8: Update umbracoUser2NodeNotify in SuperZero migration

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/SuperZero.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/SuperZero.cs
@@ -30,6 +30,7 @@
             Database.Execute("set identity_insert umbracoUser off;");
 
             Database.Execute("update umbracoUser2UserGroup set userId=-1 where userId=0;");
+            Database.Execute("update umbracoUser2NodeNotify set userId=-1 where userId=0;");
             Database.Execute("update umbracoNode set nodeUser=-1 where nodeUser=0;");
             Database.Execute("update umbracoUserLogin set userId=-1 where userId=0;");
             Database.Execute($"update {Constants.DatabaseSchema.Tables.ContentVersion} set userId=-1 where userId=0;");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6280

### Description

The SuperZero migration moves the superuser from ID 0 to -1, but it doesn't update `umbracoUser2NodeNotify`. If there are any notifications configured for user ID 0, the migration fails with a foreign key violation.

This PR just adds the missing SQL update.

Testing:
- In 7.15, set up some notifications for user ID 0 on any content.
- Upgrade to 8.1.
