### PR TITLE
V8: Correct path to datatype references that are not document types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/views/datatype.references.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/views/datatype.references.html
@@ -68,7 +68,7 @@
                         <div class="umb-table-cell umb-table__name"><span>{{::reference.name}}</span></div>
                         <div class="umb-table-cell"><span title="{{::reference.alias}}">{{::reference.alias}}</span></div>
                         <div class="umb-table-cell --noOverflow"><span>{{::reference.properties | umbCmsJoinArray:', ':'name'}}</span></div>
-                        <div class="umb-table-cell umb-table-cell--nano"><a href="#/settings/documentTypes/edit/{{::reference.id}}"><localize key="general_open">Open</localize></a></div>
+                        <div class="umb-table-cell umb-table-cell--nano"><a href="#/settings/mediaTypes/edit/{{::reference.id}}"><localize key="general_open">Open</localize></a></div>
                     </div>
                 </div>
             </div>
@@ -98,7 +98,7 @@
                         <div class="umb-table-cell umb-table__name"><span>{{::reference.name}}</span></div>
                         <div class="umb-table-cell"><span title="{{::reference.alias}}">{{::reference.alias}}</span></div>
                         <div class="umb-table-cell --noOverflow"><span>{{::reference.properties | umbCmsJoinArray:', ':'name'}}</span></div>
-                        <div class="umb-table-cell umb-table-cell--nano"><a href="#/settings/documentTypes/edit/{{::reference.id}}"><localize key="general_open">Open</localize></a></div>
+                        <div class="umb-table-cell umb-table-cell--nano"><a href="#/settings/memberTypes/edit/{{::reference.id}}"><localize key="general_open">Open</localize></a></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The "Open" links on the new datatype references tab all lead to `#/settings/documentTypes/edit/{{::reference.id}}` - also for media and member types. This obviously leads to a 404 error if you attempt to open a reference that is _not_ a document type:

![datatype-references-path-before](https://user-images.githubusercontent.com/7405322/67640231-86957e00-f8f9-11e9-8a68-b8a01086b367.gif)

This PR updates the paths according to reference type:

![datatype-references-path-after](https://user-images.githubusercontent.com/7405322/67640239-9319d680-f8f9-11e9-8efb-d1ed54634f03.gif)

