### PR TITLE
V8: Listview unpublish dialog should automatically select all languages

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.controller.js
@@ -17,8 +17,14 @@
 
             $scope.model.disableSubmitButton = !firstSelected;
 
-            //need to set the Save state to true if publish is true
-            language.save = language.unpublish;
+            if (language.isMandatory) {
+                angular.forEach($scope.model.languages, function (lang) {
+                    if (lang !== language) {
+                        lang.unpublish = true;
+                        lang.disabled = language.unpublish;
+                    }
+                });
+            }
         }
 
         function onInit() {
@@ -50,6 +56,7 @@
                     if (active) {
                         //ensure that the current one is selected
                         active.unpublish = true;
+                        changeSelection(active);
                     }
 
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.html
@@ -30,6 +30,7 @@
                                           model="language.unpublish"
                                           on-change="vm.changeSelection(language)"
                                           text="{{language.name}}"
+                                          disabled="language.disabled"
                                            />
 
                             <div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When you have a mandatory language, unpublishing content in that language will unpublish the content in all languages. 

The default unpublish dialog handles this by forcefully selecting and disabling all other language checkboxes if the mandatory languages is selected for unpublishing. But the listview unpublish dialog doesn't handle it at all:

![listview-unpublish-before](https://user-images.githubusercontent.com/7405322/67573607-0cb69680-f739-11e9-9f28-1645b34f97ca.gif)

This PR adds the same handling to the listview unpublish dialog:

![listview-unpublish-after](https://user-images.githubusercontent.com/7405322/67573630-19d38580-f739-11e9-8470-fba69db506fa.gif)

See also #6854 with regards to the mandatory language styling in the dialog 😄 