### PR TITLE
Fixes a race condition with nucache

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
@@ -601,13 +601,14 @@ namespace Umbraco.Web.PublishedCache.NuCache
         /// <param name="kits">
         /// All kits sorted by Level + Parent Id + Sort order
         /// </param>
+        /// <param name="fromDb">True if the data is coming from the database (not the local cache db)</param>
         /// <returns></returns>
         /// <remarks>
         /// This requires that the collection is sorted by Level + ParentId + Sort Order. 
         /// This should be used only on a site startup as the first generations.
         /// This CANNOT be used after startup since it bypasses all checks for Generations.
         /// </remarks>
-        internal bool SetAllFastSorted(IEnumerable<ContentNodeKit> kits)
+        internal bool SetAllFastSorted(IEnumerable<ContentNodeKit> kits, bool fromDb)
         {
             var lockInfo = new WriteLockInfo();
             var ok = true;
@@ -653,6 +654,9 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
                     _logger.Debug<ContentStore>($"Set {thisNode.Id} with parent {thisNode.ParentContentId}");
                     SetValueLocked(_contentNodes, thisNode.Id, thisNode);
+
+                    // if we are initializing from the database source ensure the local db is updated
+                    if (fromDb && _localDb != null) RegisterChange(thisNode.Id, kit);
 
                     // this node is always the last child
                     parent.LastChildContentId = thisNode.Id;

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -127,9 +127,9 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     // stores need to be populated, happens in OnResolutionFrozen which uses _localDbExists to
                     // figure out whether it can read the databases or it should populate them from sql
 
-                    _logger.Info<PublishedSnapshotService>("Creating the content store, localContentDbExists? {LocalContentDbExists}", _localContentDb != null);
+                    _logger.Info<PublishedSnapshotService>("Creating the content store, localContentDbExists? {LocalContentDbExists}", _localDbExists);
                     _contentStore = new ContentStore(publishedSnapshotAccessor, variationContextAccessor, logger, _localContentDb);
-                    _logger.Info<PublishedSnapshotService>("Creating the media store, localMediaDbExists? {LocalMediaDbExists}", _localMediaDb != null);
+                    _logger.Info<PublishedSnapshotService>("Creating the media store, localMediaDbExists? {LocalMediaDbExists}", _localDbExists);
                     _mediaStore = new ContentStore(publishedSnapshotAccessor, variationContextAccessor, logger, _localMediaDb);
                 }
                 else

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -402,7 +402,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 if (kits.Count == 0)
                 {
                     // If there's nothing in the local cache file, we should return false? YES even though the site legitately might be empty.
-                    // Is it possible that the cache file is empty but the database is not? YES...
+                    // Is it possible that the cache file is empty but the database is not? YES... (well, it used to be possible)
                     // * A new file is created when one doesn't exist, this will only be done when MainDom is acquired
                     // * The new file will be populated as soon as LoadCachesOnStartup is called
                     // * If the appdomain is going down the moment after MainDom was acquired and we've created an empty cache file,
@@ -412,6 +412,9 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     //      in the in-mem cache via DB calls, BUT this now means that there is an empty cache file which will be
                     //      loaded by the next appdomain and it won't check if it's empty, it just assumes that since the cache
                     //      file is there, that is correct.
+
+                    // Update: We will still return false here even though the above mentioned race condition has been fixed since we now
+                    // lock the entire operation of creating/populating the cache file with the same lock as releasing/closing the cache file
 
                     _logger.Info<PublishedSnapshotService>("Tried to load content from the local cache file but it was empty.");
                     return false;

--- a/src/Umbraco.Web/Scheduling/HealthCheckNotifier.cs
+++ b/src/Umbraco.Web/Scheduling/HealthCheckNotifier.cs
@@ -51,7 +51,7 @@ namespace Umbraco.Web.Scheduling
                 return false; // do NOT repeat, going down
             }
 
-            using (_logger.DebugDuration<KeepAlive>("Health checks executing", "Health checks complete"))
+            using (_logger.DebugDuration<HealthCheckNotifier>("Health checks executing", "Health checks complete"))
             {
                 var healthCheckConfig = Current.Configs.HealthChecks();
 

--- a/src/Umbraco.Web/Scheduling/SchedulerComponent.cs
+++ b/src/Umbraco.Web/Scheduling/SchedulerComponent.cs
@@ -18,6 +18,11 @@ namespace Umbraco.Web.Scheduling
 {
     internal sealed class SchedulerComponent : IComponent
     {
+        private const int DefaultDelayMilliseconds = 180000; // 3 mins
+        private const int OneMinuteMilliseconds = 60000;
+        private const int FiveMinuteMilliseconds = 300000;
+        private const int OneHourMilliseconds = 3600000;
+
         private readonly IRuntimeState _runtime;
         private readonly IContentService _contentService;
         private readonly IAuditService _auditService;
@@ -111,7 +116,7 @@ namespace Umbraco.Web.Scheduling
         {
             // ping/keepalive
             // on all servers
-            var task = new KeepAlive(_keepAliveRunner, 60000, 300000, _runtime, _logger);
+            var task = new KeepAlive(_keepAliveRunner, DefaultDelayMilliseconds, FiveMinuteMilliseconds, _runtime, _logger);
             _keepAliveRunner.TryAdd(task);
             return task;
         }
@@ -120,7 +125,7 @@ namespace Umbraco.Web.Scheduling
         {
             // scheduled publishing/unpublishing
             // install on all, will only run on non-replica servers
-            var task = new ScheduledPublishing(_publishingRunner, 60000, 60000, _runtime, _contentService, _umbracoContextFactory, _logger);
+            var task = new ScheduledPublishing(_publishingRunner, DefaultDelayMilliseconds, OneMinuteMilliseconds, _runtime, _contentService, _umbracoContextFactory, _logger);
             _publishingRunner.TryAdd(task);
             return task;
         }
@@ -133,15 +138,15 @@ namespace Umbraco.Web.Scheduling
             int delayInMilliseconds;
             if (string.IsNullOrEmpty(healthCheckConfig.NotificationSettings.FirstRunTime))
             {
-                delayInMilliseconds = 60000;
+                delayInMilliseconds = DefaultDelayMilliseconds;
             }
             else
             {
                 // Otherwise start at scheduled time
                 delayInMilliseconds = DateTime.Now.PeriodicMinutesFrom(healthCheckConfig.NotificationSettings.FirstRunTime) * 60 * 1000;
-                if (delayInMilliseconds < 60000)
+                if (delayInMilliseconds < DefaultDelayMilliseconds)
                 {
-                    delayInMilliseconds = 60000;
+                    delayInMilliseconds = DefaultDelayMilliseconds;
                 }
             }
 
@@ -155,7 +160,7 @@ namespace Umbraco.Web.Scheduling
         {
             // log scrubbing
             // install on all, will only run on non-replica servers
-            var task = new LogScrubber(_scrubberRunner, 60000, LogScrubber.GetLogScrubbingInterval(settings, _logger), _runtime, _auditService, settings, _scopeProvider, _logger);
+            var task = new LogScrubber(_scrubberRunner, DefaultDelayMilliseconds, LogScrubber.GetLogScrubbingInterval(settings, _logger), _runtime, _auditService, settings, _scopeProvider, _logger);
             _scrubberRunner.TryAdd(task);
             return task;
         }
@@ -164,7 +169,7 @@ namespace Umbraco.Web.Scheduling
         {
             // temp file cleanup, will run on all servers - even though file upload should only be handled on the master, this will
             // ensure that in the case it happes on replicas that they are cleaned up.
-            var task = new TempFileCleanup(_fileCleanupRunner, 60000, 3600000 /* 1 hr */,
+            var task = new TempFileCleanup(_fileCleanupRunner, DefaultDelayMilliseconds, OneHourMilliseconds,
                 new[] { new DirectoryInfo(IOHelper.MapPath(SystemDirectories.TempFileUploads)) },
                 TimeSpan.FromDays(1), //files that are over a day old
                 _runtime, _logger);


### PR DESCRIPTION
There is 2x issues fixed here:

## Race Condition

Is it possible that the cache file is empty but the database is not? YES... (well, it used to be possible until this fix)
* A new file is created when one doesn't exist, this will only be done when `MainDom` is acquired
* The new file will be populated as soon as `LoadCachesOnStartup` is called
* If the appdomain is going down the moment after `MainDom` was acquired and we've created an empty cache file, then the MainDom release callback is triggered and executes on a different thread, which will close the file and set the cache file reference to `null`. At this moment, it is possible that the file is closed and the reference to the file set to `null` **before** `LoadCachesOnStartup` which would mean that the current appdomain would load in the in-mem cache via DB calls and would not attempt to write back to the cache file during site operation, **but** this now means that there is an empty cache file which will be loaded by the next appdomain and it won't check if it's empty, it just assumes that since the cache file is there, that is correct.

This fixes this by:

* We'll return `false` from `LoadContentFromLocalDbLocked` if there are no items in the local cache file. This is a safety check. The site could very well have zero content items, but that's ok. This check will at least force the content to be loaded in from the database instead of the cache file. 
* Fixed the locking of the PublishedSnapshotService initialization to avoid the race condition mentioned above. This also means that the safety check above shouldn't be needed but we'll leave it there anyways. The lock fix is: 
  * We were locking on `_storesLock` to populate the cache, but not when we were creating the cache files. We were also locking on the same `_storesLock` when releasing from MainDom. The problem was we were not using the same lock to lock the whole sequence from creating a new cache file to populating the cache. This PR fixes that, this lock will be used when creating or opening a cache file and then populating the cache which will prevent the releasing/closing of the cache file before the cache is populated

## SetAllFastSorted 

`SetAllFastSorted` was also used when loading nucache from the database, it was intended originally to only be used when loading nucache from the cache files, therefore it would never also update the nucache file. This was an oversight when using SetAllFastSorted when loading from the database since when doing that we weren't writing back to the cache file ... fixed in this PR
