### PR TITLE
Only enumerate the app plugins folder if it exists

### DIFF
--- a/src/Umbraco.Web/Editors/MacrosController.cs
+++ b/src/Umbraco.Web/Editors/MacrosController.cs
@@ -323,7 +323,6 @@ namespace Umbraco.Web.Editors
         /// Finds partial view files in app plugin folders.
         /// </summary>
         /// <returns>
-        /// The <see cref="IEnumerable"/>.
         /// </returns>
         private IEnumerable<string> FindPartialViewFilesInPluginFolders()
         {

--- a/src/Umbraco.Web/Install/FilePermissionHelper.cs
+++ b/src/Umbraco.Web/Install/FilePermissionHelper.cs
@@ -45,8 +45,8 @@ namespace Umbraco.Web.Install
         /// <summary>
         /// This will test the directories for write access
         /// </summary>
-        /// <param name="directories"></param>
-        /// <param name="errorReport"></param>
+        /// <param name="dirs"></param>
+        /// <param name="errors"></param>
         /// <param name="writeCausesRestart">
         /// If this is false, the easiest way to test for write access is to write a temp file, however some folder will cause
         /// an App Domain restart if a file is written to the folder, so in that case we need to use the ACL APIs which aren't as


### PR DESCRIPTION
In MB replacement, we have removed the MB plugin, and therefore the folder do not exists..

When having a new user, the tours fail without this fix.

### Considerations
- Do we need to handle this elsewhere?
- Should we have a dummy file to ensure the folder exists?