### PR TITLE
Changed the styling of Resend Invitation button and fixed the margin

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-details.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-details.less
@@ -63,6 +63,10 @@ a.umb-user-details-details__back-link {
 
 .umb-user-details-details__sidebar {
     flex: 0 0 @sidebarwidth;
+
+    .umb-button{
+        margin-left:0px;
+    }
 }
 
 @media (max-width: 768px) {
@@ -101,6 +105,7 @@ a.umb-user-details-details__back-link {
 .umb-user-details-details__information-item {
     margin-bottom: 10px;
     font-size: 13px;
+    margin-top:10px;
 }
 
 .umb-user-details-details__information-item-label {

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -322,7 +322,7 @@
                               rows="4">
                 </textarea>
                     <umb-button type="button"
-                                button-style="[info,block]"
+                                button-style="[action,block]"
                                 action="model.resendInvite()"
                                 state="model.resendInviteButtonState"
                                 label="Resend Invite"


### PR DESCRIPTION
The "Resend Invitation" button is a currently an `info` style button (grey). I think it should be an `action` style button as it is an action. It also brings it in line with the **Invite User** screen where the Send Invite button is `action` style. There was also a margin to the left of all the buttons in the sidebar on user details screen which were causing the buttons to shift a little. In addition, I have also introduced a bit of margin after the buttons and before the "Last Login" as it was appearing too close and squished.

Let me know if this is okay :-)

**Before**
![image](https://user-images.githubusercontent.com/3941753/67633352-cc752680-f8a6-11e9-9d65-886c1a54dd4b.png)

**After**
![image](https://user-images.githubusercontent.com/3941753/67633362-e31b7d80-f8a6-11e9-8069-eee0219bb264.png)
