### PR TITLE
Use input-id on toggle in profiler dashboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/profiler.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/profiler.html
@@ -27,7 +27,7 @@
                 </div>
                 <div class="mb4">
                     <div class="flex items-center">
-                        <umb-toggle checked="vm.alwaysOn" id="profilerAlwaysOn" on-click="vm.toggle()"></umb-toggle>
+                        <umb-toggle checked="vm.alwaysOn" input-id="profilerAlwaysOn" on-click="vm.toggle()"></umb-toggle>
                         <label for="profilerAlwaysOn" class="mb0 ml2">
                             <localize key="profiling_activateByDefault">Activate the profiler by default</localize>
                         </label>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
It seems the label next to toggle didn't changed the toggle anymore. It is because the rendered id on the button was `id="profilerAlwaysOn "` (with a whitespace last) instead of `id="profilerAlwaysOn"`.

I guess the `id` attribute on the toggle in some way conflicted with the internal `id` attribute on the `button` element inside `umb-toggle`.

Instead it now use `input-id="profilerAlwaysOn"`.

The `input-id` property has been added in this PR https://github.com/umbraco/Umbraco-CMS/pull/6512