### PR TITLE
V8 - umb-box-header shows values for non-localized and localized title and description

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/html/umbbox/umbboxheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/html/umbbox/umbboxheader.directive.js
@@ -45,7 +45,7 @@ Use this directive to construct a title. Recommended to use it inside an {@link 
 (function(){
     'use strict';
 
-    function BoxHeaderDirective() {
+    function BoxHeaderDirective(localizationService) {
 
         var directive = {
             restrict: 'E',
@@ -57,6 +57,26 @@ Use this directive to construct a title. Recommended to use it inside an {@link 
                 title: "@?",
                 descriptionKey: "@?",
                 description: "@?"
+            },
+            link: function (scope) {
+
+                scope.titleLabel = scope.title;
+
+                if (scope.titleKey) {
+                    localizationService.localize(scope.titleKey).then((data) => {
+                        scope.titleLabel = data;
+                    });
+
+                }
+
+                scope.descriptionLabel = scope.description;
+
+                if (scope.descriptionKey) {
+                    localizationService.localize(scope.descriptionKey).then((data) => {
+                        scope.descriptionLabel = data;
+                    });
+
+                }
             }
         };
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/html/umbbox/umbboxheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/html/umbbox/umbboxheader.directive.js
@@ -63,7 +63,7 @@ Use this directive to construct a title. Recommended to use it inside an {@link 
                 scope.titleLabel = scope.title;
 
                 if (scope.titleKey) {
-                    localizationService.localize(scope.titleKey).then((data) => {
+                    localizationService.localize(scope.titleKey, [], scope.title).then((data) => {
                         scope.titleLabel = data;
                     });
 
@@ -72,7 +72,7 @@ Use this directive to construct a title. Recommended to use it inside an {@link 
                 scope.descriptionLabel = scope.description;
 
                 if (scope.descriptionKey) {
-                    localizationService.localize(scope.descriptionKey).then((data) => {
+                    localizationService.localize(scope.descriptionKey, [], scope.description).then((data) => {
                         scope.descriptionLabel = data;
                     });
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/html/umb-box/umb-box-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/html/umb-box/umb-box-header.html
@@ -1,12 +1,10 @@
 <div class="umb-box-header">
     <div>
-        <div class="umb-box-header-title" ng-if="title || titleKey">
-            <localize ng-if="titleKey" key="{{titleKey}}"></localize>
-            <span ng-if="title">{{title}}</span>
+        <div class="umb-box-header-title" ng-if="titleLabel">
+            {{titleLabel}}
         </div>
-        <div class="umb-box-header-description" ng-if="description || descriptionKey">
-            <localize ng-if="descriptionKey" key="{{descriptionKey}}"></localize>
-            <span ng-if="description">{{description}}</span>
+        <div class="umb-box-header-description" ng-if="descriptionLabel">
+            {{descriptionLabel}}
         </div>
     </div>
     <ng-transclude></ng-transclude>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When using the umb-box-header directive you can set a title attribute and a title-key attribute. When both are filled both values are shown. I would expect the value of the localized title-key to be shown when filled. And the title property only when the title-key is not provided or can not be localized.

Same goes for description and description-key

#### Steps to reproduce

Copy and paste the following code above the umb-box-content directive in /src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html file. 

```
<umb-box-header 
	title="Start here" 
	title-key="general_add" 
	description="Non localized description" 
	description-key="general_delete">
</umb-box-header>
```

Build the front end run your umbraco site. If login and go to the settings section you will see the following in the Welcome dashboard

![umb-box-localization-before](https://user-images.githubusercontent.com/1193822/66805682-e36e5d00-ef25-11e9-812e-a149c0d6fd50.jpg)

You can see that both the value from the title and description attribute are shown. But also the translated values for the keys passed in to title-key and description-key

With this PR only the values of the title-key and description-key are shown when the can be localized.

![umb-box-localization-after](https://user-images.githubusercontent.com/1193822/66805823-45c75d80-ef26-11e9-9ae8-090a536429c8.jpg)
