### PR TITLE
Fixes selecting Macro Content in RTE to be non editable once node is saved

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -803,6 +803,11 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             //show the throbber
             $macroDiv.addClass("loading");
 
+            // Add the contenteditable="false" attribute
+            // As just the CSS class of .mceNonEditable is not working by itself?!
+            // TODO: At later date - use TinyMCE editor DOM manipulation as opposed to jQuery
+            $macroDiv.attr("contenteditable", "false");
+
             var contentId = $routeParams.id;
 
             //need to wrap in safe apply since this might be occuring outside of angular


### PR DESCRIPTION
Adds contenteditable=false attribute as for whatever reason the CSS class of .mceNonEditable is not working when a macro is saved & loaded in a content node

## Test Notes
* Add a macro into the RTE
* Before saving the page/node (ensure you can not select inside it & can drag/move it around)
* Save the node & retry moving it (Previous to this PR it would not work)

Fixes [AB#2877](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/2877)
