### PR TITLE
V8: Fix keyboard through the sections tray on small screens

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -118,6 +118,7 @@ ul.sections-tray {
             text-decoration: none;
             display: block;
             position: relative;
+            outline: none;
 
             &::after {
                 content: "";
@@ -130,6 +131,13 @@ ul.sections-tray {
                 transition: all .2s linear;
                 top: 0;
                 left: 0;
+            }
+
+            &:focus .section__name {
+                .tabbing-active & {
+                    border: 1px solid;
+                    border-color: @gray-9;
+                }
             }
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-sections.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-sections.html
@@ -12,9 +12,11 @@
             </li>
 
             <li data-element="section-expand" class="expand" ng-class="{ 'open': showTray === true }" ng-show="needTray">
-                <a href ng-click="trayClick()"><i></i><i></i><i></i></a>
+                <a href="#" ng-click="trayClick()" prevent-default>
+                    <span class="section__name"><i></i><i></i><i></i></span>
+                </a>
 
-                <ul id="applications-tray" class="sections-tray shadow-depth-2" ng-if="showTray" on-outside-click="trayClick()">
+                <ul id="applications-tray" class="sections-tray shadow-depth-2" ng-if="showTray" on-outside-click="trayClick($event)">
                     <li ng-repeat="section in sections | limitTo: overflowingSections" ng-class="{current: section.alias == currentSection}">
                         <a href="#/{{section.alias}}"
                             ng-dblclick="sectionDblClick(section)"

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-sections.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-sections.html
@@ -16,7 +16,7 @@
                     <span class="section__name"><i></i><i></i><i></i></span>
                 </a>
 
-                <ul id="applications-tray" class="sections-tray shadow-depth-2" ng-if="showTray" on-outside-click="trayClick($event)">
+                <ul id="applications-tray" class="sections-tray shadow-depth-2" ng-if="showTray" on-outside-click="trayClick()">
                     <li ng-repeat="section in sections | limitTo: overflowingSections" ng-class="{current: section.alias == currentSection}">
                         <a href="#/{{section.alias}}"
                             ng-dblclick="sectionDblClick(section)"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

On small screens, the rightmost sections in the top menu are collapsed into a tray. While keyboard navigation *does* work as-is, it's a bit confusing and also styling wise not in line with the top menu. Notice in the GIF below how the tray dots `...` aren't highlighted even though they have input focus.

![tray-tabbing-before](https://user-images.githubusercontent.com/7405322/67157304-b0afd480-f32a-11e9-8dc9-59ae36875cea.gif)

This PR fixes that. It also updates the focused-state style for the menu items in the tray, so they look like the rest of menu items in the top menu when focused:

![tray-tabbing-after](https://user-images.githubusercontent.com/7405322/67157315-dc32bf00-f32a-11e9-8c3f-842441bd27ab.gif)
