### PR TITLE
Fixes V8: Can't navigate to another node when the editor is in "create" state #6127

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -614,7 +614,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                         }
                     }
 
-                    if (!this.redirectToCreatedContent(args.err.data.id) || args.softRedirect) {
+                    if (!this.redirectToCreatedContent(args.err.data.id, args.softRedirect) || args.softRedirect) {
                         // If we are not redirecting it's because this is not newly created content, else in some cases we are
                         // soft-redirecting which means the URL will change but the route wont (i.e. creating content). 
 
@@ -660,7 +660,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                 throw "args.savedContent cannot be null";
             }
 
-            if (!this.redirectToCreatedContent(args.redirectId ? args.redirectId : args.savedContent.id) || args.softRedirect) {
+            if (!this.redirectToCreatedContent(args.redirectId ? args.redirectId : args.savedContent.id, args.softRedirect) || args.softRedirect) {
 
                 // If we are not redirecting it's because this is not newly created content, else in some cases we are
                 // soft-redirecting which means the URL will change but the route wont (i.e. creating content). 
@@ -683,7 +683,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
          * We need to decide if we need to redirect to edito mode or if we will remain in create mode.
          * We will only need to maintain create mode if we have not fulfilled the basic requirements for creating an entity which is at least having a name and ID
          */
-        redirectToCreatedContent: function (id) {
+        redirectToCreatedContent: function (id, softRedirect) {
 
             //only continue if we are currently in create mode and not in infinite mode and if the resulting ID is valid
             if ($routeParams.create && (isValidIdentifier(id))) {
@@ -695,9 +695,11 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
 
                 //clear the query strings
                 navigationService.clearSearch(["cculture"]);
-                
+                if (softRedirect) {
+                    navigationService.setSoftRedirect();
+                }
                 //change to new path
-                $location.path("/" + $routeParams.section + "/" + $routeParams.tree + "/" + $routeParams.method + "/" + id);
+                $location.path("/" + $routeParams.section + "/" + $routeParams.tree + "/" + $routeParams.method + "/" + id);                
                 //don't add a browser history for this
                 $location.replace();
                 return true;

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -29,11 +29,9 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
     
 
     //A list of query strings defined that when changed will not cause a reload of the route
-    var nonRoutingQueryStrings = ["mculture", "cculture", "lq"];
+    var nonRoutingQueryStrings = ["mculture", "cculture", "lq", "sr"];
     var retainedQueryStrings = ["mculture"];
-    //A list of trees that don't cause a route when creating new items (TODO: eventually all trees should do this!)
-    var nonRoutingTreesOnCreate = ["content", "contentblueprints"];
-        
+    
     function setMode(mode) {
         switch (mode) {
         case 'tree':
@@ -140,11 +138,8 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
                 nextUrlParams = pathToRouteParts(nextUrlParams);
             }
 
-            //first check if this is a ?create=true url being redirected to it's true url
-            if (currUrlParams.create === "true" && currUrlParams.id && currUrlParams.section && currUrlParams.tree && currUrlParams.method === "edit" && 
-                !nextUrlParams.create && nextUrlParams.id && nextUrlParams.section === currUrlParams.section && nextUrlParams.tree === currUrlParams.tree && nextUrlParams.method === currUrlParams.method &&
-                nonRoutingTreesOnCreate.indexOf(nextUrlParams.tree.toLowerCase()) >= 0) {
-                //this means we're coming from a path like /content/content/edit/1234?create=true to the created path like /content/content/edit/9999
+            //check if there is a query string to indicate that a "soft redirect" is taking place, if so we are not changing navigation
+            if (nextUrlParams.sr === true) {
                 return false;
             }
 
@@ -202,6 +197,18 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
                     $location.search(k, currentSearch[k]);
                 }
             });
+        },
+
+        /**
+         * @ngdoc method
+         * @name umbraco.services.navigationService#setSoftRedirect
+         * @methodOf umbraco.services.navigationService
+         *
+         * @description
+         * utility to set a special query string to indicate that the pending navigation change is a soft redirect
+         */
+        setSoftRedirect: function () {
+            $location.search("sr", true);
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -155,7 +155,13 @@ app.run(['$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 
                         currentRouteParams = toRetain;
                     }
                     else {
-                        currentRouteParams = angular.copy(next.params); 
+                        currentRouteParams = angular.copy(next.params);
+                    }
+
+                    //always clear the 'sr' query string (soft redirect) if it exists
+                    if (currentRouteParams.sr) {
+                        currentRouteParams.sr = null;
+                        $route.updateParams(currentRouteParams);
                     }
                     
                 }


### PR DESCRIPTION
Fixes: #6127

The term "soft redirect" is used for content and blueprints which means that when we create a content item, the URL might be something like 

/content/content/edit/1234?create=true 

and then when the create/save button is pressed, we navigate to it's real URL now that it has an ID, like:

/content/content/edit/9999

In v7, we would actually allow for angular to do a full route and reload the currently edited page. This isn't ideal since you lose state, etc... so in v8 we do a 'soft redirect', meaning the URL changes but the route doesn't actually execute and we don't lose the current editor state.

The way this was done was fairly ugly and had specific checks for the 'create' URL (as above) and the destination URL (as above) and would allow or not allow the route to execute. This causes problems if you are in the create mode and then want to navigate away since it won't actually route. 

This fix is a bit cleaner, it means you need to 'opt-in' to a soft redirect when using the $location service. This adds a temporary 'sr' query string which we detect during routing, if it exists, we know that this was an opted in soft redirect which then doesn't let the route execute and also clears the 'sr' query string since it is a 'once off'. This makes things more flexible and there's no longer a need for hard coded tree types.



