### PR TITLE
V8: Turn the "empty recycle bin" warning into an actual warning

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/emptyrecyclebin.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/emptyrecyclebin.html
@@ -4,12 +4,12 @@
 
             <umb-loader ng-show="busy"></umb-loader>
 
-            <p class="abstract">
-                <localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.
+            <div class="umb-alert umb-alert--warning">
+                <p><localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.</p>
                 <localize key="general_areyousure">Are you sure?</localize>
-            </p>
+            </div>
 
-            <umb-confirm on-confirm="performDelete" on-cancel="cancel">
+            <umb-confirm on-confirm="performDelete" on-cancel="cancel" confirm-button-style="danger">
             </umb-confirm>
         </umb-pane>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/emptyrecyclebin.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/emptyrecyclebin.html
@@ -5,12 +5,12 @@
 
             <umb-loader ng-show="busy"></umb-loader>
 
-            <p class="abstract">
-                <localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.
+            <div class="umb-alert umb-alert--warning">
+                <p><localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.</p>
                 <localize key="general_areyousure">Are you sure?</localize>
-            </p>
+            </div>
 
-            <umb-confirm on-confirm="performDelete" on-cancel="cancel">
+            <umb-confirm on-confirm="performDelete" on-cancel="cancel" confirm-button-style="danger">
             </umb-confirm>
         </umb-pane>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The "empty recycle bin" warning doesn't quite feel like much of a warning; it looks more like a confirmation dialog, despite its destructive behavior:

![image](https://user-images.githubusercontent.com/7405322/66345040-79671e00-e94f-11e9-8ae5-860cebcac19c.png)

This PR updates the warning so it looks like an actual warning:

![image](https://user-images.githubusercontent.com/7405322/66344890-268d6680-e94f-11e9-80bc-fd63a2c373a8.png)

...and similarly for the media section:

![image](https://user-images.githubusercontent.com/7405322/66344973-4fadf700-e94f-11e9-900d-80e0255efbb1.png)
