### PR TITLE
Show the "remove" action for assigned user groups when editing users

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -71,6 +71,7 @@
                                             sections="userGroup.sections"
                                             content-start-node="userGroup.contentStartNode"
                                             media-start-node="userGroup.mediaStartNode"
+                                            allow-remove="true"
                                             on-remove="model.removeSelectedItem($index, model.user.userGroups)">
                     </umb-user-group-preview>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

You can't remove the assigned user groups directly when editing a user; the workaround is to select "Add" and then deselect the groups you want removed:

![edit-user-remove-groups-before](https://user-images.githubusercontent.com/7405322/66646632-0d263c00-ec27-11e9-839e-5296e99522ac.gif)

By the looks of the code, there's supposed to be a "Remove" option per group - it just hasn't been enabled. So... this PR enables that:

![edit-user-remove-groups](https://user-images.githubusercontent.com/7405322/66646668-25965680-ec27-11e9-8f8a-f78f7d437f94.gif)

