### PR TITLE
Don't show actions menu if there are no actions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
@@ -1,4 +1,4 @@
-<div class="pull-right" style="position: relative;">
+<div class="pull-right" style="position: relative;" ng-if="actions && actions.length > 0">
 
     <umb-button
         type="button"


### PR DESCRIPTION
The umb-editor-menu directive is responsible for fetching menu items based on a current node, but if there are no menu items returned for that node an empty menu is displayed.

This PR prevents the menu from being rendered if there are no menu items to display in the menu.