### PR TITLE
V8: Do not allow deleting inherited content type groups

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -419,7 +419,7 @@
       };
 
       scope.canRemoveGroup = function(group){
-        return _.find(group.properties, function(property) { return property.locked === true; }) == null;
+        return group.inherited !== true && _.find(group.properties, function(property) { return property.locked === true; }) == null;
       }
 
       scope.removeGroup = function(groupIndex) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The backoffice lets us delete inherited groups from content types. Fortunately the server doesn't actually delete the inherited groups, but still... the client shouldn't allow it in the first place:

![delete-inherited-groups-before](https://user-images.githubusercontent.com/7405322/67150151-20cf4380-f2b4-11e9-885b-6122f015e028.gif)

Fortunately it's a simple fix. With this PR, inherited groups can't be deleted clientside:

![delete-inherited-groups-after](https://user-images.githubusercontent.com/7405322/67150158-2fb5f600-f2b4-11e9-9e2e-fa8b7e6a6f77.gif)


