### PR TITLE
Allow replacing UmbracoPlan through DI

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -126,6 +126,7 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<RenameMediaVersionTable>("{5CB66059-45F4-48BA-BCBD-C5035D79206B}");
             To<VariantsMigration>("{FB0A5429-587E-4BD0-8A67-20F0E7E62FF7}");
             To<DropMigrationsTable>("{F0C42457-6A3B-4912-A7EA-F27ED85A2092}");
+            To<AddContentTypeIsElementColumn>("{0009109C-A0B8-4F3F-8FEB-C137BBDDA268}");
             To<DataTypeMigration>("{8640C9E4-A1C0-4C59-99BB-609B4E604981}");
             To<TagsMigration>("{DD1B99AF-8106-4E00-BAC7-A43003EA07F8}");
             To<SuperZero>("{9DF05B77-11D1-475C-A00A-B656AF7E0908}");
@@ -153,7 +154,6 @@ namespace Umbraco.Core.Migrations.Upgrade
             To<TablesForScheduledPublishing>("{7EB0254C-CB8B-4C75-B15B-D48C55B449EB}");
             To<MakeTagsVariant>("{C39BF2A7-1454-4047-BBFE-89E40F66ED63}");
             To<MakeRedirectUrlVariant>("{64EBCE53-E1F0-463A-B40B-E98EFCCA8AE2}");
-            To<AddContentTypeIsElementColumn>("{0009109C-A0B8-4F3F-8FEB-C137BBDDA268}");
             To<ConvertRelatedLinksToMultiUrlPicker>("{ED28B66A-E248-4D94-8CDB-9BDF574023F0}");
             To<UpdatePickerIntegerValuesToUdi>("{38C809D5-6C34-426B-9BEA-EFD39162595C}");
             To<RenameUmbracoDomainsTable>("{6017F044-8E70-4E10-B2A3-336949692ADD}");

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/DefaultPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/DataTypes/DefaultPreValueMigrator.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0.DataTypes
 {
-    class DefaultPreValueMigrator : IPreValueMigrator
+    public class DefaultPreValueMigrator : IPreValueMigrator
     {
         public virtual bool CanMigrate(string editorAlias)
             => true;

--- a/src/Umbraco.Core/Persistence/NPocoDatabaseTypeExtensions.cs
+++ b/src/Umbraco.Core/Persistence/NPocoDatabaseTypeExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Umbraco.Core.Persistence
 {
-    internal static class NPocoDatabaseTypeExtensions
+    public static class NPocoDatabaseTypeExtensions
     {
         public static bool IsSqlServer(this DatabaseType databaseType)
         {

--- a/src/Umbraco.Core/Runtime/CoreInitialComposer.cs
+++ b/src/Umbraco.Core/Runtime/CoreInitialComposer.cs
@@ -10,6 +10,7 @@ using Umbraco.Core.Manifest;
 using Umbraco.Core.Migrations;
 using Umbraco.Core.Migrations.Install;
 using Umbraco.Core.Migrations.PostMigrations;
+using Umbraco.Core.Migrations.Upgrade;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PackageActions;
 using Umbraco.Core.Persistence;
@@ -53,6 +54,8 @@ namespace Umbraco.Core.Runtime
             // register database builder
             // *not* a singleton, don't want to keep it around
             composition.Register<DatabaseBuilder>();
+
+            composition.RegisterUnique<UmbracoPlan>();
 
             // register manifest parser, will be injected in collection builders where needed
             composition.RegisterUnique<ManifestParser>();


### PR DESCRIPTION
Allows the standard database migration plan to be modified from outside Umbraco.Core, adding custom steps. Modifies `DatabaseUpgradeStep` to request an implementation of `UmbracoPlan` via DI, allowing another assembly to replace it with `composition.RegisterUnique<UmbracoPlan, ModifiedPlan>()` in a composer. 

UmbracoPlan is also used in other places, but only to read the FinalState. We check that the replacement plan has the same FinalState as the standard plan, so I've left these using the standard plan. Some would be inconvenient to change.

Also makes `NPocoDatabaseTypeExtensions` and `DefaultPreValueMigrator` public so that they can be used in custom migrations. These aren't essential, but I don't think there's any need for them to be internal.