### PR TITLE
Aligns the padding of .umb-overlay-container with .umb-overlay-header

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -66,7 +66,7 @@
     flex-shrink: 1;
     flex-basis: auto;
     position: relative;
-    padding: 20px;
+    padding: 30px;
     background: @white;
     max-height: calc(100vh - 170px);
     overflow-y: auto;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
`.umb-overlay-container` doesn't have the same padding as `.umb-overlay-header` which makes it look broken. This PR fixes that.

#### Before
![firefox_2019-10-27_10-57-40](https://user-images.githubusercontent.com/3726467/67632835-270f8200-f8a9-11e9-931e-27d62f7d79d2.png)

#### After
![firefox_2019-10-27_10-57-56](https://user-images.githubusercontent.com/3726467/67632840-2d9df980-f8a9-11e9-9108-68e4816041b7.png)

### To test
Open the logviewer, do a search, try to save it (click the star icon), make sure the overlay looks like the after image.