### PR TITLE
V8: Reload the media tree when folder contents changes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -262,10 +262,10 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
 
     $scope.getContent = function (contentId) {
 
-        $scope.reloadView($scope.contentId);
+        $scope.reloadView($scope.contentId, true);
     }
 
-    $scope.reloadView = function (id) {
+    $scope.reloadView = function (id, reloadActiveNode) {
         $scope.viewLoaded = false;
         $scope.folders = [];
 
@@ -297,9 +297,20 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
                 $scope.options.pageNumber = $scope.listViewResultSet.totalPages;
 
                 //reload!
-                $scope.reloadView(id);
+                $scope.reloadView(id, reloadActiveNode);
             }
-
+            // in the media section, the list view items are by default also shown in the tree, so we need 
+            // to refresh the current tree node when changing the folder contents (adding and removing)
+            else if (reloadActiveNode && section === "media") {
+                var activeNode = appState.getTreeState("selectedNode");
+                if (activeNode) {
+                    if (activeNode.expanded) {
+                        navigationService.reloadNode(activeNode);
+                    }
+                } else {
+                    navigationService.reloadSection(section);
+                }
+            }
         });
     };
 
@@ -411,7 +422,7 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
                 var key = (total === 1 ? "bulk_deletedItem" : "bulk_deletedItems");
                 return localizationService.localize(key, [total]);
             }).then(function () {
-                $scope.reloadView($scope.contentId);
+                $scope.reloadView($scope.contentId, true);
             });
     }
 
@@ -536,7 +547,7 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
                 var key = (total === 1 ? "bulk_unpublishedItem" : "bulk_unpublishedItems");
                 return localizationService.localize(key, [total]);
             }).then(function () {
-                $scope.reloadView($scope.contentId);
+                $scope.reloadView($scope.contentId, true);
             });
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As-is the media tree doesn't update when you add or remove media. This can be a tad confusing, because you can see the creation/deletion in the list view (grid view) but the same changes aren't reflected in the tree.

With this PR, the media tree updates whenever folder contents changes (added/removed media):

![media-listview-reload-on-change](https://user-images.githubusercontent.com/7405322/66037956-13266980-e511-11e9-8587-2f73814f9de7.gif)
