### PR TITLE
 8.4RC: MediaIndexPopulator should use IUmbracoContentIndex instead of Umbrac…

### DIFF
--- a/src/Umbraco.Examine/MediaIndexPopulator.cs
+++ b/src/Umbraco.Examine/MediaIndexPopulator.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Examine
     /// <summary>
     /// Performs the data lookups required to rebuild a media index
     /// </summary>
-    public class MediaIndexPopulator : IndexPopulator<UmbracoContentIndex>
+    public class MediaIndexPopulator : IndexPopulator<IUmbracoContentIndex>
     {
         private readonly int? _parentId;
         private readonly IMediaService _mediaService;
@@ -69,6 +69,6 @@ namespace Umbraco.Examine
                 pageIndex++;
             } while (media.Length == pageSize);
         }
-        
+
     }
 }


### PR DESCRIPTION
Hi @Shazwazza ,
as I was doing changes in ContentPopulators I notice I didn't make a change for Media and fixing bug which will be introduced for custom examine providers as Media wouldn't be populated.
that issue is not affecting Umbraco with basic Examine.
Related PR:
https://github.com/umbraco/Umbraco-CMS/pull/6824

---
_This item has been added to our backlog [AB#4028](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/4028)_