### PR TITLE
Allow pasted & dragged images that are not yet saved to allow ALT text to be edited 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -664,23 +664,37 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
                 } else{
                     // We need to create a NEW DOM <img> element to insert
+                    // setting an attribute of ID to __mcenew, so we can gather a reference to the node, to be able to update its size accordingly to the size of the image.
                     var data = {
                         alt: img.altText || "",
                         src: (img.url) ? img.url : "nothing.jpg",
                         id: "__mcenew",
                         "data-udi": img.udi
                     };
+                    
                     editor.selection.setContent(editor.dom.createHTML('img', data));
-
-                    // Insert a DOM element with an ID of __mcenew
-                    // So we can select it after 500ms by that ID
-                    // In order to call the sizeImageEditor function to size img correctly
+                    
+                    // Using settimeout to wait for a DoM-render, so we can find the new element by ID.
                     $timeout(function () {
+
                         var imgElm = editor.dom.get("__mcenew");
-                        sizeImageInEditor(editor, imgElm, img.url);
                         editor.dom.setAttrib(imgElm, "id", null);
-                        editor.fire("Change");
-                    }, 500);
+
+                        // When image is loaded we are ready to call sizeImageInEditor.
+                        var onImageLoaded = function() {
+                            sizeImageInEditor(editor, imgElm, img.url);
+                            editor.fire("Change");
+                        }
+
+                        // Check if image already is loaded.
+                        if(imgElm.complete === true) {
+                            onImageLoaded();
+                        } else {
+                            imgElm.onload = onImageLoaded;
+                        }
+
+                    });
+                    
                 }
             }
         },

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -617,7 +617,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                     userService.getCurrentUser().then(function (userData) {
                         if (callback) {
                             angularHelper.safeApply($rootScope, function() {
-                                console.log('current data in create media picker', currentTarget);
                                 callback(currentTarget, userData, imgDomElement);
                             });
                         }
@@ -631,14 +630,11 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 // imgElement is only definied if updating an image
                 // if null/undefinied then its a BRAND new image
                 if(imgDomElement){
-                    console.log('UPDATING IMG', img);
-
                     // Check if the img src has changed
                     // If it has we will need to do some resizing/recalc again
                     var hasImageSrcChanged = false;
 
                     if(img.url !==  editor.dom.getAttrib(imgDomElement, "src")){
-                        console.log("IMG SRC CHANGED !!!!");
                         hasImageSrcChanged = true;
                     }
 
@@ -667,7 +663,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                     }
 
                 } else{
-                    console.log('CREATE NEW IMAGE', img);
                     // We need to create a NEW DOM <img> element to insert
                     var data = {
                         alt: img.altText || "",

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -101,17 +101,18 @@ angular.module("umbraco")
                     // if a target is specified, go look it up - generally this target will just contain ids not the actual full
                     // media object so we need to look it up
                     var id = $scope.target.udi ? $scope.target.udi : $scope.target.id;
-
+                    var altText = $scope.target.altText;
+                    
                     // ID of a UDI or legacy int ID still could be null/undefinied here
                     // As user may dragged in an image that has not been saved to media section yet
                     if(id){
                         entityResource.getById(id, "Media")
                         .then(function (node) {
-                            //$scope.target = node; //Not 100% sure why we override it here?!
+                            $scope.target = node;
                             if (ensureWithinStartNode(node)) {
                                 selectImage(node);
-                                //$scope.target.url = mediaHelper.resolveFile(node);
-                                //$scope.target.altText = altText;
+                                $scope.target.url = mediaHelper.resolveFile(node);
+                                $scope.target.altText = altText;
                                 $scope.openDetailsDialog();
                             }
                         },

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -98,21 +98,30 @@ angular.module("umbraco")
                         gotoStartNode();
                     }
                 } else {
-                    //if a target is specified, go look it up - generally this target will just contain ids not the actual full
-                    //media object so we need to look it up
+                    // if a target is specified, go look it up - generally this target will just contain ids not the actual full
+                    // media object so we need to look it up
                     var id = $scope.target.udi ? $scope.target.udi : $scope.target.id;
-                    var altText = $scope.target.altText;
-                    entityResource.getById(id, "Media")
+
+                    // ID of a UDI or legacy int ID still could be null/undefinied here
+                    // As user may dragged in an image that has not been saved to media section yet
+                    if(id){
+                        entityResource.getById(id, "Media")
                         .then(function (node) {
-                            $scope.target = node;
+                            //$scope.target = node; //Not 100% sure why we override it here?!
                             if (ensureWithinStartNode(node)) {
                                 selectImage(node);
-                                $scope.target.url = mediaHelper.resolveFile(node);
-                                $scope.target.altText = altText;
+                                //$scope.target.url = mediaHelper.resolveFile(node);
+                                //$scope.target.altText = altText;
                                 $scope.openDetailsDialog();
                             }
                         },
                             gotoStartNode);
+                    }
+                    else {
+                        // No ID set - then this is going to be a tmpimg that has not been uploaded
+                        // User editing this will want to be changing the ALT text
+                        $scope.openDetailsDialog();
+                    }
                 }
             }
 


### PR DESCRIPTION
_Fix for incorrect PR base branch: https://github.com/umbraco/Umbraco-CMS/pull/6552_

-----
Try and support images in the RTE that are pasted/dragged in and are NOT in media yet to be able to update the ALT text

## Test Notes
**Not all changes in the DIFF are mine,** its because I had to re-target the PR against `v8/8.2-rc` where I was working in `v8/8.2`

### Pasted/Dragged images
* Drag image into RTE (do not save the page/node)
* Click media/image button
* Add some ALT text
* Verify alt text is in code with View Source Code button in RTE
* Ammend alt text again & verify it's updated (be new text or removing it)

### New Images
* Insert a brand new RTE image
* Ensure width is resized correctly
* Use img button to update/edit ALT text
* Use img button to choose brand new media item (This is kinda weird you can do)
* Verify new width/dimensions are correct proportions
* Verify UDI updated

_NOTE: As this touches/changes code in the mediapicker please test the mediapicker on its own as a property editor and anywhere else we re-use this component/directive._


Fixes https://github.com/umbraco/Umbraco-CMS/issues/6516

Fixes [AB#2997](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/2997)
