### PR TITLE
Missing indexes on umbracoContentVersion and perf optimizations for content paging

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -185,6 +185,7 @@ namespace Umbraco.Core.Migrations.Upgrade
 
             // to 8.6.0
             To<AddPropertyTypeValidationMessageColumns>("{3D67D2C8-5E65-47D0-A9E1-DC2EE0779D6B}");
+            To<MissingContentVersionsIndexes>("{EE288A91-531B-4995-8179-1D62D9AA3E2E}");
 
             //FINAL
         }

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_6_0/AddPropertyTypeValidationMessageColumns.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_6_0/AddPropertyTypeValidationMessageColumns.cs
@@ -3,6 +3,7 @@ using Umbraco.Core.Persistence.Dtos;
 
 namespace Umbraco.Core.Migrations.Upgrade.V_8_6_0
 {
+
     public class AddPropertyTypeValidationMessageColumns : MigrationBase
     {
         public AddPropertyTypeValidationMessageColumns(IMigrationContext context)

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_6_0/MissingContentVersionsIndexes.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_6_0/MissingContentVersionsIndexes.cs
@@ -15,16 +15,11 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_6_0
                 .OnTable(ContentVersionDto.TableName)
                 .OnColumn("nodeId")
                 .Ascending()
-                .WithOptions().NonClustered()
-                .Do();
-
-            Create
-                .Index("IX_" + ContentVersionDto.TableName + "_Current")
-                .OnTable(ContentVersionDto.TableName)
                 .OnColumn("current")
                 .Ascending()
                 .WithOptions().NonClustered()
                 .Do();
+
         }
     }
 }

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_6_0/MissingContentVersionsIndexes.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_6_0/MissingContentVersionsIndexes.cs
@@ -1,0 +1,30 @@
+﻿using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_6_0
+{
+    public class MissingContentVersionsIndexes : MigrationBase
+    {
+        public MissingContentVersionsIndexes(IMigrationContext context) : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            Create
+                .Index("IX_" + ContentVersionDto.TableName + "_NodeId")
+                .OnTable(ContentVersionDto.TableName)
+                .OnColumn("nodeId")
+                .Ascending()
+                .WithOptions().NonClustered()
+                .Do();
+
+            Create
+                .Index("IX_" + ContentVersionDto.TableName + "_Current")
+                .OnTable(ContentVersionDto.TableName)
+                .OnColumn("current")
+                .Ascending()
+                .WithOptions().NonClustered()
+                .Do();
+        }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Dtos/ContentVersionDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ContentVersionDto.cs
@@ -19,6 +19,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("nodeId")]
         [ForeignKey(typeof(ContentDto))]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_NodeId")]
         public int NodeId { get; set; }
 
         [Column("versionDate")] // TODO: db rename to 'updateDate'
@@ -30,8 +31,8 @@ namespace Umbraco.Core.Persistence.Dtos
         [NullSetting(NullSetting = NullSettings.Null)]
         public int? UserId { get => _userId == 0 ? null : _userId; set => _userId = value; } //return null if zero
 
-        // TODO: we need an index on this it is used almost always in querying and sorting
         [Column("current")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_Current")]
         public bool Current { get; set; }
 
         // about current:

--- a/src/Umbraco.Core/Persistence/Dtos/ContentVersionDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ContentVersionDto.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("nodeId")]
         [ForeignKey(typeof(ContentDto))]
-        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_NodeId")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_NodeId", ForColumns = "nodeId,current")]
         public int NodeId { get; set; }
 
         [Column("versionDate")] // TODO: db rename to 'updateDate'
@@ -32,7 +32,6 @@ namespace Umbraco.Core.Persistence.Dtos
         public int? UserId { get => _userId == 0 ? null : _userId; set => _userId = value; } //return null if zero
 
         [Column("current")]
-        [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_Current")]
         public bool Current { get; set; }
 
         // about current:

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -128,6 +128,7 @@
     </Compile>
     -->
     <Compile Include="AssemblyExtensions.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_6_0\MissingContentVersionsIndexes.cs" />
     <Compile Include="SystemLock.cs" />
     <Compile Include="Attempt.cs" />
     <Compile Include="AttemptOfTResult.cs" />


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/7245

There is a missing in dex on the umbracoContentVersion table (nodeid, current) which is needed for the paging query (among many other things). We were also loading in too much data for content when paging or displaying in the list view so this optimizes that. Normally getting content loads the content, templates, variants, properties and publishing schedule but most of this is not required for list view or paging through content so now for that it just loads in the content and properties. 

## Testing

* Ensure the db migration works on startup
* Test out paging in content and ensure that you can still display a property value
* You can populate a ton of data in a list view:
  * Create a doc type that is a list view and a doc type for it's children called 'subPage' that has properties called 'content' (rte) and 'title' (text string)
  * Use the following surface controller to load in content and change the parentId variable to your parent
  * Then you can hit the endpoint: `/umbraco/surface/test/CreateData?count=1000` to create 1000 items, or adjust the number to your needs
  * Then make sure when you've got tons in there that paging is still all happy no matter what page you are on.

```cs
public class TestController : SurfaceController
{
    public ActionResult CreateData(int count)
    {
        var parentId = 23924;
        var docTypeAlias = "subPage";

        for (int i = 0; i < count; i++)
        {
            var content = Services.ContentService.Create(Guid.NewGuid().ToString(), parentId , docTypeAlias);
            content.SetValue("content", @"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sed varius augue, in tincidunt lorem. In non nisl at velit elementum consequat mollis non quam. Vestibulum sodales nisl ante, non sodales tortor eleifend sagittis. Nullam ornare malesuada tristique. Suspendisse pulvinar sollicitudin leo ut lacinia. Sed sem lorem, cursus quis pulvinar vitae, suscipit non justo. Curabitur commodo, orci aliquet consequat viverra, mi dolor eleifend risus, quis dictum odio nibh quis nulla. Cras luctus venenatis diam ut convallis. Nam libero lorem, cursus eu erat vitae, pharetra feugiat urna. Integer orci metus, finibus vitae posuere at, ultricies sed mi. Sed pellentesque neque sit amet mattis porta. Aenean egestas lectus non dui pharetra, a hendrerit urna commodo. Fusce quis semper est. Donec blandit dapibus eros, in sollicitudin massa.

Phasellus viverra libero vel enim suscipit viverra. Phasellus ut lacus vel dui interdum tempor. Aenean ipsum mauris, hendrerit quis nulla quis, sagittis vestibulum ligula. Duis molestie nunc metus, vel rhoncus lacus fermentum eget. Nunc tempus lacus quis sollicitudin facilisis. Vestibulum laoreet eu lorem et feugiat. Sed et feugiat diam, eu imperdiet massa. Cras eget arcu in ante pretium aliquam. Fusce mattis, ex nec ullamcorper tristique, augue est maximus mi, at porttitor arcu ligula vitae orci. Praesent faucibus urna nec massa pharetra scelerisque. Phasellus elementum, mi laoreet tincidunt pretium, magna enim blandit lorem, et luctus enim sapien vel risus. Maecenas eu volutpat turpis, nec dictum augue. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.

In dignissim ex eu quam tristique tempor. Cras ullamcorper et nisi id rhoncus. Mauris id est eros. Ut vehicula vitae justo non hendrerit. Vivamus dictum, metus et congue facilisis, sem neque dapibus odio, ut vulputate ligula est a nisi. Integer et commodo turpis. Praesent pellentesque lacinia augue eu ornare.

Ut pretium tincidunt condimentum. Ut et sem tincidunt, lacinia ipsum eget, pretium nisl. Fusce ut sapien ac urna hendrerit laoreet. Nulla ac condimentum magna, quis tincidunt nunc. Suspendisse laoreet vehicula est, ut aliquet ante luctus mattis. Fusce enim metus, convallis sit amet rutrum scelerisque, egestas ut eros. Praesent finibus lectus et posuere tincidunt. In vel egestas tortor. Ut accumsan bibendum risus, eget condimentum lorem. Donec ante libero, dictum venenatis ex sit amet, lobortis pellentesque mauris. Etiam a sem tortor. Donec aliquam, ex vitae vehicula mollis, neque odio commodo neque, vitae aliquet ex ante ut erat. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Maecenas fermentum mollis felis, vel molestie ante. Vivamus id justo facilisis, sollicitudin tortor vel, sagittis arcu.");

            content.SetValue("title", Guid.NewGuid().ToString());

            Services.ContentService.Save(content);
        }
        return Content("Done");
    }
}
```