### PR TITLE
Drag/Drop & Pasted images in RTE aren't resized to configured max image width setting

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -277,7 +277,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         if (editor.settings.maxImageSize && editor.settings.maxImageSize !== 0) {
             var newSize = imageHelper.scaleToMaxSize(editor.settings.maxImageSize, size.w, size.h);
 
-            console.log('new size', newSize);
 
             editor.dom.setAttrib(imageDomElement, 'width', newSize.width);
             editor.dom.setAttrib(imageDomElement, 'height', newSize.height);

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -272,7 +272,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
     function sizeImageInEditor(editor, imageDomElement, imgUrl) {
 
         var size = editor.dom.getSize(imageDomElement);
-        console.log('size', size);
 
         if (editor.settings.maxImageSize && editor.settings.maxImageSize !== 0) {
             var newSize = imageHelper.scaleToMaxSize(editor.settings.maxImageSize, size.w, size.h);

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -284,7 +284,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             // Images inserted via Media Picker will have a URL we can use for ImageResizer QueryStrings
             // Images pasted/dragged in are not persisted to media until saved & thus will need to be added
             if(imgUrl){
-                console.log('got an img src use QS');
                 var src = imgUrl + "?width=" + newSize.width + "&height=" + newSize.height;
                 editor.dom.setAttrib(imageDomElement, 'data-mce-src', src);
             }

--- a/src/Umbraco.Web/Templates/TemplateUtilities.cs
+++ b/src/Umbraco.Web/Templates/TemplateUtilities.cs
@@ -237,9 +237,19 @@ namespace Umbraco.Web.Templates
                 var udi = mediaFile.GetUdi();
                 img.SetAttributeValue("data-udi", udi.ToString());
 
-                //Get the new persisted image url
+                // Get the new persisted image url
                 var mediaTyped = Current.UmbracoHelper.Media(mediaFile.Id);
                 var location = mediaTyped.Url;
+
+                // Find the width & height attributes as we need to set the imageprocessor QueryString
+                var width = img.GetAttributeValue("width", int.MinValue);
+                var height = img.GetAttributeValue("height", int.MinValue);
+
+                if(width != int.MinValue && height != int.MinValue)
+                {
+                    location = $"{location}?width={width}&height={height}&mode=max";
+                }
+                
                 img.SetAttributeValue("src", location);
 
                 // Remove the data attribute (so we do not re-process this)


### PR DESCRIPTION
When we choose an image using the media picker in the RTE, when the image is inserted it is resized to a configured width/height, but when you drag/drop an image, it retains the original (probably hi-res) size which isn't very usable. The drag/drop functionality should behave the same as the media picker and resize to the configured width/height.

## Test Notes
* Verify code changes
* Test with a RTE & ensure you change/set a desired max width for images in the datatype config
* Test with nested content
* Test in the Grid

Fixes [AB#2737](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/2737)