### PR TITLE
Use aria attributes in dialog markup

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -47,6 +47,7 @@
 .umb-overlay__title {
     font-size: @fontSizeLarge;
     color: @black;
+    line-height: 20px;
     font-weight: bold;
     margin: 7px 0;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -6,6 +6,10 @@
     animation: fadeIn 0.2s;
     box-shadow: 0 10px 50px rgba(0,0,0,0.1), 0 6px 20px rgba(0,0,0,0.16);
     text-align: left;
+    
+    .scoped-view{
+        display: none;
+    }
 }
 
 .umb-overlay__form {
@@ -20,7 +24,6 @@
     margin-top: 0;
     flex-grow: 0;
     flex-shrink: 0;
-    
     padding: 20px 30px 0;
 }
 
@@ -28,11 +31,11 @@
     width: 100%;
     margin-top:30px;
     margin-bottom: 10px;
-    
+
     h5 {
         display: inline;
     }
-    
+
     button {
         display: inline;
         float: right;
@@ -63,8 +66,7 @@
     flex-shrink: 1;
     flex-basis: auto;
     position: relative;
-    
-    padding: 0px 30px;
+    padding: 0 30px;
     margin-bottom: 10px;
     max-height: calc(100vh - 170px);
     overflow-y: auto;
@@ -76,7 +78,6 @@
     flex-basis: 31px;
     padding: 10px 20px;
     margin: 0;
-
     background: @gray-10;
     border-top: 1px solid @purple-l3;
 }
@@ -125,11 +126,7 @@
     max-height: 100vh;
     box-sizing: border-box;
     border-radius: @baseBorderRadius;
-    /* default:
-    &.umb-overlay--small {
-        width: 400px;
-    }
-    */
+
     &.umb-overlay--medium {
         width: 480px;
     }
@@ -229,12 +226,12 @@
 }
 
 .umb-overlay__item-details-title {
-    margin-top: 0;
-    margin-bottom: 0;
+    margin: 0;
+    font-size: 15px;
 }
 
 .umb-overlay__item-details-description {
-    margin-top: 10px;
+    margin: 10px 0 0;
     font-size: 12px;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -6,7 +6,7 @@
     animation: fadeIn 0.2s;
     box-shadow: 0 10px 50px rgba(0,0,0,0.1), 0 6px 20px rgba(0,0,0,0.16);
     text-align: left;
-    
+
     .scoped-view{
         display: none;
     }

--- a/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
@@ -15,8 +15,8 @@
         <div class="umb-overlay__item-details" ng-if="model.itemDetails">
 
             <div class="umb-overlay__item-details-title-wrapper" ng-if="model.itemDetails.icon || model.itemDetails.title">
-                <i class="{{ model.itemDetails.icon }} umb-overlay__item-details-icon" ng-if="model.itemDetails.icon"></i>
-                <h5 class="umb-overlay__item-details-title" ng-if="model.itemDetails.title">{{ model.itemDetails.title }}</h5>
+                <i class="{{ model.itemDetails.icon }} umb-overlay__item-details-icon" ng-if="model.itemDetails.icon" aria-hidden="true"></i>
+                <h2 class="umb-overlay__item-details-title" ng-if="model.itemDetails.title">{{ model.itemDetails.title }}</h2>
             </div>
 
             <div class="umb-overlay__item-details-description" ng-if="model.itemDetails.description">{{ model.itemDetails.description }}</div>
@@ -27,9 +27,12 @@
 
             <div ng-if="model.confirmSubmit.show">
 
-                <h5 class="red" ng-if="model.confirmSubmit.title"><i class="icon-alert"></i> {{ model.confirmSubmit.title }}</h5>
+                <h2 class="red" ng-if="model.confirmSubmit.title">
+                    <i class="icon-alert" aria-hidden="true"></i> {{ model.confirmSubmit.title }}
+                </h2>
                 <p ng-if="model.confirmSubmit.description">{{ model.confirmSubmit.description }}</p>
 
+                <!-- TODO: Maybe use the checkbox directive here -->
                 <label class="checkbox no-indent">
                     <input type="checkbox" ng-model="directive.enableConfirmButton" />
                     <strong>{{model.confirmSubmit.checkboxLabel}}</strong>

--- a/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
@@ -8,18 +8,16 @@
         <div data-element="overlay-content" class="umb-overlay-container form-horizontal">
             <ng-transclude></ng-transclude>
             <div ng-if="view && !parentScope" ng-include="view"></div>
-            <div class="scoped-view" style="display: none;"></div>
+            <div class="scoped-view"></div>
         </div>
 
+        <!-- If model contains the property of "itemDetails" we render  the relevant content here -->
         <div class="umb-overlay__item-details" ng-if="model.itemDetails">
-
             <div class="umb-overlay__item-details-title-wrapper" ng-if="model.itemDetails.icon || model.itemDetails.title">
                 <i class="{{ model.itemDetails.icon }} umb-overlay__item-details-icon" ng-if="model.itemDetails.icon" aria-hidden="true"></i>
                 <h2 class="umb-overlay__item-details-title" ng-if="model.itemDetails.title">{{ model.itemDetails.title }}</h2>
             </div>
-
-            <div class="umb-overlay__item-details-description" ng-if="model.itemDetails.description">{{ model.itemDetails.description }}</div>
-
+            <p class="umb-overlay__item-details-description" ng-if="model.itemDetails.description">{{ model.itemDetails.description }}</p>
         </div>
 
         <div data-element="overlay-footer" class="umb-overlay-drawer" ng-class="{'-auto-height': model.confirmSubmit.show}">

--- a/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
@@ -29,7 +29,6 @@
                 </h2>
                 <p ng-if="model.confirmSubmit.description">{{ model.confirmSubmit.description }}</p>
 
-                <!-- TODO: Maybe use the checkbox directive here -->
                 <label class="checkbox no-indent">
                     <input type="checkbox" ng-model="directive.enableConfirmButton" />
                     <strong>{{model.confirmSubmit.checkboxLabel}}</strong>

--- a/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
@@ -2,7 +2,7 @@
     <ng-form class="umb-overlay__form" name="overlayForm" novalidate val-form-manager>
 
         <div data-element="overlay-header" class="umb-overlay-header">
-            <h4 class="umb-overlay__title" id="umb-overlay-title">{{model.title}}</h4> <!-- TODO: Turn this into a <h1> -->
+            <h1 class="umb-overlay__title" id="umb-overlay-title">{{model.title}}</h1>
             <p class="umb-overlay__subtitle" id="umb-overlay-description">{{model.subtitle}}</p>
         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
@@ -1,9 +1,9 @@
-<div data-element="overlay" class="umb-overlay umb-overlay-{{position}} umb-overlay--{{size}}" on-outside-click="outSideClick()">
+<div data-element="overlay" class="umb-overlay umb-overlay-{{position}} umb-overlay--{{size}}" on-outside-click="outSideClick()" role="dialog" aria-labelledby="umb-overlay-title" aria-describedby="umb-overlay-description">
     <ng-form class="umb-overlay__form" name="overlayForm" novalidate val-form-manager>
 
         <div data-element="overlay-header" class="umb-overlay-header">
-            <h4 class="umb-overlay__title">{{model.title}}</h4>
-            <p class="umb-overlay__subtitle">{{model.subtitle}}</p>
+            <h4 class="umb-overlay__title" id="umb-overlay-title">{{model.title}}</h4> <!-- TODO: Turn this into a <h1> -->
+            <p class="umb-overlay__subtitle" id="umb-overlay-description">{{model.subtitle}}</p>
         </div>
 
         <div data-element="overlay-content" class="umb-overlay-container form-horizontal">

--- a/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
@@ -1,9 +1,8 @@
 <div data-element="overlay" class="umb-overlay umb-overlay-{{position}} umb-overlay--{{size}}" on-outside-click="outSideClick()" role="dialog" aria-labelledby="umb-overlay-title" aria-describedby="umb-overlay-description">
     <ng-form class="umb-overlay__form" name="overlayForm" novalidate val-form-manager>
-
         <div data-element="overlay-header" class="umb-overlay-header">
             <h1 class="umb-overlay__title" id="umb-overlay-title">{{model.title}}</h1>
-            <p class="umb-overlay__subtitle" id="umb-overlay-description">{{model.subtitle}}</p>
+            <p class="umb-overlay__subtitle" id="umb-overlay-description" ng-if="model.subtitle">{{model.subtitle}}</p>
         </div>
 
         <div data-element="overlay-content" class="umb-overlay-container form-horizontal">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR addresses issue **no. 157** from the #5277 

### Description
This PR adds some modification to the markup of the overlay markup in order to improve its accessibility - I have followed the guideline from https://bitsofco.de/accessible-modal-dialog/ for the markup pattern.

Once this is done there will still be some outstanding issues concerning the focus lock, which I'm still awaiting some feedback on in #4526 since using the suggested polyfill will handle much of the heavy listing for us very easily - Of course we should aim to make a generic directive or whatever makes sense so we can easily reuse it when dealing with different kinds of dialogs/overlays. But I've purposefully left this out of this scope until further discussion has been done in the referenced PR 😃 

What's been done
- Added `role="dialog"` to the container
- Added `aria-labelledby="umb-overlay-title"` to the container
- Added `aria-describedby="umb-overlay-description"` to the container
- Changed the `<h4>` containing the title to `<h1>` since it will be the primary headline in the overlay context (None of the stuff it lays on top of should be possible to navigate to - Read my above comment 😉 ) - Also added an `id="umb-overlay-title"` so the `aria-labelledby` attribute is linked to correctly to the title/headline
- Added `id="umb-overlay-description` id to the subtitle paragraph so the `aria-describedby` knows where to find some relevant data. If this description is empty it's not rendered and it should be OK since the `aria-describedby` isoptional as far as I know and remember
- I have changed some semantics for some areas containing `<h5>` elements and where `<div>` elements wrapped some text. `<h5>` is changed to `<h2>` and the div's have been change to `<p>` elements. The styling has been updated accordingly

I was having a play with the overlay to figure out if I would be able to deal with reassigning the focus back to the triggering element - However this will require some more effort since it's not only a "open dialog" / "close dialog" scenario that is in play here. There is a bit more to it and think it's better to do an independent PR for this.

When I'm looking at the content in the overlay component I'm having a feeling that some of it might not be used anymore? Those scenarios I have been able to find where the overlay is being used does not trigger any of the conditions needed to render the div with the class of `.umb-overlay__item-details` - When I tried removing all the `ng-if` attribute and add dummy data it looked like some leftover stuff that does not belong - But I could be wrong of course 😃 But if I'm not I think it might be better to remove it? Same goes for the part in the footer that is only displayed if  `model.confirmSubmit.show` is true... but this part has not been wrapped in nice classes for easier styling etc. and looks pretty outdated to me as well.

I also noticed that some of the texts may be a tad too generic in terms of providing a better non-visual context but I think that's for another PR do resolve maybe. 