### PR TITLE
V8: Reload node children after publishing with descendants

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -4,7 +4,7 @@
     function ContentEditController($rootScope, $scope, $routeParams, $q, $window,
         appState, contentResource, entityResource, navigationService, notificationsService,
         serverValidationManager, contentEditingHelper, localizationService, formHelper, umbRequestHelper,
-        editorState, $http, eventsService, overlayService, $location, localStorageService) {
+        editorState, $http, eventsService, overlayService, $location, localStorageService, treeService) {
 
         var evts = [];
         var infiniteMode = $scope.infiniteModel && $scope.infiniteModel.infiniteMode;
@@ -305,7 +305,7 @@
         }
 
         /** Syncs the content item to it's tree node - this occurs on first load and after saving */
-        function syncTreeNode(content, path, initialLoad) {
+        function syncTreeNode(content, path, initialLoad, reloadChildren) {
 
             if (infiniteMode || !path) {
                 return;
@@ -315,6 +315,9 @@
                 navigationService.syncTree({ tree: $scope.treeAlias, path: path.split(","), forceReload: initialLoad !== true })
                     .then(function (syncArgs) {
                         $scope.page.menu.currentNode = syncArgs.node;
+                        if (reloadChildren && syncArgs.node.expanded) {
+                            treeService.loadNodeChildren({node: syncArgs.node});
+                        }
                     }, function () {
                         //handle the rejection
                         console.log("A problem occurred syncing the tree! A path is probably incorrect.")
@@ -446,7 +449,7 @@
                 //needs to be manually set for infinite editing mode
                 $scope.page.isNew = false;
 
-                syncTreeNode($scope.content, data.path);
+                syncTreeNode($scope.content, data.path, false, args.reloadChildren);
 
                 eventsService.emit("content.saved", { content: $scope.content, action: args.action });
 
@@ -859,7 +862,8 @@
                                 return contentResource.publishWithDescendants(content, create, model.includeUnpublished, files, showNotifications);
                             },
                             action: "publishDescendants",
-                            showNotifications: false
+                            showNotifications: false,
+                            reloadChildren: model.includeUnpublished
                         }).then(function (data) {
                             //show all notifications manually here since we disabled showing them automatically in the save method
                             formHelper.showNotifications(data);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When publishing includes unpublished descendants, the content tree doesn't reflect the changes in published status for the descendants:

![reload-after-publish-before](https://user-images.githubusercontent.com/7405322/66265807-cb5b5700-e81c-11e9-94f6-e66a1556d28b.gif)

This PR ensures that the children of the current node are reloaded in the content tree when publishing with unpublished descendants:

![reload-after-publish-after](https://user-images.githubusercontent.com/7405322/66265816-e5953500-e81c-11e9-908a-9410ff015be6.gif)
