### PR TITLE
V8: Make validation work properly with multiple invalid properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
@@ -79,7 +79,20 @@ function valFormManager(serverValidationManager, $rootScope, $timeout, $location
 
                 //get the lengths of each array for each key in the $error collection
                 var validatorLengths = _.map(formCtrl.$error, function (val, key) {
-                    return val.length;
+                    var innerErrorCount = 0;
+                    // if there are child ng-forms, include the $error collections in those as well
+                    if (val.$error && val.$error.length) {
+                        innerErrorCount = _.reduce(
+                            _.map(val, v =>
+                                _.reduce(
+                                    _.map(v.$error, e => e.length),
+                                    (m, n) => m + n
+                                )
+                            ),
+                            (memo, num) => memo + num
+                        );
+                    }
+                    return val.length + innerErrorCount;
                 });
                 //sum up all numbers in the resulting array
                 var sum = _.reduce(validatorLengths, function (memo, num) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
@@ -79,10 +79,8 @@ function valFormManager(serverValidationManager, $rootScope, $timeout, $location
 
                 //get the lengths of each array for each key in the $error collection
                 var validatorLengths = _.map(formCtrl.$error, function (val, key) {
-                    var innerErrorCount = 0;
                     // if there are child ng-forms, include the $error collections in those as well
-                    if (val.$error && val.$error.length) {
-                        innerErrorCount = _.reduce(
+                    var innerErrorCount = _.reduce(
                             _.map(val, v =>
                                 _.reduce(
                                     _.map(v.$error, e => e.length),
@@ -91,7 +89,6 @@ function valFormManager(serverValidationManager, $rootScope, $timeout, $location
                             ),
                             (memo, num) => memo + num
                         );
-                    }
                     return val.length + innerErrorCount;
                 });
                 //sum up all numbers in the resulting array


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you have multiple invalid fields in an editor in "submitted" state, the valid state of the fields doesn't *entirely* kick in until all validation errors of that specific type are corrected (e.g. all mandatory validations must be fulfilled before all fields appear completely valid).

It gets a lot worse when you add property editors that utilize `$setValidity` to do custom validation - for example MNTP with min/max count bounds.

Here's a GIF that shows all of the above:

![validation-multiple-invalid-before](https://user-images.githubusercontent.com/7405322/64420669-14927c80-d0a0-11e9-9396-e7d63cbf5521.gif)

This PR ensures that the validation watcher aggregates all concrete errors and not just the different types of errors (e.g. mandatory, min-count). When it's applied, things work a tad more intuitively:

![validation-multiple-invalid-after](https://user-images.githubusercontent.com/7405322/64420735-3855c280-d0a0-11e9-8cbb-aa66db67e106.gif)
