### PR TITLE
Removed Microsoft.Net.Compilers dependency

### DIFF
--- a/build/NuSpecs/UmbracoCms.nuspec
+++ b/build/NuSpecs/UmbracoCms.nuspec
@@ -30,7 +30,6 @@
                 <dependency id="ImageProcessor.Web" version="[4.10.0.100,4.999999)" />
                 <dependency id="ImageProcessor.Web.Config" version="[2.5.0.100,2.999999)" />
                 <dependency id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="[2.0.1,2.999999)" />
-                <dependency id="Microsoft.Net.Compilers" version="[2.10.0,2.999999)" />
 
             </group>
 

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -94,10 +94,6 @@
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
-      <PrivateAssets>all</PrivateAssets>
-      <!-- development dependency -->
-    </PackageReference>
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.0.1" />
     <PackageReference Include="Microsoft.Owin.Security.Cookies" Version="4.0.1" />
     <PackageReference Include="Microsoft.Owin.Security.OAuth" Version="4.0.1" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6495

### Description
This PR removes the `Microsoft.Net.Compilers` dependency from both the `Umbraco.Web.UI` project and `UmbracoCms` NuGet package, as it's not required (the required version of Visual Studio 2017 v15.9 for local development already ships with the same compiler version).

All code should still build after this change, assuming the build environment also satifies the [local development requirements](https://our.umbraco.com/Documentation/Getting-Started/Setup/Requirements/#local-development).