### PR TITLE
Use umb-radiobutton in public access dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/hacks.less
+++ b/src/Umbraco.Web.UI.Client/src/less/hacks.less
@@ -110,10 +110,6 @@ iframe, .content-column-body {
     margin-top: 15px;
 }
 
-.pa-select-type label {
-    padding: 0 20px;
-}
-
 .pa-access-header {
     font-weight: bold;
     margin: 0 0 3px 0;

--- a/src/Umbraco.Web.UI.Client/src/views/content/protect.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/protect.html
@@ -20,8 +20,8 @@
 
                     <umb-pane>
                         <div class="pa-select-type">
-                            <input id="protectionTypeMember" type="radio" name="protectionType" value="member" ng-model="vm.type">
-
+                            <!--<input id="protectionTypeMember" type="radio" name="protectionType" value="member" ng-model="vm.type">-->
+                            <umb-radiobutton id="protectionTypeMember" name="protectionType" value="member" model="vm.type" />
                             <label for="protectionTypeMember">
                                 <h5 class="pa-access-header"><localize key="publicAccess_paMembers">Specific members protection</localize></h5>
                                 <p><localize key="publicAccess_paMembersHelp">If you want to grant access to specific members</localize></p>
@@ -29,8 +29,8 @@
                         </div>
 
                         <div class="pa-select-type">
-                            <input id="protectionTypeGroup" type="radio" name="protectionType" value="group" ng-model="vm.type">
-
+                            <!--<input id="protectionTypeGroup" type="radio" name="protectionType" value="group" ng-model="vm.type">-->
+                            <umb-radiobutton id="protectionTypeGroup" name="protectionType" value="group" model="vm.type" />
                             <label for="protectionTypeGroup">
                                 <h5 class="pa-access-header"><localize key="publicAccess_paGroups">Group based protection</localize></h5>
                                 <p><localize key="publicAccess_paGroupsHelp">If you want to grant access to all members of specific member groups</localize></p>


### PR DESCRIPTION
Currently the public access dialog uses `input type="radio"` . Changed it to use `umb-radiobutton`

![image](https://user-images.githubusercontent.com/3941753/66646875-55416080-ec1f-11e9-9ffa-1432d84d4f4e.png)
