### PR TITLE
fixed xml comment for GridConfigurationEditor

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/GridConfigurationEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridConfigurationEditor.cs
@@ -8,7 +8,7 @@ using Umbraco.Core.PropertyEditors.Validators;
 namespace Umbraco.Web.PropertyEditors
 {
     /// <summary>
-    /// Represents the configuration for the grid value editor.
+    /// Represents the configuration editor for the grid value editor.
     /// </summary>
     public class GridConfigurationEditor : ConfigurationEditor<GridConfiguration>
     {


### PR DESCRIPTION
previously had the same comment as the GridConfiguration. Now matches comment for other configurationEditors