### PR TITLE
"Save and publish" options clash with "Reorder"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/subheader/umb-editor-sub-header.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/subheader/umb-editor-sub-header.less
@@ -32,7 +32,7 @@
 [umb-sticky-bar] {
     transition: box-shadow 240ms;
     position:sticky;
-    z-index: 99;
+    z-index: 30;
     
     &.umb-sticky-bar--active {
         box-shadow: 0 6px 3px -3px rgba(0,0,0,.16);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR then this fixes #6299 

### Description
Lowering the z-index of the sticky directive to 30 fixes the issues where the "reorder" button clashes with the publishing options menu when it's expanded and you scroll.

**Before**
![reorder-before](https://user-images.githubusercontent.com/1932158/65689491-7d509180-e06d-11e9-93b7-ff83800f83cf.gif)


**After**
![reorder-after](https://user-images.githubusercontent.com/1932158/65689507-85103600-e06d-11e9-9f09-a7d03e7e600a.gif)

Thank you and a high 5 you rock to @webdokkeren for helping out 🙌 😃 