### PR TITLE
Replaced umb-overlay with editorService for listing fields of an Examine search result

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
@@ -26,17 +26,15 @@ function ExamineManagementController($scope, $http, $q, $timeout, $location, umb
 
     function showSearchResultDialog(values) {
         if (vm.searchResults) {
-
             localizationService.localize("examineManagement_fieldValues").then(function (value) {
-
-                vm.searchResults.overlay = {
+                editorService.open({
                     title: value,
                     searchResultValues: values,
                     view: "views/dashboard/settings/examinemanagementresults.html",
                     close: function () {
-                        vm.searchResults.overlay = null;
+                        editorService.close();
                     }
-                };
+                });
             });
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
@@ -30,6 +30,7 @@ function ExamineManagementController($scope, $http, $q, $timeout, $location, umb
                 editorService.open({
                     title: value,
                     searchResultValues: values,
+                    size: "medium",
                     view: "views/dashboard/settings/examinemanagementresults.html",
                     close: function () {
                         editorService.close();

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -411,10 +411,4 @@
         </div>
     </div>
 
-    <umb-overlay ng-if="vm.searchResults.overlay"
-                 position="center"
-                 view="vm.searchResults.overlay.view"
-                 model="vm.searchResults.overlay">
-    </umb-overlay>
-
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagementresults.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagementresults.html
@@ -20,7 +20,7 @@
                         <tbody>
                             <tr ng-repeat="(key, val) in model.searchResultValues track by key">
                                 <td>{{key}}</td>
-                                <td>{{val}}</td>
+                                <td style="word-break: break-word;">{{val}}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagementresults.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagementresults.html
@@ -1,18 +1,41 @@
 <div>
-
-    <table class="table table-bordered table-condensed">
-        <thead>
-            <tr>
-                <th class="score"><localize key="general_field">Field</localize></th>
-                <th class="id"><localize key="general_value">Value</localize></th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr ng-repeat="(key, val) in model.searchResultValues track by key">
-                <td>{{key}}</td>
-                <td>{{val}}</td>
-            </tr>
-        </tbody>
-    </table>
-
+    <umb-editor-view>
+        <umb-editor-header
+            name="model.title"
+            hide-icon="true"
+            hide-alias="true"
+            name-locked="true"
+            hide-description="true">
+        </umb-editor-header>
+        <umb-editor-container>
+            <umb-box>
+                <umb-box-content>
+                    <table class="table table-bordered table-condensed">
+                        <thead>
+                            <tr>
+                                <th class="score"><localize key="general_field">Field</localize></th>
+                                <th class="id"><localize key="general_value">Value</localize></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr ng-repeat="(key, val) in model.searchResultValues track by key">
+                                <td>{{key}}</td>
+                                <td>{{val}}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </umb-box-content>
+            </umb-box>
+        </umb-editor-container>
+        <umb-editor-footer>
+            <umb-editor-footer-content-right>
+                <umb-button
+                    type="button"
+                    button-style="link"
+                    label-key="general_close"
+                    action="model.close()">
+                </umb-button>
+            </umb-editor-footer-content-right>
+        </umb-editor-footer>
+    </umb-editor-view>
 </div>


### PR DESCRIPTION
Warren did a fantastic job of listing the fields of the search result, but I've always felt the overlay was a bit too small for content like this. And not to mention the `umb-overlay` directive is obsolete.

So with this PR, I'm turning this:

![image](https://user-images.githubusercontent.com/3634580/67602035-0f83ac80-f776-11e9-9a9e-b7fc1358fe43.png)

into this:

![image](https://user-images.githubusercontent.com/3634580/67602060-1c080500-f776-11e9-8364-2fb5e9c45c50.png)
