### PR TITLE
V8: Don't show Nested Content delete confirmation if an item can't be deleted

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -154,6 +154,11 @@
 
 .umb-nested-content__icon--disabled {
     opacity: 0.3;
+    cursor: default !important;
+
+    &:hover {
+        color: @ui-option-type;
+    }
 }
 
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -271,13 +271,15 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
         };
 
         $scope.deleteNode = function (idx) {
-            if ($scope.nodes.length > $scope.model.config.minItems) {
-                $scope.nodes.splice(idx, 1);
-                $scope.setDirty();
-                updateModel();
-            }
+            $scope.nodes.splice(idx, 1);
+            $scope.setDirty();
+            updateModel();
         };
         $scope.requestDeleteNode = function (idx) {
+            if ($scope.nodes.length <= $scope.model.config.minItems) {
+                return;
+            }
+
             if ($scope.model.config.confirmDeletes === true) {
                 localizationService.localizeMany(["content_nestedContentDeleteItem", "general_delete", "general_cancel", "contentTypeEditor_yesDelete"]).then(function (data) {
                     const overlay = {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The delete action isn't disabled when a Nested Content property has a minimum number of items allowed (but nothing happens after confirming the deletion):

![nc-delete-bounds-before](https://user-images.githubusercontent.com/7405322/64553861-7d952100-d33a-11e9-89ba-ef2821791a65.gif)

Of course the delete confirmation dialog shouldn't be displayed to begin with, nor should the trash icon give any indication that it's active on hover. This PR fixes that; here's that same operation with this PR applied:

![nc-delete-bounds-after](https://user-images.githubusercontent.com/7405322/64553926-9ef60d00-d33a-11e9-9352-d32bb26f13f5.gif)

To be honest I would rather have hidden the delete action altogether when it's not applicable, but I'm not sure that's the best course of action here.