### PR TITLE
- added delete title to trash icons in the grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -95,7 +95,7 @@
                                    </div>
 
                                     <div class="cell-tools-remove row-tool">
-                                        <i class="icon-trash" ng-click="togglePrompt(row)"></i>
+                                        <i class="icon-trash" ng-click="togglePrompt(row)" localize="title" title="@delete"></i>
                                         <umb-confirm-action
                                             ng-if="row.deletePrompt"
                                             direction="left"
@@ -200,7 +200,7 @@
                                                                           </div>
 
                                                                           <div class="umb-control-tool">
-                                                                              <i class="umb-control-tool-icon icon-trash" ng-click="togglePrompt(control)"></i>
+                                                                              <i class="umb-control-tool-icon icon-trash" ng-click="togglePrompt(control)" localize="title" title="@delete"></i>
                                                                               <umb-confirm-action ng-if="control.deletePrompt"
                                                                                                   direction="left"
                                                                                                   on-confirm="removeControl(area, $index)"


### PR DESCRIPTION
### UK Fest Hackathon PR

In the Grid Editor, when you hover over the trash icon there is no title which tells you what it is for, but there is one for the Confirm and for Cancel.

## Before

![https://i.imgur.com/lbWRf3V.jpg](https://i.imgur.com/lbWRf3V.jpg)

This PR adds the Delete title to the trash icon.

## After

![https://i.imgur.com/tCqGIiV.jpg](https://i.imgur.com/tCqGIiV.jpg)
