### PR TITLE
Refactor language picker to improve accessibility

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-language-picker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-language-picker.less
@@ -12,17 +12,20 @@
     align-items: center;
     justify-content: space-between;
     padding: 0 20px;
-    cursor: pointer;
+    background: transparent;
+    border: 0 none;
     border-bottom: 1px solid @gray-9;
     height: @editorHeaderHeight;
     box-sizing: border-box;
     color: @ui-option-type;
+    width: 100%;
 }
 
 .umb-language-picker__expand {
     font-size: 14px;
 }
 
+.umb-language-picker__toggle:focus,
 .umb-language-picker__toggle:hover {
     background: @ui-option-hover;
     color:@ui-option-type-hover;
@@ -43,20 +46,24 @@
     overflow: auto;
 }
 
-.umb-language-picker__dropdown a {
+.umb-language-picker__dropdown-item {
+    background: transparent;
+    border: 0 none;
     padding: 8px 20px;
     display: block;
     font-size: 14px;
+    width: 100%;
+    text-align: left;
 }
 
-.umb-language-picker__dropdown a:hover, 
-.umb-language-picker__dropdown a:focus {
+.umb-language-picker__dropdown-item:hover, 
+.umb-language-picker__dropdown-item:focus {
     background: @ui-option-hover;
     text-decoration: none;
     color:@ui-option-type-hover;
 }
 
-.umb-language-picker__dropdown a.umb-language-picker__dropdown-item--current {
+.umb-language-picker__dropdown .umb-language-picker__dropdown-item.umb-language-picker__dropdown-item--current {
     padding-left: 16px;
     border-left: 4px solid @ui-light-active-border;
     color:@ui-light-active-type;

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -6,13 +6,29 @@
 
         <div class="navigation-inner-container">
 
-            <div class="umb-language-picker" ng-if="currentSection === 'content' && languages.length > 1" on-outside-click="page.languageSelectorIsOpen = false">
-                <div class="umb-language-picker__toggle" ng-click="toggleLanguageSelector()">
-                    <div>{{selectedLanguage.name}}</div>
-                    <ins class="umb-language-picker__expand" ng-class="{'icon-navigation-down': !page.languageSelectorIsOpen, 'icon-navigation-up': page.languageSelectorIsOpen}" class="icon-navigation-right">&nbsp;</ins>
-                </div>
+            <div class="umb-language-picker" ng-if="currentSection === 'content' && languages.length > 1" deep-blur="page.languageSelectorIsOpen = false" on-outside-click="page.languageSelectorIsOpen = false">
+                <button type="button" class="umb-language-picker__toggle" ng-click="toggleLanguageSelector()" aria-haspopup="true" aria-expanded="{{page.languageSelectorIsOpen}}">
+                    <span>
+                        <span class="sr-only">
+                            <localize key="visuallyHiddenTexts_currentLanguage">Current language: </localize>
+                        </span>
+                        {{selectedLanguage.name}}
+                    </span>
+                    <i class="umb-language-picker__expand" ng-class="{'icon-navigation-down': !page.languageSelectorIsOpen, 'icon-navigation-up': page.languageSelectorIsOpen}" class="icon-navigation-right" aria-hidden="true"></i>
+                </button>
                 <div class="umb-language-picker__dropdown" ng-if="page.languageSelectorIsOpen">
-                    <a class="umb-language-picker__dropdown-item" ng-class="{'umb-language-picker__dropdown-item--current': language.active}" ng-click="selectLanguage(language)" ng-repeat="language in languages" href="">{{language.name}}</a>
+                    <button
+                        type="button"
+                        class="umb-language-picker__dropdown-item"
+                        ng-class="{'umb-language-picker__dropdown-item--current': language.active}"
+                        ng-click="selectLanguage(language)"
+                        ng-repeat="language in languages"
+                    >
+                    <span class="sr-only">
+                        <localize key="visuallyHiddenTexts_switchLanguage">Switch language to: </localize>
+                    </span>
+                            {{language.name}}
+                    </button>
                 </div>
             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -10,9 +10,9 @@
                 <button type="button" class="umb-language-picker__toggle" ng-click="toggleLanguageSelector()" aria-haspopup="true" aria-expanded="{{page.languageSelectorIsOpen}}">
                     <span>
                         <span class="sr-only">
-                            <localize key="visuallyHiddenTexts_currentLanguage">Current language: </localize>
+                            <localize key="visuallyHiddenTexts_currentLanguage">Current language</localize>
                         </span>
-                        {{selectedLanguage.name}}
+                        <span>: {{selectedLanguage.name}}</span>
                     </span>
                     <i class="umb-language-picker__expand" ng-class="{'icon-navigation-down': !page.languageSelectorIsOpen, 'icon-navigation-up': page.languageSelectorIsOpen}" class="icon-navigation-right" aria-hidden="true"></i>
                 </button>
@@ -25,9 +25,9 @@
                         ng-repeat="language in languages"
                     >
                     <span class="sr-only">
-                        <localize key="visuallyHiddenTexts_switchLanguage">Switch language to: </localize>
+                        <localize key="visuallyHiddenTexts_switchLanguage">Switch language to</localize>
                     </span>
-                            {{language.name}}
+                    <span>: {{language.name}}</span>
                     </button>
                 </div>
             </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1636,7 +1636,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="openBackofficeSearch">Åben backoffice søgning</key>
     <key alias="openCloseBackofficeHelp">Åben/Luk backoffice hjælp</key>
     <key alias="openCloseBackofficeProfileOptions">Åben/Luk dine profil indstillinger</key>
-    <key alias="currentLanguage">Aktivt sprog:</key>
-    <key alias="switchLanguage">Skift sprog til:</key>
+    <key alias="currentLanguage">Aktivt sprog</key>
+    <key alias="switchLanguage">Skift sprog til</key>
   </area>
 </language>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1636,5 +1636,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="openBackofficeSearch">Åben backoffice søgning</key>
     <key alias="openCloseBackofficeHelp">Åben/Luk backoffice hjælp</key>
     <key alias="openCloseBackofficeProfileOptions">Åben/Luk dine profil indstillinger</key>
+    <key alias="currentLanguage">Aktivt sprog:</key>
+    <key alias="switchLanguage">Skift sprog til:</key>
   </area>
 </language>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2150,5 +2150,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="openBackofficeSearch">Open backoffice search</key>
     <key alias="openCloseBackofficeHelp">Open/Close backoffice help</key>
     <key alias="openCloseBackofficeProfileOptions">Open/Close your profile options</key>
+    <key alias="currentLanguage">Current language:</key>
+    <key alias="switchLanguage">Switch language to:</key>
   </area>
 </language>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2150,7 +2150,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="openBackofficeSearch">Open backoffice search</key>
     <key alias="openCloseBackofficeHelp">Open/Close backoffice help</key>
     <key alias="openCloseBackofficeProfileOptions">Open/Close your profile options</key>
-    <key alias="currentLanguage">Current language:</key>
-    <key alias="switchLanguage">Switch language to:</key>
+    <key alias="currentLanguage">Current language</key>
+    <key alias="switchLanguage">Switch language to</key>
   </area>
 </language>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2164,5 +2164,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="openBackofficeSearch">Open backoffice search</key>
     <key alias="openCloseBackofficeHelp">Open/Close backoffice help</key>
     <key alias="openCloseBackofficeProfileOptions">Open/Close your profile options</key>
+    <key alias="currentLanguage">Current language:</key>
+    <key alias="switchLanguage">Switch language to:</key>
   </area>
 </language>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2164,7 +2164,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="openBackofficeSearch">Open backoffice search</key>
     <key alias="openCloseBackofficeHelp">Open/Close backoffice help</key>
     <key alias="openCloseBackofficeProfileOptions">Open/Close your profile options</key>
-    <key alias="currentLanguage">Current language:</key>
-    <key alias="switchLanguage">Switch language to:</key>
+    <key alias="currentLanguage">Current language</key>
+    <key alias="switchLanguage">Switch language to</key>
   </area>
 </language>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR I have done the following
- Changed `<div>` and `<a>` to `<button>` to fix keyboard navigation and semantics
- Adjusted the styling so the buttons are styled correctly
- Added the `aria-haspopup` and `aria-expanded` attributes
- Added visual hidden texts for providing better non-visual context so a screen reader announces "Current language: English (United States)" instead of just "English (United States)" for instance
- Added the deep-blur directive in order to have the dropdown disappear when it looses tab-focus

The visual changes from before and after can be seen below

**Before**
![language-switcher-before](https://user-images.githubusercontent.com/1932158/65995198-4b886200-e495-11e9-8eaa-9cca066cc6a5.gif)

**After**
![language-switcher-after](https://user-images.githubusercontent.com/1932158/65995210-4fb47f80-e495-11e9-85d6-f23d270d87ca.gif)

I look forward to receive any feedback you might have for this 👍 
