### PR TITLE
V8: Limit the number of tabbable elements in tree nodes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
@@ -1,5 +1,5 @@
 <li class="umb-tree-item" data-element="tree-item-{{::node.dataElement}}" ng-class="getNodeCssClass(node)" on-right-click="altSelect(node, $event)">
-    <div class="umb-tree-item__inner" ng-swipe-right="options(node, $event)" ng-dblclick="load(node)" >
+    <div class="umb-tree-item__inner" ng-swipe-right="options(node, $event)" ng-dblclick="load(node)" tabindex="-1">
         <button data-element="tree-item-expand"
              class="umb-tree-item__arrow umb-outline btn-reset"
              ng-class="{'icon-navigation-right': !node.expanded || node.metaData.isContainer, 'icon-navigation-down': node.expanded && !node.metaData.isContainer}"
@@ -9,7 +9,7 @@
             <span class="sr-only">Expand child items for {{node.name}}</span>
         </button>
 
-        <i class="icon umb-tree-icon sprTree" ng-class="::node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style"></i>
+        <i class="icon umb-tree-icon sprTree" ng-class="::node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></i>
         <span class="umb-tree-item__annotation"></span>
         <a class="umb-tree-item__label umb-outline" ng-href="#/{{::node.routePath}}" ng-click="select(node, $event)" title="{{::node.title}}">{{node.name}}</a>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The number of elements you have to tab your way through in order to navigate down a tree is really quite excessive... and the most prominent looking one of those elements (the outermost node container) has no action attached, despite it looking like it would actually open the node for editing:

![tab-tree-before](https://user-images.githubusercontent.com/7405322/67513281-d0ccf400-f69a-11e9-80a3-ec2a0d99a4cb.gif)

I have removed the tab index from a few of these elements to allow for speedier navigation through the tree, without compromising with the functionality at hand. Here's how it works:

![tab-tree-after](https://user-images.githubusercontent.com/7405322/67513266-cdd20380-f69a-11e9-86de-9b204cc415fb.gif)
