### PR TITLE
Added polyfills and fixes for older browsers. 

### DIFF
--- a/src/Umbraco.Core/Manifest/ManifestContentAppFactory.cs
+++ b/src/Umbraco.Core/Manifest/ManifestContentAppFactory.cs
@@ -19,6 +19,8 @@ namespace Umbraco.Core.Manifest
     //       '-content/foo',        // hide for content type 'foo'
     //       '+content/*',          // show for all other content types
     //       '+media/*',            // show for all media types
+    //       '-member/foo'          // hide for member type 'foo'
+    //       '+member/*'            // show for all member types
     //       '+role/admin'          // show for admin users. Role based permissions will override others.
     //     ]
     //   },
@@ -55,6 +57,10 @@ namespace Umbraco.Core.Manifest
                 case IMedia media:
                     partA = "media";
                     partB = media.ContentType.Alias;
+                    break;
+                case IMember member:
+                    partA = "member";
+                    partB = member.ContentType.Alias;
                     break;
 
                 default:

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
@@ -6,12 +6,12 @@
 
         function link($scope, $element, $attrs) {
             
-            var appRootNode = $element[0];
+            var $appRootNode = $element.first();
             
             // Directive for cached property groups.
             var propertyGroupNodesDictionary = {};
             
-            var scrollableNode = appRootNode.closest(".umb-scrollable");
+            var scrollableNode = $appRootNode.closest(".umb-scrollable")[0];
             scrollableNode.addEventListener("scroll", onScroll);
             scrollableNode.addEventListener("mousewheel", cancelScrollTween);
             

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/member/umbmembernodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/member/umbmembernodeinfo.directive.js
@@ -1,0 +1,73 @@
+﻿(function () {
+    'use strict';
+
+    function MemberNodeInfoDirective($timeout, $location, eventsService, userService, dateHelper, editorService) {
+
+        function link(scope, element, attrs, ctrl) {
+
+            var evts = [];
+
+            //TODO: Infinite editing is not working yet.
+            scope.allowChangeMemberType = false;
+
+            function onInit() {
+                // make sure dates are formatted to the user's locale
+                formatDatesToLocal();
+            }
+
+            function formatDatesToLocal() {
+                // get current backoffice user and format dates
+                userService.getCurrentUser().then(function (currentUser) {
+                    scope.node.createDateFormatted = dateHelper.getLocalDate(scope.node.createDate, currentUser.locale, 'LLL');
+                    scope.node.updateDateFormatted = dateHelper.getLocalDate(scope.node.updateDate, currentUser.locale, 'LLL');
+                });
+            }
+
+            scope.openMemberType = function (memberType) {
+                var editor = {
+                    id: memberType.id,
+                    submit: function (model) {
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.memberTypeEditor(editor);
+            };
+
+            // watch for content updates - reload content when node is saved, published etc.
+            scope.$watch('node.updateDate', function (newValue, oldValue) {
+                if (!newValue) { return; }
+                if (newValue === oldValue) { return; }
+
+                // Update the create and update dates
+                formatDatesToLocal();
+            });
+
+            //ensure to unregister from all events!
+            scope.$on('$destroy', function () {
+                for (var e in evts) {
+                    eventsService.unsubscribe(evts[e]);
+                }
+            });
+
+            onInit();
+        }
+
+        var directive = {
+            restrict: 'E',
+            replace: true,
+            templateUrl: 'views/components/member/umb-member-node-info.html',
+            scope: {
+                node: "="
+            },
+            link: link
+        };
+
+        return directive;
+    }
+
+    angular.module('umbraco.directives').directive('umbMemberNodeInfo', MemberNodeInfoDirective);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbstickybar.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbstickybar.directive.js
@@ -39,7 +39,7 @@ Use this directive make an element sticky and follow the page when scrolling. `u
         const addSentinel = current => {
             const sentinel = document.createElement('div');
             sentinel.classList.add('umb-sticky-sentinel', '-top');
-            current.parentElement.prepend(sentinel);
+            $(current.parentElement).prepend(sentinel);
         };
 
         /**
@@ -67,10 +67,11 @@ Use this directive make an element sticky and follow the page when scrolling. `u
             headerObserver.observe(current.parentElement.querySelector('.umb-sticky-sentinel.-top'));
         };
 
-        function link(scope, el, attr, ctrl) {
+        function link(scope, $el, attr, ctrl) {
 
-            let current = el[0];
-            let container = current.closest('.umb-editor-container') || current.closest('.umb-dashboard');
+            let $current = $el.first();
+            let current = $current[0];
+            let container = $current.closest('.umb-editor-container')[0] || $current.closest('.umb-dashboard')[0];
 
             if (container) {
                 addSentinel(current);

--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -647,6 +647,23 @@ When building a custom infinite editor view you can use the same components as a
 
         /**
          * @ngdoc method
+         * @name umbraco.services.editorService#memberTypeEditor
+         * @methodOf umbraco.services.editorService
+         *
+         * @description
+         * Opens the member type editor in infinite editing, the submit callback returns the saved member type
+         * @param {Object} editor rendering options
+         * @param {Callback} editor.submit Submits the editor
+         * @param {Callback} editor.close Closes the editor
+         * @returns {Object} editor object
+         */
+        function memberTypeEditor(editor) {
+            editor.view = "views/membertypes/edit.html";
+            open(editor);
+        }
+
+        /**
+         * @ngdoc method
          * @name umbraco.services.editorService#queryBuilder
          * @methodOf umbraco.services.editorService
          *

--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -169,7 +169,19 @@ When building a custom infinite editor view you can use the same components as a
         let editorsKeyboardShorcuts = [];
         var editors = [];
         var isEnabled = true;
-        
+
+        // Polyfill Object.entries
+        if (!Object.entries) {
+            Object.entries = function (obj) {
+                var ownProps = Object.keys(obj),
+                    i = ownProps.length,
+                    resArray = new Array(i); // preallocate the Array
+                while (i--)
+                    resArray[i] = [ownProps[i], obj[ownProps[i]]];
+
+                return resArray;
+            };
+        }
         
         // events for backdrop
         eventsService.on("appState.backdrop", function (name, args) {

--- a/src/Umbraco.Web.UI.Client/src/views/components/member/umb-member-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/member/umb-member-node-info.html
@@ -1,0 +1,38 @@
+<div class="umb-package-details">
+    <div class="umb-package-details__main-content">
+
+    </div>
+
+    <div class="umb-package-details__sidebar">
+        <umb-box data-element="node-info-general">
+            <umb-box-header title-key="general_general"></umb-box-header>
+            <umb-box-content class="block-form">
+
+                <umb-control-group ng-if="node.id !== 0" data-element="node-info-create-date" label="@content_createDate">
+                    {{node.createDateFormatted}} by {{ node.owner.name }}
+                </umb-control-group>
+
+                <umb-control-group ng-if="node.id !== 0" data-element="node-info-update-date" label="@content_updateDate">
+                    {{node.updateDateFormatted}}
+                </umb-control-group>
+
+                <umb-control-group data-element="node-info-document-type" label="@content_documentType">
+                    <umb-node-preview style="max-width: 100%; margin-bottom: 0px;"
+                                      icon="node.icon"
+                                      name="node.contentTypeName"
+                                      alias="node.contentTypeAlias"
+                                      allow-open="allowChangeMemberType"
+                                      on-open="openMemberType(node)">
+                    </umb-node-preview>
+                </umb-control-group>
+
+                <umb-control-group ng-if="node.id !== 0" data-element="node-info-id" label="Id">
+                    <div>{{ node.id }}</div>
+                    <small>{{ node.key }}</small>
+                </umb-control-group>
+
+            </umb-box-content>
+        </umb-box>
+    </div>
+
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
@@ -47,6 +47,65 @@
 
         vm.period = [vm.startDate, vm.endDate];
 
+        // Polyfill Object.entries
+        if (!Object.entries) {
+            Object.entries = function (obj) {
+                var ownProps = Object.keys(obj),
+                    i = ownProps.length,
+                    resArray = new Array(i); // preallocate the Array
+                while (i--)
+                    resArray[i] = [ownProps[i], obj[ownProps[i]]];
+
+                return resArray;
+            };
+        }
+        // Polyfill Array.FindIndex
+        if (!Array.prototype.findIndex) {
+            Object.defineProperty(Array.prototype, 'findIndex', {
+                value: function (predicate) {
+                    // 1. Let O be ? ToObject(this value).
+                    if (this == null) {
+                        throw new TypeError('"this" is null or not defined');
+                    }
+
+                    var o = Object(this);
+
+                    // 2. Let len be ? ToLength(? Get(O, "length")).
+                    var len = o.length >>> 0;
+
+                    // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+                    if (typeof predicate !== 'function') {
+                        throw new TypeError('predicate must be a function');
+                    }
+
+                    // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+                    var thisArg = arguments[1];
+
+                    // 5. Let k be 0.
+                    var k = 0;
+
+                    // 6. Repeat, while k < len
+                    while (k < len) {
+                        // a. Let Pk be ! ToString(k).
+                        // b. Let kValue be ? Get(O, Pk).
+                        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+                        // d. If testResult is true, return k.
+                        var kValue = o[k];
+                        if (predicate.call(thisArg, kValue, k, o)) {
+                            return k;
+                        }
+                        // e. Increase k by 1.
+                        k++;
+                    }
+
+                    // 7. Return -1.
+                    return -1;
+                },
+                configurable: true,
+                writable: true
+            });
+        }
+
         //functions
         vm.searchLogQuery = searchLogQuery;
         vm.findMessageTemplate = findMessageTemplate;

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.controller.js
@@ -1,0 +1,11 @@
+(function () {
+    "use strict";
+
+    function MemberAppContentController($scope) {
+
+        var vm = this;
+
+    }
+
+    angular.module("umbraco").controller("Umbraco.Editors.Member.Apps.ContentController", MemberAppContentController);
+})();

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
@@ -1,0 +1,17 @@
+<div class="form-horizontal" ng-controller="Umbraco.Editors.Member.Apps.ContentController as vm">
+
+    <div class="umb-group-panel" ng-repeat="group in content.tabs track by group.label">
+
+        <div class="umb-group-panel__header">
+            <div>{{ group.label }}</div>
+        </div>
+
+        <div class="umb-group-panel__content">
+            <umb-property data-element="property-{{group.alias}}" ng-repeat="property in group.properties track by property.alias" property="property">
+                <umb-property-editor model="property"></umb-property-editor>
+            </umb-property>
+        </div>
+
+    </div>
+
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/info/info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/info/info.html
@@ -1,0 +1,4 @@
+<umb-member-node-info
+    ng-if="content"
+    node="content">
+</umb-member-node-info>

--- a/src/Umbraco.Web.UI.Client/src/views/member/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/edit.html
@@ -14,27 +14,20 @@
             hide-icon="true"
             hide-description="true"
             hide-alias="true"
+            navigation="content.apps"
+            on-select-navigation-item="appChanged(item)"
             show-back-button="showBack()"
             on-back="onBack()">
           </umb-editor-header>
 
-         <umb-editor-container class="form-horizontal">
-
-            <div class="umb-group-panel" ng-repeat="group in content.tabs track by group.label">
-
-                <div class="umb-group-panel__header">
-                    <div>{{ group.label }}</div>
+          
+        <umb-editor-container>
+            <div class="umb-editor-sub-views" ng-if="!page.loading">
+                <div id="sub-view-{{$index}}" ng-repeat="app in content.apps track by app.alias">
+                    <umb-editor-sub-view model="app" content="content"  />
                 </div>
-
-                <div class="umb-group-panel__content">
-                    <umb-property data-element="property-{{group.alias}}" ng-repeat="property in group.properties track by property.alias" property="property">
-                        <umb-property-editor model="property"></umb-property-editor>
-                    </umb-property>
-                </div>
-
             </div>
-
-         </umb-editor-container>
+        </umb-editor-container>
 
          <umb-editor-footer>
 

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -41,9 +41,7 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
 
                     $scope.content = data;
 
-                    setHeaderNameState($scope.content);
-
-                    editorState.set($scope.content);
+                    init();
 
                     $scope.page.loading = false;
 
@@ -55,9 +53,7 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
                 .then(function (data) {
                     $scope.content = data;
 
-                    setHeaderNameState($scope.content);
-
-                    editorState.set($scope.content);
+                    init();
 
                     $scope.page.loading = false;
 
@@ -86,9 +82,7 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
 
                     $scope.content = data;
 
-                    setHeaderNameState($scope.content);
-
-                    editorState.set($scope.content);
+                    init();
 
                     if (!infiniteMode) {
                         var path = buildTreePath(data);
@@ -117,11 +111,48 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
 
     }
 
-    function setHeaderNameState(content) {
+    function init() {
 
-      if(content.membershipScenario === 0) {
-         $scope.page.nameLocked = true;
-      }
+        var content = $scope.content;
+
+        // we need to check wether an app is present in the current data, if not we will present the default app.
+        var isAppPresent = false;
+
+        // on first init, we dont have any apps. but if we are re-initializing, we do, but ...
+        if ($scope.app) {
+
+            // lets check if it still exists as part of our apps array. (if not we have made a change to our docType, even just a re-save of the docType it will turn into new Apps.)
+            _.forEach(content.apps, function (app) {
+                if (app === $scope.app) {
+                    isAppPresent = true;
+                }
+            });
+
+            // if we did reload our DocType, but still have the same app we will try to find it by the alias.
+            if (isAppPresent === false) {
+                _.forEach(content.apps, function (app) {
+                    if (app.alias === $scope.app.alias) {
+                        isAppPresent = true;
+                        app.active = true;
+                        $scope.appChanged(app);
+                    }
+                });
+            }
+
+        }
+
+        // if we still dont have a app, lets show the first one:
+        if (isAppPresent === false) {
+            content.apps[0].active = true;
+            $scope.appChanged(content.apps[0]);
+        }
+
+        if (content.membershipScenario === 0) {
+            $scope.page.nameLocked = true;
+        }
+
+        editorState.set($scope.content);
+
     }
 
     /** Just shows a simple notification that there are client side validation issues to be fixed */
@@ -189,6 +220,15 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
         }
 
     };
+
+    $scope.appChanged = function (app) {
+        $scope.app = app;
+
+        // setup infinite mode
+        if (infiniteMode) {
+            $scope.page.submitButtonLabelKey = "buttons_saveAndClose";
+        }
+    }
 
     $scope.showBack = function () {
         return !!listName;

--- a/src/Umbraco.Web/ContentApps/ContentEditorContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentEditorContentAppFactory.cs
@@ -14,6 +14,7 @@ namespace Umbraco.Web.ContentApps
 
         private ContentApp _contentApp;
         private ContentApp _mediaApp;
+        private ContentApp _memberApp;
 
         public ContentApp GetContentAppFor(object o, IEnumerable<IReadOnlyUserGroup> userGroups)
         {
@@ -44,6 +45,16 @@ namespace Umbraco.Web.ContentApps
 
                 case IMedia _:
                     return null;
+
+                case IMember _:
+                    return _memberApp ?? (_memberApp = new ContentApp
+                    {
+                        Alias = "umbContent",
+                        Name = "Content",
+                        Icon = Constants.Icons.Content,
+                        View = "views/member/apps/content/content.html",
+                        Weight = Weight
+                    });
 
                 default:
                     throw new NotSupportedException($"Object type {o.GetType()} is not supported here.");

--- a/src/Umbraco.Web/ContentApps/ContentInfoContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentInfoContentAppFactory.cs
@@ -13,6 +13,7 @@ namespace Umbraco.Web.ContentApps
 
         private ContentApp _contentApp;
         private ContentApp _mediaApp;
+        private ContentApp _memberApp;
 
         public ContentApp GetContentAppFor(object o, IEnumerable<IReadOnlyUserGroup> userGroups)
         {
@@ -35,6 +36,15 @@ namespace Umbraco.Web.ContentApps
                         Name = "Info",
                         Icon = "icon-info",
                         View = "views/media/apps/info/info.html",
+                        Weight = Weight
+                    });
+                case IMember _:
+                    return _mediaApp ?? (_mediaApp = new ContentApp
+                    {
+                        Alias = "umbInfo",
+                        Name = "Info",
+                        Icon = "icon-info",
+                        View = "views/member/apps/info/info.html",
                         Weight = Weight
                     });
 

--- a/src/Umbraco.Web/ContentApps/ListViewContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ListViewContentAppFactory.cs
@@ -45,6 +45,8 @@ namespace Umbraco.Web.ContentApps
                     entityType = "media";
                     dtdId = Core.Constants.DataTypes.DefaultMediaListView;
                     break;
+                case IMember member:
+                    return null;
                 default:
                     throw new NotSupportedException($"Object type {o.GetType()} is not supported here.");
             }

--- a/src/Umbraco.Web/Models/ContentEditing/MemberDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/MemberDisplay.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Umbraco.Core.Models;
+using Umbraco.Core.Models.ContentEditing;
 using Umbraco.Core.Models.Membership;
 
 namespace Umbraco.Web.Models.ContentEditing
@@ -15,6 +16,7 @@ namespace Umbraco.Web.Models.ContentEditing
         public MemberDisplay()
         {
             MemberProviderFieldMapping = new Dictionary<string, string>();
+            ContentApps = new List<ContentApp>();
         }
 
         [DataMember(Name = "username")]
@@ -34,5 +36,7 @@ namespace Umbraco.Web.Models.ContentEditing
         [DataMember(Name = "fieldConfig")]
         public IDictionary<string, string> MemberProviderFieldMapping { get; set; }
 
+        [DataMember(Name = "apps")]
+        public IEnumerable<ContentApp> ContentApps { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
@@ -76,6 +76,7 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll -Trashed -IsContainer -VariesByCulture
         private void Map(IMember source, MemberDisplay target, MapperContext context)
         {
+            target.ContentApps = _commonMapper.GetContentApps(source);
             target.ContentTypeId = source.ContentType.Id;
             target.ContentTypeAlias = source.ContentType.Alias;
             target.ContentTypeName = source.ContentType.Name;


### PR DESCRIPTION
Added some polyfills and changed some JS functions to use jQuery functions instead of native JS functions that are less supported (for example in IE11).

This fixes a couple of things:
- Not possible to add/edit links in the RTE editor in IE11 (#5662)
- LogViewer wouldn't work at all
- Some errors in directives

Regarding #5662: The UI does not show the grey overlay because css custom properties are not supported in IE11. Issue #6669