### PR TITLE
Grid layout config: Replace the old checkbox with the umb-checbox directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.html
@@ -78,17 +78,14 @@
 
 
           <umb-control-group hide-label="true">
-             <ul class="unstyled">
-                  <li>
-                      <label>
-                          <input type="checkbox"
-                                 ng-model="currentSection.allowAll"
-                                 style="float: left; margin-right: 10px;"
-                                 ng-change="toggleAllowed(currentSection)" />
-                                 <localize key="grid_allowAllRowConfigurations"/>
-                      </label>
-                  </li>
-             </ul>
+
+            <umb-checkbox
+                model="currentSection.allowAll"
+                on-change="toggleAllowed(currentSection)"
+                text="Allow all row configurations"
+                label-key="grid_allowAllRowConfigurations"
+                style="margin-left: 18px">
+            </umb-checkbox>
 
              <div ng-if="currentSection.allowAll === false">
                   <hr />

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/layoutconfig.html
@@ -79,13 +79,16 @@
 
           <umb-control-group hide-label="true">
 
-            <umb-checkbox
-                model="currentSection.allowAll"
-                on-change="toggleAllowed(currentSection)"
-                text="Allow all row configurations"
-                label-key="grid_allowAllRowConfigurations"
+            <umb-toggle
+                class="umb-toggle-group-item__toggle"
+                checked="currentSection.allowAll"
+                on-click="currentSection.allowAll = !currentSection.allowAll"
+                show-labels="true"
+                label-position="right"
+                label-off="Allow all row configurations"
+                label-on="Allow all row configurations"
                 style="margin-left: 18px">
-            </umb-checkbox>
+            </umb-toggle>
 
              <div ng-if="currentSection.allowAll === false">
                   <hr />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have replaced the old checkbox with the umb-checkbox directive - I have also temporarily added some inline styling to align the checkbox. But that's only until this PR is merged #6858

So before merging this PR please merge the other one and let me update this PR with a proper modifier CSS class 😉 

You might also wonder "Why not change the other checkboxes that are revealed when the new one is toggled?" - Well, that requires an extension to the umb-checkbox directive, which I'm having a think about these days to make it as flexible as we need it to be. Stay tuned 👀 

**Before**
![grid-layout-before](https://user-images.githubusercontent.com/1932158/67591517-e5be8b80-f75d-11e9-9e62-bd34907e7a6b.gif)

**After**
![grid-layout-after](https://user-images.githubusercontent.com/1932158/67591526-eb1bd600-f75d-11e9-97e2-5aef2a5a1cad.gif)