### PR TITLE
Embed function in RTE removes previous content from RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -544,7 +544,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 },
                 embed.preview);
             
-            // Only replace if actieElement is an Embed element.
+            // Only replace if activeElement is an Embed element.
             if (activeElement && activeElement.nodeName.toUpperCase() === "DIV" && activeElement.classList.contains("embeditem")){
                 activeElement.replaceWith(wrapper); // directly replaces the html node
             } else {

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -543,11 +543,11 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                     'contenteditable': false
                 },
                 embed.preview);
-
-            if (activeElement) {
+            
+            // Only replace if actieElement is an Embed element.
+            if (activeElement && activeElement.nodeName.toUpperCase() === "DIV" && activeElement.classList.contains("embeditem")){
                 activeElement.replaceWith(wrapper); // directly replaces the html node
-            }
-            else {
+            } else {
                 editor.selection.setNode(wrapper);
             }
         },


### PR DESCRIPTION
Only replace content if the active element is of type EmbedItem.
If a selection has been we will still be replacing the selection.

Test notes:
One document type with a Rich Text Editor property.

test A:
— Write some text, keep the pointer after the last character (do not make a new line) and then add an EmbedItem. See that text is still present.

test B: 
— Add an image, and then add a EmbedItem, see that Image is still present.

test C:
— Add an embed item, and then add another embed item.

test D:
— Add an embed item, and then select it, for then to be able to edit the EmbedItem by clicking the Embed-button. See the EmbedItem begin replaced with the updated one when you save the EmbedEdit changes.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/7147

---
_This item has been added to our backlog [AB#3856](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/3856)_