### PR TITLE
Request datatype by guid

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -303,7 +303,7 @@ namespace Umbraco.Web.Editors
         }
 
         /// <summary>
-        /// Gets the content json for the content id
+        /// Gets the content json for the content guid
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
@@ -323,7 +323,7 @@ namespace Umbraco.Web.Editors
         }
 
         /// <summary>
-        /// Gets the content json for the content id
+        /// Gets the content json for the content udi
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
@@ -341,7 +341,7 @@ namespace Umbraco.Web.Editors
         }
 
         /// <summary>
-        /// Gets an empty content item for the
+        /// Gets an empty content item for the document type.
         /// </summary>
         /// <param name="contentTypeAlias"></param>
         /// <param name="parentId"></param>

--- a/src/Umbraco.Web/Editors/DataTypeController.cs
+++ b/src/Umbraco.Web/Editors/DataTypeController.cs
@@ -71,6 +71,40 @@ namespace Umbraco.Web.Editors
         }
 
         /// <summary>
+        /// Gets the datatype json for the datatype guid
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public DataTypeDisplay GetById(Guid id)
+        {
+            var dataType = Services.DataTypeService.GetDataType(id);
+            if (dataType == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+            return Mapper.Map<IDataType, DataTypeDisplay>(dataType);
+        }
+
+        /// <summary>
+        /// Gets the datatype json for the datatype udi
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public DataTypeDisplay GetById(Udi id)
+        {
+            var guidUdi = id as GuidUdi;
+            if (guidUdi == null)
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+
+            var dataType = Services.DataTypeService.GetDataType(guidUdi.Guid);
+            if (dataType == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+            return Mapper.Map<IDataType, DataTypeDisplay>(dataType);
+        }
+
+        /// <summary>
         /// Deletes a data type with a given ID
         /// </summary>
         /// <param name="id"></param>

--- a/src/Umbraco.Web/Editors/DataTypeController.cs
+++ b/src/Umbraco.Web/Editors/DataTypeController.cs
@@ -20,6 +20,7 @@ using Umbraco.Web.Composing;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;
+using System.Web.Http.Controllers;
 
 namespace Umbraco.Web.Editors
 {
@@ -42,6 +43,19 @@ namespace Umbraco.Web.Editors
             : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper)
         {
             _propertyEditors = propertyEditors;
+        }
+
+        /// <summary>
+        /// Configures this controller with a custom action selector
+        /// </summary>
+        private class DataTypeControllerConfigurationAttribute : Attribute, IControllerConfiguration
+        {
+            public void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+            {
+                controllerSettings.Services.Replace(typeof(IHttpActionSelector), new ParameterSwapControllerActionSelector(
+                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetById", "id", typeof(int), typeof(Guid), typeof(Udi))
+                ));
+            }
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Editors/DataTypeController.cs
+++ b/src/Umbraco.Web/Editors/DataTypeController.cs
@@ -35,6 +35,7 @@ namespace Umbraco.Web.Editors
     [PluginController("UmbracoApi")]
     [UmbracoTreeAuthorize(Constants.Trees.DataTypes, Constants.Trees.DocumentTypes, Constants.Trees.MediaTypes, Constants.Trees.MemberTypes)]
     [EnableOverrideAuthorization]
+    [DataTypeControllerConfiguration]
     public class DataTypeController : BackOfficeNotificationsController
     {
         private readonly PropertyEditorCollection _propertyEditors;

--- a/src/Umbraco.Web/Editors/MacrosController.cs
+++ b/src/Umbraco.Web/Editors/MacrosController.cs
@@ -112,19 +112,7 @@ namespace Umbraco.Web.Editors
                 return this.ReturnErrorResponse($"Macro with id {id} does not exist");
             }
 
-            var macroDisplay = Mapper.Map<IMacro, MacroDisplay>(macro);
-
-            var parameters = macro.Properties.Values
-                                .OrderBy(x => x.SortOrder)
-                                .Select(x => new MacroParameterDisplay()
-                                {
-                                    Editor = x.EditorAlias,
-                                    Key = x.Alias,
-                                    Label = x.Name,
-                                    Id = x.Id
-                                });
-
-            macroDisplay.Parameters = parameters;
+            var macroDisplay = MapToDisplay(macro);
 
             return this.Request.CreateResponse(HttpStatusCode.OK, macroDisplay);
         }
@@ -139,19 +127,7 @@ namespace Umbraco.Web.Editors
                 return this.ReturnErrorResponse($"Macro with id {id} does not exist");
             }
 
-            var macroDisplay = Mapper.Map<IMacro, MacroDisplay>(macro);
-
-            var parameters = macro.Properties.Values
-                                .OrderBy(x => x.SortOrder)
-                                .Select(x => new MacroParameterDisplay()
-                                {
-                                    Editor = x.EditorAlias,
-                                    Key = x.Alias,
-                                    Label = x.Name,
-                                    Id = x.Id
-                                });
-
-            macroDisplay.Parameters = parameters;
+            var macroDisplay = MapToDisplay(macro);
 
             return this.Request.CreateResponse(HttpStatusCode.OK, macroDisplay);
         }
@@ -169,19 +145,7 @@ namespace Umbraco.Web.Editors
                 return this.ReturnErrorResponse($"Macro with id {id} does not exist");
             }
 
-            var macroDisplay = Mapper.Map<IMacro, MacroDisplay>(macro);
-
-            var parameters = macro.Properties.Values
-                                .OrderBy(x => x.SortOrder)
-                                .Select(x => new MacroParameterDisplay()
-                                {
-                                    Editor = x.EditorAlias,
-                                    Key = x.Alias,
-                                    Label = x.Name,
-                                    Id = x.Id
-                                });
-
-            macroDisplay.Parameters = parameters;
+            var macroDisplay = MapToDisplay(macro);
 
             return this.Request.CreateResponse(HttpStatusCode.OK, macroDisplay);
         }
@@ -439,6 +403,30 @@ namespace Umbraco.Web.Editors
                     prefixVirtualPath.TrimEnd('/') + "/" + (path.Replace(orgPath, string.Empty).Trim('/') + "/" + file.Name).Trim('/')));
 
             return files;
+        }
+
+        /// <summary>
+        /// Used to map an <see cref="IMacro"/> instance to a <see cref="MacroDisplay"/>
+        /// </summary>
+        /// <param name="macro"></param>
+        /// <returns></returns>
+        private MacroDisplay MapToDisplay(IMacro macro)
+        {
+            var display = Mapper.Map<MacroDisplay>(macro);
+
+            var parameters = macro.Properties.Values
+                                .OrderBy(x => x.SortOrder)
+                                .Select(x => new MacroParameterDisplay()
+                                {
+                                    Editor = x.EditorAlias,
+                                    Key = x.Alias,
+                                    Label = x.Name,
+                                    Id = x.Id
+                                });
+
+            display.Parameters = parameters;
+
+            return display;
         }
     }
 }

--- a/src/Umbraco.Web/Editors/MacrosController.cs
+++ b/src/Umbraco.Web/Editors/MacrosController.cs
@@ -114,18 +114,15 @@ namespace Umbraco.Web.Editors
 
             var macroDisplay = Mapper.Map<IMacro, MacroDisplay>(macro);
 
-            var parameters = new List<MacroParameterDisplay>();
-
-            foreach (var param in macro.Properties.Values.OrderBy(x => x.SortOrder))
-            {
-                parameters.Add(new MacroParameterDisplay
-                {
-                    Editor = param.EditorAlias,
-                    Key = param.Alias,
-                    Label = param.Name,
-                    Id = param.Id
-                });
-            }
+            var parameters = macro.Properties.Values
+                                .OrderBy(x => x.SortOrder)
+                                .Select(x => new MacroParameterDisplay()
+                                {
+                                    Editor = x.EditorAlias,
+                                    Key = x.Alias,
+                                    Label = x.Name,
+                                    Id = x.Id
+                                });
 
             macroDisplay.Parameters = parameters;
 
@@ -144,18 +141,15 @@ namespace Umbraco.Web.Editors
 
             var macroDisplay = Mapper.Map<IMacro, MacroDisplay>(macro);
 
-            var parameters = new List<MacroParameterDisplay>();
-
-            foreach (var param in macro.Properties.Values.OrderBy(x => x.SortOrder))
-            {
-                parameters.Add(new MacroParameterDisplay
-                {
-                    Editor = param.EditorAlias,
-                    Key = param.Alias,
-                    Label = param.Name,
-                    Id = param.Id
-                });
-            }
+            var parameters = macro.Properties.Values
+                                .OrderBy(x => x.SortOrder)
+                                .Select(x => new MacroParameterDisplay()
+                                {
+                                    Editor = x.EditorAlias,
+                                    Key = x.Alias,
+                                    Label = x.Name,
+                                    Id = x.Id
+                                });
 
             macroDisplay.Parameters = parameters;
 
@@ -177,18 +171,15 @@ namespace Umbraco.Web.Editors
 
             var macroDisplay = Mapper.Map<IMacro, MacroDisplay>(macro);
 
-            var parameters = new List<MacroParameterDisplay>();
-
-            foreach (var param in macro.Properties.Values.OrderBy(x => x.SortOrder))
-            {
-                parameters.Add(new MacroParameterDisplay
-                {
-                    Editor = param.EditorAlias,
-                    Key = param.Alias,
-                    Label = param.Name,
-                    Id = param.Id
-                });
-            }
+            var parameters = macro.Properties.Values
+                                .OrderBy(x => x.SortOrder)
+                                .Select(x => new MacroParameterDisplay()
+                                {
+                                    Editor = x.EditorAlias,
+                                    Key = x.Alias,
+                                    Label = x.Name,
+                                    Id = x.Id
+                                });
 
             macroDisplay.Parameters = parameters;
 

--- a/src/Umbraco.Web/Editors/MacrosController.cs
+++ b/src/Umbraco.Web/Editors/MacrosController.cs
@@ -112,20 +112,7 @@ namespace Umbraco.Web.Editors
                 return this.ReturnErrorResponse($"Macro with id {id} does not exist");
             }
 
-            var macroDisplay = new MacroDisplay
-            {
-                Alias = macro.Alias,
-                Id = macro.Id,
-                Key = macro.Key,
-                Name = macro.Name,
-                CacheByPage = macro.CacheByPage,
-                CacheByUser = macro.CacheByMember,
-                CachePeriod = macro.CacheDuration,
-                View = macro.MacroSource,
-                RenderInEditor = !macro.DontRender,
-                UseInEditor = macro.UseInEditor,
-                Path = $"-1,{macro.Id}"
-            };
+            var macroDisplay = Mapper.Map<IMacro, MacroDisplay>(macro);
 
             var parameters = new List<MacroParameterDisplay>();
 
@@ -141,9 +128,6 @@ namespace Umbraco.Web.Editors
             }
 
             macroDisplay.Parameters = parameters;
-
-            // TODO: Should probably map to MacroDisplay as for datatypes
-            //return Mapper.Map<IMacro, MacroDisplay>(macro);
 
             return this.Request.CreateResponse(HttpStatusCode.OK, macroDisplay);
         }
@@ -158,20 +142,7 @@ namespace Umbraco.Web.Editors
                 return this.ReturnErrorResponse($"Macro with id {id} does not exist");
             }
 
-            var macroDisplay = new MacroDisplay
-            {
-                Alias = macro.Alias,
-                Id = macro.Id,
-                Key = macro.Key,
-                Name = macro.Name,
-                CacheByPage = macro.CacheByPage,
-                CacheByUser = macro.CacheByMember,
-                CachePeriod = macro.CacheDuration,
-                View = macro.MacroSource,
-                RenderInEditor = !macro.DontRender,
-                UseInEditor = macro.UseInEditor,
-                Path = $"-1,{macro.Id}"
-            };
+            var macroDisplay = Mapper.Map<IMacro, MacroDisplay>(macro);
 
             var parameters = new List<MacroParameterDisplay>();
 
@@ -187,9 +158,6 @@ namespace Umbraco.Web.Editors
             }
 
             macroDisplay.Parameters = parameters;
-
-            // TODO: Should probably map to MacroDisplay as for datatypes
-            //return Mapper.Map<IMacro, MacroDisplay>(macro);
 
             return this.Request.CreateResponse(HttpStatusCode.OK, macroDisplay);
         }
@@ -207,20 +175,7 @@ namespace Umbraco.Web.Editors
                 return this.ReturnErrorResponse($"Macro with id {id} does not exist");
             }
 
-            var macroDisplay = new MacroDisplay
-            {
-                Alias = macro.Alias,
-                Id = macro.Id,
-                Key = macro.Key,
-                Name = macro.Name,
-                CacheByPage = macro.CacheByPage,
-                CacheByUser = macro.CacheByMember,
-                CachePeriod = macro.CacheDuration,
-                View = macro.MacroSource,
-                RenderInEditor = !macro.DontRender,
-                UseInEditor = macro.UseInEditor,
-                Path = $"-1,{macro.Id}"
-            };
+            var macroDisplay = Mapper.Map<IMacro, MacroDisplay>(macro);
 
             var parameters = new List<MacroParameterDisplay>();
 
@@ -236,9 +191,6 @@ namespace Umbraco.Web.Editors
             }
 
             macroDisplay.Parameters = parameters;
-
-            // TODO: Should probably map to MacroDisplay as for datatypes
-            //return Mapper.Map<IMacro, MacroDisplay>(macro);
 
             return this.Request.CreateResponse(HttpStatusCode.OK, macroDisplay);
         }

--- a/src/Umbraco.Web/Editors/MacrosController.cs
+++ b/src/Umbraco.Web/Editors/MacrosController.cs
@@ -19,6 +19,7 @@ using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
 using Umbraco.Web.WebApi.Filters;
 using Constants = Umbraco.Core.Constants;
+using System.Web.Http.Controllers;
 
 namespace Umbraco.Web.Editors
 {
@@ -28,6 +29,7 @@ namespace Umbraco.Web.Editors
     /// </summary>
     [PluginController("UmbracoApi")]
     [UmbracoTreeAuthorize(Constants.Trees.Macros)]
+    [MacrosControllerConfiguration]
     public class MacrosController : BackOfficeNotificationsController
     {
         private readonly IMacroService _macroService;
@@ -36,6 +38,19 @@ namespace Umbraco.Web.Editors
             : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper)
         {
             _macroService = Services.MacroService;
+        }
+
+        /// <summary>
+        /// Configures this controller with a custom action selector
+        /// </summary>
+        private class MacrosControllerConfigurationAttribute : Attribute, IControllerConfiguration
+        {
+            public void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+            {
+                controllerSettings.Services.Replace(typeof(IHttpActionSelector), new ParameterSwapControllerActionSelector(
+                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetById", "id", typeof(int), typeof(Guid), typeof(Udi))
+                ));
+            }
         }
 
         /// <summary>
@@ -127,9 +142,106 @@ namespace Umbraco.Web.Editors
 
             macroDisplay.Parameters = parameters;
 
+            // TODO: Should probably map to MacroDisplay as for datatypes
+            //return Mapper.Map<IMacro, MacroDisplay>(macro);
+
             return this.Request.CreateResponse(HttpStatusCode.OK, macroDisplay);
         }
 
+        [HttpGet]
+        public HttpResponseMessage GetById(Guid id)
+        {
+            var macro = _macroService.GetById(id);
+
+            if (macro == null)
+            {
+                return this.ReturnErrorResponse($"Macro with id {id} does not exist");
+            }
+
+            var macroDisplay = new MacroDisplay
+            {
+                Alias = macro.Alias,
+                Id = macro.Id,
+                Key = macro.Key,
+                Name = macro.Name,
+                CacheByPage = macro.CacheByPage,
+                CacheByUser = macro.CacheByMember,
+                CachePeriod = macro.CacheDuration,
+                View = macro.MacroSource,
+                RenderInEditor = !macro.DontRender,
+                UseInEditor = macro.UseInEditor,
+                Path = $"-1,{macro.Id}"
+            };
+
+            var parameters = new List<MacroParameterDisplay>();
+
+            foreach (var param in macro.Properties.Values.OrderBy(x => x.SortOrder))
+            {
+                parameters.Add(new MacroParameterDisplay
+                {
+                    Editor = param.EditorAlias,
+                    Key = param.Alias,
+                    Label = param.Name,
+                    Id = param.Id
+                });
+            }
+
+            macroDisplay.Parameters = parameters;
+
+            // TODO: Should probably map to MacroDisplay as for datatypes
+            //return Mapper.Map<IMacro, MacroDisplay>(macro);
+
+            return this.Request.CreateResponse(HttpStatusCode.OK, macroDisplay);
+        }
+
+        [HttpGet]
+        public HttpResponseMessage GetById(Udi id)
+        {
+            var guidUdi = id as GuidUdi;
+            if (guidUdi == null)
+                this.ReturnErrorResponse($"Macro with id {id} does not exist");
+
+            var macro = _macroService.GetById(guidUdi.Guid);
+            if (macro == null)
+            {
+                return this.ReturnErrorResponse($"Macro with id {id} does not exist");
+            }
+
+            var macroDisplay = new MacroDisplay
+            {
+                Alias = macro.Alias,
+                Id = macro.Id,
+                Key = macro.Key,
+                Name = macro.Name,
+                CacheByPage = macro.CacheByPage,
+                CacheByUser = macro.CacheByMember,
+                CachePeriod = macro.CacheDuration,
+                View = macro.MacroSource,
+                RenderInEditor = !macro.DontRender,
+                UseInEditor = macro.UseInEditor,
+                Path = $"-1,{macro.Id}"
+            };
+
+            var parameters = new List<MacroParameterDisplay>();
+
+            foreach (var param in macro.Properties.Values.OrderBy(x => x.SortOrder))
+            {
+                parameters.Add(new MacroParameterDisplay
+                {
+                    Editor = param.EditorAlias,
+                    Key = param.Alias,
+                    Label = param.Name,
+                    Id = param.Id
+                });
+            }
+
+            macroDisplay.Parameters = parameters;
+
+            // TODO: Should probably map to MacroDisplay as for datatypes
+            //return Mapper.Map<IMacro, MacroDisplay>(macro);
+
+            return this.Request.CreateResponse(HttpStatusCode.OK, macroDisplay);
+        }
 
         [HttpPost]
         public HttpResponseMessage DeleteById(int id)

--- a/src/Umbraco.Web/Models/Mapping/MacroMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MacroMapDefinition.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
@@ -23,6 +24,7 @@ namespace Umbraco.Web.Models.Mapping
         public void DefineMaps(UmbracoMapper mapper)
         {
             mapper.Define<IMacro, EntityBasic>((source, context) => new EntityBasic(), Map);
+            mapper.Define<IMacro, MacroDisplay>((source, context) => new MacroDisplay(), Map);
             mapper.Define<IMacro, IEnumerable<MacroParameter>>((source, context) => context.MapEnumerable<IMacroProperty, MacroParameter>(source.Properties.Values));
             mapper.Define<IMacroProperty, MacroParameter>((source, context) => new MacroParameter(), Map);
         }
@@ -40,6 +42,23 @@ namespace Umbraco.Web.Models.Mapping
             target.Udi = Udi.Create(Constants.UdiEntityType.Macro, source.Key);
         }
 
+        private void Map(IMacro source, MacroDisplay target, MapperContext context)
+        {
+            target.Alias = source.Alias;
+            target.Icon = Constants.Icons.Macro;
+            target.Id = source.Id;
+            target.Key = source.Key;
+            target.Name = source.Name;
+            target.ParentId = -1;
+            target.Path = "-1," + source.Id;
+            target.Udi = Udi.Create(Constants.UdiEntityType.Macro, source.Key);
+            target.CacheByPage = source.CacheByPage;
+            target.CacheByUser = source.CacheByMember;
+            target.CachePeriod = source.CacheDuration;
+            target.UseInEditor = source.UseInEditor;
+            target.RenderInEditor = !source.DontRender;
+            target.View = source.MacroSource;
+        }
         // Umbraco.Code.MapAll -Value
         private void Map(IMacroProperty source, MacroParameter target, MapperContext context)
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At the moment it is possible to get content, media and member by id, but also by guid.

For datatypes it request datatype by id and if you try to request it by guid, it returns a console error.

![chrome_2019-10-23_00-32-02](https://user-images.githubusercontent.com/2919859/67563340-c1908980-f720-11e9-8340-cc928b84697a.png)

![chrome_2019-10-23_00-32-54](https://user-images.githubusercontent.com/2919859/67563351-c7866a80-f720-11e9-8768-0357cf42b7cc.png)