### PR TITLE
V8: Lazy load thumbnails in the media grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbimagelazyload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbimagelazyload.directive.js
@@ -53,6 +53,10 @@ Use this directive to lazy-load an image only when it is scrolled into view.
                 });
             }
 
+            // make sure to disconnect the observer when the scope is destroyed
+            scope.$on('$destroy', function () {
+                observer.disconnect();
+            });
         }
 
         var directive = {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbimagelazyload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbimagelazyload.directive.js
@@ -1,0 +1,68 @@
+/**
+@ngdoc directive
+@name umbraco.directives.directive:umbImageLazyLoad
+@restrict E
+@scope
+
+@description
+Use this directive to lazy-load an image only when it is scrolled into view.
+
+<h3>Markup example</h3>
+<pre>
+    <div ng-controller="My.Controller as vm">
+        <img umb-image-lazy-load="{{vm.imageUrl}}" />
+    </div>
+</pre>
+
+<h3>Controller example</h3>
+<pre>
+    (function () {
+        "use strict";
+
+        function Controller() {
+
+            var vm = this;
+            vm.imageUrl = "/media/TODO";
+        }
+
+        angular.module("umbraco").controller("My.Controller", Controller);
+    })();
+</pre>
+
+**/
+
+(function() {
+    'use strict';
+
+    function ImageLazyLoadDirective() {
+
+        const placeholder = "assets/img/transparent.png";
+
+        function link(scope, element, attrs) {
+
+            const observer = new IntersectionObserver(loadImg);
+            const img = angular.element(element)[0];
+            img.src = placeholder;
+            observer.observe(img);
+
+            function loadImg(changes) {
+                changes.forEach(change => {
+                    if (change.intersectionRatio > 0 && change.target.src.indexOf(placeholder) > 0) {
+                        change.target.src = attrs.umbImageLazyLoad;
+                    }
+                });
+            }
+
+        }
+
+        var directive = {
+            restrict: "A",
+            link: link
+        };
+
+        return directive;
+    }
+
+    angular.module('umbraco.directives').directive('umbImageLazyLoad', ImageLazyLoadDirective);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -13,7 +13,7 @@
             <div class="umb-media-grid__image-background" ng-if="item.thumbnail || item.extension === 'svg'"></div>
 
             <!-- Image thumbnail -->
-            <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="item.thumbnail" ng-src="{{item.thumbnail}}" alt="{{item.name}}" draggable="false" />
+            <img umb-image-lazy-load="{{item.thumbnail}}" class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="item.thumbnail" alt="{{item.name}}" draggable="false" />
 
             <!-- SVG -->
             <img class="umb-media-grid__item-image" width="{{item.width}}" height="{{item.height}}" ng-if="!item.thumbnail && item.extension === 'svg'" ng-src="{{item.image}}" alt="{{item.name}}" draggable="false" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6389

### Description

⚠️ Huge GIFs ahead ⚠️ 

This PR adds lazy loading to the thumbnails in the media grid as explained in #6389. 

With this PR applied, media thumbnails only load when they're scrolled into view; until then it simply shows the transparent background.

Here's a GIF of this PR in action when working with the media library:

![lazy-load-images-1](https://user-images.githubusercontent.com/7405322/65978799-9e9ded00-e474-11e9-8dad-d33ae4e4ad4d.gif)

...and here's when using the media picker:

![lazy-load-images-2](https://user-images.githubusercontent.com/7405322/65978848-b07f9000-e474-11e9-9b1b-e6ba2b220e50.gif)


