### PR TITLE
Fix FileUploadCleanupFilterAttribute

### DIFF
--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.EnterpriseServices" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/src/Umbraco.Web/WebApi/Filters/FileUploadCleanupFilterAttribute.cs
+++ b/src/Umbraco.Web/WebApi/Filters/FileUploadCleanupFilterAttribute.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Web.Http.Filters;
@@ -36,8 +34,6 @@ namespace Umbraco.Web.WebApi.Filters
         {
             base.OnActionExecuted(actionExecutedContext);
 
-            var tempFolders = new List<string>();
-
             if (_incomingModel)
             {
                 foreach (var haveUploadedFiles in actionExecutedContext.ActionContext.ActionArguments.Values.OfType<IHaveUploadedFiles>())
@@ -50,13 +46,6 @@ namespace Umbraco.Web.WebApi.Filters
                     // Cleanup any files associated
                     foreach (var uploadedFile in haveUploadedFiles.UploadedFiles)
                     {
-                        // Track all temp folders, so we can remove old files afterwards
-                        var dir = Path.GetDirectoryName(uploadedFile.TempFilePath);
-                        if (tempFolders.Contains(dir) == false)
-                        {
-                            tempFolders.Add(dir);
-                        }
-
                         try
                         {
                             File.Delete(uploadedFile.TempFilePath);
@@ -78,13 +67,6 @@ namespace Umbraco.Web.WebApi.Filters
                     if (string.IsNullOrWhiteSpace(uploadedFile.TempFilePath))
                     {
                         continue;
-                    }
-
-                    // Track all temp folders, so we can remove old files afterwards
-                    var dir = Path.GetDirectoryName(uploadedFile.TempFilePath);
-                    if (tempFolders.Contains(dir) == false)
-                    {
-                        tempFolders.Add(dir);
                     }
 
                     try


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6827.

### Description
The `FileUploadCleanupFilterAttribute` only did null-checks on `actionExecutedContext.Request.Content`, but then used `actionExecutedContext.Response.Content`.

This fixes all the checks and:
- Removes redundant logging: if there's nothing we can do, just skip cleaning up the uploaded files (the log messages do not provide real help anyway)
- Check all action arguments for `IHaveUploadedFiles` models (not only the first)
- Remove unused folder tracking

We could use the `actionExecutedContext.Response.TryGetContentValue<T>()` extension method instead of getting the `ObjectContent` and then the `Value`, but the current logic will probably be exactly the same...

When testing, the following should still work:
- Upload of media, media on content, local package install, document type import, user avatar (current or other), member import and blueprint/content template import
- Temporary files should be cleaned up (`App_Data\Temp\FileUploads`)