### PR TITLE
Opens templates from umb-grid-selector in infinite editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgridselector.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgridselector.directive.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    function GridSelector($location, overlayService) {
+    function GridSelector($location, overlayService, editorService) {
 
         function link(scope, el, attr, ctrl) {
 
@@ -56,8 +56,16 @@
             };
 
             scope.openTemplate = function (selectedItem) {
-                var url = "/settings/templates/edit/" + selectedItem.id;
-                $location.url(url);
+                const editor = {
+                    id: selectedItem.id,
+                    submit: function () {
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.templateEditor(editor);
             }
 
             scope.setAsDefaultItem = function (selectedItem) {


### PR DESCRIPTION
This makes templates in `umb-grid-selector` (used in the doctype editor) open in an infinite editor instead of changing the url.

To test
Open a document type, go to templates. Click "Open" on one of the templates, notice the template opening in an infinite editor.

![2019-10-26_21-22-47](https://user-images.githubusercontent.com/3726467/67624887-263e0800-f837-11e9-848a-01bc7c1d2226.gif)
