### PR TITLE
V8: Remove "double tabbing" and duplicate editor for datatype picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.html
@@ -48,13 +48,14 @@
                                         <li ng-repeat="systemDataType in value | orderBy:'name'"
                                             data-element="editor-{{systemDataType.name}}"
                                             ng-mouseover="vm.showDetailsOverlay(systemDataType)"
-                                            ng-click="vm.pickEditor(systemDataType)">
-                                            <a class="umb-card-grid-item" href="" title="{{ systemDataType.name }}">
+                                            ng-click="vm.pickEditor(systemDataType)"
+                                            class="cursor-pointer">
+                                            <span class="umb-card-grid-item" title="{{ systemDataType.name }}">
                                                 <span>
                                                     <i class="{{ systemDataType.icon }}" ng-class="{'icon-autofill': systemDataType.icon == null}"></i>
                                                     {{ systemDataType.name }}
                                                 </span>
-                                            </a>
+                                            </span>
                                         </li>
                                     </ul>
                                 </div>
@@ -66,16 +67,17 @@
                                         <li ng-repeat="dataType in value | orderBy:'name'"
                                             data-element="editor-{{dataType.name}}"
                                             ng-mouseover="vm.showDetailsOverlay(dataType)"
-                                            ng-click="vm.pickDataType(dataType)">
+                                            ng-click="vm.pickDataType(dataType)"
+                                            class="cursor-pointer">
                                             <div ng-if="dataType.loading" class="umb-card-grid-item__loading">
                                                 <div class="umb-button__progress"></div>
                                             </div>
-                                            <a class="umb-card-grid-item" href="" title="{{ dataType.name }}">
+                                            <span class="umb-card-grid-item" title="{{ dataType.name }}">
                                                 <span>
                                                     <i class="{{ dataType.icon }}" ng-class="{'icon-autofill': dataType.icon == null}"></i>
                                                     {{ dataType.name }}
                                                 </span>
-                                            </a>
+                                            </span>
                                         </li>
                                     </ul>
                                 </div>
@@ -93,16 +95,17 @@
                                     <ul class="umb-card-grid -four-in-row" ng-mouseleave="vm.hideDetailsOverlay()">
                                         <li ng-repeat="dataType in result.dataTypes | orderBy:'name'"
                                             ng-mouseover="vm.showDetailsOverlay(dataType)"
-                                            ng-click="vm.pickDataType(dataType)">
+                                            ng-click="vm.pickDataType(dataType)"
+                                            class="cursor-pointer">
                                             <div ng-if="dataType.loading" class="umb-card-grid-item__loading">
                                                 <div class="umb-button__progress"></div>
                                             </div>
-                                            <a class="umb-card-grid-item" href="" title="{{dataType.name}}">
+                                            <span class="umb-card-grid-item" title="{{dataType.name}}">
                                                 <span>
                                                     <i class="{{dataType.icon}}" ng-class="{'icon-autofill': dataType.icon == null}"></i>
                                                     {{dataType.name}}
                                                 </span>
-                                            </a>
+                                            </span>
                                         </li>
                                     </ul>
                                 </div>
@@ -116,13 +119,14 @@
                                     <ul class="umb-card-grid -four-in-row" ng-mouseleave="vm.hideDetailsOverlay()">
                                         <li ng-repeat="systemDataType in result.dataTypes | orderBy:'name'"
                                             ng-mouseover="vm.showDetailsOverlay(systemDataType)"
-                                            ng-click="vm.pickEditor(systemDataType)">
-                                            <a class="umb-card-grid-item" href="" title="{{systemDataType.name}}">
+                                            ng-click="vm.pickEditor(systemDataType)"
+                                            class="cursor-pointer">
+                                            <span class="umb-card-grid-item" title="{{systemDataType.name}}">
                                                 <span>
                                                     <i class="{{systemDataType.icon}}" ng-class="{'icon-autofill': systemDataType.icon == null}"></i>
                                                     {{systemDataType.name}}
                                                 </span>
-                                            </a>
+                                            </span>
                                         </li>
                                     </ul>
                                 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you're prone to tabbing your way through the content type creation, it's a bit of a hassle picking the right datatype for properties. You have to tab twice for each datatype when you're moving through the list of datatypes; once to highlight the datatype - the outer `li` element - and once more to highlight the contained `a` element.

What's worse is if you hit enter when the inner `a` element is highlighted, the "new datatype" editor is displayed twice (it's only displayed once if you hit enter on the outer `li` though):

![property-type-tabbing-before-annotated](https://user-images.githubusercontent.com/7405322/67150685-211f0d00-f2bb-11e9-8d44-a82819b925c3.gif)

This PR fixes it all up so you can tab your way through the datatype picker like you'd expect:

![property-type-tabbing-after](https://user-images.githubusercontent.com/7405322/67150681-1bc1c280-f2bb-11e9-8c34-2d125d407d9d.gif)
