### PR TITLE
Assign domain: Add autofocus

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/assigndomain.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/assigndomain.html
@@ -45,7 +45,7 @@
                         <tbody>
                             <tr ng-repeat="domain in vm.domains">
                                 <td>
-                                    <input style="width: 100%; margin-bottom: 0;" type="text" ng-model="domain.name" name="domain_name_{{$index}}" required />
+                                    <input style="width: 100%; margin-bottom: 0;" type="text" ng-model="domain.name" name="domain_name_{{$index}}" required umb-auto-focus />
                                     <span ng-if="vm.domainForm.$submitted" ng-messages="vm.domainForm['domain_name_' + $index].$error">
                                         <span class="help-inline" ng-message="required"><localize key="validation_invalidEmpty"></localize></span>
                                     </span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have added the umb-auto-focus directive to the domain input field so it becomes focused whenever "Add" is clicked making it easier to start entering a domain name.

**Before**
![assign-domain-before](https://user-images.githubusercontent.com/1932158/67955321-b17e1b80-fbf2-11e9-88db-8ba1201f3991.gif)

**After**
![assign-domain-after](https://user-images.githubusercontent.com/1932158/67955650-349f7180-fbf3-11e9-84e4-70bcef7f0abb.gif)
