### PR TITLE
V7: Editors should always be allowed to delete their own content

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -28,6 +28,7 @@ using Constants = Umbraco.Core.Constants;
 using umbraco.cms.businesslogic;
 using System.Collections;
 using umbraco;
+using umbraco.BusinessLogic.Actions;
 
 namespace Umbraco.Web.Editors
 {
@@ -1170,6 +1171,12 @@ namespace Umbraco.Web.Editors
             //if there is no content item for this id, than just use the id as the path (i.e. -1 or -20)
             var path = contentItem != null ? contentItem.Path : nodeId.ToString();
             var permission = userService.GetPermissionsForPath(user, path);
+
+            // users are allowed to delete their own stuff - see ContentTreeControllerBase.GetAllowedUserMenuItemsForNode()
+            if(contentItem != null && contentItem.CreatorId == user.Id)
+            {
+                permission.PermissionsSet.Add(new EntityPermission(0, contentItem.Id, new [] { ActionDelete.Instance.Letter.ToString() } ));
+            }
 
             var allowed = true;
             foreach (var p in permissionsToCheck)

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -1172,7 +1172,7 @@ namespace Umbraco.Web.Editors
             var path = contentItem != null ? contentItem.Path : nodeId.ToString();
             var permission = userService.GetPermissionsForPath(user, path);
 
-            // users are allowed to delete their own stuff - see ContentTreeControllerBase.GetAllowedUserMenuItemsForNode()
+            // users are allowed to delete their own content - see ContentTreeControllerBase.GetAllowedUserMenuItemsForNode()
             if(contentItem != null && contentItem.CreatorId == user.Id)
             {
                 permission.PermissionsSet.Add(new EntityPermission(0, contentItem.Id, new [] { ActionDelete.Instance.Letter.ToString() } ));


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Editors should always be able to delete the content they create - even if deletion is explicitly disallowed by means of group permissions assigned to a (parent) node. That's why the "Delete" action remains in the node menu. 

It just doesn't work, because this special exemption isn't honored when the delete action is executed:

![delete-own-content-before](https://user-images.githubusercontent.com/7405322/67233757-222f7600-f444-11e9-9357-5a5690dda10e.gif)

This PR adds this special case handling to the action execution, and thus you're always able to delete the content you have created:

![delete-own-content-after](https://user-images.githubusercontent.com/7405322/67233746-1fcd1c00-f444-11e9-8f9e-e9f64ee9f2c4.gif)

