### PR TITLE
Buttons on the healthcheck dashboard made more consistent

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-panel-group.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-panel-group.less
@@ -107,4 +107,5 @@
 .umb-panel-group__details-status-action-description {
     margin-top: 5px;
     font-size: 12px;
+    padding-left:165px;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-panel-group.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-panel-group.less
@@ -107,5 +107,4 @@
 .umb-panel-group__details-status-action-description {
     margin-top: 5px;
     font-size: 12px;
-    padding-left: 165px;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/dashboards/healthcheck.less
+++ b/src/Umbraco.Web.UI.Client/src/less/dashboards/healthcheck.less
@@ -8,7 +8,6 @@
 
 .umb-healthcheck-help-text {
 	line-height: 1.6em;
-	max-width: 750px;
 }
 
 .umb-healthcheck-action-bar {

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/healthcheck.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/healthcheck.html
@@ -4,19 +4,22 @@
 
         <umb-box>
             <umb-box-content>
-                <div class="flex justify-between items-center">
-                    <h3 class="bold">Health Check</h3>
-                    <umb-button
-                        type="button"
-                        button-style="success"
-                        label="Check All Groups"
-                        action="vm.checkAllGroups(vm.groups)">
-                    </umb-button>
-                </div>
 
                 <div class="umb-healthcheck-help-text">
-                    <p>The health checker evaluates various areas of your site for best practice settings, configuration, potential problems, etc. You can easily fix problems by pressing a button.
-                    You can add your own health checks, have a look at <a href="https://our.umbraco.com/documentation/Extending/Healthcheck/" target="_blank" class="btn-link -underline">the documentation for more information</a> about custom health checks.</p>
+                    <p>
+                        The health checker evaluates various areas of your site for best practice settings, configuration, potential problems, etc. You can easily fix problems by pressing a button.
+                        You can add your own health checks, have a look at <a href="https://our.umbraco.com/documentation/Extending/Healthcheck/" target="_blank" class="btn-link -underline">the documentation for more information</a> about custom health checks.
+                    </p>
+                </div>
+
+                <div class="umb-panel-group__details-status-actions">
+                    <div class="umb-panel-group__details-status-action">
+                        <umb-button type="button"
+                                    button-style="success"
+                                    label="Check All Groups"
+                                    action="vm.checkAllGroups(vm.groups)">
+                        </umb-button>
+                    </div>
                 </div>
             </umb-box-content>
         </umb-box>
@@ -26,50 +29,48 @@
             <div class="umb-air" ng-repeat="group in vm.groups">
                 <button type="button" class="umb-healthcheck-group" ng-click="vm.openGroup(group);">
 
-                        <div class="umb-healthcheck-title">{{group.name}}</div>
+                    <div class="umb-healthcheck-title">{{group.name}}</div>
 
-                        <div class="umb-healthcheck-group__load-container" ng-if="group.loading">
-                            <umb-load-indicator></umb-load-indicator>
+                    <div class="umb-healthcheck-group__load-container" ng-if="group.loading">
+                        <umb-load-indicator></umb-load-indicator>
+                    </div>
+
+                    <div class="umb-healthcheck-messages"
+                         ng-hide="group.loading || !group.totalSuccess && !group.totalWarning && !group.totalError && !group.totalInfo">
+
+                        <div class="umb-healthcheck-message" ng-if="group.totalSuccess > 0">
+                            <i class="icon-check color-green" aria-hidden="true"></i>
+                            {{ group.totalSuccess }}
+                            <span class="sr-only">
+                                <localize key="visuallyHiddenTexts_passed">passed</localize>
+                            </span>
                         </div>
 
-                        <div
-                            class="umb-healthcheck-messages"
-                            ng-hide="group.loading || !group.totalSuccess && !group.totalWarning && !group.totalError && !group.totalInfo"
-                        >
-
-                            <div class="umb-healthcheck-message" ng-if="group.totalSuccess > 0">
-                                <i class="icon-check color-green" aria-hidden="true"></i>
-                                {{ group.totalSuccess }}
-                                <span class="sr-only">
-                                    <localize key="visuallyHiddenTexts_passed">passed</localize>
-                                </span>
-                            </div>
-
-                            <div class="umb-healthcheck-message" ng-if="group.totalWarning > 0">
-                                <i class="icon-alert color-orange" aria-hidden="true"></i>
-                                {{ group.totalWarning }}
-                                <span class="sr-only">
-                                    <localize key="visuallyHiddenTexts_warning">warning</localize>
-                                </span>
-                            </div>
-
-                            <div class="umb-healthcheck-message" ng-if="group.totalError > 0">
-                                <i class="icon-delete color-red" aria-hidden="true"></i>
-                                {{ group.totalError }}
-                                <span class="sr-only">
-                                    <localize key="visuallyHiddenTexts_failed">failed</localize>
-                                </span>
-                            </div>
-
-                            <div class="umb-healthcheck-message" ng-if="group.totalInfo > 0">
-                                <i class="umb-healthcheck-status-icon icon-info" aria-hidden="true"></i>
-                                {{ group.totalInfo }}
-                                <span class="sr-only">
-                                    <localize key="visuallyHiddenTexts_suggestion">suggestion</localize>
-                                </span>
-                            </div>
-
+                        <div class="umb-healthcheck-message" ng-if="group.totalWarning > 0">
+                            <i class="icon-alert color-orange" aria-hidden="true"></i>
+                            {{ group.totalWarning }}
+                            <span class="sr-only">
+                                <localize key="visuallyHiddenTexts_warning">warning</localize>
+                            </span>
                         </div>
+
+                        <div class="umb-healthcheck-message" ng-if="group.totalError > 0">
+                            <i class="icon-delete color-red" aria-hidden="true"></i>
+                            {{ group.totalError }}
+                            <span class="sr-only">
+                                <localize key="visuallyHiddenTexts_failed">failed</localize>
+                            </span>
+                        </div>
+
+                        <div class="umb-healthcheck-message" ng-if="group.totalInfo > 0">
+                            <i class="umb-healthcheck-status-icon icon-info" aria-hidden="true"></i>
+                            {{ group.totalInfo }}
+                            <span class="sr-only">
+                                <localize key="visuallyHiddenTexts_suggestion">suggestion</localize>
+                            </span>
+                        </div>
+
+                    </div>
 
                 </button>
             </div>
@@ -95,13 +96,21 @@
 
                 <div class="umb-panel-group__details-group-title">
                     <div class="umb-panel-group__details-group-name">{{ vm.selectedGroup.name }}</div>
-                    <umb-button
-                        type="button"
-                        action="vm.checkAllInGroup(vm.selectedGroup, vm.selectedGroup.checks)"
-                        label="Check group">
-                    </umb-button>
-                </div>
 
+                </div>
+                <div class="umb-panel-group__details-status">
+
+                    <div class="umb-panel-group__details-status-content">
+                        <div class="umb-panel-group__details-status-actions">
+                            <div class="umb-panel-group__details-status-action">
+                                <umb-button type="button" button-style="success"
+                                            action="vm.checkAllInGroup(vm.selectedGroup, vm.selectedGroup.checks)"
+                                            label="Check group">
+                                </umb-button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <div class="umb-panel-group__details-checks">
 
                     <div class="umb-panel-group__details-check" ng-repeat="check in vm.selectedGroup.checks">
@@ -145,16 +154,15 @@
 
                                             <div ng-if="action.valueRequired">
                                                 <div><label class="bold">Set new value:</label></div>
-                                                <input name="providedValue" type="text" ng-model="action.providedValue" required val-email/>
+                                                <input name="providedValue" type="text" ng-model="action.providedValue" required val-email />
                                             </div>
 
-                                            <umb-button
-                                                type="button"
-                                                button-style="success"
-                                                size="s"
-                                                disabled="healthCheckAction.providedValue.$invalid"
-                                                action="vm.executeAction(check, $parent.$index, action)"
-                                                label="{{action.name}}">
+                                            <umb-button type="button"
+                                                        button-style="success"
+                                                        size="s"
+                                                        disabled="healthCheckAction.providedValue.$invalid"
+                                                        action="vm.executeAction(check, $parent.$index, action)"
+                                                        label="{{action.name}}">
                                             </umb-button>
 
                                         </ng-form>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/healthcheck.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/healthcheck.html
@@ -4,28 +4,23 @@
 
         <umb-box>
             <umb-box-content>
-
                 <div class="umb-healthcheck-help-text">
                     <p>
                         The health checker evaluates various areas of your site for best practice settings, configuration, potential problems, etc. You can easily fix problems by pressing a button.
                         You can add your own health checks, have a look at <a href="https://our.umbraco.com/documentation/Extending/Healthcheck/" target="_blank" class="btn-link -underline">the documentation for more information</a> about custom health checks.
                     </p>
                 </div>
-
                 <div class="umb-panel-group__details-status-actions">
-                    <div class="umb-panel-group__details-status-action">
                         <umb-button type="button"
                                     button-style="success"
                                     label="Check All Groups"
                                     action="vm.checkAllGroups(vm.groups)">
-                        </umb-button>
-                    </div>
+                        </umb-button>                    
                 </div>
             </umb-box-content>
         </umb-box>
 
         <div class="umb-healthcheck">
-
             <div class="umb-air" ng-repeat="group in vm.groups">
                 <button type="button" class="umb-healthcheck-group" ng-click="vm.openGroup(group);">
 
@@ -69,14 +64,10 @@
                                 <localize key="visuallyHiddenTexts_suggestion">suggestion</localize>
                             </span>
                         </div>
-
                     </div>
-
                 </button>
             </div>
-
         </div>
-
     </div>
 
     <div ng-if="vm.viewState === 'details'">
@@ -89,39 +80,25 @@
             </umb-editor-sub-header-content-left>
         </umb-editor-sub-header>
 
-
         <div class="umb-panel-group__details">
 
             <div class="umb-panel-group__details-group">
-
                 <div class="umb-panel-group__details-group-title">
                     <div class="umb-panel-group__details-group-name">{{ vm.selectedGroup.name }}</div>
-
+                    <umb-button type="button" button-style="success"
+                                action="vm.checkAllInGroup(vm.selectedGroup, vm.selectedGroup.checks)"
+                                label="Check group">
+                    </umb-button>
                 </div>
-                <div class="umb-panel-group__details-status">
 
-                    <div class="umb-panel-group__details-status-content">
-                        <div class="umb-panel-group__details-status-actions">
-                            <div class="umb-panel-group__details-status-action">
-                                <umb-button type="button" button-style="success"
-                                            action="vm.checkAllInGroup(vm.selectedGroup, vm.selectedGroup.checks)"
-                                            label="Check group">
-                                </umb-button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
                 <div class="umb-panel-group__details-checks">
-
                     <div class="umb-panel-group__details-check" ng-repeat="check in vm.selectedGroup.checks">
-
                         <div class="umb-panel-group__details-check-title">
                             <div class="umb-panel-group__details-check-name">{{ check.name }}</div>
                             <div class="umb-panel-group__details-check-description">{{ check.description }}</div>
                         </div>
 
                         <div class="umb-panel-group__details-status" ng-repeat="status in check.status">
-
                             <div class="umb-panel-group__details-status-icon-container" aria-hidden="true">
                                 <i class="umb-healthcheck-status-icon icon-check color-green" ng-if="status.resultType === 0"></i>
                                 <i class="umb-healthcheck-status-icon icon-alert icon-alert color-yellow" ng-if="status.resultType === 1"></i>
@@ -130,7 +107,6 @@
                             </div>
 
                             <div class="umb-panel-group__details-status-content">
-
                                 <div class="umb-panel-group__details-status-text">
                                     <span class="sr-only" ng-if="status.resultType === 0">
                                         <localize key="visuallyHiddenTexts_checkPassed">Check passed</localize>:
@@ -170,9 +146,7 @@
                                         <div class="umb-panel-group__details-status-action-description" ng-if="action.description" ng-bind-html="action.description"></div>
                                     </div>
                                 </div>
-
                             </div>
-
                         </div>
 
                         <div ng-show="check.loading">
@@ -181,13 +155,8 @@
                         </div>
 
                     </div>
-
                 </div>
-
             </div>
-
         </div>
-
     </div>
-
 </div>


### PR DESCRIPTION
Made the buttons on healthcheck dashboard made more consistent. I have also removed the `h3` heading.

**Before**
![image](https://user-images.githubusercontent.com/3941753/66668169-82583800-ec4c-11e9-8e18-a84063e252f6.png)

![image](https://user-images.githubusercontent.com/3941753/66668184-8e43fa00-ec4c-11e9-812e-65471bb92271.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/66668286-c5b2a680-ec4c-11e9-953f-f20f750b82d9.png)

![image](https://user-images.githubusercontent.com/3941753/66668305-d3682c00-ec4c-11e9-9812-4d661242467d.png)

There was also a big space by the description which I have removed
**Before**
![image](https://user-images.githubusercontent.com/3941753/66668254-b6335d80-ec4c-11e9-9a48-3321deb9c320.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/66668333-ebd84680-ec4c-11e9-964e-71122ce6bc7b.png)
