### PR TITLE
Removes continually loading banner if there is no current editor state

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -239,12 +239,13 @@ Use this directive to construct a header inside the main editor window.
                 if (scope.editorfor) {
                     localizeVars.push(scope.editorfor);
                 }
-                localizationService.localizeMany(localizeVars).then(function (data) {
+                localizationService.localizeMany(localizeVars).then(function(data) {
                     setAccessibilityForEditor(data);
                     scope.loading = false;
                 });
+            } else {
+                scope.loading = false;
             }
-
             scope.goBack = function () {
                 if (scope.onBack) {
                     scope.onBack();


### PR DESCRIPTION
The loading banner continues to display when in the following sections:
- When the creating/editing users
- When the creating/editing user groups
- When the creating/editing languages
- When in the log viewer

The continually loading banner introduced in  #6315 and this PR removes it