### PR TITLE
Revert unnecesary changes for the css class

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -117,7 +117,7 @@
 .umb-overlay.umb-overlay-center .umb-overlay-drawer {
     border: none;
     background: transparent;
-    padding: 0 20px 20px;
+    padding: 0 30px 20px;
 }
 
 /* ---------- OVERLAY TARGET ---------- */


### PR DESCRIPTION
This PR removes an unneccessary change to the css class that was introduced by the PR [6848](https://github.com/umbraco/Umbraco-CMS/pull/6848) . The changes had to be applied to `.umb-overlay.umb-overlay-center .umb-overlay-header` while in reality it has been applied to `.umb-overlay.umb-overlay-center .umb-overlay-drawer ` 