### PR TITLE
Avoid breadcrumbs in mini list are misaligned

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-breadcrumbs.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-breadcrumbs.less
@@ -8,7 +8,7 @@
 
 .umb-breadcrumbs__ancestor {
    display: flex;
-   min-height: 25px;
+   align-items: center;
 }
 
 .umb-breadcrumbs__action {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-mini-list-view.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-mini-list-view.less
@@ -13,9 +13,15 @@
     margin-right: 5px;
 }
 
+.umb-mini-list-view__breadcrumb {
+    .flex;
+    margin-bottom: 10px;
+    min-height: 25px;
+}
+
 .umb-mini-list-view__back {
-    font-size: 12px;
-    margin-right: 5px; 
+    font-size: 13px;
+    margin-right: 5px;
     color: @gray-4;
     display: flex;
     align-items: center;

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
@@ -9,7 +9,7 @@
             <h4 class="umb-mini-list-view__title-text">{{ miniListView.node.name }}</h4>
         </div>
 
-        <div class="flex" style="margin-bottom: 10px;">
+        <div class="umb-mini-list-view__breadcrumb">
 
             <a ng-if="showBackButton()" href="" class="umb-mini-list-view__back" ng-click="exitMiniListView()">
                 <i class="icon-arrow-left umb-mini-list-view__back-icon"></i>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Breadcrumb links were vertically misaligned from the second item. 

Breadcrumb items were already flex but needed to be vertically centered.
Match font-size for  "Back" link, to the other breadcrumb items.
No real impact, but moved height (25px) to a parent container - it should not be a child who sets this. Also moved some inline styles to less.

Test by creating a document type and turn on "Enable list view". 
Allow children for it.
Create a page and add some children.
Add a "Content Picker" property to a document. Try to pick the deepest child.
Watch the breadcrumb-path is fully aligned.

![picker_before](https://user-images.githubusercontent.com/507992/67895165-47199c80-fb5a-11e9-97ba-ef8d830807d2.png)
![picker_after](https://user-images.githubusercontent.com/507992/67895173-48e36000-fb5a-11e9-9517-93582c921268.png)

Also test "Copy" and "Move" for an existing page with children as it also uses this breadcrumb
Also footer uses the breadcrumb 
