### PR TITLE
adding timeout for Chrome to render before making the correction

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautoresize.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautoresize.directive.js
@@ -138,7 +138,11 @@ angular.module("umbraco.directives")
             var unbindModelWatcher = scope.$watch(function() {
                return ngModelController.$modelValue;
             }, function(newValue) {
-               update(true);
+                $timeout(
+                    function() {
+                        update(true);
+                    }
+                );
             });
 
             scope.$on('$destroy', function() {


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/7247

Now you can see and edit the DocType Alias in Chrome.