### PR TITLE
- updated usage of EmptyRecycleBin to pass in the user id as instructed

### DIFF
--- a/src/Umbraco.Tests/Integration/ContentEventsTests.cs
+++ b/src/Umbraco.Tests/Integration/ContentEventsTests.cs
@@ -1087,7 +1087,7 @@ namespace Umbraco.Tests.Integration
         [Test]
         public void EmptyRecycleBinContent()
         {
-            ServiceContext.ContentService.EmptyRecycleBin();
+            ServiceContext.ContentService.EmptyRecycleBin(Constants.Security.SuperUserId);
 
             var content = CreateContent();
             Assert.IsNotNull(content);
@@ -1095,7 +1095,7 @@ namespace Umbraco.Tests.Integration
             ServiceContext.ContentService.MoveToRecycleBin(content);
 
             ResetEvents();
-            ServiceContext.ContentService.EmptyRecycleBin();
+            ServiceContext.ContentService.EmptyRecycleBin(Constants.Security.SuperUserId);
 
             Assert.AreEqual(2, _msgCount);
             Assert.AreEqual(2, _events.Count);
@@ -1109,7 +1109,7 @@ namespace Umbraco.Tests.Integration
         [Test]
         public void EmptyRecycleBinContents()
         {
-            ServiceContext.ContentService.EmptyRecycleBin();
+            ServiceContext.ContentService.EmptyRecycleBin(Constants.Security.SuperUserId);
 
             var content1 = CreateContent();
             Assert.IsNotNull(content1);
@@ -1120,7 +1120,7 @@ namespace Umbraco.Tests.Integration
             ServiceContext.ContentService.MoveToRecycleBin(content2);
 
             ResetEvents();
-            ServiceContext.ContentService.EmptyRecycleBin();
+            ServiceContext.ContentService.EmptyRecycleBin(Constants.Security.SuperUserId);
 
             Assert.AreEqual(3, _msgCount);
             Assert.AreEqual(4, _events.Count);
@@ -1136,7 +1136,7 @@ namespace Umbraco.Tests.Integration
         [Test]
         public void EmptyRecycleBinBranch()
         {
-            ServiceContext.ContentService.EmptyRecycleBin();
+            ServiceContext.ContentService.EmptyRecycleBin(Constants.Security.SuperUserId);
 
             var content1 = CreateBranch();
             Assert.IsNotNull(content1);
@@ -1151,7 +1151,7 @@ namespace Umbraco.Tests.Integration
             var content4C = Children(content1C[2]).ToArray();
             var content5C = Children(content1C[3]).ToArray();
 
-            ServiceContext.ContentService.EmptyRecycleBin();
+            ServiceContext.ContentService.EmptyRecycleBin(Constants.Security.SuperUserId);
 
             Assert.AreEqual(14, _msgCount);
             Assert.AreEqual(14, _events.Count);

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -1616,7 +1616,7 @@ namespace Umbraco.Tests.Services
             Assert.IsTrue(descendants.All(x => x.Path.StartsWith("-1,-20,")));
             Assert.True(descendants.All(x => x.Trashed));
 
-            contentService.EmptyRecycleBin();
+            contentService.EmptyRecycleBin(Constants.Security.SuperUserId);
             var trashed = contentService.GetPagedContentInRecycleBin(0, int.MaxValue, out var _).ToList();
             Assert.IsEmpty(trashed);
         }
@@ -1628,7 +1628,7 @@ namespace Umbraco.Tests.Services
             var contentService = ServiceContext.ContentService;
 
             // Act
-            contentService.EmptyRecycleBin();
+            contentService.EmptyRecycleBin(Constants.Security.SuperUserId);
             var contents = contentService.GetPagedContentInRecycleBin(0, int.MaxValue, out var _).ToList();
 
             // Assert
@@ -1804,7 +1804,7 @@ namespace Umbraco.Tests.Services
 
             // Act
             ServiceContext.ContentService.MoveToRecycleBin(content1);
-            ServiceContext.ContentService.EmptyRecycleBin();
+            ServiceContext.ContentService.EmptyRecycleBin(Constants.Security.SuperUserId);
             var contents = ServiceContext.ContentService.GetPagedContentInRecycleBin(0, int.MaxValue, out var _).ToList();
 
             // Assert


### PR DESCRIPTION
When you build the core project you get warnings about needing to pass in the userId to the EmptyRecycleBin method as the method without userId in it is obsolete and marked as so.

There are some tests which use this method without passing the user in. If we update these then the messages will go away.

This PR updates them and therefore fixes the issue #6622 