### PR TITLE
Add code snippet component

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/code.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/code.less
@@ -9,14 +9,13 @@ pre.code {
   padding: 0 3px 2px;
   #font > #family > .monospace;
   font-size: @baseFontSize - 2;
-  color: @grayDark;
+  color: @blueExtraDark;
   .border-radius(3px);
 }
 
 // Inline code
 code {
   padding: 2px 4px;
-  color: #d14;
   background-color: #f7f7f9;
   border: 1px solid #e1e1e8;
   white-space: nowrap;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcodesnippet.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcodesnippet.directive.js
@@ -1,0 +1,100 @@
+﻿/**
+@ngdoc directive
+@name umbraco.directives.directive:umbCodeSnippet
+@restrict E
+@scope
+
+@description
+
+<h3>Markup example</h3>
+<pre>
+	<div ng-controller="My.Controller as vm">
+
+        <umb-code-snippet 
+            language="charp">
+            {{code}}
+        </umb-code-snippet>
+
+	</div>
+</pre>
+
+<h3>Controller example</h3>
+<pre>
+	(function () {
+		"use strict";
+
+		function Controller() {
+
+            var vm = this;
+
+        }
+
+		angular.module("umbraco").controller("My.Controller", Controller);
+
+	})();
+</pre>
+
+@param {object} language (<code>binding</code>): Language of the code snippet.
+**/
+
+
+(function () {
+    'use strict';
+
+    var umbCodeSnippet = {
+        templateUrl: 'views/components/umb-code-snippet.html',
+        controller: UmbCodeSnippetController,
+        controllerAs: 'vm',
+        //replace: true,
+        transclude: true,
+        bindings: {
+            language: '<'
+        }
+    };
+
+    function UmbCodeSnippetController($timeout) {
+
+        const vm = this;
+
+        vm.page = {};
+
+        vm.$onInit = onInit;
+        vm.copySuccess = copySuccess;
+        vm.copyError = copyError;
+
+        function onInit() {
+            vm.guid = String.CreateGuid();
+        }
+
+        // copy to clip board success
+        function copySuccess() {
+            if (vm.page.copyCodeButtonState !== "success") {
+                $timeout(function () {
+                    vm.page.copyCodeButtonState = "success";
+                });
+                $timeout(function () {
+                    resetClipboardButtonState();
+                }, 1000);
+            }
+        }
+
+        // copy to clip board error
+        function copyError() {
+            if (vm.page.copyCodeButtonState !== "error") {
+                $timeout(function () {
+                    vm.page.copyCodeButtonState = "error";
+                });
+                $timeout(function () {
+                    resetClipboardButtonState();
+                }, 1000);
+            }
+        }
+
+        function resetClipboardButtonState() {
+            vm.page.copyCodeButtonState = "init";
+        }
+    }
+
+    angular.module('umbraco.directives').component('umbCodeSnippet', umbCodeSnippet);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcodesnippet.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcodesnippet.directive.js
@@ -11,7 +11,7 @@
 	<div ng-controller="My.Controller as vm">
 
         <umb-code-snippet 
-            language="charp">
+            language="'csharp'">
             {{code}}
         </umb-code-snippet>
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcodesnippet.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcodesnippet.directive.js
@@ -64,6 +64,26 @@
 
         function onInit() {
             vm.guid = String.CreateGuid();
+
+            if (vm.language)
+            {
+                switch (vm.language.toLowerCase()) {
+                    case "csharp":
+                    case "c#":
+                        vm.language = "C#";
+                        break;
+                    case "html":
+                        vm.language = "HTML";
+                        break;
+                    case "css":
+                        vm.language = "CSS";
+                        break;
+                    case "javascript":
+                        vm.language = "JavaScript";
+                        break;
+                }
+            }
+            
         }
 
         // copy to clip board success

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcodesnippet.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcodesnippet.directive.js
@@ -34,7 +34,7 @@
 	})();
 </pre>
 
-@param {object} language (<code>binding</code>): Language of the code snippet.
+@param {string=} language Language of the code snippet, e.g csharp, html, css.
 **/
 
 
@@ -45,7 +45,6 @@
         templateUrl: 'views/components/umb-code-snippet.html',
         controller: UmbCodeSnippetController,
         controllerAs: 'vm',
-        //replace: true,
         transclude: true,
         bindings: {
             language: '<'

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -140,6 +140,7 @@
 @import "components/umb-empty-state.less";
 @import "components/umb-property-editor.less";
 @import "components/umb-property-actions.less";
+@import "components/umb-code-snippet.less";
 @import "components/umb-color-swatches.less";
 @import "components/check-circle.less";
 @import "components/umb-file-icon.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
@@ -1,11 +1,11 @@
 ﻿.umb-code-snippet {
     .umb-code-snippet__header {
         box-sizing: content-box;
-        background-color: #f2f2f2;
+        background-color: @gray-10;
         display: flex;
         flex-direction: row;
         font-size: .8rem;
-        border: 1px solid #e3e3e3;
+        border: 1px solid @gray-8;
         border-bottom: 0;
         margin-top: 16px;
         min-height: 30px;
@@ -21,7 +21,7 @@
         button {
             background-color: transparent;
             border: none;
-            border-left: 1px solid #bbb;
+            border-left: 1px solid @gray-8;
             border-radius: 0;
             color: #000;
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
@@ -11,13 +11,17 @@
         min-height: 30px;
 
         .language {
-            padding: 2px 16px;
+            display: flex;
+            align-items: center;
+            justify-content: flex-start;
             flex-grow: 1;
+            padding: 2px 16px;
         }
 
         button {
             background-color: transparent;
-            border: 1px solid #bbb;
+            border: none;
+            border-left: 1px solid #bbb;
             border-radius: 0;
             color: #000;
 
@@ -28,6 +32,7 @@
     }
 
     pre {
+        border-radius: 0;
         overflow: auto;
         white-space: nowrap;
     }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
@@ -1,0 +1,34 @@
+﻿.umb-code-snippet {
+    .umb-code-snippet__header {
+        box-sizing: content-box;
+        background-color: #f2f2f2;
+        display: flex;
+        flex-direction: row;
+        font-size: .8rem;
+        border: 1px solid #e3e3e3;
+        border-bottom: 0;
+        margin-top: 16px;
+        min-height: 30px;
+
+        .language {
+            padding: 2px 16px;
+            flex-grow: 1;
+        }
+
+        button {
+            background-color: transparent;
+            border: 1px solid #bbb;
+            border-radius: 0;
+            color: #000;
+
+            &:hover {
+                background-color: @grayLighter;
+            }
+        }
+    }
+
+    pre {
+        overflow: auto;
+        white-space: nowrap;
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
@@ -31,9 +31,11 @@
         }
     }
 
-    pre {
-        border-radius: 0;
-        overflow: auto;
-        white-space: nowrap;
+    .umb-code-snippet__content {
+        pre {
+            border-radius: 0;
+            overflow: auto;
+            white-space: nowrap;
+        }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
@@ -15,7 +15,7 @@
             align-items: center;
             justify-content: flex-start;
             flex-grow: 1;
-            padding: 2px 16px;
+            padding: 2px 10px;
         }
 
         button {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
@@ -1,4 +1,5 @@
 ﻿.umb-code-snippet {
+
     .umb-code-snippet__header {
         box-sizing: content-box;
         background-color: @gray-10;
@@ -6,6 +7,7 @@
         flex-direction: row;
         font-size: .8rem;
         border: 1px solid @gray-8;
+        border-radius: 3px 3px 0 0;
         border-bottom: 0;
         margin-top: 16px;
         min-height: 30px;
@@ -33,7 +35,7 @@
 
     .umb-code-snippet__content {
         pre {
-            border-radius: 0;
+            border-radius: 0 0 3px 3px;
             overflow: auto;
             white-space: nowrap;
         }

--- a/src/Umbraco.Web.UI.Client/src/less/hacks.less
+++ b/src/Umbraco.Web.UI.Client/src/less/hacks.less
@@ -185,40 +185,38 @@ iframe, .content-column-body {
 
 // Inline code
 // 1: Revert border radius to match look and feel of 7.4+
-code{
-  .border-radius(@baseBorderRadius); // 1
+code {
+    .border-radius(@baseBorderRadius); // 1
 }
 
 // Blocks of code
 // 1: Wrapping code is unreadable on small devices.
 pre {
-  display: block;
-  padding: (@baseLineHeight - 1) / 2;
-  margin: 0 0 @baseLineHeight / 2;
-  font-family: @sansFontFamily;
-  //font-size: @baseFontSize - 1; // 14px to 13px
-  color: @gray-2;
-  line-height: @baseLineHeight;
-  white-space: pre-wrap; // 1
-  overflow-x: auto; // 1
-  background-color: @gray-10;
-  border: 1px solid @gray-8;
-  .border-radius(@baseBorderRadius);
+    display: block;
+    padding: (@baseLineHeight - 1) / 2;
+    margin: 0 0 @baseLineHeight / 2;
+    font-family: @sansFontFamily;
+    color: @gray-2;
+    line-height: @baseLineHeight;
+    white-space: pre-wrap; // 1
+    overflow-x: auto; // 1
+    background-color: @brownGrayLight;
+    border: 1px solid @gray-8;
+    .border-radius(@baseBorderRadius);
 
+    // Make prettyprint styles more spaced out for readability
+    &.prettyprint {
+        margin-bottom: @baseLineHeight;
+    }
 
-  // Make prettyprint styles more spaced out for readability
-  &.prettyprint {
-    margin-bottom: @baseLineHeight;
-  }
-
-  // Account for some code outputs that place code tags in pre tags
-  code {
-    padding: 0;
-    white-space: pre; // 1 
-    word-wrap: normal; // 1
-    background-color: transparent;
-    border: 0;
-  }
+    // Account for some code outputs that place code tags in pre tags
+    code {
+        padding: 0;
+        white-space: pre; // 1
+        word-wrap: normal; // 1
+        background-color: transparent;
+        border: 0;
+    }
 }
 
 /* Styling for content/media sort order dialog */

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.controller.js
@@ -31,7 +31,6 @@
         vm.datePickerChange = datePickerChange;
         vm.submit = submit;
         vm.close = close;
-        vm.copyQuery = copyQuery;
 
         function onInit() {
 
@@ -119,11 +118,6 @@
 
         function addFilter(query) {
             query.filters.push({});
-        }
-
-        function copyQuery() {
-            var copyText = $scope.model.result.queryExpression;
-            navigator.clipboard.writeText(copyText);
         }
 
         function trashFilter(query, filter) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
@@ -163,7 +163,7 @@
                             </li>
                         </ul>
 
-                        <umb-code-snippet language="csharp">{{model.result.queryExpression}}</umb-code-snippet>
+                        <umb-code-snippet language="'csharp'">{{model.result.queryExpression}}</umb-code-snippet>
 
                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
@@ -113,11 +113,11 @@
                                 </span>
 
                                 <a href ng-click="vm.addFilter(vm.query)">
-                                    <i class="icon-add"></i>
+                                    <i class="icon-add" aria-hidden="true"></i>
                                 </a>
 
                                 <a href ng-click="vm.trashFilter(vm.query, filter)">
-                                    <i class="icon-trash"></i>
+                                    <i class="icon-trash" aria-hidden="true"></i>
                                 </a>
 
                             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
@@ -159,14 +159,11 @@
 
                         <ul class="nav unstyled">
                             <li ng-repeat="item in model.result.sampleResults">
-                                <i class="icon icon-document turquoise-d1"></i> {{item.name}}
+                                <i class="icon icon-document turquoise-d1" aria-hidden="true"></i> {{item.name}}
                             </li>
                         </ul>
 
-                        <pre>{{model.result.queryExpression}}</pre>
-                        <a href ng-click="vm.copyQuery()">
-                            <i class="icon-document"></i> <localize key="template_copyToClipboard">copy to clipboard</localize>
-                        </a>
+                        <umb-code-snippet language="csharp">{{model.result.queryExpression}}</umb-code-snippet>
 
                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
@@ -14,7 +14,9 @@
         </umb-button>
 
     </div>
-    <pre id="code-shippet-text_{{vm.guid}}">
-        <code ng-transclude></code>
-    </pre>
+    <div class="umb-code-snippet__content">
+        <pre id="code-shippet-text_{{vm.guid}}">
+            <code ng-transclude></code>
+        </pre>
+    </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
@@ -9,6 +9,7 @@
                     state="vm.page.copyCodeButtonState"
                     icon="icon-documents"
                     type="button"
+                    size="s"
                     label="Copy"
                     label-key="general_copy">
         </umb-button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
@@ -1,0 +1,20 @@
+﻿<div class="umb-code-snippet">
+    <div class="umb-code-snippet__header">
+        <span class="language">{{vm.language}}</span>
+
+        <umb-button umb-clipboard
+                    umb-clipboard-success="vm.copySuccess()"
+                    umb-clipboard-error="vm.copyError()"
+                    umb-clipboard-target="#code-shippet-text_{{vm.guid}}"
+                    state="vm.page.copyCodeButtonState"
+                    icon="icon-documents"
+                    type="button"
+                    label="Copy"
+                    label-key="general_copy">
+        </umb-button>
+
+    </div>
+    <pre id="code-shippet-text_{{vm.guid}}">
+        <code ng-transclude></code>
+    </pre>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
@@ -5,7 +5,7 @@
         <umb-button umb-clipboard
                     umb-clipboard-success="vm.copySuccess()"
                     umb-clipboard-error="vm.copyError()"
-                    umb-clipboard-target="#code-snippet-text_{{vm.guid}}"
+                    umb-clipboard-target="#umbCodeSnippet_{{vm.guid}}"
                     state="vm.page.copyCodeButtonState"
                     icon="icon-documents"
                     type="button"
@@ -15,7 +15,7 @@
 
     </div>
     <div class="umb-code-snippet__content">
-        <pre id="code-snippet-text_{{vm.guid}}">
+        <pre id="umbCodeSnippet_{{vm.guid}}">
             <code ng-transclude></code>
         </pre>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
@@ -1,6 +1,6 @@
 ﻿<div class="umb-code-snippet">
     <div class="umb-code-snippet__header">
-        <span class="language">{{vm.language}}</span>
+        <span class="language" ng-if="vm.language">{{vm.language}}</span>
 
         <umb-button umb-clipboard
                     umb-clipboard-success="vm.copySuccess()"

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-code-snippet.html
@@ -5,7 +5,7 @@
         <umb-button umb-clipboard
                     umb-clipboard-success="vm.copySuccess()"
                     umb-clipboard-error="vm.copyError()"
-                    umb-clipboard-target="#code-shippet-text_{{vm.guid}}"
+                    umb-clipboard-target="#code-snippet-text_{{vm.guid}}"
                     state="vm.page.copyCodeButtonState"
                     icon="icon-documents"
                     type="button"
@@ -15,7 +15,7 @@
 
     </div>
     <div class="umb-code-snippet__content">
-        <pre id="code-shippet-text_{{vm.guid}}">
+        <pre id="code-snippet-text_{{vm.guid}}">
             <code ng-transclude></code>
         </pre>
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

![2019-12-08_20-32-47](https://user-images.githubusercontent.com/2919859/70394925-071bc400-19fa-11ea-89bf-ce6e30d5220b.gif)

### Description
This PR add a `umb-code-snippet` component, which includes a copy button to copy the code and enhance this feature from this PR https://github.com/umbraco/Umbraco-CMS/pull/6584#issuecomment-549855172

I have been inspired by these code samples https://docs.microsoft.com/en-us/odata/webapi/netcore (which are using highlight.js)

The idea is that package developers also can re-use this component in e.g. the view after installation, in dashboard and in another part of backoffice UI in core.

At the moment this doesn't use third parthy plugins like [highlight.js](https://highlightjs.org/) or [Prism](https://prismjs.com/). https://github.com/umbraco/Umbraco-CMS/issues/7060

Prism is lightweight and it supported by default in TinyMCE, but doesn't out of the box support razor (cshtml/vbhtml)

Highlight.js seems to have some support for razor (cshtml - not sure about vbhtml) https://github.com/highlightjs/highlightjs-cshtml-razor

It could use one of these or maybe the Ace Editor in readonly mode (https://ace.c9.io/#nav=api&api=editor under setReadOnly) https://github.com/Microsoft/monaco-editor/issues/54

It is also possible in Monaco Editor to set readonly mode https://github.com/Microsoft/monaco-editor/issues/54 if Umbraco choose to switch editor https://github.com/umbraco/Umbraco-CMS/pull/6267

Some enhancements that can be added/improved later

- Syntax highlighting: Prism, Highlight.js, Ace Editor, Monaco Editor
- Choose to show/hide copy button or entire "header" (maybe this should be shown by default).