### PR TITLE
Updated language discrepancies on database install steps

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
@@ -15,11 +15,11 @@
 		</div>
 
 		<div class="controls" ng-if="installer.current.model.dbType == 0">
-            <p>Great!, no need to configure anything then, you simply click the <strong>continue</strong> button below to continue to the next step</p>
+            <p>Great! No need to configure anything, you can simply click the <strong>continue</strong> button below to continue to the next step</p>
 		</div>
 
 		<div ng-if="installer.current.model.dbType < 0">
-			<legend>What is the exact connectionstring we should use?</legend>
+			<legend>What is the exact connection string we should use?</legend>
 			<div class="control-group">
 				<label class="control-label" for="server">Connection string</label>
 				  <div class="controls">
@@ -64,7 +64,7 @@
 							<label class="control-label" for="login">Login</label>
 							<div class="controls">
 								<input type="text" id="login" name="login"
-									placeholder="databaseuser"
+									placeholder="umbraco-database-user"
 									required ng-model="installer.current.model.login"  />
 								<small class="inline-help">Enter the database user name</small>
 							</div>

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/permissionsreport.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/permissionsreport.html
@@ -1,8 +1,8 @@
 ﻿<div>
-    <h1>Your permission settings are not ready for umbraco</h1>
+    <h1>Your permission settings are not ready for Umbraco</h1>
     <p>        
-        In order to run umbraco, you'll need to update your permission settings.
-        Detailed information about the correct file & folder permissions for Umbraco can be found 
+        In order to run Umbraco, you'll need to update your permission settings.
+        Detailed information about the correct file and folder permissions for Umbraco can be found 
         <a href="https://our.umbraco.com/documentation/Installation/permissions"><strong>here</strong></a>. 
     </p>
     <p>

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/version7upgradereport.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/version7upgradereport.html
@@ -2,11 +2,11 @@
     <h1>Major version upgrade from {{installer.current.model.currentVersion}} to {{installer.current.model.newVersion}}</h1>
     <h2>There were {{installer.current.model.errors.length}} issues detected</h2>
     <p>
-        The following compatibility issues were found. If you continue all non-compatible property editors will be converted to a Readonly/Label.                             
+        The following compatibility issues were found. If you continue, all non-compatible property editors will be converted to a Readonly/Label.                             
         You will be able to change the property editor to a compatible type manually by editing the data type after installation.
     </p>
     <p>
-        Otherwise if you choose not to proceed you will need to fix the errors listed below. 
+        Otherwise, if you choose not to proceed, you will need to fix the errors listed below. 
         Refer to v{{installer.current.model.newVersion}} upgrade instructions for full details.
     </p>
     


### PR DESCRIPTION
### Prerequisites

- [ x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7033 

### Description
Updated the following phrasing and language:

* "Great!, no need to configure..." becomes **"Great! No need to configure anything, you can simply click..."**
* "databaseuser" all one word and inconsistent becomes **"umbraco-database-user"**
* "connectionstring" all one word becomes **"connection string"**
* capitalisation of "Umbraco" on permissionsresport.html
* sentence flow on version7upgradereport.html
