### PR TITLE
lets not set a specific width, but do it by CSS.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1172,7 +1172,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             var tinyMceRect = editor.editorContainer.getBoundingClientRect();
             var tinyMceTop = tinyMceRect.top;
             var tinyMceBottom = tinyMceRect.bottom;
-            var tinyMceWidth = tinyMceRect.width;
 
             var tinyMceEditArea = tinyMce.find(".mce-edit-area");
 
@@ -1184,15 +1183,13 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                     .css("visibility", "visible")
                     .css("position", "fixed")
                     .css("top", "177px")
-                    .css("margin-top", "0")
-                    .css("width", tinyMceWidth);
+                    .css("margin-top", "0");
             } else {
                 toolbar
                     .css("visibility", "visible")
                     .css("position", "absolute")
                     .css("top", "auto")
-                    .css("margin-top", "0")
-                    .css("width", tinyMceWidth);
+                    .css("margin-top", "0");
             }
 
         },

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -657,6 +657,8 @@
 // had to overwrite defaults from TinyMCE, needed for buttons panel to float to new line in narrow space.
 .umb-grid .mce-container > div {
     white-space: normal;
+    left:0;
+    right:0;
 }
 
 


### PR DESCRIPTION
Using CSS to set the width instead of Javascript. Fixes issue with toolbar staying narrow when there is more space available.