### PR TITLE
Changed the Disable button in user details to be warning style

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -249,7 +249,7 @@
                     <div>
                         <umb-button ng-if="model.user.userDisplayState.key !== 'Disabled' && model.user.userDisplayState.key !== 'Invited' && !model.user.isCurrentUser"
                                     type="button"
-                                    button-style="[info,block]"
+                                    button-style="[warning,block]"
                                     action="model.disableUser()"
                                     state="model.disableUserButtonState"
                                     label="Disable"


### PR DESCRIPTION
Currently the disable button in the user details screen is the grey `info` style button. I have changed it to `warning` style.

**Before**
![image](https://user-images.githubusercontent.com/3941753/67754647-bc884e80-fa2e-11e9-9549-78b7def80f46.png)


**After**
![image](https://user-images.githubusercontent.com/3941753/67754471-6b785a80-fa2e-11e9-850c-91e489ebe030.png)
