### PR TITLE
Fix initialization problem with TinyMCE 4

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -89,7 +89,10 @@ angular.module("umbraco")
                 
                 angular.extend(baseLineConfigObj, standardConfig);
                 
-                tinymce.init(baseLineConfigObj);
+                // We need to wait for DOM to have rendered before we can find the element by ID.
+                $timeout(function () {
+                    tinymce.init(baseLineConfigObj);
+                }, 150);
                 
                 //listen for formSubmitting event (the result is callback used to remove the event subscription)
                 var unsubscribe = $scope.$on("formSubmitting", function () {


### PR DESCRIPTION
Added timeout for init, cause rendering is not always complete if not. Ugly solution, but we had this before, and we tried without, but not working everywhere.