### PR TITLE
#6812 AuditService some methods not returning any values

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/AuditRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/AuditRepository.cs
@@ -77,7 +77,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         public IEnumerable<IAuditItem> Get(AuditType type, IQuery<IAuditItem> query)
         {
             var sqlClause = GetBaseQuery(false)
-                .Where<LogDto>(x => x.Header == type.ToString());
+                .Where("(logHeader=@0)", type.ToString());
+
             var translator = new SqlTranslator<IAuditItem>(sqlClause, query);
             var sql = translator.Translate();
 

--- a/src/Umbraco.Core/Services/Implement/AuditService.cs
+++ b/src/Umbraco.Core/Services/Implement/AuditService.cs
@@ -142,6 +142,7 @@ namespace Umbraco.Core.Services.Implement
             if (pageIndex < 0) throw new ArgumentOutOfRangeException(nameof(pageIndex));
             if (pageSize <= 0) throw new ArgumentOutOfRangeException(nameof(pageSize));
 
+            //TODO: Why not -1? This would mean that we're not showing the admin-users changes..?
             if (userId < 0)
             {
                 totalRecords = 0;

--- a/src/Umbraco.Core/Services/Implement/AuditService.cs
+++ b/src/Umbraco.Core/Services/Implement/AuditService.cs
@@ -142,8 +142,7 @@ namespace Umbraco.Core.Services.Implement
             if (pageIndex < 0) throw new ArgumentOutOfRangeException(nameof(pageIndex));
             if (pageSize <= 0) throw new ArgumentOutOfRangeException(nameof(pageSize));
 
-            //TODO: Why not -1? This would mean that we're not showing the admin-users changes..?
-            if (userId < 0)
+            if (userId < -1)
             {
                 totalRecords = 0;
                 return Enumerable.Empty<IAuditItem>();

--- a/src/Umbraco.Core/Services/Implement/AuditService.cs
+++ b/src/Umbraco.Core/Services/Implement/AuditService.cs
@@ -142,7 +142,7 @@ namespace Umbraco.Core.Services.Implement
             if (pageIndex < 0) throw new ArgumentOutOfRangeException(nameof(pageIndex));
             if (pageSize <= 0) throw new ArgumentOutOfRangeException(nameof(pageSize));
 
-            if (userId < -1)
+            if (userId < Constants.Security.SuperUserId)
             {
                 totalRecords = 0;
                 return Enumerable.Empty<IAuditItem>();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

https://github.com/umbraco/Umbraco-CMS/issues/6812

### Description

Create a backoffice user (not the admin) and perform some Saves, Publish, Unpublish in the backoffice.

Then following code in for example a view should all return results.

```
var pagedByUser = Services.AuditService.GetPagedItemsByUser(1, 0, 100, out totalItems);

var byUserBydate = Services.AuditService.GetUserLogs(1,AuditType.Publish,DateTime.Now.AddDays(-15));

var logsByType = Services.AuditService.GetLogs(AuditType.Publish);

// Might need to change the hardcoded id here when testing
var pagedByEntity = Services.AuditService.GetPagedItemsByEntity(1104, 0,100, out totalItems);
```

