### PR TITLE
Make the source code build documentation a bit less complex

### DIFF
--- a/.github/BUILD.md
+++ b/.github/BUILD.md
@@ -43,6 +43,8 @@ If you only see a build.bat-file, you're probably on the wrong branch. If you sw
 
 You might run into [Powershell quirks](#powershell-quirks).
 
+If it runs without errors; Hooray! Now you can continue with [the next step](CONTRIBUTING.md#how-do-i-begin) and open the solution and build it.
+
 ### Build Infrastructure
 
 The Umbraco Build infrastructure relies on a PowerShell object. The object can be retrieved with:


### PR DESCRIPTION
You don't have to read the whole complex documentation. Just build it and then go to the next step :)