### PR TITLE
Confirm uninstall package: Change old checkbox to use umb-checkbox

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -31,6 +31,7 @@
 @param {boolean} disabled Set the checkbox to be disabled.
 @param {boolean} required Set the checkbox to be required.
 @param {callback} onChange Callback when the value of the checkbox change by interaction.
+@param {string} cssClass Set a css class modifier
 
 **/
 
@@ -78,7 +79,8 @@
             serverValidationField: "@",
             disabled: "<",
             required: "<",
-            onChange: "&?"
+            onChange: "&?",
+            cssClass: "@?"
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -12,6 +12,14 @@
     line-height: 22px;
     cursor: pointer !important;
 
+    &.-small-text{
+        font-size: 13px;
+    }
+
+    &.-bold{
+        font-weight: 700;
+    }
+
     &__text {
         margin: 0 0 0 26px;
         position: relative;

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -1,4 +1,4 @@
-<label class="checkbox umb-form-check umb-form-check--checkbox" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
+<label class="checkbox umb-form-check umb-form-check--checkbox {{vm.cssClass}}" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
     <input type="checkbox"
            id="{{vm.inputId}}"
            name="{{vm.name}}"

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/installed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/installed.html
@@ -97,10 +97,15 @@
                         </div>
 
                         <div class="umb-info-local-item mt4 flex items-center flex-column" ng-if="vm.installState.status == ''">
-                            <label for="confirm-uninstall" class="umb-package-installer-label">
-                                <input type="checkbox" id="confirm-uninstall" ng-model="vm.package.confirmUninstall" required no-dirty-check>
-                                <strong class="label-text"><localize key="packager_packageUninstallConfirm">Confirm package uninstall</localize></strong>
-                            </label>
+
+                            <umb-checkbox
+                                css-class="-small-text -bold"
+                                model="vm.package.confirmUninstall"
+                                text="Confirm package uninstall"
+                                label-key="packager_packageUninstallConfirm"
+                                required="true">
+                            </umb-checkbox>
+
                             <umb-button
                                 class="mt3"
                                 type="button"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have done 2 things in this PR

1: I extended the umb-checkbox directive with a parameter called "cssClass" making it possible to pass override classes as needed
2: I changed the old checkbox to using the umb-checkbox directive passing css modifiers for making the text smaller and bold like it was using the old pattern

The "no-dirty-check" directive has been removed since the checkbox is a boolean so it should not really be necessary unless I misunderstand something 😅 

**Before**
![package-uninstall-before](https://user-images.githubusercontent.com/1932158/67590242-cbcf7980-f75a-11e9-9c2f-a61de4c62d6f.gif)

**After**
![package-uninstall-after](https://user-images.githubusercontent.com/1932158/67590230-c70ac580-f75a-11e9-87ed-543f25570b34.gif)
