### PR TITLE
AB3875 untouchability checker: do not check style for document fragments

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tabbable.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tabbable.service.js
@@ -184,7 +184,13 @@
               });
               if (cached) return cached[1];
 
-              nodeComputedStyle = nodeComputedStyle || this.doc.defaultView.getComputedStyle(node);
+              if (!nodeComputedStyle) {
+                if (node instanceof DocumentFragment) {
+                  return false;
+                } else {
+                  nodeComputedStyle = this.doc.defaultView.getComputedStyle(node);
+                }
+              }
 
               var result = false;
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/tabbable.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tabbable.service.js
@@ -186,7 +186,7 @@
 
               if (!nodeComputedStyle) {
                 if (node instanceof DocumentFragment) {
-                  return true;// though DocumentFragment dosnt directly have display 'none', we know that it will never be visible, and therefor we return true. (and do not cache this, cause it will change if appended to the DOM)
+                  return true;// though DocumentFragment doesn't directly have display 'none', we know that it will never be visible, and therefore we return true. (and do not cache this, cause it will change if appended to the DOM)
                 } else {
                   nodeComputedStyle = this.doc.defaultView.getComputedStyle(node);
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/services/tabbable.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tabbable.service.js
@@ -186,7 +186,7 @@
 
               if (!nodeComputedStyle) {
                 if (node instanceof DocumentFragment) {
-                  return false;
+                  return true;// though DocumentFragment dosnt directly have display 'none', we know that it will never be visible, and therefor we return true. (and do not cache this, cause it will change if appended to the DOM)
                 } else {
                   nodeComputedStyle = this.doc.defaultView.getComputedStyle(node);
                 }


### PR DESCRIPTION
Do not test style on DocumentFragment.

Test notes: Go to DocumentType Editor and see if error still appears in console.

Mark AB3875 as done when merged, thanks!