### PR TITLE
Get missing crops from configuration

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/ImageCropperValue.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/ImageCropperValue.cs
@@ -160,12 +160,11 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
             // merge the crop values - the alias + width + height comes from
             // configuration, but each crop can store its own coordinates
 
-            if (Crops == null) return;
-
             var configuredCrops = configuration?.Crops;
             if (configuredCrops == null) return;
 
-            var crops = Crops.ToList();
+            //Use Crops if it's not null, otherwise create a new list
+            var crops = Crops?.ToList() ?? new List<ImageCropperCrop>();
 
             foreach (var configuredCrop in configuredCrops)
             {


### PR DESCRIPTION
### Prerequisites

This fixes issue #5737 and Replaces pull request #5739 

### Description
When you add a crop alias to Image Cropper after media already exists in your Media library it doesn't pick up any of the crops. This PR updates ImageCropperTemplateExtensions to check for this condition and configure crops from the DataType.Configuration. 

### Steps to reproduce
As per issue #5737 
- V8 with SK installed
- Update Image Media Type -> Update umbracoFile Image Cropper DataType settings to include a crop type (ie test)
- Update Products.cshtml / template to use that crop ie ```@product.Pho0tos.GetCropUrl("test")``` 
- View page on frontend & confirm images render (they don't before PR)
- Goto Media Section & Choose a Product Image
- Set manual crops for an image
- View page on frontend & confirm all images render (only the updated image does before PR)
