### PR TITLE
Fixes #6269: Can't delete language because of tags

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/LanguageRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/LanguageRepository.cs
@@ -102,17 +102,17 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override IEnumerable<string> GetDeleteClauses()
         {
-
             var list = new List<string>
                            {
                                //NOTE: There is no constraint between the Language and cmsDictionary/cmsLanguageText tables (?)
                                // but we still need to remove them
-                               "DELETE FROM cmsLanguageText WHERE languageId = @id",
-                               "DELETE FROM umbracoPropertyData WHERE languageId = @id",
-                               "DELETE FROM umbracoContentVersionCultureVariation WHERE languageId = @id",
-                               "DELETE FROM umbracoDocumentCultureVariation WHERE languageId = @id",
-                               "DELETE FROM umbracoLanguage WHERE id = @id",
-                               "DELETE FROM " + Constants.DatabaseSchema.Tables.Tag + " WHERE languageId = @id"
+                               "DELETE FROM " + Constants.DatabaseSchema.Tables.DictionaryValue + " WHERE languageId = @id",
+                               "DELETE FROM " + Constants.DatabaseSchema.Tables.PropertyData + " WHERE languageId = @id",
+                               "DELETE FROM " + Constants.DatabaseSchema.Tables.ContentVersionCultureVariation + " WHERE languageId = @id",
+                               "DELETE FROM " + Constants.DatabaseSchema.Tables.DocumentCultureVariation + " WHERE languageId = @id",
+                               "DELETE FROM " + Constants.DatabaseSchema.Tables.TagRelationship + " WHERE tagId IN (SELECT id FROM " + Constants.DatabaseSchema.Tables.Tag + " WHERE languageId = @id)",
+                               "DELETE FROM " + Constants.DatabaseSchema.Tables.Tag + " WHERE languageId = @id",
+                               "DELETE FROM " + Constants.DatabaseSchema.Tables.Language + " WHERE id = @id"
                            };
             return list;
         }


### PR DESCRIPTION
Issue here seems to be that the delete operations weren't in the correct order with respect to tags, and a related table wasn't having it's content deleted.

Have fixed by re-ordering and updating the language delete clauses in language repositoy to ensure any tags for the language are deleted before the language itself is deleted.

Fixes #6269.