### PR TITLE
umb-checkbox: Fix text alignment

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -15,7 +15,7 @@
     &__text {
         margin: 0 0 0 26px;
         position: relative;
-        top: 0;
+        top: 1px;
         user-select: none;
     }
 
@@ -24,7 +24,7 @@
         top: 0;
         left: 0;
         opacity: 0;
-        
+
         &:hover ~ .umb-form-check__state .umb-form-check__check {
             border-color: @inputBorderFocus;
         }
@@ -36,7 +36,7 @@
                 background: @ui-option-type-hover;
             }
         }
-        
+
         &:checked ~ .umb-form-check__state {
             .umb-form-check__check {
                 // This only happens if the state has a radiobutton modifier
@@ -62,8 +62,7 @@
             }
         }
     }
-    
-    
+
     .tabbing-active &.umb-form-check--radiobutton &__input:focus ~ .umb-form-check__state .umb-form-check__check {
         //outline: 2px solid @inputBorderTabFocus;
         border: 2px solid @inputBorderTabFocus;
@@ -75,11 +74,11 @@
     .tabbing-active &.umb-form-check--checkbox &__input:checked:focus ~ .umb-form-check__state .umb-form-check__check {
         border-color: white;
     }
-    
+
     // add spacing between when flexed/inline, equal to the width of the input
     .flex & + & {
         margin-left:@checkboxWidth;
-    } 
+    }
 
     &__state {
         display: flex;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I'll admit this can be hard to spot and I feel werid for doing this PR - But in this tiny PR I have adjusted the text in the umb-checkbox directive by 1 pixel since I noticed it was a bit off when I made PR #6835 

**Before**
![text-before](https://user-images.githubusercontent.com/1932158/67518418-1393c980-f6a5-11e9-96d8-526eb89ad058.png)

**After**
![text-after](https://user-images.githubusercontent.com/1932158/67518429-18587d80-f6a5-11e9-877a-e02d6dfad15d.png)
