### PR TITLE
Security health checks must ignore the case of http headers

### DIFF
--- a/src/Umbraco.Web/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
@@ -115,7 +115,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 
         private bool DoHttpHeadersContainHeader(WebResponse response)
         {
-            return response.Headers.AllKeys.Contains(_header);
+             return response.Headers.AllKeys.Contains(_header, StringComparer.InvariantCultureIgnoreCase);
         }
 
         private bool DoMetaTagsContainKeyForHeader(WebResponse response)


### PR DESCRIPTION
This came out of the Security Training Course today. The HTTP Header names are case-insensitive. However the healthchecks does not take that into consideration while checking the security group. The check considers the exact following names for HTTP Headers now. If we start messing with the casing of letters in the header names it reports them as not found

` X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Strict-Transport-Security"`

Something like the below entered into the web.config will be reported as HTTP Headers not found
`       <remove name="X-Frame-Options"/>
        <add name="X-frame-Options" value="DENY"/>
        <remove name="X-Content-Type-Options"/>
        <add name="X-content-Type-Options" value="nosniff"/>
        <remove name="X-xSS-Protection"/>
        <add name="X-xSS-Protections" value="1; mode=block"/>`

With the fix I have implemented the header name checks to be case insensitive. So with the above value entered into web.config the security checks should pass and report on the HTTP Headers found

**Test**

- Enter the above code into `customHeaders` section in web.config
- Go to Settings->HealthCheck -> Security -> Click the "Check Group" button
- Without the fix implemented it should report the HTTP Headers not found
- With my fix implemented it should not complain and should say HTTP Headers found

Let me know if this is okay :-)
