### PR TITLE
Remove unneccessary cursor:pointer on checkmark

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-checkmark.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-checkmark.less
@@ -9,7 +9,6 @@
     justify-content: center;
     align-items: center;
     color: @gray-7;
-    cursor: pointer;
     font-size: 15px;
 }
 


### PR DESCRIPTION
This fixes [6703](https://github.com/umbraco/Umbraco-CMS/issues/6703)

### Description
Editing css file umb-checkmark.less to remove cursor: pointer style, I searched all references to this class and think that i checked them all, and removing the style had no adverse affects on the interface.

Locations checked were tours, user group adding, user invite and creation, most cases simply didnt need cursor pointer, however user group adding did need it, but the parent anchor was providing the cursor.
