### PR TITLE
Get EnableComposer and DisableComposer attributes from all assemblies

### DIFF
--- a/src/Umbraco.Core/Composing/Composers.cs
+++ b/src/Umbraco.Core/Composing/Composers.cs
@@ -26,18 +26,16 @@ namespace Umbraco.Core.Composing
         /// Initializes a new instance of the <see cref="Composers" /> class.
         /// </summary>
         /// <param name="composition">The composition.</param>
-        /// <param name="composerTypes">The composer types.</param>
-        /// <param name="enableDisableAttributes">The enable/disable attributes.</param>
-        /// <param name="logger">A profiling logger.</param>
-        /// <exception cref="ArgumentNullException">
-        /// composition
+        /// <param name="composerTypes">The <see cref="IComposer" /> types.</param>
+        /// <param name="enableDisableAttributes">The <see cref="EnableComposerAttribute" /> and/or <see cref="DisableComposerAttribute" /> attributes.</param>
+        /// <param name="logger">The profiling logger.</param>
+        /// <exception cref="ArgumentNullException">composition
         /// or
         /// composerTypes
         /// or
         /// enableDisableAttributes
         /// or
-        /// logger
-        /// </exception>
+        /// logger</exception>
 
         public Composers(Composition composition, IEnumerable<Type> composerTypes, IEnumerable<Attribute> enableDisableAttributes, IProfilingLogger logger)
         {

--- a/src/Umbraco.Core/Composing/Composers.cs
+++ b/src/Umbraco.Core/Composing/Composers.cs
@@ -27,6 +27,28 @@ namespace Umbraco.Core.Composing
         /// </summary>
         /// <param name="composition">The composition.</param>
         /// <param name="composerTypes">The <see cref="IComposer" /> types.</param>
+        /// <param name="logger">The profiling logger.</param>
+        [Obsolete("This overload only gets the EnableComposer/DisableComposer attributes from the composerTypes assemblies.")]
+        public Composers(Composition composition, IEnumerable<Type> composerTypes, IProfilingLogger logger)
+            : this(composition, composerTypes, Enumerable.Empty<Attribute>(), logger)
+        {
+            var enableDisableAttributes = new List<Attribute>();
+
+            var assemblies = composerTypes.Select(t => t.Assembly).Distinct();
+            foreach (var assembly in assemblies)
+            {
+                enableDisableAttributes.AddRange(assembly.GetCustomAttributes(typeof(EnableComposerAttribute)));
+                enableDisableAttributes.AddRange(assembly.GetCustomAttributes(typeof(DisableComposerAttribute)));
+            }
+
+            _enableDisableAttributes = enableDisableAttributes;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Composers" /> class.
+        /// </summary>
+        /// <param name="composition">The composition.</param>
+        /// <param name="composerTypes">The <see cref="IComposer" /> types.</param>
         /// <param name="enableDisableAttributes">The <see cref="EnableComposerAttribute" /> and/or <see cref="DisableComposerAttribute" /> attributes.</param>
         /// <param name="logger">The profiling logger.</param>
         /// <exception cref="ArgumentNullException">composition

--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -521,6 +521,17 @@ namespace Umbraco.Core.Composing
         }
 
         /// <summary>
+        /// Gets all the assembly attributes.
+        /// </summary>
+        /// <returns>
+        /// All assembly attributes.
+        /// </returns>
+        public IEnumerable<Attribute> GetAssemblyAttributes()
+        {
+            return AssembliesToScan.SelectMany(a => a.GetCustomAttributes()).ToList();
+        }
+
+        /// <summary>
         /// Gets the assembly attributes of the specified <paramref name="attributeTypes" />.
         /// </summary>
         /// <param name="attributeTypes">The attribute types.</param>

--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -508,20 +508,20 @@ namespace Umbraco.Core.Composing
         #region Get Assembly Attributes
 
         /// <summary>
-        /// Gets the assembly attributes.
+        /// Gets the assembly attributes of the specified type <typeparamref name="T" />.
         /// </summary>
         /// <typeparam name="T">The attribute type.</typeparam>
         /// <returns>
-        /// The assembly attributes of the specified type.
+        /// The assembly attributes of the specified type <typeparamref name="T" />.
         /// </returns>
         public IEnumerable<T> GetAssemblyAttributes<T>()
             where T : Attribute
         {
-            return AssembliesToScan.SelectMany(a => a.GetCustomAttributes<T>());
+            return AssembliesToScan.SelectMany(a => a.GetCustomAttributes<T>()).ToList();
         }
 
         /// <summary>
-        /// Gets the assembly attributes.
+        /// Gets the assembly attributes of the specified <paramref name="attributeTypes" />.
         /// </summary>
         /// <param name="attributeTypes">The attribute types.</param>
         /// <returns>

--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -505,6 +505,38 @@ namespace Umbraco.Core.Composing
 
         #endregion
 
+        #region Get Assembly Attributes
+
+        /// <summary>
+        /// Gets the assembly attributes.
+        /// </summary>
+        /// <typeparam name="T">The attribute type.</typeparam>
+        /// <returns>
+        /// The assembly attributes of the specified type.
+        /// </returns>
+        public IEnumerable<T> GetAssemblyAttributes<T>()
+            where T : Attribute
+        {
+            return AssembliesToScan.SelectMany(a => a.GetCustomAttributes<T>());
+        }
+
+        /// <summary>
+        /// Gets the assembly attributes.
+        /// </summary>
+        /// <param name="attributeTypes">The attribute types.</param>
+        /// <returns>
+        /// The assembly attributes of the specified types.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">attributeTypes</exception>
+        public IEnumerable<Attribute> GetAssemblyAttributes(params Type[] attributeTypes)
+        {
+            if (attributeTypes == null) throw new ArgumentNullException(nameof(attributeTypes));
+
+            return AssembliesToScan.SelectMany(a => attributeTypes.SelectMany(at => a.GetCustomAttributes(at))).ToList();
+        }
+
+        #endregion
+
         #region Get Types
 
         /// <summary>

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -147,8 +147,9 @@ namespace Umbraco.Core.Runtime
 
                 // get composers, and compose
                 var composerTypes = ResolveComposerTypes(typeLoader);
+                var enableDisableAttributes = typeLoader.GetAssemblyAttributes(typeof(EnableComposerAttribute), typeof(DisableComposerAttribute));
                 composition.WithCollectionBuilder<ComponentCollectionBuilder>();
-                var composers = new Composers(composition, composerTypes, typeLoader.AssembliesToScan, ProfilingLogger);
+                var composers = new Composers(composition, composerTypes, enableDisableAttributes, ProfilingLogger);
                 composers.Compose();
 
                 // create the factory

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -148,7 +148,6 @@ namespace Umbraco.Core.Runtime
                 // get composers, and compose
                 var composerTypes = ResolveComposerTypes(typeLoader);
                 var enableDisableAttributes = typeLoader.GetAssemblyAttributes(typeof(EnableComposerAttribute), typeof(DisableComposerAttribute));
-                composition.WithCollectionBuilder<ComponentCollectionBuilder>();
                 var composers = new Composers(composition, composerTypes, enableDisableAttributes, ProfilingLogger);
                 composers.Compose();
 

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -148,7 +148,7 @@ namespace Umbraco.Core.Runtime
                 // get composers, and compose
                 var composerTypes = ResolveComposerTypes(typeLoader);
                 composition.WithCollectionBuilder<ComponentCollectionBuilder>();
-                var composers = new Composers(composition, composerTypes, ProfilingLogger);
+                var composers = new Composers(composition, composerTypes, typeLoader.AssembliesToScan, ProfilingLogger);
                 composers.Compose();
 
                 // create the factory

--- a/src/Umbraco.Tests/Components/ComponentTests.cs
+++ b/src/Umbraco.Tests/Components/ComponentTests.cs
@@ -5,15 +5,12 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Core;
 using Umbraco.Core.Cache;
-using Umbraco.Core.Compose;
 using Umbraco.Core.Composing;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Mappers;
 using Umbraco.Core.Scoping;
-
-[assembly:DisableComposer(typeof(Umbraco.Tests.Components.ComponentTests.Composer26))]
 
 namespace Umbraco.Tests.Components
 {
@@ -356,14 +353,15 @@ namespace Umbraco.Tests.Components
             var typeLoader = MockTypeLoader();
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
-            var types = new[] { typeof(Composer26) }; // 26 disabled by assembly attribute
-            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
+            var types = new[] { typeof(Composer26) };
+            var enableDisableAttributes = new[] { new DisableComposerAttribute(typeof(Composer26)) };
+            var composers = new Composers(composition, types, enableDisableAttributes, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(0, Composed.Count); // 26 gone
 
             types = new[] { typeof(Composer26), typeof(Composer27) }; // 26 disabled by assembly attribute, enabled by 27
-            composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, enableDisableAttributes, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(2, Composed.Count); // both
@@ -519,7 +517,6 @@ namespace Umbraco.Tests.Components
         public class Composer25 : TestComposerBase, IComposer23
         { }
 
-        // disabled by assembly attribute
         public class Composer26 : TestComposerBase
         { }
 

--- a/src/Umbraco.Tests/Components/ComponentTests.cs
+++ b/src/Umbraco.Tests/Components/ComponentTests.cs
@@ -69,7 +69,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = TypeArray<Composer1, Composer2, Composer3, Composer4>();
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             // 2 is Core and requires 4
             // 3 is User - goes away with RuntimeLevel.Unknown
@@ -109,7 +109,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Run));
 
             var types = TypeArray<Composer1, Composer2, Composer3, Composer4>();
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             // 2 is Core and requires 4
             // 3 is User - stays with RuntimeLevel.Run
@@ -126,7 +126,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = TypeArray<Composer20, Composer21>();
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             // 21 is required by 20
             // => reorder components accordingly
@@ -142,7 +142,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = TypeArray<Composer22, Composer24, Composer25>();
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             // i23 requires 22
             // 24, 25 implement i23
@@ -160,7 +160,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = TypeArray<Composer1, Composer2, Composer3>();
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             try
             {
@@ -184,7 +184,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = TypeArray<Composer2, Composer4, Composer13>();
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             // 2 is Core and requires 4
             // 13 is required by 1
@@ -220,7 +220,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer1), typeof(Composer5), typeof(Composer5a) };
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
 
             Assert.IsEmpty(Composed);
             composers.Compose();
@@ -247,7 +247,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer6), typeof(Composer7), typeof(Composer8) };
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(2, Composed.Count);
@@ -263,7 +263,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer9), typeof(Composer2), typeof(Composer4) };
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(2, Composed.Count);
@@ -281,7 +281,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Run));
 
             var types = new[] { typeof(Composer9), typeof(Composer2), typeof(Composer4) };
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             var builder = composition.WithCollectionBuilder<ComponentCollectionBuilder>();
@@ -301,32 +301,32 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer10) };
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(1, Composed.Count);
             Assert.AreEqual(typeof(Composer10), Composed[0]);
 
             types = new[] { typeof(Composer11) };
-            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             Assert.Throws<Exception>(() => composers.Compose());
             Console.WriteLine("throws:");
-            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             var requirements = composers.GetRequirements(false);
             Console.WriteLine(Composers.GetComposersReport(requirements));
 
             types = new[] { typeof(Composer2) };
-            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             Assert.Throws<Exception>(() => composers.Compose());
             Console.WriteLine("throws:");
-            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             requirements = composers.GetRequirements(false);
             Console.WriteLine(Composers.GetComposersReport(requirements));
 
             types = new[] { typeof(Composer12) };
-            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(1, Composed.Count);
@@ -341,7 +341,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer6), typeof(Composer8) }; // 8 disables 7 which is not in the list
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(2, Composed.Count);
@@ -357,13 +357,13 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer26) }; // 26 disabled by assembly attribute
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(0, Composed.Count); // 26 gone
 
             types = new[] { typeof(Composer26), typeof(Composer27) }; // 26 disabled by assembly attribute, enabled by 27
-            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(2, Composed.Count); // both
@@ -380,7 +380,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Run));
 
             var types = typeLoader.GetTypes<IComposer>().Where(x => x.FullName.StartsWith("Umbraco.Core.") || x.FullName.StartsWith("Umbraco.Web"));
-            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, Enumerable.Empty<Attribute>(), Mock.Of<IProfilingLogger>());
             var requirements = composers.GetRequirements();
             var report = Composers.GetComposersReport(requirements);
             Console.WriteLine(report);

--- a/src/Umbraco.Tests/Components/ComponentTests.cs
+++ b/src/Umbraco.Tests/Components/ComponentTests.cs
@@ -65,10 +65,11 @@ namespace Umbraco.Tests.Components
         public void Boot1A()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = TypeArray<Composer1, Composer2, Composer3, Composer4>();
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             // 2 is Core and requires 4
             // 3 is User - goes away with RuntimeLevel.Unknown
@@ -104,10 +105,11 @@ namespace Umbraco.Tests.Components
         public void Boot1B()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Run));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Run));
 
             var types = TypeArray<Composer1, Composer2, Composer3, Composer4>();
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             // 2 is Core and requires 4
             // 3 is User - stays with RuntimeLevel.Run
@@ -120,10 +122,11 @@ namespace Umbraco.Tests.Components
         public void Boot2()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = TypeArray<Composer20, Composer21>();
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             // 21 is required by 20
             // => reorder components accordingly
@@ -135,10 +138,11 @@ namespace Umbraco.Tests.Components
         public void Boot3()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = TypeArray<Composer22, Composer24, Composer25>();
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             // i23 requires 22
             // 24, 25 implement i23
@@ -152,10 +156,11 @@ namespace Umbraco.Tests.Components
         public void BrokenRequire()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = TypeArray<Composer1, Composer2, Composer3>();
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             try
             {
@@ -175,10 +180,11 @@ namespace Umbraco.Tests.Components
         public void BrokenRequired()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = TypeArray<Composer2, Composer4, Composer13>();
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             // 2 is Core and requires 4
             // 13 is required by 1
@@ -196,6 +202,7 @@ namespace Umbraco.Tests.Components
             Terminated.Clear();
 
             var register = MockRegister();
+            var typeLoader = MockTypeLoader();
             var factory = MockFactory(m =>
             {
                 m.Setup(x => x.TryGetInstance(It.Is<Type>(t => t == typeof (ISomeResource)))).Returns(() => new SomeResource());
@@ -210,10 +217,10 @@ namespace Umbraco.Tests.Components
                     throw new NotSupportedException(type.FullName);
                 });
             });
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer1), typeof(Composer5), typeof(Composer5a) };
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
 
             Assert.IsEmpty(Composed);
             composers.Compose();
@@ -236,10 +243,11 @@ namespace Umbraco.Tests.Components
         public void Requires1()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer6), typeof(Composer7), typeof(Composer8) };
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(2, Composed.Count);
@@ -251,10 +259,11 @@ namespace Umbraco.Tests.Components
         public void Requires2A()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer9), typeof(Composer2), typeof(Composer4) };
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(2, Composed.Count);
@@ -267,11 +276,12 @@ namespace Umbraco.Tests.Components
         public void Requires2B()
         {
             var register = MockRegister();
+            var typeLoader = MockTypeLoader();
             var factory = MockFactory();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Run));
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Run));
 
             var types = new[] { typeof(Composer9), typeof(Composer2), typeof(Composer4) };
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             var builder = composition.WithCollectionBuilder<ComponentCollectionBuilder>();
@@ -287,35 +297,36 @@ namespace Umbraco.Tests.Components
         public void WeakDependencies()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer10) };
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(1, Composed.Count);
             Assert.AreEqual(typeof(Composer10), Composed[0]);
 
             types = new[] { typeof(Composer11) };
-            composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             Assert.Throws<Exception>(() => composers.Compose());
             Console.WriteLine("throws:");
-            composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             var requirements = composers.GetRequirements(false);
             Console.WriteLine(Composers.GetComposersReport(requirements));
 
             types = new[] { typeof(Composer2) };
-            composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             Assert.Throws<Exception>(() => composers.Compose());
             Console.WriteLine("throws:");
-            composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             requirements = composers.GetRequirements(false);
             Console.WriteLine(Composers.GetComposersReport(requirements));
 
             types = new[] { typeof(Composer12) };
-            composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(1, Composed.Count);
@@ -326,10 +337,11 @@ namespace Umbraco.Tests.Components
         public void DisableMissing()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer6), typeof(Composer8) }; // 8 disables 7 which is not in the list
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(2, Composed.Count);
@@ -341,16 +353,17 @@ namespace Umbraco.Tests.Components
         public void AttributesPriorities()
         {
             var register = MockRegister();
-            var composition = new Composition(register, MockTypeLoader(), Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
+            var typeLoader = MockTypeLoader();
+            var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Unknown));
 
             var types = new[] { typeof(Composer26) }; // 26 disabled by assembly attribute
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(0, Composed.Count); // 26 gone
 
             types = new[] { typeof(Composer26), typeof(Composer27) }; // 26 disabled by assembly attribute, enabled by 27
-            composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             Composed.Clear();
             composers.Compose();
             Assert.AreEqual(2, Composed.Count); // both
@@ -367,7 +380,7 @@ namespace Umbraco.Tests.Components
             var composition = new Composition(register, typeLoader, Mock.Of<IProfilingLogger>(), MockRuntimeState(RuntimeLevel.Run));
 
             var types = typeLoader.GetTypes<IComposer>().Where(x => x.FullName.StartsWith("Umbraco.Core.") || x.FullName.StartsWith("Umbraco.Web"));
-            var composers = new Composers(composition, types, Mock.Of<IProfilingLogger>());
+            var composers = new Composers(composition, types, typeLoader.AssembliesToScan, Mock.Of<IProfilingLogger>());
             var requirements = composers.GetRequirements();
             var report = Composers.GetComposersReport(requirements);
             Console.WriteLine(report);

--- a/src/Umbraco.Tests/Runtimes/StandaloneTests.cs
+++ b/src/Umbraco.Tests/Runtimes/StandaloneTests.cs
@@ -83,7 +83,7 @@ namespace Umbraco.Tests.Runtimes
             var composerTypes = typeLoader.GetTypes<IComposer>() // all of them
                 .Where(x => !x.FullName.StartsWith("Umbraco.Tests.")) // exclude test components
                 .Where(x => x != typeof(WebInitialComposer) && x != typeof(WebFinalComposer)); // exclude web runtime
-            var composers = new Composers(composition, composerTypes, typeLoader.AssembliesToScan, profilingLogger);
+            var composers = new Composers(composition, composerTypes, Enumerable.Empty<Attribute>(), profilingLogger);
             composers.Compose();
 
             // must registers stuff that WebRuntimeComponent would register otherwise
@@ -272,7 +272,7 @@ namespace Umbraco.Tests.Runtimes
                 .Where(x => !x.FullName.StartsWith("Umbraco.Tests"));
             // single?
             //var componentTypes = new[] { typeof(CoreRuntimeComponent) };
-            var composers = new Composers(composition, composerTypes, typeLoader.AssembliesToScan, profilingLogger);
+            var composers = new Composers(composition, composerTypes, Enumerable.Empty<Attribute>(), profilingLogger);
 
             // get components to compose themselves
             composers.Compose();

--- a/src/Umbraco.Tests/Runtimes/StandaloneTests.cs
+++ b/src/Umbraco.Tests/Runtimes/StandaloneTests.cs
@@ -83,7 +83,7 @@ namespace Umbraco.Tests.Runtimes
             var composerTypes = typeLoader.GetTypes<IComposer>() // all of them
                 .Where(x => !x.FullName.StartsWith("Umbraco.Tests.")) // exclude test components
                 .Where(x => x != typeof(WebInitialComposer) && x != typeof(WebFinalComposer)); // exclude web runtime
-            var composers = new Composers(composition, composerTypes, profilingLogger);
+            var composers = new Composers(composition, composerTypes, typeLoader.AssembliesToScan, profilingLogger);
             composers.Compose();
 
             // must registers stuff that WebRuntimeComponent would register otherwise
@@ -272,7 +272,7 @@ namespace Umbraco.Tests.Runtimes
                 .Where(x => !x.FullName.StartsWith("Umbraco.Tests"));
             // single?
             //var componentTypes = new[] { typeof(CoreRuntimeComponent) };
-            var composers = new Composers(composition, composerTypes, profilingLogger);
+            var composers = new Composers(composition, composerTypes, typeLoader.AssembliesToScan, profilingLogger);
 
             // get components to compose themselves
             composers.Compose();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6624.

### Description
The changes in this PR makes sure all `EnableComposer` and `DisableComposer` attributes are loaded from all assemblies and not only those containing `IComposer`s.

I've done what @zpqrtbnk suggested first (https://github.com/umbraco/Umbraco-CMS/issues/6624#issuecomment-539911444): passing all assemblies in the `Composers` constructor. This made testing a lot harder and didn't feel right, as you're also passing in assemblies that aren't even used...

So I've introduced `GetAssemblyAttributes<T>()` and `GetAssemblyAttributes(param Type[] attributeTypes)` to `TypeLoader`, making it easy to retrieve all assembly attributes (from the same assemblies the types are loaded, e.g. without the known exclusions).

The final fix only passes the attributes to the `Composers` constructor. This is more in-line with how the `IComposer` types are passed in and makes testing easier (although I'm not sure how to test loading the attributes from external/empty assemblies).
