### PR TITLE
Don't hide content in umb-editors while animating

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editors.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editors.html
@@ -18,7 +18,7 @@
         'umb-editor--level3': model.level === 3}"
         >
         <div ng-if="!model.view && !model.animating" ng-transclude></div>
-        <div ng-if="model.view && !model.animating" ng-include="model.view"></div>
+        <div ng-if="model.view" ng-include="model.view"></div>
         <div class="umb-editor__overlay"></div>
     </div>
 


### PR DESCRIPTION
Right now content inside `umb-editors` first appear when the `umb-editor` is done animating.
With this PR, content is shown while the `umb-editor` is animating.

Testet in Firefox 69, Chrome 77, Safari 13 on macOS.