### PR TITLE
V8: Prevent/remove duplicate nodes for editors with start nodes (take two)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -289,9 +289,8 @@ body.touch .umb-tree {
 }
 
 .no-access {
-    .umb-tree-icon,
-    .root-link,
-    .umb-tree-item__label {
+    > .umb-tree-item__inner .umb-tree-icon,
+    > .umb-tree-item__inner .umb-tree-item__label {
         color: @gray-7;
         cursor: not-allowed;
     }

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -195,19 +195,29 @@ namespace Umbraco.Web.Trees
             //get the current user start node/paths
             GetUserStartNodes(out var userStartNodes, out var userStartNodePaths);
 
-            nodes.AddRange(entities.Select(x => GetSingleTreeNodeWithAccessCheck(x, id, queryStrings, userStartNodes, userStartNodePaths)).Where(x => x != null));
-
             // if the user does not have access to the root node, what we have is the start nodes,
-            // but to provide some context we also need to add their topmost nodes when they are not
+            // but to provide some context we need to add their topmost nodes when they are not
             // topmost nodes themselves (level > 1).
             if (id == rootIdString && hasAccessToRoot == false)
             {
-                var topNodeIds = entities.Where(x => x.Level > 1).Select(GetTopNodeId).Where(x => x != 0).Distinct().ToArray();
+                // first add the entities that are topmost to the nodes collection
+                var topMostEntities = entities.Where(x => x.Level == 1).ToArray();
+                nodes.AddRange(topMostEntities.Select(x => GetSingleTreeNodeWithAccessCheck(x, id, queryStrings, userStartNodes, userStartNodePaths)).Where(x => x != null));
+
+                // now add the topmost nodes of the entities that aren't topmost to the nodes collection as well
+                // - these will appear as "no-access" nodes in the tree, but will allow the editors to drill down through the tree
+                //   until they reach their start nodes
+                var topNodeIds = entities.Except(topMostEntities).Select(GetTopNodeId).Where(x => x != 0).Distinct().ToArray();
                 if (topNodeIds.Length > 0)
                 {
                     var topNodes = Services.EntityService.GetAll(UmbracoObjectType, topNodeIds.ToArray());
                     nodes.AddRange(topNodes.Select(x => GetSingleTreeNodeWithAccessCheck(x, id, queryStrings, userStartNodes, userStartNodePaths)).Where(x => x != null));
                 }
+            }
+            else
+            {
+                // the user has access to the root, just add the entities
+                nodes.AddRange(entities.Select(x => GetSingleTreeNodeWithAccessCheck(x, id, queryStrings, userStartNodes, userStartNodePaths)).Where(x => x != null));
             }
 
             return nodes;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

*This is a redo of #6687 based on the comments from @nielslyngsoe*

There's something weird going on when editors have start nodes; the same content nodes are being loaded twice, and things generally feels broken.

Consider an editor with these start nodes configured:

![image](https://user-images.githubusercontent.com/7405322/67316692-34271c80-f509-11e9-9e65-f69363c374c8.png)

Here's the corresponding editor experience:

![editor-with-start-nodes-before](https://user-images.githubusercontent.com/7405322/67317506-7735bf80-f50a-11e9-8ea9-e5949c2a383d.gif)

Personally I'd be genuinely confused about the duplicate nodes - even more so because the the root nodes isn't duplicated. And also:

- When you select a node in the tree that is built from your start node, the corresponding node underneath the "full" tree is highlighted instead of the one you selected.
- When you right click a node anywhere, both that node and the corresponding duplicate are highlighted.
- All nodes in the "full" tree have a "not-allowed" cursor and are dimmed down - even the ones you can actually edit.

This PR removes the duplicate start nodes, leaving behind only the "full" tree. This I believe is also the behavior in V7.

Here's the editor experience for the same setup with this PR applied:

![editor-with-start-nodes-after](https://user-images.githubusercontent.com/7405322/67317198-0f7f7480-f50a-11e9-82ff-dd5160bb5401.gif)

