### PR TITLE
Make sure the configured url provider mode is used when getting a url

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1193,7 +1193,7 @@ namespace Umbraco.Web
         /// if any. In addition, when the content type is multi-lingual, this is the url for the
         /// specified culture. Otherwise, it is the invariant url.</para>
         /// </remarks>
-        public static string Url(this IPublishedContent content, string culture = null, UrlMode mode = UrlMode.Auto)
+        public static string Url(this IPublishedContent content, string culture = null, UrlMode mode = UrlMode.Default)
         {
             var umbracoContext = Composing.Current.UmbracoContext;
 
@@ -1201,6 +1201,12 @@ namespace Umbraco.Web
                 throw new InvalidOperationException("Cannot resolve a Url when Current.UmbracoContext is null.");
             if (umbracoContext.UrlProvider == null)
                 throw new InvalidOperationException("Cannot resolve a Url when Current.UmbracoContext.UrlProvider is null.");
+
+            // if it is the default mode, get the one that is configured
+            if (mode == UrlMode.Default)
+            {
+                mode = umbracoContext.UrlProvider.Mode;
+            }
 
             switch (content.ContentType.ItemType)
             {

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1202,12 +1202,6 @@ namespace Umbraco.Web
             if (umbracoContext.UrlProvider == null)
                 throw new InvalidOperationException("Cannot resolve a Url when Current.UmbracoContext.UrlProvider is null.");
 
-            // if it is the default mode, get the one that is configured
-            if (mode == UrlMode.Default)
-            {
-                mode = umbracoContext.UrlProvider.Mode;
-            }
-
             switch (content.ContentType.ItemType)
             {
                 case PublishedItemType.Content:


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

You can configure Umbraco to generate absolute urls out of the box by changing the web.Routing section umbracoSetttings.config file.  You can do this by settting `urlProviderMode="Absolute"`

So by setting this I would expect umbraco to generate absolute urls when I request the url through the url property of a IPublishedContent item.

However on 8.3.0 it still generates relative urls after setting this in the config. This is cased by the default value for mode being Auto on the Url method in PublishedContentExtensions. 

I changed the default value of the mode to UrlMode.Default. And when it is set it will get the mode configured on the url provider. This is backwards compatible because when there is no urlProvider mode configured in the web.Routing section it will default to Auto.

Can this be part of 8.3.1 ? This is blocking me now. I don't want to write a lot of custom code just to have absolute urls

Dave

