### PR TITLE
V8: Update the descriptions of the Nested Content configuration options

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class NestedContentConfiguration
     {
-        [ConfigurationField("contentTypes", "Document types", "views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html", Description = "Select the document types to use as the item blueprints. Only \"element\" types can be used.")]
+        [ConfigurationField("contentTypes", "Element types", "views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html", Description = "Select the element types to use as models for the items.")]
         public ContentType[] ContentTypes { get; set; }
 
         [ConfigurationField("minItems", "Min Items", "number", Description = "Set the minimum number of items allowed.")]
@@ -17,13 +17,13 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("maxItems", "Max Items", "number", Description = "Set the maximum number of items allowed.")]
         public int? MaxItems { get; set; }
 
-        [ConfigurationField("confirmDeletes", "Confirm Deletes", "boolean", Description = "Set whether item deletions should require confirming.")]
+        [ConfigurationField("confirmDeletes", "Confirm Deletes", "boolean", Description = "Set whether item deletions requires editor confirmation.")]
         public bool ConfirmDeletes { get; set; } = true;
 
-        [ConfigurationField("showIcons", "Show Icons", "boolean", Description = "Set whether to show the items doc type icon in the list.")]
+        [ConfigurationField("showIcons", "Show Icons", "boolean", Description = "Set whether to show the element type icons for the items.")]
         public bool ShowIcons { get; set; } = true;
 
-        [ConfigurationField("hideLabel", "Hide Label", "boolean", Description = "Set whether to hide the editor label and have the list take up the full width of the editor window.")]
+        [ConfigurationField("hideLabel", "Hide Label", "boolean", Description = "Set whether to hide the property label and let the item list span the full width of the editor window.")]
         public bool HideLabel { get; set; }
 
         public class ContentType

--- a/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
@@ -8,22 +8,22 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class NestedContentConfiguration
     {
-        [ConfigurationField("contentTypes", "Element types", "views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html", Description = "Select the element types to use as models for the items.")]
+        [ConfigurationField("contentTypes", "Element Types", "views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html", Description = "Select the Element Types to use as models for the items.")]
         public ContentType[] ContentTypes { get; set; }
 
-        [ConfigurationField("minItems", "Min Items", "number", Description = "Set the minimum number of items allowed.")]
+        [ConfigurationField("minItems", "Min Items", "number", Description = "Minimum number of items allowed.")]
         public int? MinItems { get; set; }
 
-        [ConfigurationField("maxItems", "Max Items", "number", Description = "Set the maximum number of items allowed.")]
+        [ConfigurationField("maxItems", "Max Items", "number", Description = "Maximum number of items allowed.")]
         public int? MaxItems { get; set; }
 
-        [ConfigurationField("confirmDeletes", "Confirm Deletes", "boolean", Description = "Set whether item deletions requires editor confirmation.")]
+        [ConfigurationField("confirmDeletes", "Confirm Deletes", "boolean", Description = "Requires editor confirmation for delete actions.")]
         public bool ConfirmDeletes { get; set; } = true;
 
-        [ConfigurationField("showIcons", "Show Icons", "boolean", Description = "Set whether to show the element type icons for the items.")]
+        [ConfigurationField("showIcons", "Show Icons", "boolean", Description = "Show the Element Type icons.")]
         public bool ShowIcons { get; set; } = true;
 
-        [ConfigurationField("hideLabel", "Hide Label", "boolean", Description = "Set whether to hide the property label and let the item list span the full width of the editor window.")]
+        [ConfigurationField("hideLabel", "Hide Label", "boolean", Description = "Hide the property label and let the item list span the full width of the editor window.")]
         public bool HideLabel { get; set; }
 
         public class ContentType


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7218

### Description

This PR updates the descriptions (and one label) of the Nested Content configuration options, hopefully making them a bit clearer (and all in present tense)

These are the configuration options as-is:

![image](https://user-images.githubusercontent.com/7405322/69610853-ee400580-102c-11ea-984c-8cab92e9bed7.png)

And here are the configuration options with this PR applied. I have marked the changed ones:

![image](https://user-images.githubusercontent.com/7405322/69610702-9c977b00-102c-11ea-9e44-c0623010e5ea.png)

