### PR TITLE
AB3608 - Implement WebAPI & UI for displaying media relations/references

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
@@ -552,8 +552,31 @@ function mediaResource($q, $http, umbDataFormatter, umbRequestHelper) {
                         "Search",
                         args)),
                 'Failed to retrieve media items for search: ' + query);
-        }
+        },
 
+        /**
+         * @ngdoc method
+         * @name umbraco.resources.mediaResource#getReferences
+         * @methodOf umbraco.resources.mediaResource
+         *
+         * @description
+         * Retrieves references of a given media item.
+         *
+         * @param {Int} id id of media node to retrieve references for
+         * @returns {Promise} resourcePromise object.
+         *
+         */
+        getReferences: function (id) {
+
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "mediaApiBaseUrl",
+                        "GetReferences",
+                        { id: id })),
+                "Failed to retrieve usages for media of id " + id);
+
+        }
     };
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
@@ -1,20 +1,25 @@
 <div class="umb-package-details">
-    <div class="umb-package-details__main-content">
+
+    <umb-load-indicator ng-if="loading === true"></umb-load-indicator>
+
+    <!-- Main Column -->
+    <div class="umb-package-details__main-content" ng-if="loading === false">
+
+        <!-- Links -->
         <umb-box data-element="node-info-urls">
             <umb-box-header title-key="general_links"></umb-box-header>
             <umb-box-content class="block-form">
 
-                <umb-empty-state
-                    ng-if="!nodeUrl"
-                    size="small">
+                <umb-empty-state ng-if="!nodeUrl"
+                                 size="small">
                     <localize key="content_noMediaLink"></localize>
                 </umb-empty-state>
 
                 <ul ng-if="nodeUrl" class="nav nav-stacked" style="margin-bottom: 0;">
                     <li>
                         <a ng-attr-href="{{node.extension !== 'svg' ? nodeUrl : undefined}}" ng-click="node.extension === 'svg' && openSVG()" target="_blank">
-                                <i class="icon icon-out"></i>
-                                <span>{{nodeFileName}}</span>
+                            <i class="icon icon-out"></i>
+                            <span>{{nodeFileName}}</span>
 
                         </a>
                     </li>
@@ -23,9 +28,106 @@
             </umb-box-content>
         </umb-box>
 
+        <!-- Media Tracking (NO Items) -->
+        <umb-box ng-if="loading === false && hasReferences === false">
+            <umb-box-header title-key="references_tabName"></umb-box-header>
+            <umb-box-content>
+                <umb-empty-state size="small">
+                    This Media item has no references.
+                </umb-empty-state>
+            </umb-box-content>
+        </umb-box>
+
+        <!-- Media Tracking (With Items) -->
+        <div ng-if="loading === false && hasReferences === true">
+
+            <!-- Content -->
+            <div ng-if="references.content.length > 0">
+
+                <h5 class="mt4" style="margin-bottom: 20px;">
+                    <localize key="references_labelUsedByDocuments">Used in Documents</localize>
+                </h5>
+
+                <div class="umb-table">
+                    <div class="umb-table-head">
+                        <div class="umb-table-row">
+                            <div class="umb-table-cell"></div>
+                            <div class="umb-table-cell umb-table__name not-fixed"><localize key="general_name">Name</localize></div>
+                            <div class="umb-table-cell"><localize key="content_alias">Alias</localize></div>
+                            <div class="umb-table-cell umb-table-cell--nano"><localize key="general_open" style="visibility:hidden;">Open</localize></div>
+                        </div>
+                    </div>
+                    <div class="umb-table-body">
+                        <div class="umb-table-row" ng-repeat="reference in references.content">
+                            <div class="umb-table-cell"><i class="umb-table-body__icon {{reference.icon}}"></i></div>
+                            <div class="umb-table-cell umb-table__name"><span>{{::reference.name}}</span></div>
+                            <div class="umb-table-cell"><span title="{{::reference.alias}}">{{::reference.alias}}</span></div>
+                            <div class="umb-table-cell umb-table-cell--nano"><a ng-href="#/content/content/edit/{{::reference.id}}"><localize key="general_open">Open</localize></a></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Members -->
+            <div ng-if="references.members.length > 0">
+
+                <h5 class="mt4" style="margin-bottom: 20px;">
+                    <localize key="references_labelUsedByMembers">Used in Members</localize>
+                </h5>
+
+                <div class="umb-table">
+                    <div class="umb-table-head">
+                        <div class="umb-table-row">
+                            <div class="umb-table-cell"></div>
+                            <div class="umb-table-cell umb-table__name not-fixed"><localize key="general_name">Name</localize></div>
+                            <div class="umb-table-cell"><localize key="content_alias">Alias</localize></div>
+                            <div class="umb-table-cell umb-table-cell--nano"><localize key="general_open" style="visibility:hidden;">Open</localize></div>
+                        </div>
+                    </div>
+                    <div class="umb-table-body">
+                        <div class="umb-table-row" ng-repeat="reference in references.members">
+                            <div class="umb-table-cell"><i class="umb-table-body__icon {{reference.icon}}"></i></div>
+                            <div class="umb-table-cell umb-table__name"><span>{{::reference.name}}</span></div>
+                            <div class="umb-table-cell"><span title="{{::reference.alias}}">{{::reference.alias}}</span></div>
+                            <div class="umb-table-cell umb-table-cell--nano"><a href="#/member/member/edit/{{::reference.key}}"><localize key="general_open">Open</localize></a></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Media -->
+            <div ng-if="references.media.length > 0">
+
+                <h5 class="mt4" style="margin-bottom: 20px;">
+                    <localize key="references_labelUsedByMedia">Used in Media</localize>
+                </h5>
+
+                <div class="umb-table">
+                    <div class="umb-table-head">
+                        <div class="umb-table-row">
+                            <div class="umb-table-cell"></div>
+                            <div class="umb-table-cell umb-table__name not-fixed"><localize key="general_name">Name</localize></div>
+                            <div class="umb-table-cell"><localize key="content_alias">Alias</localize></div>
+                            <div class="umb-table-cell umb-table-cell--nano"><localize key="general_open" style="visibility:hidden;">Open</localize></div>
+                        </div>
+                    </div>
+                    <div class="umb-table-body">
+                        <div class="umb-table-row" ng-repeat="reference in references.media">
+                            <div class="umb-table-cell"><i class="umb-table-body__icon {{reference.icon}}"></i></div>
+                            <div class="umb-table-cell umb-table__name"><span>{{::reference.name}}</span></div>
+                            <div class="umb-table-cell"><span title="{{::reference.alias}}">{{::reference.alias}}</span></div>
+                            <div class="umb-table-cell umb-table-cell--nano"><a href="#/media/media/edit/{{::reference.id}}"><localize key="general_open">Open</localize></a></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
     </div>
 
-    <div class="umb-package-details__sidebar">
+    <!-- Sidebar -->
+    <div class="umb-package-details__sidebar" ng-if="loading === false">
+        <!-- General Info -->
         <umb-box data-element="node-info-general">
             <umb-box-header title-key="general_general"></umb-box-header>
             <umb-box-content class="block-form">
@@ -39,12 +141,11 @@
                 </umb-control-group>
 
                 <umb-control-group data-element="node-info-media-type" label="@content_mediatype">
-                    <umb-node-preview
-                        style="max-width: 100%; margin-bottom: 0px;"
-                        icon="node.icon"
-                        name="node.contentTypeName"
-                        allow-open="allowChangeMediaType"
-                        on-open="openMediaType(mediaType)">
+                    <umb-node-preview style="max-width: 100%; margin-bottom: 0px;"
+                                      icon="node.icon"
+                                      name="node.contentTypeName"
+                                      allow-open="allowChangeMediaType"
+                                      on-open="openMediaType(mediaType)">
                     </umb-node-preview>
                 </umb-control-group>
 

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2181,6 +2181,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="labelUsedByMemberTypes">Used in Member Types</key>
     <key alias="noMemberTypes">No references to Member Types.</key>
     <key alias="usedByProperties">Used by</key>
+    <key alias="labelUsedByDocuments">Used in Documents</key>
+    <key alias="labelUsedByMembers">Used in Members</key>
+    <key alias="labelUsedByMedia">Used in Media</key>
   </area>
   <area alias="logViewer">
     <key alias="logLevels">Log Levels</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2197,6 +2197,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="labelUsedByMemberTypes">Used in  Member Types</key>
     <key alias="noMemberTypes">No references to Member Types.</key>
     <key alias="usedByProperties">Used by</key>
+    <key alias="labelUsedByDocuments">Used in Documents</key>
+    <key alias="labelUsedByMembers">Used in Members</key>
+    <key alias="labelUsedByMedia">Used in Media</key>
   </area>
   <area alias="logViewer">
       <key alias="logLevels">Log Levels</key>

--- a/src/Umbraco.Web/Models/ContentEditing/MediaReferences.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/MediaReferences.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace Umbraco.Web.Models.ContentEditing
+{
+    [DataContract(Name = "mediaReferences", Namespace = "")]
+    public class MediaReferences
+    {
+        [DataMember(Name = "content")]
+        public IEnumerable<EntityTypeReferences> Content { get; set; } = Enumerable.Empty<EntityTypeReferences>();
+
+        [DataMember(Name = "members")]
+        public IEnumerable<EntityTypeReferences> Members { get; set; } = Enumerable.Empty<EntityTypeReferences>();
+
+        [DataMember(Name = "media")]
+        public IEnumerable<EntityTypeReferences> Media { get; set; } = Enumerable.Empty<EntityTypeReferences>();
+
+        [DataContract(Name = "entityType", Namespace = "")]
+        public class EntityTypeReferences : EntityBasic
+        {
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Models\ContentEditing\LinkDisplay.cs" />
     <Compile Include="Models\ContentEditing\MacroDisplay.cs" />
     <Compile Include="Models\ContentEditing\MacroParameterDisplay.cs" />
+    <Compile Include="Models\ContentEditing\MediaReferences.cs" />
     <Compile Include="Models\ContentEditing\UrlAndAnchors.cs" />
     <Compile Include="Models\Mapping\CommonMapper.cs" />
     <Compile Include="Models\Mapping\MapperContextExtensions.cs" />


### PR DESCRIPTION
This PR is for two tasks on the Azure Board

Fixes [AB#3608](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/3608) - Implement the WebAPI method
Fixes [AB#3609](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/3609) - Implement usage report on Info Content App

## Testing Notes
* This is targeting branch `v8/feature/media-tracking`
* Install SK (Makes life easier)~
* Visit one of the media items and ensure it displays the correct usages in Document/Content nodes
* Ensure the open links work & take you to the correct section/area

* Add a new property to `MemberType` that is a `Media Picker`
* Go and select an image on a member
* Check it shows up on the info tab as a relation
* Ensure the open link works & takes you back to the member

* Repeat same process above but for `MediaType` such as `Image`

## Preview
![media-tracking-references](https://user-images.githubusercontent.com/1389894/68306622-cdc20280-00a1-11ea-8e8c-e45a2fcac0a0.gif)
