### PR TITLE
Log exceptions thrown while terminating components

### DIFF
--- a/src/Umbraco.Core/Composing/ComponentCollection.cs
+++ b/src/Umbraco.Core/Composing/ComponentCollection.cs
@@ -39,8 +39,6 @@ namespace Umbraco.Core.Composing
         {
             using (_logger.DebugDuration<ComponentCollection>($"Terminating. (log components when >{LogThresholdMilliseconds}ms)", "Terminated."))
             {
-                var exceptions = new List<Exception>();
-
                 foreach (var component in this.Reverse()) // terminate components in reverse order
                 {
                     var componentType = component.GetType();
@@ -53,14 +51,9 @@ namespace Umbraco.Core.Composing
                         }
                         catch (Exception ex)
                         {
-                            exceptions.Add(ex);
+                            _logger.Error(componentType, ex, "Error while terminating component.");
                         }
                     }
-                }
-
-                if (exceptions.Count > 0)
-                {
-                    throw new AggregateException("One or more errors occurred while terminating components.", exceptions);
                 }
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6616.

### Description
This PR makes sure the `Terminate` method of all components are executed and any exceptions are logged as errors.

I first combined all exceptions into a single `AggregateException`, but that would still result in an unhandled exception while terminating the runtime and not run all logic within the `HandleApplicationEnd`:

https://github.com/umbraco/Umbraco-CMS/blob/27223738c6af045b637bb9944b53134e681ce5e5/src/Umbraco.Core/Runtime/CoreRuntime.cs#L281-L284

https://github.com/umbraco/Umbraco-CMS/blob/3332e93d4c2b44fbd11fb86fe89e62b61b28f96d/src/Umbraco.Web/UmbracoApplicationBase.cs#L109-L150

Testing can be done by following the reproduction steps from the linked issue. It should log both exceptions as errors and still log the detailed shutdown message.