### PR TITLE
Listview: Add table class

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
@@ -12,7 +12,7 @@
         <span class="help-inline" ng-bind="errorMsg"</span>
     </div>
     <div class="control-group">
-        <table ng-show="model.value.length > 0">
+        <table class="table" ng-show="model.value.length > 0">
             <thead>
                 <tr>
                     <td></td>
@@ -31,7 +31,7 @@
                        <div class="list-view-layout__name flex-column content-start">
                             <span class="list-view-layout__name-text" ng-if="!val.isSystem" ng-bind="val.alias"></span>
                             <span class="list-view-layout__name-text" ng-if="val.isSystem == 1" ng-bind="val.alias"></span>
-                            <span class="list-view-layout__system" ng-show="val.isSystem == 1">(system field)</span> 
+                            <span class="list-view-layout__system" ng-show="val.isSystem == 1">(system field)</span>
                        </div>
                     </td>
                     <td>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR adds the already existing `.table` class to the column table making it look much better.

Before
![column-table-before](https://user-images.githubusercontent.com/1932158/67641037-17228d00-f8ff-11e9-84ba-557600318365.png)

After
![column-table-after](https://user-images.githubusercontent.com/1932158/67641040-1d186e00-f8ff-11e9-9c20-79c807929d6e.png)
