### PR TITLE
V8: Do not show the breadcrumb for immediate children in the recycle bin

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -42,7 +42,7 @@
                 $scope.page.isNew = Object.toBoolean(newVal);
 
                 //We fetch all ancestors of the node to generate the footer breadcrumb navigation
-                if (content.parentId && content.parentId !== -1) {
+                if (content.parentId && content.parentId !== -1 && content.parentId !== -20) {
                     loadBreadcrumb();
                     if (!watchingCulture) {
                         $scope.$watch('culture',

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -245,7 +245,7 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
                     syncTreeNode($scope.content, data.path, true); 
                 }
                
-                if ($scope.content.parentId && $scope.content.parentId != -1) {
+                if ($scope.content.parentId && $scope.content.parentId !== -1 && $scope.content.parentId !== -21) {
                     //We fetch all ancestors of the node to generate the footer breadcrump navigation
                     entityResource.getAncestors(nodeId, "media")
                         .then(function (anc) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The editor breadcrumb isn't shown for 1st level items under the content and media roots:

![image](https://user-images.githubusercontent.com/7405322/67885512-07e25000-fb48-11e9-893c-6d56fc122cee.png)
 
For 1st level items under the recycle bin the breadcrumb _is_ shown, but it's pretty useless as it can't be interacted with:

![image](https://user-images.githubusercontent.com/7405322/67885573-20526a80-fb48-11e9-8530-995b7187a01b.png)

This PR removes the breadcrumb for 1st level items under the recycle bin in both the content and media trees. When applied it works like this:

![recye](https://user-images.githubusercontent.com/7405322/67885657-4415b080-fb48-11e9-9900-aa79b1136040.gif)
