### PR TITLE
V7: Discard MiniProfiler results when not in debug mode

### DIFF
--- a/src/Umbraco.Web/Profiling/WebProfiler.cs
+++ b/src/Umbraco.Web/Profiling/WebProfiler.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Web;
 using StackExchange.Profiling;
 using StackExchange.Profiling.SqlFormatters;
+using StackExchange.Profiling.Storage;
 using Umbraco.Core;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Logging;
@@ -32,6 +33,7 @@ namespace Umbraco.Web.Profiling
             MiniProfiler.Settings.SqlFormatter = new SqlServerFormatter();
             MiniProfiler.Settings.StackMaxLength = 5000;
             MiniProfiler.Settings.ProfilerProvider = _provider;
+            MiniProfiler.Settings.Storage = new HttpRuntimeCacheStorage(TimeSpan.FromMinutes(30));
 
             //Binds to application events to enable the MiniProfiler with a real HttpRequest
             UmbracoApplicationBase.ApplicationInit += UmbracoApplicationApplicationInit;

--- a/src/Umbraco.Web/Profiling/WebProfiler.cs
+++ b/src/Umbraco.Web/Profiling/WebProfiler.cs
@@ -82,7 +82,7 @@ namespace Umbraco.Web.Profiling
             if (isBootRequest)
                 _provider.EndBootRequest();
             if (isBootRequest || ShouldProfile(sender))
-                Stop();
+                Stop(!GlobalSettings.DebugMode);
         }
 
         private bool ShouldProfile(object sender)

--- a/src/Umbraco.Web/Profiling/WebProfilerProvider.cs
+++ b/src/Umbraco.Web/Profiling/WebProfilerProvider.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Linq;
 using System.Threading;
 using System.Web;
-using System.Web.Routing;
 using StackExchange.Profiling;
-using Umbraco.Core.Configuration;
 
 namespace Umbraco.Web.Profiling
 {
@@ -27,20 +24,6 @@ namespace Umbraco.Web.Profiling
         {
             // booting...
             _bootPhase = BootPhase.Boot;
-
-            // Remove Mini Profiler routes when not in debug mode
-            if (GlobalSettings.DebugMode == false)
-            {
-                //NOTE: Keep the global fully qualified name, for some reason without it I was getting null refs
-                var prefix = global::StackExchange.Profiling.MiniProfiler.Settings.RouteBasePath.Replace("~/", string.Empty);
-
-                using (RouteTable.Routes.GetWriteLock())
-                {
-                    var routes = RouteTable.Routes.Where(x => x is Route r && r.Url.StartsWith(prefix)).ToList();
-                    foreach(var r in routes)
-                        RouteTable.Routes.Remove(r);
-                }
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR undos the fix (ugly hack IMHO) applied in https://github.com/umbraco/Umbraco-CMS/pull/6114 and correctly discards the MiniProfiler results when not in debug mode. This ensures the results aren't even stored, which seems the best thing to do (instead of removing the MVC routes to disable accessing them via the results URL).

Because of [this bug in MiniProfiler](https://github.com/MiniProfiler/dotnet/issues/96), the results URL would throw a `NullReferenceException` when nothing is stored and no storage is set. This PR also explicitly sets the storage to the default `HttpRuntimeCacheStorage`, but with a cache duration of 30 minutes (instead of 1 day). This should be enough time to view the profiling results and is actually the [default since MiniProfiler 4.1.0](https://github.com/MiniProfiler/dotnet/blob/6b3a42a65fed15b8f8b35804668fbc2ea429402b/src/MiniProfiler/MiniProfilerOptions.cs#L25-L26).

Steps to test this:
- Set `system.web/compilation@debug=true`, start the site and check the profiling results URL: you should see results
- Set `system.web/compilation@debug=false`, start the site and check whether the results URL returns a 404 status code and does not return any results

---
_This item has been added to our backlog [AB#4561](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/4561)_