### PR TITLE
Fix some accessibility misunderstandings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
@@ -46,7 +46,7 @@
             hotkey-when-hidden="{{subButton.hotKeyWhenHidden}}"
             prevent-default>
                <localize key="{{subButton.labelKey}}">{{subButton.labelKey}}</localize>
-               <span ng-if="subButton.addEllipsis === 'true'" aria-hidden="true">...</span>
+               <span ng-if="subButton.addEllipsis === 'true'">...</span>
          </button>
       </umb-dropdown-item>
    </umb-dropdown>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
@@ -31,10 +31,9 @@
             title="Edit {{name}}"
             ng-if="allowEdit && !editUrl"
             ng-click="onEdit()"
-            aria-haspopup="dialog"
         >
             <localize key="general_edit">Edit</localize>
-            <span class="sr-only">{{name}}</span>
+            <span class="sr-only">{{name}}...</span>
         </button>
 
         <!-- If openUrl has a value we render a link otherwise a button-->
@@ -55,10 +54,9 @@
             title="Open {{name}}"
             ng-if="allowOpen && !openUrl"
             ng-click="onOpen()"
-            aria-haspopup="dialog"
         >
             <localize key="general_open">Open</localize>
-            <span class="sr-only">{{name}}</span>
+            <span class="sr-only">{{name}}...</span>
         </button>
 
         <!-- If removeUrl has a value we render a link otherwise a button-->

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -26,9 +26,9 @@
             ng-click="openCurrentPicker()"
             id="{{model.alias}}"
             aria-label="{{model.label}}: {{labels.general_add}}"
-            aria-haspopup="dialog"
         >
             <localize key="general_add">Add</localize>
+            <span class="sr-only">...</span>
         </button>
 
         <div class="umb-contentpicker__min-max-help" ng-if="model.config.multiPicker === true">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR fixes some accessibility misunderstandings on my part for some of PR's that has gotten accepted into the core already.

1. The usage of `aria-haspopup="dialog"` will not make screen readers announce that a dialog will be visible currenlty - NVDA for instances will announce that it's a menu. So for now it's better to use the ellipsis convention. Therefore I have added a `<span class="sr-only">...</span>` after having a good chat with Florian Beijers about this. He suggested adding the text "(Opens dialog)" since the ellipsis approach is not used much on the web but mostly in software - But then we agreed that while "(Opens dialog)" would be nice it was less work to use the ellipsis since it does not require translation
2. Which leads me to the next fix addressed in this PR - I removed the `aria-hidden="true"` attribute from the ellipsis since I realized that it's of course very relevant to have them announced letting screen reader users know that it will popup some kind of dialog - HQ got this correct from the start. #h5is 😄 