### PR TITLE
Updated list view headers styling to have the link/hand cursor visible only if the header is sortable

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-table.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-table.less
@@ -50,18 +50,19 @@ input.umb-table__input {
     font-weight: bold;
 }
 
-.umb-table-head__link {
+a.umb-table-head__link {
     position: relative;
     cursor: default;
     text-decoration: none;
     color: @gray-3;
     &:hover {
         text-decoration: none;
+        cursor: default;
         color: @gray-3;
     }
 }
 
-.umb-table-head__link .sortable {
+a.umb-table-head__link.sortable {
     &:hover {
         text-decoration: none;
         cursor: pointer;


### PR DESCRIPTION
Non-sortable list view headers are already not clickable (i.e. clicking has no effect) but it's not obvious, as the default link "hand" cursor is shown.  This PR updates this for non-sortable headers to show the default "arrow" cursor.

Raised in #6477.
