### PR TITLE
Angular API documentation: Adds styling for <code> elements

### DIFF
--- a/src/Umbraco.Web.UI.Docs/umb-docs.css
+++ b/src/Umbraco.Web.UI.Docs/umb-docs.css
@@ -76,3 +76,12 @@ a:hover {
     width: 50px;
     margin-top: 5px;
 }
+
+.content .methods code {
+    border: 1px solid #e1e1e8;
+    background-color: #f7f7f9;
+    padding: 0px 3px;
+    font-size: 85%;
+    color: #d14;
+    white-space: nowrap;
+}


### PR DESCRIPTION
`<code>` elements in the descriptions are now properly styled 🎉 

The `gulp-ngdocs` task will by default remove all styling from `<code>` elements - probably because it uses them throughout the generated documentation where the styling doesn't make sense (eg. in the `<h1>` element). This PR will therefore only target `<code>` elements in the list of methods.

## Before

![image](https://user-images.githubusercontent.com/3634580/67978330-29137100-fc1a-11e9-80b4-85b8c2963222.png)

## After

![image](https://user-images.githubusercontent.com/3634580/67978082-9672d200-fc19-11e9-81cd-5fef458cef71.png)
