### PR TITLE
V8: Do not submit the current content editor when editing a media picker item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -36,7 +36,7 @@
                 </umb-file-icon>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
-                    <button aria-label="Edit media" ng-if="allowEditMedia" class="umb-sortable-thumbnails__action btn-reset" data-element="action-edit" ng-click="vm.editItem(media)">
+                    <button type="button" aria-label="Edit media" ng-if="allowEditMedia" class="umb-sortable-thumbnails__action btn-reset" data-element="action-edit" ng-click="vm.editItem(media)">
                         <i class="icon icon-edit" aria-hidden="true"></i>
                     </button>
                     <button aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="vm.remove($index)">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7185

### Description

See #7185 for an issue description. To reproduce it you need a content type where the media picker is *not* in multipicker mode and is somewhat topmost in the list of property editors.

Here's a GIF of the issue in action:

![edit-media-item-before](https://user-images.githubusercontent.com/7405322/69216004-5f824300-0b6b-11ea-9f98-84ad29a7c3e4.gif)

It is a side effect of turning the buttons into actual <button> tags instead of <a> tags (in an effort to make the media picker more accessible, see #6805). Depending on your property editor order and configuration this means that the browser might see the link picker edit media button as the first <button> element in the form and thus treat it as a submit button.

This PR fixes it by applying an explicit type to the edit button (`type="button"`), thus explicitly instructing the browser how to interpret it. The `prevent-default` directive could also have been used here, but the proposed solution leverages the built-in browser functionality and I do think that's preferable.

Here's a GIF of the fix in action:

![edit-media-item-after](https://user-images.githubusercontent.com/7405322/69216175-cc95d880-0b6b-11ea-975f-0f1e17ed2b3f.gif)
