### PR TITLE
Help Drawer - Hide "Tours" heading if there are no tours

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
@@ -9,7 +9,7 @@
         <umb-drawer-content>
 
         <!-- Tours -->
-        <div class="umb-help-section" ng-if="vm.tours" data-element="help-tours">
+        <div class="umb-help-section" ng-if="vm.tours.length > 0" data-element="help-tours">
 
             <h5 class="umb-help-section__title">Tours</h5>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In Umbraco v8.1.4, I'd opened the Help drawer and notices that there were no tours listed _(I'm not sure why exactly),_ but the "Tours" heading was still being displayed, (with no items below it).

In the AngularJS view, there's an `ng-if="vm.tours"` check, but in the controller `vm.tours` is declared as an empty array. Which is one of those weird JS "truthy" quirks, where an empty arrays are true.

Anyway, by adding the array length check, this fixes it.

In terms of testing, it's a case of checking that the "Tours" heading isn't displayed when there are no tours available.