### PR TITLE
V8: Datetime picker should submit its value on enter when entering time

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbdatetimepicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbdatetimepicker.directive.js
@@ -131,13 +131,24 @@ Use this directive to render a date time picker
 				return console.warn('Unable to find any flatpickr installation');
 			}
 
+            var fpInstance;
+
 			setUpCallbacks();
 
             if (!ctrl.options.locale) {
                 ctrl.options.locale = userLocale;
             }
 
-            var fpInstance = new fpLib(element, ctrl.options);
+            // handle special keydown events
+            ctrl.options.onKeyDown = function (selectedDates, dateStr, instance, event) {
+                var code = event.keyCode || event.which;
+                if (code === 13) {
+                    // close the datepicker on enter (this happens when entering time)
+                    fpInstance.close()
+                }
+            };
+
+            fpInstance = new fpLib(element, ctrl.options);
             
 			if (ctrl.onSetup) {
 				ctrl.onSetup({


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When you have a datetime picker, I would expect it to submit its value on enter after you input the time. But it doesn't. You have to hit escape to close the datepicker (which incidentally does submit the value... that's arguable):

![datepicker-enter-before](https://user-images.githubusercontent.com/7405322/67149970-190e9f80-f2b2-11e9-8428-ec1c7494fc34.gif)

This PR ensures that the datetime picker submits its value when enter is pressed. It works like this:

![datepicker-enter-after](https://user-images.githubusercontent.com/7405322/67149979-29bf1580-f2b2-11e9-906f-41d5379f2153.gif)
