### PR TITLE
Implemented route hijacking via attributes

### DIFF
--- a/src/Umbraco.Web/Mvc/HijackRouteAttribute.cs
+++ b/src/Umbraco.Web/Mvc/HijackRouteAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Umbraco.Web.Mvc
+{
+    /// <summary>
+    /// Used to define a controller action as being
+    /// an entry point for a hijacked route
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HijackRouteAttribute : Attribute
+    {
+        public string ContentTypeAlias { get; set; }
+        public string TemplateAlias { get; set; }
+
+        public HijackRouteAttribute(string contentTypeAlias)
+        {
+            ContentTypeAlias = contentTypeAlias;
+            TemplateAlias = null;
+        }
+
+        public HijackRouteAttribute(string contentTypeAlias, string templateAlias)
+        {
+            ContentTypeAlias = contentTypeAlias;
+            TemplateAlias = templateAlias;
+        }
+    }
+
+}

--- a/src/Umbraco.Web/Mvc/RenderControllerFactory.cs
+++ b/src/Umbraco.Web/Mvc/RenderControllerFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Mvc;
+﻿using System.Collections.Generic;
+using System.Web.Mvc;
 using System.Web.Routing;
 
 namespace Umbraco.Web.Mvc
@@ -10,6 +11,10 @@ namespace Umbraco.Web.Mvc
     /// <remarks></remarks>
     public class RenderControllerFactory : UmbracoControllerFactory
     {
+        public RenderControllerFactory(IEnumerable<IRenderController> renderControllers)
+            : base(renderControllers)
+        { }
+
         /// <summary>
         /// Determines whether this instance can handle the specified request.
         /// </summary>

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Models\Mapping\MapperContextExtensions.cs" />
     <Compile Include="Models\PublishedContent\HybridVariationContextAccessor.cs" />
     <Compile Include="Models\TemplateQuery\QueryConditionExtensions.cs" />
+    <Compile Include="Mvc\HijackRouteAttribute.cs" />
     <Compile Include="Mvc\HttpUmbracoFormRouteStringException.cs" />
     <Compile Include="Mvc\ModelBindingExceptionFilter.cs" />
     <Compile Include="Mvc\SurfaceControllerTypeCollectionBuilder.cs" />


### PR DESCRIPTION
PR for issue #7219 adding route hijacking support using attributes.

I don't think my approach is that optimal, but I don't really fully understand all the moving parts so I just implemented it as best as I could. Please let me know if you know of any better approach.

To test, create a basic install using standard starter kit, then in `App_Code` folder create a `MyPeopleController` containing the following:

````csharp
using System;
using System.Web.Mvc;

namespace Demo
{
    public class MyPeopleController : Umbraco.Web.Mvc.RenderMvcController
    {
        [Umbraco.Web.Mvc.HijackRoute("People")]
        public ActionResult Index2(Umbraco.Web.Models.ContentModel model)
        {
            // Do some stuff here, the return the base Index method
            return View("People", model);
        }
    }
}
````

If everything works, navigating to `/people/` on the front end should hit your controller action (even though the controller name no longer matches the name convention).

---
_This item has been added to our backlog [AB#4649](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/4649)_