### PR TITLE
Adds ability to customize text on "Add content" button in Nested Content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/dictionary.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/dictionary.resource.js
@@ -97,6 +97,36 @@ function dictionaryResource($q, $http, $location, umbRequestHelper, umbDataForma
     }
 
     /**
+     * @ngdoc method
+     * @name umbraco.resources.dictionaryResource#getByKey
+     * @methodOf umbraco.resources.dictionaryResource
+     *
+     * @description
+     * Gets a dictionary item with a given key
+     *
+     * ##usage
+     * <pre>
+     * dictionaryResource.getByKey('general_add')
+     *    .then(function() {
+     *        alert('Found it!');
+     *    });
+     * </pre>
+     *
+     * @param {String} key key of dictionary item to get
+     * @returns {Promise} resourcePromise object.
+     *
+     */
+    function getByKey(key) {
+        return umbRequestHelper.resourcePromise(
+            $http.get(
+                umbRequestHelper.getApiUrl(
+                    "dictionaryApiBaseUrl",
+                    "GetByKey",
+                    [{ key: key }])),
+            "Failed to get item " + key);
+    }
+
+    /**
         * @ngdoc method
         * @name umbraco.resources.dictionaryResource#save
         * @methodOf umbraco.resources.dictionaryResource
@@ -150,6 +180,7 @@ function dictionaryResource($q, $http, $location, umbRequestHelper, umbDataForma
     deleteById: deleteById,
     create: create,
     getById: getById,
+    getByKey: getByKey,
     save: save,
     getList : getList
   };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -168,10 +168,14 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
     "localizationService",
     "iconHelper",
     "clipboardService",
+    "dictionaryResource",
     "eventsService",
     "overlayService",
+    "$routeParams",
+    "editorState",
+    "userService",
     
-    function ($scope, $interpolate, $filter, $timeout, contentResource, localizationService, iconHelper, clipboardService, eventsService, overlayService, $routeParams, editorState) {
+    function ($scope, $interpolate, $filter, $timeout, contentResource, localizationService, iconHelper, clipboardService, dictionaryResource, eventsService, overlayService, $routeParams, editorState, userService) {
         
         var contentTypeAliases = [];
         _.each($scope.model.config.contentTypes, function (contentType) {
@@ -207,6 +211,24 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.Prop
             $scope.labels.grid_addElement = data[0];
             $scope.labels.content_createEmpty = data[1];
         });
+
+        var helpText = $scope.model.config.helpText;
+
+        if (helpText) {
+            $scope.labels.helpText = helpText;
+            if (helpText.startsWith("#")) {
+                dictionaryResource.getByKey(helpText.substring(1)).then(function (value) {
+                    userService.getCurrentUser().then(function (user) {
+                        if (value && value.translations && user.locale) {
+                            var translation = value.translations.filter(function (t) { return t.isoCode == user.locale });
+                            if (translation.length > 0) {
+                                $scope.labels.helpText = translation[0].translation;
+                            }
+                        }
+                    });
+                });
+            }
+        }
 
         // helper to force the current form into the dirty state
         $scope.setDirty = function () {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.html
@@ -40,7 +40,7 @@
 
         <div class="umb-nested-content__footer-bar" ng-hide="hasContentTypes === false || nodes.length >= maxItems">
             <a href class="umb-nested-content__add-content" ng-class="{ '--disabled': !scaffolds.length }" ng-click="openNodeTypePicker($event)" prevent-default>
-                <localize key="grid_addElement"></localize>
+                {{ labels.helpText || labels.grid_addElement }}
             </a>
         </div>
 

--- a/src/Umbraco.Web/Editors/DictionaryController.cs
+++ b/src/Umbraco.Web/Editors/DictionaryController.cs
@@ -137,6 +137,28 @@ namespace Umbraco.Web.Editors
         }
 
         /// <summary>
+        /// Gets a dictionary item by key
+        /// </summary>
+        /// <param name="key">
+        /// The key.
+        /// </param>
+        /// <returns>
+        /// The <see cref="DictionaryDisplay"/>.
+        /// </returns>
+        /// <exception cref="HttpResponseException">
+        ///  Returrns a not found response when dictionary item does not exist
+        /// </exception>
+        public DictionaryDisplay GetByKey(string key)
+        {
+            var dictionary = Services.LocalizationService.GetDictionaryItemByKey(key);
+
+            if (dictionary == null)
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+
+            return Mapper.Map<IDictionaryItem, DictionaryDisplay>(dictionary);
+        }
+
+        /// <summary>
         /// Saves a dictionary item
         /// </summary>
         /// <param name="dictionary">

--- a/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
@@ -37,5 +37,8 @@ namespace Umbraco.Web.PropertyEditors
             [JsonProperty("nameTemplate")]
             public string Template { get; set; }
         }
+
+        [ConfigurationField("helpText", "Help Text", "textstring", Description = "Set the help text visible while adding new element.")]
+        public string HelpText { get; set; }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
This one adds the ability to customize the text on the "Add content" button in Nested Content as originally added in #3702.

It adds a new setting on Nested Content data types, where you can add your text. You can have the text localized using the dictionary by setting the help text in the format #DictionaryKey. 

If no help text is set, it will fall back to the default Add Content label.

See screenshots as example:

![firefox_2019-10-30_21-45-32](https://user-images.githubusercontent.com/3726467/67901200-81893680-fb66-11e9-889c-1e7ebea3296b.png)
![firefox_2019-10-30_21-45-50](https://user-images.githubusercontent.com/3726467/67901201-8221cd00-fb66-11e9-811e-81a0eead7893.png)
![firefox_2019-10-30_21-46-18](https://user-images.githubusercontent.com/3726467/67901202-8221cd00-fb66-11e9-9cf0-cbe9c58de9e6.png)
![firefox_2019-10-30_22-37-32](https://user-images.githubusercontent.com/3726467/67901205-8221cd00-fb66-11e9-8b8a-3b8151394b09.png)
![firefox_2019-10-30_22-37-21](https://user-images.githubusercontent.com/3726467/67901204-8221cd00-fb66-11e9-847b-cedd3a5bf874.png)


###To test
Open an existing (or create a new) Nested Content data type. Set the value of help text. Verify that the value is used for the add-button.

Try setting a dictionary value (starts with # then the key of the item). Verify that the dictionary is used to translate the value.