### PR TITLE
Icon picker button: Fix accessibility

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -341,6 +341,7 @@
 .umb-panel-header-icon {
   cursor: pointer;
   margin-right: 5px;
+  margin-top: -6px;
   height: 50px;
   display: flex;
   justify-content: center;

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -12,13 +12,17 @@
         <div class="flex items-center" style="flex: 1;">
 
             <ng-form data-element="editor-icon" name="iconForm">
-                <div class="umb-panel-header-icon" ng-if="!hideIcon" ng-click="openIconPicker()" ng-class="{'-placeholder': $parent.icon==='' || $parent.icon===null}"
-                     title="{{$parent.icon}}">
-                    <i class="icon {{$parent.icon}}" ng-if="$parent.icon!=='' && $parent.icon!==null"></i>
-                    <div class="umb-panel-header-icon-text" ng-if="$parent.icon==='' || $parent.icon===null">
-                        <localize key="settings_addIcon"></localize>
-                    </div>
-                </div>
+                <button 
+                    type="button" class="umb-panel-header-icon" 
+                    ng-if="!hideIcon" 
+                    ng-click="openIconPicker()" 
+                    ng-class="{'-placeholder': $parent.icon==='' || $parent.icon===null}"
+                    title="{{$parent.icon}}">
+                        <i class="icon {{$parent.icon}}" ng-if="$parent.icon!=='' && $parent.icon!==null" aria-hidden="true"></i>
+                        <div class="umb-panel-header-icon-text" ng-if="$parent.icon==='' || $parent.icon===null">
+                            <localize key="settings_addIcon">Add icon</localize>
+                        </div>
+                </button>
             </ng-form>
 
             <div id="nameField" class="umb-editor-header__name-and-description" style="flex: 1 1 auto;">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The button one clicks on a document type has been changed from `<div>` to `<button>` and the icon has been hidden from screen readers.

Looks the same as before the PR 😃 