### PR TITLE
V8: Fix mandatory validation clientside for Content Picker and MNTP

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -117,6 +117,12 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         }
         //merge the server config on top of the default config, then set the server config to use the result
         $scope.model.config = angular.extend(defaultConfig, $scope.model.config);
+
+        // if the property is mandatory, set the minCount config to 1 (unless of course it is set to something already),
+        // that way the minCount/maxCount validation handles the mandatory as well
+        if ($scope.model.validation && $scope.model.validation.mandatory && !$scope.model.config.minNumber) {
+            $scope.model.config.minNumber = 1;
+        }
     }
 
     //Umbraco persists boolean for prevalues as "0" or "1" so we need to convert that!


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6270

### Description

See #6270 for a description of the issue. Note that this applies to both MNTP and Content Picker properties.

With this PR applied, both property types expect at least one selected item before clientside validation passes:

![mntp-content-picker-mandatory](https://user-images.githubusercontent.com/7405322/64256336-8c876800-cf23-11e9-829c-dcb4e4f3784c.gif)
