### PR TITLE
V8: Make multiple media property editor same width as other property editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -232,6 +232,7 @@
 }
 .umb-mediapicker-multi > div {
     width:100%;
+    .umb-property-editor--limit-width();
 }
 
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Media picker properties that allow multiselect take up the full width of the screen. This doesn't look terribly good when they're used alongside other properties that have the default max width of 800px:

![image](https://user-images.githubusercontent.com/7405322/67848409-e6ac4000-fb04-11e9-8a6e-89a7c155f363.png)

There is a functional merit when you pick a lot of images, but still... it looks a bit awkward:

![image](https://user-images.githubusercontent.com/7405322/67848456-03487800-fb05-11e9-9401-9ae0402edf13.png)

This PR enforces the same max width of 800px to the media picker:

![image](https://user-images.githubusercontent.com/7405322/67848302-a8af1c00-fb04-11e9-8f2b-2d862103b595.png)

Obviously this means it takes up more vertical space when you pick a lot of images, but I think it's worth it:

![image](https://user-images.githubusercontent.com/7405322/67848345-c11f3680-fb04-11e9-94db-78d3dcf232bf.png)
