### PR TITLE
#6785 - Alters use of Server.MapPath to IOHelper.MapPath

### DIFF
--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -239,8 +239,8 @@ namespace Umbraco.Web.Editors
             var gridConfig = UmbracoConfig.For.GridConfig(
                 Logger,
                 ApplicationContext.ApplicationCache.RuntimeCache,
-                new DirectoryInfo(Server.MapPath(SystemDirectories.AppPlugins)),
-                new DirectoryInfo(Server.MapPath(SystemDirectories.Config)),
+                new DirectoryInfo(IOHelper.MapPath(SystemDirectories.AppPlugins)),
+                new DirectoryInfo(IOHelper.MapPath(SystemDirectories.Config)),
                 HttpContext.IsDebuggingEnabled);
             return new JsonNetResult { Data = gridConfig.EditorsConfig.Editors, Formatting = Formatting.None };
         }


### PR DESCRIPTION
Relates to : https://github.com/umbraco/Umbraco-CMS/issues/6785

I put some logging statements in the call to /umbraco/GetGridConfig - and noted that the path for the ~/config directory was being resolved to 'D:\Windows\system32\~\config\grid.editors.config.js'.

This meant that eventually when Umbraco.Core.Configuration.Grid.GridEditorsConfig.Editors is called, the config path is not resolved on line 37 `(File.Exists(gridConfig))`, and the property resolves just those grid editors that have configuration in App_Plugin manifests.

Notably, these issues were only replicated in an Azure App Service as locally the code always resolved to the correct config path. However, I noted that other parts of the code base use Umbraco.Core.IO.IOHelper.MapPath instead of Server.MapPath, with the difference being that the path is being resolved using `HostingEnvironment.MapPath(path)`. Changing to use this instead appears to resolve the correct path.

As to _why_ this is occurring, I'm still not sure. I'm thinking whether it's to do with the /umbraco/GetGridConfig being a Web API call, and `Server.MapPath(path)` being dependent on HttpContext? It should be noted that I'm running the project in .Net 4.7.1 - whether this is generating the issue in itself?
