### PR TITLE
Pr/fix our tests

### DIFF
--- a/src/Umbraco.Tests/Testing/TestOptionAttributeBase.cs
+++ b/src/Umbraco.Tests/Testing/TestOptionAttributeBase.cs
@@ -39,7 +39,8 @@ namespace Umbraco.Tests.Testing
                     .FirstOrDefault(x => x != null);
                 if (type == null)
                 { 
-                    throw new PanicException($"Could not resolve the running test fixture from type name {typeName}"); // makes no sense
+                    throw new PanicException($"Could not resolve the running test fixture from type name {typeName}.\n" +
+                                             $"To use base classes from Umbraco.Tests, add your test assembly to TestOptionAttributeBase.ScanAssemblies");
                 }
             }
             var methodInfo = type.GetMethod(methodName); // what about overloads?

--- a/src/Umbraco.Tests/Testing/TestOptionAttributeBase.cs
+++ b/src/Umbraco.Tests/Testing/TestOptionAttributeBase.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Tests.Testing
 {
     public abstract class TestOptionAttributeBase : Attribute
     {
-        public static readonly List<string> ScanAssemblies = new List<string>();
+        public static readonly List<Assembly> ScanAssemblies = new List<Assembly>();
 
         public static TOptions GetTestOptions<TOptions>(MethodInfo method)
             where TOptions : TestOptionAttributeBase, new()
@@ -35,11 +35,11 @@ namespace Umbraco.Tests.Testing
             if (type == null)
             {
                 type = ScanAssemblies
-                    .Select(x => Type.GetType(typeName + ", " + x, false))
+                    .Select(assembly => assembly.GetType(typeName, false))
                     .FirstOrDefault(x => x != null);
                 if (type == null)
                 { 
-                    throw new PanicException($"Could not resolve the type from type name {typeName}"); // makes no sense
+                    throw new PanicException($"Could not resolve the running test fixture from type name {typeName}"); // makes no sense
                 }
             }
             var methodInfo = type.GetMethod(methodName); // what about overloads?

--- a/src/Umbraco.Tests/Testing/TestOptionAttributeBase.cs
+++ b/src/Umbraco.Tests/Testing/TestOptionAttributeBase.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Tests.Testing
             var test = TestContext.CurrentContext.Test;
             var typeName = test.ClassName;
             var methodName = test.MethodName;
-            var type = Type.GetType(typeName, true);
+            var type = Type.GetType(typeName, false);
             if (type == null)
             {
                 type = ScanAssemblies


### PR DESCRIPTION
### Prerequisites
- [x] I have added steps to test this contribution in the description below

### Description

I quite forgot that I had left my test-API PR in WIP with an important change in it that should go in ASAP. Per today we can't really use the Our.Umbraco.Community.Tests package for our own tests. As far as I understand peeps are mocking too much or doing other dirty tricks to test v8 now. 

In any case, this small change to the test assembly only will at least make it so that we can exploit umbraco's base tests again. 

I'll leave the WIP there for when I get time to fiddle with stubbed content.

Reference usage of this:
https://github.com/lars-erik/umbraco-unit-testing-samples/tree/master-v8

To use Our.Umbraco.Community.Tests now:

    // can be on global namespace
    [SetUpFixture]
    public class Setup_UmbracoTest_Discovery
    {
        [OneTimeSetUp]
        public static void Register()
        {
            TestOptionAttributeBase.ScanAssemblies.Add(typeof(Setup_UmbracoTest_Discovery).Assembly.FullName);
        }
    }