### PR TITLE
V8: Make Multi URL Picker mandatory validation work clientside

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -134,6 +134,12 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
             .then(function (data) {
                 vm.labels.general_recycleBin = data[0];
             });
+
+        // if the property is mandatory, set the minCount config to 1 (unless of course it is set to something already),
+        // that way the minCount/maxCount validation handles the mandatory as well
+        if ($scope.model.validation && $scope.model.validation.mandatory && !$scope.model.config.minNumber) {
+            $scope.model.config.minNumber = 1;
+        }
     }
 
     init();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

*This is the Multi URL Picker equivalent of #6282*

Multi URL Picker does not perform its mandatory validation on the clientside like it does its min/max bounds validation. The validation is performed serverside, but it would be more consistent to have it work clientside as well:

![multi-url-picker-mandatory-before](https://user-images.githubusercontent.com/7405322/64453845-cefaa180-d0e9-11e9-97eb-77bd2c6398ad.gif)

This PR fixes the validation in exactly the same way as MNTP handles mandatory validation clientside:

![multi-url-picker-mandatory-after](https://user-images.githubusercontent.com/7405322/64453872-e043ae00-d0e9-11e9-83d2-de73b381a0af.gif)

#### Testing this PR

1. Create a doctype with a mandatory Multi URL Picker property.
2. Ensure you can't create content of this type without picking at least one URL.
3. Update the Multi URL Picker so it requires at least two or more URLs picked.
4. Verify that the new minimum number of URLs is enforced when editing the content.