### PR TITLE
V8: Split IndexCreator and Index config methods

### DIFF
--- a/src/Umbraco.Examine/IUmbracoIndexConfig.cs
+++ b/src/Umbraco.Examine/IUmbracoIndexConfig.cs
@@ -1,0 +1,12 @@
+using Examine;
+
+namespace Umbraco.Examine
+{
+    public abstract class IUmbracoIndexConfig
+    {
+        public abstract IContentValueSetValidator GetContentValueSetValidator();
+        public abstract IContentValueSetValidator GetPublishedContentValueSetValidator();
+        public abstract IValueSetValidator GetMemberValueSetValidator();
+
+    }
+}

--- a/src/Umbraco.Examine/IUmbracoIndexConfig.cs
+++ b/src/Umbraco.Examine/IUmbracoIndexConfig.cs
@@ -2,11 +2,11 @@ using Examine;
 
 namespace Umbraco.Examine
 {
-    public abstract class IUmbracoIndexConfig
+    public interface IUmbracoIndexConfig
     {
-        public abstract IContentValueSetValidator GetContentValueSetValidator();
-        public abstract IContentValueSetValidator GetPublishedContentValueSetValidator();
-        public abstract IValueSetValidator GetMemberValueSetValidator();
+        IContentValueSetValidator GetContentValueSetValidator();
+        IContentValueSetValidator GetPublishedContentValueSetValidator();
+        IValueSetValidator GetMemberValueSetValidator();
 
     }
 }

--- a/src/Umbraco.Examine/Umbraco.Examine.csproj
+++ b/src/Umbraco.Examine/Umbraco.Examine.csproj
@@ -68,7 +68,7 @@
     <Compile Include="IIndexCreator.cs" />
     <Compile Include="IIndexDiagnostics.cs" />
     <Compile Include="IIndexPopulator.cs" />
-    <Compile Include="UmbracoUmbracoIndexConfig.cs" />
+    <Compile Include="UmbracoIndexConfig.cs" />
     <Compile Include="IndexPopulator.cs" />
     <Compile Include="IndexRebuilder.cs" />
     <Compile Include="IPublishedContentValueSetBuilder.cs" />

--- a/src/Umbraco.Examine/Umbraco.Examine.csproj
+++ b/src/Umbraco.Examine/Umbraco.Examine.csproj
@@ -64,9 +64,11 @@
     <Compile Include="ExamineExtensions.cs" />
     <Compile Include="IContentValueSetBuilder.cs" />
     <Compile Include="IContentValueSetValidator.cs" />
+    <Compile Include="IUmbracoIndexConfig.cs" />
     <Compile Include="IIndexCreator.cs" />
     <Compile Include="IIndexDiagnostics.cs" />
     <Compile Include="IIndexPopulator.cs" />
+    <Compile Include="UmbracoUmbracoIndexConfig.cs" />
     <Compile Include="IndexPopulator.cs" />
     <Compile Include="IndexRebuilder.cs" />
     <Compile Include="IPublishedContentValueSetBuilder.cs" />

--- a/src/Umbraco.Examine/UmbracoIndexConfig.cs
+++ b/src/Umbraco.Examine/UmbracoIndexConfig.cs
@@ -4,20 +4,20 @@ using Umbraco.Core.Services.Implement;
 
 namespace Umbraco.Examine
 {
-    public class UmbracoUmbracoIndexConfig : IUmbracoIndexConfig
+    public class UmbracoIndexConfig : IUmbracoIndexConfig
     {
-        public UmbracoUmbracoIndexConfig(IPublicAccessService publicAccessService)
+        public UmbracoIndexConfig(IPublicAccessService publicAccessService)
         {
             PublicAccessService = publicAccessService;
         }
 
         protected IPublicAccessService PublicAccessService { get; }
-        public override IContentValueSetValidator GetContentValueSetValidator()
+        public IContentValueSetValidator GetContentValueSetValidator()
         {
             return new ContentValueSetValidator(false, true, PublicAccessService);
         }
 
-        public override IContentValueSetValidator GetPublishedContentValueSetValidator()
+        public IContentValueSetValidator GetPublishedContentValueSetValidator()
         {
             return new ContentValueSetValidator(true, false, PublicAccessService);
         }
@@ -26,7 +26,7 @@ namespace Umbraco.Examine
         /// Returns the <see cref="IValueSetValidator"/> for the member indexer
         /// </summary>
         /// <returns></returns>
-        public override IValueSetValidator GetMemberValueSetValidator()
+        public IValueSetValidator GetMemberValueSetValidator()
         {
             return new MemberValueSetValidator();
         }

--- a/src/Umbraco.Examine/UmbracoUmbracoIndexConfig.cs
+++ b/src/Umbraco.Examine/UmbracoUmbracoIndexConfig.cs
@@ -1,0 +1,34 @@
+using Examine;
+using Umbraco.Core.Services;
+using Umbraco.Core.Services.Implement;
+
+namespace Umbraco.Examine
+{
+    public class UmbracoUmbracoIndexConfig : IUmbracoIndexConfig
+    {
+        public UmbracoUmbracoIndexConfig(IPublicAccessService publicAccessService)
+        {
+            PublicAccessService = publicAccessService;
+        }
+
+        protected IPublicAccessService PublicAccessService { get; }
+        public override IContentValueSetValidator GetContentValueSetValidator()
+        {
+            return new ContentValueSetValidator(false, true, PublicAccessService);
+        }
+
+        public override IContentValueSetValidator GetPublishedContentValueSetValidator()
+        {
+            return new ContentValueSetValidator(true, false, PublicAccessService);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="IValueSetValidator"/> for the member indexer
+        /// </summary>
+        /// <returns></returns>
+        public override IValueSetValidator GetMemberValueSetValidator()
+        {
+            return new MemberValueSetValidator();
+        }
+    }
+}

--- a/src/Umbraco.Web/Search/ExamineComposer.cs
+++ b/src/Umbraco.Web/Search/ExamineComposer.cs
@@ -29,6 +29,7 @@ namespace Umbraco.Web.Search
             composition.Register<MediaIndexPopulator>(Lifetime.Singleton);
 
             composition.Register<IndexRebuilder>(Lifetime.Singleton);
+            composition.RegisterUnique<IUmbracoIndexConfig, UmbracoUmbracoIndexConfig>();
             composition.RegisterUnique<IUmbracoIndexesCreator, UmbracoIndexesCreator>();
             composition.RegisterUnique<IPublishedContentValueSetBuilder>(factory =>
                 new ContentValueSetBuilder(

--- a/src/Umbraco.Web/Search/ExamineComposer.cs
+++ b/src/Umbraco.Web/Search/ExamineComposer.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Web.Search
             composition.Register<MediaIndexPopulator>(Lifetime.Singleton);
 
             composition.Register<IndexRebuilder>(Lifetime.Singleton);
-            composition.RegisterUnique<IUmbracoIndexConfig, UmbracoUmbracoIndexConfig>();
+            composition.RegisterUnique<IUmbracoIndexConfig, UmbracoIndexConfig>();
             composition.RegisterUnique<IUmbracoIndexesCreator, UmbracoIndexesCreator>();
             composition.RegisterUnique<IPublishedContentValueSetBuilder>(factory =>
                 new ContentValueSetBuilder(

--- a/src/Umbraco.Web/Search/UmbracoIndexesCreator.cs
+++ b/src/Umbraco.Web/Search/UmbracoIndexesCreator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Services;
 using Umbraco.Examine;
@@ -57,7 +58,8 @@ namespace Umbraco.Web.Search
                 new CultureInvariantWhitespaceAnalyzer(),
                 ProfilingLogger,
                 LanguageService,
-                UmbracoIndexConfig.GetContentValueSetValidator());
+                GetContentValueSetValidator()
+                );
             return index;
         }
 
@@ -70,7 +72,7 @@ namespace Umbraco.Web.Search
                 new StandardAnalyzer(Lucene.Net.Util.Version.LUCENE_30),
                 ProfilingLogger,
                 LanguageService,
-                UmbracoIndexConfig.GetPublishedContentValueSetValidator());
+                GetPublishedContentValueSetValidator());
             return index;
         }
 
@@ -82,10 +84,30 @@ namespace Umbraco.Web.Search
                 CreateFileSystemLuceneDirectory(Constants.UmbracoIndexes.MembersIndexPath),
                 new CultureInvariantWhitespaceAnalyzer(),
                 ProfilingLogger,
-                UmbracoIndexConfig.GetMemberValueSetValidator());
+                GetMemberValueSetValidator()
+                );
             return index;
         }
+        [Obsolete]
+        public virtual IContentValueSetValidator GetContentValueSetValidator()
+        {
+            return UmbracoIndexConfig.GetContentValueSetValidator();
+        }
+        [Obsolete]
+        public virtual IContentValueSetValidator GetPublishedContentValueSetValidator()
+        {
+            return UmbracoIndexConfig.GetPublishedContentValueSetValidator();
+        }
 
+        /// <summary>
+        /// Returns the <see cref="IValueSetValidator"/> for the member indexer
+        /// </summary>
+        /// <returns></returns>
+        [Obsolete]
+        public virtual IValueSetValidator GetMemberValueSetValidator()
+        {
+            return UmbracoIndexConfig.GetMemberValueSetValidator();
+        }
 
 
     }

--- a/src/Umbraco.Web/Search/UmbracoIndexesCreator.cs
+++ b/src/Umbraco.Web/Search/UmbracoIndexesCreator.cs
@@ -19,18 +19,20 @@ namespace Umbraco.Web.Search
         public UmbracoIndexesCreator(IProfilingLogger profilingLogger,
             ILocalizationService languageService,
             IPublicAccessService publicAccessService,
-            IMemberService memberService)
+            IMemberService memberService, IUmbracoIndexConfig umbracoIndexConfig)
         {
             ProfilingLogger = profilingLogger ?? throw new System.ArgumentNullException(nameof(profilingLogger));
             LanguageService = languageService ?? throw new System.ArgumentNullException(nameof(languageService));
             PublicAccessService = publicAccessService ?? throw new System.ArgumentNullException(nameof(publicAccessService));
             MemberService = memberService ?? throw new System.ArgumentNullException(nameof(memberService));
+            UmbracoIndexConfig = umbracoIndexConfig;
         }
 
         protected IProfilingLogger ProfilingLogger { get; }
         protected ILocalizationService LanguageService { get; }
         protected IPublicAccessService PublicAccessService { get; }
         protected IMemberService MemberService { get; }
+        protected IUmbracoIndexConfig UmbracoIndexConfig { get; }
 
         /// <summary>
         /// Creates the Umbraco indexes
@@ -55,7 +57,7 @@ namespace Umbraco.Web.Search
                 new CultureInvariantWhitespaceAnalyzer(),
                 ProfilingLogger,
                 LanguageService,
-                GetContentValueSetValidator());
+                UmbracoIndexConfig.GetContentValueSetValidator());
             return index;
         }
 
@@ -68,7 +70,7 @@ namespace Umbraco.Web.Search
                 new StandardAnalyzer(Lucene.Net.Util.Version.LUCENE_30),
                 ProfilingLogger,
                 LanguageService,
-                GetPublishedContentValueSetValidator());
+                UmbracoIndexConfig.GetPublishedContentValueSetValidator());
             return index;
         }
 
@@ -80,28 +82,11 @@ namespace Umbraco.Web.Search
                 CreateFileSystemLuceneDirectory(Constants.UmbracoIndexes.MembersIndexPath),
                 new CultureInvariantWhitespaceAnalyzer(),
                 ProfilingLogger,
-                GetMemberValueSetValidator());
+                UmbracoIndexConfig.GetMemberValueSetValidator());
             return index;
         }
-        
-        public virtual IContentValueSetValidator GetContentValueSetValidator()
-        {
-            return new ContentValueSetValidator(false, true, PublicAccessService);
-        }
 
-        public virtual IContentValueSetValidator GetPublishedContentValueSetValidator()
-        {
-            return new ContentValueSetValidator(true, false, PublicAccessService);
-        }
 
-        /// <summary>
-        /// Returns the <see cref="IValueSetValidator"/> for the member indexer
-        /// </summary>
-        /// <returns></returns>
-        public virtual IValueSetValidator GetMemberValueSetValidator()
-        {
-            return new MemberValueSetValidator();
-        }
 
     }
 }

--- a/src/Umbraco.Web/Search/UmbracoIndexesCreator.cs
+++ b/src/Umbraco.Web/Search/UmbracoIndexesCreator.cs
@@ -88,12 +88,12 @@ namespace Umbraco.Web.Search
                 );
             return index;
         }
-        [Obsolete]
+        [Obsolete("This method should not be used and will be removed in future versions. GetContentValueSetValidator was moved to IUmbracoIndexConfig")]
         public virtual IContentValueSetValidator GetContentValueSetValidator()
         {
             return UmbracoIndexConfig.GetContentValueSetValidator();
         }
-        [Obsolete]
+        [Obsolete("This method should not be used and will be removed in future versions. GetPublishedContentValueSetValidator was moved to IUmbracoIndexConfig")]
         public virtual IContentValueSetValidator GetPublishedContentValueSetValidator()
         {
             return UmbracoIndexConfig.GetPublishedContentValueSetValidator();
@@ -103,7 +103,7 @@ namespace Umbraco.Web.Search
         /// Returns the <see cref="IValueSetValidator"/> for the member indexer
         /// </summary>
         /// <returns></returns>
-        [Obsolete]
+        [Obsolete("This method should not be used and will be removed in future versions. GetMemberValueSetValidator was moved to IUmbracoIndexConfig")]
         public virtual IValueSetValidator GetMemberValueSetValidator()
         {
             return UmbracoIndexConfig.GetMemberValueSetValidator();


### PR DESCRIPTION
I notice IndexCreator actually has 2 responsibilities, which in my opinion is not the best way of doing that and I think it should be separate as in that case it looks weird: 
I want override index config I have to override whole umbracoindexcreator.

And here I have an additional case which could be useful:
I am preparing the package which creates elasticsearch indexes and second developer @callumbwhyte  have a package which wants override config in examine and actually we are hitting here wall if we want install both packages as both cases overriding umbracoindexcreator. 

In a way what I am proposing we could have both packages without stress about the ordering of components and handling differently situation depends on installed packages.