### PR TITLE
V8: Fix JS error when editing content type in infinite mode

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -519,7 +519,8 @@
         }));
 
         evts.push(eventsService.on("editors.documentType.saved", function(name, args) {
-            if(args.documentType.allowedTemplates.length > 0){
+            // sync the templates tree if the content type has any templates assigned (unless we're in infinite mode)
+            if(args.documentType.allowedTemplates.length > 0 && !infiniteMode){
                 navigationService.syncTree({ tree: "templates", path: [], forceReload: true })
                     .then(function (syncArgs) {
                         navigationService.reloadNode(syncArgs.node)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/7181

### Description

See steps to reproduce in https://github.com/umbraco/Umbraco-CMS/issues/7181 - the error manifests like this:

![infinite-edit-content-type-js-error](https://user-images.githubusercontent.com/7405322/69171852-0380d580-0afd-11ea-9183-77c82d057a47.gif)

It happens because we attempt to reload the templates tree when the content type is saved, and of course this won't work very well in infinite editing. So this PR ensures that we do not attempt to reload the templates tree when in infinite editing mode.
