### PR TITLE
Unpublished content appearing in macro results

### DIFF
--- a/src/Umbraco.Web/Editors/MacroRenderingController.cs
+++ b/src/Umbraco.Web/Editors/MacroRenderingController.cs
@@ -135,14 +135,19 @@ namespace Umbraco.Web.Editors
             // must have an active variation context!
             _variationContextAccessor.VariationContext = new VariationContext(culture);
 
-            var result = Request.CreateResponse();
-            //need to create a specific content result formatted as HTML since this controller has been configured
-            //with only json formatters.
-            result.Content = new StringContent(
-                _componentRenderer.RenderMacro(pageId, m.Alias, macroParams).ToString(),
-                Encoding.UTF8,
-                "text/html");
-            return result;
+            using (UmbracoContext.ForcedPreview(true))
+            {
+
+                var result = Request.CreateResponse();
+                //need to create a specific content result formatted as HTML since this controller has been configured
+                //with only json formatters.
+                result.Content = new StringContent(
+                    _componentRenderer.RenderMacro(publishedContent, m.Alias, macroParams).ToString(),
+                    Encoding.UTF8,
+                    "text/html");
+
+                return result;
+            }
         }
 
         [HttpPost]

--- a/src/Umbraco.Web/Editors/MacroRenderingController.cs
+++ b/src/Umbraco.Web/Editors/MacroRenderingController.cs
@@ -142,7 +142,7 @@ namespace Umbraco.Web.Editors
                 //need to create a specific content result formatted as HTML since this controller has been configured
                 //with only json formatters.
                 result.Content = new StringContent(
-                    _componentRenderer.RenderMacro(publishedContent, m.Alias, macroParams).ToString(),
+                    _componentRenderer.RenderMacro(pageId, m.Alias, macroParams).ToString(),
                     Encoding.UTF8,
                     "text/html");
 

--- a/src/Umbraco.Web/IUmbracoComponentRenderer.cs
+++ b/src/Umbraco.Web/IUmbracoComponentRenderer.cs
@@ -42,5 +42,15 @@ namespace Umbraco.Web
         /// <param name="parameters">The parameters.</param>
         /// <returns></returns>
         IHtmlString RenderMacro(int contentId, string alias, IDictionary<string, object> parameters);
+
+        /// <summary>
+        /// Renders the macro with the specified alias, passing in the specified parameters.
+        /// </summary>
+        /// <param name="content"></param>
+        /// <param name="alias">The alias.</param>
+        /// <param name="parameters">The parameters.</param>
+        /// <returns></returns>
+        IHtmlString RenderMacro(IPublishedContent content, string alias, IDictionary<string, object> parameters);
+
     }
 }

--- a/src/Umbraco.Web/IUmbracoComponentRenderer.cs
+++ b/src/Umbraco.Web/IUmbracoComponentRenderer.cs
@@ -42,15 +42,5 @@ namespace Umbraco.Web
         /// <param name="parameters">The parameters.</param>
         /// <returns></returns>
         IHtmlString RenderMacro(int contentId, string alias, IDictionary<string, object> parameters);
-
-        /// <summary>
-        /// Renders the macro with the specified alias, passing in the specified parameters.
-        /// </summary>
-        /// <param name="content"></param>
-        /// <param name="alias">The alias.</param>
-        /// <param name="parameters">The parameters.</param>
-        /// <returns></returns>
-        IHtmlString RenderMacro(IPublishedContent content, string alias, IDictionary<string, object> parameters);
-
     }
 }

--- a/src/Umbraco.Web/UmbracoComponentRenderer.cs
+++ b/src/Umbraco.Web/UmbracoComponentRenderer.cs
@@ -92,12 +92,12 @@ namespace Umbraco.Web
             if (contentId == default)
                 throw new ArgumentException("Invalid content id " + contentId);
 
-            var content = _umbracoContextAccessor.UmbracoContext.Content?.GetById(true, contentId);
+            var content = _umbracoContextAccessor.UmbracoContext.Content?.GetById(contentId);
 
             if (content == null)
                 throw new InvalidOperationException("Cannot render a macro, no content found by id " + contentId);
 
-            return RenderMacro(alias, parameters, content);
+            return RenderMacro(content, alias, parameters);
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace Umbraco.Web
         /// <param name="parameters">The parameters.</param>
         /// <param name="content">The content used for macro rendering</param>
         /// <returns></returns>
-        private IHtmlString RenderMacro(string alias, IDictionary<string, object> parameters, IPublishedContent content)
+        public IHtmlString RenderMacro(IPublishedContent content, string alias, IDictionary<string, object> parameters)
         {
             if (content == null) throw new ArgumentNullException(nameof(content));
 
@@ -117,51 +117,7 @@ namespace Umbraco.Web
                 x => x.Key.ToLowerInvariant(),
                 i => (i.Value is string) ? HttpUtility.HtmlDecode(i.Value.ToString()) : i.Value);
             
-            var macroControl = _macroRenderer.Render(alias, content, macroProps).GetAsControl();
-
-            string html;
-            if (macroControl is LiteralControl control)
-            {
-                // no need to execute, we already have text
-                html = control.Text;
-            }
-            else
-            {
-                using (var containerPage = new FormlessPage())
-                {
-                    containerPage.Controls.Add(macroControl);
-
-                    using (var output = new StringWriter())
-                    {
-                        // .Execute() does a PushTraceContext/PopTraceContext and writes trace output straight into 'output'
-                        // and I do not see how we could wire the trace context to the current context... so it creates dirty
-                        // trace output right in the middle of the page.
-                        //
-                        // The only thing we can do is fully disable trace output while .Execute() runs and restore afterwards
-                        // which means trace output is lost if the macro is a control (.ascx or user control) that is invoked
-                        // from within Razor -- which makes sense anyway because the control can _not_ run correctly from
-                        // within Razor since it will never be inserted into the page pipeline (which may even not exist at all
-                        // if we're running MVC).
-                        //
-                        // I'm sure there's more things that will get lost with this context changing but I guess we'll figure
-                        // those out as we go along. One thing we lose is the content type response output.
-                        // http://issues.umbraco.org/issue/U4-1599 if it is setup during the macro execution. So
-                        // here we'll save the content type response and reset it after execute is called.
-
-                        var contentType = _umbracoContextAccessor.UmbracoContext.HttpContext.Response.ContentType;
-                        var traceIsEnabled = containerPage.Trace.IsEnabled;
-                        containerPage.Trace.IsEnabled = false;
-                        _umbracoContextAccessor.UmbracoContext.HttpContext.Server.Execute(containerPage, output, true);
-                        containerPage.Trace.IsEnabled = traceIsEnabled;
-                        //reset the content type
-                        _umbracoContextAccessor.UmbracoContext.HttpContext.Response.ContentType = contentType;
-
-                        //Now, we need to ensure that local links are parsed
-                        html = TemplateUtilities.ParseInternalLinks(output.ToString(), _umbracoContextAccessor.UmbracoContext.UrlProvider);
-                    }
-                }
-                    
-            }
+            string html = _macroRenderer.Render(alias, content, macroProps).GetAsText();
 
             return new HtmlString(html);
         }

--- a/src/Umbraco.Web/UmbracoComponentRenderer.cs
+++ b/src/Umbraco.Web/UmbracoComponentRenderer.cs
@@ -107,7 +107,7 @@ namespace Umbraco.Web
         /// <param name="parameters">The parameters.</param>
         /// <param name="content">The content used for macro rendering</param>
         /// <returns></returns>
-        public IHtmlString RenderMacro(IPublishedContent content, string alias, IDictionary<string, object> parameters)
+        private IHtmlString RenderMacro(IPublishedContent content, string alias, IDictionary<string, object> parameters)
         {
             if (content == null) throw new ArgumentNullException(nameof(content));
 

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -146,7 +146,7 @@ namespace Umbraco.Web
         /// <returns></returns>
         public IHtmlString RenderMacro(string alias)
         {
-            return ComponentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, new { });
+            return ComponentRenderer.RenderMacro(AssignedContentItem, alias, new Dictionary<string, object>());
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Umbraco.Web
         /// <returns></returns>
         public IHtmlString RenderMacro(string alias, object parameters)
         {
-            return ComponentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, parameters.ToDictionary<object>());
+            return ComponentRenderer.RenderMacro(AssignedContentItem, alias, parameters.ToDictionary<object>());
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Umbraco.Web
         /// <returns></returns>
         public IHtmlString RenderMacro(string alias, IDictionary<string, object> parameters)
         {
-            return ComponentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, parameters);
+            return ComponentRenderer.RenderMacro(AssignedContentItem, alias, parameters);
         }
 
         #endregion

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -146,7 +146,7 @@ namespace Umbraco.Web
         /// <returns></returns>
         public IHtmlString RenderMacro(string alias)
         {
-            return ComponentRenderer.RenderMacro(AssignedContentItem, alias, new Dictionary<string, object>());
+            return ComponentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, new Dictionary<string, object>());
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Umbraco.Web
         /// <returns></returns>
         public IHtmlString RenderMacro(string alias, object parameters)
         {
-            return ComponentRenderer.RenderMacro(AssignedContentItem, alias, parameters.ToDictionary<object>());
+            return ComponentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, parameters.ToDictionary<object>());
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Umbraco.Web
         /// <returns></returns>
         public IHtmlString RenderMacro(string alias, IDictionary<string, object> parameters)
         {
-            return ComponentRenderer.RenderMacro(AssignedContentItem, alias, parameters);
+            return ComponentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, parameters);
         }
 
         #endregion


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
`UmbracoHelper.RenderMacro` always renders the macro as though in preview mode. Also, the results of macros rendered inside grid editors or RTEs are cached even though they're based on preview content. That cached result can then be shown when viewing the page.

`MacroRenderingController` explicitly requests the preview version of the content, which is correct since it's used by the editors. However, `UmbracoContext.InPreviewMode` is still false, so `MacroRenderer` will cache the result. Calling `UmbracoContext.ForcedPreview` fixes this.

`UmbracoComponentRenderer` also explicitly requests the preview version. This is necessary when being called from `MacroRenderingController`, but also affects `UmbracoHelper`.

### Testing
UmbracoHelper:
- Create a doctype with a text string property `text` and an RTE.
- Create a macro which displays the value of `text`.
- Include that macro in the template with `Umbraco.RenderMacro`.
- Create a document and set the text property to "Published value". Save and publish.
- Set the text property to "Unpublished value" and Save.
- Check that previewing the page shows "Unpublished value" and viewing the page normally shows "Published value".

RTE:
- Enable inserting and rendering the macro in rich text editors, and set a long cache duration.
- Remove `RenderMacro` from the template and add the RTE value.
- Insert the macro in the RTE, check that "Unpublished value" is shown in the editor.
- View the page and check that "Published value" is shown.

---
_This item has been added to our backlog [AB#3414](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/3414)_