### PR TITLE
V8: Make it possible to open tabs with the keyboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,6 +1,6 @@
 <ul role="tablist" class="umb-tabs-nav">
-    <li class="umb-tab" role="tab" aria-selected="true" tabindex="0" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': tabHasError}" val-tab>
-        <a ng-href="" ng-click="vm.clickTab($event, tab)">{{ tab.label }}</a>
+    <li ng-click="vm.clickTab($event, tab)" class="umb-tab" role="tab" aria-selected="true" tabindex="0" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': tabHasError}" val-tab>
+        <a>{{ tab.label }}</a>
     </li>
 
     <li data-element="tab-expand" class="umb-tab umb-tab--expand" ng-class="{ 'open': vm.showTray }" ng-show="vm.needTray">

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -3,11 +3,11 @@
         <a>{{ tab.label }}</a>
     </li>
 
-    <li data-element="tab-expand" class="umb-tab umb-tab--expand" ng-class="{ 'open': vm.showTray }" ng-show="vm.needTray">
-        <a ng-href="" ng-click="vm.toggleTray()"><i></i><i></i><i></i></a>
+    <li data-element="tab-expand" class="umb-tab umb-tab--expand" tabindex="0" ng-click="vm.toggleTray()" ng-class="{ 'open': vm.showTray }" ng-show="vm.needTray">
+        <a ng-href=""><i></i><i></i><i></i></a>
         <umb-dropdown class="umb-tabs-tray" ng-if="vm.showTray" on-close="vm.hideTray()">
-            <umb-dropdown-item ng-repeat="tab in vm.tabs | limitTo: vm.overflowingTabs" ng-class="{'umb-tabs-tray-item--active': tab.active}">
-                <a ng-href="" href="" ng-click="vm.clickTab($event, tab)">{{ tab.label }}</a>
+            <umb-dropdown-item ng-repeat="tab in vm.tabs | limitTo: vm.overflowingTabs" ng-class="{'umb-tabs-tray-item--active': tab.active}" tabindex="0" ng-click="vm.clickTab($event, tab)">
+                <a ng-href="">{{ tab.label }}</a>
             </umb-dropdown-item>
         </umb-dropdown>
     </li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

You can navigate tabs with the keyboard, but you can't open them 😢 ... which is particularly annoying when creating document types:

![umb-tabs-nav-tabbing-before](https://user-images.githubusercontent.com/7405322/67150997-765d1d80-f2bf-11e9-876a-f8eeb8f2c24d.gif)

This PR fixes it:

![umb-tabs-nav-tabbing-after](https://user-images.githubusercontent.com/7405322/67150999-8117b280-f2bf-11e9-86cd-f46ed287035c.gif)

Added bonus: It also works for dashboard tabs:

![umb-tabs-nav-tabbing-after-dashboard](https://user-images.githubusercontent.com/7405322/67151001-8e34a180-f2bf-11e9-93e6-56f25fcca9f2.gif)
