### PR TITLE
Only show time in datepicker if format is HH:mm

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -8616,9 +8616,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==",
       "dev": true
     },
     "lodash._basecopy": {
@@ -8956,9 +8956,9 @@
       }
     },
     "marked": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.2.tgz",
-      "integrity": "sha512-fdZvBa7/vSQIZCi4uuwo2N3q+7jJURpMVCcbaX0S1Mg65WZ5ilXvC67MviJAsdjqqgD+CEq4RKo5AYGgINkVAA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
+      "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==",
       "dev": true
     },
     "matchdep": {
@@ -9356,9 +9356,9 @@
       "dev": true
     },
     "nouislider": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-14.0.1.tgz",
-      "integrity": "sha512-YNLKuABWYxmC5WXJ9TUj3N7+iyL/xT3+jm1mgOMXoqBhAL0Pj9BMgyKmLgwRnrxNN+C/fe7sFmpQDDPsxbMT2w=="
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-14.0.2.tgz",
+      "integrity": "sha512-N4AQStV4frh+XcLUwMI/hZpBP6tRboDE/4LZ7gzfxMVXFi/2J9URphnm40Ff4KEyrAVGSGaWApvljoMzTNWBlA=="
     },
     "npm": {
       "version": "6.11.3",

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-date-time-picker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-date-time-picker.html
@@ -1,5 +1,5 @@
 <div class="datepicker" style="position: relative;">
-
+    <h1>hoc!!!!!!</h1>
     <div ng-hide="hasTranscludedContent" class="input-append date">
         <input data-format="{{ options.format }}" type="text" class="datepickerinput" />
         <span class="add-on">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -53,6 +53,12 @@ function dateTimePickerController($scope, notificationsService, assetsService, a
             dateFormat: dateFormat,
             time_24hr: true
         };
+
+        // Don't show calendar if date format has been set to only time
+        if ($scope.model.config.format === "HH:mm:ss" || $scope.model.config.format === "HH:mm" || $scope.model.config.format === "HH") {
+            $scope.datePickerConfig.enableTime = true;
+            $scope.datePickerConfig.noCalendar = true;
+        }
             
         setDatePickerVal();
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

If a Date/Time property editor is configured to a HH:mm or HH:mm:ss format the calendar is no longer displayed and only hours and minutes are shown in the content editor.
![image](https://user-images.githubusercontent.com/10154582/65984634-7e742b00-e480-11e9-8abd-8aa87f0427b3.png)
![image](https://user-images.githubusercontent.com/10154582/65984693-951a8200-e480-11e9-99ae-3550b1bdc405.png)



<!-- Thanks for contributing to Umbraco CMS! -->
