### PR TITLE
maps isSensitiveData in groupsbuilder

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -554,6 +554,7 @@
               property.validation.patternMessage = propertyModel.validation.patternMessage;
               property.showOnMemberProfile = propertyModel.showOnMemberProfile;
               property.memberCanEdit = propertyModel.memberCanEdit;
+              property.isSensitiveData = propertyModel.isSensitiveData;
               property.isSensitiveValue = propertyModel.isSensitiveValue;
               property.allowCultureVariant = propertyModel.allowCultureVariant;
 


### PR DESCRIPTION
` property.isSensitiveData = propertyModel.isSensitiveData;` wasn't being set, which seems to have caused https://github.com/umbraco/Umbraco-CMS/issues/7270

### Prerequisites

https://github.com/umbraco/Umbraco-CMS/issues/7270

### Description
Allows for the saving of isSensitiveData value in a membertype editor.
