### PR TITLE
V7: Error upgrading due to SecurityStamp being null

### DIFF
--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -11,5 +11,5 @@ using System.Resources;
 
 [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyFileVersion("7.15.3")]
-[assembly: AssemblyInformationalVersion("7.15.3")]
+[assembly: AssemblyFileVersion("7.15.4")]
+[assembly: AssemblyInformationalVersion("7.15.4")]

--- a/src/Umbraco.Core/Configuration/UmbracoVersion.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoVersion.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Core.Configuration
 {
     public class UmbracoVersion
     {
-        private static readonly Version Version = new Version("7.15.3");
+        private static readonly Version Version = new Version("7.15.4");
 
         /// <summary>
         /// Gets the current version of Umbraco.

--- a/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenFifteenFour/PopulateMissingSecurityStamps.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenFifteenFour/PopulateMissingSecurityStamps.cs
@@ -1,0 +1,23 @@
+﻿using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenFifteenFour
+{
+    [Migration("7.15.4", 1, Constants.System.UmbracoMigrationName)]
+    public class PopulateMissingSecurityStamps : MigrationBase
+    {
+        public PopulateMissingSecurityStamps(ISqlSyntaxProvider sqlSyntax, ILogger logger) : base(sqlSyntax, logger)
+        {
+        }
+
+        public override void Up()
+        {
+            // A user with a NULL securityStampToken can't log in after v7.8.0
+            Execute.Sql(@"UPDATE umbracoUser SET securityStampToken = NEWID() WHERE securityStampToken IS NULL");
+        }
+
+        public override void Down()
+        {
+        }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenFifteenFour/PopulateMissingSecurityStamps.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Upgrades/TargetVersionSevenFifteenFour/PopulateMissingSecurityStamps.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.Logging;
+﻿using System;
+using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence.SqlSyntax;
 
 namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenFifteenFour
@@ -13,7 +14,7 @@ namespace Umbraco.Core.Persistence.Migrations.Upgrades.TargetVersionSevenFifteen
         public override void Up()
         {
             // A user with a NULL securityStampToken can't log in after v7.8.0
-            Execute.Sql(@"UPDATE umbracoUser SET securityStampToken = NEWID() WHERE securityStampToken IS NULL");
+            Execute.Sql($@"UPDATE umbracoUser SET securityStampToken = '{Guid.NewGuid().ToString()}' WHERE securityStampToken IS NULL");
         }
 
         public override void Down()

--- a/src/Umbraco.Core/Security/UmbracoBackOfficeIdentity.cs
+++ b/src/Umbraco.Core/Security/UmbracoBackOfficeIdentity.cs
@@ -115,6 +115,12 @@ namespace Umbraco.Core.Security
                 AddClaim(new Claim(ClaimTypes.CookiePath, "/", ClaimValueTypes.String, Issuer, Issuer, this));
             }
 
+            // if upgrading from a pre-7.3.0 version, SecurityStamp will be null
+            if (userdata.SecurityStamp == null && ApplicationContext.Current.IsUpgrading)
+            {
+                userdata.SecurityStamp = Guid.NewGuid().ToString();
+            }
+
             _currentIssuer = claimsIdentity.AuthenticationType;
             UserData = userdata;
             AddExistingClaims(claimsIdentity);
@@ -228,15 +234,7 @@ namespace Umbraco.Core.Security
             // by the SecurityStampValidator, see: https://katanaproject.codeplex.com/workitem/444
             if (HasClaim(x => x.Type == Microsoft.AspNet.Identity.Constants.DefaultSecurityStampClaimType) == false)
             {
-                if (ApplicationContext.Current.IsUpgrading && SecurityStamp == null)
-                {
-                    // if upgrading from a pre-7.3.0 version, SecurityStamp will be null
-                    AddClaim(new Claim(Microsoft.AspNet.Identity.Constants.DefaultSecurityStampClaimType, Guid.Empty.ToString(), ClaimValueTypes.String, Issuer, Issuer, this));
-                }
-                else
-                {
-                    AddClaim(new Claim(Microsoft.AspNet.Identity.Constants.DefaultSecurityStampClaimType, SecurityStamp, ClaimValueTypes.String, Issuer, Issuer, this));
-                }
+                AddClaim(new Claim(Microsoft.AspNet.Identity.Constants.DefaultSecurityStampClaimType, SecurityStamp, ClaimValueTypes.String, Issuer, Issuer, this));
             }
 
             //Add each app as a separate claim

--- a/src/Umbraco.Core/Security/UmbracoBackOfficeIdentity.cs
+++ b/src/Umbraco.Core/Security/UmbracoBackOfficeIdentity.cs
@@ -227,7 +227,17 @@ namespace Umbraco.Core.Security
             //The security stamp claim is also required... this is because this claim type is hard coded
             // by the SecurityStampValidator, see: https://katanaproject.codeplex.com/workitem/444
             if (HasClaim(x => x.Type == Microsoft.AspNet.Identity.Constants.DefaultSecurityStampClaimType) == false)
-                AddClaim(new Claim(Microsoft.AspNet.Identity.Constants.DefaultSecurityStampClaimType, SecurityStamp, ClaimValueTypes.String, Issuer, Issuer, this));
+            {
+                if (ApplicationContext.Current.IsUpgrading && SecurityStamp == null)
+                {
+                    // if upgrading from a pre-7.3.0 version, SecurityStamp will be null
+                    AddClaim(new Claim(Microsoft.AspNet.Identity.Constants.DefaultSecurityStampClaimType, Guid.Empty.ToString(), ClaimValueTypes.String, Issuer, Issuer, this));
+                }
+                else
+                {
+                    AddClaim(new Claim(Microsoft.AspNet.Identity.Constants.DefaultSecurityStampClaimType, SecurityStamp, ClaimValueTypes.String, Issuer, Issuer, this));
+                }
+            }
 
             //Add each app as a separate claim
             if (HasClaim(x => x.Type == Constants.Security.AllowedApplicationsClaimType) == false)

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -576,6 +576,7 @@
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenEightZero\AddInstructionCountColumn.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenEightZero\AddCmsMediaTable.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenEightZero\AddUserLoginTable.cs" />
+    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenFifteenFour\PopulateMissingSecurityStamps.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenFourteenZero\UpdateMemberGroupPickerData.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\RenameTrueFalseField.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionSevenTwelveZero\SetDefaultTagsStorageType.cs" />

--- a/src/Umbraco.Tests/Security/UmbracoBackOfficeIdentityTests.cs
+++ b/src/Umbraco.Tests/Security/UmbracoBackOfficeIdentityTests.cs
@@ -4,9 +4,14 @@ using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web.Security;
+using Moq;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.SqlSyntax;
+using Umbraco.Core.Profiling;
+using Umbraco.Core.Scoping;
 using Umbraco.Core.Security;
 using Umbraco.Core.Services;
 
@@ -15,8 +20,23 @@ namespace Umbraco.Tests.Security
     [TestFixture]
     public class UmbracoBackOfficeIdentityTests
     {
-
         public const string TestIssuer = "TestIssuer";
+
+        [SetUp]
+        public void Initialize()
+        {
+            var sqlSyntax = new SqlCeSyntaxProvider();
+
+            //This is needed because the Migration resolver is creating migration instances with their full ctors
+            ApplicationContext.EnsureContext(
+                new ApplicationContext(
+                    new DatabaseContext(Mock.Of<IScopeProviderInternal>(), Mock.Of<ILogger>(), sqlSyntax, "test"),
+                    new ServiceContext(),
+                    CacheHelper.CreateDisabledCacheHelper(),
+                    new ProfilingLogger(Mock.Of<ILogger>(), Mock.Of<IProfiler>())),
+                true);
+        }
+
 
         [Test]
         public void Create_From_Claims_Identity()

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -1028,9 +1028,9 @@ xcopy "$(ProjectDir)"..\packages\SqlServerCE.4.0.0.1\x86\*.* "$(TargetDir)x86\" 
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>7153</DevelopmentServerPort>
+          <DevelopmentServerPort>7154</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:7153</IISUrl>
+          <IISUrl>http://localhost:7154</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>


### PR DESCRIPTION
Implements the two suggested fixes for #6224 to enable upgrades from pre-7.3.0 to 7.15.x:

- Allow login without a SecurityStamp to authorise upgrade
- Fill in any NULL security stamp values with a migration