### PR TITLE
Added thumbs.db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 ._.DS_Store
 .vs/
 /local/
+thumbs.db
 
 # build directories
 [Bb]in/


### PR DESCRIPTION
### Description

`thumbs.db` is a windows directory cache file which sometimes gets pushed to repos, comes in commits, and can trouble other users. Now windows users can send PRs without having to worry about `thumbs.db`.

