### PR TITLE
V8: Add validation to user groups when creating new users

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -359,6 +359,8 @@
                                 <localize key="general_add">Add</localize>
                             </a>
 
+                            <input type="hidden" ng-model="vm.newUser.userGroupsValidation" ng-required="!vm.newUser.userGroups.length" />
+
                         </umb-control-group>
 
                         <umb-control-group label="@general_message" ng-if="vm.usersViewState === 'inviteUser'" label-for="message" required="true">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

A new user can't be created without at least one group assignment. But there is no clientside validation of this, only serverside validation. And there is no meaningful feedback of what went wrong when user creation fails because of missing group assignments:

![create-user-group-validation-before](https://user-images.githubusercontent.com/7405322/66706387-1c45e080-ed32-11e9-8602-cfeaa80a3067.gif)

This PR adds clientside validation to the user group assignment, just as there is clientside validation for the user name and email:

![create-user-group-validation](https://user-images.githubusercontent.com/7405322/66706408-66c75d00-ed32-11e9-9414-8547ab189cce.gif)
