### PR TITLE
V8: Make upload and image cropper mandatory validation work clientside

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbpropertyfileupload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbpropertyfileupload.directive.js
@@ -298,7 +298,8 @@
              * Called when the file collection changes (i.e. a new file has been selected but maybe it wasn't this instance that caused the change)
              */
             onFilesChanged: "&",
-            onInit: "&"
+            onInit: "&",
+            required: "@"
         },
         transclude: true,
         controllerAs: 'vm',

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
@@ -1,6 +1,7 @@
 ﻿<div class="umb-property-file-upload">
 
     <ng-form name="vm.fileUploadForm">
+        <input type="hidden" ng-model="mandatoryValidator" ng-required="vm.required && !vm.files.length" />
 
         <div class="fileinput-button umb-upload-button-big"
              style="margin-bottom: 5px;"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
@@ -2,6 +2,7 @@
     <umb-property-file-upload culture="{{model.culture}}"
                               property-alias="{{model.alias}}"
                               value="model.value"
+                              required="model.validation.mandatory"
                               on-files-selected="fileChanged(value)">
     </umb-property-file-upload>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
@@ -5,6 +5,7 @@
         <umb-property-file-upload culture="{{model.culture}}"
                                   property-alias="{{model.alias}}"
                                   value="model.value.src"
+                                  required="model.validation.mandatory"
                                   on-files-selected="filesSelected(value, files)"
                                   on-files-changed="filesChanged(files)"
                                   on-init="fileUploaderInit(value, files)"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Mandatory properties of types Upload and Image Cropper currently aren't validated clientside - only serverside:

![upload-imagecropper-mandatory-before](https://user-images.githubusercontent.com/7405322/65987075-6bb02500-e485-11e9-8719-6871d2ed2eef.gif)

This PR adds mandatory validation clientside as well:

![upload-imagecropper-mandatory-after](https://user-images.githubusercontent.com/7405322/65987108-77035080-e485-11e9-870b-74754fc020ef.gif)
