### PR TITLE
V8: Do not allow rollback of deleted content

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -3083,7 +3083,7 @@ namespace Umbraco.Core.Services.Implement
             var version = GetVersion(versionId);
 
             //Good ole null checks
-            if (content == null || version == null)
+            if (content == null || version == null || content.Trashed)
             {
                 return new OperationResult(OperationResultType.FailedCannot, evtMsgs);
             }

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -46,6 +46,7 @@
                 title="{{historyLabel}}">
                 
                 <umb-button
+                    ng-hide="node.trashed"
                     type="button"
                     button-style="outline"
                     action="openRollback()"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

At the moment we allow rollback of content in the recycle bin. While it sort of works, it makes very little sense. And you also really quickly end up with something like this:

![image](https://user-images.githubusercontent.com/7405322/67881366-acf92a80-fb40-11e9-9638-66731e7477ca.png)

So... This PR removes the rollback button from elements in the recycle bin, and also (as a precaution) denies rollback of trashed items serverside.