### PR TITLE
Add additional null conditionals to the FromEditor method of RichTextPropertyValueEditor

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -89,7 +89,7 @@ namespace Umbraco.Web.PropertyEditors
 
                 var grid = DeserializeGridValue(rawJson, out var rtes);
 
-                var userId = _umbracoContextAccessor.UmbracoContext?.Security.CurrentUser.Id ?? Constants.Security.SuperUserId;
+                var userId = _umbracoContextAccessor.UmbracoContext?.Security?.CurrentUser?.Id ?? Constants.Security.SuperUserId;
 
                 // Process the rte values
                 foreach (var rte in rtes)

--- a/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
@@ -114,7 +114,7 @@ namespace Umbraco.Web.PropertyEditors
                 if (editorValue.Value == null)
                     return null;
 
-                var userId = _umbracoContextAccessor.UmbracoContext?.Security.CurrentUser.Id ?? Constants.Security.SuperUserId;
+                var userId = _umbracoContextAccessor.UmbracoContext?.Security?.CurrentUser?.Id ?? Constants.Security.SuperUserId;
 
                 var config = editorValue.DataTypeConfiguration as RichTextConfiguration;
                 var mediaParent = config?.MediaParentId;


### PR DESCRIPTION
Adds additional null conditionals to the FromEditor method as this method is sometimes executed for front end rendering and in that scenario CurrentUser is null, this throws an exception.

See the Doc Type Grid Editor issue for details of when this issue occurs https://github.com/skttl/umbraco-doc-type-grid-editor/issues/159