### PR TITLE
6830 - fix: url segment null in preview content

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/DatabaseDataSource.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/DatabaseDataSource.cs
@@ -207,7 +207,8 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
                         VersionDate = dto.EditVersionDate,
                         WriterId = dto.EditWriterId,
                         Properties = nested.PropertyData,
-                        CultureInfos = nested.CultureData
+                        CultureInfos = nested.CultureData,
+                        UrlSegment = nested.UrlSegment
                     };
                 }
             }


### PR DESCRIPTION
### Description
Added URL segment to edited content, due to invariant content doesn't have an URL segment in preview, but variant content does have a segment. 

This fixes the bug with not being able to fetch an URL from the GetUrlById when it is invariant and unpublished.

Whether this is the correct way of doing it, I am not 100% sure, because it seems legit that the URL segment should be null when in preview. But having the segment in the DB already, it seems like it doesn't really matter if the segment exists on the preview content, and this makes it possible to use the same service to fetch preview/published URL's. 

### How to test
Add event to cache refresher, as shown below:
![image](https://user-images.githubusercontent.com/18698439/67704724-ee110380-f9b5-11e9-85f7-b75d3fa4256d.png)


The _preview_ variable should have a proper URL now when unpublishing/saving an unpublished invariant content node. 