### PR TITLE
Fix wrong assembly name for UmbracoModule

### DIFF
--- a/build/NuSpecs/tools/Web.config.install.xdt
+++ b/build/NuSpecs/tools/Web.config.install.xdt
@@ -53,7 +53,7 @@
       <add name="umbracoBaseRequestModule" xdt:Locator="Match(name)" xdt:Transform="Remove" />
       <add name="viewstateMoverModule" xdt:Locator="Match(name)" xdt:Transform="Remove" />
       <add name=" UmbracoModule" xdt:Locator="Match(name)" xdt:Transform="Remove" />
-      <add name="UmbracoModule" type="Umbraco.Web.UmbracoModule,umbraco" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
+      <add name="UmbracoModule" type="Umbraco.Web.UmbracoModule,Umbraco.Web" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
     </httpModules>
 
     <httpHandlers xdt:Transform="InsertIfMissing" />
@@ -76,7 +76,7 @@
       <!-- Note, we're removing the one that starts with a space here, don't correct it -->
       <!-- This to fix a quirk we for a lot of releases where we added it with the space by default -->
       <add name=" UmbracoModule" xdt:Locator="Match(name)" xdt:Transform="Remove" />
-      <add name="UmbracoModule" type="Umbraco.Web.UmbracoModule,umbraco" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
+      <add name="UmbracoModule" type="Umbraco.Web.UmbracoModule,Umbraco.Web" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
     </modules>
 
     <staticContent xdt:Transform="InsertIfMissing" />


### PR DESCRIPTION
Noticed that the assembly name in the xdt file still was `umbraco` but that assembly doesn't exist anymore and the module is now located in Umbraco.Web`.

It's not causing any problems which I guess is because it's being replaced somewhere else in the powershell install scripts