### PR TITLE
Use umb-checkbox in doctype collection

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/utilities/_spacing.less
+++ b/src/Umbraco.Web.UI.Client/src/less/utilities/_spacing.less
@@ -67,4 +67,18 @@
 .ml6 { margin-left: @spacing-extra-extra-large; }
 .ml7 { margin-left: @spacing-extra-extra-extra-large; }
 
+.mr0 { margin-right: @spacing-none; }
+.mr1 { margin-right: @spacing-extra-small; }
+.mr2 { margin-right: @spacing-small; }
+.mr3 { margin-right: @spacing-medium; }
+.mr4 { margin-right: @spacing-large; }
+.mr5 { margin-right: @spacing-extra-large; }
+.mr6 { margin-right: @spacing-extra-extra-large; }
+.mr7 { margin-right: @spacing-extra-extra-extra-large; }
+
 .p0 { padding: @spacing-none; }
+
+.pt0 { padding-top: @spacing-none; }
+.pb0 { padding-bottom: @spacing-none; }
+.pl0 { padding-left: @spacing-none; }
+.pr0 { padding-right: @spacing-none; }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -28,7 +28,7 @@
                         <i class="large icon icon-thumbnail-list"></i>
                         <span class="menu-label">
                             Document Type Collection...
-                            <!--                        <localize key="content_documentType_collection">Document Type Collection</localize>-->
+                            <!--<localize key="content_documentType_collection">Document Type Collection</localize>-->
                         </span>
                     </button>
                 </li>
@@ -81,18 +81,20 @@
 
                 <umb-control-group label="Name of the Parent Document Type" hide-label="false">
                     <input type="text" name="collectionName" ng-model="model.collectionName" class="umb-textstring textstring input-block-level" umb-auto-focus required />
-                    <span ng-if="model.disableTemplates === false">
-                    <input id="collectionCreateTemplate" name="collectionCreateTemplate" type="checkbox" ng-model="model.collectionCreateTemplate" style="margin-top: 0;" />
-                    <label for="collectionCreateTemplate" style="margin-bottom: 0; padding-left: 2px;">Create template for the Parent Document Type</label>
-                    </span>
+
+                    <div ng-if="model.disableTemplates === false" class="flex">
+                        <umb-checkbox input-id="collectionCreateTemplate" name="collectionCreateTemplate" model="model.collectionCreateTemplate" />
+                        <label for="collectionCreateTemplate" class="mb0">Create template for the Parent Document Type</label>
+                    </div>
                 </umb-control-group>
 
                 <umb-control-group label="Name of the Item Document Type" hide-label="false">
                     <input type="text" name="collectionItemName" ng-model="model.collectionItemName" class="umb-textstring textstring input-block-level" required />
-                    <span ng-if="model.disableTemplates === false">
-                    <input id="collectionItemCreateTemplate" name="collectionItemCreateTemplate" type="checkbox" ng-model="model.collectionItemCreateTemplate" style="margin-top: 0;" />
-                    <label for="collectionItemCreateTemplate" style="margin-bottom: 0; padding-left: 2px;">Create template for the Item Document Type</label>
-                    </span>
+
+                    <div ng-if="model.disableTemplates === false" class="flex">
+                        <umb-checkbox input-id="collectionItemCreateTemplate" name="collectionItemCreateTemplate" model="model.collectionItemCreateTemplate" />
+                        <label for="collectionItemCreateTemplate" class="mb0">Create template for the Item Document Type</label>
+                    </div>
                 </umb-control-group>
 
                 <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -97,7 +97,9 @@
                     </div>
                 </umb-control-group>
 
-                <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>
+                <div class="mt3">
+                    <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>
+                </div>
             </form>
         </div>
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When using document type collection to create a Parent and Child document type the selection of whether templates also should be created use traditional checkboxes.

I have replaced these with `umb-checkbox` so it is more consistent with rest of the UI.

I have added some more utility css classes for spacings. We had for `margin-top`, `margin-bottom` and `margin-left` but not for `margin-right`.

I have also added a few to reset padding since I have seens place where inline styling are used to set e.g. `padding-left: 0` where we can use these instead.

