### PR TITLE
V8: Auto-resize the RTE after inserting images

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -248,6 +248,8 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 var src = imgUrl + "?width=" + newSize.width + "&height=" + newSize.height;
                 editor.dom.setAttrib(imageDomElement, 'data-mce-src', src);
             }
+
+            editor.execCommand("mceAutoResize", false, null, null);
         }
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

😱 Large GIFs ahead 😱 

When inserting images in the RTE it doesn't always resize itself to fit the new content; in fact I find it fails to do so more often than not:

![rte-auto-resize-before](https://user-images.githubusercontent.com/7405322/67711593-9200ac00-f9c2-11e9-8a1d-0eec11a3dd80.gif)

As soon as you click virtually anywhere in the UI, the editor auto-resizes to fit... but it kinda feels like it should do that on its own when the image is inserted. So! This PR forces the RTE to auto-resize after an image is inserted. It works like this:

![rte-auto-resize-after](https://user-images.githubusercontent.com/7405322/67711715-da1fce80-f9c2-11e9-9dd5-d319fe77f236.gif)

_In these GIFs I've used the new RTE image upload to demo the issue, but it also happens when inserting images from the media library._