### PR TITLE
V8: Ensure media ALT text is saved in grid RTEs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -662,6 +662,9 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                         sizeImageInEditor(editor, imgDomElement, img.url);
                     }
 
+                    // make sure the RTE picks up on the changes (this seems particularly relevant for Grid RTEs)
+                    editor.fire("Change");
+
                 } else{
                     // We need to create a NEW DOM <img> element to insert
                     // setting an attribute of ID to __mcenew, so we can gather a reference to the node, to be able to update its size accordingly to the size of the image.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7119

### Description

This PR fixes #7119 by explicitly signaling a change to the RTE when a media is edited. When applied the image ALT text is persisted as you'd expect:

![grid-rte-alt-text](https://user-images.githubusercontent.com/7405322/68715318-03835180-05a2-11ea-9ca7-c3fdace21c2f.gif)

#### Testing notes

The media picker/editor component is used both in grid RTEs and regular RTEs. I have tested both with this PR and everything seems to work just fine... but it's probably worth giving both a test.