### PR TITLE
v7/bug/6366 - Update rte.controller.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -257,7 +257,10 @@ angular.module("umbraco")
                     // Update model on change, i.e. copy/pasted text, plugins altering content
                     editor.on('SetContent', function (e) {
                         if (!e.initial) {
-                            syncContent(editor);
+                              // sync content if editor is dirty
+                              if (!editor.isNotDirty) {
+                                syncContent(editor);
+                            }
                         }
                     });
 


### PR DESCRIPTION
Fix issue where an embedded macro prevents RTE editor from returning to pristine/valid after a publish and causes the save changes dialog to appear.

### Prerequisites

Tested on the starter kit. v7.15.3

### Description

There seems to be a significant TODO comment in this file discussing issues with event handling of the RTE. So this is an interim fix prior to anyone working on a more permanent solution.

During debugging I noticed after a save and publish the editor always returned to valid/pristine despite the editor.on('SetContent') event being called each time immediately after, even if no changes had occurred inside the RTE itself. So it was a simple matter of adding an isDirty check to this event to prevent the syncContent method from being called if the editor had become valid/pristine.


