### PR TITLE
V8: Filter itempicker items explicitly by their names

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
@@ -11,7 +11,7 @@
                no-dirty-check />
     </div>
 
-    <div class="umb-overlay__section-header" ng-if="(model.pasteItems | filter:searchTerm).length > 0">
+    <div class="umb-overlay__section-header" ng-if="(model.pasteItems | filter:{name: searchTerm}).length > 0">
         <h5><localize key="content_createFromClipboard">Paste from clipboard</localize></h5>
         <button ng-if="model.clickClearPaste" ng-click="model.clickClearPaste($event)" alt="Clear clipboard for entries accepted in this context.">
             <i class="icon-trash"></i>
@@ -19,7 +19,7 @@
     </div>
 
     <ul class="umb-card-grid" ng-class="{'-three-in-row': model.availableItems.length < 7, '-four-in-row': model.availableItems.length >= 7}">
-        <li ng-repeat="pasteItem in model.pasteItems | filter:searchTerm"
+        <li ng-repeat="pasteItem in model.pasteItems | filter:{name: searchTerm}"
             ng-click="model.clickPasteItem(pasteItem)">
             <a class="umb-card-grid-item" href="" title="{{ pasteItem.name }}">
                 <span>
@@ -30,12 +30,12 @@
         </li>
     </ul>
 
-    <div class="umb-overlay__section-header" ng-if="model.pasteItems.length > 0 && (model.availableItems | filter:searchTerm).length > 0">
+    <div class="umb-overlay__section-header" ng-if="model.pasteItems.length > 0 && (model.availableItems | filter:{name: searchTerm}).length > 0">
         <h5><localize key="content_createEmpty">Create new</localize></h5>
     </div>
 
     <ul class="umb-card-grid" ng-class="{'-three-in-row': model.availableItems.length < 7, '-four-in-row': model.availableItems.length >= 7}">
-        <li ng-repeat="availableItem in model.availableItems | compareArrays:model.selectedItems:'alias' | orderBy:model.orderBy | filter:searchTerm"
+        <li ng-repeat="availableItem in model.availableItems | compareArrays:model.selectedItems:'alias' | orderBy:model.orderBy | filter:{name: searchTerm}"
             ng-click="selectItem(availableItem)">
             <a class="umb-card-grid-item" href="" title="{{ availableItem.name }}">
                 <span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The itempicker overlay filtering has a weird behavior: It always returns all items when filtering for "Icon":

![image](https://user-images.githubusercontent.com/7405322/69619068-467e0400-103b-11ea-936e-da25b8040f84.png)

It happens because all items have an icon property with a textual value that contains "icon".

This is particularly annoying if you have a lot of element types and you're trying to find the "Icon list". And if you have 12 or more element types available in a Nested Content configuration, the editors will also experience this, as the filtering option is enabled at 12+ element types when editing Nested Content.

This PR ensures that the filtering is done explicitly on the item names, thus fixing this issue:

![itempicker-filtering-after](https://user-images.githubusercontent.com/7405322/69619455-e176de00-103b-11ea-850b-e2e3fe390585.gif)
