### PR TITLE
Add umb-checkbox for publish unpublished content items with no variants

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -1,15 +1,14 @@
 <div ng-controller="Umbraco.Overlays.PublishDescendantsController as vm">
 
     <div ng-if="vm.variants.length === 1">
-        <div style="margin-bottom: 15px;">
+        <div class="mb3">
             <p><localize key="{{vm.labels.help.key}}" tokens="vm.labels.help.tokens"></localize></p>
         </div>
 
-        <div style="margin-bottom: 15px;">
-            <label>
-                <input type="checkbox"
-                       ng-model="model.includeUnpublished"
-                       style="margin-right: 8px;" />
+        <div class="mb3">
+            <umb-checkbox input-id="includeUnpublishedSelector" model="model.includeUnpublished" />
+
+            <label for="includeUnpublishedSelector">
                 <localize key="content_includeUnpublished"></localize>
             </label>
         </div>
@@ -18,29 +17,26 @@
 
     <div ng-if="vm.variants.length > 1">
 
-        <div style="margin-bottom: 15px;">
+        <div class="mb3">
             <p><localize key="content_publishDescendantsWithVariantsHelp"></localize></p>
         </div>
 
-        <div style="margin-bottom: 15px;" class="flex">
+        <div class="flex mb3">
 
-            <umb-checkbox
-                input-id="includeUnpublishedSelector"
-                model="model.includeUnpublished" />
+            <umb-checkbox input-id="includeUnpublishedSelector" model="model.includeUnpublished" />
 
             <label for="includeUnpublishedSelector">
                 <localize key="content_includeUnpublished"></localize>
             </label>
         </div>
 
-        <div class="bold" style="margin-bottom: 5px;">
+        <div class="bold mb1">
             <localize key="treeHeaders_languages"></localize>
         </div>
 
         <div class="umb-list umb-list--condensed">
 
-            <div class="umb-list-item umb-list--condensed"
-                 ng-repeat="variant in vm.variants">
+            <div class="umb-list-item umb-list--condensed" ng-repeat="variant in vm.variants">
                 <ng-form name="publishVariantSelectorForm">
                     <div class="flex" ng-class="{'umb-list-item--error': publishVariantSelectorForm.publishVariantSelector.$invalid}">
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -5,7 +5,8 @@
             <p><localize key="{{vm.labels.help.key}}" tokens="vm.labels.help.tokens"></localize></p>
         </div>
 
-        <div class="mb3">
+        <div class="flex mb3">
+
             <umb-checkbox input-id="includeUnpublishedSelector" model="model.includeUnpublished" />
 
             <label for="includeUnpublishedSelector">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed that the "Save and publish > Publish with descendants" overlay was using `umb-checkbox` when using variants.

![image](https://user-images.githubusercontent.com/2919859/65914175-48c43900-e3d1-11e9-8797-cf45d31beaec.png)

But not without any variants as now:

![image](https://user-images.githubusercontent.com/2919859/65914385-9b055a00-e3d1-11e9-8f38-0869a0de3fa8.png)

This is how it looks at the moment using a traditional checkbox, while it does use `umb-checkbox` when the document type vary by culture.

![image](https://user-images.githubusercontent.com/2919859/65914559-e61f6d00-e3d1-11e9-9d3f-3b6bbc89be34.png)