### PR TITLE
Removing unnecessary delete confirmation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -1,6 +1,6 @@
 /**
  * @ngdoc controller
- * @name Umbraco.Editors.ContentDeleteController
+ * @name Umbraco.Editors.Content.DeleteController
  * @function
  * 
  * @description

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting content
  */
-function ContentDeleteController($scope, $timeout, contentResource, treeService, navigationService, editorState, $location, overlayService) {
+function ContentDeleteController($scope, $timeout, contentResource, treeService, navigationService, editorState, $location, overlayService, languageResource) {
 
     /**
      * Used to toggle UI elements during delete operations
@@ -80,6 +80,20 @@ function ContentDeleteController($scope, $timeout, contentResource, treeService,
     $scope.close = function () {
         navigationService.hideDialog();
     };
+
+  
+    languageResource.getAll().then(function (data) {
+
+        $scope.hasMoreThanOneLanguage = data.length > 1;
+    }, function (err) {
+        toggleDeleting(false);
+
+        //check if response is ysod
+        if (err.status && err.status >= 500) {
+            // TODO: All YSOD handling should be done with an interceptor
+            overlayService.ysod(err);
+        }
+    });
 }
 
 angular.module("umbraco").controller("Umbraco.Editors.Content.DeleteController", ContentDeleteController);

--- a/src/Umbraco.Web.UI.Client/src/views/content/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/delete.html
@@ -14,7 +14,7 @@
                 <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong>?
             </p>
 
-            <div class="umb-alert umb-alert--warning">
+            <div class="umb-alert umb-alert--warning" ng-show="hasMoreThanOneLanguage">
                 <localize key="defaultdialogs_variantdeletewarning">This will delete the node and all its languages. If you only want to delete one language go and unpublish it instead.</localize>
             </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [6436](https://github.com/umbraco/Umbraco-CMS/issues/6436)

### Description
When showing delete-node-dialog, it only show warning: "This will delete the node and all its languages", when site has more than one language.
