### PR TITLE
V8: Harmonize content save/publish dialogs with mandatory languages

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
@@ -24,8 +24,6 @@
                                   text="{{ variant.language.name }}"
                     />
                     <div>
-                            <strong ng-if="variant.language.isMandatory" class="umb-control-required">*</strong>
-
                             <span class="db umb-list-item__description umb-list-item__description--checkbox" ng-if="!publishVariantSelectorForm.publishVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
                                 <umb-variant-state variant="variant"></umb-variant-state>
                                 <span ng-if="variant.language.isMandatory"> - </span>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.html
@@ -29,10 +29,9 @@
                         />
 
                         <div>
-                                <strong ng-if="variant.language.isMandatory" class="umb-control-required">*</strong>
-
-                                <span class="db" ng-if="!saveVariantSelectorForm.$invalid && !(variant.notifications && variant.notifications.length > 0)">
-                                    <umb-variant-state class="umb-list-item__description umb-list-item__description--checkbox" variant="variant"></umb-variant-state>
+                                <span class="db umb-list-item__description umb-list-item__description--checkbox" ng-if="!saveVariantSelectorForm.$invalid && !(variant.notifications && variant.notifications.length > 0)">
+                                    <umb-variant-state variant="variant"></umb-variant-state>
+                                    <span ng-if="variant.language.isMandatory"> - <localize key="languages_mandatoryLanguage"></localize></span>
                                 </span>
 
                                 <span class="db" ng-messages="saveVariantSelectorForm.saveVariantSelector.$error" show-validation-on-submit>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.html
@@ -24,10 +24,9 @@
                     />
 
                     <div>
-                        <strong ng-if="variant.language.isMandatory" class="umb-control-required">*</strong>
-
-                        <span class="db" ng-if="!publishVariantSelectorForm.publishVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
-                            <umb-variant-state class="umb-list-item__description umb-list-item__description--checkbox" variant="variant"></umb-variant-state>
+                        <span class="db umb-list-item__description umb-list-item__description--checkbox" ng-if="!publishVariantSelectorForm.publishVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
+                            <umb-variant-state variant="variant"></umb-variant-state>
+                            <span ng-if="variant.language.isMandatory"> - <localize key="languages_mandatoryLanguage"></localize></span>
                         </span>
 
                         <span class="db" ng-messages="publishVariantSelectorForm.publishVariantSelector.$error" show-validation-on-submit>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The save/publish dialogs for multilingual content are a bit inconsistent when you have a mandatory language. In some dialogs an asterisk is displayed next to the language, in some the label "Mandatory language" is added - and some have both. 

On top of that, #5635 has the unintended side effect of pushing the asterisk down below the checkbox, leaving the variant status label somewhat floating.

![image](https://user-images.githubusercontent.com/7405322/67120405-873b5f80-f1e9-11e9-8b3d-e2e9700b24f7.png)

![image](https://user-images.githubusercontent.com/7405322/67120441-98846c00-f1e9-11e9-9c8e-ec11d74ed5d3.png)

![image](https://user-images.githubusercontent.com/7405322/67120368-74c12600-f1e9-11e9-82a8-28cc3a70c500.png)


Considering how the asterisk usually denotes "required" and that it's not necessarily required to tick the mandatory languages in these dialogs, I think we should simply remove them and add the "Mandatory language" everywhere instead. So this PR does just that:

![image](https://user-images.githubusercontent.com/7405322/67120140-fbc1ce80-f1e8-11e9-8965-b9b71388f684.png)

![image](https://user-images.githubusercontent.com/7405322/67120168-0c724480-f1e9-11e9-8569-5f0f134ada6c.png)

![image](https://user-images.githubusercontent.com/7405322/67120274-417e9700-f1e9-11e9-882a-ad74fa5656a5.png)
