### PR TITLE
V8: Don't YSOD when publishing content if a property editor has been removed

### DIFF
--- a/src/Umbraco.Core/Services/PropertyValidationService.cs
+++ b/src/Umbraco.Core/Services/PropertyValidationService.cs
@@ -131,6 +131,12 @@ namespace Umbraco.Core.Services
         private bool IsPropertyValueValid(PropertyType propertyType, object value)
         {
             var editor = _propertyEditors[propertyType.PropertyEditorAlias];
+            if (editor == null)
+            {
+                // nothing much we can do validation wise if the property editor has been removed.
+                // the property will be displayed as a label, so flagging it as invalid would be pointless.
+                return true;
+            }
             var configuration = _dataTypeService.GetDataType(propertyType.DataTypeId).Configuration;
             var valueEditor = editor.GetValueEditor(configuration);
             return !valueEditor.Validate(value, propertyType.Mandatory, propertyType.ValidationRegExp).Any();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you remove custom property editors that are in use on one or more content types, content of these types will replace the missing property editor with a Label property editor that displays the raw property value. This works really well - until you attempt to publish the content:

![content-with-removed-pe-before](https://user-images.githubusercontent.com/7405322/67510705-be03f080-f695-11e9-9800-bf2d89049aa4.gif)

This is particularly annoying when you're building custom editor experiences in different branches against the same database.

Turns out the validation routine doesn't expect the property editor to be missing... so this PR adds some defensive programming to counter this scenario. When applied, properties with missing property editors always pass validation, and thus things start working again:

![content-with-removed-pe-after](https://user-images.githubusercontent.com/7405322/67510901-2226b480-f696-11e9-95c3-e5aa9b7efaa7.gif)

#### Testing this PR

Here's a simple custom property editor that can be used for testing: [TestPropertyEditor.zip](https://github.com/umbraco/Umbraco-CMS/files/3768784/TestPropertyEditor.zip)



Steps:

1. Add the property editor to `App_Plugins`.
2. Create a content type that uses this property editor.
3. Create some content based on this content type. 
4. Remove the property editor from `App_Plugins` and restart the site.
5. Verify that you can publish content that contains the now missing property editor.
