### PR TITLE
Make Nested Content actually save the item content again

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.component.js
@@ -53,8 +53,8 @@
         });
 
         function setCurrentNode(node) {
-            vm.currentNode = node;
             updateModel();
+            vm.currentNode = node;
         }
         
         var copyAllEntries = function() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

After #7222, Nested Content no longer saves of the item content 😲 only when you copy and paste items is the content saved:

![nc-save-content-before](https://user-images.githubusercontent.com/7405322/70504156-6d513580-1b25-11ea-9c91-a39f8b11a346.gif)

Specifically the refactoring in 503fd188 seems to be the culprit. Basically what happens is the controller wipes its "current node" from state before attempting to sync back the item content into the very same "current node".

This PR fixes things up:

![nc-save-content-after](https://user-images.githubusercontent.com/7405322/70504274-b1443a80-1b25-11ea-8d6e-6e5b509d1971.gif)

When testing this PR, make sure that all Nested Content operations save back the item content to the correct item - in particular:

1. Create new items with and without collapsing previously edited items
2. Edit existing items with and without collapsing previously edited items
3. Reorder items without collapsing previously edited items
4. Delete items with and without collapsing previously edited items
5. Copy and paste items

