### PR TITLE
Cache lookup of macro by alias

### DIFF
--- a/src/Umbraco.Core/Cache/CacheKeys.cs
+++ b/src/Umbraco.Core/Cache/CacheKeys.cs
@@ -11,5 +11,6 @@
         public const string TemplateFrontEndCacheKey = "template";
 
         public const string MacroContentCacheKey = "macroContent_"; // used in MacroRenderers
+        public const string MacroFromAliasCacheKey = "macroFromAlias_";
     }
 }

--- a/src/Umbraco.Web/Cache/MacroCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/MacroCacheRefresher.cs
@@ -99,6 +99,7 @@ namespace Umbraco.Web.Cache
             return new[]
                 {
                     CacheKeys.MacroContentCacheKey, // macro render cache
+                    CacheKeys.MacroFromAliasCacheKey, // lookup macro by alias
                 };
         }
 

--- a/src/Umbraco.Web/Macros/MacroRenderer.cs
+++ b/src/Umbraco.Web/Macros/MacroRenderer.cs
@@ -197,7 +197,8 @@ namespace Umbraco.Web.Macros
 
         public MacroContent Render(string macroAlias, IPublishedContent content, IDictionary<string, object> macroParams)
         {
-            var m = _macroService.GetByAlias(macroAlias);
+            var m = _appCaches.RuntimeCache.GetCacheItem(CacheKeys.MacroFromAliasCacheKey + macroAlias, () => _macroService.GetByAlias(macroAlias));
+
             if (m == null)
                 throw new InvalidOperationException("No macro found by alias " + macroAlias);
 


### PR DESCRIPTION
### Description
Rendering a macro always queries the database to get the macro details from the alias. This is true even if the macro result is already cached, since we need the macro's details to generate the correct cache key.

This PR adds caching of the `IMacro` results within `MacroRenderer`.

It may be safe to cache within MacroService.GetByAlias instead, but it seemed better to make MacroRenderer responsible for its own cache, with no risk of side effects for other code using MacroService.