### PR TITLE
Checking nodeType on activeNode to ensure that nodes originate from same treeAlias

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -90,7 +90,9 @@ angular.module("umbraco.directives")
                     css.push("umb-tree-item--deleted");
                 }
 
-                if (actionNode) {
+                // checking the nodeType to ensure that this node and actionNode is from the same treeAlias
+                if (actionNode && actionNode.nodeType === node.nodeType) {
+
                     if (actionNode.id === node.id && String(node.id) !== "-1") {
                         css.push("active");
                     }


### PR DESCRIPTION
This fix ensures that the method 'getNodeCssClass' checks whether the given node and the activeNode have the same nodeType. aka. TreeAlias, that's at least what I could conclude. Quite some naming confusion.

This change only affects what nodes get the active class, so it should have a minor impact. But still important to test firmly if anything is broken by this change.