### PR TITLE
V8: Add autofocus to treepicker search box

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreesearchbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreesearchbox.directive.js
@@ -14,7 +14,8 @@ function treeSearchBox(localizationService, searchService, $q) {
             section: "@",
             datatypeKey: "@",
             hideSearchCallback: "=",
-            searchCallback: "="
+            searchCallback: "=",
+            autoFocus: "="
         },
         restrict: "E",    // restrict to an element
         replace: true,   // replace the html element with the template

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
@@ -37,7 +37,8 @@
                                         search-from-name="{{vm.searchInfo.searchFromName}}"
                                         show-search="{{vm.searchInfo.showSearch}}"
                                         datatype-key="{{vm.searchInfo.dataTypeKey}}"
-                                        section="{{vm.section}}">
+                                        section="{{vm.section}}"
+                                        auto-focus="true">
                                     </umb-tree-search-box>
                                 </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-box.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-box.html
@@ -5,7 +5,7 @@
            ng-model="term"
            class="umb-search-field search-query -full-width-input"
            placeholder="{{searchPlaceholderText}}"           
-           focus-when="{{showSearch}}">
+           umb-auto-focus="{{autoFocus ? 'true' : 'false'}}">
     <h4 ng-if="showSearch && searchFromName">
         <small><localize key="general_search">Search</localize>:&nbsp;</small>
         {{searchFromName}}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Media Picker applies autofocus to the search box when the picker is opened, which means the editors can instantly search for the media they want. 

The treepicker component (which powers MNTP and Content Picker) does not apply the same autofocus:

![treepicker-search-autofocus-before](https://user-images.githubusercontent.com/7405322/67721121-13156e80-f9d6-11e9-86bc-8d0945e41920.gif)

Being a huge fan of the search boxes, I think that's a darn shame. So this PR ensures that the treepicker search box automatically receives focus when the treepicker is opened:

![treepicker-search-autofocus-after](https://user-images.githubusercontent.com/7405322/67721187-3a6c3b80-f9d6-11e9-8194-33e3955e316f.gif)

