### PR TITLE
Disable rename alias of system user groups

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -195,6 +195,7 @@ Use this directive to construct a header inside the main editor window.
 @param {string=} icon Show and edit the content icon. Opens an overlay to change the icon.
 @param {boolean=} hideIcon Set to <code>true</code> to hide icon.
 @param {string=} alias show and edit the content alias.
+@param {boolean=} aliasLocked Set to <code>true</code> to lock the alias.
 @param {boolean=} hideAlias Set to <code>true</code> to hide alias.
 @param {string=} description Add a description to the content.
 @param {boolean=} hideDescription Set to <code>true</code> to hide description.
@@ -207,7 +208,6 @@ Use this directive to construct a header inside the main editor window.
     function EditorHeaderDirective(editorService) {
 
         function link(scope) {
-
             scope.vm = {};
             scope.vm.dropdownOpen = false;
             scope.vm.currentVariant = "";
@@ -262,6 +262,7 @@ Use this directive to construct a header inside the main editor window.
                 icon: "=",
                 hideIcon: "@",
                 alias: "=",
+                aliasLocked: "<",
                 hideAlias: "=",
                 description: "=",
                 hideDescription: "@",

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-locked-field.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-locked-field.less
@@ -29,7 +29,8 @@
    color: @gray-3;
 }
 
-input.umb-locked-field__input {
+input.umb-locked-field__input,
+.umb-locked-field__text {
   background: rgba(255, 255, 255, 0); // if using transparent it will hide the text in safari
   border-color: transparent !important;
   font-size: 13px;

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -46,7 +46,7 @@
                                         ng-if="!hideAlias"
                                         alias="$parent.alias"
                                         alias-from="$parent.name"
-                                        enable-lock="true"
+                                        enable-lock="aliasLocked !== true"
                                         validation-position="'right'"
                                         server-validation-field="Alias">
                     </umb-generate-alias>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-generate-alias.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-generate-alias.html
@@ -1,5 +1,5 @@
 <div>
-    <span ng-show="!enableLock">{{ alias }}</span>
+    <span class="umb-locked-field__text" ng-show="!enableLock">{{ alias }}</span>
     <div ng-show="enableLock">
     <umb-locked-field
       locked="locked"

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.html
@@ -9,6 +9,7 @@
             <umb-editor-header
                 name="vm.userGroup.name"
                 alias="vm.userGroup.alias"
+                alias-locked="vm.userGroup.isSystemUserGroup"
                 icon="vm.userGroup.icon"
                 hide-description="true"
                 on-back="vm.goToPage(vm.breadcrumbs[0])"

--- a/src/Umbraco.Web/Editors/Filters/UserGroupValidateAttribute.cs
+++ b/src/Umbraco.Web/Editors/Filters/UserGroupValidateAttribute.cs
@@ -50,6 +50,19 @@ namespace Umbraco.Web.Editors.Filters
                         actionContext.Response = actionContext.Request.CreateErrorResponse(HttpStatusCode.NotFound, message);
                         return;
                     }
+
+                    if (persisted.Alias != userGroupSave.Alias)
+                    {
+                        if (persisted.Alias == Constants.Security.AdminGroupAlias
+                            || persisted.Alias == Constants.Security.SensitiveDataGroupAlias
+                            || persisted.Alias == Constants.Security.TranslatorGroupAlias)
+                        {
+                            var message = $"User group with alias: {persisted.Alias} cannot be changed";
+                            actionContext.Response = actionContext.Request.CreateErrorResponse(HttpStatusCode.BadRequest, message);
+                            return;
+                        }
+                    }
+
                     //map the model to the persisted instance
                     Mapper.Map(userGroupSave, persisted);
                     break;

--- a/src/Umbraco.Web/Models/ContentEditing/UserGroupBasic.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/UserGroupBasic.cs
@@ -33,5 +33,11 @@ namespace Umbraco.Web.Models.ContentEditing
         /// </summary>
         [DataMember(Name = "userCount")]
         public int UserCount { get; set; }
+
+        /// <summary>
+        /// Is the user group a system group e.g. "Administrators", "Sensitive data" or "Translators"
+        /// </summary>
+        [DataMember(Name = "isSystemUserGroup")]
+        public bool IsSystemUserGroup { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
@@ -138,7 +138,7 @@ namespace Umbraco.Web.Models.Mapping
         }
 
         // Umbraco.Code.MapAll -ContentStartNode -UserCount -MediaStartNode -Key -Sections
-        // Umbraco.Code.MapAll -Notifications -Udi -Trashed -AdditionalData
+        // Umbraco.Code.MapAll -Notifications -Udi -Trashed -AdditionalData -IsSystemUserGroup
         private void Map(IReadOnlyUserGroup source, UserGroupBasic target, MapperContext context)
         {
             target.Alias = source.Alias;
@@ -147,11 +147,11 @@ namespace Umbraco.Web.Models.Mapping
             target.Name = source.Name;
             target.ParentId = -1;
             target.Path = "-1," + source.Id;
-            MapUserGroupBasic(target, source.AllowedSections, source.StartContentId, source.StartMediaId, context);
+            MapUserGroupBasic(target, source.Alias, source.AllowedSections, source.StartContentId, source.StartMediaId, context);
         }
 
         // Umbraco.Code.MapAll -ContentStartNode -MediaStartNode -Sections -Notifications
-        // Umbraco.Code.MapAll -Udi -Trashed -AdditionalData
+        // Umbraco.Code.MapAll -Udi -Trashed -AdditionalData -IsSystemUserGroup
         private void Map(IUserGroup source, UserGroupBasic target, MapperContext context)
         {
             target.Alias = source.Alias;
@@ -162,7 +162,7 @@ namespace Umbraco.Web.Models.Mapping
             target.ParentId = -1;
             target.Path = "-1," + source.Id;
             target.UserCount = source.UserCount;
-            MapUserGroupBasic(target, source.AllowedSections, source.StartContentId, source.StartMediaId, context);
+            MapUserGroupBasic(target, source.Alias, source.AllowedSections, source.StartContentId, source.StartMediaId, context);
         }
 
         // Umbraco.Code.MapAll -Udi -Trashed -AdditionalData -AssignedPermissions
@@ -198,7 +198,7 @@ namespace Umbraco.Web.Models.Mapping
         }
 
         // Umbraco.Code.MapAll -ContentStartNode -MediaStartNode -Sections -Notifications -Udi
-        // Umbraco.Code.MapAll -Trashed -AdditionalData -Users -AssignedPermissions
+        // Umbraco.Code.MapAll -Trashed -AdditionalData -Users -AssignedPermissions -IsSystemUserGroup
         private void Map(IUserGroup source, UserGroupDisplay target, MapperContext context)
         {
             target.Alias = source.Alias;
@@ -211,7 +211,7 @@ namespace Umbraco.Web.Models.Mapping
             target.Path = "-1," + source.Id;
             target.UserCount = source.UserCount;
 
-            MapUserGroupBasic(target, source.AllowedSections, source.StartContentId, source.StartMediaId, context);
+            MapUserGroupBasic(target, source.Alias, source.AllowedSections, source.StartContentId, source.StartMediaId, context);
 
             //Important! Currently we are never mapping to multiple UserGroupDisplay objects but if we start doing that
             // this will cause an N+1 and we'll need to change how this works.
@@ -334,8 +334,12 @@ namespace Umbraco.Web.Models.Mapping
 
         // helpers
 
-        private void MapUserGroupBasic(UserGroupBasic target, IEnumerable<string> sourceAllowedSections, int? sourceStartContentId, int? sourceStartMediaId, MapperContext context)
+        private void MapUserGroupBasic(UserGroupBasic target, string alias, IEnumerable<string> sourceAllowedSections, int? sourceStartContentId, int? sourceStartMediaId, MapperContext context)
         {
+            target.IsSystemUserGroup = alias == Constants.Security.AdminGroupAlias
+                               || alias == Constants.Security.TranslatorGroupAlias
+                               || alias == Constants.Security.SensitiveDataGroupAlias;
+
             var allSections = _sectionService.GetSections();
             target.Sections = context.MapEnumerable<ISection, Section>(allSections.Where(x => sourceAllowedSections.Contains(x.Alias)));
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6379 

I've disabled renaming of system user groups, both in the UI and at the WebAPI controller level.

This is done for the "Administrators", "Sensitive data" and the "Translators" groups

Before:

![image](https://user-images.githubusercontent.com/379886/65700679-55b6f480-e080-11e9-940d-868eb84d668b.png)

After (notice the lock is gone):

![image](https://user-images.githubusercontent.com/379886/65700579-31f3ae80-e080-11e9-9009-82bc885399e8.png)
