### PR TITLE
v8: Change button style for "create package" and "show more" (in the log viewer)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
@@ -4,6 +4,7 @@
     function LogViewerOverviewController($q, $location, $timeout, logViewerResource, navigationService) {
 
         var vm = this;
+
         vm.loading = false;
         vm.canLoadLogs = false;
         vm.searches = [];
@@ -50,6 +51,7 @@
         vm.searchLogQuery = searchLogQuery;
         vm.findMessageTemplate = findMessageTemplate;
         vm.searchErrors = searchErrors;
+        vm.showMore = showMore;
 
         function preFlightCheck(){
             vm.loading = true;
@@ -66,6 +68,9 @@
             });
         }
 
+        function showMore() {
+            vm.commonLogMessagesCount += 10;
+        }
 
         function init() {
 

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
@@ -53,17 +53,22 @@
                                 <em>Total Unique Message types</em>: {{ vm.commonLogMessages.length }}
                                 <table class="table table-hover">
                                     <tbody>
-                                    <tr ng-repeat="template in vm.commonLogMessages | limitTo:vm.commonLogMessagesCount" ng-click="vm.findMessageTemplate(template)" style="cursor: pointer;">
-                                        <td>
-                                            {{ template.MessageTemplate }}
-                                        </td>
-                                        <td>
-                                            {{ template.Count }}
-                                        </td>
-                                    </tr>
+                                        <tr ng-repeat="template in vm.commonLogMessages | limitTo:vm.commonLogMessagesCount" ng-click="vm.findMessageTemplate(template)" style="cursor: pointer;">
+                                            <td>
+                                                {{ template.MessageTemplate }}
+                                            </td>
+                                            <td>
+                                                {{ template.Count }}
+                                            </td>
+                                        </tr>
                                     </tbody>
                                 </table>
-                                <a class="btn btn-primary" ng-if="vm.commonLogMessagesCount < vm.commonLogMessages.length" ng-click="vm.commonLogMessagesCount = vm.commonLogMessagesCount +10">Show More</a>
+                                <umb-button ng-if="vm.commonLogMessagesCount < vm.commonLogMessages.length"
+                                            button-style="action"
+                                            type="button"
+                                            action="vm.showMore()"
+                                            label="Show More">
+                                </umb-button>
                             </umb-box-content>
                         </umb-box>
                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
@@ -88,7 +88,6 @@
         vm.deleteSavedSearch = deleteSavedSearch;
         vm.back = back;
 
-
         function init() {
 
             //If we have a Querystring set for lq (log query)

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -87,9 +87,9 @@
                 </umb-editor-sub-header>
             </form>
 
-            <div class=" ng-if="!vm.loading">
+            <div ng-if="!vm.loading">
 
-                <div class="">
+                <div>
 
                     <!-- Loader for the main logs content when paging -->
                     <umb-load-indicator ng-if="vm.logsLoading"></umb-load-indicator>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/created.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/created.html
@@ -4,7 +4,7 @@
 
         <umb-editor-sub-header-content-left>
             <umb-button
-                button-style="success"
+                button-style="action"
                 type="button" 
                 action="vm.createPackage()"
                 label="Create package"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR replace the `success` button style for "Create package" with `action` button style (purple) which is now used in most places like users, languages, etc.

It also change button style for "Show more" in log viewer and change this button to use `umb-button` component and I have cleaned up some odd empty class attributes in logviewer. The logviewer also need to be cleaned up for inline styles, but we can do that in another PR :)

![image](https://user-images.githubusercontent.com/2919859/65631306-94dd3b00-dfd7-11e9-94d2-60df98eb68e0.png)

![image](https://user-images.githubusercontent.com/2919859/65631320-99a1ef00-dfd7-11e9-9648-5f26ca4d07f6.png)

