### PR TITLE
V8: Make sure the media picker can survive a logout and subsequent login

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -311,7 +311,7 @@ angular.module("umbraco")
 
                 // also make sure the node is not trashed
                 if (nodePath.indexOf($scope.startNodeId.toString()) !== -1 && node.trashed === false) {
-                    gotoFolder({ id: $scope.lastOpenedNode, name: "Media", icon: "icon-folder", path: node.path });
+                    gotoFolder({ id: $scope.lastOpenedNode || $scope.startNodeId, name: "Media", icon: "icon-folder", path: node.path });
                     return true;
                 } else {
                     gotoFolder({ id: $scope.startNodeId, name: "Media", icon: "icon-folder" });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7126

### Description

Fix for #7126. 

Notice that the issue described in #7126 is not limited to the grid RTE, but is applicable to any RTE.

#### Steps to test

1. Create some content with an RTE and add an image to this RTE.
2. Save the content.
3. Log out.
4. Log back in and open the previously created content.
5. Select the image in the RTE and open it for editing (by clicking the Media Picker toolbar item).
![image](https://user-images.githubusercontent.com/7405322/68704406-8d282480-058c-11ea-926e-f2f4c09aa796.png)
6. Verify that the image is opened for editing with no errors in the JS console.