### PR TITLE
Allow querystring parameters to set IsElementType checkbox on create document type route

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -62,6 +62,8 @@
                 documentTypeId = $scope.model.id;
                 create = $scope.model.create;
                 noTemplate = $scope.model.notemplate;
+                isElement = $scope.model.iselement;
+                allowVaryByCulture = $scope.model.allowvarybyculture;
                 vm.submitButtonKey = "buttons_saveAndClose";
                 vm.generateModelsKey = "buttons_generateModelsAndClose";
             }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -62,8 +62,8 @@
                 documentTypeId = $scope.model.id;
                 create = $scope.model.create;
                 noTemplate = $scope.model.notemplate;
-                isElement = $scope.model.iselement;
-                allowVaryByCulture = $scope.model.allowvarybyculture;
+                isElement = $scope.model.isElement;
+                allowVaryByCulture = $scope.model.allowVaryByCulture;
                 vm.submitButtonKey = "buttons_saveAndClose";
                 vm.generateModelsKey = "buttons_generateModelsAndClose";
             }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -18,6 +18,8 @@
         var documentTypeId = $routeParams.id;
         var create = $routeParams.create;
         var noTemplate = $routeParams.notemplate;
+        var isElement = $routeParams.iselement;
+        var allowVaryByCulture = $routeParams.culturevary;
         var infiniteMode = $scope.model && $scope.model.infiniteMode;
 
         vm.save = save;
@@ -427,7 +429,14 @@
                 contentType.defaultTemplate = contentTypeHelper.insertDefaultTemplatePlaceholder(contentType.defaultTemplate);
                 contentType.allowedTemplates = contentTypeHelper.insertTemplatePlaceholder(contentType.allowedTemplates);
             }
-
+            // set isElement checkbox by default
+            if (isElement) {
+                contentType.isElement = true;
+            }
+            // set vary by culture checkbox by default
+            if (allowVaryByCulture) {
+                contentType.allowCultureVariant = true;
+            }
             // convert icons for content type
             convertLegacyIcons(contentType);
 


### PR DESCRIPTION
### Prerequisites

- [  + ] I have added steps to test this contribution in the description below

Relates to issue https://github.com/umbraco/Umbraco-CMS/issues/6410

### Description

Some of the cool Umbraco folk I know were chatting around the issue #6410 which is essentially is 'all about' adding to the Create Document Type options, a super fast way to create an Element Type, instead of having to create first a Document Type Without Template, and then remember to manually check the Is An Element Type checkbox on the permissions tab...

... why can't they just have a new option to do that on that menu ... speed up everyone's daily workflow...

![image](https://user-images.githubusercontent.com/260802/67152542-68fc5f00-f2d0-11e9-86c4-c237286b0844.png)

... well there are concerns on how to present these options, in a way that doesn't confuse people new to Umbraco (what is a Document Type Collection anyway? etc)... which will involve some due consideration and perhaps an RFC...

... anyway in the meantime, devs are pulling their hair out, everyday, right click create, document type without template, permissions check is an element type and they are getting frustrated, and well I don't know just how far this is going to escalate...

So this PR doesn't address the menu, or adding that in... there is a whole lot of discussion required first - so what does it do? and why am I proposing it?

This PR, updates the DocumentTypes edit.controller.js to look on the querystring for two new parameters

iselement
&
culturevary

if these parameters are set to true on the querystring, then the checkbox toggle for 'Is an Element Type' and 'Allow varying by culture' will by default be also set to true.

![image](https://user-images.githubusercontent.com/260802/67152556-96e1a380-f2d0-11e9-83ed-48e60a79aabb.png)

![image](https://user-images.githubusercontent.com/260802/67152560-b678cc00-f2d0-11e9-90bb-be4d94bfe933.png)

![image](https://user-images.githubusercontent.com/260802/67152570-dad4a880-f2d0-11e9-9d4b-427b9df65661.png)

This changes nothing for day to day creating of Document Types! - nothing is visible to anyone via the menu, shhhsshsh nobody needs to know this change has happened... just merge it in... nobody will know... 

... but what it enables is a cool kid package developer to experiment with the options for this menu... to allow a 'power tools' document type options plugin to be created - that can perhaps enable evolution in the realm of the package sphere to identify and test the long term improvements required to be made to this menu in the core product... in the short term, devs can have a boost to their productivity, whilst buying some time for the longer term considerations...
   

<!-- Thanks for receiving this contribution to Umbraco CMS! -->
