### PR TITLE
Correct URL decoding of macro partial view names

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/macro.settings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/macro.settings.controller.js
@@ -35,7 +35,7 @@ function MacrosSettingsController($scope, editorService, localizationService) {
             },
             filterCssClass: "not-allowed",
             select: function (node) {
-                const id = unescape(node.id.replace(/\+/g, " "));
+                const id = decodeURIComponent(node.id.replace(/\+/g, " "));
 
                 //vm.macro.view = id;
                 $scope.model.macro.view = "~/Views/MacroPartials/" + id;

--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/macro.settings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/macro.settings.controller.js
@@ -35,7 +35,7 @@ function MacrosSettingsController($scope, editorService, localizationService) {
             },
             filterCssClass: "not-allowed",
             select: function (node) {
-                const id = unescape(node.id);
+                const id = unescape(node.id.replace(/\+/g, " "));
 
                 //vm.macro.view = id;
                 $scope.model.macro.view = "~/Views/MacroPartials/" + id;

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -243,7 +243,7 @@
                 select: function(node) {
                     node.selected = !node.selected;
 
-                    const id = unescape(node.id.replace(/\+/g, " "));
+                    const id = decodeURIComponent(node.id.replace(/\+/g, " "));
                     const index = selection.indexOf(id);
 
                     if(node.selected) {
@@ -284,7 +284,7 @@
                 },
                 filterCssClass: "not-allowed",
                 select: function(node) {
-                    const id = unescape(node.id.replace(/\+/g, " "));
+                    const id = decodeURIComponent(node.id.replace(/\+/g, " "));
                     vm.package.packageView = id;
                     editorService.close();
                 },

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -243,7 +243,7 @@
                 select: function(node) {
                     node.selected = !node.selected;
 
-                    const id = unescape(node.id);
+                    const id = unescape(node.id.replace(/\+/g, " "));
                     const index = selection.indexOf(id);
 
                     if(node.selected) {
@@ -284,7 +284,7 @@
                 },
                 filterCssClass: "not-allowed",
                 select: function(node) {
-                    const id = unescape(node.id);
+                    const id = unescape(node.id.replace(/\+/g, " "));
                     vm.package.packageView = id;
                     editorService.close();
                 },


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6590

### Description
When picking a partial view in a macro's settings, the picker returns the filename URL-encoded. Any spaces are left encoded as +, and we store `~/Views/MacroPartials/Name+with+spaces.cshtml`. Then when trying to render the macro, the file can't be found.

Testing:
- Create a macro partial view with spaces in the name.
- Create a macro and pick that partial view.
- The filename should be displayed with spaces, not +.