### PR TITLE
Improved the editor service documentation a bit

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -606,10 +606,12 @@ When building a custom infinite editor view you can use the same components as a
          * @methodOf umbraco.services.editorService
          *
          * @description
-         * Opens the document type editor in infinite editing, the submit callback returns the saved document type
+         * Opens the document type editor in infinite editing, the submit callback returns the alias of the saved document type.
          * @param {Object} editor rendering options
-         * @param {Callback} editor.submit Submits the editor
-         * @param {Callback} editor.close Closes the editor
+         * @param {Callback} editor.id Indicates the ID of the document type to be edited. Alternatively the ID may be set to `-1` in combination with `create` being set to `true` to open the document type editor for creating a new document type.
+         * @param {Callback} editor.create Set to `true` to open the document type editor for creating a new document type.
+         * @param {Callback} editor.submit Submits the editor.
+         * @param {Callback} editor.close Closes the editor.
          * @returns {Object} editor object
          */
         function documentTypeEditor(editor) {


### PR DESCRIPTION
The documentation for the `documentTypeEditor` function in the editor service was missing the `id` and `create` properties, so I've added them as well as improved the surrounding text a bit.

<hr />

I haven't been able to build the documentation locally. The guide on how to do so mentions Grunt, which is no longer in use. There used to be a `docs` task for Grunt, but this also seems to be gone now. I was curious to see how the back ticks would look, and if they would brake anything.

P.S.: Shouldn't the `documentTypeEditor` function be marked as deprecated, and then replaced by a `contentTypeEditor` function instead?

![image](https://user-images.githubusercontent.com/3634580/67599254-f677fd00-f76f-11e9-892e-d92af0141b78.png)



