### PR TITLE
Fixes the media refs within the RTE in the Grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1188,6 +1188,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             var tinyMceRect = editor.editorContainer.getBoundingClientRect();
             var tinyMceTop = tinyMceRect.top;
             var tinyMceBottom = tinyMceRect.bottom;
+            var tinyMceWidth = tinyMceRect.width;
 
             var tinyMceEditArea = tinyMce.find(".mce-edit-area");
 
@@ -1196,16 +1197,18 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
             if (tinyMceTop < 177 && ((177 + toolbarHeight) < tinyMceBottom)) {
                 toolbar
-                    .css("visibility", "visible")
                     .css("position", "fixed")
                     .css("top", "177px")
-                    .css("margin-top", "0");
+                    .css("left", "auto")
+                    .css("right", "auto")
+                    .css("width", tinyMceWidth);
             } else {
                 toolbar
-                    .css("visibility", "visible")
                     .css("position", "absolute")
-                    .css("top", "auto")
-                    .css("margin-top", "0");
+                    .css("left", "")
+                    .css("right", "")
+                    .css("top", "")
+                    .css("width", "");
             }
 
         },

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -638,7 +638,11 @@
 
 .umb-grid .mce-toolbar {
     border-bottom: 1px solid @gray-7;
+    background-color: white;
     display: none;
+    
+    left: 0;
+    right: 0;
 }
 
 .umb-grid .umb-control.-active .mce-toolbar {

--- a/src/Umbraco.Web.UI.Client/src/less/rte.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte.less
@@ -63,8 +63,9 @@
 }
 
 /* Special case to support helviticons for the tiny mce button controls */
-.umb-rte .mce-ico.mce-i-custom[class^="icon-"],
-.umb-rte .mce-ico.mce-i-custom[class*=" icon-"] {
+// Also used in Prevalue editor.
+.mce-ico.mce-i-custom[class^="icon-"],
+.mce-ico.mce-i-custom[class*=" icon-"] {
     font-family: icomoon;
     font-size: 16px !important;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/rte.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte.less
@@ -162,4 +162,5 @@
 
 .umb-grid .umb-rte {
     border: 1px solid #d8d7d9;
+    max-width: none;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -89,7 +89,10 @@ angular.module("umbraco")
                 
                 angular.extend(baseLineConfigObj, standardConfig);
                 
-                tinymce.init(baseLineConfigObj);
+                // We need to wait for DOM to have rendered before we can find the element by ID.
+                $timeout(function () {
+                    tinymce.init(baseLineConfigObj);
+                }, 150);
                 
                 //listen for formSubmitting event (the result is callback used to remove the event subscription)
                 var unsubscribe = $scope.$on("formSubmitting", function () {

--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
@@ -83,12 +84,9 @@ namespace Umbraco.Web.PropertyEditors
 
                 // editorValue.Value is a JSON string of the grid
                 var rawJson = editorValue.Value.ToString();
-                var grid = JsonConvert.DeserializeObject<GridValue>(rawJson);
+                var grid = DeserializeGridValue(rawJson, out var rtes);
 
-                // Find all controls that use the RTE editor
-                var controls = grid.Sections.SelectMany(x => x.Rows.SelectMany(r => r.Areas).SelectMany(a => a.Controls));
-                var rtes = controls.Where(x => x.Editor.Alias.ToLowerInvariant() == "rte");
-
+                //process the rte values
                 foreach(var rte in rtes)
                 {
                     // Parse the HTML
@@ -96,12 +94,52 @@ namespace Umbraco.Web.PropertyEditors
 
                     var userId = _umbracoContextAccessor.UmbracoContext?.Security.CurrentUser.Id ?? Constants.Security.SuperUserId;
 
-                    var parsedHtml = TemplateUtilities.FindAndPersistPastedTempImages(html, mediaParentId, userId, _mediaService, _contentTypeBaseServiceProvider, _logger);
+                    var editorValueWithMediaUrlsRemoved = TemplateUtilities.RemoveMediaUrlsFromTextString(html);
+
+                    var parsedHtml = TemplateUtilities.FindAndPersistPastedTempImages(editorValueWithMediaUrlsRemoved, mediaParentId, userId, _mediaService, _contentTypeBaseServiceProvider, _logger);
                     rte.Value = parsedHtml;
                 }
 
                 // Convert back to raw JSON for persisting
                 return JsonConvert.SerializeObject(grid);
+            }
+
+            /// <summary>
+            /// Ensures that the rich text editor values are processed within the grid
+            /// </summary>
+            /// <param name="property"></param>
+            /// <param name="dataTypeService"></param>
+            /// <param name="culture"></param>
+            /// <param name="segment"></param>
+            /// <returns></returns>
+            public override object ToEditor(Property property, IDataTypeService dataTypeService, string culture = null, string segment = null)
+            {
+                var val = property.GetValue(culture, segment);
+                if (val == null) return string.Empty;
+
+                var grid = DeserializeGridValue(val.ToString(), out var rtes);
+
+                //process the rte values
+                foreach (var rte in rtes.ToList())
+                {
+                    var html = rte.Value?.ToString();
+
+                    var propertyValueWithMediaResolved = TemplateUtilities.ResolveMediaFromTextString(html);
+                    rte.Value = propertyValueWithMediaResolved;
+                }
+
+                return grid;
+            }
+
+            private GridValue DeserializeGridValue(string rawJson, out IEnumerable<GridValue.GridControl> richTextValues)
+            {
+                var grid = JsonConvert.DeserializeObject<GridValue>(rawJson);
+
+                // Find all controls that use the RTE editor
+                var controls = grid.Sections.SelectMany(x => x.Rows.SelectMany(r => r.Areas).SelectMany(a => a.Controls));
+                richTextValues = controls.Where(x => x.Editor.Alias.ToLowerInvariant() == "rte");
+
+                return grid;
             }
         }
     }

--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -86,18 +86,18 @@ namespace Umbraco.Web.PropertyEditors
                 var rawJson = editorValue.Value.ToString();
                 var grid = DeserializeGridValue(rawJson, out var rtes);
 
+                var userId = _umbracoContextAccessor.UmbracoContext?.Security.CurrentUser.Id ?? Constants.Security.SuperUserId;
+
                 //process the rte values
-                foreach(var rte in rtes)
+                foreach (var rte in rtes)
                 {
                     // Parse the HTML
                     var html = rte.Value?.ToString();
 
-                    var userId = _umbracoContextAccessor.UmbracoContext?.Security.CurrentUser.Id ?? Constants.Security.SuperUserId;
+                    var parseAndSavedTempImages = TemplateUtilities.FindAndPersistPastedTempImages(html, mediaParentId, userId, _mediaService, _contentTypeBaseServiceProvider, _logger);
+                    var editorValueWithMediaUrlsRemoved = TemplateUtilities.RemoveMediaUrlsFromTextString(parseAndSavedTempImages);
 
-                    var editorValueWithMediaUrlsRemoved = TemplateUtilities.RemoveMediaUrlsFromTextString(html);
-
-                    var parsedHtml = TemplateUtilities.FindAndPersistPastedTempImages(editorValueWithMediaUrlsRemoved, mediaParentId, userId, _mediaService, _contentTypeBaseServiceProvider, _logger);
-                    rte.Value = parsedHtml;
+                    rte.Value = editorValueWithMediaUrlsRemoved;
                 }
 
                 // Convert back to raw JSON for persisting

--- a/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
@@ -114,16 +114,16 @@ namespace Umbraco.Web.PropertyEditors
                 if (editorValue.Value == null)
                     return null;
 
-                var editorValueWithMediaUrlsRemoved = TemplateUtilities.RemoveMediaUrlsFromTextString(editorValue.Value.ToString());
-                var parsed = MacroTagParser.FormatRichTextContentForPersistence(editorValueWithMediaUrlsRemoved);
-
                 var userId = _umbracoContextAccessor.UmbracoContext?.Security.CurrentUser.Id ?? Constants.Security.SuperUserId;
 
                 var config = editorValue.DataTypeConfiguration as RichTextConfiguration;
                 var mediaParent = config?.MediaParentId;
                 var mediaParentId = mediaParent == null ? Guid.Empty : mediaParent.Guid;
 
-                parsed = TemplateUtilities.FindAndPersistPastedTempImages(parsed, mediaParentId, userId, _mediaService, _contentTypeBaseServiceProvider, _logger);
+                var parseAndSavedTempImages = TemplateUtilities.FindAndPersistPastedTempImages(editorValue.Value.ToString(), mediaParentId, userId, _mediaService, _contentTypeBaseServiceProvider, _logger);
+                var editorValueWithMediaUrlsRemoved = TemplateUtilities.RemoveMediaUrlsFromTextString(parseAndSavedTempImages);
+                var parsed = MacroTagParser.FormatRichTextContentForPersistence(editorValueWithMediaUrlsRemoved);
+
                 return parsed;
             }
         }


### PR DESCRIPTION
This is sort of a regression from 8.1 where when we updated the media references within the RTE, the values would be persisted with UDI references and without the actual media paths.

Unfortunately the code for the Grid's RTE's was not updated so this never took place for the Grid.

The images stored in the DB should look something like this within the html:

```html
<img src="?width=500&amp;height=232.00514138817482" alt="" width="500" height="232.00514138817482" data-udi="umb://media/b6891d9fc71c40ffa00931fb64c2ae4d" />
```

But for the grid rte it would still maintain the path:

```html
<img src="/media/m2njyrqd/image.png?width=500&amp;height=302.08333333333337" alt="" width="500" height="302.08333333333337" data-udi="umb://media/469c1a6112034b8a81767e486dd2ed76" />
```

When the RTE is re-rendered in the back office, the `src` attribute is then re-updated with the correct media path. This was also not happening in the Grid's RTE.

This PR fixes this issue so now the RTE and the Grid RTE behave the same way.

 You can test this by:

Inserting an image into a normal RTE and save/publish, go check your DB:

```sql
SELECT TOP (1000) [id]
      ,[versionId]
      ,[propertyTypeId]
      ,[languageId]
      ,[segment]
      ,[intValue]
      ,[decimalValue]
      ,[dateValue]
      ,[varcharValue]
      ,[textValue]
  FROM [v80].[dbo].[umbracoPropertyData]
  ORDER BY id DESC
```

You'll be able to find your value near the top of this list in the `textValue` and it should have a `src` attribute without the media path

And of course in the back office the image should still render just fine.

Then perform the same test with the Grid's RTE. The behavior should be the same.
