### PR TITLE
Bug: RTE Image deletion error for images that has not been saved as media items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -4,7 +4,7 @@
     function ContentEditController($rootScope, $scope, $routeParams, $q, $window,
         appState, contentResource, entityResource, navigationService, notificationsService,
         serverValidationManager, contentEditingHelper, localizationService, formHelper, umbRequestHelper,
-        editorState, $http, eventsService, overlayService, $location) {
+        editorState, $http, eventsService, overlayService, $location, localStorageService) {
 
         var evts = [];
         var infiniteMode = $scope.infiniteModel && $scope.infiniteModel.infiniteMode;
@@ -188,6 +188,13 @@
             evts.push(eventsService.on("rte.file.uploaded", function(){
                 $scope.page.saveButtonState = "success";
                 $scope.page.buttonGroupState = "success";
+            }));
+
+            evts.push(eventsService.on("content.saved", function(){
+                // Clear out localstorage keys that start with tinymce__
+                // When we save/perist a content node
+                // NOTE: clearAll supports a RegEx pattern of items to remove
+                localStorageService.clearAll(/^tinymce__/);
             }));
         }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -230,6 +230,26 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                         tinymce.activeEditor.$(img).attr({ "data-tmpimg": tmpLocation });
                     });
                 });
+
+                // Get all img where src starts with blob: AND does NOT have a data=tmpimg attribute
+                // This is most likely seen as a duplicate image that has already been uploaded
+                // editor.uploadImages() does not give us any indiciation that the image been uploaded already
+                var blobImageWithNoTmpImgAttribute = editor.dom.select("img[src^='blob:']:not([data-tmpimg])");
+
+                //For each of these selected items
+                blobImageWithNoTmpImgAttribute.forEach(imageElement => {
+                    var blobSrcUri = editor.dom.getAttrib(imageElement, "src");
+
+                    // Select/find the same image uploaded with the matching SRC uri
+                    var uploadedImage = editor.dom.select(`img[src="${blobSrcUri}"][data-tmpimg]`);
+
+                    if(uploadedImage){
+                        // Get the value of the tmpimg - so we can apply it to the matched/duplicate image
+                        var dataTmpImg = editor.dom.getAttrib(uploadedImage, "data-tmpimg");
+                        editor.dom.setAttrib(imageElement, "data-tmpimg", dataTmpImg);
+                    }
+                });
+
             }
         });
     }

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -266,6 +266,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                     var tmpLocation = localStorageService.get(`tinymce__${blobSrcUri}`)
 
                     if(tmpLocation){
+                        sizeImageInEditor(editor, imageElement);
                         editor.dom.setAttrib(imageElement, "data-tmpimg", tmpLocation);
                     }
                 });

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -228,10 +228,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                         // When its being persisted in RTE property editor
                         // To create a media item & delete this tmp one etc
                         tinymce.activeEditor.$(img).attr({ "data-tmpimg": tmpLocation });
-
-                        // We need to remove the image from the cache, otherwise we can't handle if we upload the exactly 
-                        // same image twice
-                        tinymce.activeEditor.editorUpload.blobCache.removeByUri(imgSrc);
                     });
                 });
             }

--- a/src/Umbraco.Web.UI.Client/test/unit/app/propertyeditors/rte-controller.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/app/propertyeditors/rte-controller.spec.js
@@ -13,6 +13,8 @@ describe('RTE controller tests', function () {
         }
     }
 
+    beforeEach(module('LocalStorageModule'));
+
     beforeEach(module('umbraco', function ($provide) {
         $provide.value('tinyMceAssets', []);
     }));

--- a/src/Umbraco.Web/Templates/TemplateUtilities.cs
+++ b/src/Umbraco.Web/Templates/TemplateUtilities.cs
@@ -1,5 +1,6 @@
 ﻿using HtmlAgilityPack;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using Umbraco.Core;
@@ -201,7 +202,11 @@ namespace Umbraco.Web.Templates
             var tmpImages = htmlDoc.DocumentNode.SelectNodes($"//img[@{TemporaryImageDataAttribute}]");
             if (tmpImages == null || tmpImages.Count == 0)
                 return html;
-            
+
+            // An array to contain a list of URLs that
+            //  we have already processed to avoid dupes
+            var uploadedImages = new Dictionary<string, GuidUdi>();
+
             foreach (var img in tmpImages)
             {
                 // The data attribute contains the path to the tmp img to persist as a media item
@@ -209,55 +214,70 @@ namespace Umbraco.Web.Templates
 
                 if (string.IsNullOrEmpty(tmpImgPath))
                     continue;
-
+                                
                 var absoluteTempImagePath = IOHelper.MapPath(tmpImgPath);
                 var fileName = Path.GetFileName(absoluteTempImagePath);
                 var safeFileName = fileName.ToSafeFileName();
 
                 var mediaItemName = safeFileName.ToFriendlyName();
                 IMedia mediaFile;
+                GuidUdi udi;
 
-                if(mediaParentFolder == Guid.Empty)
-                    mediaFile = mediaService.CreateMedia(mediaItemName, Constants.System.Root, Constants.Conventions.MediaTypes.Image, userId);
-                else
-                    mediaFile = mediaService.CreateMedia(mediaItemName, mediaParentFolder, Constants.Conventions.MediaTypes.Image, userId);
-                               
-                var fileInfo = new FileInfo(absoluteTempImagePath);
-
-                var fileStream = fileInfo.OpenReadWithRetry();
-                if (fileStream == null) throw new InvalidOperationException("Could not acquire file stream");
-                using (fileStream)
+                if (uploadedImages.ContainsKey(tmpImgPath) == false)
                 {
-                    mediaFile.SetValue(contentTypeBaseServiceProvider, Constants.Conventions.Media.File, safeFileName, fileStream);
-                }
+                    if (mediaParentFolder == Guid.Empty)
+                        mediaFile = mediaService.CreateMedia(mediaItemName, Constants.System.Root, Constants.Conventions.MediaTypes.Image, userId);
+                    else
+                        mediaFile = mediaService.CreateMedia(mediaItemName, mediaParentFolder, Constants.Conventions.MediaTypes.Image, userId);
 
-                mediaService.Save(mediaFile, userId);
+                    var fileInfo = new FileInfo(absoluteTempImagePath);
+
+                    var fileStream = fileInfo.OpenReadWithRetry();
+                    if (fileStream == null) throw new InvalidOperationException("Could not acquire file stream");
+                    using (fileStream)
+                    {
+                        mediaFile.SetValue(contentTypeBaseServiceProvider, Constants.Conventions.Media.File, safeFileName, fileStream);
+                    }
+
+                    mediaService.Save(mediaFile, userId);
+
+                    udi = mediaFile.GetUdi();
+                }
+                else
+                {
+                    // Already been uploaded & we have it's UDI
+                    udi = uploadedImages[tmpImgPath];
+                }                
 
                 // Add the UDI to the img element as new data attribute
-                var udi = mediaFile.GetUdi();
                 img.SetAttributeValue("data-udi", udi.ToString());
 
                 //Get the new persisted image url
-                var mediaTyped = Current.UmbracoHelper.Media(mediaFile.Id);
+                var mediaTyped = Current.UmbracoHelper.Media(udi.Guid);
                 var location = mediaTyped.Url;
                 img.SetAttributeValue("src", location);
 
                 // Remove the data attribute (so we do not re-process this)
                 img.Attributes.Remove(TemporaryImageDataAttribute);
 
-                // Delete folder & image now its saved in media
-                // The folder should contain one image - as a unique guid folder created
-                // for each image uploaded from TinyMceController
-                var folderName = Path.GetDirectoryName(absoluteTempImagePath);
-                try
-                {   
-                    Directory.Delete(folderName, true);
-                }
-                catch (Exception ex)
+                // Add to the dictionary to avoid dupes
+                if(uploadedImages.ContainsKey(tmpImgPath) == false)
                 {
-                    logger.Error(typeof(TemplateUtilities), ex, "Could not delete temp file or folder {FileName}", absoluteTempImagePath);
+                    uploadedImages.Add(tmpImgPath, udi);
+
+                    // Delete folder & image now its saved in media
+                    // The folder should contain one image - as a unique guid folder created
+                    // for each image uploaded from TinyMceController
+                    var folderName = Path.GetDirectoryName(absoluteTempImagePath);
+                    try
+                    {
+                        Directory.Delete(folderName, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Error(typeof(TemplateUtilities), ex, "Could not delete temp file or folder {FileName}", absoluteTempImagePath);
+                    }
                 }
-                
             }
 
             return htmlDoc.DocumentNode.OuterHtml;


### PR DESCRIPTION
## Reported Error
When an image is added to a RTE and is uploaded to the TEMP directory but the content node is not saved, when the image is deleted/removed it would throw an error in the console about the missing blob image.

See attached video from @Shazwazza 
https://www.screencast.com/t/CCdOkqpvkEe

## Test Notes
* Have browser devtools open
* Add an image to the editor - wait for it to be uploaded
* Do not save/publish the content node
* Highlight & remove the image
* Verify that no error is no longer thrown in the browser devtools console

### More Notes & Testing

This was fixed by removing the following line
`tinymce.activeEditor.editorUpload.blobCache.removeByUri(imgSrc);`

However, this was originally added with @bergmania as if the same image is added to the RTE more than once it would not add the **data-tempimg** attribute and thus this would not persist correctly into the database. This PR also now fixes this bug at the same time.

* Drag an image into the RTE
* Drag it in again (several times if you wish)
* View the HTML source code using TinyMCE button
* Verify that all the images have the exact same data-tempimg attribute
* Save/Publish the node and verify that only one image is created in the media library
