### PR TITLE
V8: Re-apply input focus to the last focused element when closing dialogs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -169,6 +169,7 @@ When building a custom infinite editor view you can use the same components as a
         let editorsKeyboardShorcuts = [];
         var editors = [];
         var isEnabled = true;
+        var lastElementInFocus = null;
         
         
         // events for backdrop
@@ -261,6 +262,12 @@ When building a custom infinite editor view you can use the same components as a
             */
             unbindKeyboardShortcuts();
 
+            // if this is the first editor layer, save the currently focused element
+            // so we can re-apply focus to it once all the editor layers are closed 
+            if (editors.length === 0) {
+                lastElementInFocus = document.activeElement;
+            }
+
             // set flag so we know when the editor is open in "infinite mode"
             editor.infiniteMode = true;
 
@@ -301,6 +308,10 @@ When building a custom infinite editor view you can use the same components as a
             $timeout(function() {
                 // rebind keyboard shortcuts for the new editor in focus
                 rebindKeyboardShortcuts();
+
+                if (editors.length === 0 && lastElementInFocus) {
+                    lastElementInFocus.focus();
+                }
             }, 0);
 
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Tabbing through the content editor is made really hard by pickers and other dialogs spawned by `editorService`. When they're closed, input focus is set to the first applicable element on the page, which is in the top menu:

![reapply-focus-before](https://user-images.githubusercontent.com/7405322/67802416-5e3d8900-fa8b-11e9-90b9-85ff4f4d350e.gif)

This PR makes `editorService` attempt to re-apply input focus to the element that had input focus before the dialog was opened:

![reapply-focus-after](https://user-images.githubusercontent.com/7405322/67802521-98a72600-fa8b-11e9-82b5-15f021e7b1d0.gif)


See also #6934.