### PR TITLE
Fix for #5644: assetsService.load now handles assets with no extension

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/assets.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/assets.service.js
@@ -250,9 +250,10 @@ angular.module('umbraco.services')
              *
              * @param {Array} pathArray string array of paths to the files to load
              * @param {Scope} scope optional scope to pass into the loader
+             * @param {string} defaultAssetType optional default asset type used to load assets with no extension 
              * @returns {Promise} Promise object which resolves when all the files has loaded
              */
-            load: function (pathArray, scope) {
+            load: function (pathArray, scope, defaultAssetType) {
                 var promise;
 
                 if (!angular.isArray(pathArray)) {
@@ -294,14 +295,29 @@ angular.module('umbraco.services')
                 promise = $q.all(promises);
 
                 // Split into css and js asset arrays, and use LazyLoad on each array
-                var cssAssets = _.filter(assets,
-                    function (asset) {
-                        return asset.path.match(/(\.css$|\.css\?)/ig);
-                    });
-                var jsAssets = _.filter(assets,
-                    function (asset) {
-                        return asset.path.match(/(\.js$|\.js\?)/ig);
-                    });
+                var cssAssets = [];
+                var jsAssets = [];
+
+                for (var i = 0; i < assets.length; i++) {
+                    var asset = assets[i];
+                    if (asset.path.match(/(\.css$|\.css\?)/ig)) {
+                        cssAssets.push(asset);
+                    } else if (asset.path.match(/(\.js$|\.js\?)/ig)) {
+                        jsAssets.push(asset);
+                    } else {
+                        // Handle unknown assets
+                        switch (defaultAssetType) {
+                            case "css":
+                                cssAssets.push(asset);
+                                break;
+                            case "js":
+                                jsAssets.push(asset);
+                                break;
+                            default:
+                                throw "Found unknown asset without a valid defaultAssetType specified";
+                        }
+                    }
+                }
 
                 function assetLoaded(asset) {
                     asset.state = "loaded";


### PR DESCRIPTION
This fix resolves #5644. Previously `assetsService.load` would not load any assets without an extension (the promise would never resolve).

Per @nul800sebastiaan's suggestion, this change adds an optional  `defaultAssetType` parameter that can be used to specify how to handle unknown assets. If `defaultAssetType` is omitted and an asset is missing an extension the method will throw (much better than dying quietly).

There are currently no unit tests for this service and I didn't have time to add any. To test this change I created another branch [v8/dev/feature/issue-5644-test](https://github.com/harry-gordon/Umbraco-CMS/tree/v8/feature/issue-5644-test) and added a small snippet to the start of `main.controller.js` that loads two dummy files (a script that prints to console and a CSS file that changes the tree background to fuschia pink) and the Bing maps JS which has no extension. So to test:

1. Run the test branch.
2. Go to the dashboard (you'll need to go through the install process).
3. Check the browser console.
4. Repeat with variations (e.g. remove `defaultAssetType` value to check that `load` throws as expected). Note you'll need to run the `js` task and refresh your browser to see any changes.

If the load function is working you should see the following messages:
```
Loaded script with an extension
Success: Loaded various asset
window.Microsoft: [object Object]
```