### PR TITLE
V8: Use member type icon in member pickers

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
@@ -42,9 +42,6 @@ namespace Umbraco.Web.Models.Mapping
             target.Trashed = source.Trashed;
             target.Udi = Udi.Create(ObjectTypes.GetUdiType(source.NodeObjectType), source.Key);
 
-            if (source.NodeObjectType == Constants.ObjectTypes.Member && target.Icon.IsNullOrWhiteSpace())
-                target.Icon = Constants.Icons.Member;
-
             if (source is IContentEntitySlim contentSlim)
             {
                 source.AdditionalData["ContentTypeAlias"] = contentSlim.ContentTypeAlias;
@@ -226,7 +223,18 @@ namespace Umbraco.Web.Models.Mapping
         }
 
         private static string MapContentTypeIcon(IEntitySlim entity)
-            => entity is ContentEntitySlim contentEntity ? contentEntity.ContentTypeIcon : null;
+        {
+            switch (entity)
+            {
+                case ContentEntitySlim contentEntity:
+                    // NOTE: this case covers both content and media entities
+                    return contentEntity.ContentTypeIcon;
+                case MemberEntitySlim memberEntity:
+                    return memberEntity.ContentTypeIcon;
+            }
+
+            return null;
+        }
 
         private static string MapName(IEntitySlim source, MapperContext context)
         {

--- a/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
@@ -230,7 +230,7 @@ namespace Umbraco.Web.Models.Mapping
                     // NOTE: this case covers both content and media entities
                     return contentEntity.ContentTypeIcon;
                 case MemberEntitySlim memberEntity:
-                    return memberEntity.ContentTypeIcon;
+                    return memberEntity.ContentTypeIcon.IfNullOrWhiteSpace(Constants.Icons.Member);
             }
 
             return null;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The member pickers (both the dedicated one and MNTP) do not show the correct member type icons for members of different types. 

In this case I have the members "Hello Mister" and "Hello to you too" of type "Test 1234" (so imaginative) which uses a different icon than the default one:

![image](https://user-images.githubusercontent.com/7405322/66823598-e0379900-ef46-11e9-9a07-c1438d090773.png)

...yet in the member pickers, all members look the same:

![image](https://user-images.githubusercontent.com/7405322/66823506-b3838180-ef46-11e9-9fc3-2c5d3f14dc05.png)

Indeed had I changed the icon for the default member type, the pickers would still show the default icon because it is hard coded 😞 

This PR updates the mapping of the member entities so their member type icons are used in pickers:

![image](https://user-images.githubusercontent.com/7405322/66823288-36580c80-ef46-11e9-967e-d5e590e11168.png)
