### PR TITLE
V8: Remove duplicate language labels in publish with descendants dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -48,8 +48,6 @@
 
                         <div>
                             <span class="db umb-list-item__description umb-list-item__description--checkbox" ng-if="!publishVariantSelectorForm.publishVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
-                                <span>{{variant.language.name}}</span>
-
                                 <span class="db umb-list-item__description" ng-if="!publishVariantSelectorForm.publishVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
                                     <umb-variant-state variant="variant"></umb-variant-state>
                                     <span ng-if="variant.language.isMandatory"> - <localize key="languages_mandatoryLanguage"></localize></span>
@@ -60,6 +58,7 @@
                                 </span>
 
                                 <umb-variant-notification-list notifications="variant.notifications"></umb-variant-notification-list>
+                            </span>
                         </div>
                     </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In #5635 the language name was added to the checkbox label in the "Publish with descendants" dialog - which is awesome! Unfortunately the language wasn't removed from its previous location, leaving us with duplicate language labels:

![image](https://user-images.githubusercontent.com/7405322/67119556-b650d180-f1e7-11e9-979c-5505af4ba654.png)

This PR removes the duplicate, and fixes some invalid markup too:

![image](https://user-images.githubusercontent.com/7405322/67119474-873a6000-f1e7-11e9-981f-25eec88be8dc.png)

