### PR TITLE
V8: Do not save content when opening the content template

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -169,7 +169,7 @@
                                 ng-change="updateTemplate(node.template)">
                             <option value="">{{chooseLabel}}...</option>
                         </select>
-                        <button ng-show="allowChangeTemplate && node.template !== null" class="umb-node-preview__action" style="margin-left:15px;" ng-click="openTemplate()">
+                        <button type="button" ng-show="allowChangeTemplate && node.template !== null" class="umb-node-preview__action" style="margin-left:15px;" ng-click="openTemplate()">
                             <localize key="general_open">Open</localize>
                         </button>
                     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In an effort to make things more accessible, the link that used to open the current content template has been turned into a button (see #7094). As a result, the content editor now saves the current content when you open its template in infinite editing:

![edit-template-prompt-save-before](https://user-images.githubusercontent.com/7405322/69936653-ab70a880-14d8-11ea-9cc5-7be402be2027.gif)

If you're editing invariant content you probably won't even notice it being saved. That's not so good.

This issue is much along the lines of #7185, and the fix is the same: Applying an explicit type to the edit button (type="button"), thus explicitly instructing the browser how to interpret it.

Here's the same operation with this PR applied:

![edit-template-prompt-save-after](https://user-images.githubusercontent.com/7405322/69936730-f4286180-14d8-11ea-8ea8-70dd5e6b5c2b.gif)

