### PR TITLE
- set the border for the today class on the date picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-date-time-picker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-date-time-picker.less
@@ -7,6 +7,9 @@ span.flatpickr-day {
     border-radius: @baseBorderRadius;
     border: none;
 
+    &.today:not(.active) {
+        border: 1px solid;
+    }
 }
 
 span.flatpickr-day:hover {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-date-time-picker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-date-time-picker.less
@@ -6,6 +6,7 @@
 span.flatpickr-day {
     border-radius: @baseBorderRadius;
     border: none;
+
 }
 
 span.flatpickr-day:hover {


### PR DESCRIPTION
When using the datepicker, today is not highlighted which makes for a poor user experience, as raised in this issue #6618 

I was expecting to see today's date highlighted somehow, perhaps like this:

There is a style for the border colour of the element with the `today` class on it, but there is no border set.

This PR fixes the issue

## Before
![https://i.imgur.com/Z3AcOiw.jpg](https://i.imgur.com/Z3AcOiw.jpg)

## After
![https://i.imgur.com/ArWhjYx.jpg](https://i.imgur.com/ArWhjYx.jpg)