### PR TITLE
Space missing before name of Installed package and |

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/installed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/installed.html
@@ -18,7 +18,7 @@
                             <div class="umb-package-list__item-content">
                                 <div class="umb-package-list__item-name">{{ installedPackage.name }}</div>
                                 <div class="umb-package-list__item-description">
-                                    {{ installedPackage.version }} | <a href="{{ installedPackage.url }}" target="_blank">{{ installedPackage.url }}</a>| {{ installedPackage.author }}
+                                    {{ installedPackage.version }} | <a href="{{ installedPackage.url }}" target="_blank">{{ installedPackage.url }}</a> | {{ installedPackage.author }}
                                 </div>
                             </div>
                         </td>


### PR DESCRIPTION
#### Description
Dead simple one, the name of the package was right up next to the following object, so i just added a space for formatting, to match the other locations this same code is used.

Can be seen here, just after package name:

https://gyazo.com/8a017d383dc1c07bd61a75287279984f
