### PR TITLE
Adds udi to the content+media indexes

### DIFF
--- a/src/Umbraco.Examine/ContentValueSetBuilder.cs
+++ b/src/Umbraco.Examine/ContentValueSetBuilder.cs
@@ -45,6 +45,7 @@ namespace Umbraco.Examine
                     {"icon", c.ContentType.Icon?.Yield() ?? Enumerable.Empty<string>()},
                     {UmbracoExamineIndex.PublishedFieldName, new object[] {c.Published ? "y" : "n"}},   //Always add invariant published value
                     {"id", new object[] {c.Id}},
+                    {"udi", new object[] { c.GetUdi() } },
                     {UmbracoExamineIndex.NodeKeyFieldName, new object[] {c.Key}},
                     {"parentID", new object[] {c.Level > 1 ? c.ParentId : -1}},
                     {"level", new object[] {c.Level}},

--- a/src/Umbraco.Examine/MediaValueSetBuilder.cs
+++ b/src/Umbraco.Examine/MediaValueSetBuilder.cs
@@ -33,6 +33,7 @@ namespace Umbraco.Examine
                 {
                     {"icon", m.ContentType.Icon?.Yield() ?? Enumerable.Empty<string>()},
                     {"id", new object[] {m.Id}},
+                    {"udi", new object[] { m.GetUdi() } },
                     {UmbracoExamineIndex.NodeKeyFieldName, new object[] {m.Key}},
                     {"parentID", new object[] {m.Level > 1 ? m.ParentId : -1}},
                     {"level", new object[] {m.Level}},

--- a/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
+++ b/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
@@ -61,7 +61,7 @@ namespace Umbraco.Web.Search
 
             string type;
             var indexName = Constants.UmbracoIndexes.InternalIndexName;
-            var fields = new[] { "id", "__NodeId" };
+            var fields = new[] { "id", "__NodeId", "udi" };
 
             // TODO: WE should try to allow passing in a lucene raw query, however we will still need to do some manual string
             // manipulation for things like start paths, member types, etc...
@@ -196,6 +196,8 @@ namespace Umbraco.Web.Search
 
                     sb.Append("+(");
 
+                    AppendUdiExactWithBoost(sb, query);
+
                     AppendNodeNameExactWithBoost(sb, query, allLangs);
 
                     AppendNodeNameWithWildcards(sb, querywords, allLangs);
@@ -224,6 +226,16 @@ namespace Umbraco.Web.Search
             sb.Append(type);
 
             return true;
+        }
+
+        private void AppendUdiExactWithBoost(StringBuilder sb, string query)
+        {
+            //udi exactly boost x 10
+            sb.Append("udi:");
+            sb.Append("\"");
+            sb.Append(query.ToLower());
+            sb.Append("\"");
+            sb.Append("^10.0 ");
         }
 
         private void AppendNodeNamePhraseWithBoost(StringBuilder sb, string query, IEnumerable<string> allLangs)


### PR DESCRIPTION
Fixes #4019 

Adds a UDI field to both content and media indexes, and makes the TreeSearcher use this.

![billede](https://user-images.githubusercontent.com/3726467/65275930-ffe5c800-db26-11e9-8aff-c46250d26f91.png)

![billede](https://user-images.githubusercontent.com/3726467/65275950-0ecc7a80-db27-11e9-8d54-53553e2ad674.png)

I don't know if it is intended, or a bug, but you need to escape the `:` in the examine dashboard for searching the Udi.