### PR TITLE
V8: Sections tray dropdown uses old colours

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -2,129 +2,135 @@
 // -------------------------
 
 ul.sections {
-	margin: 0;
-	display: flex;
-	margin-left: -20px;
-}
-
-ul.sections>li {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	position: relative;
-}
-
-ul.sections>li>a {
-	color: @white;
-	height: @appHeaderHeight;
+    margin: 0;
     display: flex;
-	align-items: center;
-	justify-content: center;
-	position: relative;
-	padding: 0 10px;
-	text-decoration: none;
-	outline: none;
-	cursor: pointer;
-}
+    margin-left: -20px;
 
-ul.sections>li>a .section__name {
-    border-radius: 3px;
-    margin-top:1px;
-    padding: 3px 10px 4px 10px;
-	opacity: 0.8;
-	transition: opacity .1s linear, box-shadow .1s;
-}
+    > li {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        position: relative;
 
-ul.sections>li>a::after {
-	content: "";
-    left: 10px;
-    right: 10px;
-	height: 4px;
-	bottom: 0;
-    transform: translateY(4px);
-	background-color: @pinkLight;
-    position: absolute;
-	border-radius: 3px 3px 0 0;
-	opacity: 0;
-	padding: 0 2px;
-	transition: transform 240ms ease-in-out;
-}
+        > a {
+            color: @white;
+            height: @appHeaderHeight;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            position: relative;
+            padding: 0 10px;
+            text-decoration: none;
+            outline: none;
+            cursor: pointer;
 
-ul.sections>li.current>a {
-    color:@pinkLight;
-}
-ul.sections>li.current>a::after {
-	opacity: 1;
-    transform: translateY(0px);
-}
-ul.sections > li.current > a .section__name,
-ul.sections > li > a:hover .section__name {
-    opacity: 1;
-    -webkit-font-smoothing: subpixel-antialiased;
-}
+            &::after {
+                content: "";
+                left: 10px;
+                right: 10px;
+                height: 4px;
+                bottom: 0;
+                transform: translateY(4px);
+                background-color: @ui-active;
+                position: absolute;
+                border-radius: 3px 3px 0 0;
+                opacity: 0;
+                padding: 0 2px;
+                transition: transform 240ms ease-in-out;
+            }
 
-ul.sections > li > a:focus .section__name {
-    .tabbing-active & {
-        
-        border: 1px solid;
-        border-color: @gray-9;
+            &:focus .section__name {
+                .tabbing-active & {
+                    border: 1px solid;
+                    border-color: @gray-9;
+                }
+            }
+        }
+
+        .section__name {
+            border-radius: 3px;
+            margin-top: 1px;
+            padding: 3px 10px 4px 10px;
+            opacity: 0.8;
+            transition: opacity .1s linear, box-shadow .1s;
+        }
+
+        &.current a {
+            color: @ui-active;
+
+            &::after {
+                opacity: 1;
+                transform: translateY(0px);
+            }
+        }
+
+        &.expand {
+            i {
+                height: 5px;
+                width: 5px;
+                border-radius: 50%;
+                background: @white;
+                display: inline-block;
+                margin: 0 5px 0 0;
+                opacity: 0.6;
+                transition: opacity .1s linear;
+            }
+            
+            &:hover i {
+                opacity:1;
+            }
+        }
+
+        &.current .section__name,
+        a:hover .section__name {
+            opacity: 1;
+            -webkit-font-smoothing: subpixel-antialiased;
+        }
     }
 }
 
-
-
 /* Sections tray */
 
-ul.sections>li.expand i {
-	height: 5px;
-    width: 5px;
-    border-radius: 50%;
-    background: #fff;
-    display: inline-block;
-    margin: 0 5px 0 0;
-    opacity: 0.6;
-}
-
 ul.sections-tray {
-	position: absolute;
-	top: @appHeaderHeight;
-	left: 0;
-	margin: 0;
+    position: absolute;
+    top: @appHeaderHeight;
+    left: 0;
+    margin: 0;
     list-style: none;
-	background: @purple;
-	z-index: 10000;
-	border-radius: 0 0 3px 3px;
-}
+    background: @blueExtraDark;
+    z-index: 10000;
+    border-radius: 0 0 3px 3px;
 
-ul.sections-tray>li>a {
-	padding: 8px 24px;
-	color: @white;
-	text-decoration: none;
-	display: block;
-	position: relative;
-}
+    li {
 
-ul.sections-tray>li>a::after {
-	content: "";
-	width: 4px;
-	height: 100%;
-	background-color: @ui-active;
-	position: absolute;
-	border-radius: 0 3px 3px 0;
-	opacity: 0;
-	transition: all .2s linear;
-	top: 0;
-	left: 0;
-}
+        &.current a {
+            color: @ui-active;
+            opacity: 1;
 
-ul.sections-tray>li.current>a::after {
-	opacity: 1;
-}
+            &::after {
+                opacity: 1;
+            }
+        }
 
-ul.sections-tray>li>a .section__name {
-	opacity: 0.6;
-}
+        a {
+            padding: 8px 24px;
+            color: @white;
+            text-decoration: none;
+            display: block;
+            position: relative;
 
-ul.sections-tray>li>a:hover	.section__name {
-	opacity: 1;
+            &::after {
+                content: "";
+                width: 4px;
+                height: 100%;
+                background-color: @ui-active;
+                position: absolute;
+                border-radius: 0 3px 3px 0;
+                opacity: 0;
+                transition: all .2s linear;
+                top: 0;
+                left: 0;
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6287

### Description
Sections tray is purple:

![purple tray](https://user-images.githubusercontent.com/3248070/64403883-86c58a00-d0bd-11e9-86f6-8bae17c819ad.gif)

Changes in this PR make it not purple:

![blue tray](https://user-images.githubusercontent.com/3248070/64403906-92b14c00-d0bd-11e9-897e-ec5478c77d8f.gif)

There's not really a whole lot more to say... I tidied up the CSS partial a bit too, replacing hardcoded colors with variables, using the same variable when referencing a colour in multiple places, added a bit of nesting/structure to the SCSS to remove duplicated rules. But most importantly, purple is gone.
