### PR TITLE
- removed usage of obsolete ToSHA1() and replaced it with GenerateHash()

### DIFF
--- a/src/Umbraco.Core/MainDom.cs
+++ b/src/Umbraco.Core/MainDom.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Core
             // a new process for the same application path
 
             var appPath = HostingEnvironment.ApplicationPhysicalPath;
-            var hash = (appId + ":::" + appPath).ToSHA1();
+            var hash = (appId + ":::" + appPath).GenerateHash();
 
             var lockName = "UMBRACO-" + hash + "-MAINDOM-LCK";
             _asyncLock = new AsyncLock(lockName);

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -67,7 +67,7 @@ namespace Umbraco.Core.Models
 
             if (user.Avatar.IsNullOrWhiteSpace())
             {
-                var gravatarHash = user.Email.ToMd5();
+                var gravatarHash = user.Email.GenerateHash();
                 var gravatarUrl = "https://www.gravatar.com/avatar/" + gravatarHash + "?d=404";
 
                 //try Gravatar

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -105,7 +105,7 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
                 CreateDateUtc = redirectUrl.CreateDateUtc,
                 Url = redirectUrl.Url,
                 Culture = redirectUrl.Culture,
-                UrlHash = redirectUrl.Url.ToSHA1()
+                UrlHash = redirectUrl.Url.GenerateHash()
             };
         }
 
@@ -134,7 +134,7 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
 
         public IRedirectUrl Get(string url, Guid contentKey, string culture)
         {
-            var urlHash = url.ToSHA1();
+            var urlHash = url.GenerateHash();
             var sql = GetBaseQuery(false).Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash && x.ContentKey == contentKey && x.Culture == culture);
             var dto = Database.Fetch<RedirectUrlDto>(sql).FirstOrDefault();
             return dto == null ? null : Map(dto);
@@ -157,7 +157,7 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
 
         public IRedirectUrl GetMostRecentUrl(string url)
         {
-            var urlHash = url.ToSHA1();
+            var urlHash = url.GenerateHash();
             var sql = GetBaseQuery(false)
                 .Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash)
                 .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -105,7 +105,7 @@ namespace Umbraco.Web.Editors
             if (Current.Configs.Settings().Content.DisallowedUploadFiles.Contains(ext) == false)
             {
                 //generate a path of known data, we don't want this path to be guessable
-                user.Avatar = "UserAvatars/" + (user.Id + safeFileName).ToSHA1() + "." + ext;
+                user.Avatar = "UserAvatars/" + (user.Id + safeFileName).GenerateHash() + "." + ext;
 
                 using (var fs = System.IO.File.OpenRead(file.LocalFileName))
                 {


### PR DESCRIPTION
In the StringExtensions class, it says that the string extension method `.ToSHA1()` is now obsolete and may be removed in future versions. It advises the developer to use `.GenerateHash()` instead.

However, there are still usages of `.ToSHA1()` in the code base and they show up in the output window as warnings.

These need to be updated to use GenerateHash()

This PR fixes the issue #6620