### PR TITLE
Fix for #3510 - health check for http headers was case sensitive, but…

### DIFF
--- a/src/Umbraco.Web/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
@@ -115,7 +115,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 
         private bool DoHttpHeadersContainHeader(WebResponse response)
         {
-            return response.Headers.AllKeys.Contains(_header);
+            return response.Headers.AllKeys.Contains(_header, StringComparer.InvariantCultureIgnoreCase);
         }
 
         private bool DoMetaTagsContainKeyForHeader(WebResponse response)
@@ -186,24 +186,22 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
                 }
 
                 var removeHeaderElement = customHeadersElement.Elements("remove")
-                    .SingleOrDefault(x => x.Attribute("name") != null &&
-                                          x.Attribute("name")?.Value == _value);
+                    .SingleOrDefault(x => x.Attribute("name")?.Value.Equals(_value, StringComparison.InvariantCultureIgnoreCase) == true);
                 if (removeHeaderElement == null)
                 {
-                    removeHeaderElement = new XElement("remove");
-                    removeHeaderElement.Add(new XAttribute("name", _header));
-                    customHeadersElement.Add(removeHeaderElement);
+                    customHeadersElement.Add(
+                        new XElement("remove",
+                            new XAttribute("name", _header)));
                 }
 
                 var addHeaderElement = customHeadersElement.Elements("add")
-                    .SingleOrDefault(x => x.Attribute("name") != null &&
-                                          x.Attribute("name").Value == _header);
+                    .SingleOrDefault(x => x.Attribute("name")?.Value.Equals(_header, StringComparison.InvariantCultureIgnoreCase) == true);
                 if (addHeaderElement == null)
                 {
-                    addHeaderElement = new XElement("add");
-                    addHeaderElement.Add(new XAttribute("name", _header));
-                    addHeaderElement.Add(new XAttribute("value", _value));
-                    customHeadersElement.Add(addHeaderElement);
+                    customHeadersElement.Add(
+                        new XElement("add",
+                            new XAttribute("name", _header),
+                            new XAttribute("value", _value)));
                 }
 
                 doc.Save(configFile);


### PR DESCRIPTION
This came up in todays Umbraco Security training course. 

The health checks look for HttpHeaders but was case sensitive, but HTTP spec states headers are case insensitive. Looks like this was raised long ago in #3510 - hopefully it can now be merged and closed
