### PR TITLE
Rollback dropdown - convert version dates to local

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function RollbackController($scope, contentResource, localizationService, assetsService) {
+    function RollbackController($scope, contentResource, localizationService, assetsService, dateHelper, userService) {
         
         var vm = this;
 
@@ -90,11 +90,15 @@
             const culture = $scope.model.node.variants.length > 1 ? vm.currentVersion.language.culture : null;
 
             return contentResource.getRollbackVersions(nodeId, culture)
-                .then(function(data){
-                    vm.previousVersions = data.map(version => {
-                        version.displayValue = version.versionDate + " - " + version.versionAuthorName;
-                        return version;
-                    }); 
+                .then(function (data) {
+                    // get current backoffice user and format dates
+                    userService.getCurrentUser().then(function (currentUser) {
+                        vm.previousVersions = data.map(version => {
+                            var timestampFormatted = dateHelper.getLocalDate(version.versionDate, currentUser.locale, 'LLL');
+                            version.displayValue = timestampFormatted + ' - ' + version.versionAuthorName;
+                            return version;
+                        }); 
+                    });
                 });
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6738

### Description
The History section of a document's Info tab converts times to the client's local time, but the "Rollback to" dropdown displays times in the server's timezone.

This PR converts the times in the dropdown to local times.

Testing:
- With a server in a different timezone from the client, compare the times displayed in the History section and the "Rollback to" dropdown. They should match, both in the client's local time.