### PR TITLE
Introduced new "Element Type" option for the create document type dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
@@ -125,6 +125,13 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
         navigationService.hideMenu();
     };
 
+    $scope.createElementType = function () {
+        $location.search("create", null);
+        $location.search("iselement", null);
+        $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true").search("iselement", "true");
+        navigationService.hideMenu();
+    };
+
     $scope.close = function() {
         const showMenu = true;
         navigationService.hideDialog(showMenu);

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -32,6 +32,14 @@
                         </span>
                     </button>
                 </li>
+                <li data-element="action-elementType" class="umb-action">
+                    <button href="" ng-click="createElementType()" class="umb-action-link umb-outline btn-reset">
+                        <i class="large icon icon-item-arrangement"></i>
+                        <span class="menu-label">
+                            <localize key="content_elementType">Element Type</localize>
+                        </span>
+                    </button>
+                </li>
                 <li data-element="action-folder" ng-if="model.allowCreateFolder" class="umb-action">
                     <button href="" ng-click="showCreateFolder()" class="umb-action-link umb-outline btn-reset">
                         <i class="large icon icon-folder"></i>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -220,6 +220,7 @@
     <key alias="createDateDesc" version="7.0">Date/time this document was created</key>
     <key alias="documentType">Document Type</key>
     <key alias="editing">Editing</key>
+    <key alias="elementType">Element Type</key>
     <key alias="expireDate">Remove at</key>
     <key alias="itemChanged">This item has been changed after publication</key>
     <key alias="itemNotPublished">This item is not published</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -222,6 +222,7 @@
     <key alias="createDateDesc" version="7.0">Date/time this document was created</key>
     <key alias="documentType">Document Type</key>
     <key alias="editing">Editing</key>
+    <key alias="elementType">Element Type</key>
     <key alias="expireDate">Remove at</key>
     <key alias="itemChanged">This item has been changed after publication</key>
     <key alias="itemNotPublished">This item is not published</key>


### PR DESCRIPTION
When using Nested Content or similar and creating many element types, it would be useful with an **Element Type** option in the create dialog. So here is a PR for that.

![image](https://user-images.githubusercontent.com/3634580/69271361-f9caa100-0bd4-11ea-8652-03e8f370d380.png)
