### PR TITLE
Links components (e.g. 'Footer links'), 'Add' is identfied as "Add link" but doesn't identify the label

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
@@ -89,11 +89,13 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    background: transparent;
     border: 1px dashed @ui-action-discreet-border;
     color: @ui-action-discreet-type;
     font-weight: bold;
     padding: 5px 15px;
     box-sizing: border-box;
+    width: 100%;
 }
 
 .umb-node-preview-add:hover {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -80,7 +80,6 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     $scope.sortableModel = [];
 
     $scope.labels = vm.labels;
-    $scope.currentPickerIsOpen = false;
 
     $scope.dialogEditor = editorState && editorState.current && editorState.current.isDialogEditor === true;
 
@@ -230,7 +229,6 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     //dialog
     $scope.openCurrentPicker = function () {
         $scope.currentPicker = dialogOptions;
-        $scope.currentPickerIsOpen = true;
 
         $scope.currentPicker.submit = function (model) {
             if (angular.isArray(model.selection)) {
@@ -244,7 +242,6 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         }
 
         $scope.currentPicker.close = function () {
-            $scope.currentPickerIsOpen = false;
             editorService.close();
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -16,7 +16,8 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
 
     var vm = {
         labels: {
-            general_recycleBin: ""
+            general_recycleBin: "",
+            general_add: ""
         }
     };
 
@@ -77,6 +78,8 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
 
     $scope.renderModel = [];
     $scope.sortableModel = [];
+
+    $scope.labels = vm.labels;
 
     $scope.dialogEditor = editorState && editorState.current && editorState.current.isDialogEditor === true;
 
@@ -479,9 +482,10 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     }
 
     function init() {
-        localizationService.localizeMany(["general_recycleBin"])
+        localizationService.localizeMany(["general_recycleBin", "general_add"])
             .then(function(data) {
                 vm.labels.general_recycleBin = data[0];
+                vm.labels.general_add = data[1];
 
                 syncRenderModel(false).then(function () {
                     //everything is loaded, start the watch on the model

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -80,6 +80,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     $scope.sortableModel = [];
 
     $scope.labels = vm.labels;
+    $scope.currentPickerIsOpen = false;
 
     $scope.dialogEditor = editorState && editorState.current && editorState.current.isDialogEditor === true;
 
@@ -229,6 +230,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
     //dialog
     $scope.openCurrentPicker = function () {
         $scope.currentPicker = dialogOptions;
+        $scope.currentPickerIsOpen = true;
 
         $scope.currentPicker.submit = function (model) {
             if (angular.isArray(model.selection)) {
@@ -242,6 +244,7 @@ function contentPickerController($scope, entityResource, editorState, iconHelper
         }
 
         $scope.currentPicker.close = function () {
+            $scope.currentPickerIsOpen = false;
             editorService.close();
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -19,13 +19,16 @@
             </umb-node-preview>
         </div>
 
-        <a ng-show="model.config.multiPicker === true && renderModel.length < model.config.maxNumber || renderModel.length === 0 || !model.config.maxNumber"
-           class="umb-node-preview-add"
-           href=""
-           ng-click="openCurrentPicker()"
-           prevent-default>
+        <button
+            ng-show="model.config.multiPicker === true && renderModel.length < model.config.maxNumber || renderModel.length === 0 || !model.config.maxNumber"
+            type="button"
+            class="umb-node-preview-add"
+            ng-click="openCurrentPicker()"
+            id="{{model.alias}}"
+            aria-label="{{model.label}}: {{labels.general_add}}"
+        >
             <localize key="general_add">Add</localize>
-        </a>
+        </button>
 
         <div class="umb-contentpicker__min-max-help" ng-if="model.config.multiPicker === true">
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -26,8 +26,7 @@
             ng-click="openCurrentPicker()"
             id="{{model.alias}}"
             aria-label="{{model.label}}: {{labels.general_add}}"
-            aria-haspopup="true"
-            aria-expanded="{{currentPickerIsOpen}}"
+            aria-haspopup="dialog"
         >
             <localize key="general_add">Add</localize>
         </button>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -26,6 +26,8 @@
             ng-click="openCurrentPicker()"
             id="{{model.alias}}"
             aria-label="{{model.label}}: {{labels.general_add}}"
+            aria-haspopup="true"
+            aria-expanded="{{currentPickerIsOpen}}"
         >
             <localize key="general_add">Add</localize>
         </button>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes issue **37** from #5277

### Description
Unfortunately I can't illustrate the changes with any kind of graphics for this one 😄 

The following is what has been done
- Changed the `<a>` to `<button>` - The `prevent-default` directive has been removed since adding `type="button"` is enough to avoid form submission of any potential outer form the element may be wrapped inside
- Added `id` attribute so the label with the property name is connected/attached to the `button` - This is not possible when using `<a>` for instance but there are many reasons to why `<a>` should not be used in this case
- I have extended the labels array in the controller to also look up "general_add" and added it to the scope since we need to override the default label setup so the "Add" text from the element is also announced to screen readers - This is done by adding `aria-label` and then concatenating the two strings like in this snippet `aria-label="{{model.label}}: {{labels.general_add}}"` - This will make the screen reader say "Call to action link: Add" indicating what action to expect
- ~~Since the "Add" button will trigger a popup `aria-haspopup` and `aria-expanded` attributes have been added as well indicating that a popup will be triggered and whether it's expanded or not~~
- I have pushed a new update rolling back some changes - `aria-haspopup="dialog"` is what should be used instead since it has been added to the spec - The other combination is suited for when dealing with menus, which we are not in this scenario hence the change. Not all screen readers may have implemented support for using "dialog" but I suspect that if they don't understand the value then they don't announce anything. At least that is what NVDA appears to be doing.