### PR TITLE
Added polyfills and fixes for older browsers (#6688).

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
@@ -6,12 +6,12 @@
 
         function link($scope, $element, $attrs) {
             
-            var appRootNode = $element[0];
+            var $appRootNode = $element.first();
             
             // Directive for cached property groups.
             var propertyGroupNodesDictionary = {};
             
-            var scrollableNode = appRootNode.closest(".umb-scrollable");
+            var scrollableNode = $appRootNode.closest(".umb-scrollable")[0];
             scrollableNode.addEventListener("scroll", onScroll);
             scrollableNode.addEventListener("mousewheel", cancelScrollTween);
             

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbstickybar.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbstickybar.directive.js
@@ -39,7 +39,7 @@ Use this directive make an element sticky and follow the page when scrolling. `u
         const addSentinel = current => {
             const sentinel = document.createElement('div');
             sentinel.classList.add('umb-sticky-sentinel', '-top');
-            current.parentElement.prepend(sentinel);
+            $(current.parentElement).prepend(sentinel);
         };
 
         /**
@@ -67,10 +67,11 @@ Use this directive make an element sticky and follow the page when scrolling. `u
             headerObserver.observe(current.parentElement.querySelector('.umb-sticky-sentinel.-top'));
         };
 
-        function link(scope, el, attr, ctrl) {
+        function link(scope, $el, attr, ctrl) {
 
-            let current = el[0];
-            let container = current.closest('.umb-editor-container') || current.closest('.umb-dashboard');
+            let $current = $el.first();
+            let current = $current[0];
+            let container = $current.closest('.umb-editor-container')[0] || $current.closest('.umb-dashboard')[0];
 
             if (container) {
                 addSentinel(current);

--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -169,7 +169,19 @@ When building a custom infinite editor view you can use the same components as a
         let editorsKeyboardShorcuts = [];
         var editors = [];
         var isEnabled = true;
-        
+
+        // Polyfill Object.entries
+        if (!Object.entries) {
+            Object.entries = function (obj) {
+                var ownProps = Object.keys(obj),
+                    i = ownProps.length,
+                    resArray = new Array(i); // preallocate the Array
+                while (i--)
+                    resArray[i] = [ownProps[i], obj[ownProps[i]]];
+
+                return resArray;
+            };
+        }
         
         // events for backdrop
         eventsService.on("appState.backdrop", function (name, args) {

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
@@ -47,6 +47,65 @@
 
         vm.period = [vm.startDate, vm.endDate];
 
+        // Polyfill Object.entries
+        if (!Object.entries) {
+            Object.entries = function (obj) {
+                var ownProps = Object.keys(obj),
+                    i = ownProps.length,
+                    resArray = new Array(i); // preallocate the Array
+                while (i--)
+                    resArray[i] = [ownProps[i], obj[ownProps[i]]];
+
+                return resArray;
+            };
+        }
+        // Polyfill Array.FindIndex
+        if (!Array.prototype.findIndex) {
+            Object.defineProperty(Array.prototype, 'findIndex', {
+                value: function (predicate) {
+                    // 1. Let O be ? ToObject(this value).
+                    if (this == null) {
+                        throw new TypeError('"this" is null or not defined');
+                    }
+
+                    var o = Object(this);
+
+                    // 2. Let len be ? ToLength(? Get(O, "length")).
+                    var len = o.length >>> 0;
+
+                    // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+                    if (typeof predicate !== 'function') {
+                        throw new TypeError('predicate must be a function');
+                    }
+
+                    // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+                    var thisArg = arguments[1];
+
+                    // 5. Let k be 0.
+                    var k = 0;
+
+                    // 6. Repeat, while k < len
+                    while (k < len) {
+                        // a. Let Pk be ! ToString(k).
+                        // b. Let kValue be ? Get(O, Pk).
+                        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+                        // d. If testResult is true, return k.
+                        var kValue = o[k];
+                        if (predicate.call(thisArg, kValue, k, o)) {
+                            return k;
+                        }
+                        // e. Increase k by 1.
+                        k++;
+                    }
+
+                    // 7. Return -1.
+                    return -1;
+                },
+                configurable: true,
+                writable: true
+            });
+        }
+
         //functions
         vm.searchLogQuery = searchLogQuery;
         vm.findMessageTemplate = findMessageTemplate;


### PR DESCRIPTION
Added some polyfills and changed some JS functions to use jQuery functions instead of native JS functions that are less supported (for example in IE11).

This fixes a couple of things:
- Not possible to add/edit links in the RTE editor in IE11 (#5662)
- LogViewer wouldn't work at all
- Some errors in directives

Regarding #5662: The UI does not show the grey overlay because css custom properties are not supported in IE11. Issue #6669