### PR TITLE
Log Viewer - Fix search toggle accessibility

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -151,11 +151,18 @@
                                                 </tbody>
                                             </table>
 
-                                            <div class="btn-group">
-                                                <a class="btn btn-info dropdown-toggle" data-toggle="dropdown" ng-href="" ng-click="log.searchDropdownOpen = !log.searchDropdownOpen">
-                                                    <i class="icon-search"></i> <localize key="general_search">Search</localize>
-                                                    <span class="caret"></span>
-                                                </a>
+                                            <div class="btn-group" deep-blur="log.searchDropdownOpen = !log.searchDropdownOpen">
+                                                <button 
+                                                    type="button" 
+                                                    class="btn btn-info dropdown-toggle" 
+                                                    data-toggle="dropdown" 
+                                                    aria-haspopup="true"
+                                                    aria-expanded="{{log.searchDropdownOpen === undefined ? false : log.searchDropdownOpen}}"
+                                                    ng-click="log.searchDropdownOpen = !log.searchDropdownOpen">
+                                                        <i class="icon-search" aria-hidden="true"></i> 
+                                                        <localize key="general_search">Search</localize>
+                                                        <span class="caret" aria-hidden="true"></span>
+                                                </button>
 
                                                 <umb-dropdown ng-if="log.searchDropdownOpen" on-close="log.searchDropdownOpen = false">
                                                     <umb-dropdown-item>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -154,8 +154,7 @@
                                             <div class="btn-group" deep-blur="log.searchDropdownOpen = !log.searchDropdownOpen">
                                                 <button 
                                                     type="button" 
-                                                    class="btn btn-info dropdown-toggle" 
-                                                    data-toggle="dropdown" 
+                                                    class="btn btn-info dropdown-toggle"
                                                     aria-haspopup="true"
                                                     aria-expanded="{{log.searchDropdownOpen === undefined ? false : log.searchDropdownOpen}}"
                                                     ng-click="log.searchDropdownOpen = !log.searchDropdownOpen">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When you expand a line in the log viewer you will see a "Search" button, which will list some options of searching the issue on different search engines, on Github etc. I've improved the accessibility and the UX doing the following

- Convert `<a>` to `<button>`
- Added `aria-haspopup="true"` and `aria-expanded="true/false"`
- Removed `data-toggle="dropdown`, which has no impact at all. I think it's an old Bootstrap pattern that has been abandoned at some point
- Added the `deep-blur` directive to the parent element so that the "dropdown" will disappear when it's tabbed out of

**Before**
![logviewer-search-dropdown-before](https://user-images.githubusercontent.com/1932158/67638014-96ed2f00-f8e0-11e9-93fe-b4a54d40f1f2.gif)

**After**
![logviewer-search-dropdown-after](https://user-images.githubusercontent.com/1932158/67638018-9ce31000-f8e0-11e9-96df-1b95d05070d3.gif)
