### PR TITLE
V8: Prevent/remove duplicate nodes for editors with start nodes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
@@ -810,8 +810,17 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
             var node = args.node;
 
             var doSync = function () {
-                //check if it exists in the already loaded children
-                var child = self.getChildNode(node, args.path[currPathIndex]);
+                // dig through the rest of the path to find the applicable child (the tree path may not be complete for users with start nodes)
+                var child = null;
+                _.find(_.rest(args.path, currPathIndex), function (id) {
+                    child = self.getChildNode(node, id);
+                    if (child != null) {
+                        // fast forward the current index to the index of the found child
+                        currPathIndex = _.indexOf(args.path, id);
+                        return true;
+                    }
+                    return false;
+                });
                 if (child) {
                     if (args.path.length === (currPathIndex + 1)) {
                         //woot! synced the node

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -184,19 +184,7 @@ namespace Umbraco.Web.Trees
             GetUserStartNodes(out var userStartNodes, out var userStartNodePaths);
 
             nodes.AddRange(entities.Select(x => GetSingleTreeNodeWithAccessCheck(x, id, queryStrings, userStartNodes, userStartNodePaths)).Where(x => x != null));
-
-            // if the user does not have access to the root node, what we have is the start nodes,
-            // but to provide some context we also need to add their topmost nodes when they are not
-            // topmost nodes themselves (level > 1).
-            if (id == rootIdString && hasAccessToRoot == false)
-            {
-                var topNodeIds = entities.Where(x => x.Level > 1).Select(GetTopNodeId).Where(x => x != 0).Distinct().ToArray();
-                if (topNodeIds.Length > 0)
-                {
-                    var topNodes = Services.EntityService.GetAll(UmbracoObjectType, topNodeIds.ToArray());
-                    nodes.AddRange(topNodes.Select(x => GetSingleTreeNodeWithAccessCheck(x, id, queryStrings, userStartNodes, userStartNodePaths)).Where(x => x != null));
-                }
-            }
+            
 
             return nodes;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When an editor has start nodes, there's something really weird going on in the content tree. The start nodes are loaded as you'd expect, but the entire tree above the start nodes is also loaded and inserted below the start nodes.

Apparently this is by design to provide the editors with some context as to where they're editing. To me it seems like an annoyance than a genuine help. Besides having all nodes duplicated in the tree, the behavior is also very strange once you start editing:

1. If you select a node in the tree that is built from your start node, the corresponding node underneath the entire tree is highlighted instead of the one you selected.
2. If you right click a node anywhere, both that node and the corresponding duplicate is highlighted.
3. All nodes in the "context" tree have a "not-allowed" cursor and are dimmed down - even the ones you can actually edit.

While none of these are really wrong (except perhaps item 3), it just seems like a strange, confusing editor experience:

![start-nodes-remove-duplicates-before](https://user-images.githubusercontent.com/7405322/66751447-57115b00-ee8f-11e9-9bf2-5e3bdbf4345d.gif)

This PR removes the additional "context" tree, leaving behind only the start nodes. While the editor obviously looses the context, I believe the editing experience less confusing this way:

![start-nodes-remove-duplicates-after](https://user-images.githubusercontent.com/7405322/66751619-b5d6d480-ee8f-11e9-8f29-20099d629e2c.gif)

Clearly this PR is mostly a matter of opinion. I wonder if @nielslyngsoe has some input here?