### PR TITLE
Notification Component should log warning if siteUri is null. 

### DIFF
--- a/src/Umbraco.Web/Compose/NotificationsComponent.cs
+++ b/src/Umbraco.Web/Compose/NotificationsComponent.cs
@@ -204,7 +204,11 @@ namespace Umbraco.Web.Compose
             private void SendNotification(IUser sender, IEnumerable<IContent> entities, IAction action, Uri siteUri)
             {
                 if (sender == null) throw new ArgumentNullException(nameof(sender));
-                if (siteUri == null) throw new ArgumentNullException(nameof(siteUri));
+                if (siteUri == null)
+                {
+                    _logger.Warn(typeof(Notifier), "Notifications can not be sent, no site url is set (might be during boot process?)");
+                    return;
+                }
 
                 //group by the content type variation since the emails will be different
                 foreach(var contentVariantGroup in entities.GroupBy(x => x.ContentType.Variations))


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

fixes #6464 

### Description

Changes the SendNotification Component to log a warning when the SiteUrl is null as opposed to throwing an error. 

If a content item is updated during startup of the site, then the SiteUrl will not be set, and while the item will be updated the calling method gets an exception returned because the notification failed. 

This PR logs a warning in the log file instead of throwing an argument exception, so the error doesn't give the impression of a failed update. 

This is the 'quick fix' pending a larger task to queue notifications (see https://github.com/umbraco/Umbraco-CMS/issues/6464#issuecomment-542981823) 
