### PR TITLE
v8: Use umb-radiobutton component in relation types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -46,7 +46,7 @@
                     vm.onChange({ model: vm.model, value: vm.value });
                 }, 0);
             }
-        }     
+        }    
     }
 
     var component = {
@@ -58,8 +58,8 @@
             value: "@",
             name: "@",
             text: "@",
-            disabled: "=",
-            required: "=",
+            disabled: "<",
+            required: "<",
             onChange: "&?"
         }
     };

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -1,5 +1,6 @@
 <label class="radio umb-form-check umb-form-check--radiobutton" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
-    <input type="radio" name="{{vm.name}}"
+    <input type="radio"
+        name="{{vm.name}}"
         value="{{vm.value}}"
         class="umb-form-check__input"
         ng-model="vm.model"

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
@@ -56,7 +56,7 @@ function RelationTypeEditController($scope, $routeParams, relationTypeResource, 
         formatDates(relationType.relations);
         getRelationNames(relationType);
 
-        // Convert property value to string, so umb-radiobutton component can handle the value as a string
+        // Convert property value to string, since the umb-radiobutton component at the moment only handle string values.
         // Sometime later the umb-radiobutton might be able to handle value as boolean.
         relationType.isBidirectional = (relationType.isBidirectional || false).toString();
 

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
@@ -56,6 +56,10 @@ function RelationTypeEditController($scope, $routeParams, relationTypeResource, 
         formatDates(relationType.relations);
         getRelationNames(relationType);
 
+        // Convert property value to string, so umb-radiobutton component can handle the value as a string
+        // Sometime later the umb-radiobutton might be able to handle value as boolean.
+        relationType.isBidirectional = (relationType.isBidirectional || false).toString();
+
         vm.relationType = relationType;
 
         editorState.set(vm.relationType);

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
@@ -22,7 +22,12 @@ function RelationTypeEditController($scope, $routeParams, relationTypeResource, 
     function init() {
         vm.page.loading = true;
 
-        localizationService.localizeMany(["relationType_tabRelationType", "relationType_tabRelations"]).then(function (data) {
+        var labelKeys = [
+            "relationType_tabRelationType",
+            "relationType_tabRelations"
+        ];
+
+        localizationService.localizeMany(labelKeys).then(function (data) {
             vm.page.navigation = [
                 {
                     "name": data[0],

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.html
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.html
@@ -1,36 +1,38 @@
-<umb-box>
-    <umb-box-content>
-        <!-- ID -->
-        <umb-control-group label="Id">
-            <div>{{model.relationType.id}}</div>
-            <small>{{model.relationType.key}}</small>
-        </umb-control-group>
+<div ng-controller="Umbraco.Editors.RelationTypes.SettingsController as vm">
+    <umb-box>
+        <umb-box-content>
+            <!-- ID -->
+            <umb-control-group label="Id">
+                <div>{{model.relationType.id}}</div>
+                <small>{{model.relationType.key}}</small>
+            </umb-control-group>
 
-        <!-- Direction -->
-        <umb-control-group label="@relationType_direction">
-            <ul class="unstyled">
-                <li>
-                    <umb-radiobutton name="relationTypeDirection" value="false" model="model.relationType.isBidirectional"></umb-radiobutton> <localize key="relationType_parentToChild">Parent to child</localize>
-                </li>
-                <li>
-                    <umb-radiobutton name="relationTypeDirection" value="true" model="model.relationType.isBidirectional"></umb-radiobutton> <localize key="relationType_bidirectional">Bidirectional</localize>
-                </li>
-            </ul>
-        </umb-control-group>
+            <!-- Direction -->
+            <umb-control-group label="@relationType_direction">
+                <ul class="unstyled">
+                    <li>
+                        <umb-radiobutton name="relationTypeDirection" value="false" model="model.relationType.isBidirectional" text="{{vm.labels.parentToChild}}"></umb-radiobutton>
+                    </li>
+                    <li>
+                        <umb-radiobutton name="relationTypeDirection" value="true" model="model.relationType.isBidirectional" text="{{vm.labels.bidirectional}}"></umb-radiobutton>
+                    </li>
+                </ul>
+            </umb-control-group>
 
-        <!-- Parent-->
-        <umb-control-group label="@relationType_parent">
-            <div>{{model.relationType.parentObjectTypeName}}</div>
-        </umb-control-group>
+            <!-- Parent-->
+            <umb-control-group label="@relationType_parent">
+                <div>{{model.relationType.parentObjectTypeName}}</div>
+            </umb-control-group>
 
-        <!-- Child -->
-        <umb-control-group label="@relationType_child">
-            <div>{{model.relationType.childObjectTypeName}}</div>
-        </umb-control-group>
+            <!-- Child -->
+            <umb-control-group label="@relationType_child">
+                <div>{{model.relationType.childObjectTypeName}}</div>
+            </umb-control-group>
 
-        <!-- Relation count -->
-        <umb-control-group label="@relationType_count" ng-if="model.relationType.relations.length > 0">
-            <div>{{model.relationType.relations.length}}</div>
-        </umb-control-group>
-    </umb-box-content>
-</umb-box>
+            <!-- Relation count -->
+            <umb-control-group label="@relationType_count" ng-if="model.relationType.relations.length > 0">
+                <div>{{model.relationType.relations.length}}</div>
+            </umb-control-group>
+        </umb-box-content>
+    </umb-box>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.html
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.html
@@ -10,14 +10,10 @@
         <umb-control-group label="@relationType_direction">
             <ul class="unstyled">
                 <li>
-                    <label class="radio">
-                        <input type="radio" name="relationType-direction" ng-model="model.relationType.isBidirectional" ng-value="false"> <localize key="relationType_parentToChild">Parent to child</localize>
-                    </label>
+                    <umb-radiobutton name="relationTypeDirection" value="false" model="model.relationType.isBidirectional"></umb-radiobutton> <localize key="relationType_parentToChild">Parent to child</localize>
                 </li>
                 <li>
-                    <label class="radio">
-                        <input type="radio" name="relationType-direction" ng-model="model.relationType.isBidirectional" ng-value="true"> <localize key="relationType_bidirectional">Bidirectional</localize>
-                    </label>
+                    <umb-radiobutton name="relationTypeDirection" value="true" model="model.relationType.isBidirectional"></umb-radiobutton> <localize key="relationType_bidirectional">Bidirectional</localize>
                 </li>
             </ul>
         </umb-control-group>

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.settings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.settings.controller.js
@@ -1,0 +1,38 @@
+/**
+ * @ngdoc controller
+ * @name Umbraco.Editors.RelationTypes.EditController
+ * @function
+ *
+ * @description
+ * The controller for editing relation types.
+ */
+function RelationTypeSettingsController($scope, localizationService) {
+
+    var vm = this;
+
+    vm.labels = {};
+
+    vm.changeDirection = changeDirection;
+
+    function changeDirection(model, value) {
+        console.log("model", model, value);
+    }
+
+    function init() {
+
+        var labelKeys = [
+            "relationType_parentToChild",
+            "relationType_bidirectional"
+        ];
+
+        localizationService.localizeMany(labelKeys).then(function (data) {
+            console.log("data", data);
+            vm.labels.parentToChild = data[0];
+            vm.labels.bidirectional = data[1];
+        });
+    }
+
+    init();
+}
+
+angular.module("umbraco").controller("Umbraco.Editors.RelationTypes.SettingsController", RelationTypeSettingsController);

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.settings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.settings.controller.js
@@ -12,12 +12,6 @@ function RelationTypeSettingsController($scope, localizationService) {
 
     vm.labels = {};
 
-    vm.changeDirection = changeDirection;
-
-    function changeDirection(model, value) {
-        console.log("model", model, value);
-    }
-
     function init() {
 
         var labelKeys = [
@@ -26,7 +20,6 @@ function RelationTypeSettingsController($scope, localizationService) {
         ];
 
         localizationService.localizeMany(labelKeys).then(function (data) {
-            console.log("data", data);
             vm.labels.parentToChild = data[0];
             vm.labels.bidirectional = data[1];
         });

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.settings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.settings.controller.js
@@ -1,10 +1,10 @@
 /**
  * @ngdoc controller
- * @name Umbraco.Editors.RelationTypes.EditController
+ * @name Umbraco.Editors.RelationTypes.SettingsController
  * @function
  *
  * @description
- * The controller for editing relation types.
+ * The controller for editing relation type settings.
  */
 function RelationTypeSettingsController($scope, localizationService) {
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR replace the traditional radiobuttons in relation type view with `umb-radiobutton` component.

The `value` property is defined as one-way binding using `@` which also convert the value as a string, while `<` has ability to pass an object with its original data type to component: https://stackoverflow.com/a/36667226/1693918

I tried the latter one, but it seemed to cause some other issues in checkbox list and radibutton list property editor where it use interpolation like this `value="{{item.value}}"`.

When the current behaviour in `umb-radiobutton` and `umb-checkbox` the initial model value passed in to the component could be a boolean true/false, where it didn't select the radiobutton when model and value was equal because model was a boolean, but value is converted to a boolean and when making a change in radiobutton options the original value e.g. a json string changed from boolean to a string value.

There is a great article about this behaviour here: https://medium.com/front-end-weekly/angularjs-component-binding-types-my-experiences-10f354d4660

For now I have converted the original value to a string, which seems to work well.

Example where the original value of `isBidirectional` property not is converted to a string.

![2019-09-26_18-33-08](https://user-images.githubusercontent.com/2919859/65707223-5eadc300-e08c-11e9-90fb-825f2ef564fe.gif)

Example where the original value of `isBidirectional` property is converted to a string.

![2019-09-26_18-36-20](https://user-images.githubusercontent.com/2919859/65707332-9c125080-e08c-11e9-870a-61beb32295e8.gif)
