### PR TITLE
Changed the style of the Import button on Doctype Import to action style

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/importdocumenttype.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/importdocumenttype.html
@@ -9,7 +9,7 @@
         <form name="importDoctype">
 
             <!-- Select files -->
-            <button class="btn"
+            <button class="btn btn-action"
                 name="file"
                 ngf-select
                 ng-model="filesHolder"


### PR DESCRIPTION
Currrently the Import button is the grey default button, I have changed it to action style (blue background, white text) as I feel Import Doc Type is an action.

![image](https://user-images.githubusercontent.com/3941753/67818570-9ce23c00-faa9-11e9-98b6-4eec10edefb6.png)
