### PR TITLE
Add null check in allowed template check

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -135,6 +135,9 @@ namespace Umbraco.Web
 
         public static bool IsAllowedTemplate(this IPublishedContent content, int templateId)
         {
+            if (content == null)
+                return false;
+
             if (UmbracoConfig.For.UmbracoSettings().WebRouting.DisableAlternativeTemplates == true)
                 return content.TemplateId == templateId;
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

This pull request solves bug #6564.

### Description
This adds a null check in the code which is checking for a valid alternate template.  Without this null check, if a node is unpublished the content finder classes (specifically ContentFinderByNiceUrlAndTemplate) will try to check for a valid template on a null node, and this will throw the exception seen in bug report #6564.

To test this, simply unpublish a page and try to access it using an alternate template syntax (for example, /about-us/contentpage on the sample site).  You should get a 404 not found page, not a 500 error page.