### PR TITLE
Added @ngdoc to the new property editor service

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/propertyeditor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/propertyeditor.service.js
@@ -1,3 +1,8 @@
+/**
+ @ngdoc service
+ * @name umbraco.services.propertyEditorService
+ */
+
 (function() {
     'use strict';
 


### PR DESCRIPTION
The **ngdoc** comment were missing, which prevented a successful build of the Angular API documentation. Adding the comment block fixes this issue.
