### PR TITLE
V8: Don't show "max items" help text for content pickers in single item configuration

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -31,7 +31,7 @@
             <span class="sr-only">...</span>
         </button>
 
-        <div class="umb-contentpicker__min-max-help" ng-if="model.config.multiPicker === true">
+        <div class="umb-contentpicker__min-max-help" ng-if="model.config.multiPicker === true && (model.config.maxNumber > 1 || model.config.minNumber > 0)">
 
             <!-- Both min and max items -->
             <span ng-if="model.config.minNumber && model.config.maxNumber && model.config.minNumber !== model.config.maxNumber">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When a content picker is configured to pick max 1 item, the help text is a little redundant - usually the property label and/or description would be sufficient to help the editors:

![image](https://user-images.githubusercontent.com/7405322/67803045-8b3e6b80-fa8c-11e9-8761-cfbddb3cf5c5.png)

This PR hides the help text when max items is set to 0 or 1 _and_ min items is set to 0:

![content-picker-helptext-after](https://user-images.githubusercontent.com/7405322/67803196-cf317080-fa8c-11e9-82c9-08755b7ffd68.gif)

#### Testing this PR

1. Validate that the help text is _not_ shown when max items is set to 0 or 1 and min items is set to 0.
2. Validate that the help text is shown if max items is set to more than 1.
3. Validate that the help text is shown if min items is set to more than 0.
