### PR TITLE
V8: Allow copying and pasting all Nested Content items in one go

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -38,10 +38,14 @@
             </div>
         </div>
 
-        <div class="umb-nested-content__footer-bar" ng-hide="hasContentTypes === false || nodes.length >= maxItems">
-            <a href class="umb-nested-content__add-content" ng-class="{ '--disabled': !scaffolds.length }" ng-click="openNodeTypePicker($event)" prevent-default>
+        <div class="umb-nested-content__footer-bar" ng-hide="hasContentTypes === false">
+            <a href ng-hide="nodes.length >= maxItems" class="umb-nested-content__add-content mb1" ng-class="{ '--disabled': !scaffolds.length }" ng-click="openNodeTypePicker($event)" prevent-default>
                 <localize key="grid_addElement"></localize>
             </a>
+            <button ng-show="nodes.length" class="btn btn-link" ng-click="clickCopyAll($event)">
+                <i class="icon icon-documents"></i>
+                <span>{{labels.copyProperty}}</span>
+            </button>
         </div>
 
     </ng-form>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -298,6 +298,7 @@
     <key alias="schedulePublishHelp">Vælg dato og klokkeslæt for at udgive og/eller afpublicere indholdet.</key>
     <key alias="createEmpty">Opret ny</key>
     <key alias="createFromClipboard">Indsæt fra udklipsmappen</key>
+    <key alias="copyPropertyToClipboard">Kopiér alt indhold fra %0%</key>
   </area>
   <area alias="blueprints">
     <key alias="createBlueprintFrom">Opret en ny indholdsskabelon fra '%0%'</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -275,6 +275,7 @@
     <key alias="nestedContentDeleteItem">Are you sure you want to delete this item?</key>
     <key alias="nestedContentEditorNotSupported">Property %0% uses editor %1% which is not supported by Nested Content.</key>
     <key alias="nestedContentNoContentTypes">No content types are configured for this property.</key>
+    <key alias="nestedContentCopyAllItemsName">%0% from %1%</key>
     <key alias="addTextBox">Add another text box</key>
     <key alias="removeTextBox">Remove this text box</key>
     <key alias="contentRoot">Content root</key>
@@ -298,6 +299,7 @@
     <key alias="schedulePublishHelp">Select the date and time to publish and/or unpublish the content item.</key>
     <key alias="createEmpty">Create new</key>
     <key alias="createFromClipboard">Paste from clipboard</key>
+    <key alias="copyPropertyToClipboard">Copy all contents of %0%</key>
   </area>
   <area alias="blueprints">
     <key alias="createBlueprintFrom">Create a new Content Template from '%0%'</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -279,6 +279,7 @@
     <key alias="nestedContentDeleteItem">Are you sure you want to delete this item?</key>
     <key alias="nestedContentEditorNotSupported">Property %0% uses editor %1% which is not supported by Nested Content.</key>
     <key alias="nestedContentNoContentTypes">No content types are configured for this property.</key>
+    <key alias="nestedContentCopyAllItemsName">%0% from %1%</key>
     <key alias="addTextBox">Add another text box</key>
     <key alias="removeTextBox">Remove this text box</key>
     <key alias="contentRoot">Content root</key>
@@ -302,6 +303,7 @@
     <key alias="schedulePublishHelp">Select the date and time to publish and/or unpublish the content item.</key>
     <key alias="createEmpty">Create new</key>
     <key alias="createFromClipboard">Paste from clipboard</key>
+    <key alias="copyPropertyToClipboard">Copy all contents of %0%</key>
   </area>
   <area alias="blueprints">
     <key alias="createBlueprintFrom">Create a new Content Template from '%0%'</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5551

### Description

This is a redo of #5706, this time non-breaking (clientside only).

When applied you can copy and paste all items from one Nested Content property to another (or the same, if you really want) in one go. It works like this:

![nc-copy-all](https://user-images.githubusercontent.com/7405322/66288348-2a7ea180-e8d9-11e9-9a31-75482d449cd3.gif)


#### Testing this PR

1. Ensure that all items on a Nested Content property can be copied to another Nested Content property on content of the same type.
2. For language variant content where the Nested Content property is allowed to vary by language, ensure that all items can be copied between languages.
3. Verify that you can't copy items from one Nested Content to another if one or more of the copied item types aren't allowed on the target property configuration.
4. Ensure that single items can be copied between Nested Content properties (that this PR didn't break the single item copy feature, in other words).

