### PR TITLE
Save a member twice without any changes causes an error.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -139,7 +139,7 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
 
             //anytime a user is changing a member's password without the oldPassword, we are in effect resetting it so we need to set that flag here
             var passwordProp = _.find(contentEditingHelper.getAllProps($scope.content), function (e) { return e.alias === '_umb_password' });
-            if (passwordProp && passwordProp.value && !passwordProp.value.reset) {
+            if (passwordProp && passwordProp.value && (typeof passwordProp.value.reset !== 'undefined') && !passwordProp.value.reset) {
                 //so if the admin is not explicitly resetting the password, flag it for resetting if a new password is being entered
                 passwordProp.value.reset = !passwordProp.value.oldPassword && passwordProp.config.allowManuallyChangingPassword;
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7272

### Description

See issue #7272 for details - saving a member with no changes for a second time will cause the error `Cannot set an empty password` 

To test:

- Create a member and set `allowManuallyChangingPassword` to `true` in web.config
- Before this fix: save the member twice and switch to the "Properties" tab, you will see the member having gotten a new password
- After this fix: the same should not lead to the password being updated 

Furthermore, check:

- That you can log in with the member, with the password that you initially set for them, the password should not have changed after a couple of Save operations.
- Updating the password both through the "reset password" checkbox or by manually entering a new password twice should work and you can log in on the frontend with that new password
- Do the all the same tests when `allowManuallyChangingPassword` is set to `false` 

---
_This item has been added to our backlog [AB#6579](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/6579)_