### PR TITLE
v8: Change confirm delete button style

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.controller.js
@@ -70,6 +70,7 @@
                 view: "views/languages/overlays/delete.html",
                 language: language,
                 submitButtonLabelKey: "contentTypeEditor_yesDelete",
+                submitButtonStyle: "danger",
                 submit: function (model) {
                     performDelete(model.language);
                     overlayService.close();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -383,6 +383,7 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
             view: "views/propertyeditors/listview/overlays/delete.html",
             deletesVariants: selectionHasVariants(),
             submitButtonLabelKey: "contentTypeEditor_yesDelete",
+            submitButtonStyle: "danger",
             submit: function (model) {
                 performDelete();
                 overlayService.close();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6376

### Description
This  PR simply change button style to `danger` in delete confirm in listview (both list and grid layout) in content, media and member section. Furthermore it also change button style for delete confirm in languages.

![image](https://user-images.githubusercontent.com/2919859/65633510-94936e80-dfdc-11e9-9834-db2a0e729bc9.png)

![image](https://user-images.githubusercontent.com/2919859/65633523-9eb56d00-dfdc-11e9-9064-e27a4de8fc03.png)

![image](https://user-images.githubusercontent.com/2919859/65633488-85142580-dfdc-11e9-873d-649a70047f03.png)

![image](https://user-images.githubusercontent.com/2919859/65633547-aa089880-dfdc-11e9-8b9f-488d9b3a6cf5.png)
