### PR TITLE
Replace old checkbox markup with umb-checkbox

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
@@ -34,10 +34,12 @@
                                    />
 
                             <div class="form-search__toggle">
-                                <label>
-                                    <input type="checkbox" ng-model="showChilds" ng-change="vm.toggle()" />
-                                    <localize key="general_includeFromsubFolders">Include subfolders in search</localize>
-                                </label>
+                                <umb-checkbox
+                                    model="showChilds"
+                                    on-change="vm.toggle()"
+                                    text="Include subfolders in search"
+                                    label-key="general_includeFromsubFolders">
+                                </umb-checkbox>
                             </div>
                         </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have changed the good ol' standard checkbox in the media pickers "Include subfolders in search" to use the umb-checkbox directive instead.

**Before**
![media-picker-checkbox-before](https://user-images.githubusercontent.com/1932158/67516616-345a2000-f6a1-11e9-817d-7473a22f638e.gif)

**After**
![media-picker-checkbox-after](https://user-images.githubusercontent.com/1932158/67516635-3f14b500-f6a1-11e9-9be9-12ba7cc3d372.gif)
