### PR TITLE
Idea: only show property-actions on hover or when focus-within

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -61,12 +61,23 @@
     font-size: 16px;
     padding: 4px;
     line-height: 10px;
-
+    opacity: 0;
+    transition: opacity .12s ease-in-out;
+    
+    &:focus {
+        opacity: 1;
+    }
     &:hover {
         color: @ui-option-type-hover;
         text-decoration: none;
     }
 }
+.umb-property:hover .umb-property__copy,
+.umb-property:focus .umb-property__copy,
+.umb-property:focus-within .umb-property__copy {
+    opacity: 1;
+}
+
 
 //
 // Content picker

--- a/src/Umbraco.Web.UI.Client/src/less/rte.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte.less
@@ -120,7 +120,7 @@
 }
 
 .umb-rte .mce-btn.mce-active, .umb-rte .mce-btn.mce-active:active, 
-.umb-rte .mce-btn.mce-active:hover, .umb-rte .mce-btn.mce-active:focus {
+.umb-rte .mce-btn.mce-active:hover, .umb-rte .mce-btn.mce-active:focus-within {
     background: @gray-9;
     border-color: transparent;
     button {


### PR DESCRIPTION
We want to minimize the amount of visual elements on the screen, to underline a simple, calm and friendly visual environment. To ensure this in the future when more data-types will be supporting the property-copy-action or other future property-actions, it would be nice to already now hide the property-copy action, to avoid having it constantly shown.

![image](https://user-images.githubusercontent.com/6791648/65968765-f41dce00-e463-11e9-9308-9f9d9e03ae37.png)

The concept is to only show the property-actions on hover, when there is focus-within (thought that might have it difficulties...) and when the user have tabbed to on of the actions.

This PR, does the first two, meaning it's still missing the ability to tab to the actions.

If you have any thought or concerns regarding this PR, please share them in this thread, thanks.