### PR TITLE
Close unclosed key element in italian language file

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/it.xml
@@ -339,7 +339,7 @@
     <key alias="width">Larghezza</key>
     <key alias="yes">Si</key>
     <key alias="reorder">Riordina</key>
-    <key alias="reorderDone">Ho finito di ordinare/key>
+    <key alias="reorderDone">Ho finito di ordinare</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">Colore di sfondo</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: No issue has been created

### Description
The `Umbraco.Web.UI/Umbraco/Config/Lang/it.xml` file is broken at line 342, because a key element havnt been closed proper. This fixes it

<!-- Thanks for contributing to Umbraco CMS! -->
