### PR TITLE
Removed the extra padding on the left on the overlay header

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -117,7 +117,7 @@
 .umb-overlay.umb-overlay-center .umb-overlay-drawer {
     border: none;
     background: transparent;
-    padding: 0 30px 20px;
+    padding: 0 20px 20px;
 }
 
 /* ---------- OVERLAY TARGET ---------- */


### PR DESCRIPTION
There are a number of overlays in the backoffice which has a en extra padding on the header by the left.

![image](https://user-images.githubusercontent.com/3941753/67566874-afaee680-f720-11e9-9f37-6bf8d2510932.png)

Another example is "You have unsaved changes" overlay
![image](https://user-images.githubusercontent.com/3941753/67566922-d40ac300-f720-11e9-8b7a-0bdec92b5844.png)

I have fixed the padding so the header and the confirmation text align up.

![image](https://user-images.githubusercontent.com/3941753/67567023-0b796f80-f721-11e9-999b-0881110df8e3.png)


![image](https://user-images.githubusercontent.com/3941753/67567001-fd2b5380-f720-11e9-85ad-a29dcb296556.png)


