### PR TITLE
- fixed the focus state on the create user and create group buttons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/buttons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/buttons.less
@@ -211,6 +211,10 @@ input[type="button"] {
 // Made for Umbraco, 2019
 .btn-action {
   .buttonBackground(@blueExtraDark, @blueDark, @white, @u-white);
+
+  &:focus {
+      background-color: @blueExtraDark;
+  }
 }
 // Made for Umbraco, 2019
 .btn-selection {

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button.less
@@ -10,6 +10,7 @@
 
 .umb-button__button:focus {
     outline: none;
+    box-shadow: 0 0 0 2px highlight;
     .tabbing-active &:after {
         content: '';
         position: absolute;


### PR DESCRIPTION
### UK Festival Hackathon PR

## [Accessibility Issue 106 - "Create user" doesn't have a very clear focus (tab) state](https://trello.com/c/JlRH12qZ/106-106-create-user-doesnt-have-a-very-clear-focus-tab-state)

After speaking to the accessibility team, I have created this PR to change the focus state of the create user and create group action buttons.

### Before:

Previously the focus state just changed the background-colour of the button.

![https://i.imgur.com/8mO6ERA.gif](https://i.imgur.com/8mO6ERA.gif)

### Aiming for this

I found the focus state of the toggles which looked better:

![https://i.imgur.com/zfXPKyr.gif](https://i.imgur.com/zfXPKyr.gif)

### After

![https://i.imgur.com/p6lJGj4.gif](https://i.imgur.com/p6lJGj4.gif)
