### PR TITLE
Update styles of API docs to match new identity

### DIFF
--- a/src/ApiDocs/umbracotemplate/styles/main.css
+++ b/src/ApiDocs/umbracotemplate/styles/main.css
@@ -8,6 +8,15 @@ body {
     word-wrap: break-word
 }
 
+.navbar-header .navbar-brand {
+    background: url(https://our.umbraco.com/assets/images/logo.svg) left center no-repeat;
+    background-size: 40px auto;
+    width:50px;
+}
+
+#_content>a {
+    margin-top: 5px;
+}
 /* HEADINGS */
 
 h1 {

--- a/src/ApiDocs/umbracotemplate/styles/main.css
+++ b/src/ApiDocs/umbracotemplate/styles/main.css
@@ -1,73 +1,206 @@
 body {
-	color: rgba(0,0,0,.8);
+    color: #34393e;
+    font-family: 'Roboto', sans-serif;
+    line-height: 1.5;
+    font-size: 16px;
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
+    word-wrap: break-word
 }
-.navbar-inverse {
-  background: #a3db78;
+
+/* HEADINGS */
+
+h1 {
+    font-weight: 600;
+    font-size: 32px;
 }
-.navbar-inverse .navbar-nav>li>a, .navbar-inverse .navbar-text {
-  color: rgba(0,0,0,.8);
+
+h2 {
+    font-weight: 600;
+    font-size: 24px;
+    line-height: 1.8;
+}
+
+h3 {
+    font-weight: 600;
+    font-size: 20px;
+    line-height: 1.8;
+}
+
+h5 {
+    font-size: 14px;
+    padding: 10px 0px;
+}
+
+article h1,
+article h2,
+article h3,
+article h4 {
+    margin-top: 35px;
+    margin-bottom: 15px;
+}
+
+article h4 {
+    padding-bottom: 8px;
+    border-bottom: 2px solid #ddd;
+}
+
+/* NAVBAR */
+
+.navbar-brand>img {
+    color: #fff;
+}
+
+.navbar {
+    border: none;
+    /* Both navbars use box-shadow */
+    -webkit-box-shadow: 0px 1px 3px 0px rgba(100, 100, 100, 0.5);
+    -moz-box-shadow: 0px 1px 3px 0px rgba(100, 100, 100, 0.5);
+    box-shadow: 0px 1px 3px 0px rgba(100, 100, 100, 0.5);
+}
+
+.subnav {
+    border-top: 1px solid #ddd;
+    background-color: #fff;
 }
 
 .navbar-inverse {
-    border-color: transparent;
+    background-color: #303ea1;
+    z-index: 100;
+}
+
+.navbar-inverse .navbar-nav>li>a,
+.navbar-inverse .navbar-text {
+    color: #fff;
+    background-color: #303ea1;
+    border-bottom: 3px solid transparent;
+    padding-bottom: 12px;
+}
+
+.navbar-inverse .navbar-nav>li>a:focus,
+.navbar-inverse .navbar-nav>li>a:hover {
+    color: #fff;
+    background-color: #303ea1;
+    border-bottom: 3px solid white;
+}
+
+.navbar-inverse .navbar-nav>.active>a,
+.navbar-inverse .navbar-nav>.active>a:focus,
+.navbar-inverse .navbar-nav>.active>a:hover {
+    color: #fff;
+    background-color: #303ea1;
+    border-bottom: 3px solid white;
+}
+
+.navbar-form .form-control {
+    border: none;
+    border-radius: 20px;
+}
+
+/* SIDEBAR */
+
+.toc .level1>li {
+    font-weight: 400;
+}
+
+.toc .nav>li>a {
+    color: #34393e;
+}
+
+.sidefilter {
+    background-color: #fff;
+    border-left: none;
+    border-right: none;
+}
+
+.sidefilter {
+    background-color: #fff;
+    border-left: none;
+    border-right: none;
+}
+
+.toc-filter {
+    padding: 10px;
+    margin: 0;
+}
+
+.toc-filter>input {
+    border: 2px solid #ddd;
+    border-radius: 20px;
+}
+
+.toc-filter>.filter-icon {
+    display: none;
+}
+
+.sidetoc>.toc {
+    background-color: #fff;
+    overflow-x: hidden;
 }
 
 .sidetoc {
-  background-color: #f5fbf1;
-}
-body .toc {
-  background-color: #f5fbf1;
-}
-.sidefilter {
-  background-color: #daf0c9;
-}
-.subnav {
-  background-color: #f5fbf1;
-}
-
-.navbar-inverse .navbar-nav>.active>a {
-	color: rgba(0,0,0,.8);
-    background-color: #daf0c9;
-}
-
-.navbar-inverse .navbar-nav>.active>a:focus, .navbar-inverse .navbar-nav>.active>a:hover {
-	color: rgba(0,0,0,.8);
-    background-color: #daf0c9;
-}
-
-.btn-primary {
-    color: rgba(0,0,0,.8);
     background-color: #fff;
-    border-color: rgba(0,0,0,.8);
-}
-.btn-primary:hover {
-    background-color: #daf0c9;
-	color: rgba(0,0,0,.8);
-	border-color: rgba(0,0,0,.8);
+    border: none;
 }
 
-.toc .nav > li > a {
-    color: rgba(0,0,0,.8);
+/* ALERTS */
+
+.alert {
+    padding: 0px 0px 5px 0px;
+    color: inherit;
+    background-color: inherit;
+    border: none;
+    box-shadow: 0px 2px 2px 0px rgba(100, 100, 100, 0.4);
 }
 
-button, a {
-    color: #f36f21;
+.alert>p {
+    margin-bottom: 0;
+    padding: 5px 10px;
 }
 
-button:hover,
-button:focus,
-a:hover,
-a:focus {
-  color: #143653;
-  text-decoration: none;
+.alert>ul {
+    margin-bottom: 0;
+    padding: 5px 40px;
 }
 
-.navbar-header .navbar-brand {
-    background: url(https://our.umbraco.com/assets/images/logo.svg) left center no-repeat;
-    background-size: 40px auto;
-    width:50px;
+.alert>h5 {
+    padding: 10px 15px;
+    margin-top: 0;
+    text-transform: uppercase;
+    font-weight: bold;
+    border-radius: 4px 4px 0 0;
 }
 
-.toc .nav > li.active > a {
-    color: #f36f21;
+.alert-info>h5 {
+    color: #1976d2;
+    border-bottom: 4px solid #1976d2;
+    background-color: #e3f2fd;
+}
+
+.alert-warning>h5 {
+    color: #f57f17;
+    border-bottom: 4px solid #f57f17;
+    background-color: #fff3e0;
+}
+
+.alert-danger>h5 {
+    color: #d32f2f;
+    border-bottom: 4px solid #d32f2f;
+    background-color: #ffebee;
+}
+
+/* CODE HIGHLIGHT */
+pre {
+	padding: 9.5px;
+	margin: 0 0 10px;
+	font-size: 13px;
+	word-break: break-all;
+	word-wrap: break-word;
+	background-color: #fffaef;
+	border-radius: 4px;
+	box-shadow: 0px 1px 4px 1px rgba(100, 100, 100, 0.4);
+}
+
+.sideaffix {
+    overflow: visible;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

The current API documentation on Our has not been updated to fit the new Umbraco identity. This change will change this:
![image](https://user-images.githubusercontent.com/36075913/65981969-83ce7700-e47a-11e9-921f-188e63539318.png)

Into this:
![image](https://user-images.githubusercontent.com/36075913/65982002-95178380-e47a-11e9-9e5b-966965039167.png)

## How to test
The easiest way to test is to navigate to the .\src\ApiDocs folder and run this command:
`C:\Umbraco\UmbracoRepos\v8Hackathon\build\temp\docfx.console.2.45.1\tools\docfx.exe build --serve` it will build the DocFX site and run it on localhost:8080 for quick and easy testing 🙂 

<!-- Thanks for contributing to Umbraco CMS! -->
