### PR TITLE
V8: Automatically select uploaded media in media pickers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -1,7 +1,7 @@
 //used for the media picker dialog
 angular.module("umbraco")
     .controller("Umbraco.Editors.MediaPickerController",
-        function ($scope, mediaResource, entityResource, userService, mediaHelper, mediaTypeHelper, eventsService, treeService, localStorageService, localizationService, editorService) {
+        function ($scope, $timeout, mediaResource, entityResource, userService, mediaHelper, mediaTypeHelper, eventsService, treeService, localStorageService, localizationService, editorService) {
 
             var vm = this;
             
@@ -292,13 +292,20 @@ angular.module("umbraco")
 
             function onUploadComplete(files) {
                 gotoFolder($scope.currentFolder).then(function () {
-                    if (files.length === 1 && $scope.model.selection.length === 0) {
-                        var image = $scope.images[$scope.images.length - 1];
-                        $scope.target = image;
-                        $scope.target.url = mediaHelper.resolveFile(image);
-                        selectMedia(image);
-                    }
-                })
+                    $timeout(function () {
+                        if ($scope.multiPicker) {
+                            var images = _.rest($scope.images, $scope.images.length - files.length);
+                            _.each(images, function(image) {
+                                selectMedia(image);
+                            });
+                        } else {
+                            var image = $scope.images[$scope.images.length - 1];
+                            $scope.target = image;
+                            $scope.target.url = mediaHelper.resolveFile(image);
+                            selectMedia(image);
+                        }
+                    });
+                });
             }
 
             function onFilesQueue() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes (part of) https://github.com/umbraco/Umbraco-CMS/issues/6844

### Description

The media picker used to select media automatically when they were uploaded within the picker. Somewhere along the line this got broken.

This PR fixes it - and thus in part also fixes #6844.

With this PR applied, here's how the media picker works:

![select-uploaded-media](https://user-images.githubusercontent.com/7405322/67894669-4cc2b280-fb59-11e9-8c9a-68488be35c3c.gif)

This works both for media pickers in "multiple images" and in "single image" mode; for "single image" mode the last uploaded media is automatically selected.
