### PR TITLE
Extend the umb-radio button directive to handle localizations

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -26,6 +26,7 @@
 @param {string} value Set the value of the radiobutton.
 @param {string} name Set the name of the radiobutton.
 @param {string} text Set the text for the radiobutton label.
+@param {string} labelKey Set a dictinary/localization string for the checkbox label
 @param {boolean} disabled Set the radiobutton to be disabled.
 @param {boolean} required Set the radiobutton to be required.
 @param {callback} onChange Callback when the value of the radiobutton change by interaction.
@@ -39,7 +40,19 @@
 
         var vm = this;
 
+        vm.$onInit = onInit;
         vm.change = change;
+
+        function onInit() {
+            // If a labelKey is passed let's update the returned text if it's does not contain an opening square bracket [
+            if (vm.labelKey) {
+                 localizationService.localize(vm.labelKey).then(function (data) {
+                      if(data.indexOf('[') === -1){
+                        vm.text = data;
+                      }
+                 });
+            }
+        }
 
         function change() {
             if (vm.onChange) {
@@ -47,7 +60,7 @@
                     vm.onChange({ model: vm.model, value: vm.value });
                 }, 0);
             }
-        }    
+        }
     }
 
     var component = {
@@ -60,6 +73,7 @@
             value: "@",
             name: "@",
             text: "@",
+            labelKey: "@?",
             disabled: "<",
             required: "<",
             onChange: "&?"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The umb-radiobutton directive has been extended so it's possible to pass it a labelkey like it was recently added to the umb-checkbox directive in #5635, which will come in handy when it's needed to pass a dictionary item.