### PR TITLE
Adding context for screen readers to content menu dot expand button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -3,7 +3,7 @@
 * @name umbraco.directives.directive:umbTree
 * @restrict E
 **/
-function umbTreeDirective($q, $rootScope, treeService, notificationsService, userService) {
+function umbTreeDirective($q, $rootScope, treeService, notificationsService, userService, localizationService) {
 
     return {
         restrict: 'E',
@@ -232,8 +232,12 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
                 return $scope.activeTree;
             }
 
-            /** Method to load in the tree data */
             function loadTree() {
+                localizationService.localize("visuallyHiddenTexts_openContextMenu").then(function (value) {
+                    $scope.optionsText = value;
+                })
+
+            /** Method to load in the tree data */
                 if ($scope.section) {
 
                     //default args

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
@@ -8,7 +8,11 @@
                     {{tree.name}}
                 </a>
             </h5>
-            <button data-element="tree-item-options" class="umb-options btn-reset sr-only sr-only--focusable sr-only--hoverable" ng-hide="tree.root.isContainer || !tree.root.menuUrl" ng-click="options(tree.root, $event)" ng-swipe-right="options(tree.root, $event)">
+            <button data-element="tree-item-options"
+                    class="umb-options btn-reset sr-only sr-only--focusable sr-only--hoverable"
+                    aria-label="{{optionsText}} {{tree.name}}"
+                    ng-hide="tree.root.isContainer || !tree.root.menuUrl" ng-click="options(tree.root, $event)"
+                    ng-swipe-right="options(tree.root, $event)">
                 <i></i><i></i><i></i>
             </button>
         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
When you're in the back office, the content tab menu has no context for a screen reader. So currently, this button...

![image](https://user-images.githubusercontent.com/37150989/67638882-85585700-f8e1-11e9-8397-c0fbda2f4576.png)

...is described as just 'button'

With my change, a screen reader will describe the button as 'Open context menu for Content'. 

To test:
1. Open screen reader software (I've used NVDA)
2. Open back office,
3. open content tab,
4. click on the Content header
5. Tab to three dots.
6. Listen to screen reader description.


<!-- Thanks for contributing to Umbraco CMS! -->
