### PR TITLE
Style delete package overlay button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/created.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/created.controller.js
@@ -28,6 +28,7 @@
                 view: "views/packages/overlays/delete.html",
                 package: createdPackage,
                 submitButtonLabelKey: "contentTypeEditor_yesDelete",
+                submitButtonStyle:"danger",
                 submit: function (model) {
                     performDelete(index, createdPackage);
                     overlayService.close();


### PR DESCRIPTION
I have changed the button style to be `danger`

**Before**
![image](https://user-images.githubusercontent.com/3941753/67242428-6bd08e80-f44d-11e9-81f4-a36ca298dfae.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/67242445-7854e700-f44d-11e9-966e-43a18d74febd.png)
