### PR TITLE
Fix bug when saving a search in the logviewer

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
@@ -262,11 +262,7 @@
                 submitButtonLabel: "Save Search",
                 disableSubmitButton: true,
                 view: "logviewersearch",
-                query: {
-                    filterExpression: vm.logOptions.filterExpression,
-                    startDate: vm.logOptions.startDate,
-                    endDate: vm.logOptions.endDate
-                },
+                query: vm.logOptions.filterExpression,
                 submit: function (model) {
                     //Resource call with two params (name & query)
                     //API that opens the JSON and adds it to the bottom


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When you try to save a search in the logviewer you get an error, because you are sending the complete json object with dates to the controller.

![2019-10-27_00-29-18](https://user-images.githubusercontent.com/3726467/67626789-e3892980-f850-11e9-9b59-e02c7719ee0d.gif)

I fixed this by only sending the filterexpression, so it now works.

![2019-10-27_00-26-06](https://user-images.githubusercontent.com/3726467/67626796-ef74eb80-f850-11e9-83f0-74857549dfa1.gif)

To test, open the logviewer, perform a search, try to save it.
Find the search in the dropdown of saved searches and verify that it works.
