### PR TITLE
V8: Migration of obsolete picker properties

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -20,6 +20,7 @@ namespace Umbraco.Core
                 {
                     public const string Textbox = "Umbraco.Textbox";
                     public const string Date = "Umbraco.Date";
+                    public const string ContentPicker = "Umbraco.ContentPickerAlias";
                     public const string ContentPicker2 = "Umbraco.ContentPicker2";
                     public const string MediaPicker2 = "Umbraco.MediaPicker2";
                     public const string MemberPicker2 = "Umbraco.MemberPicker2";

--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -129,6 +129,7 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<DataTypeMigration>("{8640C9E4-A1C0-4C59-99BB-609B4E604981}");
             To<TagsMigration>("{DD1B99AF-8106-4E00-BAC7-A43003EA07F8}");
             To<SuperZero>("{9DF05B77-11D1-475C-A00A-B656AF7E0908}");
+            To<LegacyPickersPropertyEditorsMigration>("{258CE811-4201-4004-95EF-402086B38B77}");
             To<PropertyEditorsMigration>("{6FE3EF34-44A0-4992-B379-B40BC4EF1C4D}");
             To<LanguageColumns>("{7F59355A-0EC9-4438-8157-EB517E6D2727}");
             ToWithReplace<AddVariationTables2, AddVariationTables1A>("{941B2ABA-2D06-4E04-81F5-74224F1DB037}", "{76DF5CD7-A884-41A5-8DC6-7860D95B1DF5}"); // kill AddVariationTable1

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypeMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypeMigration.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
             Constants.PropertyEditors.Legacy.Aliases.MemberPicker2,
             Constants.PropertyEditors.Legacy.Aliases.RelatedLinks2,
             Constants.PropertyEditors.Legacy.Aliases.TextboxMultiple,
-            Constants.PropertyEditors.Legacy.Aliases.MultiNodeTreePicker2,
+            Constants.PropertyEditors.Legacy.Aliases.MultiNodeTreePicker2
         };
 
         public DataTypeMigration(IMigrationContext context, PreValueMigratorCollection preValueMigrators, PropertyEditorCollection propertyEditors, ILogger logger)

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/ContentPickerPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/ContentPickerPreValueMigrator.cs
@@ -1,9 +1,17 @@
-﻿namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
+﻿using System.Linq;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
 {
     class ContentPickerPreValueMigrator : DefaultPreValueMigrator
     {
+        private readonly string[] _editors =
+        {
+            Constants.PropertyEditors.Legacy.Aliases.ContentPicker2,
+            Constants.PropertyEditors.Legacy.Aliases.ContentPicker
+        };
+
         public override bool CanMigrate(string editorAlias)
-            => editorAlias == Constants.PropertyEditors.Legacy.Aliases.ContentPicker2;
+            => _editors.Contains(editorAlias);
 
         public override string GetNewAlias(string editorAlias)
             => null;

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/ContentPickerPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/ContentPickerPreValueMigrator.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
             => _editors.Contains(editorAlias);
 
         public override string GetNewAlias(string editorAlias)
-            => null;
+            => Constants.PropertyEditors.Aliases.ContentPicker;
 
         protected override object GetPreValueValue(PreValueDto preValue)
         {

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/MediaPickerPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/MediaPickerPreValueMigrator.cs
@@ -7,7 +7,8 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
         private readonly string[] _editors =
         {
             Constants.PropertyEditors.Legacy.Aliases.MediaPicker2,
-            Constants.PropertyEditors.Aliases.MediaPicker
+            Constants.PropertyEditors.Aliases.MediaPicker,
+            Constants.PropertyEditors.Aliases.MultipleMediaPicker
         };
 
         public override bool CanMigrate(string editorAlias)

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/ValueListPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/ValueListPreValueMigrator.cs
@@ -20,7 +20,16 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
             => _editors.Contains(editorAlias);
 
         public virtual string GetNewAlias(string editorAlias)
-            => null;
+        {
+            switch (editorAlias)
+            {
+                case "Umbraco.RadioButtonList":
+                case "Umbraco.CheckBoxList":
+                    return editorAlias;
+                default:
+                    return "Umbraco.DropDown.Flexible";
+            }
+        }            
 
         public object GetConfiguration(int dataTypeId, string editorAlias, Dictionary<string, PreValueDto> preValues)
         {

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/LegacyPickersPropertyEditorsMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/LegacyPickersPropertyEditorsMigration.cs
@@ -29,8 +29,9 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
                     ).ToDictionary(n => n.NodeId)
                 );
 
-            var refreshCache = Migrate(GetDataTypes("Umbraco.ContentPickerAlias"));
+            var refreshCache = Migrate(GetDataTypes(Constants.PropertyEditors.Legacy.Aliases.ContentPicker));
             refreshCache |= Migrate(GetDataTypes(Constants.PropertyEditors.Aliases.MediaPicker));
+            refreshCache |= Migrate(GetDataTypes(Constants.PropertyEditors.Aliases.MultipleMediaPicker));
             refreshCache |= Migrate(GetDataTypes(Constants.PropertyEditors.Aliases.MemberPicker));
             refreshCache |= Migrate(GetDataTypes(Constants.PropertyEditors.Aliases.MultiNodeTreePicker));
             

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/LegacyPickersPropertyEditorsMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/LegacyPickersPropertyEditorsMigration.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Migrations.PostMigrations;
+using Umbraco.Core.Models;
+using Newtonsoft.Json;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
+{
+    public class LegacyPickersPropertyEditorsMigration : PropertyEditorsMigrationBase
+    {
+        private Lazy<Dictionary<int, NodeDto>> _nodeIdToKey;
+
+        public LegacyPickersPropertyEditorsMigration(IMigrationContext context)
+            : base(context)
+        { }
+
+        public override void Migrate()
+        {
+            _nodeIdToKey = new Lazy<Dictionary<int, NodeDto>>(
+                () => Context.Database.Fetch<NodeDto>(
+                    Context.SqlContext.Sql()
+                        .Select<NodeDto>(x => x.NodeId, x => x.NodeObjectType, x => x.UniqueId)
+                        .From<NodeDto>()
+                    ).ToDictionary(n => n.NodeId)
+                );
+
+            var refreshCache = Migrate(GetDataTypes("Umbraco.ContentPickerAlias"));
+            refreshCache |= Migrate(GetDataTypes(Constants.PropertyEditors.Aliases.MediaPicker));
+            refreshCache |= Migrate(GetDataTypes(Constants.PropertyEditors.Aliases.MemberPicker));
+            refreshCache |= Migrate(GetDataTypes(Constants.PropertyEditors.Aliases.MultiNodeTreePicker));
+            
+            // if some data types have been updated directly in the database (editing DataTypeDto and/or PropertyDataDto),
+            // bypassing the services, then we need to rebuild the cache entirely, including the umbracoContentNu table
+            if (refreshCache)
+                Context.AddPostMigration<RebuildPublishedSnapshot>();
+        }
+
+        private bool Migrate(IEnumerable<DataTypeDto> dataTypes)
+        {
+            var refreshCache = false;
+
+            foreach (var dataType in dataTypes)
+            {
+                Context.Logger.Info<LegacyPickersPropertyEditorsMigration>("Migrating " + dataType.EditorAlias + ", " + dataType.NodeId);
+
+                dataType.DbType = ValueStorageType.Ntext.ToString();
+                Database.Update(dataType);
+
+                // get property data dtos
+                var propertyDataDtos = Database.Fetch<PropertyDataDto>(Sql()
+                    .Select<PropertyDataDto>()
+                    .From<PropertyDataDto>()
+                    .InnerJoin<PropertyTypeDto>().On<PropertyTypeDto, PropertyDataDto>((pt, pd) => pt.Id == pd.PropertyTypeId)
+                    .InnerJoin<DataTypeDto>().On<DataTypeDto, PropertyTypeDto>((dt, pt) => dt.NodeId == pt.DataTypeId)
+                    .Where<PropertyTypeDto>(x => x.DataTypeId == dataType.NodeId));
+
+                // update dtos
+                var updatedDtos = propertyDataDtos.Where(x => UpdatePropertyDataDto(x, true));
+
+                // persist changes
+                foreach (var propertyDataDto in updatedDtos)
+                    Database.Update(propertyDataDto);
+
+                refreshCache = true;
+            }
+
+            return refreshCache;
+        }
+
+        private bool UpdatePropertyDataDto(PropertyDataDto propData, bool isMultiple)
+        {
+            //Get the INT ids stored for this property/drop down
+            int[] ids = null;
+            if (!propData.VarcharValue.IsNullOrWhiteSpace())
+            {
+                ids = ConvertStringValues(propData.VarcharValue);
+            }
+            else if (!propData.TextValue.IsNullOrWhiteSpace())
+            {
+                ids = ConvertStringValues(propData.TextValue);
+            }
+            else if (propData.IntegerValue.HasValue)
+            {
+                ids = new[] { propData.IntegerValue.Value };
+            }
+
+            if (ids == null || ids.Length <= 0) return false;
+
+            // map ids to values
+            var values = new List<Udi>();
+            var canConvert = true;
+
+            foreach (var id in ids)
+            {
+                if (_nodeIdToKey.Value.TryGetValue(id, out var node))
+                {
+                    values.Add(Udi.Create(ObjectTypes.GetUdiType(node.NodeObjectType.Value), node.UniqueId));
+                    continue;
+                }
+                canConvert = false;
+            }
+
+            if (!canConvert) return false;
+
+            propData.TextValue = String.Join(",", values);
+            propData.VarcharValue = null;
+            propData.IntegerValue = null;
+            return true;
+        }
+
+
+
+    }
+}

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/PropertyEditorsMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/PropertyEditorsMigration.cs
@@ -12,8 +12,10 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
 
         public override void Migrate()
         {
+            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.ContentPicker, Constants.PropertyEditors.Aliases.ContentPicker);
             RenameDataType(Constants.PropertyEditors.Legacy.Aliases.ContentPicker2, Constants.PropertyEditors.Aliases.ContentPicker);
             RenameDataType(Constants.PropertyEditors.Legacy.Aliases.MediaPicker2, Constants.PropertyEditors.Aliases.MediaPicker);
+            RenameDataType(Constants.PropertyEditors.Aliases.MultipleMediaPicker, Constants.PropertyEditors.Aliases.MediaPicker);
             RenameDataType(Constants.PropertyEditors.Legacy.Aliases.MemberPicker2, Constants.PropertyEditors.Aliases.MemberPicker);
             RenameDataType(Constants.PropertyEditors.Legacy.Aliases.MultiNodeTreePicker2, Constants.PropertyEditors.Aliases.MultiNodeTreePicker);
             RenameDataType(Constants.PropertyEditors.Legacy.Aliases.TextboxMultiple, Constants.PropertyEditors.Aliases.TextArea);

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/PropertyEditorsMigration.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/PropertyEditorsMigration.cs
@@ -16,36 +16,12 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
             RenameDataType(Constants.PropertyEditors.Legacy.Aliases.MediaPicker2, Constants.PropertyEditors.Aliases.MediaPicker);
             RenameDataType(Constants.PropertyEditors.Legacy.Aliases.MemberPicker2, Constants.PropertyEditors.Aliases.MemberPicker);
             RenameDataType(Constants.PropertyEditors.Legacy.Aliases.MultiNodeTreePicker2, Constants.PropertyEditors.Aliases.MultiNodeTreePicker);
-            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.TextboxMultiple, Constants.PropertyEditors.Aliases.TextArea, false);
-            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.Textbox, Constants.PropertyEditors.Aliases.TextBox, false);
+            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.TextboxMultiple, Constants.PropertyEditors.Aliases.TextArea);
+            RenameDataType(Constants.PropertyEditors.Legacy.Aliases.Textbox, Constants.PropertyEditors.Aliases.TextBox);
         }
 
-        private void RenameDataType(string fromAlias, string toAlias, bool checkCollision = true)
+        private void RenameDataType(string fromAlias, string toAlias)
         {
-            if (checkCollision)
-            {
-                var oldCount = Database.ExecuteScalar<int>(Sql()
-                    .SelectCount()
-                    .From<DataTypeDto>()
-                    .Where<DataTypeDto>(x => x.EditorAlias == toAlias));
-
-                if (oldCount > 0)
-                {
-                    // If we throw it means that the upgrade will exit and cannot continue.
-                    // This will occur if a v7 site has the old "Obsolete" property editors that are already named with the `toAlias` name.
-                    // TODO: We should have an additional upgrade step when going from 7 -> 8 like we did with 6 -> 7 that shows a compatibility report,
-                    // this would include this check and then we can provide users with information on what they should do (i.e. before upgrading to v8 they will
-                    // need to migrate these old obsolete editors to non-obsolete editors)
-
-                    throw new InvalidOperationException(
-                        $"Cannot rename datatype alias \"{fromAlias}\" to \"{toAlias}\" because the target alias is already used." +
-                        $"This is generally because when upgrading from a v7 to v8 site, the v7 site contains Data Types that reference old and already Obsolete " +
-                        $"Property Editors. Before upgrading to v8, any Data Types using property editors that are named with the prefix '(Obsolete)' must be migrated " +
-                        $"to the non-obsolete v7 property editors of the same type.");
-                }
-
-            }
-
             Database.Execute(Sql()
                 .Update<DataTypeDto>(u => u.Set(x => x.EditorAlias, toAlias))
                 .Where<DataTypeDto>(x => x.EditorAlias == fromAlias));

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\RenamingPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\RichTextPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\DropDownFlexiblePreValueMigrator.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_0_0\LegacyPickersPropertyEditorsMigration.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\MergeDateAndDateTimePropertyEditor.cs" />
     <Compile Include="Models\Entities\EntityExtensions.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\PreValueMigratorBase.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6241

### Description
Content migration currently fails if the database includes any properties of the pre-7.6 picker types, which store integer IDs rather than UDIs.

This PR adds a migration which converts these properties to the UDI-based versions.

Testing:
- In 7.15, enable obsolete property editors and create a content picker, media picker, and multi-node tree picker using the obsolete types. Add some test content.
- Upgrade to 8.1
- Check that the properties have been converted to the up-to-date versions, and the selected values are still visible in the editor.