### PR TITLE
Some changes to the Redirect Url Management dashboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.controller.js
@@ -82,6 +82,7 @@
                 view: "views/dashboard/content/overlays/disable.html",
                 submitButtonLabel: "Disable",
                 submitButtonLabelKey: "actions_disable",
+                submitButtonStyle:"danger",
                 submit: function (model) {
                     performDisable();
                     overlayService.close();

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
@@ -14,7 +14,7 @@
                     size="s"
                     action="vm.disableUrlTracker($event)"
                     label-key="redirectUrls_disableUrlTracker"
-                    button-style="white">
+                    button-style="danger">
                 </umb-button>
 
                 <umb-button
@@ -23,8 +23,7 @@
                     size="s"
                     button-style="success"
                     action="vm.enableUrlTracker()"
-                    label-key="redirectUrls_enableUrlTracker"
-                    button-style="success">
+                    label-key="redirectUrls_enableUrlTracker">
                 </umb-button>
 
             </umb-editor-sub-header-section>


### PR DESCRIPTION
I have changed 3 things on the dashboard
- The "Disable" button has been changed to danger style (red bg colour)
- The Disable button on the confirm dialog changed to danger style
- There was duplicate `button-style` on the enable button which I have removed.

Notice the style change on the button on the dashboard and the confirm overlay below.

**Before**
![image](https://user-images.githubusercontent.com/3941753/67104992-e2f0f300-f1bf-11e9-9456-0baa56a45e07.png)


**After**
![image](https://user-images.githubusercontent.com/3941753/67104842-96a5b300-f1bf-11e9-9611-66125b293376.png)
