### PR TITLE
V8: Make decimal properties work with mandatory validation clientside

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
@@ -5,6 +5,8 @@
                pattern="[\-0-9]+([,\.][0-9]+)?"
                class="umb-property-editor umb-number"
                ng-model="model.value"
+               ng-required="model.validation.mandatory"
+               aria-required="{{model.validation.mandatory}}"
                val-server="value"
                fix-number min="{{model.config.min}}" max="{{model.config.max}}" step="{{model.config.step}}" />
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Decimal properties only validate mandatory validation on the serverside:

![decimal-mandatory-before](https://user-images.githubusercontent.com/7405322/64492713-46117080-d277-11e9-9698-e7d9136003d8.gif)

This PR ensures that the mandatory validation is also performed clientside:

![decimal-mandatory-after](https://user-images.githubusercontent.com/7405322/64492719-50cc0580-d277-11e9-82b7-7fd844f6ccf8.gif)
