### PR TITLE
Fixes #2997 - ContentService returns outdated result

### DIFF
--- a/src/Umbraco.Tests/Cache/RefresherTests.cs
+++ b/src/Umbraco.Tests/Cache/RefresherTests.cs
@@ -12,20 +12,22 @@ namespace Umbraco.Tests.Cache
         [Test]
         public void MediaCacheRefresherCanDeserializeJsonPayload()
         {
-            var source = new[] { new MediaCacheRefresher.JsonPayload(1234, TreeChangeTypes.None) };
+            var source = new[] { new MediaCacheRefresher.JsonPayload(1234, Guid.NewGuid(), TreeChangeTypes.None) };
             var json = JsonConvert.SerializeObject(source);
             var payload = JsonConvert.DeserializeObject<MediaCacheRefresher.JsonPayload[]>(json);
             Assert.AreEqual(source[0].Id, payload[0].Id);
+            Assert.AreEqual(source[0].Key, payload[0].Key);
             Assert.AreEqual(source[0].ChangeTypes, payload[0].ChangeTypes);
         }
 
         [Test]
         public void ContentCacheRefresherCanDeserializeJsonPayload()
         {
-            var source = new[] { new ContentCacheRefresher.JsonPayload(1234, TreeChangeTypes.None) };
+            var source = new[] { new ContentCacheRefresher.JsonPayload(1234, Guid.NewGuid(), TreeChangeTypes.None) };
             var json = JsonConvert.SerializeObject(source);
             var payload = JsonConvert.DeserializeObject<ContentCacheRefresher.JsonPayload[]>(json);
             Assert.AreEqual(source[0].Id, payload[0].Id);
+            Assert.AreEqual(source[0].Key, payload[0].Key);
             Assert.AreEqual(source[0].ChangeTypes, payload[0].ChangeTypes);
         }
 

--- a/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
@@ -458,7 +458,7 @@ namespace Umbraco.Tests.PublishedContent
             };
 
             // notify
-            _snapshotService.Notify(new[] { new ContentCacheRefresher.JsonPayload(10, TreeChangeTypes.RefreshBranch) }, out _, out _);
+            _snapshotService.Notify(new[] { new ContentCacheRefresher.JsonPayload(10, Guid.Empty, TreeChangeTypes.RefreshBranch) }, out _, out _);
 
             // changes that *I* make are immediately visible on the current snapshot
             var documents = snapshot.Content.GetAtRoot().ToArray();
@@ -500,7 +500,7 @@ namespace Umbraco.Tests.PublishedContent
             };
 
             // notify
-            _snapshotService.Notify(new[] { new ContentCacheRefresher.JsonPayload(1, TreeChangeTypes.RefreshBranch) }, out _, out _);
+            _snapshotService.Notify(new[] { new ContentCacheRefresher.JsonPayload(1, Guid.Empty, TreeChangeTypes.RefreshBranch) }, out _, out _);
 
             // changes that *I* make are immediately visible on the current snapshot
             var documents = snapshot.Content.GetAtRoot().ToArray();
@@ -580,7 +580,7 @@ namespace Umbraco.Tests.PublishedContent
             };
 
             // notify
-            _snapshotService.Notify(new[] { new ContentCacheRefresher.JsonPayload(kit.Node.ParentContentId, TreeChangeTypes.RefreshBranch) }, out _, out _);
+            _snapshotService.Notify(new[] { new ContentCacheRefresher.JsonPayload(kit.Node.ParentContentId, Guid.Empty, TreeChangeTypes.RefreshBranch) }, out _, out _);
 
             // changes that *I* make are immediately visible on the current snapshot
             var documents = snapshot.Content.GetById(kit.Node.ParentContentId).Children().ToArray();
@@ -677,8 +677,8 @@ namespace Umbraco.Tests.PublishedContent
             _snapshotService.Notify(new[]
             {
                 // removal must come first
-                new ContentCacheRefresher.JsonPayload(2, TreeChangeTypes.RefreshBranch),
-                new ContentCacheRefresher.JsonPayload(1, TreeChangeTypes.RefreshBranch)
+                new ContentCacheRefresher.JsonPayload(2, Guid.Empty, TreeChangeTypes.RefreshBranch),
+                new ContentCacheRefresher.JsonPayload(1, Guid.Empty, TreeChangeTypes.RefreshBranch)
             }, out _, out _);
 
             // changes that *I* make are immediately visible on the current snapshot
@@ -873,9 +873,9 @@ namespace Umbraco.Tests.PublishedContent
             // notify
             _snapshotService.Notify(new[]
             {
-                new ContentCacheRefresher.JsonPayload(3, TreeChangeTypes.Remove), // remove last
-                new ContentCacheRefresher.JsonPayload(5, TreeChangeTypes.Remove), // remove middle
-                new ContentCacheRefresher.JsonPayload(9, TreeChangeTypes.Remove), // remove first
+                new ContentCacheRefresher.JsonPayload(3, Guid.Empty, TreeChangeTypes.Remove), // remove last
+                new ContentCacheRefresher.JsonPayload(5, Guid.Empty, TreeChangeTypes.Remove), // remove middle
+                new ContentCacheRefresher.JsonPayload(9, Guid.Empty, TreeChangeTypes.Remove), // remove first
             }, out _, out _);
 
             documents = snapshot.Content.GetAtRoot().ToArray();
@@ -890,9 +890,9 @@ namespace Umbraco.Tests.PublishedContent
             // notify
             _snapshotService.Notify(new[]
             {
-                new ContentCacheRefresher.JsonPayload(1, TreeChangeTypes.Remove), // remove first
-                new ContentCacheRefresher.JsonPayload(8, TreeChangeTypes.Remove), // remove
-                new ContentCacheRefresher.JsonPayload(7, TreeChangeTypes.Remove), // remove
+                new ContentCacheRefresher.JsonPayload(1, Guid.Empty, TreeChangeTypes.Remove), // remove first
+                new ContentCacheRefresher.JsonPayload(8, Guid.Empty, TreeChangeTypes.Remove), // remove
+                new ContentCacheRefresher.JsonPayload(7, Guid.Empty, TreeChangeTypes.Remove), // remove
             }, out _, out _);
 
             documents = snapshot.Content.GetAtRoot().ToArray();
@@ -922,8 +922,8 @@ namespace Umbraco.Tests.PublishedContent
             // notify
             _snapshotService.Notify(new[]
             {
-                new ContentCacheRefresher.JsonPayload(1, TreeChangeTypes.RefreshBranch),
-                new ContentCacheRefresher.JsonPayload(2, TreeChangeTypes.RefreshNode),
+                new ContentCacheRefresher.JsonPayload(1, Guid.Empty, TreeChangeTypes.RefreshBranch),
+                new ContentCacheRefresher.JsonPayload(2, Guid.Empty, TreeChangeTypes.RefreshNode),
             }, out _, out _);
 
             documents = snapshot.Content.GetAtRoot().ToArray();
@@ -979,7 +979,7 @@ namespace Umbraco.Tests.PublishedContent
 
             _snapshotService.Notify(new[]
             {
-                new ContentCacheRefresher.JsonPayload(2, TreeChangeTypes.Remove)
+                new ContentCacheRefresher.JsonPayload(2, Guid.Empty, TreeChangeTypes.Remove)
             }, out _, out _);
 
             parentNodes = contentStore.Test.GetValues(1);
@@ -1038,7 +1038,7 @@ namespace Umbraco.Tests.PublishedContent
 
             _snapshotService.Notify(new[]
             {
-                new ContentCacheRefresher.JsonPayload(3, TreeChangeTypes.Remove) //remove middle child
+                new ContentCacheRefresher.JsonPayload(3, Guid.Empty, TreeChangeTypes.Remove) //remove middle child
             }, out _, out _);
 
             Assert.AreEqual(2, contentStore.Test.LiveGen);
@@ -1113,7 +1113,7 @@ namespace Umbraco.Tests.PublishedContent
 
             _snapshotService.Notify(new[]
             {
-                new ContentCacheRefresher.JsonPayload(3, TreeChangeTypes.RefreshBranch) //remove middle child
+                new ContentCacheRefresher.JsonPayload(3, Guid.Empty, TreeChangeTypes.RefreshBranch) //remove middle child
             }, out _, out _);
 
             Assert.AreEqual(2, contentStore.Test.LiveGen);

--- a/src/Umbraco.Web/Cache/ContentCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/ContentCacheRefresher.cs
@@ -51,7 +51,10 @@ namespace Umbraco.Web.Cache
 
             foreach (var payload in payloads.Where(x => x.Id != default))
             {
+                //By INT Id
                 isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent>(payload.Id));
+                //By GUID Key
+                isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent>(payload.Key));
 
                 _idkMap.ClearCache(payload.Id);
 
@@ -137,14 +140,15 @@ namespace Umbraco.Web.Cache
 
         public class JsonPayload
         {
-            public JsonPayload(int id, TreeChangeTypes changeTypes)
+            public JsonPayload(int id, Guid? key, TreeChangeTypes changeTypes)
             {
                 Id = id;
+                Key = key;
                 ChangeTypes = changeTypes;
             }
 
             public int Id { get; }
-
+            public Guid? Key { get; }
             public TreeChangeTypes ChangeTypes { get; }
         }
 

--- a/src/Umbraco.Web/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Web/Cache/DistributedCacheExtensions.cs
@@ -106,7 +106,7 @@ namespace Umbraco.Web.Cache
 
         public static void RefreshAllContentCache(this DistributedCache dc)
         {
-            var payloads = new[] { new ContentCacheRefresher.JsonPayload(0, TreeChangeTypes.RefreshAll) };
+            var payloads = new[] { new ContentCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) };
 
             // note: refresh all content cache does refresh content types too
             dc.RefreshByPayload(ContentCacheRefresher.UniqueId, payloads);
@@ -117,7 +117,7 @@ namespace Umbraco.Web.Cache
             if (changes.Length == 0) return;
 
             var payloads = changes
-                .Select(x => new ContentCacheRefresher.JsonPayload(x.Item.Id, x.ChangeTypes));
+                .Select(x => new ContentCacheRefresher.JsonPayload(x.Item.Id, x.Item.Key, x.ChangeTypes));
 
             dc.RefreshByPayload(ContentCacheRefresher.UniqueId, payloads);
         }
@@ -157,7 +157,7 @@ namespace Umbraco.Web.Cache
 
         public static void RefreshAllMediaCache(this DistributedCache dc)
         {
-            var payloads = new[] { new MediaCacheRefresher.JsonPayload(0, TreeChangeTypes.RefreshAll) };
+            var payloads = new[] { new MediaCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) };
 
             // note: refresh all media cache does refresh content types too
             dc.RefreshByPayload(MediaCacheRefresher.UniqueId, payloads);
@@ -168,7 +168,7 @@ namespace Umbraco.Web.Cache
             if (changes.Length == 0) return;
 
             var payloads = changes
-                .Select(x => new MediaCacheRefresher.JsonPayload(x.Item.Id, x.ChangeTypes));
+                .Select(x => new MediaCacheRefresher.JsonPayload(x.Item.Id, x.Item.Key, x.ChangeTypes));
 
             dc.RefreshByPayload(MediaCacheRefresher.UniqueId, payloads);
         }

--- a/src/Umbraco.Web/Cache/MediaCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/MediaCacheRefresher.cs
@@ -62,6 +62,7 @@ namespace Umbraco.Web.Cache
                     // it *was* done for each pathId but really that does not make sense
                     // only need to do it for the current media
                     mediaCache.Result.Clear(RepositoryCacheKeys.GetKey<IMedia>(payload.Id));
+                    mediaCache.Result.Clear(RepositoryCacheKeys.GetKey<IMedia>(payload.Key));
 
                     // remove those that are in the branch
                     if (payload.ChangeTypes.HasTypesAny(TreeChangeTypes.RefreshBranch | TreeChangeTypes.Remove))
@@ -104,14 +105,15 @@ namespace Umbraco.Web.Cache
 
         public class JsonPayload
         {
-            public JsonPayload(int id, TreeChangeTypes changeTypes)
+            public JsonPayload(int id, Guid? key, TreeChangeTypes changeTypes)
             {
                 Id = id;
+                Key = key;
                 ChangeTypes = changeTypes;
             }
 
             public int Id { get; }
-
+            public Guid? Key { get; }
             public TreeChangeTypes ChangeTypes { get; }
         }
 

--- a/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
+++ b/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
@@ -54,8 +54,8 @@ namespace Umbraco.Web.Compose
                         // note: refresh all content & media caches does refresh content types too
                         var svc = Current.PublishedSnapshotService;
                         svc.Notify(new[] { new DomainCacheRefresher.JsonPayload(0, DomainChangeTypes.RefreshAll) });
-                        svc.Notify(new[] { new ContentCacheRefresher.JsonPayload(0, TreeChangeTypes.RefreshAll) }, out _, out _);
-                        svc.Notify(new[] { new MediaCacheRefresher.JsonPayload(0, TreeChangeTypes.RefreshAll) }, out _);
+                        svc.Notify(new[] { new ContentCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) }, out _, out _);
+                        svc.Notify(new[] { new MediaCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) }, out _);
                     },
 
                     //rebuild indexes if the server is not synced

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -801,8 +801,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 using (_contentStore.GetScopedWriteLock(_scopeProvider))
                 using (_mediaStore.GetScopedWriteLock(_scopeProvider))
                 {
-                    NotifyLocked(new[] { new ContentCacheRefresher.JsonPayload(0, TreeChangeTypes.RefreshAll) }, out var draftChanged, out var publishedChanged);
-                    NotifyLocked(new[] { new MediaCacheRefresher.JsonPayload(0, TreeChangeTypes.RefreshAll) }, out var anythingChanged);
+                    NotifyLocked(new[] { new ContentCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) }, out var draftChanged, out var publishedChanged);
+                    NotifyLocked(new[] { new MediaCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) }, out var anythingChanged);
                 }
             }
 


### PR DESCRIPTION
Fixes #2997 - ContentService returns outdated result

This fixes the issue when using ContentService.GetById(Guid) and MediaService.GetById(Guid), the cache for these methods is not refreshed with the cache refreshers since they are only evicting the cache by INT. 

This will need to be backported to 7.x

Testing:

Create a controller:

```cs
public class TestController : SurfaceController
{
    public ActionResult GetContentByKey(System.Guid key)
    {
        var c1 = Services.ContentService.GetById(key);
        var c2 = c1 == null ? null : Services.ContentService.GetById(c1.Id);
        return Content(c1?.Name + " - " + c2?.Name);
    }

    public ActionResult GetMediaByKey(System.Guid key)
    {
        var m1 = Services.MediaService.GetById(key);
        var m2 = m1 == null ? null : Services.MediaService.GetById(m1.Id);
        return Content(m1?.Name + " - " + m2?.Name);
    }
}
```

Then go find a content's GUID and a media item's GUID.

Open 2x tabs in your browser (of course use your own GUIDs accordingly):
* /umbraco/surface/test/GetContentBykey?key=df1eb830-411b-4d41-a343-3917b76d533c 
* /umbraco/surface/test/GetMediaBykey?key=64478ab3-b117-4891-aa30-2f635de1bd5d

You will see the name by INT and by GUID

Then go change the name of the content and media item and refresh these tabs - the names should be the same since the cache has refreshed for both the INT and the GUID. Previously only the INT name would be refreshed.

