### PR TITLE
V8: Prevent the Nested Content item picker from crashing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -134,7 +134,7 @@
         };
 
         vm.openNodeTypePicker = function ($event) {
-            if (vm.nodes.length >= vm.maxItems) {
+            if (vm.overlayMenu || vm.nodes.length >= vm.maxItems) {
                 return;
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you're tabbing your way through content editing and you accidentally hit the Enter key twice when adding new items to Nested Content, the itempicker overlay crashes hard:

![nc-itempicker-double-enter-before](https://user-images.githubusercontent.com/7405322/70602872-a953cb80-1bf5-11ea-8b10-8dba0d1270b4.gif)

This is an unintended side effect of #6998 - the new `<button>` element for "Add content" retains focus whereas the previous `<a>` element did not. Thus the Nested Content controller attempts to open the overlay twice, which causes it to fail.

I have tried applying autofocus to the overlay as a solution, but `umb-auto-focus` doesn't really work in this case. So I have opted to let the Nested Content controller handle it instead by ensuring it doesn't open the overlay twice.