### PR TITLE
Content Blueprint save button style change

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -265,8 +265,7 @@
         function createButtons(content) {
 
             // for trashed and element type items, the save button is the primary action - otherwise it's a secondary action
-            $scope.page.saveButtonStyle = content.trashed || content.isElement ? "primary" : "info";
-
+            $scope.page.saveButtonStyle = content.trashed || content.isElement || content.isBlueprint ? "primary" : "info";
             // only create the save/publish/preview buttons if the
             // content app is "Conent"
             if ($scope.app && $scope.app.alias !== "umbContent" && $scope.app.alias !== "umbInfo" && $scope.app.alias !== "umbListView") {


### PR DESCRIPTION
The "Save" button in the Content Blueprint is "info" style at the moment. Trying to make is consistent with the other parts of the application by making it "primary" style. 

**Before**
![image](https://user-images.githubusercontent.com/3941753/67022686-82977e00-f0f9-11e9-9316-291b30e0eded.png)

After
![image](https://user-images.githubusercontent.com/3941753/67024300-1702e000-f0fc-11e9-8100-6aebd0c6bee0.png)
