### PR TITLE
Introduced confirm and confirmDelete functions in the Angular overlay service

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js
@@ -65,10 +65,26 @@
             open(overlay);
         }
 
+        function confirm(overlay) {
+            if (!overlay.closeButtonLabelKey) overlay.closeButtonLabelKey = "general_cancel";
+            if (!overlay.submitButtonLabelKey) overlay.submitButtonLabelKey = "general_confirm";
+            if (!overlay.view) overlay.view = "views/common/overlays/confirm/confirm.html";
+            if (!overlay.close) overlay.close = function () { close(); };
+            open(overlay);
+        }
+
+        function confirmDelete(overlay) {
+            if (!overlay.submitButtonStyle) overlay.submitButtonStyle = "danger";
+            if (!overlay.submitButtonLabelKey) overlay.submitButtonLabelKey = "contentTypeEditor_yesDelete";
+            confirm(overlay);
+        }
+
         var service = {
             open: open,
             close: close,
-            ysod: ysod
+            ysod: ysod,
+            confirm: confirm,
+            confirmDelete: confirmDelete
         };
 
         return service;

--- a/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js
@@ -66,16 +66,29 @@
         }
 
         function confirm(overlay) {
+
             if (!overlay.closeButtonLabelKey) overlay.closeButtonLabelKey = "general_cancel";
-            if (!overlay.submitButtonLabelKey) overlay.submitButtonLabelKey = "general_confirm";
             if (!overlay.view) overlay.view = "views/common/overlays/confirm/confirm.html";
             if (!overlay.close) overlay.close = function () { close(); };
+
+            switch (overlay.confirmType) {
+
+                case "delete":
+                    if (!overlay.confirmMessageStyle) overlay.confirmMessageStyle = "danger";
+                    if (!overlay.submitButtonStyle) overlay.submitButtonStyle = "danger";
+                    if (!overlay.submitButtonLabelKey) overlay.submitButtonLabelKey = "contentTypeEditor_yesDelete";
+                    break;
+                
+                default:
+                    if (!overlay.submitButtonLabelKey) overlay.submitButtonLabelKey = "general_confirm";
+
+            }
+
             open(overlay);
+
         }
 
         function confirmDelete(overlay) {
-            if (!overlay.submitButtonStyle) overlay.submitButtonStyle = "danger";
-            if (!overlay.submitButtonLabelKey) overlay.submitButtonLabelKey = "contentTypeEditor_yesDelete";
             confirm(overlay);
         }
 


### PR DESCRIPTION
Implementing https://github.com/umbraco/Umbraco-CMS/issues/6507

Based on [Bjarne's PR for a confirm overlay](https://github.com/umbraco/Umbraco-CMS/pull/5487), this PR adds the `confirm` and `confirmDelete` methods to the Angular overlay service.

The `confirm` function has some default settings:

- Specify the HTML view from Bjarne's PR
- Set `closeButtonLabelKey` to `general_cancel`
- Set `submitButtonLabelKey` to `general_confirm`
- Add a default `close` callback which just closes the overlay

It looks like this:

![image](https://user-images.githubusercontent.com/3634580/65985872-fcd1cc80-e482-11e9-95bb-7114af1114cc.png)

The `confirmDelete` functions does what `confirm` does, but then also:

- Set `submitButtonStyle` to `danger`
- Set `submitButtonLabelKey` to `contentTypeEditor_yesDelete`

It looks like this:

![image](https://user-images.githubusercontent.com/3634580/65985886-065b3480-e483-11e9-91dd-2f023a41d8f9.png)



I haven't updated the code in Bjarne's PR, but:

```js
const overlay = {
    view: "confirm",
    title: data[0],
    content: confirmationMessage,
    confirmMessage: "This will delete the account.",
    confirmMessageStyle: "danger",
    closeButtonLabel: data[1],
    submitButtonLabel: data[2],
    submitButtonStyle: "danger",
    close: function () {
        vm.deleteNotLoggedInUserButtonState = "danger";
        overlayService.close();
    },
    submit: function () {
        //performDelete();
        overlayService.close();
    }
};
overlayService.open(overlay);
```

could now be shortened to:



```js
const overlay = {
    title: data[0],
    content: confirmationMessage,
    confirmMessage: "This will delete the account.",
    confirmMessageStyle: "danger",
    close: function () {
        vm.deleteNotLoggedInUserButtonState = "danger";
        overlayService.close();
    },
    submit: function () {
        //performDelete();
        overlayService.close();
    }
};
overlayService.confirmDelete(overlay);
```
