### PR TITLE
V8: Make "add property" shortcut work with multiple groups

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -475,6 +475,23 @@
 
       /* ---------- PROPERTIES ---------- */
 
+      scope.addPropertyToActiveGroup = function () {
+        var group = _.find(scope.model.groups, group => group.tabState === "active");
+        if (!group && scope.model.groups.length) {
+          group = scope.model.groups[0];
+        }
+
+        if (!group || !group.name) {
+          return;
+        }
+
+        var property = _.find(group.properties, property => property.propertyState === "init");
+        if (!property) {
+          return;
+        }
+        scope.addProperty(property, group);
+      }
+
       scope.addProperty = function(property, group) {
 
         // set property sort order

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -37,6 +37,8 @@
         <localize key="contentTypeEditor_noGroups"></localize>
     </div>
 
+    <a ng-if="!sortingMode" hotkey="alt+shift+p" ng-click="addPropertyToActiveGroup()"></a>    
+
     <ul class="umb-group-builder__groups" ui-sortable="sortableOptionsGroup" ng-model="model.groups">
 
         <li ng-repeat="tab in model.groups" ng-class="{'umb-group-builder__group-sortable': sortingMode}" data-element="group-{{tab.name}}">
@@ -119,8 +121,6 @@
                             data-element="property-add"
                             class="umb-group-builder__group-add-property"
                             ng-if="property.propertyState=='init' && !sortingMode"
-                            hotkey="alt+shift+p"
-                            hotkey-when="{{tab.tabState === 'active' && property.propertyState=='init'}}"
                             ng-click="addProperty(property, tab)"
                             ng-focus="activateGroup(tab)"
                             focus-when="{{property.focus}}">

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -49,7 +49,7 @@
             </a>
 
             <!-- TAB ACTIVE OR INACTIVE STATE -->
-            <div class="umb-group-builder__group" ng-if="tab.tabState !== 'init'" ng-class="{'-active':tab.tabState=='active', '-inherited': tab.inherited, 'umb-group-builder__group-handle -sortable': sortingMode && !tab.inherited}" ng-click="activateGroup(tab)" ng-focus="activateGroup(tab)">
+            <div class="umb-group-builder__group" ng-if="tab.tabState !== 'init'" ng-class="{'-active':tab.tabState=='active', '-inherited': tab.inherited, 'umb-group-builder__group-handle -sortable': sortingMode && !tab.inherited}" tabindex="0" ng-focus="activateGroup(tab)">
 
                 <div class="umb-group-builder__group-title-wrapper">
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -49,7 +49,7 @@
             </a>
 
             <!-- TAB ACTIVE OR INACTIVE STATE -->
-            <div class="umb-group-builder__group" ng-if="tab.tabState !== 'init'" ng-class="{'-active':tab.tabState=='active', '-inherited': tab.inherited, 'umb-group-builder__group-handle -sortable': sortingMode && !tab.inherited}" ng-click="activateGroup(tab)">
+            <div class="umb-group-builder__group" ng-if="tab.tabState !== 'init'" ng-class="{'-active':tab.tabState=='active', '-inherited': tab.inherited, 'umb-group-builder__group-handle -sortable': sortingMode && !tab.inherited}" ng-click="activateGroup(tab)" ng-focus="activateGroup(tab)">
 
                 <div class="umb-group-builder__group-title-wrapper">
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you have multiple groups in the content type builder, the "add property" shortcut (alt+shift+p) only works for the last group:

![add-property-shortcut-before](https://user-images.githubusercontent.com/7405322/67460929-89177f80-f63c-11e9-8f70-bd5932065d6d.gif)

This is because the shortcut is registered for every group and the last registration simply wins.

This PR moves the shortcut registration outside the property groups and adds logic to figure out which group is currently targeted the "add property" action. It works like this:

![add-property-shortcut-after](https://user-images.githubusercontent.com/7405322/67461079-cf6cde80-f63c-11e9-9772-059cd548cfb5.gif)
