### PR TITLE
Fix incorrect path in member group mapping

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
@@ -144,7 +144,7 @@ namespace Umbraco.Web.Models.Mapping
             target.Id = source.Id;
             target.Key = source.Key;
             target.Name = source.Name;
-            target.Path = "-1" + source.Id;
+            target.Path = $"-1,{source.Id}";
             target.Udi = Udi.Create(Constants.UdiEntityType.MemberGroup, source.Key);
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6614

### Description
Member group nodes was not highlighted because an incorrect path in member group mapping.
The path was missing a comma, so instead of `syncTree` in `navigationService` was using `path: "-1,1159"` it was using  `path: "-11159"`.

![2019-10-08_22-39-19](https://user-images.githubusercontent.com/2919859/66431622-9ae20b80-ea1c-11e9-80e4-38eb2881edf9.gif)