### PR TITLE
Accessibility improvements to Multivalues view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/multivalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/multivalues.html
@@ -9,12 +9,12 @@
     </div>
     <div ui-sortable="sortableOptions">
         <div class="control-group umb-prevalues-multivalues__listitem" ng-repeat="item in model.value">
-            <i class="icon icon-navigation handle"></i>
+            <i class="icon icon-navigation handle" aria-hidden="true"></i>
             <div class="umb-prevalues-multivalues__left">
                 <input type="text" ng-model="item.value" val-server="item_{{$index}}" required />
             </div>
             <div class="umb-prevalues-multivalues__right">
-                <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></a>
+                <button class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Currently in the `multivalues.html` view the Remove option is an `<a>`. I have changed it to a `button`. 

I have also made the drag and drop hide on-screen readers using `aria-hidden=true`. Don't know whether that is okay on second thoughts..

To test, add prevalues to the following data types and make sure the Remove button can be tabbed into using keyboard. 
- Checkbox list
- Radiobutton list
- Dropdown
- Dropdown multiple
These are the only ones I can think of now. Color Picker has its own prevalues screen.

An example of how it should work..
![prevalues](https://user-images.githubusercontent.com/3941753/67942355-8fbf6d00-fbcf-11e9-8e77-64097127bb8f.gif)
