### PR TITLE
V8: Make the active state clearly visible for property "edit" and "delete" icons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -367,7 +367,6 @@ input.umb-group-builder__group-title-input:disabled:hover {
         overflow: visible;
         background: transparent;
         line-height: normal;
-        outline: 0;
         -webkit-appearance: none;
         
         &:hover, &:focus  {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When you tab around the content type editor, the active state for the "edit" and "delete" icons for properties is *very* subtle:

![image](https://user-images.githubusercontent.com/7405322/67163513-28ecb900-f370-11e9-84ba-c03ea22582d9.png)

This PR adds outlines to these icons, in line with the other elements in the content editor - specially the group "delete" icon:

![tab-navigate-property-edit-icons](https://user-images.githubusercontent.com/7405322/67163523-47eb4b00-f370-11e9-84aa-17362efbd614.gif)

