### PR TITLE
V8 - Make it possible to set content app badge through content app factory

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/ContentApp.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentApp.cs
@@ -67,6 +67,12 @@ namespace Umbraco.Core.Models.ContentEditing
         /// </remarks>
         [DataMember(Name = "active")]
         public bool Active { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content app badge.
+        /// </summary>
+        [DataMember(Name = "badge")]
+        public ContentAppBadge Badge { get; set; }
     }
 }
 

--- a/src/Umbraco.Core/Models/ContentEditing/ContentAppBadge.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentAppBadge.cs
@@ -11,6 +11,14 @@
     public class ContentAppBadge
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ContentAppBadge"/> class.
+        /// </summary>
+        public ContentAppBadge()
+        {
+            this.Type = ContentAppBadgeType.Default;
+        }
+
+        /// <summary>
         /// Gets or sets the number displayed in the badge
         /// </summary>
         [DataMember(Name = "count")]

--- a/src/Umbraco.Core/Models/ContentEditing/ContentAppBadge.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentAppBadge.cs
@@ -1,0 +1,31 @@
+﻿namespace Umbraco.Core.Models.ContentEditing
+{
+    using System.Runtime.Serialization;
+
+    using Umbraco.Core.Events;
+
+    /// <summary>
+    /// Represents a content app badge
+    /// </summary>
+    [DataContract(Name = "badge", Namespace = "")]
+    public class ContentAppBadge
+    {
+        /// <summary>
+        /// Gets or sets the number displayed in the badge
+        /// </summary>
+        [DataMember(Name = "count")]
+        public int Count { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of badge to display
+        /// </summary>
+        /// <remarks>
+        /// <para>This controls the background color of the badge.</para>
+        /// <para>Warning will display a dark yellow badge</para>
+        /// <para>Alert will display a red badge</para>
+        /// <para>Default will display a turquoise badge</para>
+        /// </remarks>
+        [DataMember(Name = "type")]
+        public ContentAppBadgeType Type { get; set; }
+    }
+}

--- a/src/Umbraco.Core/Models/ContentEditing/ContentAppBadgeType.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentAppBadgeType.cs
@@ -2,10 +2,14 @@
 {
     using System.Runtime.Serialization;
 
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
     /// <summary>
     /// Represent the content app badge types
     /// </summary>
     [DataContract(Name = "contentAppBadgeType")]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ContentAppBadgeType
     {
         [EnumMember(Value = "default")]

--- a/src/Umbraco.Core/Models/ContentEditing/ContentAppBadgeType.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentAppBadgeType.cs
@@ -1,0 +1,20 @@
+﻿namespace Umbraco.Core.Models.ContentEditing
+{
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Represent the content app badge types
+    /// </summary>
+    [DataContract(Name = "contentAppBadgeType")]
+    public enum ContentAppBadgeType
+    {
+        [EnumMember(Value = "default")]
+        Default = 0,
+
+        [EnumMember(Value = "warning")]
+        Warning = 1,
+
+        [EnumMember(Value = "alert")]
+        Alert = 2
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -245,6 +245,8 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\RichTextPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\DropDownFlexiblePreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\MergeDateAndDateTimePropertyEditor.cs" />
+    <Compile Include="Models\ContentEditing\ContentAppBadge.cs" />
+    <Compile Include="Models\ContentEditing\ContentAppBadgeType.cs" />
     <Compile Include="Models\Entities\EntityExtensions.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\PreValueMigratorBase.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\PreValueDto.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this [PR](https://github.com/umbraco/Umbraco-CMS/pull/3426)  @kjac introduced the option of adding badges to content app icons.

At the moment this is only possible by setting it in the angular controller of the content app.

When you register a content app through a [content app factory](https://our.umbraco.com/documentation/Extending/Content-Apps/#creating-a-content-app-in-c). If you register a content app you can already set the viewmodel from the factory. So it makes sense that you can set the badge as well.

This PR enables you do that.

#### Steps to test

Copy the code from this [folder](https://github.com/dawoe/umbraco-content-apps-in-depth/tree/master/example-04) in to your umbraco website.

Run the website and make sure the app is visible on a content item (need to be in admin role)

Change the code in the /App_Code/AppFactory.cs file to this

```csharp
using System;
using System.Collections.Generic;
using System.Linq;
using Umbraco.Core.Composing;
using Umbraco.Core.Models;
using Umbraco.Core.Models.ContentEditing;
using Umbraco.Core.Models.Membership;

namespace ContentAppsInDepth
{
    public class ExampleFourApp : IContentAppFactory
    {
        public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
        {
            if (source is IMedia)
            {
                return null;
            }

            if (userGroups.Any(x => x.Alias.ToLowerInvariant() == "admin") == false)
            {
                return null;
            }

            var content = source as IContent;

            if (content.Id == 0)
            {
                return null;
            }

            var exampleApp = new ContentApp
            {
                Alias = "example04",
                Name = "Example 04",
                Icon = "icon-piracy",
                View = "/App_Plugins/Example04/view.html",
                Weight = 0,
                ViewModel = "This is data set from the factory",
				Badge = new ContentAppBadge { Count = 5 , Type = ContentAppBadgeType.Warning }
            };
            return exampleApp;
        }
    }
}
```

Refresh the backend. The same content app should now display a warning style badge.

If this get's merged in let me know for which version. Than I will update the documentation as well.