### PR TITLE
V8: Follow guidelines from .editorconfig

### DIFF
--- a/src/Umbraco.Core/ObjectExtensions.cs
+++ b/src/Umbraco.Core/ObjectExtensions.cs
@@ -542,7 +542,7 @@ namespace Umbraco.Core
                 {
                     return "\"{0}\"".InvariantFormat(obj);
                 }
-                if (obj is int || obj is Int16 || obj is Int64 || obj is float || obj is double || obj is bool || obj is int? || obj is Int16? || obj is Int64? || obj is float? || obj is double? || obj is bool?)
+                if (obj is int || obj is short || obj is long || obj is float || obj is double || obj is bool || obj is int? || obj is float? || obj is double? || obj is bool?)
                 {
                     return "{0}".InvariantFormat(obj);
                 }
@@ -723,7 +723,7 @@ namespace Umbraco.Core
             {
                 return typeConverter;
             }
-            
+
             var converter = TypeDescriptor.GetConverter(target);
             if (converter.CanConvertFrom(source))
             {
@@ -788,6 +788,6 @@ namespace Umbraco.Core
             return BoolConvertCache[type] = false;
         }
 
-        
+
     }
 }

--- a/src/Umbraco.Core/Persistence/BulkDataReader.cs
+++ b/src/Umbraco.Core/Persistence/BulkDataReader.cs
@@ -470,7 +470,7 @@ namespace Umbraco.Core.Persistence
                     break;
 
                 case SqlDbType.SmallInt:
-                    dataType = typeof(Int16);
+                    dataType = typeof(short);
                     dataTypeName = "smallint";
                     break;
 
@@ -688,34 +688,34 @@ namespace Umbraco.Core.Persistence
 
             DataColumnCollection columns = _schemaTable.Columns;
 
-            columns.Add(SchemaTableColumn.ColumnName, typeof(System.String));
-            columns.Add(SchemaTableColumn.ColumnOrdinal, typeof(System.Int32));
-            columns.Add(SchemaTableColumn.ColumnSize, typeof(System.Int32));
-            columns.Add(SchemaTableColumn.NumericPrecision, typeof(System.Int16));
-            columns.Add(SchemaTableColumn.NumericScale, typeof(System.Int16));
-            columns.Add(SchemaTableColumn.IsUnique, typeof(System.Boolean));
-            columns.Add(SchemaTableColumn.IsKey, typeof(System.Boolean));
-            columns.Add(SchemaTableOptionalColumn.BaseServerName, typeof(System.String));
-            columns.Add(SchemaTableOptionalColumn.BaseCatalogName, typeof(System.String));
-            columns.Add(SchemaTableColumn.BaseColumnName, typeof(System.String));
-            columns.Add(SchemaTableColumn.BaseSchemaName, typeof(System.String));
-            columns.Add(SchemaTableColumn.BaseTableName, typeof(System.String));
-            columns.Add(SchemaTableColumn.DataType, typeof(System.Type));
-            columns.Add(SchemaTableColumn.AllowDBNull, typeof(System.Boolean));
-            columns.Add(SchemaTableColumn.ProviderType, typeof(System.Int32));
-            columns.Add(SchemaTableColumn.IsAliased, typeof(System.Boolean));
-            columns.Add(SchemaTableColumn.IsExpression, typeof(System.Boolean));
-            columns.Add(BulkDataReader.IsIdentitySchemaColumn, typeof(System.Boolean));
-            columns.Add(SchemaTableOptionalColumn.IsAutoIncrement, typeof(System.Boolean));
-            columns.Add(SchemaTableOptionalColumn.IsRowVersion, typeof(System.Boolean));
-            columns.Add(SchemaTableOptionalColumn.IsHidden, typeof(System.Boolean));
-            columns.Add(SchemaTableColumn.IsLong, typeof(System.Boolean));
-            columns.Add(SchemaTableOptionalColumn.IsReadOnly, typeof(System.Boolean));
-            columns.Add(SchemaTableOptionalColumn.ProviderSpecificDataType, typeof(System.Type));
-            columns.Add(BulkDataReader.DataTypeNameSchemaColumn, typeof(System.String));
-            columns.Add(BulkDataReader.XmlSchemaCollectionDatabaseSchemaColumn, typeof(System.String));
-            columns.Add(BulkDataReader.XmlSchemaCollectionOwningSchemaSchemaColumn, typeof(System.String));
-            columns.Add(BulkDataReader.XmlSchemaCollectionNameSchemaColumn, typeof(System.String));
+            columns.Add(SchemaTableColumn.ColumnName, typeof(string));
+            columns.Add(SchemaTableColumn.ColumnOrdinal, typeof(int));
+            columns.Add(SchemaTableColumn.ColumnSize, typeof(int));
+            columns.Add(SchemaTableColumn.NumericPrecision, typeof(short));
+            columns.Add(SchemaTableColumn.NumericScale, typeof(short));
+            columns.Add(SchemaTableColumn.IsUnique, typeof(bool));
+            columns.Add(SchemaTableColumn.IsKey, typeof(bool));
+            columns.Add(SchemaTableOptionalColumn.BaseServerName, typeof(string));
+            columns.Add(SchemaTableOptionalColumn.BaseCatalogName, typeof(string));
+            columns.Add(SchemaTableColumn.BaseColumnName, typeof(string));
+            columns.Add(SchemaTableColumn.BaseSchemaName, typeof(string));
+            columns.Add(SchemaTableColumn.BaseTableName, typeof(string));
+            columns.Add(SchemaTableColumn.DataType, typeof(Type));
+            columns.Add(SchemaTableColumn.AllowDBNull, typeof(bool));
+            columns.Add(SchemaTableColumn.ProviderType, typeof(int));
+            columns.Add(SchemaTableColumn.IsAliased, typeof(bool));
+            columns.Add(SchemaTableColumn.IsExpression, typeof(bool));
+            columns.Add(BulkDataReader.IsIdentitySchemaColumn, typeof(bool));
+            columns.Add(SchemaTableOptionalColumn.IsAutoIncrement, typeof(bool));
+            columns.Add(SchemaTableOptionalColumn.IsRowVersion, typeof(bool));
+            columns.Add(SchemaTableOptionalColumn.IsHidden, typeof(bool));
+            columns.Add(SchemaTableColumn.IsLong, typeof(bool));
+            columns.Add(SchemaTableOptionalColumn.IsReadOnly, typeof(bool));
+            columns.Add(SchemaTableOptionalColumn.ProviderSpecificDataType, typeof(Type));
+            columns.Add(BulkDataReader.DataTypeNameSchemaColumn, typeof(string));
+            columns.Add(BulkDataReader.XmlSchemaCollectionDatabaseSchemaColumn, typeof(string));
+            columns.Add(BulkDataReader.XmlSchemaCollectionOwningSchemaSchemaColumn, typeof(string));
+            columns.Add(BulkDataReader.XmlSchemaCollectionNameSchemaColumn, typeof(string));
         }
 
         #endregion
@@ -1090,7 +1090,7 @@ namespace Umbraco.Core.Persistence
         /// <seealso cref="IDataRecord.GetDecimal(Int32)"/>
         public decimal GetDecimal(int i)
         {
-            return (Decimal)GetValue(i);
+            return (decimal)GetValue(i);
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Xml/DynamicContext.cs
+++ b/src/Umbraco.Core/Xml/DynamicContext.cs
@@ -236,7 +236,7 @@ namespace Umbraco.Core.Xml
                 _name = name;
                 _value = value;
 
-                if (value is String)
+                if (value is string)
                     _type = XPathResultType.String;
                 else if (value is bool)
                     _type = XPathResultType.Boolean;

--- a/src/Umbraco.Tests/Composing/TypeHelperTests.cs
+++ b/src/Umbraco.Tests/Composing/TypeHelperTests.cs
@@ -165,7 +165,7 @@ namespace Umbraco.Tests.Composing
             Assert.IsTrue(TypeHelper.MatchType(typeof(int?), typeof(Nullable<>)));
 
 
-            Assert.IsTrue(TypeHelper.MatchType(typeof(Derived<int>), typeof(Object)));
+            Assert.IsTrue(TypeHelper.MatchType(typeof(Derived<int>), typeof(object)));
             Assert.IsFalse(TypeHelper.MatchType(typeof(Derived<int>), typeof(List<>)));
             Assert.IsFalse(TypeHelper.MatchType(typeof(Derived<int>), typeof(IEnumerable<>)));
             Assert.IsTrue(TypeHelper.MatchType(typeof(Derived<int>), typeof(Base<int>)));

--- a/src/Umbraco.Web/Media/TypeDetector/SvgDetector.cs
+++ b/src/Umbraco.Web/Media/TypeDetector/SvgDetector.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Web.Media.TypeDetector
             {
                 document = XDocument.Load(fileStream);
             }
-            catch (System.Exception ex)
+            catch (System.Exception)
             {
                 return false;
             }


### PR DESCRIPTION
# Description

The current .editorconfig file has the following line:
https://github.com/umbraco/Umbraco-CMS/blob/v8/dev/.editorconfig#L20
```
dotnet_style_predefined_type_for_locals_parameters_members = true:error
```

But the codebase do not follow this guideline. This PR fixe this.
Also removes an unused variable - To remove all errors from resharper/rider.

To test this PR, of cause the automated test should pass and the solution should start. But the most important part is the review.

Before: 
![image](https://user-images.githubusercontent.com/1561480/67567939-35d02a80-f72b-11e9-9d2d-f74470c4fcdf.png)

After:
![image](https://user-images.githubusercontent.com/1561480/67567986-48e2fa80-f72b-11e9-99e9-166ec3da6e2e.png)




