### PR TITLE
V8: Handle permissions for users in multiple groups

### DIFF
--- a/src/Umbraco.Core/Services/UserServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/UserServiceExtensions.cs
@@ -104,5 +104,17 @@ namespace Umbraco.Core.Services
 
             return found;
         }
+
+        /// <summary>
+        /// Gets the concrete assigned permissions for the provided user and node
+        /// </summary>
+        /// <param name="userService"></param>
+        /// <param name="user"></param>
+        /// <param name="nodeId"></param>
+        internal static string[] GetAssignedPermissions(this IUserService userService, IUser user, int nodeId)
+        {
+            var permissionCollection = userService.GetPermissions(user, nodeId);
+            return permissionCollection.SelectMany(c => c.AssignedPermissions).Distinct().ToArray();
+        }
     }
 }

--- a/src/Umbraco.Web/Actions/ActionCollection.cs
+++ b/src/Umbraco.Web/Actions/ActionCollection.cs
@@ -28,15 +28,5 @@ namespace Umbraco.Web.Actions
                 .WhereNotNull()
                 .ToList();
         }
-
-        internal IReadOnlyList<IAction> FromEntityPermission(EntityPermission entityPermission)
-        {
-            var actions = this.ToArray(); // no worry: internally, it's already an array
-            return entityPermission.AssignedPermissions
-                .Where(x => x.Length == 1)
-                .SelectMany(x => actions.Where(y => y.Letter == x[0]))
-                .WhereNotNull()
-                .ToList();
-        }
     }
 }

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -1679,9 +1679,9 @@ namespace Umbraco.Web.Editors
                 throw new HttpResponseException(response);
             }
 
-            var permission = Services.UserService.GetPermissions(Security.CurrentUser, node.Path);
+            var assignedPermissions = Services.UserService.GetAssignedPermissions(Security.CurrentUser, node.Id);
 
-            if (permission.AssignedPermissions.Contains(ActionAssignDomain.ActionLetter.ToString(), StringComparer.Ordinal) == false)
+            if (assignedPermissions.Contains(ActionAssignDomain.ActionLetter.ToString(), StringComparer.Ordinal) == false)
             {
                 var response = Request.CreateResponse(HttpStatusCode.BadRequest);
                 response.Content = new StringContent("You do not have permission to assign domains on that node.");

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -124,8 +124,8 @@ namespace Umbraco.Web.Trees
                 menu.DefaultMenuAlias = ActionNew.ActionAlias;
 
                 // we need to get the default permissions as you can't set permissions on the very root node
-                var permission = Services.UserService.GetPermissions(Security.CurrentUser, Constants.System.Root).First();
-                var nodeActions = _actions.FromEntityPermission(permission)
+                var assignedPermissions = Services.UserService.GetAssignedPermissions(Security.CurrentUser, Constants.System.Root);
+                var nodeActions = _actions.GetByLetters(assignedPermissions)
                     .Select(x => new MenuItem(x));
 
                 //these two are the standard items

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -442,8 +442,8 @@ namespace Umbraco.Web.Trees
 
         internal IEnumerable<MenuItem> GetAllowedUserMenuItemsForNode(IUmbracoEntity dd)
         {
-            var permission = Services.UserService.GetPermissions(Security.CurrentUser, dd.Path);
-            return Current.Actions.FromEntityPermission(permission).Select(x => new MenuItem(x));
+            var assignedPermissions = Services.UserService.GetAssignedPermissions(Security.CurrentUser, dd.Id);
+            return Current.Actions.GetByLetters(assignedPermissions).Select(x => new MenuItem(x));
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6647

### Description

This PR fixes an issue with item context menus permissions for users that are assigned multiple groups. See #6647 for an excellent description of the issue.

#### Testing this PR

1. Create a new user and assign two groups with different permissions defined; e.g. the Writers and the Editors groups.
2. Log in as this user and verify that all actions defined for both groups are available in the context menu for content items.
3. As the administrator, assign specific permissions to a content node, changing the access for the chosen groups.
4. As the new user, verify that the specific node permissions are applied.
