### PR TITLE
Log viewer: Filter toggle

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -77,6 +77,7 @@
 @import "listview.less"; 
 @import "gridview.less";
 @import "footer.less";
+@import "filter-toggle.less";
 
 @import "forms/umb-validation-label.less";
 

--- a/src/Umbraco.Web.UI.Client/src/less/filter-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/filter-toggle.less
@@ -1,0 +1,20 @@
+.filter-toggle{
+    margin: 0;
+    padding: 0 8px 0 0;
+    position: relative;
+}
+
+.filter-toggle__level{
+    display: inline-block;
+    font-weight: 700;
+    margin: 0 5px;
+    max-width: 150px;
+}
+
+.filter-toggle__icon{
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    margin: auto 0;
+}

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -20,14 +20,19 @@
 
                 <umb-editor-sub-header>
                     <umb-editor-sub-header-content-left class="flex-auto flex-wrap">
-
                         <!-- Log Level filter -->
-                        <div class="flex" style="position: relative;">
-                            <a class="btn btn-link dropdown-toggle flex mb2" href="" ng-click="vm.page.showLevelFilter = !vm.page.showLevelFilter">
-                                <span>Log Levels:</span>
-                                <span class="bold truncate dib" style="margin-left: 5px; margin-right: 3px; max-width: 150px;">{{ vm.getFilterName(vm.logLevels) }}</span>
-                                <span class="caret"></span>
-                            </a>
+                        <div class="flex log-viewer-filter" style="position: relative;" deep-blur="vm.page.showLevelFilter = !vm.page.showLevelFilter">
+                            <button 
+                                type="button" 
+                                class="btn-link dropdown-toggle flex mb2 filter-toggle" 
+                                ng-click="vm.page.showLevelFilter = !vm.page.showLevelFilter"
+                                aria-haspopup="true" 
+                                aria-expanded="{{vm.page.showLevelFilter === undefined ? false : vm.page.showLevelFilter}}"
+                                >
+                                <span class="filter-toggle__text">Log Levels:</span>
+                                <span class="filter-toggle__level truncate">{{ vm.getFilterName(vm.logLevels) }}</span>
+                                <span class="filter-toggle__icon caret" aria-hidden="true"></span>
+                            </button>
                             <umb-dropdown class="pull-left" ng-if="vm.page.showLevelFilter" on-close="vm.page.showLevelFilter = false;">
                                 <umb-dropdown-item ng-repeat="level in vm.logLevels" style="padding: 8px 20px 8px 16px;">
                                     <div class="flex items-center">
@@ -43,7 +48,7 @@
                         <div class="flex" style="width:100%;">
                             <div class="flex-auto" style="position:relative;">
                                 <!-- Search/expression filter -->
-                                <input class="form-control search-input" type="text" ng-model="vm.logOptions.filterExpression" style="width:100%; padding-right: 160px;" placeholder="Search logs&hellip;" />
+                                <input class="form-control search-input" type="text" ng-model="vm.logOptions.filterExpression" style="width:100%; padding-right: 160px;" placeholder="Search logs..." />
 
                                 <!-- Save Search & Clear Search icon buttons -->
                                 <ins class="icon-rate" ng-show="vm.checkForSavedSearch()" ng-click="vm.addToSavedSearches()" style="position: absolute; top: 0; line-height: 32px; right: 140px; color: #fdb45c; cursor: pointer;">&nbsp;</ins>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -21,7 +21,7 @@
                 <umb-editor-sub-header>
                     <umb-editor-sub-header-content-left class="flex-auto flex-wrap">
                         <!-- Log Level filter -->
-                        <div class="flex log-viewer-filter" style="position: relative;" deep-blur="vm.page.showLevelFilter = !vm.page.showLevelFilter">
+                        <div class="flex log-viewer-filter" style="position: relative;">
                             <button 
                                 type="button" 
                                 class="btn-link dropdown-toggle flex mb2 filter-toggle" 

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -165,37 +165,37 @@
                                                 <umb-dropdown ng-if="log.searchDropdownOpen" on-close="log.searchDropdownOpen = false">
                                                     <umb-dropdown-item>
                                                         <a ng-href="https://www.google.com/search?q={{ log.RenderedMessage }}" target="_blank" title="Search this message with Google">
-                                                            <img src="https://www.google.com/favicon.ico" width="16" height="16" /> Search With Google
+                                                            <img src="https://www.google.com/favicon.ico" width="16" height="16" alt="" /> Search With Google
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
                                                         <a ng-href="https://www.bing.com/search?q={{ log.RenderedMessage }}" target="_blank" title="Search this message with Bing">
-                                                            <img src="https://www.bing.com/favicon.ico" width="16" height="16" /> Search With Bing
+                                                            <img src="https://www.bing.com/favicon.ico" width="16" height="16" alt="" /> Search With Bing
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
                                                         <a ng-href="https://our.umbraco.com/search?q={{ log.RenderedMessage }}&content=wiki,forum,documentation" target="_blank" title="Search this message on Our Umbraco forums and docs">
-                                                            <img src="https://our.umbraco.com/assets/images/app-icons/favicon.png" width="16" height="16" /> Search Our Umbraco
+                                                            <img src="https://our.umbraco.com/assets/images/app-icons/favicon.png" width="16" height="16" alt="" /> Search Our Umbraco
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
                                                         <a ng-href="https://www.google.co.uk/?q=site:our.umbraco.com {{ log.RenderedMessage }}&safe=off#q=site:our.umbraco.com {{ log.RenderedMessage }} {{ log.Properties['SourceContext'].Value }}&safe=off" target="_blank" title="Search Our Umbraco forums using Google">
-                                                            <img src="https://www.google.com/favicon.ico" width="16" height="16" /> Search Our Umbraco with Google
+                                                            <img src="https://www.google.com/favicon.ico" width="16" height="16" alt="" /> Search Our Umbraco with Google
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
                                                         <a ng-href="https://github.com/umbraco/Umbraco-CMS/search?q={{ log.Properties['SourceContext'].Value }}" target="_blank" title="Search within Umbraco source code on Github">
-                                                            <img src="https://www.github.com/favicon.ico" width="16" height="16" /> Search Umbraco Source
+                                                            <img src="https://www.github.com/favicon.ico" width="16" height="16" alt="" /> Search Umbraco Source
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
                                                         <a ng-href="https://github.com/umbraco/Umbraco-CMS/issues?q={{ log.Properties['SourceContext'].Value }}" target="_blank" title="Search Umbraco Issues on Github">
-                                                            <img src="https://www.github.com/favicon.ico" width="16" height="16" /> Search Umbraco Issues
+                                                            <img src="https://www.github.com/favicon.ico" width="16" height="16" alt="" /> Search Umbraco Issues
                                                         </a>
                                                     </umb-dropdown-item>
                                                 </umb-dropdown>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have improved the filter dropdown, converting the `<a>` to `<button>` and adding appropiate aria attributes as well.

I have also added some empty `alt` attributes on the images rendering the favicons for different searches. This is done in order to let screen readers know they can safely ignore the image since the provided text is adequate in a non-visual context.

Furthermore I have modified some styling so the control aligns with the left edge and looks better in general.

There is more stuff to be done in this view but I'm going to split it all up in smaller PR's since doing one big file, would be confusing for everyone involved 😃 

**Before**
![log-filter-before](https://user-images.githubusercontent.com/1932158/67604230-588a2f80-f77b-11e9-840e-e1444e8e2a38.png)

**After**
![log-filter-after](https://user-images.githubusercontent.com/1932158/67604238-5de77a00-f77b-11e9-9f40-10d8b173579e.png)