### PR TITLE
V8: Filter out invalid selections in the MNTP "Allowed items" picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.controller.js
@@ -42,6 +42,11 @@ function TreeSourceTypePickerController($scope, contentTypeResource, mediaTypeRe
 
         var editor = {
             multiPicker: true,
+            filterCssClass: "not-allowed not-published",
+            filter: function (item) {
+                // filter out folders (containers), element types (for content) and already selected items
+                return item.nodeType === "container" || item.metaData.isElement || _.findWhere(vm.itemTypes, { udi: item.udi }) !== null;
+            },
             submit: function (model) {
                 var newItemTypes = _.map(model.selection,
                     function(selected) {

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.controller.js
@@ -45,7 +45,7 @@ function TreeSourceTypePickerController($scope, contentTypeResource, mediaTypeRe
             filterCssClass: "not-allowed not-published",
             filter: function (item) {
                 // filter out folders (containers), element types (for content) and already selected items
-                return item.nodeType === "container" || item.metaData.isElement || _.findWhere(vm.itemTypes, { udi: item.udi }) !== null;
+                return item.nodeType === "container" || item.metaData.isElement || !!_.findWhere(vm.itemTypes, { udi: item.udi });
             },
             submit: function (model) {
                 var newItemTypes = _.map(model.selection,

--- a/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
@@ -49,8 +49,10 @@ namespace Umbraco.Web.Trees
             //if the request is for folders only then just return
             if (queryStrings["foldersonly"].IsNullOrWhiteSpace() == false && queryStrings["foldersonly"] == "1") return nodes;
 
+            var children = Services.EntityService.GetChildren(intId.Result, UmbracoObjectTypes.DocumentType).ToArray();
+            var contentTypes = Services.ContentTypeService.GetAll(children.Select(c => c.Id).ToArray()).ToDictionary(c => c.Id);
             nodes.AddRange(
-                Services.EntityService.GetChildren(intId.Result, UmbracoObjectTypes.DocumentType)
+                children
                     .OrderBy(entity => entity.Name)
                     .Select(dt =>
                     {
@@ -60,6 +62,12 @@ namespace Umbraco.Web.Trees
                         var node = CreateTreeNode(dt, Constants.ObjectTypes.DocumentType, id, queryStrings, Constants.Icons.ContentType, hasChildren);
 
                         node.Path = dt.Path;
+
+                        // enrich the result with content type data that's not available in the entity service output
+                        var contentType = contentTypes[dt.Id];
+                        node.Alias = contentType.Alias;
+                        node.AdditionalData["isElement"] = contentType.IsElement;
+
                         return node;
                     }));
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The "Allowed items" picker does not impose any limitations when configuring the MNTP. In fact it allows you to select container nodes (folders), even though that makes no sense whatsoever and also leads to an error:

![image](https://user-images.githubusercontent.com/7405322/66561361-9f600e80-eb59-11e9-807b-32f603e80817.png)

This PR imposes the following restrictions on the "Allowed items" picker:

1. Do not pick containers (folders).
2. Do not pick element types (specifically for content).
3. Do not pick any item that has already been picked.

It all comes together like this:

![tree-source-invalid-selections](https://user-images.githubusercontent.com/7405322/66561475-d504f780-eb59-11e9-9908-ce518228dcc0.gif)
