### PR TITLE
Fixes null reference caused in GridPropertyValueEditor when the value is empty

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -83,6 +83,9 @@ namespace Umbraco.Web.PropertyEditors
 
                 // editorValue.Value is a JSON string of the grid
                 var rawJson = editorValue.Value.ToString();
+                if (rawJson.IsNullOrWhiteSpace())
+                    return null;
+
                 var grid = JsonConvert.DeserializeObject<GridValue>(rawJson);
 
                 // Find all controls that use the RTE editor


### PR DESCRIPTION
Fixes null reference caused in GridPropertyValueEditor when the value is empty.

This can occur when the value stored for the grid is an empty string, in which case we were not checking for that scenario and a null ref exception was thrown.

---
_This item has been added to our backlog [AB#2972](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/2972)_