### PR TITLE
V7: Don't call ClearPreviewXmlContent from ClearDocumentXmlCache

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/content.cs
+++ b/src/Umbraco.Web/umbraco.presentation/content.cs
@@ -478,8 +478,6 @@ namespace umbraco
                     safeXml.AcceptChanges();
                 }
             }
-
-            ClearPreviewXmlContent(id);
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6629

### Description
Removing a document from the in-memory XML cache also removes it (and all its descendants) from the in-memory XML cache for preview, so it is no longer possible to preview the descendants.

Testing:
- Unpublish a page which has some descendants
- Preview one of the descendants, you should get a correct preview rather than a 404.