### PR TITLE
Only allow one media folder to be picked for RTE paste/drag image upload location

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/mediafolderpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/mediafolderpicker.controller.js
@@ -27,7 +27,7 @@ function mediaFolderPickerController($scope, editorService, entityResource) {
     $scope.add = function() {
         var mediaPickerOptions = {
             view: "mediapicker",
-            multiPicker: true,
+            multiPicker: false, // We only want to allow you to pick one folder at a given time
             disableFolderSelect: false,
             onlyImages: false,
             onlyFolders: true,


### PR DESCRIPTION
We only want to allow you to pick one folder in the media library for the MediaFolderPicker prevalue editor

A super simple change in passing the options to the underlying MediaPicker component to not `allowMultiple`

Fixes [AB#2996](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/2996)
Fixes https://github.com/umbraco/Umbraco-CMS/issues/6513