### PR TITLE
V8: Fix broken grid when reordering grid rows that contain RTE's

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -73,7 +73,10 @@ angular.module("umbraco")
                     ui.item.find(".umb-rte").each(function (key, value) {
                         // remove all RTEs in the dragged row and save their settings
                         var rteId = value.id;
-                        draggedRteSettings[rteId] = _.findWhere(tinyMCE.editors, { id: rteId }).settings;
+                        var editor = _.findWhere(tinyMCE.editors, { id: rteId });
+                        if (editor) {
+                            draggedRteSettings[rteId] = editor.settings;
+                        }
                     });
                 },
 
@@ -85,9 +88,17 @@ angular.module("umbraco")
                     // reset all RTEs affected by the dragging
                     ui.item.parents(".umb-column").find(".umb-rte").each(function (key, value) {
                         var rteId = value.id;
-                        draggedRteSettings[rteId] = draggedRteSettings[rteId] || _.findWhere(tinyMCE.editors, { id: rteId }).settings;
-                        tinyMCE.execCommand("mceRemoveEditor", false, rteId);
-                        tinyMCE.init(draggedRteSettings[rteId]);
+                        var settings = draggedRteSettings[rteId];
+                        if (!settings) {
+                            var editor = _.findWhere(tinyMCE.editors, { id: rteId });
+                            if (editor) {
+                                settings = editor.settings;
+                            }
+                        }
+                        if (settings) {
+                            tinyMCE.execCommand("mceRemoveEditor", false, rteId);
+                            tinyMCE.init(settings);
+                        }
                     });
                     currentForm.$setDirty();
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6947

### Description

While I don't exactly pride myself of being any kind of a Grid expert, I do believe this PR fixes the issues concerning reordering grid rows containing RTE's (described in #6947).

With this PR applied at least I seem able to drag RTE's around without breaking things:

![grid-rte-reordering](https://user-images.githubusercontent.com/7405322/67808267-aca45500-fa96-11e9-8fc8-86e20f87c7de.gif)
