### PR TITLE
V8: Make the listview delete dialog warn about irreversible deletions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -403,6 +403,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
         const dialog = {
             view: "views/propertyeditors/listview/overlays/delete.html",
             deletesVariants: selectionHasVariants(),
+            isTrashed: $scope.isTrashed,
             submitButtonLabelKey: "contentTypeEditor_yesDelete",
             submitButtonStyle: "danger",
             submit: function (model) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/delete.html
@@ -1,11 +1,15 @@
 <div>
-    
-    <div ng-if="model.deletesVariants" class="umb-alert umb-alert--warning mb2">
-        <localize key="defaultdialogs_variantdeletewarning">
-            This will delete the node and all its languages. If you only want to delete one language go and unpublish it instead.
-        </localize>
+
+    <p class="abstract">
+        <localize key="defaultdialogs_confirmdelete"></localize>?
+    </p>
+
+    <div class="umb-alert umb-alert--warning" ng-show="model.deletesVariants && !model.isTrashed">
+        <localize key="defaultdialogs_variantdeletewarning">This will delete the node and all its languages. If you only want to delete one language go and unpublish it instead.</localize>
     </div>
-    
-    <localize key="defaultdialogs_confirmdelete"></localize>?
+
+    <div class="umb-alert umb-alert--warning" ng-show="model.isTrashed">
+        <localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.
+    </div>
 
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

_If it feels like deja-vu here, it's because #6600 is a lot along the same lines as this one..._

When you delete items from the recycle bin, the warning dialog is the same as is used when deleting items from any other listview. Among other things it tells you to unpublish languages (for culture variant content), which is meaningless in this context:

![image](https://user-images.githubusercontent.com/7405322/67572741-1f2fd080-f737-11e9-8ad4-e2fa6d9ce666.png)

This PR adds a proper warning message to the delete dialog when it's used in context of the recycle bin:

![image](https://user-images.githubusercontent.com/7405322/67572792-3cfd3580-f737-11e9-99fe-bc2cf795c69f.png)

...while retaining the warning when deleting (culture variant) content from other list views:

![image](https://user-images.githubusercontent.com/7405322/67572862-5e5e2180-f737-11e9-8fe3-56dc8a98bc16.png)
