### PR TITLE
V7: Media uploader in RTE doesn't select uploaded image

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -251,7 +251,12 @@ angular.module("umbraco")
                     if (files.length === 1 && $scope.model.selectedImages.length === 0) {
                         var image = $scope.images[$scope.images.length - 1];
                         $scope.target = image;
-                        $scope.target.url = mediaHelper.resolveFile(image);
+                        // handle both entity and full media object
+                        if (image.image) {
+                            $scope.target.url = image.image;
+                        } else {
+                            $scope.target.url = mediaHelper.resolveFile(image);
+                        }
                         selectImage(image);
                     }
                 });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6720 

### Description
This was previously fixed as #3022, but a further change is needed after 7.15's changes to the media tree.

Testing:
- In 7.15.x, open the media picker from an RTE and upload a new image.
- The image should be correctly inserted, rather than a reference to "nothing.jpg".
