### PR TITLE
Adds ability to get paged relations by type

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IRelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IRelationRepository.cs
@@ -1,10 +1,14 @@
 ﻿using System.Collections.Generic;
 using Umbraco.Core.Models;
+using Umbraco.Core.Persistence.Querying;
+using Umbraco.Core.Services;
 
 namespace Umbraco.Core.Persistence.Repositories
 {
     public interface IRelationRepository : IReadWriteQueryRepository<int, IRelation>
     {
+        IEnumerable<IRelation> GetPagedRelationsByQuery(IQuery<IRelation> query, long pageIndex, int pageSize, out long totalRecords, Ordering ordering);
+
         /// <summary>
         /// Deletes all relations for a parent for any specified relation type alias
         /// </summary>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
@@ -516,11 +516,17 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             // TODO: although the default ordering string works for name, it wont work for others without a table or an alias of some sort
             // As more things are attempted to be sorted we'll prob have to add more expressions here
-            var orderBy = ordering.OrderBy.ToUpperInvariant() switch
+            string orderBy;
+            switch (ordering.OrderBy.ToUpperInvariant())
             {
-                "PATH" => SqlSyntax.GetQuotedColumn(NodeDto.TableName, "path"),
-                _ => ordering.OrderBy
-            };
+                case "PATH":
+                    orderBy = SqlSyntax.GetQuotedColumn(NodeDto.TableName, "path");
+                    break;
+
+                default:
+                    orderBy = ordering.OrderBy;
+                    break;
+            }            
 
             if (ordering.Direction == Direction.Ascending)
                 sql.OrderBy(orderBy);

--- a/src/Umbraco.Core/Services/IRelationService.cs
+++ b/src/Umbraco.Core/Services/IRelationService.cs
@@ -8,151 +8,161 @@ namespace Umbraco.Core.Services
     public interface IRelationService : IService
     {
         /// <summary>
-        /// Gets a <see cref="Relation"/> by its Id
+        /// Gets a <see cref="IRelation"/> by its Id
         /// </summary>
-        /// <param name="id">Id of the <see cref="Relation"/></param>
-        /// <returns>A <see cref="Relation"/> object</returns>
+        /// <param name="id">Id of the <see cref="IRelation"/></param>
+        /// <returns>A <see cref="IRelation"/> object</returns>
         IRelation GetById(int id);
 
         /// <summary>
-        /// Gets a <see cref="RelationType"/> by its Id
+        /// Gets a <see cref="IRelationType"/> by its Id
         /// </summary>
-        /// <param name="id">Id of the <see cref="RelationType"/></param>
-        /// <returns>A <see cref="RelationType"/> object</returns>
+        /// <param name="id">Id of the <see cref="IRelationType"/></param>
+        /// <returns>A <see cref="IRelationType"/> object</returns>
         IRelationType GetRelationTypeById(int id);
 
         /// <summary>
-        /// Gets a <see cref="RelationType"/> by its Id
+        /// Gets a <see cref="IRelationType"/> by its Id
         /// </summary>
-        /// <param name="id">Id of the <see cref="RelationType"/></param>
-        /// <returns>A <see cref="RelationType"/> object</returns>
+        /// <param name="id">Id of the <see cref="IRelationType"/></param>
+        /// <returns>A <see cref="IRelationType"/> object</returns>
         IRelationType GetRelationTypeById(Guid id);
 
         /// <summary>
-        /// Gets a <see cref="RelationType"/> by its Alias
+        /// Gets a <see cref="IRelationType"/> by its Alias
         /// </summary>
-        /// <param name="alias">Alias of the <see cref="RelationType"/></param>
-        /// <returns>A <see cref="RelationType"/> object</returns>
+        /// <param name="alias">Alias of the <see cref="IRelationType"/></param>
+        /// <returns>A <see cref="IRelationType"/> object</returns>
         IRelationType GetRelationTypeByAlias(string alias);
 
         /// <summary>
-        /// Gets all <see cref="Relation"/> objects
+        /// Gets all <see cref="IRelation"/> objects
         /// </summary>
         /// <param name="ids">Optional array of integer ids to return relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetAllRelations(params int[] ids);
 
         /// <summary>
-        /// Gets all <see cref="Relation"/> objects by their <see cref="RelationType"/>
+        /// Gets all <see cref="IRelation"/> objects by their <see cref="IRelationType"/>
         /// </summary>
-        /// <param name="relationType"><see cref="RelationType"/> to retrieve Relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <param name="relationType"><see cref="IRelation"/> to retrieve Relations for</param>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetAllRelationsByRelationType(IRelationType relationType);
 
         /// <summary>
-        /// Gets all <see cref="Relation"/> objects by their <see cref="RelationType"/>'s Id
+        /// Gets all <see cref="IRelation"/> objects by their <see cref="IRelationType"/>'s Id
         /// </summary>
-        /// <param name="relationTypeId">Id of the <see cref="RelationType"/> to retrieve Relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <param name="relationTypeId">Id of the <see cref="IRelationType"/> to retrieve Relations for</param>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetAllRelationsByRelationType(int relationTypeId);
 
         /// <summary>
-        /// Gets all <see cref="Relation"/> objects
+        /// Gets all <see cref="IRelation"/> objects
         /// </summary>
         /// <param name="ids">Optional array of integer ids to return relationtypes for</param>
-        /// <returns>An enumerable list of <see cref="RelationType"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelationType> GetAllRelationTypes(params int[] ids);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by their parent Id
+        /// Gets a list of <see cref="IRelation"/> objects by their parent Id
         /// </summary>
         /// <param name="id">Id of the parent to retrieve relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByParentId(int id);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by their parent Id
+        /// Gets a list of <see cref="IRelation"/> objects by their parent Id
         /// </summary>
         /// <param name="id">Id of the parent to retrieve relations for</param>
         /// <param name="relationTypeAlias">Alias of the type of relation to retrieve</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByParentId(int id, string relationTypeAlias);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by their parent entity
+        /// Gets a list of <see cref="IRelation"/> objects by their parent entity
         /// </summary>
         /// <param name="parent">Parent Entity to retrieve relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByParent(IUmbracoEntity parent);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by their parent entity
+        /// Gets a list of <see cref="IRelation"/> objects by their parent entity
         /// </summary>
         /// <param name="parent">Parent Entity to retrieve relations for</param>
         /// <param name="relationTypeAlias">Alias of the type of relation to retrieve</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByParent(IUmbracoEntity parent, string relationTypeAlias);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by their child Id
+        /// Gets a list of <see cref="IRelation"/> objects by their child Id
         /// </summary>
         /// <param name="id">Id of the child to retrieve relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByChildId(int id);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by their child Id
+        /// Gets a list of <see cref="IRelation"/> objects by their child Id
         /// </summary>
         /// <param name="id">Id of the child to retrieve relations for</param>
         /// <param name="relationTypeAlias">Alias of the type of relation to retrieve</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByChildId(int id, string relationTypeAlias);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by their child Entity
+        /// Gets a list of <see cref="IRelation"/> objects by their child Entity
         /// </summary>
         /// <param name="child">Child Entity to retrieve relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByChild(IUmbracoEntity child);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by their child Entity
+        /// Gets a list of <see cref="IRelation"/> objects by their child Entity
         /// </summary>
         /// <param name="child">Child Entity to retrieve relations for</param>
         /// <param name="relationTypeAlias">Alias of the type of relation to retrieve</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByChild(IUmbracoEntity child, string relationTypeAlias);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by their child or parent Id.
+        /// Gets a list of <see cref="IRelation"/> objects by their child or parent Id.
         /// Using this method will get you all relations regards of it being a child or parent relation.
         /// </summary>
         /// <param name="id">Id of the child or parent to retrieve relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByParentOrChildId(int id);
 
         IEnumerable<IRelation> GetByParentOrChildId(int id, string relationTypeAlias);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by the Name of the <see cref="RelationType"/>
+        /// Gets a list of <see cref="IRelation"/> objects by the Name of the <see cref="IRelationType"/>
         /// </summary>
-        /// <param name="relationTypeName">Name of the <see cref="RelationType"/> to retrieve Relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <param name="relationTypeName">Name of the <see cref="IRelationType"/> to retrieve Relations for</param>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByRelationTypeName(string relationTypeName);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by the Alias of the <see cref="RelationType"/>
+        /// Gets a list of <see cref="IRelation"/> objects by the Alias of the <see cref="IRelationType"/>
         /// </summary>
-        /// <param name="relationTypeAlias">Alias of the <see cref="RelationType"/> to retrieve Relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <param name="relationTypeAlias">Alias of the <see cref="IRelationType"/> to retrieve Relations for</param>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByRelationTypeAlias(string relationTypeAlias);
 
         /// <summary>
-        /// Gets a list of <see cref="Relation"/> objects by the Id of the <see cref="RelationType"/>
+        /// Gets a list of <see cref="IRelation"/> objects by the Id of the <see cref="IRelationType"/>
         /// </summary>
-        /// <param name="relationTypeId">Id of the <see cref="RelationType"/> to retrieve Relations for</param>
-        /// <returns>An enumerable list of <see cref="Relation"/> objects</returns>
+        /// <param name="relationTypeId">Id of the <see cref="IRelationType"/> to retrieve Relations for</param>
+        /// <returns>An enumerable list of <see cref="IRelation"/> objects</returns>
         IEnumerable<IRelation> GetByRelationTypeId(int relationTypeId);
+
+        /// <summary>
+        /// Gets a paged result of <see cref="IRelation"/>
+        /// </summary>
+        /// <param name="relationTypeId"></param>
+        /// <param name="pageIndex"></param>
+        /// <param name="pageSize"></param>
+        /// <param name="totalChildren"></param>
+        /// <returns></returns>
+        IEnumerable<IRelation> GetPagedByRelationTypeId(int relationTypeId, long pageIndex, int pageSize, out long totalRecords, Ordering ordering = null);
 
         /// <summary>
         /// Gets the Child object from a Relation as an <see cref="IUmbracoEntity"/>
@@ -202,7 +212,7 @@ namespace Umbraco.Core.Services
         /// <param name="parentId">Id of the parent</param>
         /// <param name="childId">Id of the child</param>
         /// <param name="relationType">The type of relation to create</param>
-        /// <returns>The created <see cref="Relation"/></returns>
+        /// <returns>The created <see cref="IRelation"/></returns>
         IRelation Relate(int parentId, int childId, IRelationType relationType);
 
         /// <summary>
@@ -211,7 +221,7 @@ namespace Umbraco.Core.Services
         /// <param name="parent">Parent entity</param>
         /// <param name="child">Child entity</param>
         /// <param name="relationType">The type of relation to create</param>
-        /// <returns>The created <see cref="Relation"/></returns>
+        /// <returns>The created <see cref="IRelation"/></returns>
         IRelation Relate(IUmbracoEntity parent, IUmbracoEntity child, IRelationType relationType);
 
         /// <summary>
@@ -220,7 +230,7 @@ namespace Umbraco.Core.Services
         /// <param name="parentId">Id of the parent</param>
         /// <param name="childId">Id of the child</param>
         /// <param name="relationTypeAlias">Alias of the type of relation to create</param>
-        /// <returns>The created <see cref="Relation"/></returns>
+        /// <returns>The created <see cref="IRelation"/></returns>
         IRelation Relate(int parentId, int childId, string relationTypeAlias);
 
         /// <summary>
@@ -229,14 +239,14 @@ namespace Umbraco.Core.Services
         /// <param name="parent">Parent entity</param>
         /// <param name="child">Child entity</param>
         /// <param name="relationTypeAlias">Alias of the type of relation to create</param>
-        /// <returns>The created <see cref="Relation"/></returns>
+        /// <returns>The created <see cref="IRelation"/></returns>
         IRelation Relate(IUmbracoEntity parent, IUmbracoEntity child, string relationTypeAlias);
 
         /// <summary>
-        /// Checks whether any relations exists for the passed in <see cref="RelationType"/>.
+        /// Checks whether any relations exists for the passed in <see cref="IRelationType"/>.
         /// </summary>
-        /// <param name="relationType"><see cref="RelationType"/> to check for relations</param>
-        /// <returns>Returns <c>True</c> if any relations exists for the given <see cref="RelationType"/>, otherwise <c>False</c></returns>
+        /// <param name="relationType"><see cref="IRelationType"/> to check for relations</param>
+        /// <returns>Returns <c>True</c> if any relations exists for the given <see cref="IRelationType"/>, otherwise <c>False</c></returns>
         bool HasRelations(IRelationType relationType);
 
         /// <summary>
@@ -281,33 +291,33 @@ namespace Umbraco.Core.Services
         bool AreRelated(int parentId, int childId, string relationTypeAlias);
 
         /// <summary>
-        /// Saves a <see cref="Relation"/>
+        /// Saves a <see cref="IRelation"/>
         /// </summary>
         /// <param name="relation">Relation to save</param>
         void Save(IRelation relation);
 
         /// <summary>
-        /// Saves a <see cref="RelationType"/>
+        /// Saves a <see cref="IRelationType"/>
         /// </summary>
         /// <param name="relationType">RelationType to Save</param>
         void Save(IRelationType relationType);
 
         /// <summary>
-        /// Deletes a <see cref="Relation"/>
+        /// Deletes a <see cref="IRelation"/>
         /// </summary>
         /// <param name="relation">Relation to Delete</param>
         void Delete(IRelation relation);
 
         /// <summary>
-        /// Deletes a <see cref="RelationType"/>
+        /// Deletes a <see cref="IRelationType"/>
         /// </summary>
         /// <param name="relationType">RelationType to Delete</param>
         void Delete(IRelationType relationType);
 
         /// <summary>
-        /// Deletes all <see cref="Relation"/> objects based on the passed in <see cref="RelationType"/>
+        /// Deletes all <see cref="IRelation"/> objects based on the passed in <see cref="IRelationType"/>
         /// </summary>
-        /// <param name="relationType"><see cref="RelationType"/> to Delete Relations for</param>
+        /// <param name="relationType"><see cref="IRelationType"/> to Delete Relations for</param>
         void DeleteRelationsOfType(IRelationType relationType);
     }
 }

--- a/src/Umbraco.Core/Services/Implement/RelationService.cs
+++ b/src/Umbraco.Core/Services/Implement/RelationService.cs
@@ -208,6 +208,16 @@ namespace Umbraco.Core.Services.Implement
         }
 
         /// <inheritdoc />
+        public IEnumerable<IRelation> GetPagedByRelationTypeId(int relationTypeId, long pageIndex, int pageSize, out long totalRecords, Ordering ordering = null)
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                var query = Query<IRelation>().Where(x => x.RelationTypeId == relationTypeId);
+                return _relationRepository.GetPagedRelationsByQuery(query, pageIndex, pageSize, out totalRecords, ordering);
+            }
+        }
+
+        /// <inheritdoc />
         public IUmbracoEntity GetChildEntityFromRelation(IRelation relation)
         {
             var objectType = ObjectTypes.GetUmbracoObjectType(relation.ChildObjectType);


### PR DESCRIPTION
Adds new `IRelationService.GetPagedByRelationTypeId` to be able to get paged relation by type + unit tests

links [AB#3466](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/3466)