### PR TITLE
V8: Fix section and user assignment to groups

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -105,6 +105,7 @@
             var sectionPicker = {
                 selection: currentSelection,
                 submit: function (model) {
+                    vm.userGroup.sections = model.selection;
                     editorService.close();
                 },
                 close: function () {
@@ -168,7 +169,8 @@
             angular.copy(vm.userGroup.users, currentSelection);
             var userPicker = {
                 selection: currentSelection,
-                submit: function () {
+                submit: function (model) {
+                    vm.userGroup.users = model.selection;
                     editorService.close();
                 },
                 close: function () {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#6481 seems to have introduced an unfortunate bug: You can no assign users and sections to groups:

![group-section-and-users-before](https://user-images.githubusercontent.com/7405322/66646033-45c51600-ec25-11e9-91ee-e3933bee10c5.gif)

This PR fixes it; here are the same operations with this PR applied:

![group-section-and-users-after](https://user-images.githubusercontent.com/7405322/66646039-4b226080-ec25-11e9-806f-d0a095d16288.gif)
