### PR TITLE
V8: Add irreversible warning when deleting items from the recycle bin

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/delete.html
@@ -14,8 +14,12 @@
                 <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong>?
             </p>
 
-            <div class="umb-alert umb-alert--warning" ng-show="hasMoreThanOneLanguage">
+            <div class="umb-alert umb-alert--warning" ng-show="hasMoreThanOneLanguage && !currentNode.trashed">
                 <localize key="defaultdialogs_variantdeletewarning">This will delete the node and all its languages. If you only want to delete one language go and unpublish it instead.</localize>
+            </div>
+
+            <div class="umb-alert umb-alert--warning" ng-show="currentNode.trashed">
+                <localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.
             </div>
 
             <umb-confirm on-confirm="performDelete" confirm-button-style="danger" on-cancel="cancel"></umb-confirm>

--- a/src/Umbraco.Web.UI.Client/src/views/media/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/delete.html
@@ -14,7 +14,11 @@
                 <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong>?
             </p>
 
-            <umb-confirm on-confirm="performDelete" on-cancel="close"></umb-confirm>
+            <div class="umb-alert umb-alert--warning" ng-show="currentNode.trashed">
+                <localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.
+            </div>
+
+            <umb-confirm on-confirm="performDelete" on-cancel="close" confirm-button-style="danger"></umb-confirm>
         </div>
 
     </div>

--- a/src/Umbraco.Web/Trees/TreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/TreeControllerBase.cs
@@ -265,6 +265,7 @@ namespace Umbraco.Web.Trees
             treeNode.Path = entity.Path;
             treeNode.Udi = Udi.Create(ObjectTypes.GetUdiType(entityObjectType), entity.Key);
             treeNode.HasChildren = hasChildren;
+            treeNode.Trashed = entity.Trashed;
             return treeNode;
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When deleting content from the recycle bin, the warning message is the same as when you move content to the recycle bin - and it makes no sense in the context of deleting content from the recycle bin:

![image](https://user-images.githubusercontent.com/7405322/66373671-78fb7100-e9a9-11e9-9323-a976d37a8351.png)

With this PR, the warning makes a little more sense when deleting content:

![image](https://user-images.githubusercontent.com/7405322/66373471-068a9100-e9a9-11e9-864a-68aba5730e54.png)

...and the same applies to media:

![image](https://user-images.githubusercontent.com/7405322/66373552-26ba5000-e9a9-11e9-8f0c-63c29659476a.png)

And as an added bonus, the confirmation button is now red when moving media to the recycle bin (it is currently green):

![image](https://user-images.githubusercontent.com/7405322/66373609-4baec300-e9a9-11e9-8081-ce2f7b560f3e.png)

