### PR TITLE
Styling for the DataType Delete Dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -187,6 +187,8 @@
 @import "components/users/umb-user-preview.less";
 @import "components/users/umb-user-picker-list.less";
 
+@import "components/contextdialogs/umb-dialog-datatype-delete.less";
+
 
 // Utilities
 @import "utilities/layout/_display.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/contextdialogs/umb-dialog-datatype-delete.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/contextdialogs/umb-dialog-datatype-delete.less
@@ -1,0 +1,33 @@
+.umb-dialog-datatype-delete {
+    
+
+    .umb-dialog-datatype-delete__table-head-column-name {
+        width: 140px;
+    }
+
+    .umb-table-body__icon {
+        margin-right: 5px;
+        vertical-align: top;
+        display: inline-block;
+    }
+
+    .table tbody td {
+        vertical-align: top;
+    }
+    .table tbody td > span {
+        margin: 5px 0;
+        vertical-align: middle;
+    }
+    .table tbody p {
+        line-height: 12px;
+        margin: 5px 0;
+        vertical-align: middle;
+    }
+
+    .table tbody .icon {
+        vertical-align: top;
+        margin-right: 5px;
+        display: inline-block;
+    }
+
+}

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/delete.html
@@ -51,7 +51,7 @@
                                 <tbody>
                                     <tr ng-repeat="relation in vm.references.documentTypes">
                                         <td><span title="{{::relation.name}}({{::relation.alias}})"><i class="umb-table-body__icon {{relation.icon}}"></i>{{::relation.name}}</span></td>
-                                        <td><span><p class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}</p></span></td>
+                                        <td><div><p class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}</p></div></td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -75,7 +75,7 @@
                                 <tbody>
                                     <tr ng-repeat="relation in vm.references.mediaTypes">
                                         <td><span title="{{::relation.name}}({{::relation.alias}})"><i class="umb-table-body__icon {{relation.icon}}"></i>{{::relation.name}}</span></td>
-                                        <td><span><p class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}</p></span></td>
+                                        <td><div><p class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}</p></div></td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -99,7 +99,7 @@
                                     <tbody>
                                         <tr ng-repeat="relation in vm.references.memberTypes">
                                             <td><span title="{{::relation.name}}({{::relation.alias}})"><i class="umb-table-body__icon {{relation.icon}}"></i>{{::relation.name}}</span></td>
-                                            <td><span><p class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}</p></span></td>
+                                            <td><div><p class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}</p></div></td>
                                         </tr>
                                     </tbody>
                                 </table>

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/delete.html
@@ -1,4 +1,4 @@
-<div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.DataType.DeleteController as vm">
+<div class="umb-dialog umb-pane umb-dialog-datatype-delete" ng-controller="Umbraco.Editors.DataType.DeleteController as vm">
     <div class="umb-dialog-body">
 
         <ng-switch on="currentNode.nodeType">
@@ -44,14 +44,14 @@
                             <table class="table table-condensed table-bordered">
                                 <thead>
                                     <tr>
-                                        <th><localize key="general_name">Name</localize></th>
+                                        <th class="umb-dialog-datatype-delete__table-head-column-name"><localize key="general_name">Name</localize></th>
                                         <th><localize key="general_properties">Properties</localize></th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                     <tr ng-repeat="relation in vm.references.documentTypes">
                                         <td><span title="{{::relation.name}}({{::relation.alias}})"><i class="umb-table-body__icon {{relation.icon}}"></i>{{::relation.name}}</span></td>
-                                        <td><span><span class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}{{$last ? '' : ', '}}</span></span></td>
+                                        <td><span><p class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}</p></span></td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -68,14 +68,14 @@
                             <table class="table table-condensed table-bordered">
                                 <thead>
                                     <tr>
-                                        <th><localize key="general_name">Name</localize></th>
+                                        <th class="umb-dialog-datatype-delete__table-head-column-name"><localize key="general_name">Name</localize></th>
                                         <th><localize key="general_properties">Properties</localize></th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                     <tr ng-repeat="relation in vm.references.mediaTypes">
                                         <td><span title="{{::relation.name}}({{::relation.alias}})"><i class="umb-table-body__icon {{relation.icon}}"></i>{{::relation.name}}</span></td>
-                                        <td><span><span class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}{{$last ? '' : ', '}}</span></span></td>
+                                        <td><span><p class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}</p></span></td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -92,14 +92,14 @@
                             <table class="table table-condensed table-bordered">
                                     <thead>
                                         <tr>
-                                            <th><localize key="general_name">Name</localize></th>
+                                            <th class="umb-dialog-datatype-delete__table-head-column-name"><localize key="general_name">Name</localize></th>
                                             <th><localize key="general_properties">Properties</localize></th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         <tr ng-repeat="relation in vm.references.memberTypes">
                                             <td><span title="{{::relation.name}}({{::relation.alias}})"><i class="umb-table-body__icon {{relation.icon}}"></i>{{::relation.name}}</span></td>
-                                            <td><span><span class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}{{$last ? '' : ', '}}</span></span></td>
+                                            <td><span><p class="red" ng-repeat="property in relation.properties"><i class="icon icon-alert red"></i>{{::property.name}}</p></span></td>
                                         </tr>
                                     </tbody>
                                 </table>


### PR DESCRIPTION
Added specific styling to the DataType Delete dialog for better looks and a better overview.

So now it even looks fairly decent even with this datatype that is used a lot:

![image](https://user-images.githubusercontent.com/6791648/67788640-03983300-fa73-11e9-94c4-e818121a6429.png)
