### PR TITLE
V8: Move misplaced colon in language selector

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -11,8 +11,9 @@
                     <span>
                         <span class="sr-only">
                             <localize key="visuallyHiddenTexts_currentLanguage">Current language</localize>
+                            <span>: </span>
                         </span>
-                        <span>: {{selectedLanguage.name}}</span>
+                        <span>{{selectedLanguage.name}}</span>
                     </span>
                     <i class="umb-language-picker__expand" ng-class="{'icon-navigation-down': !page.languageSelectorIsOpen, 'icon-navigation-up': page.languageSelectorIsOpen}" class="icon-navigation-right" aria-hidden="true"></i>
                 </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -27,8 +27,9 @@
                     >
                     <span class="sr-only">
                         <localize key="visuallyHiddenTexts_switchLanguage">Switch language to</localize>
+                        <span>: </span>
                     </span>
-                    <span>: {{language.name}}</span>
+                    <span>{{language.name}}</span>
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As an unintended side effect of #6538, preceding colons have appeared in the language selector:

![image](https://user-images.githubusercontent.com/7405322/66816279-20dce580-ef3a-11e9-80e9-0ea8d552b790.png)

The colons are intended for screen readers, so this PR moves these colons inside the `sr-only` block, and thus the language selector looks normal again:

![image](https://user-images.githubusercontent.com/7405322/66816245-11f63300-ef3a-11e9-8c7a-26f990d3f0c8.png)
