### PR TITLE
V8: use regex for finding images where src attribute is a blob

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1287,8 +1287,9 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 var content = e.content;
 
                 // Upload BLOB images (dragged/pasted ones)
-                if(content.indexOf('<img src="blob:') > -1){
-
+                // find src attribute where value starts with `blob:`
+                // search is case-insensitive and allows single or double quotes 
+                if(content.search(/src=["']blob:.*?["']/gi) !== -1){
                     args.editor.uploadImages(function(data) {
                         // Once all images have been uploaded
                         data.forEach(function(item) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6476 

### Description
Change replaces `n.indexOf()` with `n.search()` to better manage casing, whitespace, punctuation, attribute order etc.

Verify by dragging an image into an rte, save and publish, image should now be in the media section. Confirm too that the image src in the rte is updated to the correct media asset path.