### PR TITLE
V8/feature/5914 broken backoffice validation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.controller.js
@@ -15,7 +15,22 @@ function textAreaController($scope) {
     if ($scope.model.config && $scope.model.config.maxChars) {
         $scope.model.maxlength = true;
     }
-    
+
+    $scope.$on("formSubmitting", function() {
+        if ($scope.isLengthValid()) {
+            $scope.textareaFieldForm.textarea.$setValidity("maxChars", true);
+        } else {
+            $scope.textareaFieldForm.textarea.$setValidity("maxChars", false);
+        }
+    });
+
+    $scope.isLengthValid = function() {
+        if (!$scope.model.maxlength) {
+            return true;
+        } 
+        return $scope.model.config.maxChars >= $scope.model.count;
+    }
+
     $scope.model.change = function () {
         if ($scope.model.value) {
             $scope.model.count = $scope.model.value.length;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
@@ -10,7 +10,7 @@
         <div class="help" ng-if="model.maxlength === true && model.count >= (model.config.maxChars*.8) && model.count <= model.config.maxChars">
             <localize key="textbox_characters_left" tokens="[model.config.maxChars - model.count]" watch-tokens="true">%0% characters left.</localize>
         </div>
-        <div class="help text-error" ng-if="model.maxlength === true && model.count > model.config.maxChars">
+        <div class="help text-error" ng-if="!isLengthValid()">
             <localize key="textbox_characters_exceed" tokens="[model.config.maxChars, model.count - model.config.maxChars]" watch-tokens="true">Maximum %0% characters, <strong>%1%</strong> too many.</localize>
         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.controller.js
@@ -11,7 +11,19 @@ function textboxController($scope) {
         // if no max is specified in the config
         $scope.model.config.maxChars = 500;
     }
-    
+
+    $scope.$on("formSubmitting", function() {
+        if ($scope.isLengthValid()) {
+            $scope.textboxFieldForm.textbox.$setValidity("maxChars", true);
+        } else {
+            $scope.textboxFieldForm.textbox.$setValidity("maxChars", false);
+        }
+    });
+
+    $scope.isLengthValid = function() {
+        return $scope.model.config.maxChars >= $scope.model.count;
+    }
+
     $scope.model.change = function () {
         if ($scope.model.value) {
             $scope.model.count = $scope.model.value.length;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
@@ -19,7 +19,7 @@
             <p class="sr-only" tabindex="0">{{model.label}} <localize key="textbox_characters_left" tokens="[model.config.maxChars - model.count]" watch-tokens="true">%0% characters left.</localize></p>
             <p aria-hidden="True"><localize key="textbox_characters_left" tokens="[model.config.maxChars - model.count]" watch-tokens="true">%0% characters left.</localize></p>
         </div>
-        <div class="help text-error" ng-if="model.count > model.config.maxChars">
+        <div class="help text-error" ng-if="!isLengthValid()">
             <p class="sr-only" tabindex="0">{{model.label}} <localize key="textbox_characters_exceed" tokens="[model.config.maxChars, model.count - model.config.maxChars]" watch-tokens="true">Maximum %0% characters, <strong>%1%</strong> too many.</localize></p>
             <p aria-hidden="true"><localize key="textbox_characters_exceed" tokens="[model.config.maxChars, model.count - model.config.maxChars]" watch-tokens="true">Maximum %0% characters, <strong>%1%</strong> too many.</localize></p>
         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/5914

### Description

The maxlength property defined on the datatype is now enforced on Save.
User can still add too much text, but is not allowed to save the invalid amount of data

This is implemented for both textarea and textfield
See GIF for new behavior 

![text-length-validation](https://user-images.githubusercontent.com/1798386/67887719-19c5f200-fb4c-11e9-9a74-5d7f193b9da0.gif)

