### PR TITLE
V8/consistent selectable img and macro styling in rte

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/rte-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte-content.less
@@ -27,6 +27,10 @@
     outline: 2px solid @pinkLight;
 }
 
+.umb-rte .umb-macro-holder {
+    border: 2px solid @pinkLight;
+}
+
 .umb-rte .embeditem::before {
     z-index:1000;
     width:100%;

--- a/src/Umbraco.Web.UI.Client/src/less/rte-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte-content.less
@@ -22,6 +22,7 @@
     }
 }
 
+.umb-rte img[data-mce-selected],
 .umb-rte .embeditem[data-mce-selected] {
     outline: 2px solid @pinkLight;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/rte-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte-content.less
@@ -22,7 +22,7 @@
     }
 }
 
-.umb-rte img[data-mce-selected],
+.umb-rte img,
 .umb-rte .embeditem[data-mce-selected] {
     outline: 2px solid @pinkLight;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6427 

### Description
Some of the issues in the issue seemed to have already been fixed (links and OEmbed), however for images and macro's the pink border was not present, so I added styles for those aswell. The gif below shows how they look now

![ui-fix-image-macro-in-rte](https://user-images.githubusercontent.com/693269/67891891-cd7eb000-fb53-11e9-8221-65676005c833.gif)
