### PR TITLE
V8: Ensure that listview status messages are vertically centered

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -117,6 +117,12 @@ h5.-black {
 }
 .umb-control-group {
     position: relative;
+
+    &.umb-control-group__listview {
+        // position: relative messes up the listview status messages (e.g. "no search results")
+        position: unset;
+    }
+
     &::after {
         content: '';
         display:block;

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -1,6 +1,6 @@
 <div class="umb-property">
     <ng-form name="propertyForm">
-        <div class="control-group umb-control-group" ng-class="{hidelabel:property.hideLabel}">
+        <div class="control-group umb-control-group" ng-class="{hidelabel:property.hideLabel, 'umb-control-group__listview': property.alias === '_umb_containerView'}">
 
             <val-property-msg></val-property-msg>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There is some content positioning going on that breaks the status messages of listviews (e.g. "No child items" and "No search results"):

![image](https://user-images.githubusercontent.com/7405322/68030674-4ef05280-fcba-11e9-9979-9c5c30befc02.png)

This PR ensures that we display the listview status messages correctly:

![image](https://user-images.githubusercontent.com/7405322/68030592-210b0e00-fcba-11e9-8702-de3a1ef91854.png)
