### PR TITLE
Fixes Return 503 status code when in upgrade mode #6334

### DIFF
--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -145,6 +145,7 @@ namespace Umbraco.Web.Editors
         /// </summary>
         /// <returns></returns>
         [HttpGet]
+        [StatusCodeResult(System.Net.HttpStatusCode.ServiceUnavailable)]
         public async Task<ActionResult> AuthorizeUpgrade()
         {
             return await RenderDefaultOrProcessExternalLoginAsync(

--- a/src/Umbraco.Web/Install/Controllers/InstallController.cs
+++ b/src/Umbraco.Web/Install/Controllers/InstallController.cs
@@ -6,6 +6,7 @@ using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Migrations.Install;
 using Umbraco.Web.JavaScript;
+using Umbraco.Web.Mvc;
 using Umbraco.Web.Security;
 
 namespace Umbraco.Web.Install.Controllers
@@ -35,6 +36,7 @@ namespace Umbraco.Web.Install.Controllers
         }
 
         [HttpGet]
+        [StatusCodeResult(System.Net.HttpStatusCode.ServiceUnavailable)]
         public ActionResult Index()
         {
             if (_runtime.Level == RuntimeLevel.Run)

--- a/src/Umbraco.Web/Mvc/StatusCodeFilterAttribute.cs
+++ b/src/Umbraco.Web/Mvc/StatusCodeFilterAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System.Net;
+using System.Web.Mvc;
+
+namespace Umbraco.Web.Mvc
+{
+    /// <summary>
+    /// Forces the response to have a specific http status code
+    /// </summary>
+    internal class StatusCodeResultAttribute : ActionFilterAttribute
+    {
+        private readonly HttpStatusCode _statusCode;
+
+        public StatusCodeResultAttribute(HttpStatusCode statusCode)
+        {
+            _statusCode = statusCode;
+        }
+
+        public override void OnActionExecuted(ActionExecutedContext filterContext)
+        {
+            base.OnActionExecuted(filterContext);
+
+            filterContext.HttpContext.Response.StatusCode = (int)_statusCode;
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Models\TemplateQuery\QueryConditionExtensions.cs" />
     <Compile Include="Mvc\HttpUmbracoFormRouteStringException.cs" />
     <Compile Include="Mvc\ModelBindingExceptionFilter.cs" />
+    <Compile Include="Mvc\StatusCodeFilterAttribute.cs" />
     <Compile Include="Mvc\SurfaceControllerTypeCollectionBuilder.cs" />
     <Compile Include="Mvc\ValidateUmbracoFormRouteStringAttribute.cs" />
     <Compile Include="Profiling\WebProfilingController.cs" />


### PR DESCRIPTION
Fixes #6334 Return 503 status code when in upgrade mode

## Testing

* Log out of umbraco
* Change the web.config umbraco version to 8.2.0 (since dev/v8 is 8.3.0) , this will force umbraco installer to execute
* Open chrome dev tools and view network tab
* run Umbraco, notice that requests for AuthorizeUpgrade endpoint returns 503 status and that there are no JS errors
* log in and it will redirect to the installer, see that it returns 503 for the Installer endpoint, ensure no JS errors and click through to upgrade

🎉 