### PR TITLE
Improve keyboard accessibility for media library items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -42,6 +42,10 @@
 
 .umb-media-grid__item.-selectable {
     cursor: pointer;
+
+    .tabbing-active &:focus {
+        outline: 2px solid @inputBorderTabFocus;
+    }
 }
 
 .umb-media-grid__item.-file {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -122,6 +122,7 @@
 
 .umb-media-grid__item-overlay {
    display: flex;
+   width: 100%;
    opacity: 0;
    position: absolute;
    right: 0;
@@ -140,6 +141,10 @@
    
    &:hover {
        text-decoration: underline;
+   }
+
+   .tabbing-active &:focus {
+       opacity: 1;
    }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -4,10 +4,10 @@
             <!--<i ng-show="item.selected" class="icon-check umb-media-grid__checkmark"></i>-->
             <a ng-if="allowOnClickEdit === 'true'" ng-click="clickEdit(item, $event)" ng-href="" class="icon-edit umb-media-grid__edit"></a>
 
-            <div data-element="media-grid-item-edit" class="umb-media-grid__item-overlay" ng-class="{'-locked': item.selected || !item.file || !item.thumbnail}" ng-click="clickItemName(item, $event, $index)">
+            <button data-element="media-grid-item-edit" class="umb-media-grid__item-overlay btn-reset" ng-class="{'-locked': item.selected || !item.file || !item.thumbnail}" ng-click="clickItemName(item, $event, $index)" type="button">
                 <i ng-if="onDetailsHover" class="icon-info umb-media-grid__info" ng-mouseover="hoverItemDetails(item, $event, true)" ng-mouseleave="hoverItemDetails(item, $event, false)"></i>
                 <div class="umb-media-grid__item-name">{{item.name}}</div>
-            </div>
+            </button>
 
             <!-- Check backgrund -->
             <div class="umb-media-grid__image-background" ng-if="item.thumbnail || item.extension === 'svg'"></div>


### PR DESCRIPTION
## Description

This PR improved to visibility for focus states for media library items. Previously, it was not possible to see the overlay button, and the default focus state wasn't always obvious enough.

## Demo GIF
![keyboard accessibile media items](https://user-images.githubusercontent.com/6573613/67667128-16bcdd00-f965-11e9-88eb-9a2afd6afdcc.gif)