### PR TITLE
"Actions" is identified as a button, but behaves like a drop down

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
@@ -67,6 +67,9 @@ Use this directive to render an umbraco button. The directive can be used to gen
 @param {boolean=} disabled Set to <code>true</code> to disable the button.
 @param {string=} addEllipsis Adds an ellipsis character (…) to the button label which means the button will open a dialog or prompt the user for more information.
 @param {string=} showCaret Shows a caret on the right side of the button label
+@param {string=} autoFocus add autoFocus to the button
+@param {string=} hasPopup Used to expose to the accessibility API whether the button will trigger a popup or not
+@param {string=]} isExpanded Used to add an aria-expanded attribute and expose whether the button has expanded a popup or not
 
 **/
 
@@ -96,7 +99,9 @@ Use this directive to render an umbraco button. The directive can be used to gen
                 alias: "@?",
                 addEllipsis: "@?",
                 showCaret: "@?",
-                autoFocus: "@?"
+                autoFocus: "@?",
+                hasPopup: "@?",
+                isExpanded: "=?"
             }
         });
 
@@ -126,13 +131,13 @@ Use this directive to render an umbraco button. The directive can be used to gen
 
                 // make it possible to pass in multiple styles
                 if(vm.buttonStyle.startsWith("[") && vm.buttonStyle.endsWith("]")) {
-                    
+
                     // when using an attr it will always be a string so we need to remove square brackets
                     // and turn it into and array
                     var withoutBrackets = vm.buttonStyle.replace(/[\[\]']+/g,'');
                     // split array by , + make sure to catch whitespaces
                     var array = withoutBrackets.split(/\s?,\s?/g);
-                    
+
                     angular.forEach(array, function(item){
                         vm.style = vm.style + " " + "btn-" + item;
                         if(item === "block") {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
@@ -101,7 +101,7 @@ Use this directive to render an umbraco button. The directive can be used to gen
                 showCaret: "@?",
                 autoFocus: "@?",
                 hasPopup: "@?",
-                isExpanded: "=?"
+                isExpanded: "<?"
             }
         });
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
@@ -9,9 +9,9 @@
 
     <a ng-if="vm.type === 'link'" ng-href="{{vm.href}}" class="btn umb-button__button {{vm.style}} umb-button--{{vm.size}}" ng-click="vm.clickButton($event)" hotkey="{{vm.shortcut}}" hotkey-when-hidden="{{vm.shortcutWhenHidden}}">
         <span class="umb-button__content" ng-class="{'-hidden': vm.innerState !== 'init'}">
-            <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon"></i>
+            <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon" aria-hidden="true"></i>
             {{vm.buttonLabel}}
-            <span ng-if="vm.showCaret" class="umb-button__caret caret"></span>
+            <span ng-if="vm.showCaret" class="umb-button__caret caret" aria-hidden="true"></span>
         </span>
     </a>
 
@@ -36,9 +36,9 @@
 
     <button ng-if="vm.type === 'submit'" type="submit" class="btn umb-button__button {{vm.style}} umb-button--{{vm.size}}" hotkey="{{vm.shortcut}}" hotkey-when-hidden="{{vm.shortcutWhenHidden}}" ng-disabled="vm.disabled" umb-auto-focus="{{vm.autoFocus && !vm.disabled ? 'true' : 'false'}}">
         <span class="umb-button__content" ng-class="{'-hidden': vm.innerState !== 'init'}">
-            <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon"></i>
+            <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon" aria-hidden="true"></i>
             {{vm.buttonLabel}}
-            <span ng-if="vm.showCaret" class="umb-button__caret caret"></span>
+            <span ng-if="vm.showCaret" class="umb-button__caret caret" aria-hidden="true"></span>
         </span>
     </button>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
@@ -15,11 +15,22 @@
         </span>
     </a>
 
-    <button ng-if="vm.type === 'button'" type="button" class="btn umb-button__button {{vm.style}} umb-button--{{vm.size}}" ng-click="vm.clickButton($event)" hotkey="{{vm.shortcut}}" hotkey-when-hidden="{{vm.shortcutWhenHidden}}" ng-disabled="vm.disabled" umb-auto-focus="{{vm.autoFocus && !vm.disabled ? 'true' : 'false'}}">
+    <button
+        ng-if="vm.type === 'button'"
+        type="button"
+        class="btn umb-button__button {{vm.style}} umb-button--{{vm.size}}"
+        ng-click="vm.clickButton($event)"
+        hotkey="{{vm.shortcut}}"
+        hotkey-when-hidden="{{vm.shortcutWhenHidden}}"
+        ng-disabled="vm.disabled"
+        umb-auto-focus="{{vm.autoFocus && !vm.disabled ? 'true' : 'false'}}"
+        aria-haspopup="{{vm.hasPopup}}"
+        aria-expanded="{{vm.isExpanded}}"
+        >
         <span class="umb-button__content" ng-class="{'-hidden': vm.innerState !== 'init'}">
-            <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon"></i>
+            <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon" aria-hidden="true"></i>
             {{vm.buttonLabel}}
-            <span ng-if="vm.showCaret" class="umb-button__caret caret"></span>
+            <span ng-if="vm.showCaret" class="umb-button__caret caret" aria-hidden="true"></span>
         </span>
     </button>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
@@ -6,8 +6,8 @@
         action="dropdown.isOpen = !dropdown.isOpen"
         label-key="general_actions"
         show-caret="true"
-        hasPopup="true"
-        isExpanded="dropdown.isOpen"
+        has-popup="true"
+        is-expanded="dropdown.isOpen"
         >
     </umb-button>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
@@ -11,7 +11,7 @@
         >
     </umb-button>
 
-    <umb-dropdown ng-if="dropdown.isOpen" class="umb-actions" on-close="dropdown.isOpen = false">
+    <umb-dropdown ng-if="dropdown.isOpen" class="umb-actions" on-close="dropdown.isOpen = false" deep-blur="dropdown.isOpen = false">
         <umb-dropdown-item class="umb-action" ng-class="{'sep':action.separatorm, '-opens-dialog': action.opensDialog}" ng-repeat="action in actions">
             <button type="button" ng-click="executeMenuItem(action)">
                 <i class="icon icon-{{action.cssclass}}" aria-hidden="true"></i>

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
@@ -5,7 +5,10 @@
         button-style="white"
         action="dropdown.isOpen = !dropdown.isOpen"
         label-key="general_actions"
-        show-caret="true">
+        show-caret="true"
+        hasPopup="true"
+        isExpanded="dropdown.isOpen"
+        >
     </umb-button>
 
     <umb-dropdown ng-if="dropdown.isOpen" class="umb-actions" on-close="dropdown.isOpen = false">

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
@@ -10,10 +10,10 @@
 
     <umb-dropdown ng-if="dropdown.isOpen" class="umb-actions" on-close="dropdown.isOpen = false">
         <umb-dropdown-item class="umb-action" ng-class="{'sep':action.separatorm, '-opens-dialog': action.opensDialog}" ng-repeat="action in actions">
-            <a href="" ng-click="executeMenuItem(action)" prevent-default>
-                <i class="icon icon-{{action.cssclass}}"></i>
+            <button type="button" ng-click="executeMenuItem(action)">
+                <i class="icon icon-{{action.cssclass}}" aria-hidden="true"></i>
                 <span class="menu-label">{{action.name}}</span>
-            </a>
+            </button>
         </umb-dropdown-item>
     </umb-dropdown>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes issue no. **8** and **44** from #5277 

### Description
Much of the groundwork for this was done in #5884 so the following things have been fixed
- Addition of `aria-haspopup` and `aria-expanded` attributes on the button that triggers the action dropdown
- The menu items have been changed from `<a>` to `<button>` elements
- the `aria-hidden="true"` attribute has been added to `<i>` and `<span>` elements that are used to display icons (This goes for all the possible outcomes in the umb-button.html view)
- The umb-botton directive has been extended so it's possible to add the above mentioned aria attributes by passing values for "isExpanded" and "hasPopup"
- The deep-blur directive has been added so the dropdown disappears when it's being tabbed out of using keyboard navigation (See the gif below)

**Before**
![actions-dropdown-before](https://user-images.githubusercontent.com/1932158/64480922-0e042200-d1d2-11e9-8ac7-420d65b1f00e.gif)

**After**
![actions-dropdown-after](https://user-images.githubusercontent.com/1932158/64480924-13fa0300-d1d2-11e9-9e65-70fe4d4771c3.gif)
