### PR TITLE
V8: Fix Nested Content configuration overflow on smaller screens

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -235,7 +235,6 @@
 }
 
 .umb-nested-content__placeholder {
-    height: 22px;
     padding: 4px 6px;    
     border: 1px dashed #d8d7d9;
     background: 0 0;
@@ -246,13 +245,10 @@
     text-align: center;
 
     &--selected {
-        border: 1px solid #d8d7d9;
+        border: none;
         text-align: left;
+        padding: 0;
     }
-}
-
-.umb-nested-content__placeholder-name{
-    font-size: 15px;
 }
 
 .umb-nested-content__placeholder:hover {
@@ -260,18 +256,6 @@
     border-color: #2152a3;
     text-decoration: none;
 }
-
-.umb-nested-content__placeholder-icon-holder {    
-    width: 20px;
-    text-align: center;
-    display: inline-block;
-}
-
-.umb-nested-content__placeholder-icon {
-    font-size: 18px;
-    vertical-align: middle;
-}
-
 
 .form-horizontal .umb-nested-content--narrow .controls-row {
     margin-left: 40% !important;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -24,12 +24,7 @@
                     <td>
                         {{ph = placeholder(config);""}}
                         <div class="umb-nested-content__placeholder" ng-class="{'umb-nested-content__placeholder--selected':ph}" ng-click="openElemTypeModal($event, config)">
-                            <span class="umb-nested-content__placeholder-icon-holder" ng-if="ph">
-                                <i class="umb-nested-content__placeholder-icon {{ ph.icon }}"></i>
-                            </span>
-                            <span class="umb-nested-content__placeholder-name" ng-if="ph">
-                                {{ ph.name }}
-                            </span>
+                            <umb-node-preview ng-if="ph" icon="ph.icon" name="ph.name"></umb-node-preview>
                             <localize key="content_nestedContentAddElementType" ng-if="!ph">Add element type</localize>
                         </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The new Nested Content configuration doesn't work very gracefully on smaller screens:

![image](https://user-images.githubusercontent.com/7405322/67931569-719f4000-fbc2-11e9-8a81-1a6bf77cf329.png)

Also there's really no need to invent new styling etc. for displaying an icon and a label, as we have the `umb-node-preview` for just that... so this PR cleans up the code a little bit and ensures we handle smaller screens gracefully:

![image](https://user-images.githubusercontent.com/7405322/67931540-5c2a1600-fbc2-11e9-851a-c75a53d3327e.png)
