### PR TITLE
V8: Make member types searchable

### DIFF
--- a/src/Umbraco.Web/Trees/MemberTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/MemberTypeTreeController.cs
@@ -2,7 +2,10 @@
 using System.Linq;
 using System.Net.Http.Formatting;
 using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Web.Models.ContentEditing;
 using Umbraco.Web.Models.Trees;
+using Umbraco.Web.Search;
 using Umbraco.Web.WebApi.Filters;
 
 namespace Umbraco.Web.Trees
@@ -10,8 +13,15 @@ namespace Umbraco.Web.Trees
     [CoreTree]
     [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
     [Tree(Constants.Applications.Settings, Constants.Trees.MemberTypes, SortOrder = 2, TreeGroup = Constants.Trees.Groups.Settings)]
-    public class MemberTypeTreeController : MemberTypeAndGroupTreeControllerBase
+    public class MemberTypeTreeController : MemberTypeAndGroupTreeControllerBase, ISearchableTree
     {
+        private readonly UmbracoTreeSearcher _treeSearcher;
+
+        public MemberTypeTreeController(UmbracoTreeSearcher treeSearcher)
+        {
+            _treeSearcher = treeSearcher;
+        }
+
         protected override TreeNode CreateRootNode(FormDataCollection queryStrings)
         {
             var root = base.CreateRootNode(queryStrings);
@@ -25,5 +35,9 @@ namespace Umbraco.Web.Trees
                 .OrderBy(x => x.Name)
                 .Select(dt => CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings, Constants.Icons.MemberType, false));
         }
+
+        public IEnumerable<SearchResultEntity> Search(string query, int pageSize, long pageIndex, out long totalFound, string searchFrom = null)
+            => _treeSearcher.EntitySearch(UmbracoObjectTypes.MemberType, query, pageSize, pageIndex, out totalFound, searchFrom);
+
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Member types do not show up in the global search results. I can't really think of a great reason to leave them out, so this PR makes member types searchable:

![member-types-searchable](https://user-images.githubusercontent.com/7405322/67641402-2f47db80-f902-11e9-9910-6d8a8432567a.gif)
