### PR TITLE
Fixes #6424 - Prevent drag & drop of images if button to insert media is not enabled

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -251,6 +251,16 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         }
     }
 
+    function isMediaPickerEnabled(toolbarItemArray){
+        var insertMediaButtonFound = false;
+        toolbarItemArray.forEach(toolbarItem => {
+            if(toolbarItem.indexOf("umbmediapicker") > -1){
+                insertMediaButtonFound = true;
+            }
+        });
+        return insertMediaButtonFound;
+    }
+
     return {
 
         /**
@@ -343,14 +353,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
                 // Need to check if we are allowed to UPLOAD images
                 // This is done by checking if the insert image toolbar button is available
-                var insertMediaButtonFound = false;
-                args.toolbar.forEach(toolbarItem => {
-                    if(toolbarItem.indexOf("umbmediapicker") > -1){
-                        insertMediaButtonFound = true;
-                    }
-                });
-
-                if(insertMediaButtonFound){
+                if(isMediaPickerEnabled(args.toolbar)){
                     // Update the TinyMCE Config object to allow pasting
                     config.images_upload_handler = uploadImageHandler;
                     config.automatic_uploads = false;
@@ -1264,16 +1267,8 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             // Then we need to add an event listener to the editor
             // That will update native browser drag & drop events
             // To update the icon to show you can NOT drop something into the editor
-            var insertMediaButtonFound = false;
-            var toolbarItems = args.editor.settings.toolbar;
-            toolbarItems = toolbarItems.split(" ");
-            toolbarItems.forEach(toolbarItem => {
-                if(toolbarItem.indexOf("umbmediapicker") > -1){
-                    insertMediaButtonFound = true;
-                }
-            });
-
-            if(insertMediaButtonFound === false){
+            var toolbarItems = args.editor.settings.toolbar.split(" ");
+            if(isMediaPickerEnabled(toolbarItems) === false){
                 // Wire up the event listener
                 args.editor.on('dragend dragover draggesture dragdrop drop drag', function (e) {
                     e.preventDefault();


### PR DESCRIPTION
* Ensure you can only drag and drop or paste images in when the insert image/media button is enabled in the RTE toolbar/config

* If disallowed then we add a new native browser event for dragover etc to prevent dropping & showing the no/stop sign icon

## Test Notes
* Try to drag an image when the insert media button enabled (Upload should work etc)
* Disable button for insert media - ensure you can not drag or paste images into content
* Note: you should see red cross, no entry style sign/icon when you do try
* Test with vanilla RTE, Nested Content that uses RTE & the Grid RTE
* Test with one or more RTEs on the page with different configs to ensure events bound in isolation to the correct editor/s

Fixes #6424 
Fixes [AB#2881](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/2881)