### PR TITLE
V8/fix user group selection

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -213,9 +213,10 @@
         }
 
         function openUserGroupPicker() {
-            var oldSelection = angular.copy(vm.user.userGroups);
+            var currentSelection = [];
+            angular.copy(vm.user.userGroups, currentSelection);
             var userGroupPicker = {
-                selection: vm.user.userGroups,
+                selection: currentSelection,
                 submit: function (model) {
                     // apply changes
                     if (model.selection) {
@@ -223,9 +224,7 @@
                     }
                     editorService.close();
                 },
-                close: function () {
-                    // roll back the selection
-                    vm.user.userGroups = oldSelection;
+                close: function () {        
                     editorService.close();
                 }
             };

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -350,9 +350,10 @@
         }
 
         function openUserGroupPicker() {
-            var oldSelection = angular.copy(vm.newUser.userGroups);
+            var currentSelection = [];
+            angular.copy(vm.newUser.userGroups, currentSelection);
             var userGroupPicker = {
-                selection: vm.newUser.userGroups,
+                selection: currentSelection,
                 submit: function (model) {
                     // apply changes
                     if (model.selection) {
@@ -362,7 +363,6 @@
                 },
                 close: function () {
                     // rollback on close
-                    vm.newUser.userGroups = oldSelection;
                     editorService.close();
                 }
             };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When creating or editing a user the selection made in the group selection dialog is immediatly visible in the edit screen. If the user clicks close it reverts back to the original state. See gif for behavior

![user group selection before](https://user-images.githubusercontent.com/1193822/65905833-a3559900-e3c1-11e9-8da3-3cfcdc2370df.gif)

This was because the "actual" current selection was passed to the dialog, instead of a copy triggering the updates immediatly. After this PR the behavior is fixed

![user group selection after](https://user-images.githubusercontent.com/1193822/65906352-aef58f80-e3c2-11e9-80bb-5f085a42083f.gif)

I have seen this in more places in the backend. So expect some more PR's

Dave

PS : Should i create PR targeted at V7 for this as well ?