### PR TITLE
Health Check - Text alternatives for icons missing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/healthcheck.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/healthcheck.html
@@ -32,26 +32,41 @@
                             <umb-load-indicator></umb-load-indicator>
                         </div>
 
-                        <div class="umb-healthcheck-messages" ng-hide="group.loading || !group.totalSuccess && !group.totalWarning && !group.totalError && !group.totalInfo">
+                        <div
+                            class="umb-healthcheck-messages"
+                            ng-hide="group.loading || !group.totalSuccess && !group.totalWarning && !group.totalError && !group.totalInfo"
+                        >
 
                             <div class="umb-healthcheck-message" ng-if="group.totalSuccess > 0">
                                 <i class="icon-check color-green" aria-hidden="true"></i>
                                 {{ group.totalSuccess }}
+                                <span class="sr-only">
+                                    <localize key="visuallyHiddenTexts_passed">passed</localize>
+                                </span>
                             </div>
 
                             <div class="umb-healthcheck-message" ng-if="group.totalWarning > 0">
                                 <i class="icon-alert color-orange" aria-hidden="true"></i>
                                 {{ group.totalWarning }}
+                                <span class="sr-only">
+                                    <localize key="visuallyHiddenTexts_warning">warning</localize>
+                                </span>
                             </div>
 
                             <div class="umb-healthcheck-message" ng-if="group.totalError > 0">
                                 <i class="icon-delete color-red" aria-hidden="true"></i>
                                 {{ group.totalError }}
+                                <span class="sr-only">
+                                    <localize key="visuallyHiddenTexts_failed">failed</localize>
+                                </span>
                             </div>
 
                             <div class="umb-healthcheck-message" ng-if="group.totalInfo > 0">
                                 <i class="umb-healthcheck-status-icon icon-info" aria-hidden="true"></i>
                                 {{ group.totalInfo }}
+                                <span class="sr-only">
+                                    <localize key="visuallyHiddenTexts_suggestion">suggestion</localize>
+                                </span>
                             </div>
 
                         </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1621,6 +1621,10 @@ Mange hilsner fra Umbraco robotten
     <key alias="goBack">Gå tilbage</key>
     <key alias="activeListLayout">Aktivt layout:</key>
     <key alias="jumpTo">Gå til</key>
-    <key alias="group">gruppe</key>    
+    <key alias="group">gruppe</key>
+    <key alias="passed">bestået</key>
+    <key alias="warning">advarsel</key>
+    <key alias="failed">fejlet</key>
+    <key alias="suggestion">forslag</key>
   </area>
 </language>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2139,6 +2139,10 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="goBack">Go back</key>
     <key alias="activeListLayout">Active layout:</key>
     <key alias="jumpTo">Jump to</key>
-    <key alias="group">group</key>    
+    <key alias="group">group</key>
+    <key alias="passed">passed</key>
+    <key alias="warning">warning</key>
+    <key alias="failed">failed</key>
+    <key alias="suggestion">suggestion</key>
   </area>
 </language>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2153,6 +2153,10 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="goBack">Go back</key>
     <key alias="activeListLayout">Active layout:</key>
     <key alias="jumpTo">Jump to</key>
-    <key alias="group">group</key>    
+    <key alias="group">group</key>
+    <key alias="passed">passed</key>
+    <key alias="warning">warning</key>
+    <key alias="failed">failed</key>
+    <key alias="suggestion">suggestion</key>
   </area>
 </language>


### PR DESCRIPTION
Co-authored-by: @webdokkeren <thormadsenholm@gmail.com>

### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes issue **no. 152** from #5277 

### Description
In this PR we have added a few next texts for "passed", "warning", "failed" and "suggestion" in the language files.

In the health check view these texts have been added inside a `<span class="sr-only">`, which means a screen reader will announce for instance "Configuration 1 passed, 2 warning" depending on what's exposed to the DOM.

We realise that pluralized texts need to be handled but that is something that needs to be done in another task as it's something that's not available out of the box currently and will affect other scenarios as well. This is a lot better than having no texts at all 😃 
