### PR TITLE
Fixed casing for the "noTemplate" option

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -64,6 +64,7 @@
             if (infiniteMode) {
                 documentTypeId = $scope.model.id;
                 create = $scope.model.create;
+                if (create && !documentTypeId) documentTypeId = -1;
                 noTemplate = $scope.model.notemplate || $scope.model.noTemplate;
                 isElement = $scope.model.isElement;
                 allowVaryByCulture = $scope.model.allowVaryByCulture;

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -64,7 +64,7 @@
             if (infiniteMode) {
                 documentTypeId = $scope.model.id;
                 create = $scope.model.create;
-                noTemplate = $scope.model.notemplate;
+                noTemplate = $scope.model.notemplate || $scope.model.noTemplate;
                 isElement = $scope.model.isElement;
                 allowVaryByCulture = $scope.model.allowVaryByCulture;
                 vm.submitButtonKey = "buttons_saveAndClose";


### PR DESCRIPTION
The option should be named using camel casing similar to pretty much all other options. The fix is made so either "notemplate" or "noTemplate" can be specified, making the fix backwards compatible instead of creating a breaking change.

While I had the controller open, I also fixed so the `id` option is no longer required when the `create` option is is set to `true`. When the latter is the case, the ID is automatically set to `-1` if not already specified.

The PR can be tested by running the following code:

```js
$scope.danger = function() {
    editorService.documentTypeEditor({
        create: true,
        noTemplate: true
    });
};
```




