### PR TITLE
V8: Improve treepicker keyboard navigation for trees with listviews

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -63,6 +63,8 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
 
         var currentNode = $scope.model.currentNode;
 
+        var previouslyFocusedElement = null;
+
         function initDialogTree() {
             vm.dialogTreeApi.callbacks.treeLoaded(treeLoadedHandler);
             // TODO: Also deal with unexpanding!!
@@ -486,6 +488,7 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
         }
 
         function openMiniListView(node) {
+            previouslyFocusedElement = document.activeElement;
             vm.miniListView = node;
         }
 
@@ -649,6 +652,12 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
 
         function closeMiniListView() {
             vm.miniListView = undefined;
+            if (previouslyFocusedElement) {
+                $timeout(function () {
+                    previouslyFocusedElement.focus();
+                    previouslyFocusedElement = null;
+                });
+            }
         }
 
         function submit(model) {

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
@@ -44,6 +44,7 @@
                                     ng-model="search"
                                     ng-change="searchMiniListView(search, miniListView)"
                                     prevent-enter-submit
+                                    umb-auto-focus
                                     no-dirty-check>
                             </div>
                         </form>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When you navigate the treepicker using the keyboard (tabbing around), you run into all sorts of issues if the tree contains a listview. The default tab focus more often than not moves to the dialog footer in the transition between views:

![treepicker-listview-navigation-before](https://user-images.githubusercontent.com/7405322/67986405-3dac3500-fc2b-11e9-9242-12f1d7769835.gif)

This PR fixes it by:

1. Applying default input focus to the search box within the list views.
2. Restoring input focus to the last focused element in the tree when you close the last listview.

Here's how it works:

![treepicker-listview-navigation-after](https://user-images.githubusercontent.com/7405322/67986422-43097f80-fc2b-11e9-971f-cca694f1553d.gif)
