### PR TITLE
Allows members to be ordered by additional system fields

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
@@ -546,6 +546,9 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             if (ordering.OrderBy.InvariantEquals("userName"))
                 return SqlSyntax.GetFieldName<MemberDto>(x => x.LoginName);
 
+            if (ordering.OrderBy.InvariantEquals("updateDate"))
+                return SqlSyntax.GetFieldName<ContentVersionDto>(x => x.VersionDate);
+
             return base.ApplySystemOrdering(ref sql, ordering);
         }
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
@@ -133,7 +133,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
                 // joining the type so we can do a query against the member type - not sure if this adds much overhead or not?
                 // the execution plan says it doesn't so we'll go with that and in that case, it might be worth joining the content
-                // types by default on the document and media repo's so we can query by content type there too.
+                // types by default on the document and media repos so we can query by content type there too.
                 .InnerJoin<ContentTypeDto>().On<ContentDto, ContentTypeDto>(left => left.ContentTypeId, right => right.NodeId);
 
             sql.Where<NodeDto>(x => x.NodeObjectType == NodeObjectTypeId);
@@ -548,6 +548,12 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             if (ordering.OrderBy.InvariantEquals("updateDate"))
                 return SqlSyntax.GetFieldName<ContentVersionDto>(x => x.VersionDate);
+
+            if (ordering.OrderBy.InvariantEquals("createDate"))
+                return SqlSyntax.GetFieldName<NodeDto>(x => x.CreateDate);
+
+            if (ordering.OrderBy.InvariantEquals("contentTypeAlias"))
+                return SqlSyntax.GetFieldName<ContentTypeDto>(x => x.Alias);
 
             return base.ApplySystemOrdering(ref sql, ordering);
         }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -197,8 +197,10 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
         // (see MemberRepository.ApplySystemOrdering)
         if (e.isSystem && $scope.entityType === "member") {
             e.allowSorting = e.alias === "username" ||
-                             e.alias === "email" ||
-                             e.alias === "updateDate";
+                e.alias === "email" ||
+                e.alias === "updateDate" ||
+                e.alias === "createDate" ||
+                e.alias === "contentTypeAlias";
         }
 
         if (e.isSystem) {
@@ -774,7 +776,7 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
                     ? "content_documentType"
                     : $scope.entityType === "media"
                         ? "content_mediatype"
-                        : "content_memberType";
+                        : "content_membertype";
             case "email":
                 return "general_email";
             case "username":

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -193,9 +193,12 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
     _.each($scope.options.includeProperties, function (e, i) {
         e.allowSorting = true;
 
-        // Special case for members, only fields on the base table (cmsMember) can be used for sorting
-        if (e.isSystem && $scope.entityType == "member") {
-            e.allowSorting = e.alias == 'username' || e.alias == 'email';
+        // Special case for members, only the configured system fields should be enabled sorting
+        // (see MemberRepository.ApplySystemOrdering)
+        if (e.isSystem && $scope.entityType === "member") {
+            e.allowSorting = e.alias === "username" ||
+                             e.alias === "email" ||
+                             e.alias === "updateDate";
         }
 
         if (e.isSystem) {
@@ -767,8 +770,11 @@ function listViewController($scope, $routeParams, $injector, $timeout, currentUs
             case "published":
                 return "content_isPublished";
             case "contentTypeAlias":
-                // TODO: Check for members
-                return $scope.entityType === "content" ? "content_documentType" : "content_mediatype";
+                return $scope.entityType === "content"
+                    ? "content_documentType"
+                    : $scope.entityType === "media"
+                        ? "content_mediatype"
+                        : "content_memberType";
             case "email":
                 return "general_email";
             case "username":


### PR DESCRIPTION
It was raised in #6477 that the last edited field on the default members list view doesn't allow sorting.

This PR adds that ability, along with two other system fields that developers are able to add to the list view - the created date, and the content type alias.

Also fixes a minor issue that when adding the content type alias as a header on the member list view, it was displaying the localised text of "media type" instead of "member type".