### PR TITLE
Clean up of the compositions dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-checkbox-list.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-checkbox-list.less
@@ -4,12 +4,17 @@
 .umb-checkbox-list {
   list-style: none;
   margin-left: 0;
+  margin-top: 6px;
 }
 
 .umb-checkbox-list__item {
   display: flex;
   align-items: center;
   margin-bottom: 2px;
+}
+
+.umb-checkbox-list li:first-child {
+    font-weight: bold;
 }
 
 .umb-checkbox-list__item:last-child {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -76,7 +76,7 @@
                                            id="umb-overlay-comp-{{compositeContentType.contentType.key}}"
                                            checklist-model="model.compositeContentTypes"
                                            checklist-value="compositeContentType.contentType.alias"
-                                           ng-change="c"
+                                           ng-change="model.selectCompositeContentType(compositeContentType.contentType)"
                                            ng-disabled="compositeContentType.allowed===false || compositeContentType.inherited" />                                  
 
                                 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -62,7 +62,7 @@
 
                     <div ng-if="vm.availableGroups.length > 0">
                         <ul class="umb-checkbox-list" ng-repeat="group in vm.availableGroups | filter:searchTerm">
-                            <li style="font-weight: bold" ng-show="vm.availableGroups.length > 1">
+                            <li ng-show="vm.availableGroups.length > 1">
                                 <i class="icon-folder umb-checkbox-list__item-icon"></i>
                                 {{group.containerPath}}
                             </li>
@@ -76,8 +76,9 @@
                                            id="umb-overlay-comp-{{compositeContentType.contentType.key}}"
                                            checklist-model="model.compositeContentTypes"
                                            checklist-value="compositeContentType.contentType.alias"
-                                           ng-change="model.selectCompositeContentType(compositeContentType.contentType)"
-                                           ng-disabled="compositeContentType.allowed===false || compositeContentType.inherited" />
+                                           ng-change="c"
+                                           ng-disabled="compositeContentType.allowed===false || compositeContentType.inherited" />                                  
+
                                 </div>
 
                                 <label for="umb-overlay-comp-{{compositeContentType.contentType.key}}" class="umb-checkbox-list__item-text" ng-class="{'-faded': compositeContentType.allowed===false}">


### PR DESCRIPTION
I have attempted a little clean up of the compositions dialog, introducing a bit of margin below the grey line(look at the spacing between the grey line and "Compositions" and removing some inline styles. 

**Before**
![image](https://user-images.githubusercontent.com/3941753/66920411-1e9e8800-f01b-11e9-938b-a47054cb3748.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/66920436-30802b00-f01b-11e9-920d-a368ea646e98.png)
