### PR TITLE
WIP: Add missing database indexes for foreign keys

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -6,6 +6,7 @@ using Umbraco.Core.Migrations.Upgrade.Common;
 using Umbraco.Core.Migrations.Upgrade.V_8_0_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_0_1;
 using Umbraco.Core.Migrations.Upgrade.V_8_1_0;
+using Umbraco.Core.Migrations.Upgrade.V_8_4_0;
 
 namespace Umbraco.Core.Migrations.Upgrade
 {
@@ -181,6 +182,11 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<ConvertTinyMceAndGridMediaUrlsToLocalLink>("{B69B6E8C-A769-4044-A27E-4A4E18D1645A}");
             To<RenameUserLoginDtoDateIndex>("{0372A42B-DECF-498D-B4D1-6379E907EB94}");
             To<FixContentNuCascade>("{5B1E0D93-F5A3-449B-84BA-65366B84E2D4}");
+            // release-8.1.0
+
+            // to 8.4.0...
+            To<AddForeignKeyIndexes>("{B4C38ABC-20B8-46C8-B166-2F61BF40818D}");
+            // release-8.4.0
 
             //FINAL
         }

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_4_0/AddForeignKeyIndexes.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_4_0/AddForeignKeyIndexes.cs
@@ -1,0 +1,75 @@
+﻿using NPoco;
+using System;
+using System.Linq;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_4_0
+{
+    public class AddForeignKeyIndexes : MigrationBase
+    {
+        public AddForeignKeyIndexes(IMigrationContext context)
+            : base(context)
+        { }
+
+        public override void Migrate()
+        {
+            var newIndexes = new[]
+            {
+                (typeof(DictionaryDto), nameof(DictionaryDto.Parent)),
+                (typeof(LanguageTextDto), nameof(LanguageTextDto.LanguageId)),
+                (typeof(LanguageTextDto), nameof(LanguageTextDto.UniqueId)),
+                (typeof(Member2MemberGroupDto), nameof(Member2MemberGroupDto.MemberGroup)),
+                (typeof(PropertyTypeDto), nameof(PropertyTypeDto.DataTypeId)),
+                (typeof(PropertyTypeDto), nameof(PropertyTypeDto.ContentTypeId)),
+                (typeof(PropertyTypeDto), nameof(PropertyTypeDto.PropertyTypeGroupId)),
+                (typeof(PropertyTypeGroupDto), nameof(PropertyTypeGroupDto.ContentTypeNodeId)),
+                (typeof(TagRelationshipDto), nameof(TagRelationshipDto.TagId)),
+                (typeof(TagRelationshipDto), nameof(TagRelationshipDto.PropertyTypeId)),
+                (typeof(AccessRuleDto), nameof(AccessRuleDto.AccessId)),
+                (typeof(ContentDto), nameof(ContentDto.ContentTypeId)),
+                (typeof(ContentScheduleDto), nameof(ContentScheduleDto.NodeId)),
+                (typeof(ContentVersionDto), nameof(ContentVersionDto.NodeId)),
+                (typeof(ContentVersionDto), nameof(ContentVersionDto.UserId)),
+                (typeof(ContentVersionDto), nameof(ContentVersionDto.Current)),
+                (typeof(LogDto), nameof(LogDto.UserId)),
+                (typeof(LogDto), nameof(LogDto.Datestamp)),
+                (typeof(LogDto), nameof(LogDto.Header)),
+                (typeof(NodeDto), nameof(NodeDto.UserId)),
+                (typeof(RedirectUrlDto), nameof(RedirectUrlDto.ContentKey)),
+                (typeof(User2NodeNotifyDto), nameof(User2NodeNotifyDto.NodeId)),
+                (typeof(User2UserGroupDto), nameof(User2UserGroupDto.UserGroupId)),
+                (typeof(UserGroupDto), nameof(UserGroupDto.StartContentId)),
+                (typeof(UserGroupDto), nameof(UserGroupDto.StartMediaId)),
+                (typeof(UserLoginDto), nameof(UserLoginDto.UserId)),
+                (typeof(UserStartNodeDto), nameof(UserStartNodeDto.UserId)),
+                (typeof(UserStartNodeDto), nameof(UserStartNodeDto.StartNode))
+            };
+
+            foreach (var (type, propertyName) in newIndexes)
+            {
+                CreateIndexIfNotExists(type, propertyName);
+            }
+        }
+
+        private void CreateIndexIfNotExists(Type dto, string propertyName)
+        {
+            var property = dto.GetProperty(propertyName);
+            var indexName = property.GetCustomAttributes(false).OfType<IndexAttribute>().Single().Name;
+
+            if (IndexExists(indexName))
+                return;
+
+            var tableName = dto.GetField("TableName").GetValue(null) as string;
+            var columnName = property.GetCustomAttributes(false).OfType<ColumnAttribute>().Single().Name;
+
+            Create
+                .Index(indexName)
+                .OnTable(tableName)
+                .OnColumn(columnName)
+                .Ascending()
+                .WithOptions().NonClustered() // All newly defined indexes are non-clustered
+                .Do();
+        }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Dtos/AccessRuleDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/AccessRuleDto.cs
@@ -5,17 +5,20 @@ using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.AccessRule)]
+    [TableName(TableName)]
     [PrimaryKey("id", AutoIncrement = false)]
     [ExplicitColumns]
     internal class AccessRuleDto
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.AccessRule;
+
         [Column("id")]
         [PrimaryKeyColumn(Name = "PK_umbracoAccessRule", AutoIncrement = false)]
         public Guid Id { get; set; }
 
         [Column("accessId")]
         [ForeignKey(typeof(AccessDto), Name = "FK_umbracoAccessRule_umbracoAccess_id")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_AccessId")]
         public Guid AccessId { get; set; }
 
         [Column("ruleValue")]

--- a/src/Umbraco.Core/Persistence/Dtos/ContentDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ContentDto.cs
@@ -17,6 +17,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("contentTypeId")]
         [ForeignKey(typeof(ContentTypeDto), Column = "NodeId")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_ContentTypeId")]
         public int ContentTypeId { get; set; }
 
         [ResultColumn]

--- a/src/Umbraco.Core/Persistence/Dtos/ContentScheduleDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ContentScheduleDto.cs
@@ -17,6 +17,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("nodeId")]
         [ForeignKey(typeof(ContentDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_NodeId")]
         public int NodeId { get; set; }
 
         [Column("languageId")]

--- a/src/Umbraco.Core/Persistence/Dtos/ContentVersionDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ContentVersionDto.cs
@@ -19,6 +19,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("nodeId")]
         [ForeignKey(typeof(ContentDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_NodeId")]
         public int NodeId { get; set; }
 
         [Column("versionDate")] // TODO: db rename to 'updateDate'
@@ -28,10 +29,11 @@ namespace Umbraco.Core.Persistence.Dtos
         [Column("userId")] // TODO: db rename to 'updateUserId'
         [ForeignKey(typeof(UserDto))]
         [NullSetting(NullSetting = NullSettings.Null)]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_UserId")]
         public int? UserId { get => _userId == 0 ? null : _userId; set => _userId = value; } //return null if zero
 
-        // TODO: we need an index on this it is used almost always in querying and sorting
         [Column("current")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_Current")]
         public bool Current { get; set; }
 
         // about current:

--- a/src/Umbraco.Core/Persistence/Dtos/DictionaryDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/DictionaryDto.cs
@@ -5,11 +5,13 @@ using Umbraco.Core.Persistence.DatabaseAnnotations;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.DictionaryEntry)]
+    [TableName(TableName)]
     [PrimaryKey("pk")]
     [ExplicitColumns]
     internal class DictionaryDto
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.DictionaryEntry;
+
         [Column("pk")]
         [PrimaryKeyColumn]
         public int PrimaryKey { get; set; }
@@ -21,6 +23,7 @@ namespace Umbraco.Core.Persistence.Dtos
         [Column("parent")]
         [NullSetting(NullSetting = NullSettings.Null)]
         [ForeignKey(typeof(DictionaryDto), Column = "id")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_Parent")]
         public Guid? Parent { get; set; }
 
         [Column("key")]

--- a/src/Umbraco.Core/Persistence/Dtos/LanguageTextDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/LanguageTextDto.cs
@@ -4,21 +4,25 @@ using Umbraco.Core.Persistence.DatabaseAnnotations;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.DictionaryValue)]
+    [TableName(TableName)]
     [PrimaryKey("pk")]
     [ExplicitColumns]
     internal class LanguageTextDto
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.DictionaryValue;
+
         [Column("pk")]
         [PrimaryKeyColumn]
         public int PrimaryKey { get; set; }
 
         [Column("languageId")]
         [ForeignKey(typeof(LanguageDto), Column = "id")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_LanguageId")]
         public int LanguageId { get; set; }
 
         [Column("UniqueId")]
         [ForeignKey(typeof(DictionaryDto), Column = "id")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_UniqueId")]
         public Guid UniqueId { get; set; }
 
         [Column("value")]

--- a/src/Umbraco.Core/Persistence/Dtos/LogDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/LogDto.cs
@@ -21,6 +21,7 @@ namespace Umbraco.Core.Persistence.Dtos
         [Column("userId")]
         [ForeignKey(typeof(UserDto))]
         [NullSetting(NullSetting = NullSettings.Null)]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_UserId")]
         public int? UserId { get => _userId == 0 ? null : _userId; set => _userId = value; } //return null if zero
 
         [Column("NodeId")]
@@ -35,14 +36,14 @@ namespace Umbraco.Core.Persistence.Dtos
         [NullSetting(NullSetting = NullSettings.Null)]
         public string EntityType { get; set; }
 
-        // TODO: Should we have an index on this since we allow searching on it?
         [Column("Datestamp")]
         [Constraint(Default = SystemMethods.CurrentDateTime)]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_Datestamp")]
         public DateTime Datestamp { get; set; }
 
-        // TODO: Should we have an index on this since we allow searching on it?
         [Column("logHeader")]
         [Length(50)]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_LogHeader")]
         public string Header { get; set; }
 
         [Column("logComment")]

--- a/src/Umbraco.Core/Persistence/Dtos/Member2MemberGroupDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/Member2MemberGroupDto.cs
@@ -3,11 +3,13 @@ using Umbraco.Core.Persistence.DatabaseAnnotations;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.Member2MemberGroup)]
+    [TableName(TableName)]
     [PrimaryKey("Member", AutoIncrement = false)]
     [ExplicitColumns]
     internal class Member2MemberGroupDto
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.Member2MemberGroup;
+
         [Column("Member")]
         [PrimaryKeyColumn(AutoIncrement = false, Name = "PK_cmsMember2MemberGroup", OnColumns = "Member, MemberGroup")]
         [ForeignKey(typeof(MemberDto))]
@@ -15,6 +17,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("MemberGroup")]
         [ForeignKey(typeof(NodeDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_MemberGroup")]
         public int MemberGroup { get; set; }
     }
 }

--- a/src/Umbraco.Core/Persistence/Dtos/NodeDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/NodeDto.cs
@@ -48,6 +48,7 @@ namespace Umbraco.Core.Persistence.Dtos
         [Column("nodeUser")] // TODO: db rename to 'createUserId'
         [ForeignKey(typeof(UserDto))]
         [NullSetting(NullSetting = NullSettings.Null)]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_UserId")]
         public int? UserId { get => _userId == 0 ? null : _userId; set => _userId = value; } //return null if zero
 
         [Column("text")]

--- a/src/Umbraco.Core/Persistence/Dtos/PropertyTypeDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/PropertyTypeDto.cs
@@ -5,26 +5,31 @@ using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.PropertyType)]
+    [TableName(TableName)]
     [PrimaryKey("id")]
     [ExplicitColumns]
     internal class PropertyTypeDto
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.PropertyType;
+
         [Column("id")]
         [PrimaryKeyColumn(IdentitySeed = 50)]
         public int Id { get; set; }
 
         [Column("dataTypeId")]
         [ForeignKey(typeof(DataTypeDto), Column = "nodeId")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_DataTypeId")]
         public int DataTypeId { get; set; }
 
         [Column("contentTypeId")]
         [ForeignKey(typeof(ContentTypeDto), Column = "nodeId")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_ContentTypeId")]
         public int ContentTypeId { get; set; }
 
         [Column("propertyTypeGroupId")]
         [NullSetting(NullSetting = NullSettings.Null)]
         [ForeignKey(typeof(PropertyTypeGroupDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_PropertyTypeGroupId")]
         public int? PropertyTypeGroupId { get; set; }
 
         [Index(IndexTypes.NonClustered, Name = "IX_cmsPropertyTypeAlias")]

--- a/src/Umbraco.Core/Persistence/Dtos/PropertyTypeGroupDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/PropertyTypeGroupDto.cs
@@ -6,17 +6,20 @@ using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.PropertyTypeGroup)]
+    [TableName(TableName)]
     [PrimaryKey("id", AutoIncrement = true)]
     [ExplicitColumns]
     internal class PropertyTypeGroupDto
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.PropertyTypeGroup;
+
         [Column("id")]
         [PrimaryKeyColumn(IdentitySeed = 12)]
         public int Id { get; set; }
 
         [Column("contenttypeNodeId")]
         [ForeignKey(typeof(ContentTypeDto), Column = "nodeId")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_ContentTypeNodeId")]
         public int ContentTypeNodeId { get; set; }
 
         [Column("text")]

--- a/src/Umbraco.Core/Persistence/Dtos/RedirectUrlDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/RedirectUrlDto.cs
@@ -4,11 +4,13 @@ using Umbraco.Core.Persistence.DatabaseAnnotations;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.RedirectUrl)]
+    [TableName(TableName)]
     [PrimaryKey("id", AutoIncrement = false)]
     [ExplicitColumns]
     class RedirectUrlDto
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.RedirectUrl;
+
         public RedirectUrlDto()
         {
             CreateDateUtc = DateTime.UtcNow;
@@ -31,6 +33,7 @@ namespace Umbraco.Core.Persistence.Dtos
         [Column("contentKey")]
         [NullSetting(NullSetting = NullSettings.NotNull)]
         [ForeignKey(typeof(NodeDto), Column = "uniqueID")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_ContentKey")]
         public Guid ContentKey { get; set; }
 
         [Column("createDateUtc")]

--- a/src/Umbraco.Core/Persistence/Dtos/TagRelationshipDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/TagRelationshipDto.cs
@@ -17,10 +17,12 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("tagId")]
         [ForeignKey(typeof(TagDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_TagId")]
         public int TagId { get; set; }
 
         [Column("propertyTypeId")]
         [ForeignKey(typeof(PropertyTypeDto), Name = "FK_cmsTagRelationship_cmsPropertyType")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_PropertyTypeId")]
         public int PropertyTypeId { get; set; }
     }
 }

--- a/src/Umbraco.Core/Persistence/Dtos/User2NodeNotifyDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/User2NodeNotifyDto.cs
@@ -3,11 +3,13 @@ using Umbraco.Core.Persistence.DatabaseAnnotations;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.User2NodeNotify)]
+    [TableName(TableName)]
     [PrimaryKey("userId", AutoIncrement = false)]
     [ExplicitColumns]
     internal class User2NodeNotifyDto
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.User2NodeNotify;
+
         [Column("userId")]
         [PrimaryKeyColumn(AutoIncrement = false, Name = "PK_umbracoUser2NodeNotify", OnColumns = "userId, nodeId, action")]
         [ForeignKey(typeof(UserDto))]
@@ -15,6 +17,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("nodeId")]
         [ForeignKey(typeof(NodeDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_NodeId")]
         public int NodeId { get; set; }
 
         [Column("action")]

--- a/src/Umbraco.Core/Persistence/Dtos/User2UserGroupDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/User2UserGroupDto.cs
@@ -3,10 +3,12 @@ using Umbraco.Core.Persistence.DatabaseAnnotations;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.User2UserGroup)]
+    [TableName(TableName)]
     [ExplicitColumns]
     internal class User2UserGroupDto
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.User2UserGroup;
+
         [Column("userId")]
         [PrimaryKeyColumn(AutoIncrement = false, Name = "PK_user2userGroup", OnColumns = "userId, userGroupId")]
         [ForeignKey(typeof(UserDto))]
@@ -14,6 +16,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("userGroupId")]
         [ForeignKey(typeof(UserGroupDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_UserGroupId")]
         public int UserGroupId { get; set; }
     }
 }

--- a/src/Umbraco.Core/Persistence/Dtos/UserGroupDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/UserGroupDto.cs
@@ -6,11 +6,13 @@ using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.UserGroup)]
+    [TableName(TableName)]
     [PrimaryKey("id")]
     [ExplicitColumns]
     internal class UserGroupDto
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.UserGroup;
+
         public UserGroupDto()
         {
             UserGroup2AppDtos = new List<UserGroup2AppDto>();
@@ -52,11 +54,13 @@ namespace Umbraco.Core.Persistence.Dtos
         [Column("startContentId")]
         [NullSetting(NullSetting = NullSettings.Null)]
         [ForeignKey(typeof(NodeDto), Name = "FK_startContentId_umbracoNode_id")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_StartContentId")]
         public int? StartContentId { get; set; }
 
         [Column("startMediaId")]
         [NullSetting(NullSetting = NullSettings.Null)]
         [ForeignKey(typeof(NodeDto), Name = "FK_startMediaId_umbracoNode_id")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_StartMediaId")]
         public int? StartMediaId { get; set; }
 
         [ResultColumn]

--- a/src/Umbraco.Core/Persistence/Dtos/UserLoginDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/UserLoginDto.cs
@@ -17,6 +17,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("userId")]
         [ForeignKey(typeof(UserDto), Name = "FK_" + TableName + "_umbracoUser_id")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_UserId")]
         public int UserId { get; set; }
 
         /// <summary>

--- a/src/Umbraco.Core/Persistence/Dtos/UserStartNodeDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/UserStartNodeDto.cs
@@ -4,11 +4,13 @@ using Umbraco.Core.Persistence.DatabaseAnnotations;
 
 namespace Umbraco.Core.Persistence.Dtos
 {
-    [TableName(Constants.DatabaseSchema.Tables.UserStartNode)]
+    [TableName(TableName)]
     [PrimaryKey("id", AutoIncrement = true)]
     [ExplicitColumns]
     internal class UserStartNodeDto : IEquatable<UserStartNodeDto>
     {
+        public const string TableName = Constants.DatabaseSchema.Tables.UserStartNode;
+
         [Column("id")]
         [PrimaryKeyColumn(Name = "PK_userStartNode")]
         public int Id { get; set; }
@@ -16,11 +18,13 @@ namespace Umbraco.Core.Persistence.Dtos
         [Column("userId")]
         [NullSetting(NullSetting = NullSettings.NotNull)]
         [ForeignKey(typeof(UserDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_UserId")]
         public int UserId { get; set; }
 
         [Column("startNode")]
         [NullSetting(NullSetting = NullSettings.NotNull)]
         [ForeignKey(typeof(NodeDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_StartNode")]
         public int StartNode { get; set; }
 
         [Column("startNodeType")]

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -251,6 +251,7 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\RichTextPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\DropDownFlexiblePreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\MergeDateAndDateTimePropertyEditor.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_4_0\AddForeignKeyIndexes.cs" />
     <Compile Include="Models\ContentEditing\ContentAppBadge.cs" />
     <Compile Include="Models\ContentEditing\ContentAppBadgeType.cs" />
     <Compile Include="Models\Entities\EntityExtensions.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6601 

### Description

In this PR I have implemented the missing indexes as reported by @Shazwazza, using the very helpful list compiled by @liamlaverty. I have only implemented indexes for the columns that @liamlaverty noted as definitely needing an index. I also took the liberty of including new indexes of which there was a `TODO` comment, and including the `TableName` field when not present (so it can be used in index names and the reflection in index creation). This should improve performance of various queries around the application.

#### Steps to test:

- Perform migration
- Verify if the indexes were created succesfully

#### TODO

This is still a WIP PR because of the following reasons:

- Someone (from HQ?) should verify @liamlaverty's table in #6601, also checking if some of the 'maybe's actually do need an index as well.
- I have not tested the functionality myself, as I do not know how to test a migration.. Any help guiding me in this is much appreciated!
- Is my approach in creating the indexes this way correct, or should I just use the `CreateKeysAndIndexes` migration that is already there? I opted for this approach for safety, as I don't know exactly how rigorous the `CreateKeysAndIndexes` migration is in deletion of already existing (possibly added by the user) indexes.
- Related, what should be done if a user already created an index we are defining here? In particular, on the same column, but with a different name.