### PR TITLE
V8: Add :root LESS partial for setting useful CSS variables

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -16,7 +16,7 @@
 @import "../../lib/bootstrap/less/type.less";
 @import "../../lib/bootstrap/less/code.less";
 @import "tables.less";
-
+@import "root.less";
 
 // Components: common
 @import "../../lib/bootstrap/less/dropdowns.less";

--- a/src/Umbraco.Web.UI.Client/src/less/root.less
+++ b/src/Umbraco.Web.UI.Client/src/less/root.less
@@ -1,0 +1,32 @@
+/* contains variables to make available on the :root pseudo element - ie colors, base sizing/padding units 
+   makes package developers happy :)
+*/
+
+:root {
+    --blue: @blue;
+    --blueMid: @blueMid;
+    --blueDark: @blueDark;
+    --blueExtraDark: @blueExtraDark;
+    --blueLight: @blueLight;
+    --blueNight: @blueNight;
+    
+    --pink: @pink;
+    --pinkLight: @pinkLight;
+    --pinkRedLight: @pinkRedLight;
+    
+    --brown: @brown;
+    --brownLight: @brownLight;
+    --brownGrayLight: @brownGrayLight;
+    --brownGrayExtraLight: @brownGrayExtraLight;
+        
+    --error: @red;    
+    --warning: @orange;
+    --success: @green;
+    
+    --brandPrimary: @blueExtraDark;
+    --brandSecondary: @pinkLight;
+    
+    --paddingMini: @paddingMini;
+    --paddingSmall: @paddingSmall;
+    --paddingLarge: @paddingLarge;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As a package developer, I'm often needing to use Umbraco brand colors (and others) in the backoffice - currently that means finding the hex code either in source or dev tools in the backoffice, and referencing same in my project. That's fine until the Umbraco color palette changes, and suddenly my package is using outdated/obsolete colors.

Enter CSS variables, :root pseudo-element and this PR.

I've added a new LESS partial for defining CSS variables on :root, so that developers need not look up colors but can reference these directly:

```CSS
.my-element { color: var(--brandPrimary) }
.my-other-element { padding: var(--paddingMini) }
```

This can be verified in the browser console, by inspecting the HTML element - will see a list of available :root variables in the console.

See also https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties

No functional changes in this PR, but the variables are exposed for anyone wanting to use them. Can readily add others to the root.less partial, and make life a little easier for package devs.