### PR TITLE
V8: Fix mapping YSOD for culture variant content after logout and login

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/navigation.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/navigation.controller.js
@@ -249,6 +249,8 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
 
     //when a user logs out or timesout
     evts.push(eventsService.on("app.notAuthenticated", function () {
+        // reset the isInit flag to ensure we initialize the user culture again after next login
+        isInit = false;
         $scope.authenticated = false;
     }));
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I came across this while investigating #7126: After logout and a subsequent login, `mculture` is never re-initialized. This causes list views for culture variant content to fail miserably:

![culture-variant-content-logout-login-before](https://user-images.githubusercontent.com/7405322/68697531-4d0e7500-057f-11ea-95f7-80ca104d2629.gif)

This PR ensures that the navigation controller initialization is always performed after login, thus `mculture` is always set - and thus the problem goes away:

![culture-variant-content-logout-login-after](https://user-images.githubusercontent.com/7405322/68697651-9068e380-057f-11ea-807e-291ac6ab1785.gif)

#### Testing this PR

1. Enable list view on a culture variant content type.
2. Ensure one item of this content type has one or more children.
3. Logout.
4. Login.
5. Open the content item and verify that no mapping error occurs.
