### PR TITLE
Marking the umb-overlay directive as deprecated

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
@@ -1,6 +1,7 @@
 /**
 @ngdoc directive
-@name umbraco.directives.directive:umbOverlay
+@name umbraco.directives.directive:umbOverlay*
+@deprecated
 @restrict E
 @scope
 


### PR DESCRIPTION
As confirmed by @nul800sebastiaan and @rasmusjp, the `<umb-overlay />` directive should be marked as deprecated as the newer `editorService` should be used instead.