### PR TITLE
Added punctuation

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1569,9 +1569,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="allowedTemplatesHeading">Allowed Templates</key>
     <key alias="allowedTemplatesDescription">Choose which templates editors are allowed to use on content of this type</key>
     <key alias="allowAsRootHeading">Allow as root</key>
-    <key alias="allowAsRootDescription">Allow editors to create content of this type in the root of the content tree</key>
+    <key alias="allowAsRootDescription">Allow editors to create content of this type in the root of the content tree.</key>
     <key alias="childNodesHeading">Allowed child node types</key>
-    <key alias="childNodesDescription">Allow content of the specified types to be created underneath content of this type</key>
+    <key alias="childNodesDescription">Allow content of the specified types to be created underneath content of this type.</key>
     <key alias="chooseChildNode">Choose child node</key>
     <key alias="compositionsDescription">Inherit tabs and properties from an existing document type. New tabs will be added to the current document type or merged if a tab with an identical name exists.</key>
     <key alias="compositionInUse">This content type is used in a composition, and therefore cannot be composed itself.</key>
@@ -1605,11 +1605,11 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="compositionUsageHeading">Where is this composition used?</key>
     <key alias="compositionUsageSpecification">This composition is currently used in the composition of the following content types:</key>
     <key alias="variantsHeading">Allow varying by culture</key>
-    <key alias="variantsDescription">Allow editors to create content of this type in different languages</key>
+    <key alias="variantsDescription">Allow editors to create content of this type in different languages.</key>
     <key alias="allowVaryByCulture">Allow varying by culture</key>
     <key alias="elementType">Element type</key>
     <key alias="elementHeading">Is an Element type</key>
-    <key alias="elementDescription">An Element type is meant to be used for instance in Nested Content, and not in the tree</key>
+    <key alias="elementDescription">An Element type is meant to be used for instance in Nested Content, and not in the tree.</key>
     <key alias="elementDoesNotSupport">This is not applicable for an Element type</key>
     <key alias="propertyHasChanges">You have made changes to this property. Are you sure you want to discard them?</key>
   </area>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1581,9 +1581,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="allowedTemplatesHeading">Allowed Templates</key>
     <key alias="allowedTemplatesDescription">Choose which templates editors are allowed to use on content of this type</key>
     <key alias="allowAsRootHeading">Allow as root</key>
-    <key alias="allowAsRootDescription">Allow editors to create content of this type in the root of the content tree</key>
+    <key alias="allowAsRootDescription">Allow editors to create content of this type in the root of the content tree.</key>
     <key alias="childNodesHeading">Allowed child node types</key>
-    <key alias="childNodesDescription">Allow content of the specified types to be created underneath content of this type</key>
+    <key alias="childNodesDescription">Allow content of the specified types to be created underneath content of this type.</key>
     <key alias="chooseChildNode">Choose child node</key>
     <key alias="compositionsDescription">Inherit tabs and properties from an existing document type. New tabs will be added to the current document type or merged if a tab with an identical name exists.</key>
     <key alias="compositionInUse">This content type is used in a composition, and therefore cannot be composed itself.</key>
@@ -1617,11 +1617,11 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="compositionUsageHeading">Where is this composition used?</key>
     <key alias="compositionUsageSpecification">This composition is currently used in the composition of the following content types:</key>
     <key alias="variantsHeading">Allow varying by culture</key>
-    <key alias="variantsDescription">Allow editors to create content of this type in different languages</key>
+    <key alias="variantsDescription">Allow editors to create content of this type in different languages.</key>
     <key alias="allowVaryByCulture">Allow varying by culture</key>
     <key alias="elementType">Element type</key>
     <key alias="elementHeading">Is an Element type</key>
-    <key alias="elementDescription">An Element type is meant to be used for instance in Nested Content, and not in the tree</key>
+    <key alias="elementDescription">An Element type is meant to be used for instance in Nested Content, and not in the tree.</key>
     <key alias="elementDoesNotSupport">This is not applicable for an Element type</key>
     <key alias="propertyHasChanges">You have made changes to this property. Are you sure you want to discard them?</key>
   </area>


### PR DESCRIPTION
The four descriptions were missing a period at the end. This PR adds that both for `en.xml` and `en_us.xml`:

![image](https://user-images.githubusercontent.com/3634580/65918231-6e554080-e3d9-11e9-8e02-29bc2f29a7a9.png)
