### PR TITLE
V8: Make macro partial view mandatory

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/settings.html
@@ -11,7 +11,7 @@
     <umb-box>
         <umb-box-header title="Macro partial view"></umb-box-header>
         <umb-box-content>
-            <umb-control-group label="Macro partial view">
+            <umb-control-group label="Macro partial view" required="true">
 
                 <umb-node-preview ng-if="model.macro.node"
                                   icon="model.macro.node.icon"
@@ -21,6 +21,7 @@
                                   on-edit="model.openViewPicker()"
                                   on-remove="model.removeMacroView()">
                 </umb-node-preview>
+                <input type="hidden" ng-model="mandatoryViewValidator" ng-required="!model.macro.node" />
 
                 <a href=""
                    ng-show="!model.macro.node"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When you create new macros, the macro partial view isn't set. If you then allow those macros in the RTE and enabled rendering within the RTE, this is what happens:

![image](https://user-images.githubusercontent.com/7405322/67957948-a4632b80-fbf6-11e9-9610-eae2b2c0a774.png)

Of course it makes no sense to have a macro without a view, but for newcomers that kind of error probably isn't terribly comforting. So this PR makes it mandatory to pick a view for a macro.

![image](https://user-images.githubusercontent.com/7405322/67957881-8eee0180-fbf6-11e9-9323-16fe585c3c63.png)

Obviously the macro can still be created without the view (that's how it's created after all), but at least you can't enable it for RTE without picking a view.
