### PR TITLE
V8: Handle save keyboard shortcut from within the RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -201,6 +201,10 @@
                 $scope.page.buttonGroupState = "success";
             }));
 
+            evts.push(eventsService.on("rte.shortcut.save", function(){
+                $scope.save();
+            }));
+
             evts.push(eventsService.on("content.saved", function(){
                 // Clear out localstorage keys that start with tinymce__
                 // When we save/perist a content node

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -202,7 +202,9 @@
             }));
 
             evts.push(eventsService.on("rte.shortcut.save", function(){
-                $scope.save();
+                if ($scope.page.showSaveButton) {
+                    $scope.save();
+                }
             }));
 
             evts.push(eventsService.on("content.saved", function(){

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1143,6 +1143,14 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 prependToContext: true
             });
 
+            // the editor frame catches Ctrl+S and handles it with the system save dialog
+            // - we want to handle it in the content controller, so we'll emit an event instead
+            editor.addShortcut('Ctrl+S', '', function () {
+                angularHelper.safeApply($rootScope, function() {
+                    eventsService.emit("rte.shortcut.save");
+                });
+            });
+
         },
 
         insertLinkInEditor: function (editor, target, anchorElm) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I keep getting annoyed with how the system save dialog appears whenever I hit Ctrl+S in the RTE:

![rte-save-keyboard-shortcut-before](https://user-images.githubusercontent.com/7405322/67044293-39145680-f12c-11e9-97c8-0a4579a1594d.gif)

Turns out there is an easy fix that makes Ctrl+S save the current content instead, just like it should. So this PR implements just that:

![rte-save-keyboard-shortcut](https://user-images.githubusercontent.com/7405322/67044339-52b59e00-f12c-11e9-8640-56c5f80f406d.gif)

#### What about Publish?

While it would be just as easy to handle the shortcut for publishing (Ctrl+P), I have opted not to do it. The editors might hit the shortcut by accident and trigger an unwanted publish of the entire page. 

Of course the editors could just as easily hit the shortcut for save by accident and trigger an unwanted save, but that's nowhere near as problematic. And I do believe the advantage of having a functional shortcut outweighs this potential problem.