### PR TITLE
Corrected the model variable name

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/RegisterMember.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/PartialViewMacros/Templates/RegisterMember.cshtml
@@ -85,7 +85,7 @@ else
                         easily change it. For example, if you wanted to render a custom editor for this field called "MyEditor" you would
                         create a file at ~/Views/Shared/EditorTemplates/MyEditor.cshtml", then you will change the next line of code to
                         render your specific editor template like:
-                        @Html.EditorFor(m => profileModel.MemberProperties[i].Value, "MyEditor")
+                        @Html.EditorFor(m => registerModel.MemberProperties[i].Value, "MyEditor")
                     *@
                     @Html.EditorFor(m => registerModel.MemberProperties[i].Value)
                     @Html.HiddenFor(m => registerModel.MemberProperties[i].Alias)


### PR DESCRIPTION
The model variable name is registerModel rather than profileModel.

This change corrects the comment's example code.  There is nothing to test as this is just some commented out example code.