### PR TITLE
Don't store JSON property data as indented

### DIFF
--- a/src/Umbraco.Core/Serialization/JsonNetSerializer.cs
+++ b/src/Umbraco.Core/Serialization/JsonNetSerializer.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Umbraco.Core.Configuration;
 
 namespace Umbraco.Core.Serialization
 {
@@ -60,7 +61,8 @@ namespace Umbraco.Core.Serialization
         /// <returns></returns>
         public IStreamedResult ToStream(object input)
         {
-            string s = JsonConvert.SerializeObject(input, Formatting.Indented, _settings);
+            var formatting = GlobalSettings.DebugMode ? Formatting.Indented : Formatting.None;
+            string s = JsonConvert.SerializeObject(input, formatting, _settings);
             byte[] bytes = Encoding.UTF8.GetBytes(s);
             MemoryStream ms = new MemoryStream(bytes);
 

--- a/src/Umbraco.Core/Serialization/JsonNetSerializer.cs
+++ b/src/Umbraco.Core/Serialization/JsonNetSerializer.cs
@@ -61,8 +61,7 @@ namespace Umbraco.Core.Serialization
         /// <returns></returns>
         public IStreamedResult ToStream(object input)
         {
-            var formatting = GlobalSettings.DebugMode ? Formatting.Indented : Formatting.None;
-            string s = JsonConvert.SerializeObject(input, formatting, _settings);
+            string s = JsonConvert.SerializeObject(input, Formatting.None, _settings);
             byte[] bytes = Encoding.UTF8.GetBytes(s);
             MemoryStream ms = new MemoryStream(bytes);
 

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -177,8 +177,7 @@ namespace Umbraco.Web.Editors
                 //the dictionary returned is fine but the delimiter between an 'area' and a 'value' is a '/' but the javascript
                 // in the back office requres the delimiter to be a '_' so we'll just replace it
                 .ToDictionary(key => key.Key.Replace("/", "_"), val => val.Value);
-            var formatting = GlobalSettings.DebugMode ? Formatting.Indented : Formatting.None;
-            return new JsonNetResult { Data = textForCulture, Formatting = formatting };
+            return new JsonNetResult { Data = textForCulture, Formatting = Formatting.None };
         }
 
         /// <summary>
@@ -230,8 +229,7 @@ namespace Umbraco.Web.Editors
                     typeof(BackOfficeController) + "GetManifestAssetList",
                     () => getResult(),
                     new TimeSpan(0, 10, 0));
-            var formatting = GlobalSettings.DebugMode ? Formatting.Indented : Formatting.None;
-            return new JsonNetResult { Data = result, Formatting = formatting };
+            return new JsonNetResult { Data = result, Formatting = Formatting.None };
         }
 
         [UmbracoAuthorize(Order = 0)]
@@ -244,8 +242,7 @@ namespace Umbraco.Web.Editors
                 new DirectoryInfo(Server.MapPath(SystemDirectories.AppPlugins)),
                 new DirectoryInfo(Server.MapPath(SystemDirectories.Config)),
                 HttpContext.IsDebuggingEnabled);
-            var formatting = GlobalSettings.DebugMode ? Formatting.Indented : Formatting.None;
-            return new JsonNetResult { Data = gridConfig.EditorsConfig.Editors, Formatting = formatting };
+            return new JsonNetResult { Data = gridConfig.EditorsConfig.Editors, Formatting = Formatting.None };
         }
 
         

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -177,8 +177,8 @@ namespace Umbraco.Web.Editors
                 //the dictionary returned is fine but the delimiter between an 'area' and a 'value' is a '/' but the javascript
                 // in the back office requres the delimiter to be a '_' so we'll just replace it
                 .ToDictionary(key => key.Key.Replace("/", "_"), val => val.Value);
-
-            return new JsonNetResult { Data = textForCulture, Formatting = Formatting.Indented };
+            var formatting = GlobalSettings.DebugMode ? Formatting.Indented : Formatting.None;
+            return new JsonNetResult { Data = textForCulture, Formatting = formatting };
         }
 
         /// <summary>
@@ -230,8 +230,8 @@ namespace Umbraco.Web.Editors
                     typeof(BackOfficeController) + "GetManifestAssetList",
                     () => getResult(),
                     new TimeSpan(0, 10, 0));
-
-            return new JsonNetResult { Data = result, Formatting = Formatting.Indented };
+            var formatting = GlobalSettings.DebugMode ? Formatting.Indented : Formatting.None;
+            return new JsonNetResult { Data = result, Formatting = formatting };
         }
 
         [UmbracoAuthorize(Order = 0)]
@@ -244,8 +244,8 @@ namespace Umbraco.Web.Editors
                 new DirectoryInfo(Server.MapPath(SystemDirectories.AppPlugins)),
                 new DirectoryInfo(Server.MapPath(SystemDirectories.Config)),
                 HttpContext.IsDebuggingEnabled);
-
-            return new JsonNetResult { Data = gridConfig.EditorsConfig.Editors, Formatting = Formatting.Indented };
+            var formatting = GlobalSettings.DebugMode ? Formatting.Indented : Formatting.None;
+            return new JsonNetResult { Data = gridConfig.EditorsConfig.Editors, Formatting = formatting };
         }
 
         


### PR DESCRIPTION
### Prerequisites

This fixes #2996.

### Description

In areas where Formatting.Indented was previously used, this now adds a check on GlobalSettings.DebugMode to determine whether to use JSON indentation or not (in release mode, this should substantially reduce data storage size). Should not require a unit test, as it merely affects formatting.