### PR TITLE
- only show remove photo on user avatar when there is an avatar

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -207,7 +207,7 @@
                             </a>
 
                             <a href=""
-                               ng-if="model.user.avatars"
+                               ng-if="model.user.avatars.length > 0"
                                class="umb-user-group-preview__action umb-user-group-preview__action--red"
                                ng-click="model.clearAvatar()"
                                prevent-default>


### PR DESCRIPTION
### Umbraco UK Fest Hackathon PR

On the user profile screen, under the user avatar preview, the remove photo link should only show if there is an avatar already picked. This PR fixes that.

### Before

![https://i.imgur.com/kMYrRP4.png](https://i.imgur.com/kMYrRP4.png)

### After

![https://i.imgur.com/ebpl5xP.png](https://i.imgur.com/ebpl5xP.png)