### PR TITLE
Set permission button accessibility fixes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/rights.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/rights.html
@@ -4,10 +4,10 @@
     <div ng-show="vm.viewState === 'manageGroups'">
         <div class="umb-dialog-body" ng-cloak>
 
-            <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>    
+            <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
             <div class="umb-pane" ng-show="!vm.loading">
-                
+
                 <form name="permissionsForm">
 
                     <div ng-show="vm.saveError">
@@ -27,21 +27,22 @@
                     <p class="abstract" style="margin-bottom: 20px;"><localize key="defaultdialogs_permissionsHelp"></localize></p>
 
                     <div style="position: relative; display: inline-block; margin-bottom: 20px;">
-
                         <umb-button
                             type="button"
                             button-style="info"
-                            label-key="defaultdialogs_permissionsSet" 
+                            label-key="defaultdialogs_permissionsSet"
                             action="vm.groupsDropdownOpen = !vm.groupsDropdownOpen"
+                            has-popup="true"
+                            is-expanded="vm.groupsDropdownOpen === undefined ? false : vm.groupsDropdownOpen"
                             add-ellipsis="true">
                         </umb-button>
-                        
-                        <umb-dropdown ng-if="vm.groupsDropdownOpen" on-close="vm.groupsDropdownOpen = false">
+
+                        <umb-dropdown ng-if="vm.groupsDropdownOpen" on-close="vm.groupsDropdownOpen = false" deep-blur="vm.groupsDropdownOpen = !vm.groupsDropdownOpen">
                             <umb-dropdown-item ng-repeat="group in vm.availableUserGroups | filter:{selected: '!true'}">
-                                <a href="" ng-click="vm.editPermissions(group)" prevent-default>
-                                    <i class="{{group.icon}}"></i>
+                                <button type="button" ng-click="vm.editPermissions(group)">
+                                    <i class="{{group.icon}}" aria-hidden="true"></i>
                                     {{group.name}}
-                                </a>
+                                </button>
                             </umb-dropdown-item>
                         </umb-dropdown>
 
@@ -61,7 +62,7 @@
                             on-edit="vm.editPermissions(group)">
                         </umb-user-group-preview>
                     </div>
-        
+
                 </form>
 
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed that the "Set permission" button could use some accessibility improvements so in this PR I have
- Added the deep-blur directive meaning that the popup will disappear when it's tabbed out of
- Added the aria attributes for `aria-haspopup` and `aria-expanded`
- Refactored the `<a>` elements in the dropdown to `<button>`
- Hidden the `<i>` element using `aria-hidden="true`

**Before**
![permission-dropdown-before](https://user-images.githubusercontent.com/1932158/67957610-269f2000-fbf6-11e9-8898-44f3fd0b4067.gif)

**After**
![permission-dropdown-after](https://user-images.githubusercontent.com/1932158/67957621-2b63d400-fbf6-11e9-9d20-a762b000d09e.gif)
