### PR TITLE
Change the confirm button style on delete dictionary item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/delete.html
@@ -5,7 +5,7 @@
       <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong>?
     </p>
 
-    <umb-confirm on-confirm="vm.performDelete" on-cancel="vm.cancel">    
+    <umb-confirm on-confirm="vm.performDelete" on-cancel="vm.cancel"  confirm-button-style="danger" >    
     </umb-confirm>
 
   </div>


### PR DESCRIPTION
The delete button should use the `danger` style across the board. I noticed this while I was doing #6725 I dont know whether this is a good move, hence doing this as a separate PR. Will flow it across the board if this is okay.

**Before**
![image](https://user-images.githubusercontent.com/3941753/66955225-d2266d00-f059-11e9-82a5-5348863f5a49.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/66955381-1dd91680-f05a-11e9-8b95-dfff29a9a231.png)

