### PR TITLE
V8: Make the color class prefix configurable for <umb-color-swatches/>

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
@@ -18,6 +18,7 @@ Use this directive to generate color swatches to pick from.
 @param {string} size (<code>attribute</code>): The size (s, m).
 @param {string} useLabel (<code>attribute</code>): Specify if labels should be used.
 @param {string} useColorClass (<code>attribute</code>): Specify if color values are css classes.
+@param {string} colorClassNamePrefix (<code>attribute</code>): Specify the prefix used for the class for each color (defaults to "btn").
 @param {function} onSelect (<code>expression</code>): Callback function when the item is selected.
 **/
 
@@ -31,6 +32,11 @@ Use this directive to generate color swatches to pick from.
             // Set default to true if not defined
             if (angular.isUndefined(scope.useColorClass)) {
                 scope.useColorClass = false;
+            }
+
+            // Set default to "btn" if not defined
+            if (angular.isUndefined(scope.colorClassNamePrefix)) {
+                scope.colorClassNamePrefix = "btn";
             }
             
             scope.setColor = function (color, $index, $event) {
@@ -66,7 +72,8 @@ Use this directive to generate color swatches to pick from.
                 selectedColor: '=',
                 onSelect: '&',
                 useLabel: '=',
-                useColorClass: '=?'
+                useColorClass: '=?',
+                colorClassNamePrefix: '@?'
             },
             link: link
         };

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -1,6 +1,6 @@
 ﻿<div class="umb-color-swatches" ng-class="{ 'with-labels': useLabel }">
 
-    <button type="button" class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{useLabel || useColorClass ? (color.label || color.value) : ('#' + color.value)}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': isSelectedColor(color) }" ng-click="setColor(color, $index, $event)">
+    <button type="button" class="umb-color-box umb-color-box--{{size}} {{colorClassNamePrefix}}-{{color.value}}" ng-repeat="color in colors" title="{{useLabel || useColorClass ? (color.label || color.value) : ('#' + color.value)}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': isSelectedColor(color) }" ng-click="setColor(color, $index, $event)">
         <div class="umb-color-box-inner">
             <div class="check_circle">
                 <i class="icon icon-check small" ng-show="isSelectedColor(color)"></i>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6740

### Description

This PR makes it possible to configure the prefix applied to the class name for each color option in the color swatch directive.

The prefix is defined by supplying `color-class-name-prefix="my-prefix"` in the directive. If none is supplied, the directive performs a fallback to "btn" to ensure backwards compatibility.

#### Testing this PR

First and foremost check that the color swatch performs the expected fallback - for example by opening the icon picker for a doctype. If it still looks really colorful, the fallback works.

![image](https://user-images.githubusercontent.com/7405322/67040918-c8b60700-f124-11e9-93e1-8a5129083c84.png)

Now testing it with a customized prefix isn't straightforward. What I did was to edit the color swatch used in the icon picker:

![image](https://user-images.githubusercontent.com/7405322/67040715-547b6380-f124-11e9-8ed4-480e371100c4.png)

...which caused it to look like this:

![image](https://user-images.githubusercontent.com/7405322/67040780-7674e600-f124-11e9-9ad2-678ba638aa6c.png)

Success! It's colorless 😆 