### PR TITLE
V8: Make the Multi URL Picker sorting behave the same as MNTP

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -19,7 +19,10 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
     var currentForm = angularHelper.getCurrentForm($scope);
 
     $scope.sortableOptions = {
+        axis: "y",
+        containment: "parent",
         distance: 10,
+        opacity: 0.7,
         tolerance: "pointer",
         scroll: true,
         zIndex: 6000,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The Multi URL Picker sorting doesn't quite behave like sortable lists generally does in Umbraco (e.g. in MNTP):

![multi-url-sortable-before](https://user-images.githubusercontent.com/7405322/70606395-a5777780-1bfc-11ea-8a01-33ac1b6b6dcc.gif)

Most noticeable is probably how the Multi URL Picker sorting doesn't limit the item movement to the y axis only. But also the Multi URL Picker items behave differently among themselves (when the sort is triggered) and they're not slightly transparent as is the case with other sortables. 

So this PR basically just makes the Multi URL Picker sorting behave the same way as it does for MNTP:

![multi-url-sortable-after](https://user-images.githubusercontent.com/7405322/70606512-e96a7c80-1bfc-11ea-9090-424c80fa92ff.gif)
