### PR TITLE
V8: Styling updates to image cropper and upload property editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-property-file-upload.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-property-file-upload.less
@@ -1,6 +1,7 @@
 ﻿.umb-property-file-upload {
 
     .umb-upload-button-big {
+        max-width: (@propertyEditorLimitedWidth - 40);
         display: block;
         padding: 20px;
         opacity: 1;

--- a/src/Umbraco.Web.UI.Client/src/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/src/less/mixins.less
@@ -419,7 +419,7 @@
 // --------------------------------------------------
 // Limit width of specific property editors
 .umb-property-editor--limit-width {
-    max-width: 800px;
+    max-width: @propertyEditorLimitedWidth;
 }
 
 // Horizontal dividers

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -721,6 +721,10 @@
 //
 // File upload
 // --------------------------------------------------
+.umb-fileupload {
+    display: flex;
+}
+
 .umb-fileupload .preview {
   border-radius: 5px;
   border: 1px solid @gray-6;

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -322,6 +322,7 @@
 @paddingSmall:          2px 10px;  // 26px
 @paddingMini:           0 6px;   // 22px
 
+@propertyEditorLimitedWidth: 800px;
 
 // Disabled this to keep consistency throughout the backoffice UI. Untill a better solution is thought up, this will do.
 @baseBorderRadius:      3px; // 2px;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The upload areas of the image cropper and upload property editors are a bit excessive in size, compared to most other editors:

![image](https://user-images.githubusercontent.com/7405322/67840182-8b268600-faf5-11e9-9d13-0e946d9f57e8.png)

Also when an image is uploaded to the upload property editor, the applied image border is a tad out of place:

![image](https://user-images.githubusercontent.com/7405322/67840311-dfca0100-faf5-11e9-8fa8-126967170aec.png)

With this PR applied, the upload areas have the same width as other property editors:

![image](https://user-images.githubusercontent.com/7405322/67839960-18b5a600-faf5-11e9-891a-973cf97f4b56.png)

...and when images are uploaded, the upload property border doesn't go full width:

![image](https://user-images.githubusercontent.com/7405322/67840004-35ea7480-faf5-11e9-87d8-f1dc65394e08.png)

Notice how the image cropper is still allowed to span the full browser width when an image is uploaded. I chose this approach in order to leave room for those image cropper configurations with a lot of defined crops.