### PR TITLE
Fixes issue with IValueSetValidator filtering

### DIFF
--- a/src/Umbraco.Examine/Umbraco.Examine.csproj
+++ b/src/Umbraco.Examine/Umbraco.Examine.csproj
@@ -103,6 +103,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="ValueSetExtensions.cs" />
     <Compile Include="ValueSetValidator.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Umbraco.Examine/ValueSetExtensions.cs
+++ b/src/Umbraco.Examine/ValueSetExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Examine;
+using System.Collections.Generic;
+
+namespace Umbraco.Examine
+{
+    public static class ValueSetExtensions
+    {
+        public static ValueSet Clone(this ValueSet valueSet)
+        {
+            var values = new Dictionary<string, IEnumerable<object>>();
+            foreach (var keyVal in valueSet.Values)
+                values[keyVal.Key] = keyVal.Value;
+            return new ValueSet(valueSet.Id, valueSet.Category, valueSet.ItemType, values);
+        }
+    }
+
+}


### PR DESCRIPTION
The problem is that if a custom index is created or an existing index is customized to use a custom IValueSetValidator, if that IValueSetValidator filters the ValueSet (i.e. perhaps the validator supplies the parameter to only include certain fields), then the filtered ValueSet will be sent to the other indexes too instead of the unfiltered ValueSet.

The issue is that `IndexItems` was called for all indexes with the **same** instance of ValueSet for media and member indexes. This wasn't an issue with content data because new ValueSet's were created for each index. 

The fix is relatively easy, just create a new ValueSet for each index, however I've also included a performance optimization in the fix so instead of having to manually re-create the full value set which can include some parsing, and other logic, we just create the value set once and then clone it to the indexes since cloning is faster than rebuilding them.