### PR TITLE
V8: Fix RTE full screen mode

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/rte.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte.less
@@ -83,10 +83,6 @@
     }
 }
 
-.umb-rte .mce-fullscreen {
-    position:absolute;
-}
-
 .umb-rte .mce-toolbar .mce-btn-group {
     padding: 0;
 }
@@ -164,4 +160,8 @@
 .umb-grid .umb-rte {
     border: 1px solid #d8d7d9;
     max-width: none;
+}
+
+.mce-fullscreen {
+    position: absolute;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6701

### Description

The recent RTE styling updates unfortunately broke the full screen mode:

![rte-fullscreen-before](https://user-images.githubusercontent.com/7405322/66909194-9fa25300-f00c-11e9-8ee8-37dbce0f0eac.gif)

This PR fixes it - when applied, RTE full screen mode works like it did in 8.1.5:

![rte-fullscreen-after](https://user-images.githubusercontent.com/7405322/66909252-b3e65000-f00c-11e9-9683-dc6c7072733f.gif)

