### PR TITLE
V8; Support allowed types for MNTP media picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
@@ -193,6 +193,9 @@ Use this directive to generate a thumbnail grid of media items.
             * Returns wether a item should be selectable or not.
             */
             function getSelectableState(item) {
+                if (item.filtered) {
+                    return false;
+                }
 
                 // check if item is a folder or image
                 if (item.isFolder === true) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -37,7 +37,7 @@ angular.module("umbraco")
             $scope.lastOpenedNode = localStorageService.get("umbLastOpenedMediaNodeId");
             $scope.lockedFolder = true;
             $scope.allowMediaEdit = dialogOptions.allowMediaEdit ? dialogOptions.allowMediaEdit : false;
-
+            
             var userStartNodes = [];
 
             var umbracoSettings = Umbraco.Sys.ServerVariables.umbracoSettings;
@@ -216,7 +216,7 @@ angular.module("umbraco")
             }
 
             function clickHandler(media, event, index) {
-                
+
                 if (media.isFolder) {
                     if ($scope.disableFolderSelect) {
                         gotoFolder(media);
@@ -443,21 +443,25 @@ angular.module("umbraco")
             function getChildren(id) {
                 vm.loading = true;
                 return entityResource.getChildren(id, "Media", vm.searchOptions).then(function (data) {
-                        
-                        for (var i = 0; i < data.length; i++) {
-                            if (data[i].metaData.MediaPath !== null) {
-                                data[i].thumbnail = mediaHelper.resolveFileFromEntity(data[i], true);
-                                data[i].image = mediaHelper.resolveFileFromEntity(data[i], false);
-                            }
+
+                    var allowedTypes = dialogOptions.filter ? dialogOptions.filter.split(",") : null;
+
+                    for (var i = 0; i < data.length; i++) {
+                        if (data[i].metaData.MediaPath !== null) {
+                            data[i].thumbnail = mediaHelper.resolveFileFromEntity(data[i], true);
+                            data[i].image = mediaHelper.resolveFileFromEntity(data[i], false);
                         }
 
-                        vm.searchOptions.filter = "";
-                        $scope.images = data ? data : [];
+                        data[i].filtered = allowedTypes && allowedTypes.indexOf(data[i].metaData.ContentTypeAlias) < 0;
+                    }
 
-                        // set already selected medias to selected
-                        preSelectMedia();
-                        vm.loading = false;
-                    });
+                    vm.searchOptions.filter = "";
+                    $scope.images = data ? data : [];
+
+                    // set already selected medias to selected
+                    preSelectMedia();
+                    vm.loading = false;
+                });
             }
 
             function preSelectMedia() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As-is you can pick the allowed types when configuring MNTP as a media picker. However, the picker doesn't respect the allowed types filtering like it does when configured as a content picker. This was uncovered while working on #5983 (see also [this comment](https://github.com/umbraco/Umbraco-CMS/pull/6177#issuecomment-531805007) on the PR fixing #5983)

This PR implements the filtering; when it's applied here's how the MNTP works in media picker mode:

![mntp-media-allowed-types](https://user-images.githubusercontent.com/7405322/65981822-394cfa80-e47a-11e9-9801-83d72515f5b1.gif)

...and it also works when you browse around the media library in the picker 😄 

![mntp-media-allowed-types-2](https://user-images.githubusercontent.com/7405322/65982253-36063e80-e47b-11e9-9772-5eba60b9e44c.gif)

#### Testing this PR

To test this:

1. Create a new media type (easiest to clone the default "media" one)
2. Create media of multiple types
3. Configure MNTP as a media picker and only allow one of the media types
4. Verify that the MNTP only lets you pick media of the allowed type
5. Do the same for multiple allowed media types
6. Remove the constraints on allowed media types and verify that the MNTP indeed allows you to pick any type