### PR TITLE
Remove key from the user details screen

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -397,10 +397,7 @@
                     </div>
                     <div class="umb-user-details-details__information-item-content">
                         {{ model.user.id }}
-                    </div>
-                    <div class="umb-user-details-details__information-item-content">
-                        <small>{{ model.user.key }}</small>
-                    </div>
+                    </div>                   
                 </div>
 
             </umb-box-content>


### PR DESCRIPTION
I don't know whether my thought process is right here but user does not have a key, so it should not show on the details screen.

**Before**
![image](https://user-images.githubusercontent.com/3941753/66957130-8aa1e000-f05d-11e9-821f-433bc95e6f26.png)


**After**
![image](https://user-images.githubusercontent.com/3941753/66957083-79f16a00-f05d-11e9-849a-a669ee117d9f.png)
