### PR TITLE
Adjust layout in profiler dashboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/profiler.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/profiler.html
@@ -1,5 +1,10 @@
-<div ng-controller="Umbraco.Dashboard.ProfilerController as vm" ng-hide="vm.loading">
-    <umb-box>
+<div ng-controller="Umbraco.Dashboard.ProfilerController as vm">
+
+    <div ng-show="vm.loading">
+        <umb-load-indicator></umb-load-indicator>
+    </div>
+
+    <umb-box ng-hide="vm.loading">
         <umb-box-content>
             <h3 class="bold">Performance profiling</h3>
             <div ng-show="vm.profilerEnabled">

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/profiler.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/profiler.html
@@ -3,24 +3,23 @@
         <umb-box-content>
             <h3 class="bold">Performance profiling</h3>
             <div ng-show="vm.profilerEnabled">
-                <p>
-                    Umbraco currently runs in debug mode. This means you can use the built-in performance profiler to assess the performance when rendering pages.
-                </p>
-                <p>
-                    If you want to activate the profiler for a specific page rendering, simply add <b>umbDebug=true</b> to the querystring when requesting the page.
-                </p>
-                <p>
-                    If you want the profiler to be activated by default for all page renderings, you can use the toggle below.
-                    It will set a cookie in your browser, which then activates the profiler automatically.
-                    In other words, the profiler will only be active by default in <i>your</i> browser - not everyone else's.
-                </p>
-                <p>&nbsp;</p>
-                <div class="sub-view-columns">
-                    <div class="sub-view-column-left">
-                        <h5>Activate the profiler by default</h5>
-                    </div>
-                    <div class="sub-view-column-right">
-                        <umb-toggle checked="vm.alwaysOn" on-click="vm.toggle()"></umb-toggle>
+                <div class="mb4">
+                    <p>
+                        Umbraco currently runs in debug mode. This means you can use the built-in performance profiler to assess the performance when rendering pages.
+                    </p>
+                    <p>
+                        If you want to activate the profiler for a specific page rendering, simply add <b>umbDebug=true</b> to the querystring when requesting the page.
+                    </p>
+                    <p>
+                        If you want the profiler to be activated by default for all page renderings, you can use the toggle below.
+                        It will set a cookie in your browser, which then activates the profiler automatically.
+                        In other words, the profiler will only be active by default in <i>your</i> browser - not everyone else's.
+                    </p>
+                </div>
+                <div class="mb4">
+                    <div class="flex items-center">
+                        <umb-toggle checked="vm.alwaysOn" id="profilerAlwaysOn" on-click="vm.toggle()"></umb-toggle>
+                        <label for="profilerAlwaysOn" class="mb0 ml2">Activate the profiler by default</label>
                     </div>
                 </div>
                 <h4>Friendly reminder</h4>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR just adjust the layout of the profiler dashboard a bit so the label also trigger the toggle, add a loading indicator and a few other minor changes in layout.

**Before**

![image](https://user-images.githubusercontent.com/2919859/65996282-6a87f380-e497-11e9-8518-60a281b4c819.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/65996213-4c21f800-e497-11e9-8f2e-74e37575a92e.png)
