### PR TITLE
Removes "feature in preview" text from "Show open button" option

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfiguration.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("maxNumber", "Maximum number of items", "number")]
         public int MaxNumber { get; set; }
 
-        [ConfigurationField("showOpenButton", "Show open button (this feature is in preview!)", "boolean", Description = "Opens the node in a dialog")]
+        [ConfigurationField("showOpenButton", "Show open button", "boolean", Description = "Opens the node in a dialog")]
         public bool ShowOpen { get; set; }
 
         [ConfigurationField(Core.Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes,


### PR DESCRIPTION
I guess the open button on the MNTP is no longer in preview since, so I removed the text saying so.

To test:

Open the settings for a MNTP data type, and notice that the Show open button setting no longer says the feature is in preview. 
![billede](https://user-images.githubusercontent.com/3726467/67624669-ed506400-f833-11e9-90a8-05bd7d5edf26.png)
