### PR TITLE
V8: Allow file upload and image cropper properties to be optional

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbpropertyfileupload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbpropertyfileupload.directive.js
@@ -299,7 +299,7 @@
              */
             onFilesChanged: "&",
             onInit: "&",
-            required: "@"
+            required: "="
         },
         transclude: true,
         controllerAs: 'vm',


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Seems _someone_ (ahem... me) made a tiny mistake when making upload and image cropper mandatory validation work clientside (#6527)... they can no longer be optional:

![image](https://user-images.githubusercontent.com/7405322/67843766-eb6cf600-fafc-11e9-9559-ceec74abf3ff.png)

This PR fixes it right up.

#### Testing this PR

1. Ensure that clientside mandatory validation works for image cropper and upload properties.
2. Ensure that non-mandatory properties of type image cropper and upload do not require uploaded files in order to save the content.