### PR TITLE
V8: Protect "system media types" from alias changes and deletion

### DIFF
--- a/src/Umbraco.Core/Models/MediaTypeExtensions.cs
+++ b/src/Umbraco.Core/Models/MediaTypeExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace Umbraco.Core.Models
+{
+    internal static class MediaTypeExtensions
+    {
+        internal static bool IsSystemMediaType(this IMediaType mediaType) =>
+            mediaType.Alias == Constants.Conventions.MediaTypes.File
+            || mediaType.Alias == Constants.Conventions.MediaTypes.Folder
+            || mediaType.Alias == Constants.Conventions.MediaTypes.Image;
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -268,6 +268,7 @@
     <Compile Include="Models\Entities\IMemberEntitySlim.cs" />
     <Compile Include="Models\Entities\MediaEntitySlim.cs" />
     <Compile Include="Models\Entities\MemberEntitySlim.cs" />
+    <Compile Include="Models\MediaTypeExtensions.cs" />
     <Compile Include="Models\PublishedContent\ILivePublishedModelFactory.cs" />
     <Compile Include="Models\PublishedContent\IPublishedContentType.cs" />
     <Compile Include="Models\PublishedContent\IPublishedPropertyType.cs" />

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.html
@@ -9,6 +9,7 @@
             <umb-editor-header
                 name="vm.contentType.name"
                 alias="vm.contentType.alias"
+                alias-locked="vm.contentType.isSystemMediaType"
                 key="vm.contentType.key"
                 description="vm.contentType.description"
                 navigation="vm.page.navigation"

--- a/src/Umbraco.Web/Models/ContentEditing/MediaTypeDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/MediaTypeDisplay.cs
@@ -5,6 +5,7 @@ namespace Umbraco.Web.Models.ContentEditing
     [DataContract(Name = "contentType", Namespace = "")]
     public class MediaTypeDisplay : ContentTypeCompositionDisplay<PropertyTypeDisplay>
     {
-
+        [DataMember(Name = "isSystemMediaType")]
+        public bool IsSystemMediaType { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
@@ -145,6 +145,7 @@ namespace Umbraco.Web.Models.Mapping
 
             //default listview
             target.ListViewEditorName = Constants.Conventions.DataTypes.ListViewPrefix + "Media";
+            target.IsSystemMediaType = source.IsSystemMediaType();
 
             if (string.IsNullOrEmpty(source.Name)) return;
 

--- a/src/Umbraco.Web/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTypeTreeController.cs
@@ -120,7 +120,10 @@ namespace Umbraco.Web.Trees
                 }
 
                 menu.Items.Add<ActionCopy>(Services.TextService, opensDialog: true);
-                menu.Items.Add<ActionDelete>(Services.TextService, opensDialog: true);
+                if(ct.IsSystemMediaType() == false)
+                {
+                    menu.Items.Add<ActionDelete>(Services.TextService, opensDialog: true);
+                }
                 menu.Items.Add(new RefreshNode(Services.TextService, true));
 
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The default media types "Image", "File" and "Folder" are used in a number of places and expected to be part of any Umbraco installation - things go horribly wrong if they are not present (see for example #6632).

While this dependency on "known media types" is not ideal, we should at least protect these media types from deletion and/or alias changes until a less hardcoded solution can be implemented in the core, so newcomers do not accidentally destroy their Umbraco installation simply by using the backoffice. 

This PR ensures that:

1. "Image", "File" and "Folder" can't be deleted.
2. "Image", "File" and "Folder" can't have their aliases changed (see also #6942).

![image](https://user-images.githubusercontent.com/7405322/67762681-4c85c280-fa46-11e9-8a9f-9a73a5680750.png)

![image](https://user-images.githubusercontent.com/7405322/67762734-6fb07200-fa46-11e9-8a95-083fd970882b.png)
