### PR TITLE
Color picker datatype: Improve accessibility

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -21,7 +21,7 @@
                 </div>
             </div>
             <div class="umb-prevalues-multivalues__right">
-                <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></a>
+                <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have changed the `<a>` to a `<button>` making it possible to navigate the "delete" option using keyboard.

**Before**
![color-picker-config-before](https://user-images.githubusercontent.com/1932158/67641735-beee8980-f904-11e9-89ff-c64cba26ab0c.gif)

**After**
![color-picker-config-after](https://user-images.githubusercontent.com/1932158/67641736-c3b33d80-f904-11e9-8049-d6a544d1a5fc.gif)
