### PR TITLE
Update noUiSlider to v14.1 for accessibility

### DIFF
--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -38,7 +38,7 @@
     "lazyload-js": "1.0.0",
     "moment": "2.22.2",
     "ng-file-upload": "12.2.13",
-    "nouislider": "14.1.0",
+    "nouislider": "14.1.1",
     "npm": "6.12.0",
     "signalr": "2.4.0",
     "spectrum-colorpicker": "1.8.0",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -38,7 +38,7 @@
     "lazyload-js": "1.0.0",
     "moment": "2.22.2",
     "ng-file-upload": "12.2.13",
-    "nouislider": "14.0.2",
+    "nouislider": "14.1.0",
     "npm": "6.12.0",
     "signalr": "2.4.0",
     "spectrum-colorpicker": "1.8.0",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Just a minor update noUiSlider to v14.1.1 for accessibility to support keys Home/End and Page Up/Down. https://github.com/leongersen/noUiSlider/releases

This is e.g. useful in image cropper slider with many steps and only using keyboard. It also seems Page Up/Down move the handle a bit more than e.g. Left/Right arrow keys in image cropper slider.

Maybe we can also specify step size when using keyboard Left/Right arrow keys in a future version https://github.com/leongersen/noUiSlider/issues/992 but for now this seems to be a great improvement.