### PR TITLE
Fix ContentService.DeleteVersions

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -1848,7 +1848,7 @@ namespace Umbraco.Core.Services.Implement
 
                 scope.WriteLock(Constants.Locks.ContentTree);
                 var c = _documentRepository.Get(id);
-                if (c.VersionId != versionId) // don't delete the current version
+                if (c.VersionId != versionId && c.PublishedVersionId != versionId) // don't delete the current or published version
                     _documentRepository.DeleteVersion(versionId);
 
                 scope.Events.Dispatch(DeletedVersions, this, new DeleteRevisionsEventArgs(id, false,/* specificVersion:*/ versionId));


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5919

### Description
`DocumentRepository.PerformDeleteVersion` deletes from tables in the wrong order, leading to foreign key violations.

Also, it checks that it is not deleting the current version, but does not check whether it is deleting the published version.

### Testing

Create the following controller:

```c#
public class TestController : SurfaceController
{
    public ActionResult ListVersions(int contentId)
    {
        return Content(String.Join("\n",
            Services.ContentService.GetVersions(contentId).Select(v => String.Join("\t", v.VersionId, v.UpdateDate, v.VersionId == v.PublishedVersionId))),
            "text/plain");
    }

    public ActionResult DeleteVersion(int versionId)
    {
        var v = Services.ContentService.GetVersion(versionId);
        Services.ContentService.DeleteVersion(v.Id, versionId, false);
        return Content("OK");
    }

    public ActionResult DeleteVersions(int contentId)
    {
        Services.ContentService.DeleteVersions(contentId, DateTime.Now);
        return Content("OK");
    }
}
```

Pick a document with some previous versions and request `/umbraco/surface/test/listversions?contentid={id}`. It will list the version IDs and which is published.

Request `/umbraco/surface/test/deleteversion?versionid={id}` for some of the versions. Attempting to delete the current or published versions should return successfully but not delete the version. Attempting to delete any other version should work.

Request `/umbraco/surface/test/deleteversions?contentid={id}`, which tries to delete all versions older than DateTime.Now. It should delete all but the current and published versions.