### PR TITLE
V8: Grant the default admin group access to the Translation section

### DIFF
--- a/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
@@ -190,6 +190,7 @@ namespace Umbraco.Core.Migrations.Install
             _database.Insert(new UserGroup2AppDto { UserGroupId = 1, AppAlias = Constants.Applications.Settings });
             _database.Insert(new UserGroup2AppDto { UserGroupId = 1, AppAlias = Constants.Applications.Users });
             _database.Insert(new UserGroup2AppDto { UserGroupId = 1, AppAlias = Constants.Applications.Forms });
+            _database.Insert(new UserGroup2AppDto { UserGroupId = 1, AppAlias = Constants.Applications.Translation });
 
             _database.Insert(new UserGroup2AppDto { UserGroupId = 2, AppAlias = Constants.Applications.Content });
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6359

### Description

This PR grants the default admin group access to the Translation section during install. See #6359 

This PR does *not* migrate existing admin groups on upgrade, as I don't think that makes any kind of sense.

#### Testing this PR

1. Reset your Umbraco installation.
2. Run the installer.
3. Verify that the default admin user has access to the Translation section in the top menu.