### PR TITLE
Add Swedish translations for prompt

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -182,10 +182,11 @@
     <key alias="visit">Besök</key>
   </area>
   <area alias="prompt">
-    <key alias="stay">Stay</key>
-    <key alias="discardChanges">Discard changes</key>
-    <key alias="unsavedChanges">You have unsaved changes</key>
-    <key alias="unsavedChangesWarning">Are you sure you want to navigate away from this page? - you have unsaved changes</key>
+    <key alias="stay">Stanna</key>
+    <key alias="discardChanges">Avfärda ändringar</key>
+    <key alias="unsavedChanges">Du har inte sparat dina ändringar</key>
+    <key alias="unsavedChangesWarning">Är du säker på att du vill navigera bort från denna sida? - du har inte sparat dina ändringar</key>
+    <key alias="confirmUnpublish">Avpublicering kommer att ta bort denna sida och alla dess ättlingar från hemsidan.</key>
   </area>
   <area alias="bulk">
     <key alias="done">Done</key>


### PR DESCRIPTION
### Prerequisites

- [ x] I have added steps to test this contribution in the description below


### Description

Added Swedish translations for the prompt lang section.

Unsaved changes before translation:
![swe-translation-unsaved-changes_before-changes](https://user-images.githubusercontent.com/28714079/67507484-46cb5e00-f68f-11e9-9bc2-5505062e7442.PNG)


Unsaved changes after translation:
![swe-translation-unsaved-changes](https://user-images.githubusercontent.com/28714079/67507461-3c10c900-f68f-11e9-9ba1-595623bc15e1.PNG)

Unpublished changes before translation:
![swe-translation-unpublish-before-changes_](https://user-images.githubusercontent.com/28714079/67507517-50ed5c80-f68f-11e9-8aa0-50303a400dc6.PNG)

Unpublished changes after translation:

![swe-translation-unpublish](https://user-images.githubusercontent.com/28714079/67507673-b5102080-f68f-11e9-995c-8e33813d5a06.PNG)





