### PR TITLE
Dim down the alias of locked/inherited properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -135,7 +135,7 @@
                                 <ng-form name="propertyTypeForm">
                                     <div class="control-group -no-margin" ng-if="!sortingMode">
 
-                                        <div class="umb-group-builder__property-meta-alias" ng-if="property.inherited || property.locked">{{ property.alias }}</div>
+                                        <div class="umb-group-builder__property-meta-alias umb-locked-field__text cursor-not-allowed" style="padding-left: 1px" ng-if="property.inherited || property.locked">{{ property.alias }}</div>
                                         <umb-locked-field
                                             ng-if="!property.inherited && !property.locked"
                                             locked="locked"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The aliases of inherited and locked properties ought to be dimmed down with a "not allowed" hover cursor, but they aren't (you can't see the cursor from these screenshots though):

![image](https://user-images.githubusercontent.com/7405322/67386680-b5c48c00-f595-11e9-92d3-f1f384f496b4.png)

![image](https://user-images.githubusercontent.com/7405322/67386715-c7a62f00-f595-11e9-8ec8-cbcac1de4302.png)

This PR updates the styling, so it's evident you can't mess around with the aliases of these properties (again... you can't see the hover cursor, but it's supposed to be "not allowed").

![image](https://user-images.githubusercontent.com/7405322/67386598-8f9eec00-f595-11e9-91f9-86f4c3d90c4d.png)

![image](https://user-images.githubusercontent.com/7405322/67386509-654d2e80-f595-11e9-9922-a3a135df7e52.png)

