### PR TITLE
V8: On smaller screens, trees should close when you click outside them

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/navigation.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/navigation.controller.js
@@ -510,6 +510,14 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
         if (!event) {
             return;
         }
+        closeTree();
+    };
+
+    $scope.onOutsideClick = function() {
+        closeTree();
+    }
+
+    function closeTree() {
         if (!appState.getGlobalState("touchDevice")) {
             treeActive = false;
             $timeout(function () {
@@ -518,7 +526,7 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
                 }
             }, 300);
         }
-    };
+    }
 
     $scope.toggleLanguageSelector = function () {
         $scope.page.languageSelectorIsOpen = !$scope.page.languageSelectorIsOpen;

--- a/src/Umbraco.Web.UI.Client/src/navigation.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/navigation.controller.js
@@ -515,7 +515,7 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
 
     $scope.onOutsideClick = function() {
         closeTree();
-    }
+    };
 
     function closeTree() {
         if (!appState.getGlobalState("touchDevice")) {

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -1,4 +1,4 @@
-<div id="leftcolumn" ng-controller="Umbraco.NavigationController" ng-mouseleave="leaveTree($event)" ng-mouseenter="enterTree($event)">
+<div id="leftcolumn" ng-controller="Umbraco.NavigationController" ng-mouseleave="leaveTree($event)" ng-mouseenter="enterTree($event)" on-outside-click="onOutsideClick()">
 
     <!-- navigation container -->
     <div id="navigation" ng-show="showNavigation" class="fill umb-modalcolumn" ng-animate="'slide'" nav-resize


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

On smaller screens, the trees close automatically on mouse leave. That works really well - unless you change to a section where the tree doesn't unfold directly below the mouse:

![tree-click-outside-before](https://user-images.githubusercontent.com/7405322/67960476-9f07e000-fbfa-11e9-8282-f97e625d7138.gif)

This PR ensures that trees are (also) hidden when you click outside them:

![tree-click-outside-after](https://user-images.githubusercontent.com/7405322/67960513-b0e98300-fbfa-11e9-95ac-84279b17d9aa.gif)

