### PR TITLE
Changes to delete saved searches overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
@@ -286,10 +286,11 @@
         function deleteSavedSearch(searchItem) {
 
             var overlay = {
-                title: "Delete Search",
-                subtitle: "Are you sure you wish to delete",
+                title: "Delete Saved Search",
+                subtitle: "Are you sure you wish to delete?",
                 closeButtonLabel: "Cancel",
-                submitButtonLabel: "Delete Search",
+                submitButtonLabel: "Delete Saved Search",
+                submitButtonStyle: "danger",
                 view: "default",
                 submit: function (model) {
                     //Resource call with two params (name & query)


### PR DESCRIPTION
The delete saved searches overlay was not consistent with other delete overlays across the backoffice. I have made it in line with other delete overlays.

**Before**
![image](https://user-images.githubusercontent.com/3941753/66953292-1e6fae00-f056-11e9-8ab4-4980a7a9a322.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/66953315-2d566080-f056-11e9-9ea3-6e69a802b6a4.png)
