### PR TITLE
V8: Added "double" check for the decimal label

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/LabelValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/LabelValueConverter.cs
@@ -65,6 +65,8 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
                     if (source is decimal sourceDecimal) return sourceDecimal;
                     if (source is string sourceDecimalString)
                         return decimal.TryParse(sourceDecimalString, NumberStyles.Any, CultureInfo.InvariantCulture, out var d) ? d : 0;
+					if (source is double sourceDouble)
+						return Convert.ToDecimal(sourceDouble);
                     return (decimal) 0;
                 case ValueTypes.Integer:
                     if (source is int sourceInt) return sourceInt;


### PR DESCRIPTION
### Description
The (decimal) label value converter was missing the check to see if the object stored is of type **double** and so was returning 0 instead of the correct decimal figure in the front-end. 

I've added the check now, so it matches the code in the DecimalValueConverter. 