### PR TITLE
Fixed adding/updating UmbracoMapper constructors

### DIFF
--- a/src/Umbraco.Core/Mapping/UmbracoMapper.cs
+++ b/src/Umbraco.Core/Mapping/UmbracoMapper.cs
@@ -343,16 +343,19 @@ namespace Umbraco.Core.Mapping
 
             if (ctor == null) return null;
 
-            if (_ctors.ContainsKey(sourceType))
-            {
+            _ctors.AddOrUpdate(sourceType, sourceCtor, (k, v) => {
+                // Add missing constructors
                 foreach (var c in sourceCtor)
                 {
-                    if (!_ctors[sourceType].TryGetValue(c.Key, out _))
-                        _ctors[sourceType].Add(c.Key, c.Value);
-                }   
-            }
-            else
-                _ctors[sourceType] = sourceCtor;
+                    if (!v.ContainsKey(c.Key))
+                    {
+                        v.Add(c.Key, c.Value);
+                    }
+                }
+
+                return v;
+            });
+
 
             return ctor;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6425 by incorporating the comment from https://github.com/umbraco/Umbraco-CMS/pull/6426#pullrequestreview-296840812.

### Description
The updated code in this PR makes sure the `ConcurrentDictionary<Type, Dictionary<Type, Func<object, MapperContext, object>>>` is accessed in a thread-safe manner and doesn't retrieve unnecessary values from the inner dictionary.
