### PR TITLE
Changes ManifestParser to be extendable

### DIFF
--- a/src/Umbraco.Core/Runtime/CoreInitialComposer.cs
+++ b/src/Umbraco.Core/Runtime/CoreInitialComposer.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Core.Runtime
             composition.Register<DatabaseBuilder>();
 
             // register manifest parser, will be injected in collection builders where needed
-            composition.RegisterUnique<ManifestParser>();
+            composition.RegisterUnique<ManifestParser, ManifestParserImpl>();
 
             // register our predefined validators
             composition.ManifestValueValidators()

--- a/src/Umbraco.Tests/Manifest/ManifestParserTests.cs
+++ b/src/Umbraco.Tests/Manifest/ManifestParserTests.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Tests.Manifest
                 new RequiredValidator(Mock.Of<ILocalizedTextService>()),
                 new RegexValidator(Mock.Of<ILocalizedTextService>(), null)
             };
-            _parser = new ManifestParser(AppCaches.Disabled, new ManifestValueValidatorCollection(validators), new ManifestFilterCollection(Array.Empty<IManifestFilter>()),  Mock.Of<ILogger>());
+            _parser = new ManifestParserImpl(AppCaches.Disabled, new ManifestValueValidatorCollection(validators), new ManifestFilterCollection(Array.Empty<IManifestFilter>()),  Mock.Of<ILogger>());
         }
 
         [Test]

--- a/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
@@ -365,7 +365,7 @@ namespace Umbraco.Tests.Testing
 
             // somehow property editor ends up wanting this
             Composition.WithCollectionBuilder<ManifestValueValidatorCollectionBuilder>();
-            Composition.RegisterUnique<ManifestParser>();
+            Composition.RegisterUnique<ManifestParser, ManifestParserImpl>();
 
             // note - don't register collections, use builders
             Composition.WithCollectionBuilder<DataEditorCollectionBuilder>();

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -349,6 +349,9 @@
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:8200/</IISUrl>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <DevelopmentServerPort>8130</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:8130</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>


### PR DESCRIPTION
This changes extends the `ManifestParser` class by making it `abstract` and providing a basic implementation, which allows us to setup dependency injection of the existing class. This means that we don't change any of the existing usages of the  `ManifestParser` class, but provide a way to replace the existing usages with a custom implementation.

In order to extend the `ManifestParser` you can provide your own implementation like this: 
`composition.RegisterUnique<ManifestParser, CustomManifestParser>();`.

This will allow you to load manifest files from a different source - ie. a database.
Ultimate goal here is to have everything from within the `App_Plugins` folder live in blob storage.