### PR TITLE
Use umb-checkbox for loglevel selection

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -29,14 +29,9 @@
                             <umb-dropdown class="pull-right" ng-if="vm.page.showLevelFilter" on-close="vm.page.showLevelFilter = false;">
                                 <umb-dropdown-item ng-repeat="level in vm.logLevels" style="padding: 8px 20px 8px 16px;">
                                     <div class="flex items-center">
-                                        <input
-                                            id="loglevel-{{$index}}"
-                                            type="checkbox"
-                                            ng-model="level.selected"
-                                            ng-change="vm.setLogLevelFilter(level)"
-                                            style="margin-right: 10px; margin-top: -3px;" />
+                                        <umb-checkbox input-id="loglevel-{{$index}}" name="loglevel" model="level.selected" on-change="vm.setLogLevelFilter(level)" />
                                         <label for="loglevel-{{$index}}">
-                                            <umb-badge size="s" color="{{ level.logTypeColor }}">{{ level.name }}</umb-badge>
+                                            <umb-badge size="s" color="{{level.logTypeColor}}">{{level.name}}</umb-badge>
                                         </label>
                                     </div>
                                 </umb-dropdown-item>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR change so `umb-checkbox` is used in loglevel selection in the dropdown.

![2019-09-30_23-25-31](https://user-images.githubusercontent.com/2919859/65918322-aceafb00-e3d9-11e9-8177-bd91bb703780.gif)

At the moment the dropdown opens behind the search input. First thing I think we need to change here is that the view only use a single `<umb-editor-sub-header>` element in logviewer search.
https://github.com/umbraco/Umbraco-CMS/blob/v8/dev/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html#L20

as in this example https://github.com/umbraco/Umbraco-CMS/blob/853087a75044b814df458457dc9a1f778cc89749/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/subheader/umbeditorsubheadersection.directive.js#L15-L41

but we can look at this in another PR.
