### PR TITLE
V8: Don't YSOD when editing content type from content that hasn't been saved yet

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -153,9 +153,16 @@
 
         function reload() {
             $scope.page.loading = true;
-            loadContent().then(function () {
-                $scope.page.loading = false;
-            });
+
+            if ($scope.page.isNew) {
+                loadScaffold().then(function () {
+                    $scope.page.loading = false;
+                });
+            } else {
+                loadContent().then(function () {
+                    $scope.page.loading = false;
+                });
+            }
         }
 
         function bindEvents() {
@@ -215,6 +222,28 @@
 
                 });
 
+        }
+
+        /**
+        *  This loads the content scaffold for when creating new content
+        */
+        function loadScaffold() {
+            //we are creating so get an empty content item
+            return $scope.getScaffoldMethod()()
+                .then(function (data) {
+
+                    $scope.content = data;
+
+                    init();
+                    startWatches($scope.content);
+
+                    resetLastListPageNumber($scope.content);
+
+                    eventsService.emit("content.newReady", { content: $scope.content });
+
+                    return $q.resolve($scope.content);
+
+                });
         }
 
         /**
@@ -482,22 +511,9 @@
 
             $scope.page.loading = true;
 
-            //we are creating so get an empty content item
-            $scope.getScaffoldMethod()()
-                .then(function (data) {
-
-                    $scope.content = data;
-
-                    init();
-                    startWatches($scope.content);
-
-                    resetLastListPageNumber($scope.content);
-
-                    eventsService.emit("content.newReady", { content: $scope.content });
-
-                    $scope.page.loading = false;
-
-                });
+            loadScaffold().then(function () {
+                $scope.page.loading = false;
+            });
         }
         else {
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -150,8 +150,6 @@
                 const editor = {
                     id: documentType.id,
                     submit: function (model) {
-                        const args = { node: scope.node };
-                        eventsService.emit("editors.content.reload", args);
                         editorService.close();
                     },
                     close: function () {

--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -80,17 +80,19 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
 
                         formHelper.resetForm({ scope: args.scope });
 
-                        self.handleSuccessfulSave({
-                            scope: args.scope,
-                            savedContent: data,
-                            softRedirect: args.softRedirect,
-                            rebindCallback: function () {
-                                rebindCallback.apply(self, [args.content, data]);
-                            }
-                        });
+                        if (!args.infiniteMode) {
+                            self.handleSuccessfulSave({
+                                scope: args.scope,
+                                savedContent: data,
+                                softRedirect: args.softRedirect,
+                                rebindCallback: function () {
+                                    rebindCallback.apply(self, [args.content, data]);
+                                }
+                            });
 
-                        //update editor state to what is current
-                        editorState.set(args.content);
+                            //update editor state to what is current
+                            editorState.set(args.content);
+                        }
 
                         return $q.resolve(data);
 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -338,6 +338,7 @@
                     saveMethod: contentTypeResource.save,
                     scope: $scope,
                     content: vm.contentType,
+                    infiniteMode: infiniteMode,
                     // we need to rebind... the IDs that have been created!
                     rebindCallback: function (origContentType, savedContentType) {
                         vm.contentType.id = savedContentType.id;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5238

### Description

As described in #5238: When you edit the content type in infinite editing from content that has not yet been saved, everything kinda blows up:

![edit-doctype-new-content-before](https://user-images.githubusercontent.com/7405322/65335946-b1d3d180-dbc5-11e9-878a-e79beb700f71.gif)

This is a particularly annoying issue when constructing new content types.

When this PR is applied, things work as you would expect:

![edit-doctype-new-content-after](https://user-images.githubusercontent.com/7405322/65335950-b4cec200-dbc5-11e9-9f7c-bf38f6e7b57c.gif)

#### Testing notes

Make sure to test:

- Creating new content
- Editing existing content
- Editing the content type from newly created content
- Editing the content type from existing content
