### PR TITLE
Resolves #6374: Hide settings and delete option when re-ordering doc type properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -248,7 +248,7 @@
                             </div>
 
                             <!-- row tools -->
-                            <div class="umb-group-builder__property-actions">
+                            <div class="umb-group-builder__property-actions" ng-if="!sortingMode">
 
                                 <div ng-if="!property.inherited">
 


### PR DESCRIPTION
As noted in #6374, having the settings icon visible when re-ordering document type properties makes the property elements taller than they need to be.

I've resolved that by hiding this when sorting is in operation, and also the delete button (which seems reasonable to remove when sorting, and when in place it has some UI issues as the confirm overlaps the sort number field).

Now looks like this:

![image](https://user-images.githubusercontent.com/1993459/65385885-507e4080-dd34-11e9-9cf8-10d2c3ca468d.png)
