### PR TITLE
V8: allow node preview content to wrap

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
@@ -3,6 +3,7 @@
     display: flex;
     box-sizing: border-box;
     border-bottom: 1px solid @gray-9;
+    flex-wrap: wrap;
 }
 
 .umb-editor-wrapper .umb-node-preview {
@@ -64,6 +65,7 @@
     flex: 0 0 auto;
     display: flex;
     align-items: center;
+    margin-left: auto;
 }
 
 .umb-node-preview__action {

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
@@ -1,15 +1,17 @@
 <div class="umb-node-preview" ng-class="{'umb-node-preview--sortable': sortable, 'umb-node-preview--unpublished': published === false }">
-    <i ng-if="icon" class="umb-node-preview__icon {{ icon }}" aria-hidden="true"></i>
-    <div class="umb-node-preview__content">
+    <div class="flex"> <!-- div keeps icon and nodename from wrapping -->
+        <i ng-if="icon" class="umb-node-preview__icon {{ icon }}" aria-hidden="true"></i>
+        <div class="umb-node-preview__content">
 
-        <div class="umb-node-preview__name" ng-attr-title="{{alias}}">{{ name }}</div>
-        <div class="umb-node-preview__description" ng-if="description">{{ description }}</div>
+            <div class="umb-node-preview__name" ng-attr-title="{{alias}}">{{ name }}</div>
+            <div class="umb-node-preview__description" ng-if="description">{{ description }}</div>
 
-        <div class="umb-user-group-preview__permissions" ng-if="permissions">
-            <span>
-                <span class="bold"><localize key="general_rights">Permissions</localize>:</span>
-                <span ng-repeat="permission in permissions" class="umb-user-group-preview__permission">{{ permission.name }}</span>
-            </span>
+            <div class="umb-user-group-preview__permissions" ng-if="permissions">
+                <span>
+                    <span class="bold"><localize key="general_rights">Permissions</localize>:</span>
+                    <span ng-repeat="permission in permissions" class="umb-user-group-preview__permission">{{ permission.name }}</span>
+                </span>
+            </div>
         </div>
     </div>
     <div class="umb-node-preview__actions">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5916 

### Description
On small screens, the content in the umb-node-preview directive gets all squished because the parent container is a flex element, but doesn't allow wrapping. This change adds flex-wrap:wrap, and updates the view to keep the icon and node name grouped, while allowing the actions (open, edit, remove) to wrap to a new line.

Large-ish screen is unchanged:
![chrome-capture](https://user-images.githubusercontent.com/3248070/66036045-af6f6100-e54f-11e9-8dc0-39939b04a06c.jpg)

Small screen wraps like so (this is a super-small screen example):
![chrome-capture (1)](https://user-images.githubusercontent.com/3248070/66036075-be561380-e54f-11e9-8509-f73888ea94f5.jpg)

Have verified this in nested content and the content picker editor.
