### PR TITLE
Macro parameters: Improve accessibility

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/parameters.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/parameters.html
@@ -10,13 +10,13 @@
                     <div class="umb-property-editor form-horizontal">
                         <div ui-sortable="sortableOptions" ng-model="model.macro.parameters">
                             <div class="control-group umb-prevalues-multivalues__listitem" ng-repeat="parameter in model.macro.parameters track by $id(parameter)">
-                                <i class="icon icon-navigation handle"></i>
+                                <i class="icon icon-navigation handle" aria-hidden="true"></i>
                                 <div class="umb-prevalues-multivalues__left">
                                     <span>{{parameter.label}}</span>&nbsp;<span class="muted">({{parameter.key}})</span>:&nbsp;<small>{{parameter.editor}}</small>
                                 </div>
                                 <div class="umb-prevalues-multivalues__right">
-                                    <a class="umb-node-preview__action" ng-click="vm.edit(parameter, $event)"><localize key="general_edit">Edit</localize></a>
-                                    <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.remove(parameter, $event)"><localize key="general_remove">Remove</localize></a>
+                                    <button type="button" class="umb-node-preview__action" ng-click="vm.edit(parameter, $event)"><localize key="general_edit">Edit</localize></button>
+                                    <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.remove(parameter, $event)"><localize key="general_remove">Remove</localize></button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR I have added `aria-hidden="true"` on an icon to ensure screen readers don't try to announce them.

I have also changed `<a>` to `<button>`, which makes the "edit" and "remove" options possible to navigate using keyboard.

`Before`
![macro-parameters-before](https://user-images.githubusercontent.com/1932158/67641604-5652dd00-f903-11e9-8c12-a306821a9431.gif)

`After`
![macro-parameters-after](https://user-images.githubusercontent.com/1932158/67641601-518e2900-f903-11e9-8e76-c90031f16362.gif)
