### PR TITLE
v7: Fix false matches for AltTemplate convention Urls

### DIFF
--- a/src/Umbraco.Web/Routing/ContentFinderByNiceUrlAndTemplate.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByNiceUrlAndTemplate.cs
@@ -43,16 +43,23 @@ namespace Umbraco.Web.Routing
 
                     var route = docRequest.HasDomain ? (docRequest.Domain.RootNodeId.ToString() + path) : path;
                     node = FindContent(docRequest, route);
-
-                    if (node.IsAllowedTemplate(template.Id))
-                    {
-                        docRequest.TemplateModel = template;
+                    //not guaranteed to find a node - just because last portion of url contains a template alias, doesn't mean remaining part of the url is a published node
+                    if (node !=null){
+                        if (node.IsAllowedTemplate(template.Id))
+                        {
+                            docRequest.TemplateModel = template;
+                        }
+                        else
+                        {
+                            LogHelper.Warn<ContentFinderByNiceUrlAndTemplate>("Configuration settings prevent template \"{0}\" from showing for node \"{1}\"", () => templateAlias, () => node.Id);
+                            docRequest.PublishedContent = null;
+                            node = null;
+                        }
                     }
-                    else
+                    else 
                     {
-                        LogHelper.Warn<ContentFinderByNiceUrlAndTemplate>("Configuration settings prevent template \"{0}\" from showing for node \"{1}\"", () => templateAlias, () => node.Id);
-                        docRequest.PublishedContent = null;
-                        node = null;
+                     LogHelper.Debug<ContentFinderByNiceUrlAndTemplate>("Attempt to find content by alternative template alias: \"{0}\" triggered because end portion of url matched template alias, but no node exists for the url without the alt template alias at the route: \"{1}\"", () => templateAlias, () => route);
+                     docRequest.PublishedContent = null;
                     }
                 }
                 else

--- a/src/Umbraco.Web/Routing/ContentFinderByNiceUrlAndTemplate.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByNiceUrlAndTemplate.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Web.Routing
         /// <summary>
         /// Tries to find and assign an Umbraco document to a <c>PublishedContentRequest</c>.
         /// </summary>
-        /// <param name="docRequest">The <c>PublishedContentRequest</c>.</param>		
+        /// <param name="docRequest">The <c>PublishedContentRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
         /// <remarks>If successful, also assigns the template.</remarks>
         public override bool TryFindContent(PublishedContentRequest docRequest)
@@ -44,7 +44,8 @@ namespace Umbraco.Web.Routing
                     var route = docRequest.HasDomain ? (docRequest.Domain.RootNodeId.ToString() + path) : path;
                     node = FindContent(docRequest, route);
                     //not guaranteed to find a node - just because last portion of url contains a template alias, doesn't mean remaining part of the url is a published node
-                    if (node !=null){
+                    if (node !=null)
+                    {
                         if (node.IsAllowedTemplate(template.Id))
                         {
                             docRequest.TemplateModel = template;
@@ -56,10 +57,10 @@ namespace Umbraco.Web.Routing
                             node = null;
                         }
                     }
-                    else 
+                    else
                     {
-                     LogHelper.Debug<ContentFinderByNiceUrlAndTemplate>("Attempt to find content by alternative template alias: \"{0}\" triggered because end portion of url matched template alias, but no node exists for the url without the alt template alias at the route: \"{1}\"", () => templateAlias, () => route);
-                     docRequest.PublishedContent = null;
+                        LogHelper.Debug<ContentFinderByNiceUrlAndTemplate>("Attempt to find content by alternative template alias: \"{0}\" triggered because end portion of url matched template alias, but no node exists for the url without the alt template alias at the route: \"{1}\"", () => templateAlias, () => route);
+                        docRequest.PublishedContent = null;
                     }
                 }
                 else

--- a/src/Umbraco.Web/Routing/ContentFinderByNiceUrlAndTemplate.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByNiceUrlAndTemplate.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Web.Routing
                     var route = docRequest.HasDomain ? (docRequest.Domain.RootNodeId.ToString() + path) : path;
                     node = FindContent(docRequest, route);
                     //not guaranteed to find a node - just because last portion of url contains a template alias, doesn't mean remaining part of the url is a published node
-                    if (node !=null)
+                    if (node != null)
                     {
                         if (node.IsAllowedTemplate(template.Id))
                         {


### PR DESCRIPTION
See https://our.umbraco.com/forum/using-umbraco-and-getting-started/98220-help-with-error-message

It's possible to load a published node via an alternative template by requesting it in the format:

/about-us/our-staff/staffgridlayout

where '/about-us/our-staff/' is the node in Umbraco and 'staffgridlayout' is the alias of the alternative template you want Umbraco to load the content with.

This is implemented by the ContentFinderByNiceUrlAndTemplate Content Finder...

... this is kind of a hidden feature of Umbraco that's been there for years...

Anyway the way this is implemented assumes that if the 'last portion of a url' matches a template, then the request must be a valid request trying to make use of this convention so

/orangey/crows/staffgridlayout

would cause the Content Finder to try and load the '/orangey/crows/' node with the 'staffgridlayout' template...  but of the /orangey/crows/ node doesn't exist...

... there is no null check, and so the node.IsAllowedTemplate(template.Id) triggers an error, and the request doesn't fall through to a proper 404 page, (perhaps set later in the ContentFinder stack...)

This commit, adds the null check in.

Don't think this is an issue on V8, where the convention has also been removed by default.

### Prerequisites

- [|] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Testering

Install the starter kit
Create a new additional template for a BlogPostPage, call it 'SuperBlogPost'
Verify you can visit the blog post page url , with /SuperBlogPost appended to load the blog post in the alternative template.
Now visit another made up url with /SuperBlogPost appended eg
/orangey/crows/SuperBlogPost/
The page should 404 instead of YSOD
You should get an entry in the debug log (if logs are set to debug), explaining what just happened.


<!-- Thanks to you for considering this contribution to Umbraco CMS! even though it is for the unfashionable V7 version, that isn't really getting updates anymore and so this is a bit of a waste of time! -->
