### PR TITLE
V8: Make upload and image cropper interchangeable

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/UploadPropertyConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/UploadPropertyConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Newtonsoft.Json;
 using Umbraco.Core.Models.PublishedContent;
 
 namespace Umbraco.Core.PropertyEditors.ValueConverters
@@ -20,7 +21,22 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
 
         public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel cacheLevel, object source, bool preview)
         {
-            return source?.ToString() ?? "";
+            var sourceValue = source?.ToString();
+
+            if (sourceValue?.DetectIsJson() == true)
+            {
+                // this may be an image cropper value - let's try to convert it
+                try
+                {
+                    return JsonConvert.DeserializeObject<ImageCropperValue>(sourceValue)?.Src;
+                }
+                catch
+                {
+                    // ignore, this can't be converted
+                }
+            }
+
+            return sourceValue;
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

While investigating #7052 I realized that the upload and image cropper datatypes aren't completely interchangeable:

- When changing a property from upload to image cropper, things usually go just fine.
- When changing a property from image cropper to upload, things go horribly wrong:
![image](https://user-images.githubusercontent.com/7405322/68221138-444ef980-ffe9-11e9-89d9-c3a901165c16.png)

This PR makes the two datatypes interchangeable - or rather, it enables us to swap an image cropper with an upload datatype, as it already works the other way around.

Here's how it works when changing from image cropper to upload:

![upload-imagecropper-interchangeable-1](https://user-images.githubusercontent.com/7405322/68221262-76f8f200-ffe9-11e9-81d8-17b4046704e2.gif)

...and for good measure, here's the other way around:

![upload-imagecropper-interchangeable-2](https://user-images.githubusercontent.com/7405322/68221277-7d876980-ffe9-11e9-81f4-e8d118a02508.gif)


