### PR TITLE
Set focus to Umb-Tags when clicking property label

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
@@ -18,7 +18,7 @@
                 config: "<",
                 validation: "<",
                 culture: "<?",
-                htmlId: "<?",
+                inputId: "@?",
                 onValueChanged: "&"
             }
         });
@@ -50,7 +50,7 @@
         vm.viewModel = [];
 
         function onInit() {
-            vm.htmlId = vm.htmlId || "t" + String.CreateGuid();
+            vm.inputId = vm.inputId || "t" + String.CreateGuid();
 
             assetsService.loadJs("lib/typeahead.js/typeahead.bundle.min.js").then(function () {
 
@@ -107,7 +107,7 @@
                         minLength: 1
                     };
 
-                    typeahead = $element.find('.tags-' + vm.htmlId).typeahead(opts, sources)
+                    typeahead = $element.find('.tags-' + vm.inputId).typeahead(opts, sources)
                         .bind("typeahead:selected", function (obj, datum, name) {
                             angularHelper.safeApply($rootScope, function () {
                                 addTagInternal(datum["text"]);
@@ -154,7 +154,7 @@
                 tagsHound.clearRemoteCache();
                 tagsHound = null;
             }
-            $element.find('.tags-' + vm.htmlId).typeahead('destroy');
+            $element.find('.tags-' + vm.inputId).typeahead('destroy');
         }
 
         function configureViewModel(isInitLoad) {
@@ -229,7 +229,7 @@
         function addTagOnEnter(e) {
             var code = e.keyCode || e.which;
             if (code == 13) { //Enter keycode
-                if ($element.find('.tags-' + vm.htmlId).parent().find(".tt-menu .tt-cursor").length === 0) {
+                if ($element.find('.tags-' + vm.inputId).parent().find(".tt-menu .tt-cursor").length === 0) {
                     //this is required, otherwise the html form will attempt to submit.
                     e.preventDefault();
                     addTag();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
@@ -18,6 +18,7 @@
                 config: "<",
                 validation: "<",
                 culture: "<?",
+                htmlId: "<?",
                 onValueChanged: "&"
             }
         });
@@ -43,13 +44,13 @@
         vm.hidePrompt = hidePrompt;
         vm.onKeyUpOnTag = onKeyUpOnTag;
 
-        vm.htmlId = "t" + String.CreateGuid();
         vm.isLoading = true;
         vm.tagToAdd = "";
         vm.promptIsVisible = "-1";
         vm.viewModel = [];
 
         function onInit() {
+            vm.htmlId = vm.htmlId || "t" + String.CreateGuid();
 
             assetsService.loadJs("lib/typeahead.js/typeahead.bundle.min.js").then(function () {
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
@@ -21,8 +21,8 @@
             </span>
 
             <input type="text"
-                   id="{{vm.htmlId}}"
-                   class="typeahead tags-{{vm.htmlId}}"
+                   id="{{vm.inputId}}"
+                   class="typeahead tags-{{vm.inputId}}"
                    ng-model="vm.tagToAdd"
                    ng-keydown="vm.addTagOnEnter($event)"
                    ng-blur="vm.addTag()"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.html
@@ -4,7 +4,8 @@
                      config="model.config"
                      validation="model.validation"
                      on-value-changed="valueChanged(value)"
-                     culture="model.culture">
+                     culture="model.culture"
+                     html-id="model.alias">
     </umb-tags-editor>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.html
@@ -5,7 +5,7 @@
                      validation="model.validation"
                      on-value-changed="valueChanged(value)"
                      culture="model.culture"
-                     html-id="model.alias">
+                     input-id="{{model.alias}}">
     </umb-tags-editor>
 
 </div>


### PR DESCRIPTION
### Prerequisites

If there's an existing issue for this PR then this fixes #6605

### Description
Allows the Tags property editor to pass the property alias into umb-tags-editor, where it can be used as the ID of the text box to match the label's `for` attribute.