### PR TITLE
Sort hostnames (help needed)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/assigndomain.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/assigndomain.html
@@ -28,9 +28,10 @@
                     <localize key="assignDomain_domainHelpWithVariants"></localize>
                 </small>
                 <div class="umb-el-wrap  hidelabel">
-                    <table class="table table-condensed table-bordered domains" style="margin-bottom: 10px;" ng-if="vm.domains.length > 0">
+                    <table class="table table-condensed domains" style="margin-bottom: 10px;" ng-if="vm.domains.length > 0">
                         <thead>
                             <tr>
+                                <th></th>
                                 <th>
                                     <localize key="assignDomain_domain"></localize>
                                     <span class="umb-control-required">*</span>
@@ -42,10 +43,11 @@
                                 <th />
                             </tr>
                         </thead>
-                        <tbody>
+                        <tbody ui-sortable="sortableOptions" ng-model="vm.domains">
                             <tr ng-repeat="domain in vm.domains">
+                                <td><i class="icon icon-navigation handle ui-sortable-handle"></i></td>
                                 <td>
-                                    <input style="width: 100%; margin-bottom: 0;" type="text" ng-model="domain.name" name="domain_name_{{$index}}" required />
+                                    <input style="width: 100%; margin-bottom: 0;" type="text" ng-model="domain.name" class="domain_name" name="domain_name_{{$index}}" required />
                                     <span ng-if="vm.domainForm.$submitted" ng-messages="vm.domainForm['domain_name_' + $index].$error">
                                         <span class="help-inline" ng-message="required"><localize key="validation_invalidEmpty"></localize></span>
                                     </span>

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.assigndomain.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.assigndomain.controller.js
@@ -141,6 +141,58 @@
             }
         }
 
+        // Return a helper with preserved width of cells
+        var fixHelper = function (e, ui) {
+            ui.children().each(function () {
+                $(this).width($(this).width());
+            });
+
+            var row = ui.clone();
+            row.css("background-color", "lightgray");
+
+            return row;
+        };
+
+
+        $scope.sortableOptions = {
+            helper: fixHelper,
+            handle: ".handle",
+            opacity: 0.5,
+            axis: 'y',
+            containment: 'parent',
+            cursor: 'move',
+            items: '> tr',
+            tolerance: 'pointer',
+            forcePlaceholderSize: true,
+            start: function (e, ui) {
+                ui.placeholder.height(ui.item.height());
+            },
+            update: function (e, ui) {
+
+                // Get the new and old index for the moved element (using the text as the identifier)
+                var newIndex = ui.item.index();
+                var movedName = $('.domain_name', ui.item).val().trim();
+                var originalIndex = getDomainIndexByName(movedName);
+
+                // Move the element in the model
+                if (originalIndex > -1) {
+                    var movedElement = vm.domains[originalIndex];
+                    vm.domains.splice(originalIndex, 1);
+                    vm.domains.splice(newIndex, 0, movedElement);
+                }
+            }
+        };
+
+        function getDomainIndexByName(value) {
+            for (var i = 0; i < vm.domains.length; i++) {
+                if (vm.domains[i].name === value) {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
         activate();
     }
     angular.module("umbraco").controller("Umbraco.Editors.Content.AssignDomainController", AssignDomainController);

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -1734,33 +1734,30 @@ namespace Umbraco.Web.Editors
 
             // compare the model with the domains in db
             // take each domain in the model one by one, and compare to the domains in db
-            // when the first mismatch occurs, the domain and proceeding domains should be deleted
-            // to get the right sort order
+            // when the first mismatch occurs, all the domains gets deleted, so we can recreate in a new order
             var nonWildcardDomains = domains.Where(x => !x.IsWildcard).ToArray();
-            var domainsToDelete = new List<int>();
+            var resetDomainList = false;
             for (var i=0; i < Math.Max(nonWildcardDomains.Length, model.Domains.Length); i++)
             {
                 if (nonWildcardDomains.Length > i && model.Domains.Length > i && nonWildcardDomains[i].DomainName != model.Domains[i].Name)
                 {
-                    domainsToDelete = nonWildcardDomains.Skip(i).Select(x => x.Id).ToList();
+                    resetDomainList = true;
                     break;
                 }
             }
-            if (domainsToDelete.Any())
+            if (resetDomainList)
             {
-                foreach (var domain in nonWildcardDomains.Where(x => domainsToDelete.Contains(x.Id)))
+                foreach (var domain in nonWildcardDomains) Services.DomainService.Delete(domain);
+                // remove nonWildcardDomains from the domain list, as we just deleted them
+                domains = domains.Where(x => x.IsWildcard).ToArray();
+            }
+            else
+            {
+                // delete every (non-wildcard) domain, that exists in the DB yet is not in the model
+                foreach (var domain in domains.Where(d => d.IsWildcard == false && model.Domains.All(m => m.Name.InvariantEquals(d.DomainName) == false)))
                 {
                     Services.DomainService.Delete(domain);
                 }
-            }
-            // update domains list
-            domains = Services.DomainService.GetAssignedDomains(model.NodeId, true).ToArray();
-
-
-            // delete every (non-wildcard) domain, that exists in the DB yet is not in the model
-            foreach (var domain in domains.Where(d => d.IsWildcard == false && model.Domains.All(m => m.Name.InvariantEquals(d.DomainName) == false)))
-            {
-                Services.DomainService.Delete(domain);
             }
 
             var names = new List<string>();

--- a/src/Umbraco.Web/Routing/DomainUtilities.cs
+++ b/src/Umbraco.Web/Routing/DomainUtilities.cs
@@ -278,8 +278,7 @@ namespace Umbraco.Web.Routing
             // TODO: where are we matching ?!!?
             return domains
                 .Where(d => d.IsWildcard == false)
-                .Select(d => new DomainAndUri(d, uri))
-                .OrderByDescending(d => d.Uri.ToString());
+                .Select(d => new DomainAndUri(d, uri));
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Web/Routing/UrlProviderExtensions.cs
@@ -68,13 +68,13 @@ namespace Umbraco.Web.Routing
                 // * The entire branch is invariant
                 // * If there are less domain/cultures assigned to the branch than the number of cultures/languages installed
 
-                foreach (var dUrl in urlGroup.DistinctBy(x => x.Text.ToUpperInvariant()).OrderBy(x => x.Text).ThenBy(x => x.Culture))
+                foreach (var dUrl in urlGroup.DistinctBy(x => x.Text.ToUpperInvariant()))
                     yield return dUrl;
             }
 
             // get the 'other' urls - ie not what you'd get with GetUrl() but urls that would route to the document, nevertheless.
             // for these 'other' urls, we don't check whether they are routable, collide, anything - we just report them.
-            foreach (var otherUrl in umbracoContext.UrlProvider.GetOtherUrls(content.Id).OrderBy(x => x.Text).ThenBy(x => x.Culture))
+            foreach (var otherUrl in umbracoContext.UrlProvider.GetOtherUrls(content.Id))
                 if (urls.Add(otherUrl)) //avoid duplicates
                     yield return otherUrl;
         }


### PR DESCRIPTION
#6591

This is what I got so far.

I compare the order of hostnames between the submitted list, and the persisted list, and deletes the existing domains, if the order doesn't match.

As mentioned in https://github.com/umbraco/Umbraco-CMS/issues/6591#issuecomment-539188057 there is some ordering of the domains overriding the database order. I tried removing that, but that didn't help on the ordering in the links group on the info tab. I'll keep digging.

I'm not sure how to wrap the deletion/re-adding of domains in a transaction, it just uses the domainservice for updating, like before. Any pointers is welcome :)
