### PR TITLE
Boolean editors - adds ID attribute to umbToggle

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
@@ -54,6 +54,7 @@
 </pre>
 
 @param {boolean} checked Set to <code>true</code> or <code>false</code> to toggle the switch.
+@param {string} inputId Set the <code>id</code> of the toggle.
 @param {callback} onClick The function which should be called when the toggle is clicked.
 @param {string=} showLabels Set to <code>true</code> or <code>false</code> to show a "On" or "Off" label next to the switch.
 @param {string=} labelOn Set a custom label for when the switched is turned on. It will default to "On".
@@ -122,6 +123,7 @@
             scope: {
                 checked: "=",
                 disabled: "=",
+                inputId: "@",
                 onClick: "&",
                 labelOn: "@?",
                 labelOff: "@?",

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
@@ -1,4 +1,4 @@
-<button ng-click="click()" type="button" class="umb-toggle" ng-disabled="disabled" ng-class="{'umb-toggle--checked': checked, 'umb-toggle--disabled': disabled}">
+<button ng-click="click()" type="button" class="umb-toggle" ng-disabled="disabled" ng-class="{'umb-toggle--checked': checked, 'umb-toggle--disabled': disabled}" id="{{inputId}}">
 
     <span ng-if="!labelPosition && showLabels === 'true' || labelPosition === 'left' && showLabels === 'true'">
         <span ng-if="!checked" class="umb-toggle__label umb-toggle__label--left">{{ displayLabelOff }}</span>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/boolean.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/boolean.html
@@ -1,5 +1,6 @@
 <div ng-controller="Umbraco.PrevalueEditors.BooleanController">
     <umb-toggle
+        id="{{model.alias}}"
         checked="toggleValue"
         on-click="toggle()">
     </umb-toggle>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/boolean.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/boolean.html
@@ -1,6 +1,6 @@
 <div ng-controller="Umbraco.PrevalueEditors.BooleanController">
     <umb-toggle
-        id="{{model.alias}}"
+        input-id="{{model.alias}}"
         checked="toggleValue"
         on-click="toggle()">
     </umb-toggle>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
@@ -1,5 +1,6 @@
 <div class="umb-property-editor umb-boolean" ng-controller="Umbraco.PropertyEditors.BooleanController">
     <umb-toggle
+        id="{{model.alias}}"
         checked="renderModel.value"
         on-click="toggle()"
         show-labels="{{model.config.labelOn ? 'true': 'false'}}"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
@@ -1,6 +1,6 @@
 <div class="umb-property-editor umb-boolean" ng-controller="Umbraco.PropertyEditors.BooleanController">
     <umb-toggle
-        id="{{model.alias}}"
+        input-id="{{model.alias}}"
         checked="renderModel.value"
         on-click="toggle()"
         show-labels="{{model.config.labelOn ? 'true': 'false'}}"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The Boolean editor (aka. TrueFalse, aka. Checkbox 🤔) using the `<umb-toggle>` directive (for both prevalue-editor and property-editor), isn't associated with the property's `<label>`.

![ECBnKKPXsAExgUM](https://user-images.githubusercontent.com/209066/65979493-49121200-e46d-11e9-8824-51a9c9c227fa.png)

Meaning that if a user clicks on the property label, nothing happens.  Previous with the old checkbox (e.g. native HTML input), this would check/uncheck the input.

By adding an `id` attribute, with the property's alias (e.g. `id="{{model.alias}}"`), it will be associated with the toggle control.

In terms of testing, it'd be a case of clicking the label, and see the toggle state change.
