### PR TITLE
Remove limit of dashboard tabs and fix when expand menu is shown

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tabs/umbtabsnav.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tabs/umbtabsnav.directive.js
@@ -103,29 +103,29 @@ Use this directive to render a tabs navigation.
             });
 
             function calculateWidth(){
-				$timeout(function(){
-                    // 70 is the width of the expand menu (three dots)
-                    var containerWidth = container.width() - 70;
+                $timeout(function(){
+                    // 70 is the width of the expand menu (three dots) + 20 for the margin on umb-tabs-nav
+                    var containerWidth = container.width() - 90;
                     var tabsWidth = 0;
                     ctrl.overflowingSections = 0;
                     ctrl.needTray = false;
-                    ctrl.maxTabs = 7;
-                    					
-					// detect how many tabs we can show on the screen
-					for (var i = 0; i < tabNavItemsWidths.length; i++) {
+                    ctrl.maxTabs = tabNavItemsWidths.length;
+
+                    // detect how many tabs we can show on the screen
+                    for (var i = 0; i <= tabNavItemsWidths.length; i++) {
                         
                         var tabWidth = tabNavItemsWidths[i];
                         tabsWidth += tabWidth;
 
-						if(tabsWidth >= containerWidth) {
-							ctrl.needTray = true;
-							ctrl.maxTabs = i;
-							ctrl.overflowingTabs = ctrl.maxTabs - ctrl.tabs.length;
-							break;
-						}
+                        if(tabsWidth >= containerWidth) {
+                            ctrl.needTray = true;
+                            ctrl.maxTabs = i;
+                            ctrl.overflowingTabs = ctrl.maxTabs - ctrl.tabs.length;
+                            break;
+                        }
                     }
                     
-				});
+                });
             }
 
             $(window).on('resize.tabsNav', function () {
@@ -145,7 +145,6 @@ Use this directive to render a tabs navigation.
             vm.needTray = false;
             vm.showTray = false;
             vm.overflowingSections = 0;
-            vm.maxTabs = 7;
 
             vm.clickTab = clickTab;
             vm.toggleTray = toggleTray;


### PR DESCRIPTION
I had a problem when adding dashboards to the settings section they weren't showing up if they actually could fit on the screen. They did show up in the expand menu if they couldn't fit on the screen.

It turned out there was hardcoded a max number of visible tabs set to 7, I've removed the max and now it behaves as it should.

**Before**:
![image](https://user-images.githubusercontent.com/379886/64849170-18c81800-d613-11e9-8342-abc9760e913f.png)

![image](https://user-images.githubusercontent.com/379886/64849180-1bc30880-d613-11e9-8df2-3d1c049c180b.png)

**After**:

![image](https://user-images.githubusercontent.com/379886/64849186-1fef2600-d613-11e9-8603-099ae1f38df5.png)

![image](https://user-images.githubusercontent.com/379886/64849190-21b8e980-d613-11e9-8971-74a4fbc6b404.png)


To test add a `package.manifest` with some dashboards, e.g. in `App_Plugins\test`

```json
{
  "dashboards":[
    {
      "alias": "newDashboard",
      "view": "someview.html",
      "sections": ["settings"]
    },
    {
      "alias": "anotherDashboard",
      "view": "someview.html",
      "sections": ["settings"]
    },
    {
      "alias": "moreDashboards",
      "view": "someview.html",
      "sections": ["settings"]
    }
  ]
}
```