### PR TITLE
V8: Don't allow deleting property groups with locked properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -418,6 +418,10 @@
 
       };
 
+      scope.canRemoveGroup = function(group){
+        return _.find(group.properties, function(property) { return property.locked === true; }) == null;
+      }
+
       scope.removeGroup = function(groupIndex) {
         scope.model.groups.splice(groupIndex, 1);
       };

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -98,7 +98,7 @@
                         </div>
                     </ng-form>
 
-                    <div class="umb-group-builder__group-remove" ng-if="!sortingMode">
+                    <div class="umb-group-builder__group-remove" ng-if="!sortingMode && canRemoveGroup(tab)">
                         <i class="icon-trash" ng-click="togglePrompt(tab)"></i>
                         <umb-confirm-action
                             ng-if="tab.deletePrompt"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Oh my. It's possible to delete property groups that contain locked properties, despite not being able to delete the individual properties:

![group-locked-1](https://user-images.githubusercontent.com/7405322/66106798-0ceec680-e5bf-11e9-867c-f1f575370f50.png)

It used to be so you couldn't delete the property group unless it was empty, but I guess somewhere along the line this was changed (which makes sense).

Anyway. If you go ahead and delete the locked properties on a member type, members of this type start failing miserably (as one might expect):

![group-locked-2](https://user-images.githubusercontent.com/7405322/66106831-20019680-e5bf-11e9-9f18-3a714f86e96f.png)

So... this PR removes the ability to delete a property group if it contains one or more locked properties:

![group-locked-3](https://user-images.githubusercontent.com/7405322/66106860-2f80df80-e5bf-11e9-888e-6a75db65343a.png)

#### Testing this PR

1. Verify that you're not able to delete property groups with locked properties (i.e. on member types).
2. Verify that you're still able to delete property groups *without* locked properties (i.e. on document types).