### PR TITLE
NC PropertyAction Delete-All, do not test length if value is null

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -565,7 +565,7 @@
 
         function updatePropertyActionStates() {
             copyAllEntriesAction.isDisabled = !model.value || model.value.length === 0;
-            removeAllEntriesAction.isDisabled = model.value.length === 0;
+            removeAllEntriesAction.isDisabled = !model.value || model.value.length === 0;
         }
 
 


### PR DESCRIPTION
Minor JS fix, to avoid console error.