### PR TITLE
V8: Enable editing the search results directly from Examine Management

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -898,6 +898,27 @@ When building a custom infinite editor view you can use the same components as a
             open(editor);
         }
 
+        /**
+         * @ngdoc method
+         * @name umbraco.services.editorService#memberEditor
+         * @methodOf umbraco.services.editorService
+         *
+         * @description
+         * Opens a member editor in infinite editing, the submit callback returns the updated member
+         * @param {Object} editor rendering options
+         * @param {String} editor.id The id (GUID) of the member
+         * @param {Boolean} editor.create Create new member
+         * @param {Function} editor.submit Callback function when the submit button is clicked. Returns the editor model object
+         * @param {Function} editor.close Callback function when the close button is clicked.
+         * @param {String} editor.doctype If editor.create is true, provide member type for the creation of the member
+         * 
+         * @returns {Object} editor object
+         */
+        function memberEditor(editor) {
+            editor.view = "views/member/edit.html";
+            open(editor);
+        }
+
         ///////////////////////
 
         /**
@@ -978,7 +999,8 @@ When building a custom infinite editor view you can use the same components as a
             itemPicker: itemPicker,
             macroPicker: macroPicker,
             memberGroupPicker: memberGroupPicker,
-            memberPicker: memberPicker
+            memberPicker: memberPicker,
+            memberEditor: memberEditor
         };
 
         return service;

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
@@ -1,4 +1,4 @@
-function ExamineManagementController($scope, $http, $q, $timeout, $location, umbRequestHelper, localizationService, overlayService) {
+function ExamineManagementController($scope, $http, $q, $timeout, $location, umbRequestHelper, localizationService, overlayService, editorService) {
 
     var vm = this;
 
@@ -56,17 +56,38 @@ function ExamineManagementController($scope, $http, $q, $timeout, $location, umb
             return;
         }
         // targeting a new tab/window?
-        if (event.ctrlKey || 
-            event.shiftKey ||
-            event.metaKey || // apple
-            (event.button && event.button === 1) // middle click, >IE9 + everyone else
+        if (event.ctrlKey ||
+                event.shiftKey ||
+                event.metaKey || // apple
+                (event.button && event.button === 1) // middle click, >IE9 + everyone else
         ) {
             // yes, let the link open itself
             return;
         }
+
+        const editor = {
+            id: result.editId,
+            submit: function (model) {
+                editorService.close();
+            },
+            close: function () {
+                editorService.close();
+            }
+        };
+        switch (result.editSection) {
+            case "content":
+                editorService.contentEditor(editor);
+                break;
+            case "media":
+                editorService.mediaEditor(editor);
+                break;
+            case "member":
+                editorService.memberEditor(editor);
+                break;
+        }
+
         event.stopPropagation();
         event.preventDefault();
-        $location.path(result.editUrl);
     } 
 
     function setViewState(state) {
@@ -151,9 +172,13 @@ function ExamineManagementController($scope, $http, $q, $timeout, $location, umb
                         case "content":
                         case "media":
                             result.editUrl = "/" + section + "/" + section + "/edit/" + result.values["__NodeId"];
+                            result.editId = result.values["__NodeId"];
+                            result.editSection = section;
                             break;
                         case "member":
                             result.editUrl = "/member/member/edit/" + result.values["__Key"];
+                            result.editId = result.values["__Key"];
+                            result.editSection = section;
                             break;
                     }
                 });

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -157,7 +157,9 @@
                                                                 <td>{{result.score}}</td>
                                                                 <td>{{result.id}}</td>
                                                                 <td>
-                                                                    <span>{{result.values['nodeName']}}</span>&nbsp;
+                                                                    <a ng-show="result.editUrl" ng-click="vm.goToResult(result, $event)" ng-href="#{{result.editUrl}}">{{result.values['nodeName']}}</a>
+                                                                    <span ng-hide="result.editUrl">{{result.values['nodeName']}}</span>
+                                                                    &nbsp;
                                                                     <a class="color-green" href="" ng-click="vm.showSearchResultDialog(result.values)">
                                                                         <em>({{result.fieldCount}} fields)</em>
                                                                     </a>
@@ -298,7 +300,9 @@
                                                                 <td>{{result.score}}</td>
                                                                 <td>{{result.id}}</td>
                                                                 <td>
-                                                                    <span>{{result.values['nodeName']}}</span>&nbsp;
+                                                                    <a ng-show="result.editUrl" ng-click="vm.goToResult(result, $event)" ng-href="#{{result.editUrl}}">{{result.values['nodeName']}}</a>
+                                                                    <span ng-hide="result.editUrl">{{result.values['nodeName']}}</span>
+                                                                    &nbsp;
                                                                     <a class="color-green" href="" ng-click="vm.showSearchResultDialog(result.values)">
                                                                         <em>({{result.fieldCount}} fields)</em>
                                                                     </a>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR enables direct access to the search results in Examine Management simply by clicking the result name. It works like this:

![examine-search-open-results](https://user-images.githubusercontent.com/7405322/66067752-88636000-e54c-11e9-81c1-d1c0e7f63272.gif)

With the upcoming ability to search for GUIDs, this might also come in really handy for Cloud support handling.

It only works for well known entities - for now that's content, media and members.

#### But wait! Isn't this a security concern?

Well.. no. Anyone having access to Examine Management can see the (raw) values of whatever is found when searching, and they can easily construct the URLs for editing the results by means of these values. 

#### Testing this PR

When testing this PR, verify that you can open content, media and member search results by clicking their names. 

Also test that you can open search results in a new tab by Ctrl-clicking their names.

Lastly someone should probably test this using a "configured searcher". Apparently there are none of those by default in vLatest and I have no idea how to add them 🤦‍♂ 

![image](https://user-images.githubusercontent.com/7405322/66068110-42f36280-e54d-11e9-8101-38e26dab9dfe.png)
