### PR TITLE
Add DefaultPropertyValueConverterAttribute to core Nested Content PropertyValueConverters

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json.Linq;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.PropertyEditors.ValueConverters;
 using Umbraco.Web.PublishedCache;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
@@ -14,6 +15,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
     /// <summary>
     /// Provides an implementation for <see cref="T:Umbraco.Core.PropertyEditors.IPropertyValueConverter" /> for nested content.
     /// </summary>
+    [DefaultPropertyValueConverter(typeof(JsonValueConverter))]
     public class NestedContentManyValueConverter : NestedContentValueConverterBase
     {
         private readonly IProfilingLogger _proflog;

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json.Linq;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.PropertyEditors.ValueConverters;
 using Umbraco.Web.PublishedCache;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
@@ -13,6 +14,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
     /// <summary>
     /// Provides an implementation for <see cref="T:Umbraco.Core.PropertyEditors.IPropertyValueConverter" /> for nested content.
     /// </summary>
+    [DefaultPropertyValueConverter(typeof(JsonValueConverter))]
     public class NestedContentSingleValueConverter : NestedContentValueConverterBase
     {
         private readonly IProfilingLogger _proflog;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/2925.

### Description
The is the V8 version of PR https://github.com/umbraco/Umbraco-CMS/pull/2918. By adding the `DefaultPropertyValueConverterAttribute` to the PVCs, adding a custom one doesn't require [manually removing them](https://gist.github.com/stevemegson/33c24a4b36bf9d7381aa4dc9cc01b117).
