### PR TITLE
V7: Fix for pre-value warnings being logged repeatedly

### DIFF
--- a/src/Umbraco.Core/Constants-System.cs
+++ b/src/Umbraco.Core/Constants-System.cs
@@ -58,6 +58,7 @@
             /// </remarks>
             public const string RecycleBinMediaPathPrefix = "-1,-21,";
 
+            public const int DefaultRichTextEditorDataTypeId = -87;
             public const int DefaultContentListViewDataTypeId = -95;
             public const int DefaultMediaListViewDataTypeId = -96;
             public const int DefaultMembersListViewDataTypeId = -97;

--- a/src/Umbraco.Core/Persistence/Migrations/Initial/BaseDataCreation.cs
+++ b/src/Umbraco.Core/Persistence/Migrations/Initial/BaseDataCreation.cs
@@ -277,7 +277,6 @@ namespace Umbraco.Core.Persistence.Migrations.Initial
 
         private void CreateCmsDataTypePreValuesData()
         {
-            _database.Insert("cmsDataTypePreValues", "id", false, new DataTypePreValueDto { Id = 3, Alias = "", SortOrder = 0, DataTypeNodeId = -87, Value = ",code,undo,redo,cut,copy,mcepasteword,stylepicker,bold,italic,bullist,numlist,outdent,indent,mcelink,unlink,mceinsertanchor,mceimage,umbracomacro,mceinserttable,umbracoembed,mcecharmap,|1|1,2,3,|0|500,400|1049,|true|" });
             _database.Insert("cmsDataTypePreValues", "id", false, new DataTypePreValueDto { Id = 4, Alias = "group", SortOrder = 0, DataTypeNodeId = 1041, Value = "default" });
             _database.Insert("cmsDataTypePreValues", "id", false, new DataTypePreValueDto { Id = 5, Alias = "storageType", SortOrder = 0, DataTypeNodeId = 1041, Value = "Json" });
 
@@ -306,6 +305,9 @@ namespace Umbraco.Core.Persistence.Migrations.Initial
 
             // Defaults for multiple item dropdown
             _database.Insert("cmsDataTypePreValues", "id", false, new DataTypePreValueDto { Id = 8, Alias = "multiple", SortOrder = 0, DataTypeNodeId = -39, Value = "1" });
+
+            // Defaults for rich text editor
+            _database.Insert("cmsDataTypePreValues", "id", false, new DataTypePreValueDto { Id = 3, Alias = "editor", SortOrder = 0, DataTypeNodeId = Constants.System.DefaultRichTextEditorDataTypeId, Value = "{ \"toolbar\": [ \"code\", \"styleselect\", \"bold\", \"italic\", \"alignleft\", \"aligncenter\", \"alignright\", \"bullist\", \"numlist\", \"outdent\", \"indent\", \"link\", \"umbmediapicker\", \"umbmacro\", \"umbembeddialog\" ], \"stylesheets\": [], \"dimensions\": { \"height\": 500 }, \"maxImageSize\": 500 }" });
         }
 
         private void CreateUmbracoRelationTypeData()

--- a/src/Umbraco.Web/Models/Mapping/PreValueDisplayResolver.cs
+++ b/src/Umbraco.Web/Models/Mapping/PreValueDisplayResolver.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Web.Models.Mapping
                 var preValue = preValues.SingleOrDefault(x => x.Key.InvariantEquals(field.Key));
                 if (preValue.Key == null)
                 {
-                    LogHelper.Warn<PreValueDisplayResolver>("Could not find persisted pre-value for field {0} on property editor {1}", () => field.Key, () => editorAlias);
+                    LogHelper.Debug<PreValueDisplayResolver>("Could not find default or persisted pre-value for field {0} on property editor {1}", () => field.Key, () => editorAlias);
                     continue;
                 }
 

--- a/src/Umbraco.Web/PropertyEditors/ColorListPreValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ColorListPreValueEditor.cs
@@ -81,8 +81,8 @@ namespace Umbraco.Web.PropertyEditors
             }
 
             var result = new Dictionary<string, object> { { "items", items2 } };
-            var useLabel = dictionary.ContainsKey("useLabel") && dictionary["useLabel"].Value == "1";
-            if (useLabel)
+            var hasUseLabelValue = dictionary.ContainsKey("useLabel");
+            if (hasUseLabelValue)
                 result["useLabel"] = dictionary["useLabel"].Value;
 
             return result;

--- a/src/Umbraco.Web/PropertyEditors/DatePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DatePropertyEditor.cs
@@ -17,7 +17,8 @@ namespace Umbraco.Web.PropertyEditors
             _defaultPreVals = new Dictionary<string, object>
                 {
                     {"format", "YYYY-MM-DD"},
-                    {"pickTime", false}
+                    {"pickTime", false},
+                    {"defaultEmpty", false}
                 };
         }
 

--- a/src/Umbraco.Web/PropertyEditors/DateTimePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DateTimePropertyEditor.cs
@@ -15,6 +15,7 @@ namespace Umbraco.Web.PropertyEditors
         {
             _defaultPreVals = new Dictionary<string, object>
                 {
+                    {"defaultEmpty", false},
                     //NOTE: This is very important that we do not use .Net format's there, this format
                     // is the correct format for the JS picker we are using so you cannot capitalize the HH, they need to be 'hh'
                     {"format", "YYYY-MM-DD HH:mm:ss"},

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -33,7 +33,8 @@ namespace Umbraco.Web.PropertyEditors
             _internalPreValues = new Dictionary<string, object>
                 {
                     {"focalPoint", "{left: 0.5, top: 0.5}"},
-                    {"src", ""}
+                    {"src", ""},
+                    {"crops", ""}
                 };
         }
 

--- a/src/Umbraco.Web/PropertyEditors/IntegerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/IntegerPropertyEditor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Umbraco.Core;
 using Umbraco.Core.PropertyEditors;
 
@@ -6,6 +7,24 @@ namespace Umbraco.Web.PropertyEditors
     [PropertyEditor(Constants.PropertyEditors.IntegerAlias, "Numeric", "integer", IsParameterEditor = true, ValueType = PropertyEditorValueTypes.IntegerAlternative)]
     public class IntegerPropertyEditor : PropertyEditor
     {
+        public IntegerPropertyEditor()
+        {
+            _defaultPreVals = new Dictionary<string, object>
+                {
+                    {"min", null},
+                    {"step", null},
+                    {"max", null}
+                };
+        }
+
+        private IDictionary<string, object> _defaultPreVals;
+
+        public override IDictionary<string, object> DefaultPreValues
+        {
+            get { return _defaultPreVals; }
+            set { _defaultPreVals = value; }
+        }
+
         /// <summary>
         /// Overridden to ensure that the value is validated
         /// </summary>

--- a/src/Umbraco.Web/PropertyEditors/LabelPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/LabelPropertyEditor.cs
@@ -10,6 +10,24 @@ namespace Umbraco.Web.PropertyEditors
     [PropertyEditor(Constants.PropertyEditors.NoEditAlias, "Label", "readonlyvalue", Icon = "icon-readonly")]
     public class LabelPropertyEditor : PropertyEditor
     {
+        private const string LegacyPropertyEditorValuesKey = "values";
+
+        public LabelPropertyEditor()
+        {
+            _defaultPreVals = new Dictionary<string, object>
+                {
+                    {LegacyPropertyEditorValuesKey, null}
+                };
+        }
+
+        private IDictionary<string, object> _defaultPreVals;
+
+        public override IDictionary<string, object> DefaultPreValues
+        {
+            get { return _defaultPreVals; }
+            set { _defaultPreVals = value; }
+        }
+
         protected override PropertyValueEditor CreateValueEditor()
         {
             return new LabelPropertyValueEditor(base.CreateValueEditor());
@@ -41,7 +59,6 @@ namespace Umbraco.Web.PropertyEditors
 
         internal class LabelPreValueEditor : PreValueEditor
         {
-            private const string LegacyPropertyEditorValuesKey = "values";
 
             public LabelPreValueEditor()
             {

--- a/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewPropertyEditor.cs
@@ -18,6 +18,7 @@ namespace Umbraco.Web.PropertyEditors
             {
                 return new Dictionary<string, object>
                 {
+                    {"tabName", ""},
                     {"pageSize", "10"},
                     {"displayAtTabNumber", "1"},
                     {"orderBy", "SortOrder"},

--- a/src/Umbraco.Web/PropertyEditors/MediaPicker2PropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPicker2PropertyEditor.cs
@@ -14,7 +14,12 @@ namespace Umbraco.Web.PropertyEditors
         {
             InternalPreValues = new Dictionary<string, object>
             {
-                {"idType", "udi"}
+                {"idType", "udi"},
+                {"multiPicker", false},
+                {"onlyImages", false},
+                {"disableFolderSelect", false},
+                {Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes, false},
+                {"startNodeId", null}
             };
         }
 

--- a/src/Umbraco.Web/PropertyEditors/RelatedLinks2PropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RelatedLinks2PropertyEditor.cs
@@ -15,6 +15,7 @@ namespace Umbraco.Web.PropertyEditors
             InternalPreValues = new Dictionary<string, object>
             {
                 {Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes, "0"},
+                {"max", 0},
                 {"idType", "udi"}
             };
         }

--- a/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
@@ -11,6 +11,24 @@ namespace Umbraco.Web.PropertyEditors
     [PropertyEditor(Constants.PropertyEditors.TinyMCEAlias, "Rich Text Editor", "rte", ValueType = PropertyEditorValueTypes.Text,  HideLabel = false, Group="Rich Content", Icon="icon-browser-window")]
     public class RichTextPropertyEditor : PropertyEditor
     {
+        public RichTextPropertyEditor()
+        {
+            _defaultPreVals = new Dictionary<string, object>
+                {
+                    {"editor", null},
+                    {Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes, false},
+                    {"hideLabel", false}
+                };
+        }
+
+        private IDictionary<string, object> _defaultPreVals;
+
+        public override IDictionary<string, object> DefaultPreValues
+        {
+            get { return _defaultPreVals; }
+            set { _defaultPreVals = value; }
+        }
+
         /// <summary>
         /// Create a custom value editor
         /// </summary>

--- a/src/Umbraco.Web/PropertyEditors/TextAreaPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TextAreaPropertyEditor.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core;
+﻿using System.Collections.Generic;
+using Umbraco.Core;
 using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
@@ -6,6 +7,23 @@ namespace Umbraco.Web.PropertyEditors
     [PropertyEditor(Constants.PropertyEditors.TextboxMultipleAlias, "Textarea", "textarea", IsParameterEditor = true, ValueType = PropertyEditorValueTypes.Text, Icon="icon-application-window-alt")]
     public class TextAreaPropertyEditor : PropertyEditor
     {
+        public TextAreaPropertyEditor()
+        {
+            _defaultPreVals = new Dictionary<string, object>
+                {
+                    {"maxChars", null},
+                    {"rows", null}
+                };
+        }
+
+        private IDictionary<string, object> _defaultPreVals;
+
+        public override IDictionary<string, object> DefaultPreValues
+        {
+            get { return _defaultPreVals; }
+            set { _defaultPreVals = value; }
+        }
+
         protected override PropertyValueEditor CreateValueEditor()
         {
             return new TextOnlyValueEditor(base.CreateValueEditor());

--- a/src/Umbraco.Web/PropertyEditors/TextboxPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TextboxPropertyEditor.cs
@@ -12,6 +12,22 @@ namespace Umbraco.Web.PropertyEditors
     [PropertyEditor(Constants.PropertyEditors.TextboxAlias, "Textbox", "textbox", IsParameterEditor = true, Group = "Common")]
     public class TextboxPropertyEditor : PropertyEditor
     {
+        public TextboxPropertyEditor()
+        {
+            _defaultPreVals = new Dictionary<string, object>
+                {
+                    {"maxChars", null}
+                };
+        }
+
+        private IDictionary<string, object> _defaultPreVals;
+
+        public override IDictionary<string, object> DefaultPreValues
+        {
+            get { return _defaultPreVals; }
+            set { _defaultPreVals = value; }
+        }
+
         protected override PropertyValueEditor CreateValueEditor()
         {
             return new TextOnlyValueEditor(base.CreateValueEditor());

--- a/src/Umbraco.Web/PropertyEditors/TrueFalsePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalsePropertyEditor.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core;
+﻿using System.Collections.Generic;
+using Umbraco.Core;
 using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
@@ -6,6 +7,23 @@ namespace Umbraco.Web.PropertyEditors
     [PropertyEditor(Constants.PropertyEditors.TrueFalseAlias, "Checkbox", PropertyEditorValueTypes.Integer, "boolean", IsParameterEditor = true, Group = "Common", Icon="icon-checkbox")]
     public class TrueFalsePropertyEditor : PropertyEditor
     {
+        public TrueFalsePropertyEditor()
+        {
+            _defaultPreVals = new Dictionary<string, object>
+                {
+                    {"default", false},
+                    {"labelOn", ""}
+                };
+        }
+
+        private IDictionary<string, object> _defaultPreVals;
+
+        public override IDictionary<string, object> DefaultPreValues
+        {
+            get { return _defaultPreVals; }
+            set { _defaultPreVals = value; }
+        }
+
         protected override PreValueEditor CreatePreValueEditor()
         {
             return new TrueFalsePreValueEditor();


### PR DESCRIPTION
### Description
This fixes issue #6702 and other pre-value warnings that came up while investigating.

When selecting data types in the back office many warnings appear in the log, along the lines of:
`WARN Umbraco.Web.Models.Mapping.PreValueDisplayResolver - Could not find persisted pre-value for field useLabel on property editor Umbraco.ColorPickerAlias`

This is down to various pre-values not having values saved to the DB and no default values provided to fall back on. There are more of these warnings on a fresh install of Umbraco, as saving the data type writes the pre-values to the DB.

As Sebastiaan pointed out on the issue, these warnings aren't a lot of use. The log items could have just been set to debug level and that would "solve" the issue. However, it's probably better to fix the source of the issue than the symptoms.

### Changes I have made
- Fixed a bit of logic that stopped the `useLabel` pre-value from being populated when it was set to `false` on the color picker data type (`Umbraco.ColorPickerAlias`)
- Updated the RTE data type (`Umbraco.TinyMCEv3`) pre-value that's inserted into the DB on installation. The existing one was a pipe-delimited string but there was no code to parse this. I've replaced it with the JSON string that gets written to the DB when saving the data type (without modifying anything) for the first time.
- Updated the other data types that were logging warnings to add defaults to all the pre-values.
- Downgraded the log message to the debug level and updated the text.

### Other comments
Some of the default 'values' are set to null due to them being effectively being optional. For example: `rows` on `Umbraco.TextboxMultiple`, `min` on `Umbraco.Integer`, etc. The defaults for these are set on the client-side and/or rely on having a null value and I didn't want to override that.

Some pre-values don't have defaults set in the code but also don't log the warnings. This is because their pre-values are already in the database on installation.

Ideally I think the `PreValueField` attribute could have `Optional` and `Default` parameters added but as this is for v7 I think it's out of scope.