### PR TITLE
v8: Package repo categories selection updates

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
@@ -104,10 +104,8 @@
 
             vm.loading = true;
             vm.searchQuery = "";
-            var searchCategory = selectedCategory.name;
-            if (reset === true) {
-                searchCategory = "";
-            }
+
+            var searchCategory = reset === true ? "" : selectedCategory.name;
 
             currSort = "Latest";
 
@@ -122,7 +120,7 @@
                         vm.pagination.totalPages = Math.ceil(pack.total / vm.pagination.pageSize);
                         vm.pagination.pageNumber = 1;
                     })
-            ])
+                ])
                 .then(function () {
                     vm.loading = false;
                     selectedCategory.active = reset === false;

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
@@ -34,7 +34,9 @@
 
         var labels = {};
 
-        var currSort = "Latest";
+        var defaultSort = "Latest";
+        var currSort = defaultSort;
+
         //used to cancel any request in progress if another one needs to take it's place
         var canceler = null;
 
@@ -92,22 +94,30 @@
         }
 
         function selectCategory(selectedCategory, categories) {
-            var reset = false;
+
             for (var i = 0; i < categories.length; i++) {
                 var category = categories[i];
-                if (category.name === selectedCategory.name && category.active === true) {
+                if (category.name === selectedCategory.name) {
                     //it's already selected, let's unselect to show all again
-                    reset = true;
+                    if (category.active === true) {
+                        category.active = false;
+                    }
+                    else {
+                        category.active = true;
+                    }
                 }
-                category.active = false;
+                else {
+                    category.active = false;
+                }
             }
 
             vm.loading = true;
             vm.searchQuery = "";
 
-            var searchCategory = reset === true ? "" : selectedCategory.name;
+            var reset = selectedCategory.active === false;
+            var searchCategory = reset ? "" : selectedCategory.name;
 
-            currSort = "Latest";
+            currSort = defaultSort;
 
             $q.all([
                 ourPackageRepositoryResource.getPopular(8, searchCategory)
@@ -123,7 +133,6 @@
                 ])
                 .then(function () {
                     vm.loading = false;
-                    selectedCategory.active = reset === false;
                 });
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -11,19 +11,19 @@
             </div>
         </div>
 
-        <div ng-show="vm.loading === false">
-
-            <div class="umb-packages-section" ng-if="vm.searchQuery == ''">
-                <div class="umb-packages-categories">
-                    <a href=""
-                       class="umb-packages-category"
-                       ng-click="vm.selectCategory(category, vm.categories)"
-                       ng-repeat="category in vm.categories"
-                       ng-class="{'-active': category.active, '-first': $first, '-last': $last}">
-                        <div>{{ category.name }}</div>
-                    </a>
-                </div>
+        <div class="umb-packages-section" ng-if="vm.searchQuery == ''">
+            <div class="umb-packages-categories">
+                <a href=""
+                   class="umb-packages-category"
+                   ng-click="vm.selectCategory(category, vm.categories)"
+                   ng-repeat="category in vm.categories"
+                   ng-class="{'-active': category.active, '-first': $first, '-last': $last}">
+                    <div>{{category.name}}</div>
+                </a>
             </div>
+        </div>
+
+        <div ng-show="vm.loading === false">
 
             <div class="umb-packages-section" ng-if="vm.searchQuery == ''">
                 <h4><strong><localize key="packager_packagesPopular">Popular</localize></strong></h4>
@@ -102,9 +102,8 @@
             </div>
 
             <!-- Empty state -->
-            <umb-empty-state
-                ng-if="vm.packages.length === 0 && vm.loading === false && vm.searchQuery !== ''"
-                position="center">
+            <umb-empty-state ng-if="vm.packages.length === 0 && vm.loading === false && vm.searchQuery !== ''"
+                             position="center">
                 <h4><strong><localize key="packager_packageNoResults">We couldn't find anything for</localize> '{{ vm.searchQuery }}'</strong></h4>
                 <p class="faded"><localize key="packager_packageNoResultsDescription">Please try searching for another package or browse through the categories</localize>.</p>
             </umb-empty-state>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -25,7 +25,7 @@
 
         <div ng-show="vm.loading === false">
 
-            <div class="umb-packages-section" ng-if="vm.searchQuery == ''">
+            <div class="umb-packages-section" ng-if="vm.searchQuery == '' && vm.popular.length > 0">
                 <h4><strong><localize key="packager_packagesPopular">Popular</localize></strong></h4>
                 <div class="umb-packages">
 
@@ -37,15 +37,15 @@
                             </div>
 
                             <div class="umb-package-info">
-                                <div class="umb-package-name">{{ package.name }}</div>
-                                <div class="umb-package-description">{{ package.excerpt | limitTo: 40 }}<span ng-if="package.excerpt > (package.excerpt | limitTo: 40)">...</span></div>
+                                <div class="umb-package-name">{{package.name}}</div>
+                                <div class="umb-package-description">{{package.excerpt | limitTo: 40}}<span ng-if="package.excerpt > (package.excerpt | limitTo: 40)">...</span></div>
 
                                 <div class="umb-package-numbers">
                                     <small class="umb-package-downloads">
-                                        <i class="icon-download-alt"></i> <strong>{{ package.downloads }}</strong>
+                                        <i class="icon-download-alt"></i> <strong>{{package.downloads}}</strong>
                                     </small>
                                     <small class="umb-package-likes">
-                                        <i class="icon-hearts"></i> <strong>{{ package.likes }}</strong>
+                                        <i class="icon-hearts"></i> <strong>{{package.likes}}</strong>
                                     </small>
                                 </div>
 
@@ -67,7 +67,7 @@
                         <a class="umb-package-link" href="" ng-click="vm.showPackageDetails(package)">
 
                             <div class="umb-package-icon">
-                                <img ng-src="{{ package.icon }}" alt="" />
+                                <img ng-src="{{package.icon}}" alt="" />
                             </div>
 
                             <div class="umb-package-info">
@@ -105,6 +105,12 @@
             <umb-empty-state ng-if="vm.packages.length === 0 && vm.loading === false && vm.searchQuery !== ''"
                              position="center">
                 <h4><strong><localize key="packager_packageNoResults">We couldn't find anything for</localize> '{{ vm.searchQuery }}'</strong></h4>
+                <p class="faded"><localize key="packager_packageNoResultsDescription">Please try searching for another package or browse through the categories</localize>.</p>
+            </umb-empty-state>
+
+            <umb-empty-state ng-if="vm.popular.length === 0 && vm.loading === false && vm.searchQuery === ''"
+                             position="center">
+                <h4><strong><localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize></strong></h4>
                 <p class="faded"><localize key="packager_packageNoResultsDescription">Please try searching for another package or browse through the categories</localize>.</p>
             </umb-empty-state>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add a few changes, so the categories are not hidden (while loading) on selection and also set the active class faster instead of it might wait to update the active state here https://github.com/umbraco/Umbraco-CMS/blob/v8/dev/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js#L128

Furthermore it doesn't show just Popular heading when selecting "Umbraco Pro" with no results.

![2019-09-27_00-48-23](https://user-images.githubusercontent.com/2919859/65729991-9afb1680-e0c0-11e9-873d-d289a0d6347e.gif)
