### PR TITLE
Add missing FROM clause

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/ConvertRelatedLinksToMultiUrlPicker.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/ConvertRelatedLinksToMultiUrlPicker.cs
@@ -72,6 +72,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
                             {
                                 var sqlNodeData = Sql()
                                     .Select<NodeDto>()
+                                    .From<NodeDto>()
                                     .Where<NodeDto>(x => x.NodeId == intId);
 
                                 var node = Database.Fetch<NodeDto>(sqlNodeData).FirstOrDefault();


### PR DESCRIPTION
### Description

These changes fix the issue identified in #6367.  To reproduce that problem, you need to have a v7 site with a Related Links picker with data that still references a content node by its ID, rather than a UDI.  This can often happen if you upgrade a previous v7 site with a Related Links picker (and picked data on a content node) to the latest v7 version.  Attempting to migrate the v7 site to v8 results in an exception in the ConvertRelatedLinksToMultiUrlPicker migration.

The problem was that a SQL query in the class which attempts to resolve ID references did not include a FROM clause.  The fix was to add the FROM clause.