### PR TITLE
Accessibility Improvement - Open Template in info content app changed from anchor tag to button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -169,9 +169,9 @@
                                 ng-change="updateTemplate(node.template)">
                             <option value="">{{chooseLabel}}...</option>
                         </select>
-                        <a href="" ng-show="allowChangeTemplate && node.template !== null" class="umb-node-preview__action" style="margin-left:15px;" ng-click="openTemplate()">
+                        <button ng-show="allowChangeTemplate && node.template !== null" class="umb-node-preview__action" style="margin-left:15px;" ng-click="openTemplate()">
                             <localize key="general_open">Open</localize>
-                        </a>
+                        </button>
                     </div>
                 </umb-control-group>
 


### PR DESCRIPTION
Currently, in the Info content app on any node the "Open" template is an `<a>` . Changed it to a `<button>` so thats its more accessible.

![umbraco-template-open](https://user-images.githubusercontent.com/3941753/68390333-f529d580-015c-11ea-8827-bca4ded2e2b7.gif)
