### PR TITLE
V8: Reload content after rollback

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -171,6 +171,14 @@
                 }
             }));
 
+            evts.push(eventsService.on("editors.content.reload", function (name, args) {                
+                if (args && args.node && $scope.content.id === args.node.id) {
+                    reload();
+                    loadBreadcrumb();
+                    syncTreeNode($scope.content, $scope.content.path);
+                }
+            }));
+
         }
 
         /**


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6349

### Description
The rollback dialog raises an event when it has made changes, but the content editor did not bind to that event.

Testing:
- Roll back a document to a previous version. The change should be immediately reflected in the editor, breadcrumbs, and tree.