### PR TITLE
Basic setup for differentiating compile modes in gulp

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -313,10 +313,6 @@
     $this.CopyFiles("$src\Umbraco.Web.UI\umbraco\js", "*", "$tmp\WebApp\umbraco\js")
     $this.CopyFiles("$src\Umbraco.Web.UI\umbraco\lib", "*", "$tmp\WebApp\umbraco\lib")
     $this.CopyFiles("$src\Umbraco.Web.UI\umbraco\views", "*", "$tmp\WebApp\umbraco\views")
-
-    # copied too much - delete the LESS map directory
-    # that was copied over into "$tmp\WebApp\umbraco\assets\css\maps"
-    Remove-Item "$tmp\WebApp\umbraco\assets\css\maps" -Force -Recurse -ErrorAction SilentlyContinue
   })
 
   $ubuild.DefineMethod("PackageZip",

--- a/src/Umbraco.Web.UI.Client/gulp/config.js
+++ b/src/Umbraco.Web.UI.Client/gulp/config.js
@@ -1,6 +1,14 @@
 'use strict';
 
 module.exports = {
+    compile: {
+        build: {
+            sourcemaps: false
+        },
+        dev: {
+            sourcemaps: true
+        }
+    },
     sources: {
 
         // less files used by backoffice and preview

--- a/src/Umbraco.Web.UI.Client/gulp/modes.js
+++ b/src/Umbraco.Web.UI.Client/gulp/modes.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var config = require('./config');
+var gulp = require('gulp');
+
+function setDevelopmentMode(cb) {
+
+    config.compile.current = config.compile.dev;
+
+    return cb();
+};
+
+module.exports = { setDevelopmentMode: setDevelopmentMode };

--- a/src/Umbraco.Web.UI.Client/gulp/util/processLess.js
+++ b/src/Umbraco.Web.UI.Client/gulp/util/processLess.js
@@ -19,14 +19,22 @@ module.exports = function(files, out) {
 
     console.log("LESS: ", files, " -> ", config.root + config.targets.css + out)
 
-    var task = gulp.src(files)
-        .pipe(sourcemaps.init())
-        .pipe(less())
-        .pipe(cleanCss())
-        .pipe(postcss(processors))
-        .pipe(rename(out))
-        .pipe(sourcemaps.write('./maps'))
-        .pipe(gulp.dest(config.root + config.targets.css));
+    var task = gulp.src(files);
+
+    if(config.compile.current.sourcemaps === true) {
+        task = task.pipe(sourcemaps.init());
+    }
+
+    task = task.pipe(less());
+    task = task.pipe(cleanCss());
+    task = task.pipe(postcss(processors));
+    task = task.pipe(rename(out));
+
+    if(config.compile.current.sourcemaps === true) {
+        task = task.pipe(sourcemaps.write('./maps'));
+    }
+
+    task = task.pipe(gulp.dest(config.root + config.targets.css));
 
     return task;
 

--- a/src/Umbraco.Web.UI.Client/gulpfile.js
+++ b/src/Umbraco.Web.UI.Client/gulpfile.js
@@ -12,6 +12,8 @@
 
 const { src, dest, series, parallel, lastRun } = require('gulp');
 
+const config = require('./gulp/config');
+const { setDevelopmentMode } = require('./gulp/modes');
 const { dependencies } = require('./gulp/tasks/dependencies');
 const { js } = require('./gulp/tasks/js');
 const { less } = require('./gulp/tasks/less');
@@ -19,25 +21,14 @@ const { testE2e, testUnit } = require('./gulp/tasks/test');
 const { views } = require('./gulp/tasks/views');
 const { watchTask } = require('./gulp/tasks/watchTask');
 
-// Load local overwrites, can be used to overwrite paths in your local setup.
-var fs = require('fs');
-var onlyScripts = require('./gulp/util/scriptFilter');
-try {
-    if (fs.existsSync('./gulp/overwrites/')) {
-        var overwrites = fs.readdirSync('./gulp/overwrites/').filter(onlyScripts);
-        overwrites.forEach(function(overwrite) {
-            require('./gulp/overwrites/' + overwrite);
-        });
-    }
-} catch (err) {
-    console.error(err)
-  }
+// set default current compile mode:
+config.compile.current = config.compile.build;
 
 // ***********************************************************
 // These Exports are the new way of defining Tasks in Gulp 4.x
 // ***********************************************************
 exports.build = series(parallel(dependencies, js, less, views), testUnit);
-exports.dev = series(parallel(dependencies, js, less, views), watchTask);
+exports.dev = series(setDevelopmentMode, parallel(dependencies, js, less, views), watchTask);
 exports.watch = series(watchTask);
 // 
 exports.runTests = series(js, testUnit);


### PR DESCRIPTION
Only compile CSS sourcemaps when running dev mode.

---
_This item has been added to our backlog [AB#4085](https://umbraco.visualstudio.com/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/4085)_