### PR TITLE
Lazily create content and models in NuCache

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/ContentNode.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/ContentNode.cs
@@ -75,17 +75,11 @@ namespace Umbraco.Web.PublishedCache.NuCache
             if (draftData == null && publishedData == null)
                 throw new ArgumentException("Both draftData and publishedData cannot be null at the same time.");
 
-            if (draftData != null)
-            {
-                DraftContent = new PublishedContent(this, draftData, publishedSnapshotAccessor, variationContextAccessor);
-                DraftModel = DraftContent.CreateModel();
-            }
+            _publishedSnapshotAccessor = publishedSnapshotAccessor;
+            _variationContextAccessor = variationContextAccessor;
 
-            if (publishedData != null)
-            {
-                PublishedContent = new PublishedContent(this, publishedData, publishedSnapshotAccessor, variationContextAccessor);
-                PublishedModel = PublishedContent.CreateModel();
-            }
+            _draftData = draftData;
+            _publishedData = publishedData;
         }
 
         // clone
@@ -105,14 +99,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
             CreateDate = origin.CreateDate;
             CreatorId = origin.CreatorId;
 
-            var originDraft = origin.DraftContent;
-            var originPublished = origin.PublishedContent;
-
-            DraftContent = originDraft == null ? null : new PublishedContent(this, originDraft);
-            PublishedContent = originPublished == null ? null : new PublishedContent(this, originPublished);
-
-            DraftModel = DraftContent?.CreateModel();
-            PublishedModel = PublishedContent?.CreateModel();
+            _draftData = origin._draftData;
+            _publishedData = origin._publishedData;
         }
 
         // everything that is common to both draft and published versions
@@ -131,15 +119,41 @@ namespace Umbraco.Web.PublishedCache.NuCache
         public readonly DateTime CreateDate;
         public readonly int CreatorId;
 
-        // draft and published version (either can be null, but not both)
-        // are the direct PublishedContent instances
-        public PublishedContent DraftContent;
-        public PublishedContent PublishedContent;
+        private ContentData _draftData;
+        private ContentData _publishedData;
+        private IVariationContextAccessor _variationContextAccessor;
+        private IPublishedSnapshotAccessor _publishedSnapshotAccessor;
+
+        public bool HasPublished => _publishedData != null;
+        public bool HasPublishedCulture(string culture) => _publishedData != null && _publishedData.CultureInfos.ContainsKey(culture);
 
         // draft and published version (either can be null, but not both)
         // are models not direct PublishedContent instances
-        public IPublishedContent DraftModel;
-        public IPublishedContent PublishedModel;
+        private IPublishedContent _draftModel;
+        private IPublishedContent _publishedModel;
+
+        private IPublishedContent GetModel(ref IPublishedContent model, ContentData contentData)
+        {
+            if (model != null) return model;
+            if (contentData == null) return null;
+
+            // create the model - we want to be fast, so no lock here: we may create
+            // more than 1 instance, but the lock below ensures we only ever return
+            // 1 unique instance - and locking is a nice explicit way to ensure this
+
+            var m = new PublishedContent(this, contentData, _publishedSnapshotAccessor, _variationContextAccessor).CreateModel();
+
+            // locking 'this' is not a best-practice but ContentNode is internal and
+            // we know what we do, so it is fine here and avoids allocating an object
+            lock (this)
+            {
+                return model = model ?? m;
+            }
+        }
+
+        public IPublishedContent DraftModel => GetModel(ref _draftModel, _draftData);
+
+        public IPublishedContent PublishedModel => GetModel(ref _publishedModel, _publishedData);
 
         public ContentNodeKit ToKit()
             => new ContentNodeKit
@@ -147,8 +161,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     Node = this,
                     ContentTypeId = ContentType.Id,
 
-                    DraftData = DraftContent?.ContentData,
-                    PublishedData = PublishedContent?.ContentData
+                    DraftData = _draftData,
+                    PublishedData = _publishedData
                 };
     }
 }

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
@@ -233,8 +233,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             // invariant content items)
 
             // if there is no 'published' published content, no culture can be published
-            var hasPublished = _contentNode.PublishedContent != null;
-            if (!hasPublished)
+            if (!_contentNode.HasPublished)
                 return false;
 
             // if there is a 'published' published content, and does not vary = published
@@ -247,7 +246,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
             // there is a 'published' published content, and varies
             // = depends on the culture
-            return _contentNode.PublishedContent.ContentData.CultureInfos.ContainsKey(culture);
+            return _contentNode.HasPublishedCulture(culture);
         }
 
         #endregion


### PR DESCRIPTION
This is primarily to resolve issues when schema type changes are made (i.e. content types and data types) which until this PR would result in PureLive models being rebuild dozens of times and since package install/uninstall performs many of these changes and restarts, these operations would cause all sorts of odd problems due to the amount of PureLive models being rebuilt. 

With this change, the creation of the models (calls to `CreateModel`) are done lazily so only when the content is actually request. In theory this means that in the ContentTypeCacheRefresher and DataTypeCacheRefresher we wouldn't need to explicitly call `WithSafeLiveFactory` to re-compile the models eagerly, instead we would just leave the re-compilation to execute lazily when the models are needed. 

Some investigation is needed with this PR to ensure that it works as anticipated. One thing we'll need to think about is that even though we then shouldn't call `WithSafeLiveFactory` eagerly when schema types change, this call used to call the `Refresh` method of the PureLiveFactory (see https://github.com/zpqrtbnk/Zbu.ModelsBuilder/blob/v8/dev/src/Umbraco.ModelsBuilder/Umbraco/PureLiveModelFactory.cs#L81) which would do both ResetModels + EnsureModels, whereas if we don't call this and only rely on the `CreateModel` call to ensure models, it only ends up calling `EnsureModels` and not also `ResetModels`... need to figure out if that is a required call or not.