### PR TITLE
V8: Fix `aria-required` for textbox properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
@@ -4,7 +4,7 @@
                class="umb-property-editor umb-textstring textstring"
                val-server="value"
                ng-required="model.validation.mandatory"
-               aria-required="model.validation.mandatory"
+               aria-required="{{model.validation.mandatory}}"
                aria-invalid="False"
                ng-trim="false"
                ng-keyup="model.change()" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The `aria-required` attribute of mandatory textbox properties is wrongly set to `model.validation.mandatory` - it should be a `true`/`false` value:

![image](https://user-images.githubusercontent.com/7405322/64492885-6b06e300-d279-11e9-838f-33635537feb0.png)

Obviously someone forgot to add the AngularJS curly braces to the mandatory property. This PR adds them, and thus the `aria-required` attribute behaves like you'd expect:

![image](https://user-images.githubusercontent.com/7405322/64492890-7f4ae000-d279-11e9-964d-604d08b7dc46.png)
