### PR TITLE
Allows members to be ordered by last edited field

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -186,7 +186,9 @@ function listViewController($rootScope, $scope, $routeParams, $injector, $cookie
 
         // Another special case for members, only fields on the base table (cmsMember) can be used for sorting
         if (e.isSystem && $scope.entityType == "member") {
-            e.allowSorting = e.alias == 'username' || e.alias == 'email';
+            e.allowSorting = e.alias == 'username' ||
+                             e.alias == 'email' ||
+                             e.alias == 'updateDate';
         }
 
         if (e.isSystem) {


### PR DESCRIPTION
It was raised in #6477 that the last edited field on the default members list view doesn't allow sorting.

This PR adds that ability.

Also fixes a minor issue that when adding the content type.