### PR TITLE
Fix for Umb Request Helper unit test.

### DIFF
--- a/src/Umbraco.Web.UI.Client/test/unit/common/services/umb-request-helper.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/services/umb-request-helper.spec.js
@@ -1,6 +1,7 @@
 describe('umbRequestHelper tests', function () {
     var umbRequestHelper;
 
+    beforeEach(module('umbraco'));
     beforeEach(module('umbraco.services'));
 
     beforeEach(inject(function ($injector) {


### PR DESCRIPTION
Require Umbraco module for Umb-Request-Helper test, to make it work again.