### PR TITLE
Extend umb-checkbox to allow icons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -80,7 +80,8 @@
             disabled: "<",
             required: "<",
             onChange: "&?",
-            cssClass: "@?"
+            cssClass: "@?",
+            iconClass: "@?"
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -6,7 +6,7 @@
     flex-wrap: wrap;
     align-items: center;
     position: relative;
-    padding: 0 !important;
+    padding: 0 0 0 26px !important;
     margin: 0;
     min-height: 22px;
     line-height: 22px;
@@ -21,7 +21,6 @@
     }
 
     &__text {
-        margin: 0 0 0 26px;
         position: relative;
         top: 1px;
         user-select: none;

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -16,5 +16,12 @@
         </span>
     </span>
 
+    <i class="{{vm.iconClass}}" style="margin-left: 26px;" aria-hidden="true"></i>
+
     <span class="umb-form-check__text">{{vm.text}}</span>
 </label>
+
+
+<!-- TODO
+    1: Make sure to add the margin-left class on <i> if it should be displayed otherwise add it to the text element :thumbs
+-->

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -16,9 +16,9 @@
         </span>
     </span>
 
-    <i class="{{vm.iconClass}}" style="margin-left: 26px;" aria-hidden="true"></i>
+    <i ng-if="vm.iconClass.length" class="{{vm.iconClass}}" aria-hidden="true"></i>
 
-    <span class="umb-form-check__text">{{vm.text}}</span>
+    <span ng-if="vm.text.length" class="umb-form-check__text">{{vm.text}}</span>
 </label>
 
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -20,8 +20,3 @@
 
     <span ng-if="vm.text.length" class="umb-form-check__text">{{vm.text}}</span>
 </label>
-
-
-<!-- TODO
-    1: Make sure to add the margin-left class on <i> if it should be displayed otherwise add it to the text element :thumbs
--->

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -2,13 +2,12 @@
 
     <umb-control-group label="Toolbar" description="Pick the toolbar options that should be available when editing">
         <div ng-repeat="cmd in tinyMceConfig.commands">
-            <label>
-                <umb-checkbox model="cmd.selected"
-                              on-change="selectCommand(cmd)"
-                              icon-class="mce-ico {{(cmd.isCustom ? ' mce-i-custom ' : ' mce-i-') + cmd.fontIcon}}"
-                              text="{{cmd.name}}"
-                              class="mce-cmd" />
-            </label>
+                <umb-checkbox
+                    model="cmd.selected"
+                    on-change="selectCommand(cmd)"
+                    icon-class="mce-ico {{(cmd.isCustom ? ' mce-i-custom ' : ' mce-i-') + cmd.fontIcon}}"
+                    text="{{cmd.name}}"
+                    class="mce-cmd" />
         </div>
     </umb-control-group>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -5,12 +5,9 @@
             <label>
                 <umb-checkbox model="cmd.selected"
                               on-change="selectCommand(cmd)"
+                              icon-class="mce-ico {{(cmd.isCustom ? ' mce-i-custom ' : ' mce-i-') + cmd.fontIcon}}"
+                              text="{{cmd.name}}"
                               class="mce-cmd" />
-
-                <!--<img ng-src="{{cmd.icon}}" />-->
-                <i class="mce-ico" ng-class="(cmd.isCustom ? ' mce-i-custom ' : ' mce-i-') + cmd.fontIcon"></i>
-
-                {{cmd.name}}
             </label>
         </div>
     </umb-control-group>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed that the rich text editor datatype was using the umb-checkbox directive but that there was a `<label>` wrapped around it, which should not be neccessary. But it was in order to ensure that clicking the associated config icon and text would tick the box.

Now that's not needed anymore since I have enabled the directive to accept an `iconClass` parameter, and when it's passed a value it will be rendered. if it's left empty it will not. Then things will look and act like we're used to.

Doing this fixes the markup pattern so we don't have `<label>` nested inside a `<label>` - Visually things look the same as before.

This can be tested in the "rich text editor" datatype 👍 