### PR TITLE
V8: Make the listview order direction radiobuttons look right

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/orderDirection.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/orderDirection.prevalues.html
@@ -1,7 +1,13 @@
 ﻿<div>
     <ng-form name="listViewOrderDirectionForm" class="flex">
-        <umb-radiobutton name="orderDirection" value="asc" model="model.value" text="Ascending [a-z]" required></umb-radiobutton>
-        <umb-radiobutton name="orderDirection" value="desc" model="model.value" text="Descending [z-a]" required></umb-radiobutton>
+        <ul class="unstyled">
+            <li>
+                <umb-radiobutton name="orderDirection" value="asc" model="model.value" text="Ascending [a-z]" required></umb-radiobutton>
+            </li>
+            <li>
+                <umb-radiobutton name="orderDirection" value="desc" model="model.value" text="Descending [z-a]" required></umb-radiobutton>
+            </li>
+        </ul>
 
         <span ng-messages="listViewOrderDirectionForm.orderDirection.$error" show-validation-on-submit>
             <span class="help-inline" ng-message="required">Required</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The "Order direction" radiobuttons in the listview config look a bit weird as-is:

![image](https://user-images.githubusercontent.com/7405322/68031418-e904ca80-fcbb-11e9-965e-2f899db34c37.png)

This PR applies the same rendering logic to these radiobuttons as is used when rendering radiobuttons as content properties. It looks like this:

![image](https://user-images.githubusercontent.com/7405322/68031505-15204b80-fcbc-11e9-9b27-721ade505846.png)
