### PR TITLE
V8: Do not allow copying items in the recycle bin

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -770,6 +770,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
 
         $scope.options.allowBulkPublish = $scope.options.allowBulkPublish && !$scope.isTrashed;
         $scope.options.allowBulkUnpublish = $scope.options.allowBulkUnpublish && !$scope.isTrashed;
+        $scope.options.allowBulkCopy = $scope.options.allowBulkCopy && !$scope.isTrashed;
 
         $scope.options.bulkActionsAllowed = $scope.options.allowBulkPublish ||
             $scope.options.allowBulkUnpublish ||


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It makes no sense to copy items that currently resides in the recycle bin... but nevertheless it's allowed by the UI:

![image](https://user-images.githubusercontent.com/7405322/67572019-9cf2dc80-f735-11e9-8940-de0f002bc82a.png)

This PR ensures that the "Copy..." button is hidden from the listview when it displays the recycle bin:

![image](https://user-images.githubusercontent.com/7405322/67572071-bf84f580-f735-11e9-8b20-52389cf2e857.png)

#### Testing this PR

1. Ensure that "Copy..." isn't available in the recycle bin.
2. Ensure that "Copy..." _is_ available in other list views (provided you're allowed to copy).