### PR TITLE
Editor service shouldn't overwrite the size if already set in the options

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -366,7 +366,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function contentPicker(editor) {
             editor.view = "views/common/infiniteeditors/treepicker/treepicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             editor.section = "content";
             editor.treeAlias = "content";
             open(editor);
@@ -389,7 +389,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function contentTypePicker(editor) {
             editor.view = "views/common/infiniteeditors/treepicker/treepicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             editor.section = "settings";
             editor.treeAlias = "documentTypes";
             open(editor);
@@ -412,7 +412,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function mediaTypePicker(editor) {
             editor.view = "views/common/infiniteeditors/treepicker/treepicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             editor.section = "settings";
             editor.treeAlias = "mediaTypes";
             open(editor);
@@ -435,7 +435,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function memberTypePicker(editor) {
             editor.view = "views/common/infiniteeditors/treepicker/treepicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             editor.section = "settings";
             editor.treeAlias = "memberTypes";
             open(editor);
@@ -456,7 +456,7 @@ When building a custom infinite editor view you can use the same components as a
 
         function copy(editor) {
             editor.view = "views/common/infiniteeditors/copy/copy.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -476,7 +476,7 @@ When building a custom infinite editor view you can use the same components as a
 
         function move(editor) {
             editor.view = "views/common/infiniteeditors/move/move.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -494,7 +494,7 @@ When building a custom infinite editor view you can use the same components as a
 
         function embed(editor) {
             editor.view = "views/common/infiniteeditors/embed/embed.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -513,7 +513,7 @@ When building a custom infinite editor view you can use the same components as a
 
         function rollback(editor) {
             editor.view = "views/common/infiniteeditors/rollback/rollback.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -533,7 +533,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function linkPicker(editor) {
             editor.view = "views/common/infiniteeditors/linkpicker/linkpicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -575,7 +575,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function mediaPicker(editor) {
             editor.view = "views/common/infiniteeditors/mediapicker/mediapicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             editor.updatedMediaNodes = [];
             open(editor);
         }
@@ -596,7 +596,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function iconPicker(editor) {
             editor.view = "views/common/infiniteeditors/iconpicker/iconpicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -670,7 +670,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function treePicker(editor) {
             editor.view = "views/common/infiniteeditors/treepicker/treepicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -688,7 +688,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function nodePermissions(editor) {
             editor.view = "views/common/infiniteeditors/nodepermissions/nodepermissions.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -706,7 +706,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function insertCodeSnippet(editor) {
             editor.view = "views/common/infiniteeditors/insertcodesnippet/insertcodesnippet.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -724,7 +724,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function userGroupPicker(editor) {
             editor.view = "views/common/infiniteeditors/usergrouppicker/usergrouppicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -760,7 +760,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function sectionPicker(editor) {
             editor.view = "views/common/infiniteeditors/sectionpicker/sectionpicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -778,7 +778,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function insertField(editor) {
             editor.view = "views/common/infiniteeditors/insertfield/insertfield.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -796,7 +796,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function templateSections(editor) {
             editor.view = "views/common/infiniteeditors/templatesections/templatesections.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -814,7 +814,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function userPicker(editor) {
             editor.view = "views/common/infiniteeditors/userpicker/userpicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -836,7 +836,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function itemPicker(editor) {
             editor.view = "views/common/infiniteeditors/itempicker/itempicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -854,7 +854,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function macroPicker(editor) {
             editor.view = "views/common/infiniteeditors/macropicker/macropicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -874,7 +874,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function memberGroupPicker(editor) {
             editor.view = "views/common/infiniteeditors/membergrouppicker/membergrouppicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             open(editor);
         }
 
@@ -895,7 +895,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function memberPicker(editor) {
             editor.view = "views/common/infiniteeditors/treepicker/treepicker.html";
-            editor.size = "small";
+            if (!editor.size) editor.size = "small";
             editor.section = "member";
             editor.treeAlias = "member";
             open(editor);


### PR DESCRIPTION
For most of the functions in the editor service, the `size` option is hardcoded, making it impossible to set another size.

Especially with the introduction of a `medium` size, it may be favorable to only set a size if one hasn't already been specified in the editor options.