### PR TITLE
Reset page back to 1 when free text filtering users

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -2,13 +2,12 @@
     "use strict";
 
     function UsersController($scope, $timeout, $location, $routeParams, usersResource, 
-        userGroupsResource, userService, localizationService, contentEditingHelper, 
-        usersHelper, formHelper, notificationsService, dateHelper, editorService, 
+        userGroupsResource, userService, localizationService,  
+        usersHelper, formHelper, dateHelper, editorService, 
         listViewHelper) {
 
         var vm = this;
-        var localizeSaving = localizationService.localize("general_saving");
-
+        
         vm.page = {};
         vm.users = [];
         vm.userGroups = [];
@@ -113,6 +112,7 @@
         vm.selectAll = selectAll;
         vm.areAllSelected = areAllSelected;
         vm.searchUsers = searchUsers;
+        vm.freeTextFilterUsers = freeTextFilterUsers;
         vm.getFilterName = getFilterName;
         vm.setUserStatesFilter = setUserStatesFilter;
         vm.setUserGroupFilter = setUserGroupFilter;
@@ -412,6 +412,11 @@
         }, 500);
 
         function searchUsers() {
+            search();
+        }
+
+        function freeTextFilterUsers() {
+            vm.usersOptions.pageNumber = 1;
             search();
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -34,7 +34,7 @@
                                    type="text" localize="placeholder"
                                    placeholder="@general_typeToSearch"
                                    ng-model="vm.usersOptions.filter"
-                                   ng-change="vm.searchUsers()"
+                                   ng-change="vm.freeTextFilterUsers()"
                                    prevent-enter-submit
                                    no-dirty-check>
                         </div>


### PR DESCRIPTION
### Prerequisites

[X] I have added steps to test this contribution in the description below

### Description

Fix for issue https://github.com/umbraco/Umbraco-CMS/issues/7047

### Steps to reproduce

Create more than 1 page of users.
Go to users list
Switch to page 2
Enter text to filter users so that less than 1 page of results are shown
This should now reset the user back to page 1 and show results


