### PR TITLE
V8: Use "not allowed" cursor for locked type aliases

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-generate-alias.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-generate-alias.html
@@ -1,5 +1,5 @@
 <div>
-    <span class="umb-locked-field__text" ng-show="!enableLock">{{ alias }}</span>
+    <span class="umb-locked-field__text cursor-not-allowed" ng-show="!enableLock">{{ alias }}</span>
     <div ng-show="enableLock">
     <umb-locked-field
       locked="locked"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

OK so this is a tiny thing, but...

Some type aliases are uneditable because they're reserved by the system (e.g. the built-in user group aliases). They appear in the UI without the little padlock that usually lets you "unlock" the alias to edit it. 

![image](https://user-images.githubusercontent.com/7405322/67760227-388b9200-fa41-11e9-9e46-39c83f83f255.png)

For some reason these uneditable type aliases do not have a "not allowed" cursor when you hover the mouse above them - they use the default "text highlight" cursor. This PR changes the cursor to "not allowed".