### PR TITLE
V8: Remove "double tabbing" through the itempicker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
@@ -35,9 +35,8 @@
     </div>
 
     <ul class="umb-card-grid" ng-class="{'-three-in-row': model.availableItems.length < 7, '-four-in-row': model.availableItems.length >= 7}">
-        <li ng-repeat="availableItem in model.availableItems | compareArrays:model.selectedItems:'alias' | orderBy:model.orderBy | filter:searchTerm"
-            ng-click="selectItem(availableItem)">
-            <a class="umb-card-grid-item" href="" title="{{ availableItem.name }}">
+        <li ng-repeat="availableItem in model.availableItems | compareArrays:model.selectedItems:'alias' | orderBy:model.orderBy | filter:searchTerm">
+            <a class="umb-card-grid-item" href="" ng-click="selectItem(availableItem)" prevent-default title="{{ availableItem.name }}">
                 <span>
                     <i class="{{ availableItem.icon }}"></i>
                     {{ availableItem.name }}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you use tab to navigate the item picker overlay (e.g. for Nested Content item selection), each item in the picker has two tab stops:

![nested-content-double-tab-before](https://user-images.githubusercontent.com/7405322/67713648-81eacb80-f9c6-11e9-88f3-0bed0942e197.gif)

Seems a bit excessive! This PR boils it down to just one tab stop per item:

![nested-content-double-tab-after](https://user-images.githubusercontent.com/7405322/67713691-94650500-f9c6-11e9-9a6d-d3c9b7432bdd.gif)
