### PR TITLE
UmbracoApiController Testable

### DIFF
--- a/src/Umbraco.Tests/Testing/TestingTests/MockTests.cs
+++ b/src/Umbraco.Tests/Testing/TestingTests/MockTests.cs
@@ -7,10 +7,13 @@ using NUnit.Framework;
 using Umbraco.Core;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Composing;
+using Umbraco.Core.Configuration;
 using Umbraco.Core.Dictionary;
 using Umbraco.Core.Logging;
+using Umbraco.Core.Mapping;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.Persistence;
 using Umbraco.Core.Services;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.TestHelpers.Stubs;
@@ -19,6 +22,7 @@ using Umbraco.Web;
 using Umbraco.Web.PublishedCache;
 using Umbraco.Web.Routing;
 using Umbraco.Web.Security;
+using Umbraco.Web.WebApi;
 using Current = Umbraco.Web.Composing.Current;
 
 namespace Umbraco.Tests.Testing.TestingTests
@@ -88,5 +92,41 @@ namespace Umbraco.Tests.Testing.TestingTests
 
             Assert.AreEqual("/hello/world/1234", theUrlProvider.GetUrl(publishedContent));
         }
+
+        [Test]
+        public void Can_Mock_UmbracoApiController_Dependencies_With_Injected_UmbracoMapper()
+        {
+            var umbracoContext = TestObjects.GetUmbracoContextMock();
+
+            var membershipHelper = new MembershipHelper(umbracoContext.HttpContext, Mock.Of<IPublishedMemberCache>(), Mock.Of<MembershipProvider>(), Mock.Of<RoleProvider>(), Mock.Of<IMemberService>(), Mock.Of<IMemberTypeService>(), Mock.Of<IUserService>(), Mock.Of<IPublicAccessService>(), Mock.Of<AppCaches>(), Mock.Of<ILogger>());
+            var umbracoHelper = new UmbracoHelper(Mock.Of<IPublishedContent>(), Mock.Of<ITagQuery>(), Mock.Of<ICultureDictionaryFactory>(), Mock.Of<IUmbracoComponentRenderer>(), Mock.Of<IPublishedContentQuery>(), membershipHelper);
+            var umbracoMapper = new UmbracoMapper(new MapDefinitionCollection(new[] { Mock.Of<IMapDefinition>() }));
+            
+            // ReSharper disable once UnusedVariable
+            var umbracoApiController = new FakeUmbracoApiController(Mock.Of<IGlobalSettings>(), Mock.Of<IUmbracoContextAccessor>(), Mock.Of<ISqlContext>(), ServiceContext.CreatePartial(), AppCaches.NoCache, Mock.Of<IProfilingLogger>(), Mock.Of<IRuntimeState>(), umbracoHelper, umbracoMapper);
+
+            Assert.Pass();
+        }
+
+        [Test]
+        public void Can_Mock_UmbracoApiController_Dependencies_With_ServiceLocator_UmbracoMapper()
+        {
+            var umbracoContext = TestObjects.GetUmbracoContextMock();
+
+            var membershipHelper = new MembershipHelper(umbracoContext.HttpContext, Mock.Of<IPublishedMemberCache>(), Mock.Of<MembershipProvider>(), Mock.Of<RoleProvider>(), Mock.Of<IMemberService>(), Mock.Of<IMemberTypeService>(), Mock.Of<IUserService>(), Mock.Of<IPublicAccessService>(), Mock.Of<AppCaches>(), Mock.Of<ILogger>());
+            var umbracoHelper = new UmbracoHelper(Mock.Of<IPublishedContent>(), Mock.Of<ITagQuery>(), Mock.Of<ICultureDictionaryFactory>(), Mock.Of<IUmbracoComponentRenderer>(), Mock.Of<IPublishedContentQuery>(), membershipHelper);
+            Composition.Register(new UmbracoMapper(new MapDefinitionCollection(new[] { Mock.Of<IMapDefinition>() })));
+
+            // ReSharper disable once UnusedVariable
+            var umbracoApiController = new FakeUmbracoApiController(Mock.Of<IGlobalSettings>(), Mock.Of<IUmbracoContextAccessor>(), Mock.Of<ISqlContext>(), ServiceContext.CreatePartial(), AppCaches.NoCache, Mock.Of<IProfilingLogger>(), Mock.Of<IRuntimeState>(), umbracoHelper);
+
+            Assert.Pass();
+        }
+    }
+
+    internal class FakeUmbracoApiController : UmbracoApiController
+    {
+        public FakeUmbracoApiController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper) : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper) { }
+        public FakeUmbracoApiController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper, UmbracoMapper umbracoMapper) : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper, umbracoMapper) { }
     }
 }

--- a/src/Umbraco.Tests/Testing/TestingTests/MockTests.cs
+++ b/src/Umbraco.Tests/Testing/TestingTests/MockTests.cs
@@ -107,21 +107,6 @@ namespace Umbraco.Tests.Testing.TestingTests
 
             Assert.Pass();
         }
-
-        [Test]
-        public void Can_Mock_UmbracoApiController_Dependencies_With_ServiceLocator_UmbracoMapper()
-        {
-            var umbracoContext = TestObjects.GetUmbracoContextMock();
-
-            var membershipHelper = new MembershipHelper(umbracoContext.HttpContext, Mock.Of<IPublishedMemberCache>(), Mock.Of<MembershipProvider>(), Mock.Of<RoleProvider>(), Mock.Of<IMemberService>(), Mock.Of<IMemberTypeService>(), Mock.Of<IUserService>(), Mock.Of<IPublicAccessService>(), Mock.Of<AppCaches>(), Mock.Of<ILogger>());
-            var umbracoHelper = new UmbracoHelper(Mock.Of<IPublishedContent>(), Mock.Of<ITagQuery>(), Mock.Of<ICultureDictionaryFactory>(), Mock.Of<IUmbracoComponentRenderer>(), Mock.Of<IPublishedContentQuery>(), membershipHelper);
-            Composition.Register(new UmbracoMapper(new MapDefinitionCollection(new[] { Mock.Of<IMapDefinition>() })));
-
-            // ReSharper disable once UnusedVariable
-            var umbracoApiController = new FakeUmbracoApiController(Mock.Of<IGlobalSettings>(), Mock.Of<IUmbracoContextAccessor>(), Mock.Of<ISqlContext>(), ServiceContext.CreatePartial(), AppCaches.NoCache, Mock.Of<IProfilingLogger>(), Mock.Of<IRuntimeState>(), umbracoHelper);
-
-            Assert.Pass();
-        }
     }
 
     internal class FakeUmbracoApiController : UmbracoApiController

--- a/src/Umbraco.Web/WebApi/UmbracoApiController.cs
+++ b/src/Umbraco.Web/WebApi/UmbracoApiController.cs
@@ -19,9 +19,9 @@ namespace Umbraco.Web.WebApi
         {
         }
 
-        [Obsolete("This constructor uses the service locator to fetch the UmbracoMapper from Current.Mapper, which is not good for testability. Inject the UmbracoMapper using full constructor injection instead.")]
+        [Obsolete("This constructor is obsolete since it doesn't inject the UmbracoMapper. The UmbracoMapper will be resolved from the service locator Current.Mapper, which is not good for testability. Inject the UmbracoMapper using full constructor injection instead.")]
         protected UmbracoApiController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper)
-            : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper, Current.Mapper)
+            : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper)
         {
         }
 

--- a/src/Umbraco.Web/WebApi/UmbracoApiController.cs
+++ b/src/Umbraco.Web/WebApi/UmbracoApiController.cs
@@ -1,8 +1,10 @@
-﻿using Umbraco.Core;
+﻿using System;
+using Umbraco.Core;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Logging;
+using Umbraco.Core.Mapping;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Services;
 
@@ -17,8 +19,14 @@ namespace Umbraco.Web.WebApi
         {
         }
 
+        [Obsolete("This constructor uses the service locator to fetch the UmbracoMapper from Current.Mapper, which is not good for testability. Inject the UmbracoMapper using full constructor injection instead.")]
         protected UmbracoApiController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper)
-            : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper)
+            : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper, Current.Mapper)
+        {
+        }
+
+        protected UmbracoApiController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper, UmbracoMapper umbracoMapper)
+            : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper, umbracoMapper)
         {
         }
     }

--- a/src/Umbraco.Web/WebApi/UmbracoApiControllerBase.cs
+++ b/src/Umbraco.Web/WebApi/UmbracoApiControllerBase.cs
@@ -40,14 +40,15 @@ namespace Umbraco.Web.WebApi
                 Current.Factory.GetInstance<AppCaches>(),
                 Current.Factory.GetInstance<IProfilingLogger>(),
                 Current.Factory.GetInstance<IRuntimeState>(),
-                Current.Factory.GetInstance<UmbracoHelper>()
+                Current.Factory.GetInstance<UmbracoHelper>(),
+                Current.Factory.GetInstance<UmbracoMapper>()
             )
         { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoApiControllerBase"/> class with all its dependencies.
         /// </summary>
-        protected UmbracoApiControllerBase(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper)
+        protected UmbracoApiControllerBase(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper, UmbracoMapper umbracoMapper)
         {
             UmbracoContextAccessor = umbracoContextAccessor;
             GlobalSettings = globalSettings;
@@ -57,9 +58,7 @@ namespace Umbraco.Web.WebApi
             Logger = logger;
             RuntimeState = runtimeState;
             Umbraco = umbracoHelper;
-
-            // fixme - can we break all ctors?
-            Mapper = Current.Mapper;
+            Mapper = umbracoMapper;
         }
 
         /// <summary>

--- a/src/Umbraco.Web/WebApi/UmbracoApiControllerBase.cs
+++ b/src/Umbraco.Web/WebApi/UmbracoApiControllerBase.cs
@@ -61,6 +61,22 @@ namespace Umbraco.Web.WebApi
             Mapper = umbracoMapper;
         }
 
+        [Obsolete("This constructor is obsolete since it doesn't inject the UmbracoMapper. The UmbracoMapper will be resolved from the service locator Current.Mapper, which is not good for testability. Inject the UmbracoMapper using full constructor injection instead.")]
+        protected UmbracoApiControllerBase(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper)
+        {
+            UmbracoContextAccessor = umbracoContextAccessor;
+            GlobalSettings = globalSettings;
+            SqlContext = sqlContext;
+            Services = services;
+            AppCaches = appCaches;
+            Logger = logger;
+            RuntimeState = runtimeState;
+            Umbraco = umbracoHelper;
+
+            // not good for testability, hence the obsolete.
+            Mapper = Current.Mapper;
+        }
+
         /// <summary>
         /// Gets a unique instance identifier.
         /// </summary>


### PR DESCRIPTION
From discussion on https://github.com/umbraco/Umbraco-CMS/issues/6578#issuecomment-541977675 it turned out that the UmbracoApiControllerBase used the ServiceLocator to resolve the UmbracoMapper (Current.Mapper) https://github.com/umbraco/Umbraco-CMS/blob/v8/dev/src/Umbraco.Web/WebApi/UmbracoApiControllerBase.cs#L62, which made it impossible to mock/fake (unless you mock the Current.Mapper, which you shouldn't).

This PR injects the UmbracoMapper in the constructor instead and adds a obsolete attribute on the old constructor, which is kept for backward compatibility. 

One tests has been added to verify that it is possible to mock the new constructor but also one that verifies that the old constructor can still resolve the Current.Mapper dependency, again for backward compatibility.

@Shazwazza was this what you had in mind?
Cheers.