### PR TITLE
6671 - reload macro tree after creating macro partial view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/edit.controller.js
@@ -69,9 +69,17 @@
             }).then(function (saved) {
                 // create macro if needed
                 if($routeParams.create && $routeParams.nomacro !== "true") {
-                    macroResource.createPartialViewMacroWithFile(saved.virtualPath, saved.name).then(function(created) {
+                    macroResource.createPartialViewMacroWithFile(saved.virtualPath, saved.name).then(function (created) {
+                        navigationService.syncTree({
+                            tree: "macros",
+                            path: '-1,new',
+                            forceReload: true,
+                            activate: false
+                        });
                         completeSave(saved);
                     }, angular.noop);
+
+                    
                 } else {
                     completeSave(saved);
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6711 

### Description

This fixes the linked issue.

Before this PR the macro tree would not be reloaded after creating a macro by adding a macro partial view. You were forced to reload the macro tree to see the new macro

To test.

Go in to the backoffice and then to the settings section. Create a new marco by creating a partial macro view. The macro tree should be reloaded after you saved the macro and your newly created macro is immediatly visible. 

![macro-treereload](https://user-images.githubusercontent.com/1193822/66905920-091f6300-f007-11e9-95db-a4ac03096695.gif)

I needed to add a fake path to the syncTree method to make the tree reload. Only specifying the root node would not trigger the reload.

Dave