### PR TITLE
V8: Display published state of mixed variance correctly in multi URL picker

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -79,7 +79,9 @@ namespace Umbraco.Web.PropertyEditors
                         if (entity is IDocumentEntitySlim documentEntity)
                         {
                             icon = documentEntity.ContentTypeIcon;
-                            published = culture == null ? documentEntity.Published : documentEntity.PublishedCultures.Contains(culture);
+                            published = culture == null || documentEntity.Variations.VariesByCulture() == false
+                                ? documentEntity.Published
+                                : documentEntity.PublishedCultures.Contains(culture);
                             udi = new GuidUdi(Constants.UdiEntityType.Document, documentEntity.Key);
                             url = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(entity.Key)?.Url() ?? "#";
                             trashed = documentEntity.Trashed;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If a multi URL picker on culture variant content contains culture *in*variant items, these always list as being in an unpublished state - despite them actually being published:

![image](https://user-images.githubusercontent.com/7405322/69754218-a8329100-1155-11ea-9e8e-d32aa70ba6bf.png)

This is due to a slightly wrong assumption in the property value editor. This PR fixes that assumption; once applied the published state is correct for invariant items as well:

![image](https://user-images.githubusercontent.com/7405322/69754293-db752000-1155-11ea-982d-bbac5f09f306.png)

#### Steps to test

1. Create culture variant content that contains a multi URL picker.
2. Pick published items of both culture variant and culture invariant types.
3. Save the content.
4. Reload the browser. Verify that the published states of the picked items are still listed correctly.
5. Pick some unpublished content as well, and verify that it still lists as being unpublished in the multi URL picker.