### PR TITLE
Add UmbracoVirtualNodeByUdiRouteHandler

### DIFF
--- a/src/Umbraco.Web/Mvc/UmbracoVirtualNodeByUdiRouteHandler.cs
+++ b/src/Umbraco.Web/Mvc/UmbracoVirtualNodeByUdiRouteHandler.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Web.Mvc
     {
         private readonly Udi _realNodeUdi;
 
-        public UmbracoVirtualNodeByUdiRouteHandler(Udi realNodeUdi)
+        public UmbracoVirtualNodeByUdiRouteHandler(GuidUdi realNodeUdi)
         {
             _realNodeUdi = realNodeUdi;
         }

--- a/src/Umbraco.Web/Mvc/UmbracoVirtualNodeByUdiRouteHandler.cs
+++ b/src/Umbraco.Web/Mvc/UmbracoVirtualNodeByUdiRouteHandler.cs
@@ -1,0 +1,27 @@
+﻿using System.Web.Routing;
+using Umbraco.Core;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Web.Mvc
+{
+    public class UmbracoVirtualNodeByUdiRouteHandler : UmbracoVirtualNodeRouteHandler
+    {
+        private readonly Udi _realNodeUdi;
+
+        public UmbracoVirtualNodeByUdiRouteHandler(Udi realNodeUdi)
+        {
+            _realNodeUdi = realNodeUdi;
+        }
+
+        protected sealed override IPublishedContent FindContent(RequestContext requestContext, UmbracoContext umbracoContext)
+        {
+            var byId = umbracoContext.Content.GetById(_realNodeUdi);
+            return byId == null ? null : FindContent(requestContext, umbracoContext, byId);
+        }
+
+        protected virtual IPublishedContent FindContent(RequestContext requestContext, UmbracoContext umbracoContext, IPublishedContent baseContent)
+        {
+            return baseContent;
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -250,6 +250,7 @@
     <Compile Include="Models\TemplateQuery\OperatorFactory.cs" />
     <Compile Include="UmbracoContextFactory.cs" />
     <Compile Include="UmbracoContextReference.cs" />
+    <Compile Include="Mvc\UmbracoVirtualNodeByUdiRouteHandler.cs" />
     <Compile Include="ViewDataExtensions.cs" />
     <Compile Include="WebApi\Filters\AdminUsersAuthorizeAttribute.cs" />
     <Compile Include="WebApi\Filters\OnlyLocalRequestsAttribute.cs" />


### PR DESCRIPTION
This is the same as [UmbracoVirtualNodeByIdRouteHandler ](https://github.com/umbraco/Umbraco-CMS/blob/v8/dev/src/Umbraco.Web/Mvc/UmbracoVirtualNodeByIdRouteHandler.cs) except it expects a GuidUdi so code can reference the same node across Umbraco Cloud environments etc 

Tested with this example:

            var routeGuid = new GuidUdi(Constants.UdiEntityType.Document, new Guid("e8ad9b65-cff6-4952-ac5b-efe56a60db62"));
            RouteTable.Routes.MapUmbracoRoute(
                "Product list by category",
                "category/{customId}",
                new
                {
                    controller = "People",
                    action = "Index",
                    customId = UrlParameter.Optional,
                    page = 1
                },
                new UmbracoVirtualNodeByUdiRouteHandler(routeGuid));