### PR TITLE
V8/bugfix/0000 tiny mce css icon issue

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/rte.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte.less
@@ -63,8 +63,9 @@
 }
 
 /* Special case to support helviticons for the tiny mce button controls */
-.umb-rte .mce-ico.mce-i-custom[class^="icon-"],
-.umb-rte .mce-ico.mce-i-custom[class*=" icon-"] {
+// Also used in Prevalue editor.
+.mce-ico.mce-i-custom[class^="icon-"],
+.mce-ico.mce-i-custom[class*=" icon-"] {
     font-family: icomoon;
     font-size: 16px !important;
 }


### PR DESCRIPTION
Correcting CSS for custom icons in TinyMCE, so they also can be used in PreValue Editor