### PR TITLE
Spelling mistake on word Umbraco in instructional comment.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -488,7 +488,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
          * @methodOf umbraco.services.tinyMceService
          *
          * @description
-         * Creates the umbrco insert embedded media tinymce plugin
+         * Creates the umbraco insert embedded media tinymce plugin
          *
          * @param {Object} editor the TinyMCE editor instance
          */
@@ -575,7 +575,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
          * @methodOf umbraco.services.tinyMceService
          *
          * @description
-         * Creates the umbrco insert media tinymce plugin
+         * Creates the umbraco insert media tinymce plugin
          *
          * @param {Object} editor the TinyMCE editor instance
          */
@@ -705,7 +705,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
          * @methodOf umbraco.services.tinyMceService
          *
          * @description
-         * Creates the insert umbrco macro tinymce plugin
+         * Creates the insert umbraco macro tinymce plugin
          *
          * @param {Object} editor the TinyMCE editor instance
          */


### PR DESCRIPTION
### Description
Simple spelling mistake on word Umbraco in comments of JS file.