### PR TITLE
Add aria-live to let screen readers announce notifications

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
@@ -14,7 +14,7 @@
     list-style: none;
     margin: 0;
     position: relative;
-} 
+}
 
 .umb-notifications__notification {
     padding: 5px 20px;
@@ -24,11 +24,14 @@
     position: relative;
     border-radius: 10px;
     margin: 10px;
-    
+
     .close {
+        position: absolute;
         top: 0;
-        right: -6px;
+        bottom: 0;
+        right: 6px;
         opacity: 0.4;
+        margin: auto 0;
     }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/notifications/umb-notifications.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/notifications/umb-notifications.html
@@ -1,10 +1,8 @@
 <div class="umb-notifications" id="umb-notifications-wrapper" ng-cloak>
-    <ul class="umb-notifications__notifications">
+    <ul class="umb-notifications__notifications" aria-live="assertive" aria-relevant="additions">
         <li ng-repeat="notification in notifications"
             class="alert alert-block alert-{{notification.type}} umb-notifications__notification animated -half-second fadeIn"
             ng-class="{'-no-border -extra-padding': notification.type === 'form'}">
-
-            <a class='close -align-right' ng-click="removeNotification($index)" prevent-default href>&times;</a>
 
             <div ng-if="notification.view">
                 <div ng-include="notification.view"></div>
@@ -19,6 +17,10 @@
                     <span ng-bind-html="notification.message"></span>
                 </div>
             </div>
+
+            <button type="button" class='close -align-right' ng-click="removeNotification($index)" aria-hidden="true">
+                <span aria-hidden="true">&times;</span>
+            </button>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This issue fixed **no. 158** on the list of the [Trello board](https://trello.com/c/SObDqgG2/161-158-add-aria-live-to-let-screen-readers-announce-notifications) (Added after the intital Github Issue #5277)

### Description
Currently the notifications that appear whenever a content node, templates, document type etc. is saved is not announced by screen readers. which leaves screen reader users clueless that a status message telling us whether the save/publish was a success or not.

Therefore I have added `aria-live="assertive"` and `aria-relevant="additions"`, which will make a screen reader prioritize announcing the latest added notification - So if 2 notifications are added quickly after each other it will abort reading the 1st status and start reading the 2 status instead.

I believe that some of the texts could be more meaningful not only in a non-visual context but also in a visual context but I think that is subject for another PR 😃 

Looking forward to receive any questions or feedback you may have about this PR 👍 