### PR TITLE
V8: Style the umb-overlay header and footer like the rest of the overlays

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -20,11 +20,11 @@
 }
 
 .umb-overlay .umb-overlay-header {
-    border-bottom: 1px solid @purple-l3;
+    border-bottom: 1px solid @gray-9;
     margin-top: 0;
     flex-grow: 0;
     flex-shrink: 0;
-    padding: 20px 30px 0;
+    padding: 20px 20px 0;
 }
 
 .umb-overlay__section-header {
@@ -48,11 +48,11 @@
 }
 
 .umb-overlay__title {
-    font-size: @fontSizeLarge;
+    font-size: 16px;
     color: @black;
-    line-height: 20px;
+    line-height: 16px;
     font-weight: bold;
-    margin: 7px 0;
+    margin: 5px 0;
 }
 
 .umb-overlay__subtitle {
@@ -66,8 +66,8 @@
     flex-shrink: 1;
     flex-basis: auto;
     position: relative;
-    padding: 0 30px;
-    margin-bottom: 10px;
+    padding: 20px;
+    background: @white;
     max-height: calc(100vh - 170px);
     overflow-y: auto;
 }
@@ -75,11 +75,11 @@
 .umb-overlay-drawer {
     flex-grow: 0;
     flex-shrink: 0;
-    flex-basis: 31px;
-    padding: 10px 20px;
+    flex-basis: 33px;
+    padding: 8px 20px;
     margin: 0;
-    background: @gray-10;
-    border-top: 1px solid @purple-l3;
+    background: @white;
+    border-top: 1px solid @gray-9;
 }
 
 .umb-overlay-drawer.-auto-height {
@@ -140,7 +140,6 @@
 .umb-overlay.umb-overlay-target .umb-overlay-drawer {
     border: none;
     background: transparent;
-    padding: 0 30px 20px;
 }
 
 /* ---------- OVERLAY RIGHT ---------- */
@@ -158,7 +157,7 @@
 }
 
 .umb-overlay.umb-overlay-right .umb-overlay-header {
-    flex-basis: 100px;
+    flex-basis: 70px;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The header and footer of the `umb-overlay` dialog look rather out of place when the dialog is used in "slide-in-from-right" mode; I think they may be leftovers from V7.

Here's a V8 style dialog:

![image](https://user-images.githubusercontent.com/7405322/66955320-6563a080-f062-11e9-8780-e1edb78ee567.png)

...and here are a few select samples of `umb-overlay`:

![image](https://user-images.githubusercontent.com/7405322/66955424-9643d580-f062-11e9-9ec6-91621107ac65.png)

![image](https://user-images.githubusercontent.com/7405322/66955824-782aa500-f063-11e9-9a8b-b981b2a6953b.png)

Notice:

- The height of the header and footer (and how they do not align nicely with the main window header and footer)
- The font size of the header
- The border color that separates the dialog content from the header and footer
- The background color of the footer
- The lack of padding in the top of the dialog content 
- The white border near the footer when the dialog has a scrollbar

This PR updates the styling of `umb-overlay` so it looks like a V8 dialog in "slide-in-from-right" mode:

![image](https://user-images.githubusercontent.com/7405322/66956146-2cc4c680-f064-11e9-98e3-1c0e4018a725.png)

![image](https://user-images.githubusercontent.com/7405322/66956107-1ae32380-f064-11e9-9cdd-ec8c257e3981.png)

The styling of `umb-overlay` when used e.g. for picking items types in Grid or Nested Content remains (largely) unchanged:

![image](https://user-images.githubusercontent.com/7405322/66956257-60075580-f064-11e9-93a4-0afe115d4527.png)

#### Testing this PR

Verify that the `umb-overlay` look and feel is V8-ish 😄 

At the time of writing, `umb-overlay` is used for:

- Edit dialog when inserting or editing images from RTE
- User profile dialog when clicking the user avatar in the upper left corner
- File type picker when uploading new images via the dropzone (provided you have multiple "image" media types)
- Fields list per search result in the Examine Management dashboard 
- New item type picker in the Grid
- New item type picker in Nested Content
- List view YSOD details dialog (I'm not entirely sure how to test this one...)
