### PR TITLE
V8: Apply trashed state to deleted content items with list view enabled

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -766,7 +766,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
 
 
         $scope.contentId = id;
-        $scope.isTrashed = id === "-20" || id === "-21";
+        $scope.isTrashed = editorState.current ? editorState.current.trashed : id === "-20" || id === "-21";
 
         $scope.options.allowBulkPublish = $scope.options.allowBulkPublish && !$scope.isTrashed;
         $scope.options.allowBulkUnpublish = $scope.options.allowBulkUnpublish && !$scope.isTrashed;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The listview doesn't allow for publishing and unpublishing items in the recycle bin. That makes perfect sense. Unfortunately this "trashed" state isn't propagated to list view enabled items within the recycle bin:

![image](https://user-images.githubusercontent.com/7405322/67572257-286c6d80-f736-11e9-915d-e64181f45350.png)

I have no idea what actually happens if you hit publish on a trashed item... I'm afraid to click it 🙈 - anyway, this PR fixes the problem:

![image](https://user-images.githubusercontent.com/7405322/67572357-594ca280-f736-11e9-8783-a5d3da8db804.png)


