### PR TITLE
V8: Avoid UI "jumping" when sorting nested content items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -41,11 +41,8 @@
 }
 
 .umb-nested-content__item.ui-sortable-placeholder {
-    background: @gray-10;
-    border: 1px solid @gray-9;
+    margin-top: 1px;
     visibility: visible !important;
-    height: 55px;
-    margin-top: -1px;
 }
 
 .umb-nested-content__item--single > .umb-nested-content__content {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7288

### Description

The nested content property label "jumps" a bit when you sort items, specially if you move the topmost item downwards. See #7288 for an excellent issue description.

With this PR applied, the "jumping" stops:

![nc-sort-jumping-after](https://user-images.githubusercontent.com/7405322/70474744-70bbd100-1ad3-11ea-97ff-ba7c31d511df.gif)

For this to work I had to remove the background color of the "dragged item placeholder". But this is very much in line with the sorting going on in other property editors, e.g. the tree pickers:

![nc-sort-jumping-after-comparison](https://user-images.githubusercontent.com/7405322/70474890-ac569b00-1ad3-11ea-9620-1a0188665253.gif)
