### PR TITLE
V8: Use the member type icon in the Members section

### DIFF
--- a/src/Umbraco.Web/Trees/MemberTreeController.cs
+++ b/src/Umbraco.Web/Trees/MemberTreeController.cs
@@ -131,7 +131,7 @@ namespace Umbraco.Web.Trees
                 {
                     nodes.AddRange(Services.MemberTypeService.GetAll()
                         .Select(memberType =>
-                            CreateTreeNode(memberType.Alias, id, queryStrings, memberType.Name, Constants.Icons.MemberType, true,
+                            CreateTreeNode(memberType.Alias, id, queryStrings, memberType.Name, memberType.Icon.IfNullOrWhiteSpace(Constants.Icons.Member), true,
                                 queryStrings.GetRequiredValue<string>("application") + TreeAlias.EnsureStartsWith('/') + "/list/" + memberType.Alias)));
                 }
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In the Users section we display the user groups with their respective group icons:

![image](https://user-images.githubusercontent.com/7405322/66824768-3b6a8b00-ef49-11e9-950a-5d22fda2b200.png)

But in the Members section we do not; in fact the icon displayed gives next to no value other than to look consistent with the rest of the trees:

![image](https://user-images.githubusercontent.com/7405322/66824858-681ea280-ef49-11e9-892f-a281161c81b7.png)

This PR ensures that we use the member type icon in the Members section:

![image](https://user-images.githubusercontent.com/7405322/66824972-9ef4b880-ef49-11e9-8885-05a6451c403f.png)
