### PR TITLE
Create package form missing "Include all child nodes" label by Package Content Content selector

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -37,14 +37,10 @@
 
         vm.labels = {};
 
-        vm.versionRegex = /^(\d+\.)(\d+\.)(\*|\d+)$/;  
+        vm.versionRegex = /^(\d+\.)(\d+\.)(\*|\d+)$/;
 
         function onInit() {
-
-            localizationService.localize("packager_includeAllChildNodes").then(function (value) {
-                vm.labels.includeAllChildNodes = value;
-            });
-
+           
             if (create) {
                 // Pre populate package with some values
                 packageResource.getEmpty().then(scaffold => {
@@ -57,8 +53,9 @@
                     vm.loading = false;
                 });
 
-                localizationService.localize("general_create").then(function (value) {
-                    vm.labels.button = value;
+                localizationService.localizeMany(["general_create", "packager_includeAllChildNodes"]).then(function (values) {
+                    vm.labels.button = values[0];
+                    vm.labels.includeAllChildNodes = values[1];
                 });
             } else {
                 // Load package
@@ -81,8 +78,10 @@
 
                 });
 
-                localizationService.localize("buttons_save").then(function (value) {
-                    vm.labels.button = value;
+                
+                localizationService.localizeMany(["buttons_save", "packager_includeAllChildNodes"]).then(function (values) {
+                    vm.labels.button = values[0];
+                    vm.labels.includeAllChildNodes = values[1];
                 });
             }
         }
@@ -203,8 +202,8 @@
                         //don't add a browser history for this
                         $location.replace();
                     }
-                    
-                }, function(err){
+
+                }, function (err) {
                     formHelper.handleError(err);
                     vm.buttonState = "error";
                 });
@@ -217,14 +216,14 @@
 
         function openContentPicker() {
             const contentPicker = {
-                submit: function(model) {
-                    if(model.selection && model.selection.length > 0) {
+                submit: function (model) {
+                    if (model.selection && model.selection.length > 0) {
                         vm.package.contentNodeId = model.selection[0].id.toString();
                         vm.contentNodeDisplayModel = model.selection[0];
                     }
                     editorService.close();
                 },
-                close: function() {
+                close: function () {
                     editorService.close();
                 }
             };
@@ -242,25 +241,25 @@
                 entityType: "file",
                 multiPicker: true,
                 isDialog: true,
-                select: function(node) {
+                select: function (node) {
                     node.selected = !node.selected;
 
                     const id = decodeURIComponent(node.id.replace(/\+/g, " "));
                     const index = selection.indexOf(id);
 
-                    if(node.selected) {
-                        if(index === -1) {
+                    if (node.selected) {
+                        if (index === -1) {
                             selection.push(id);
                         }
                     } else {
                         selection.splice(index, 1);
                     }
                 },
-                submit: function() {
+                submit: function () {
                     vm.package.files = selection;
                     editorService.close();
                 },
-                close: function() {
+                close: function () {
                     editorService.close();
                 }
             };
@@ -285,12 +284,12 @@
                     }
                 },
                 filterCssClass: "not-allowed",
-                select: function(node) {
+                select: function (node) {
                     const id = decodeURIComponent(node.id.replace(/\+/g, " "));
                     vm.package.packageView = id;
                     editorService.close();
                 },
-                close: function() {
+                close: function () {
                     editorService.close();
                 }
             };
@@ -386,7 +385,7 @@
         }
 
         function buildContributorsEditor(pkg) {
-            
+
             vm.contributorsEditor = {
                 alias: "contributors",
                 editor: "Umbraco.MultipleTextstring",

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -41,6 +41,10 @@
 
         function onInit() {
 
+            localizationService.localize("packager_includeAllChildNodes").then(function (value) {
+                vm.labels.includeAllChildNodes = value;
+            });
+
             if (create) {
                 // Pre populate package with some values
                 packageResource.getEmpty().then(scaffold => {
@@ -77,11 +81,9 @@
 
                 });
 
-                localizationService.localizeMany(["buttons_save", "packager_includeAllChildNodes"]).then(function (values) {
-                    vm.labels.button = values[0];
-                    vm.labels.includeAllChildNodes = values[1];
+                localizationService.localize("buttons_save").then(function (value) {
+                    vm.labels.button = value;
                 });
-
             }
         }
 


### PR DESCRIPTION
On the Create Package form the "Include all child nodes" label is missing by Package Content section.

**Before**
![image](https://user-images.githubusercontent.com/3941753/67108782-1f741d00-f1c7-11e9-9d98-d1fca2c69322.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/67108818-36b30a80-f1c7-11e9-89b1-8a7a8e4407c0.png)

