### PR TITLE
Automatically assign LuceneIndexDiagnostics instead of GenericIndexDiagnostics for LuceneIndexes

### DIFF
--- a/src/Umbraco.Web/Editors/ExamineManagementController.cs
+++ b/src/Umbraco.Web/Editors/ExamineManagementController.cs
@@ -177,8 +177,12 @@ namespace Umbraco.Web.Editors
             var indexName = index.Name;
 
             if (!(index is IIndexDiagnostics indexDiag))
-                indexDiag = new GenericIndexDiagnostics(index);
-
+            {
+                if (index is LuceneIndex luceneIndex)
+                    indexDiag = new LuceneIndexDiagnostics(luceneIndex, Logger);
+                else
+                    indexDiag = new GenericIndexDiagnostics(index);
+            }
 
             var isHealth = indexDiag.IsHealthy();
             var properties = new Dictionary<string, object>


### PR DESCRIPTION
Automatically assign LuceneIndexDiagnostics instead of GenericIndexDiagnostics for LuceneIndexes.

This is for custom created `LuceneIndex`'s so that devs don't need to create their own LuceneIndex implementation and then manually implement IIndexDiagnostics. Currently if you don't do that and only create an index with `new LuceneIndex(....)` you will automatically get assigned a `GenericIndexDiagnostics` which returns some ugly data.