### PR TITLE
V8: Use a content type picker to pick nested content element types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.controller.js
@@ -42,6 +42,11 @@ function TreeSourceTypePickerController($scope, contentTypeResource, mediaTypeRe
 
         var editor = {
             multiPicker: true,
+            filterCssClass: "not-allowed not-published",
+            filter: function (item) {
+                // filter out folders (containers), element types (for content) and already selected items
+                return item.nodeType === "container" || item.metaData.isElement || _.findWhere(vm.itemTypes, { udi: item.udi }) !== null;
+            },
             submit: function (model) {
                 var newItemTypes = _.map(model.selection,
                     function(selected) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -1,6 +1,6 @@
 ﻿<div id="{{model.alias}}" class="umb-nested-content__doctypepicker" ng-controller="Umbraco.PropertyEditors.NestedContent.DocTypePickerController">
     <div>
-        <table class="table table-striped">
+        <table class="table table-striped table-condensed">
             <thead>
                 <tr>
                     <th/>
@@ -22,9 +22,13 @@
                         <i class="icon icon-navigation handle"></i>
                     </td>
                     <td>
-                        <select id="{{model.alias}}_doctype_select"
-                            ng-options="dt.alias as dt.displayName for dt in selectableDocTypesFor(config) | orderBy: 'name'"
-                            ng-model="config.ncAlias" required></select>
+                        <umb-node-preview
+                            icon="iconFor(config)"
+                            name="displayNameFor(config)"
+                            description="config.ncAlias"
+                            allow-edit="false"
+                            allow-remove="false">
+                        </umb-node-preview>
                     </td>
                     <td>
                         <select id="{{model.alias}}_tab_select"

--- a/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
@@ -49,8 +49,10 @@ namespace Umbraco.Web.Trees
             //if the request is for folders only then just return
             if (queryStrings["foldersonly"].IsNullOrWhiteSpace() == false && queryStrings["foldersonly"] == "1") return nodes;
 
+            var children = Services.EntityService.GetChildren(intId.Result, UmbracoObjectTypes.DocumentType).ToArray();
+            var contentTypes = Services.ContentTypeService.GetAll(children.Select(c => c.Id).ToArray()).ToDictionary(c => c.Id);
             nodes.AddRange(
-                Services.EntityService.GetChildren(intId.Result, UmbracoObjectTypes.DocumentType)
+                children
                     .OrderBy(entity => entity.Name)
                     .Select(dt =>
                     {
@@ -60,6 +62,12 @@ namespace Umbraco.Web.Trees
                         var node = CreateTreeNode(dt, Constants.ObjectTypes.DocumentType, id, queryStrings, Constants.Icons.ContentType, hasChildren);
 
                         node.Path = dt.Path;
+
+                        // enrich the result with content type data that's not available in the entity service output
+                        var contentType = contentTypes[dt.Id];
+                        node.Alias = contentType.Alias;
+                        node.AdditionalData["isElement"] = contentType.IsElement;
+
                         return node;
                     }));
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

 **Please note: This PR builds on top of another PR - #6641**

The current configuration experience for Nested Content isn't very Umbraco-ish with the dropdown selectors for elemtent types:

![image](https://user-images.githubusercontent.com/7405322/66564302-fa94ff80-eb5f-11e9-8434-c27da1978216.png)

This PR makes Nested Content utilize the content type picker to select element types:

![nested-content-contenttype-picker](https://user-images.githubusercontent.com/7405322/66564352-17313780-eb60-11e9-90a5-3dc5a5d52db6.gif)

To make element types easily distinguishable, both the content type icon and the content type alias are displayed.

#### Testing this PR

When testing this PR, ensure that:

1. You can only select element types using the content type picker.
2. The PR is backwards compatible with existing Nested Content configurations.
