### PR TITLE
V8/invite user curosr ui fix

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcheckmark.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcheckmark.directive.js
@@ -10,7 +10,8 @@
             templateUrl: 'views/components/umb-checkmark.html',
             scope: {
                 size: "@?",
-                checked: "="
+                checked: "=",
+                readonly: "@?"
             }
         };
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-checkmark.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-checkmark.html
@@ -1,1 +1,1 @@
-<i class="icon-check umb-checkmark umb-checkmark--{{size}}" ng-class="{'umb-checkmark--checked': checked}"></i>
+<i class="icon-check umb-checkmark umb-checkmark--{{size}}" ng-class="{'umb-checkmark--checked': checked, 'cursor-auto': readonly}"></i>

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -505,6 +505,7 @@
                 <div class="flex items-center" style="margin-bottom: 15px;">
                     <umb-checkmark
                         checked="vm.usersViewState === 'inviteUserSuccess'"
+                        readonly="true"
                         size="m">
                     </umb-checkmark>
                     <h3 class="bold" style="margin: 0 0 0 10px;">


### PR DESCRIPTION
### Prerequisites

- [x ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6703 

### Description
When inviting a new user (when inside the users section), the checkmark icon that is shown beside the name of the user invited, has "cursor: pointer", which it inherits from the "umb-checkmark" css class. I extended the "umbcheckmark" directive with a "readonly" prop. When that is defined the icon class will also get to "cursor-auto" class, which fixes the issue. The gif below shows that the behavior is now fixed :) 

![invite-user-no-cursor](https://user-images.githubusercontent.com/693269/67883239-06af2400-fb44-11e9-9440-3ca421933cc5.gif)


