### PR TITLE
V8: Make Nested Content resilient to missing property editors

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -124,7 +124,6 @@ namespace Umbraco.Web.PropertyEditors
                                 var propEditor = _propertyEditors[propType.PropertyEditorAlias];
                                 if (propEditor == null)
                                 {
-                                    propValues[propAlias] = null;
                                     continue;
                                 }
                                 var tempConfig = dataTypeService.GetDataType(propType.DataTypeId).Configuration;
@@ -259,12 +258,16 @@ namespace Umbraco.Web.PropertyEditors
 
                             // Lookup the property editor
                             var propEditor = _propertyEditors[propType.PropertyEditorAlias];
+                            if (propEditor == null)
+                            {
+                                continue;
+                            }
 
                             // Create a fake content property data object
                             var contentPropData = new ContentPropertyData(propValues[propKey], propConfiguration);
 
                             // Get the property editor to do it's conversion
-                            var newValue = propEditor?.GetValueEditor().FromEditor(contentPropData, propValues[propKey]);
+                            var newValue = propEditor.GetValueEditor().FromEditor(contentPropData, propValues[propKey]);
 
                             // Store the value back
                             propValues[propKey] = (newValue == null) ? null : JToken.FromObject(newValue);

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -185,6 +185,11 @@ namespace Umbraco.Web.PropertyEditors
 
                                 // convert that temp property, and store the converted value
                                 var propEditor = _propertyEditors[propType.PropertyEditorAlias];
+                                if(propEditor == null)
+                                {
+                                    propValues[propAlias] = "Could not find an editor for this property type.";
+                                    continue;
+                                }
                                 var tempConfig = dataTypeService.GetDataType(propType.DataTypeId).Configuration;
                                 var valEditor = propEditor.GetValueEditor(tempConfig);
                                 var convValue = valEditor.ToEditor(tempProp, dataTypeService);

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -187,7 +187,7 @@ namespace Umbraco.Web.PropertyEditors
                                 var propEditor = _propertyEditors[propType.PropertyEditorAlias];
                                 if(propEditor == null)
                                 {
-                                    propValues[propAlias] = "Could not find an editor for this property type.";
+                                    propValues[propAlias] = tempProp.GetValue()?.ToString();
                                     continue;
                                 }
                                 var tempConfig = dataTypeService.GetDataType(propType.DataTypeId).Configuration;

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -122,6 +122,11 @@ namespace Umbraco.Web.PropertyEditors
                             {
                                 // convert the value, and store the converted value
                                 var propEditor = _propertyEditors[propType.PropertyEditorAlias];
+                                if (propEditor == null)
+                                {
+                                    propValues[propAlias] = null;
+                                    continue;
+                                }
                                 var tempConfig = dataTypeService.GetDataType(propType.DataTypeId).Configuration;
                                 var valEditor = propEditor.GetValueEditor(tempConfig);
                                 var convValue = valEditor.ConvertDbToString(propType, propValues[propAlias]?.ToString(), dataTypeService);
@@ -259,7 +264,7 @@ namespace Umbraco.Web.PropertyEditors
                             var contentPropData = new ContentPropertyData(propValues[propKey], propConfiguration);
 
                             // Get the property editor to do it's conversion
-                            var newValue = propEditor.GetValueEditor().FromEditor(contentPropData, propValues[propKey]);
+                            var newValue = propEditor?.GetValueEditor().FromEditor(contentPropData, propValues[propKey]);
 
                             // Store the value back
                             propValues[propKey] = (newValue == null) ? null : JToken.FromObject(newValue);
@@ -310,6 +315,11 @@ namespace Umbraco.Web.PropertyEditors
                         {
                             var config = dataTypeService.GetDataType(propType.DataTypeId).Configuration;
                             var propertyEditor = _propertyEditors[propType.PropertyEditorAlias];
+
+                            if (propertyEditor == null)
+                            {
+                                continue;
+                            }
 
                             foreach (var validator in propertyEditor.GetValueEditor().Validators)
                             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you remove a custom property editor that's currently used by a property on a content type, the content editor handles this rather gracefully by simply displaying the raw property value instead of the missing property editor:

![image](https://user-images.githubusercontent.com/7405322/67115559-cc0dc900-f1de-11e9-8116-cf3452650fbe.png)

Nested Content... not so much 😆

![image](https://user-images.githubusercontent.com/7405322/67115748-2e66c980-f1df-11e9-95ad-827a47f43969.png)

This is particularly annoying when you're building custom editor experiences in different branches against the same database.

This PR makes Nested Content mimic the content editor handling for missing property editors:

![image](https://user-images.githubusercontent.com/7405322/67115464-923cc280-f1de-11e9-8b3e-1eb8694fa17b.png)

#### Testing this PR

Here's a simple custom property editor you can use for testing: [TestPropertyEditor.zip](https://github.com/umbraco/Umbraco-CMS/files/3745083/TestPropertyEditor.zip)

Steps:

1. Add the property editor to `App_Plugins`.
2. Create a Nested Content configuration with an element type that uses this property editor.
3. Create some content based on this Nested Content configuration. 
4. Remove the property editor from `App_Plugins` and restart the site.
5. Verify that Nested Content loads without errors and displays the raw property value instead of the (now missing) property editor.