### PR TITLE
Template insert: Replace checkbox with umb-checkbox and remove wrong label

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/insertfield/insertfield.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/insertfield/insertfield.html
@@ -52,13 +52,14 @@
                     <div class="control-group umb-control-group">
                         <div class="umb-el-wrap">
                             <div class="controls">
-                                <label class="control-label" >
+                                <span class="control-label" >
                                     <localize key="templateEditor_recursive">Recursive</localize>
-                                </label>
-                                <label for="recursive">
-                                    <input id="recursive" type="checkbox" name="recursive" ng-model="vm.recursive">
-                                    <localize key="templateEditor_recursiveDescr">Yes, make it recursive</localize>
-                                </label>
+                                </span>
+                                <umb-checkbox
+                                    model="vm.recursive"
+                                    text="Yes, make it recursive"
+                                    label-key="templateEditor_recursiveDescr">
+                                </umb-checkbox>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have changed the old checkbox to make use of the umb-checkbox instead.

Also I have changed a `<label>` to `<span>` since the label only contains a text, which also improves the visuals imho.

**Before**
![template-insert-before](https://user-images.githubusercontent.com/1932158/67522629-5c4f8080-f6ad-11e9-9c48-fd72bf7be02a.gif)

**After**
![template-insert-after](https://user-images.githubusercontent.com/1932158/67522624-58236300-f6ad-11e9-9d82-7c5e1780419d.gif)