### PR TITLE
push overlay-right when opening help drawer

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -151,6 +151,10 @@
     bottom: 0;
     border: none;
     box-shadow: 0 0 20px rgba(0,0,0,0.19), 0 0 6px rgba(0,0,0,0.23);
+    
+    .umb-drawer-is-visible & {
+        right:400px;
+    }
 }
 
 .umb-overlay.umb-overlay-right .umb-overlay-header {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Opening the help drawer when an overlay (linkpicker, profile etc) is already open causes stacking issues - the overlay is fixed to the right edge of the screen, so obscures the help drawer.

This change pushes the overlay 400px (drawer width) to create space for the drawer to display.