### PR TITLE
Replace checkbox with umb-checkbox for relate to original

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/copy/copy.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/copy/copy.controller.js
@@ -13,7 +13,6 @@
       vm.close = close;
 
       var dialogOptions = $scope.model;
-      var searchText = "Search...";
       var node = dialogOptions.currentNode;
 
       $scope.model.relateToOriginal = true;
@@ -34,17 +33,13 @@
 
         var labelKeys = [
             "general_copy",
-            "general_search",
             "defaultdialogs_relateToOriginalLabel"
         ];
 
         localizationService.localizeMany(labelKeys).then(function (data) {
 
             vm.labels.title = data[0];
-
-            searchText = data[1] + "...";
-
-            vm.labels.relateToOriginal = data[2]; 
+            vm.labels.relateToOriginal = data[1]; 
 
             setTitle(vm.labels.title);
         });

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/copy/copy.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/copy/copy.controller.js
@@ -5,6 +5,7 @@
 
       var vm = this;
 
+      vm.labels = {};
       vm.hideSearch = hideSearch;
       vm.selectResult = selectResult;
       vm.onSearchResults = onSearchResults;
@@ -29,23 +30,34 @@
       // get entity type based on the section
       $scope.entityType = entityHelper.getEntityTypeFromSection(dialogOptions.section);
 
-        function onInit() {
+    function onInit() {
 
-            if(!$scope.model.title) {
-                localizationService.localize("general_copy").then(function (value) {
-                    $scope.model.title = value;
-                });
-            }
+        var labelKeys = [
+            "general_copy",
+            "general_search",
+            "defaultdialogs_relateToOriginalLabel"
+        ];
 
-            localizationService.localize("general_search").then(function (value) {
-                searchText = value + "...";
-            });
-            
-        }
+        localizationService.localizeMany(labelKeys).then(function (data) {
 
+            vm.labels.title = data[0];
+
+            searchText = data[1] + "...";
+
+            vm.labels.relateToOriginal = data[2]; 
+
+            setTitle(vm.labels.title);
+        });
+      }
+
+      function setTitle(value) {
+          if (!$scope.model.title) {
+              $scope.model.title = value;
+          }
+      }
 
       function nodeSelectHandler(args) {
-          if(args && args.event) {
+          if (args && args.event) {
             args.event.preventDefault();
             args.event.stopPropagation();
           }
@@ -108,19 +120,18 @@
       }
 
         function submit() {
-            if($scope.model && $scope.model.submit) {
+            if ($scope.model && $scope.model.submit) {
                 $scope.model.submit($scope.model);
             }
         }
 
         function close() {
-            if($scope.model && $scope.model.close) {
+            if ($scope.model && $scope.model.close) {
                 $scope.model.close();
             }
         }
 
         onInit();
-
 	}
 
 	angular.module("umbraco").controller("Umbraco.Editors.CopyController", CopyController);

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/copy/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/copy/copy.html
@@ -60,10 +60,9 @@
                         </div>
                     
                         <div class="umb-control-group -no-border">
-                            <label>
-                                <input type="checkbox" class="pull-left" style="margin-right: 10px;" ng-model="model.relateToOriginal" />
-                                <localize key="defaultdialogs_relateToOriginalLabel">Relate to originalt</localize>
-                            </label>
+                            <div class="flex">
+                                <umb-checkbox input-id="relateToOriginal" model="model.relateToOriginal" text="{{vm.labels.relateToOriginal}}" />
+                            </div>
                         </div>
                     </umb-box-content>
                 </umb-box>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR replaces the traditional checkbox with `umb-checkbox` for "relate to original" in copy infinite editor.

![image](https://user-images.githubusercontent.com/2919859/66000639-277e4e00-e4a0-11e9-8fa2-9c7643f437a4.png)

