### PR TITLE
V8: Evenly distribute link URL and anchor inputs in linkpicker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -878,6 +878,21 @@
 .umb-datepicker p a{color: @gray-3;}
 
 //
+// Link picker
+// --------------------------------------------------
+.umb-linkpicker {
+    .umb-linkpicker__url {
+        width: 50%;
+        padding-right: 5px;
+    }
+
+    .umb-linkpicker__anchor {
+        width: 50%;
+        padding-left: 5px;
+    }
+}
+
+//
 // Code mirror - even though this isn't a proprety editor right now, it could be so I'm putting the styles here
 // --------------------------------------------------
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
@@ -1,4 +1,4 @@
-<div ng-controller="Umbraco.Editors.LinkPickerController as vm">
+<div ng-controller="Umbraco.Editors.LinkPickerController as vm" class="umb-linkpicker">
 
     <umb-editor-view>
 
@@ -16,7 +16,7 @@
 
                     <div class="flex">
 
-                        <umb-control-group label="@defaultdialogs_urlLinkPicker">
+                        <umb-control-group label="@defaultdialogs_urlLinkPicker" class="umb-linkpicker__url">
                             <input type="text"
                                     style="margin-right: 10px;"
                                     localize="placeholder"
@@ -27,7 +27,7 @@
                                     ng-disabled="model.target.id || model.target.udi" />
                         </umb-control-group>
 
-                        <umb-control-group label="@defaultdialogs_anchorLinkPicker">
+                        <umb-control-group label="@defaultdialogs_anchorLinkPicker" class="umb-linkpicker__anchor">
                             <input type="text"
                                     list="anchors"
                                     localize="placeholder"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The inputs for link URL and anchor aren't terribly nicely aligned in the linkpicker dialog:

![image](https://user-images.githubusercontent.com/7405322/67978146-bc987200-fc19-11e9-88ac-53aa22a414f2.png)

This PR ensures that they're distributed evenly:

![image](https://user-images.githubusercontent.com/7405322/67978085-996dc280-fc19-11e9-8d26-4b04e8838179.png)
