### PR TITLE
Responsive Angular API documentation

### DIFF
--- a/src/Umbraco.Web.UI.Docs/umb-docs.css
+++ b/src/Umbraco.Web.UI.Docs/umb-docs.css
@@ -7,6 +7,21 @@ body {
     
 }
 
+.container, .navbar-static-top .container, .navbar-fixed-top .container, .navbar-fixed-bottom .container {
+    max-width: 1500px;
+    width: 95%;
+}
+
+.span3 {
+    width: 220px;
+    width: calc(90% / 12 * 3);
+}
+
+.span9 {
+    width: 700px;
+    width: calc(90% / 12 * 9);
+}
+
 .h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6 {
     font-family: inherit;
     font-weight: 400;


### PR DESCRIPTION
As the Angular API documentation uses nested tables for listing options for the options and parameters, the space quickly feels a bit cramped.

With this PR I'm making the documentation fluid. The documentation site uses Bootstrap for creating columns, but only seems to use `.span3` and `.span9`, so I've only updated those to be responsive. The other `.span{n}` classes are still fixed with.

I've set the container to a maximum width of 1500 pixels, so the site doesn't become super wide on wide monitors.

This PR will have a merge conflict with #7029. In my head it make sense to make the site responsive, so as I'm not 100% this will be merged, I've created the changes as two PRs instead of one 😮

## Before

![image](https://user-images.githubusercontent.com/3634580/67979561-d7b8b100-fc1c-11e9-9dd4-70a9c664b869.png)

## After

With a browser window with a width of 1700 pixels, the same block now looks like:

![image](https://user-images.githubusercontent.com/3634580/67979635-fae36080-fc1c-11e9-9c51-4532e005220f.png)

