### PR TITLE
Allow hash type on GenerateHash and remove obsoleted ToMd5 and ToSHA1 methods

### DIFF
--- a/src/Umbraco.Core/MainDom.cs
+++ b/src/Umbraco.Core/MainDom.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Web.Hosting;
 using Umbraco.Core.Logging;
@@ -65,7 +65,7 @@ namespace Umbraco.Core
             // a new process for the same application path
 
             var appPath = HostingEnvironment.ApplicationPhysicalPath;
-            var hash = (appId + ":::" + appPath).GenerateHash("SHA1");
+            var hash = (appId + ":::" + appPath).GenerateHash<SHA1>();
 
             var lockName = "UMBRACO-" + hash + "-MAINDOM-LCK";
             _asyncLock = new AsyncLock(lockName);

--- a/src/Umbraco.Core/MainDom.cs
+++ b/src/Umbraco.Core/MainDom.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Core
             // a new process for the same application path
 
             var appPath = HostingEnvironment.ApplicationPhysicalPath;
-            var hash = (appId + ":::" + appPath).ToSHA1();
+            var hash = (appId + ":::" + appPath).GenerateHash("SHA1");
 
             var lockName = "UMBRACO-" + hash + "-MAINDOM-LCK";
             _asyncLock = new AsyncLock(lockName);

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -67,7 +67,7 @@ namespace Umbraco.Core.Models
 
             if (user.Avatar.IsNullOrWhiteSpace())
             {
-                var gravatarHash = user.Email.GenerateHash("MD5");
+                var gravatarHash = user.Email.GenerateHash<MD5>();
                 var gravatarUrl = "https://www.gravatar.com/avatar/" + gravatarHash + "?d=404";
 
                 //try Gravatar

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -67,7 +67,7 @@ namespace Umbraco.Core.Models
 
             if (user.Avatar.IsNullOrWhiteSpace())
             {
-                var gravatarHash = user.Email.ToMd5();
+                var gravatarHash = user.Email.GenerateHash("MD5");
                 var gravatarUrl = "https://www.gravatar.com/avatar/" + gravatarHash + "?d=404";
 
                 //try Gravatar

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using NPoco;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Logging;
@@ -105,7 +106,7 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
                 CreateDateUtc = redirectUrl.CreateDateUtc,
                 Url = redirectUrl.Url,
                 Culture = redirectUrl.Culture,
-                UrlHash = redirectUrl.Url.GenerateHash("SHA1")
+                UrlHash = redirectUrl.Url.GenerateHash<SHA1>()
             };
         }
 
@@ -134,7 +135,7 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
 
         public IRedirectUrl Get(string url, Guid contentKey, string culture)
         {
-            var urlHash = url.GenerateHash("SHA1");
+            var urlHash = url.GenerateHash<SHA1>();
             var sql = GetBaseQuery(false).Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash && x.ContentKey == contentKey && x.Culture == culture);
             var dto = Database.Fetch<RedirectUrlDto>(sql).FirstOrDefault();
             return dto == null ? null : Map(dto);
@@ -157,7 +158,7 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
 
         public IRedirectUrl GetMostRecentUrl(string url)
         {
-            var urlHash = url.GenerateHash("SHA1");
+            var urlHash = url.GenerateHash<SHA1>();
             var sql = GetBaseQuery(false)
                 .Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash)
                 .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -105,7 +105,7 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
                 CreateDateUtc = redirectUrl.CreateDateUtc,
                 Url = redirectUrl.Url,
                 Culture = redirectUrl.Culture,
-                UrlHash = redirectUrl.Url.ToSHA1()
+                UrlHash = redirectUrl.Url.GenerateHash("SHA1")
             };
         }
 
@@ -134,7 +134,7 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
 
         public IRedirectUrl Get(string url, Guid contentKey, string culture)
         {
-            var urlHash = url.ToSHA1();
+            var urlHash = url.GenerateHash("SHA1");
             var sql = GetBaseQuery(false).Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash && x.ContentKey == contentKey && x.Culture == culture);
             var dto = Database.Fetch<RedirectUrlDto>(sql).FirstOrDefault();
             return dto == null ? null : Map(dto);
@@ -157,7 +157,7 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
 
         public IRedirectUrl GetMostRecentUrl(string url)
         {
-            var urlHash = url.ToSHA1();
+            var urlHash = url.GenerateHash("SHA1");
             var sql = GetBaseQuery(false)
                 .Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash)
                 .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);

--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -734,28 +734,6 @@ namespace Umbraco.Core
         }
 
         /// <summary>
-        /// Converts the string to MD5
-        /// </summary>
-        /// <param name="stringToConvert">Refers to itself</param>
-        /// <returns>The MD5 hashed string</returns>
-        [Obsolete("Please use the GenerateHash method instead. This may be removed in future versions")]
-        internal static string ToMd5(this string stringToConvert)
-        {
-            return stringToConvert.GenerateHash("MD5");
-        }
-
-        /// <summary>
-        /// Converts the string to SHA1
-        /// </summary>
-        /// <param name="stringToConvert">refers to itself</param>
-        /// <returns>The SHA1 hashed string</returns>
-        [Obsolete("Please use the GenerateHash method instead. This may be removed in future versions")]
-        internal static string ToSHA1(this string stringToConvert)
-        {
-            return stringToConvert.GenerateHash("SHA1");
-        }
-
-        /// <summary>
         /// Generate a hash of a string based on the specified <paramref name="hashType" />.
         /// </summary>
         /// <param name="str">The <see cref="string" /> to hash.</param>

--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -724,13 +724,13 @@ namespace Umbraco.Core
         /// <summary>
         /// Generates a hash of a string based on the FIPS compliance setting.
         /// </summary>
-        /// <param name="str">Refers to itself</param>
-        /// <returns>The hashed string</returns>
+        /// <param name="str">The <see cref="string" /> to hash.</param>
+        /// <returns>
+        /// The hashed string.
+        /// </returns>
         public static string GenerateHash(this string str)
         {
-            return CryptoConfig.AllowOnlyFipsAlgorithms
-                ? str.ToSHA1()
-                : str.ToMd5();
+            return str.GenerateHash(CryptoConfig.AllowOnlyFipsAlgorithms ? "SHA1" : "MD5");
         }
 
         /// <summary>
@@ -755,36 +755,33 @@ namespace Umbraco.Core
             return stringToConvert.GenerateHash("SHA1");
         }
 
-        /// <summary>Generate a hash of a string based on the hashType passed in
+        /// <summary>
+        /// Generate a hash of a string based on the specified <paramref name="hashType" />.
         /// </summary>
-        /// <param name="str">Refers to itself</param>
-        /// <param name="hashType">String with the hash type.  See remarks section of the CryptoConfig Class in MSDN docs for a list of possible values.</param>
-        /// <returns>The hashed string</returns>
-        private static string GenerateHash(this string str, string hashType)
+        /// <param name="str">The <see cref="string" /> to hash.</param>
+        /// <param name="hashType">The hash algorithm implementation to use.</param>
+        /// <returns>
+        /// The hashed string.
+        /// </returns>
+        /// <exception cref="System.InvalidOperationException">No hashing type found by name <paramref name="hashType" />.</exception>
+        /// <seealso cref="https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.create#System_Security_Cryptography_HashAlgorithm_Create_System_String_" />
+        internal static string GenerateHash(this string str, string hashType)
         {
-            //create an instance of the correct hashing provider based on the type passed in
             var hasher = HashAlgorithm.Create(hashType);
-            if (hasher == null) throw new InvalidOperationException("No hashing type found by name " + hashType);
+            if (hasher == null) throw new InvalidOperationException($"No hashing type found by name {hashType}.");
+
             using (hasher)
             {
-                //convert our string into byte array
                 var byteArray = Encoding.UTF8.GetBytes(str);
-
-                //get the hashed values created by our selected provider
                 var hashedByteArray = hasher.ComputeHash(byteArray);
 
-                //create a StringBuilder object
-                var stringBuilder = new StringBuilder();
-
-                //loop to each byte
+                var sb = new StringBuilder();
                 foreach (var b in hashedByteArray)
                 {
-                    //append it to our StringBuilder
-                    stringBuilder.Append(b.ToString("x2"));
+                    sb.Append(b.ToString("x2"));
                 }
 
-                //return the hashed value
-                return stringBuilder.ToString();
+                return sb.ToString();
             }
         }
 

--- a/src/Umbraco.Core/StringExtensions.cs
+++ b/src/Umbraco.Core/StringExtensions.cs
@@ -734,6 +734,20 @@ namespace Umbraco.Core
         }
 
         /// <summary>
+        /// Generate a hash of a string based on the specified hash algorithm.
+        /// </summary>
+        /// <typeparam name="T">The hash algorithm implementation to use.</typeparam>
+        /// <param name="str">The <see cref="string" /> to hash.</param>
+        /// <returns>
+        /// The hashed string.
+        /// </returns>
+        internal static string GenerateHash<T>(this string str)
+            where T : HashAlgorithm
+        {
+            return str.GenerateHash(typeof(T).FullName);
+        }
+
+        /// <summary>
         /// Generate a hash of a string based on the specified <paramref name="hashType" />.
         /// </summary>
         /// <param name="str">The <see cref="string" /> to hash.</param>

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.Serialization;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Http;
@@ -105,7 +106,7 @@ namespace Umbraco.Web.Editors
             if (Current.Configs.Settings().Content.DisallowedUploadFiles.Contains(ext) == false)
             {
                 //generate a path of known data, we don't want this path to be guessable
-                user.Avatar = "UserAvatars/" + (user.Id + safeFileName).GenerateHash("SHA1") + "." + ext;
+                user.Avatar = "UserAvatars/" + (user.Id + safeFileName).GenerateHash<SHA1>() + "." + ext;
 
                 using (var fs = System.IO.File.OpenRead(file.LocalFileName))
                 {

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -105,7 +105,7 @@ namespace Umbraco.Web.Editors
             if (Current.Configs.Settings().Content.DisallowedUploadFiles.Contains(ext) == false)
             {
                 //generate a path of known data, we don't want this path to be guessable
-                user.Avatar = "UserAvatars/" + (user.Id + safeFileName).ToSHA1() + "." + ext;
+                user.Avatar = "UserAvatars/" + (user.Id + safeFileName).GenerateHash("SHA1") + "." + ext;
 
                 using (var fs = System.IO.File.OpenRead(file.LocalFileName))
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6620.

### Description
These are all the changes needed to remove the obsoleted `ToMd5()` and `ToSHA1()` internal methods and replace them with a generic `GenerateHash()` method that accepts a hash type (https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.create#System_Security_Cryptography_HashAlgorithm_Create_System_String_). See the comments on PR https://github.com/umbraco/Umbraco-CMS/pull/6621.

I've kept the `GenerateHash()` method internal, but maybe this can also be publicly exposed, so everyone can easily create hashes from strings?