### PR TITLE
Removed *.security.js from karma.conf.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/test/config/karma.conf.js
+++ b/src/Umbraco.Web.UI.Client/test/config/karma.conf.js
@@ -35,7 +35,6 @@ module.exports = function (config) {
             '../Umbraco.Web.UI/Umbraco/js/*.filters.js',
             '../Umbraco.Web.UI/Umbraco/js/*.services.js',
             '../Umbraco.Web.UI/Umbraco/js/*.interceptors.js',
-            '../Umbraco.Web.UI/Umbraco/js/*.security.js',
             '../Umbraco.Web.UI/Umbraco/js/*.resources.js',
 
             //mocked data and routing


### PR DESCRIPTION
Removed `'../Umbraco.Web.UI/Umbraco/js/*.security.js'` from `karma.conf.js` since no `umbraco.security.js` is generated in `gulp/config.js`.

`security: { files: ["./src/common/interceptors/**/*.js"], out: "umbraco.interceptors.js" }` outputs: `umbraco.interceptors.js`