### PR TITLE
look for the system.web section under the root configuration node

### DIFF
--- a/src/Umbraco.Web/Install/InstallSteps/ConfigureMachineKey.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/ConfigureMachineKey.cs
@@ -39,7 +39,8 @@ namespace Umbraco.Web.Install.InstallSteps
             var fileName = IOHelper.MapPath($"{SystemDirectories.Root}/web.config");
             var xml = XDocument.Load(fileName, LoadOptions.PreserveWhitespace);
 
-            var systemWeb = xml.Root.DescendantsAndSelf("system.web").Single();
+            // we only want to get the element that is under the root, (there may be more under <location> tags we don't want them)
+            var systemWeb = xml.Root.Element("system.web");
 
             // Update appSetting if it exists, or else create a new appSetting for the given key and value
             var machineKey = systemWeb.Descendants("machineKey").FirstOrDefault();


### PR DESCRIPTION
use Element to get the root system.web. DescendantsAndSelf can return multiple

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes : #6869 Installation of Machine Key fails if config has multiple system.web sections.

### Description

When the machine key is added to the config, the code looks for DecendantsOrSelf("system.web").Single - if the file has multiple system.web elements this will throw an exception and installation will fail. 

This PR changes the lookup from DecendantsOrSelf to xml.Root.Element which will only find the `System.Web` element in the root `<configuration>` node. 

### To Test

-  NuGet Umbraco
- Add a extra system.web to the config 
e.g
```
<location path="some/path">
    <!-- Up the file upload limit for this path only -->
    <system.web>
        <httpRuntime maxRequestLength="512000" />
    </system.web>
</location>
```

Install Umbraco, ask for a machine key - key will be created in the main `system.web` and will not fail. 

- Equally normal installation will still work 