### PR TITLE
V8: Fix sorting of the immediate children of editor start nodes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.sort.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.sort.controller.js
@@ -4,7 +4,6 @@
     function ContentSortController($scope, $filter, $routeParams, contentResource, navigationService) {
 
         var vm = this;
-        var parentId = $scope.currentNode.parentId ? $scope.currentNode.parentId : "-1";
         var id = $scope.currentNode.id;
 
         vm.loading = false;
@@ -42,7 +41,7 @@
             vm.saveButtonState = "busy";
             
             var args = {
-                parentId: parentId,
+                parentId: id,
                 sortedIds: _.map(vm.children, function(child){ return child.id; })
             };
 

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.sort.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.sort.controller.js
@@ -4,7 +4,6 @@
     function MediaSortController($scope, $filter, mediaResource, navigationService) {
 
         var vm = this;
-        var parentId = $scope.currentNode.parentId ? $scope.currentNode.parentId : "-1";
         var id = $scope.currentNode.id;
 
         vm.loading = false;
@@ -42,7 +41,7 @@
             vm.saveButtonState = "busy";
             
             var args = {
-                parentId: parentId,
+                parentId: id,
                 sortedIds: _.map(vm.children, function(child){ return child.id; })
             };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6682

### Description

See #6682 for a detailed description; the gist of it is as follows:

When an editor has a start node defined, she can't sort the immediate children of that start node despite having permissions to do so:

![sort-start-node-content-before](https://user-images.githubusercontent.com/7405322/66748695-21b53f00-ee88-11e9-9832-928d108be056.gif)

Same problem exists in the media library, although the error is less gracefully handled: The editor appears to simply be logged out (although she really isn't, it just looks like it):

![sort-start-node-media-before](https://user-images.githubusercontent.com/7405322/66748782-55906480-ee88-11e9-9695-26437089d43d.gif)

It all boils down to a faulty perception of which node is the "parent node" for the sorting operation. The JS incorrectly assumes it's the parent node of the start node, when in reality it is the start node itself. This PR corrects that assumption.

When this PR is applied, sorting works for start nodes in both the content and media sections:

![sort-start-node-content-after](https://user-images.githubusercontent.com/7405322/66748863-912b2e80-ee88-11e9-8320-4f75016d8e08.gif)

![sort-start-node-media-after](https://user-images.githubusercontent.com/7405322/66748868-94beb580-ee88-11e9-9ae7-b9704bde5588.gif)

