### PR TITLE
V8: Tours - fix scrolling highlighted element into view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour.directive.js
@@ -327,10 +327,21 @@ In the following example you see how to run some custom logic before a step goes
                     }
 
                     var scrollParent = element.scrollParent();
-                    var scrollToCenterOfContainer = element[0].offsetTop - (scrollParent[0].clientHeight / 2 ) + (element[0].clientHeight / 2);
+                    var el = element;
+                    var offsetTop = 0;
+                    if (scrollParent[0] === document) {
+                        offsetTop = el[0].offsetTop;
+                    } else {
+                        while ($.contains(scrollParent[0], el[0])) {
+                            offsetTop += el[0].offsetTop;
+                            el = el.offsetParent();
+                        }
+                    }
+                    
+                    var scrollToCenterOfContainer = offsetTop - (scrollParent[0].clientHeight / 2) + (element[0].clientHeight / 2);
 
                     // Detect if scroll is needed
-                    if (element[0].offsetTop > scrollParent[0].clientHeight) {
+                    if (offsetTop > scrollParent[0].clientHeight) {
                         scrollParent.animate({
                             scrollTop: scrollToCenterOfContainer
                         }, function () {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour.directive.js
@@ -338,10 +338,13 @@ In the following example you see how to run some custom logic before a step goes
                         }
                     }
                     
-                    var scrollToCenterOfContainer = offsetTop - (scrollParent[0].clientHeight / 2) + (element[0].clientHeight / 2);
+                    var scrollToCenterOfContainer = offsetTop - (scrollParent[0].clientHeight / 2);
+                    if (element[0].clientHeight < scrollParent[0].clientHeight) {
+                        scrollToCenterOfContainer += (element[0].clientHeight / 2);
+                    }
 
                     // Detect if scroll is needed
-                    if (offsetTop > scrollParent[0].clientHeight) {
+                    if (offsetTop > scrollParent[0].clientHeight - 200) {
                         scrollParent.animate({
                             scrollTop: scrollToCenterOfContainer
                         }, function () {
@@ -402,7 +405,7 @@ In the following example you see how to run some custom logic before a step goes
                         }
 
                         if (position === "right") {
-                            if (offset.top < documentHeight / 2) {
+                            if (offset.top + popoverHeight < documentHeight) {
                                 css.top = offset.top;
                                 css.left = offset.left + width + margin;
                             } else {
@@ -422,7 +425,7 @@ In the following example you see how to run some custom logic before a step goes
                         }
 
                         if (position === "left") {
-                            if (offset.top < documentHeight / 2) {
+                            if (offset.top + popoverHeight < documentHeight) {
                                 css.top = offset.top;
                                 css.left = offset.left - popoverWidth - margin;
                             } else {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5954

### Description
Tours include code to scroll the highlighted element into view, but it incorrectly calculates the position of the highlighted item when the element's offsetParent is inside its scrollParent.

This happens in step 12 of the document types tour because property groups are position:relative.

Testing:
- View the Data structure/Document types tour
- On step 12, the page should scroll down to make the highlighted 'Add Property' button visible.