### PR TITLE
V8: Display picked item state when navigating the treepicker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
@@ -58,7 +58,9 @@
                 
                 entityResource.getPagedChildren(miniListView.node.id, scope.entityType, miniListView.pagination)
                     .then(function (data) {
-
+                        if (scope.onItemsLoaded) {
+                            scope.onItemsLoaded({items: data.items});
+                        }
                         // update children
                         miniListView.children = data.items;
                         _.each(miniListView.children, function(c) {
@@ -208,6 +210,7 @@
                 startNodeId: "=",
                 onSelect: "&",
                 onClose: "&",
+                onItemsLoaded: "&",
                 entityTypeFilter: "="
             },
             link: link

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -58,6 +58,7 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
         vm.hideSearch = hideSearch;
         vm.closeMiniListView = closeMiniListView;
         vm.selectListViewNode = selectListViewNode;
+        vm.listViewItemsLoaded = listViewItemsLoaded;
         vm.submit = submit;
         vm.close = close;
 
@@ -415,7 +416,7 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
             if ($scope.model.selection.length > 0) {
                 for (var i = 0; $scope.model.selection.length > i; i++) {
                     var selectedItem = $scope.model.selection[i];
-                    if (selectedItem.id === item.id) {
+                    if (selectedItem.id === parseInt(item.id)) {
                         found = true;
                         foundIndex = i;
                     }
@@ -630,8 +631,8 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
             _.each(vm.searchInfo.results,
                 function (result) {
                     var exists = _.find($scope.model.selection,
-                        function (selectedId) {
-                            return result.id == selectedId;
+                        function (item) {
+                            return result.id == item.id;
                         });
                     if (exists) {
                         result.selected = true;
@@ -649,6 +650,15 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
 
         function closeMiniListView() {
             vm.miniListView = undefined;
+        }
+
+        function listViewItemsLoaded(items) {
+            var selectedIds = _.pluck($scope.model.selection, "id");
+            _.each(items, function (item) {
+                if (_.contains(selectedIds, item.id)) {
+                    item.selected = true;
+                }
+            });
         }
 
         function submit(model) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
@@ -75,6 +75,7 @@
                                 start-node-id="vm.startNodeId"
                                 on-select="vm.selectListViewNode(node)"
                                 on-close="vm.closeMiniListView()"
+                                on-items-loaded="vm.listViewItemsLoaded(items)"
                                 entity-type-filter="vm.filter">
                             </umb-mini-list-view>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The treepicker isn't super great at displaying the current picked item state when you're moving around in the tree. It's particularly bad when navigating listview nodes and when searching:

![treepicker-browse-selected-state-before](https://user-images.githubusercontent.com/7405322/67720057-57ebd600-f9d3-11e9-8493-9bc5f107c155.gif)

This PR makes a brave attempt at fixing these issues, so the currently picked items are always marked with the checkbox on matter how you navigate the tree:

![treepicker-browse-selected-state-after](https://user-images.githubusercontent.com/7405322/67720154-879ade00-f9d3-11e9-9760-08d6609236b7.gif)

