### PR TITLE
Sets the appState currentNode when executing a menu action (Fixes #5416)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -463,6 +463,8 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
                 throw "section cannot be null";
             }
 
+            appState.setMenuState("currentNode", node);
+
             if (action.metaData && action.metaData["actionRoute"] && angular.isString(action.metaData["actionRoute"])) {
                 //first check if the menu item simply navigates to a route
                 var parts = action.metaData["actionRoute"].split("?");


### PR DESCRIPTION
When calling `navigationService.executeMenuAction`  dialog actions are not aware of the current node. To resolve this `appState.setMenuState("currentNode", node);` needs to be called so that dialogs are aware of this.