### PR TITLE
V8: Lazy loaded properties can be interacted with when creating content types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/util/disabletabindex.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/util/disabletabindex.directive.js
@@ -17,9 +17,9 @@ angular.module("umbraco.directives")
                 var observer = new MutationObserver(domChange);
 
                 // Options for the observer (which mutations to observe)
-                var config = { attributes: true, childList: true, subtree: false };
+                var config = { attributes: true, childList: true, subtree: true };
 
-                function domChange(mutationsList, observer){
+                function domChange(mutationsList, observer) {
                     for(var mutation of mutationsList) {
 
                         //DOM items have been added or removed

--- a/src/Umbraco.Web.UI.Client/src/common/services/tabbable.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tabbable.service.js
@@ -15,7 +15,8 @@
             '[tabindex]',
             'audio[controls]',
             'video[controls]',
-            '[contenteditable]:not([contenteditable="false"])'
+            '[contenteditable]:not([contenteditable="false"])',
+            'iframe[data-mce-style]'
           ];
           var candidateSelector = candidateSelectors.join(',');
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When creating content types using the keyboard (i.e. tab a lot), some of the property editors that use lazy loading can actually be interacted with - for example the RTE and Nested Content:

![content-type-tabindex-before](https://user-images.githubusercontent.com/7405322/66991024-8c07f280-f0c7-11e9-90bd-0b7111b7e71b.gif)

This PR ensures that we observe changes in the editors marked with the `disable-tabindex` directive and apply the tabindex disabling whenever these editors are done loading. Also the RTE `iframe` has been added explicitly to the whitelist of "tab-able elements".

Here's the same operation with this PR applied:

![content-type-tabindex-after](https://user-images.githubusercontent.com/7405322/66991211-e7d27b80-f0c7-11e9-9588-b71c1355b03b.gif)

/cc @clausjensen, a.k.a. Sir Tabs-A-Lot 😆 