### PR TITLE
Fixes #7317 issue with RegEx for media in ContentBaseFactory

### DIFF
--- a/src/Umbraco.Core/Persistence/Factories/ContentBaseFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/ContentBaseFactory.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Umbraco.Core.IO;
 using Umbraco.Core.Models;
 using Umbraco.Core.Persistence.Dtos;
 using Umbraco.Core.Persistence.Repositories;
@@ -10,7 +11,7 @@ namespace Umbraco.Core.Persistence.Factories
 {
     internal class ContentBaseFactory
     {
-        private static readonly Regex MediaPathPattern = new Regex(@"(/media/.+?)(?:['""]|$)", RegexOptions.Compiled);
+        private static readonly Regex MediaPathPattern = new Regex("(" + SystemDirectories.Media.TrimStart("~").EnsureEndsWith("/") + ".+?)(?:['\"]|$)", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Builds an IContent item from a dto and content type.

--- a/src/Umbraco.Core/Persistence/Factories/ContentBaseFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/ContentBaseFactory.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Core.Persistence.Factories
 {
     internal class ContentBaseFactory
     {
-        private static readonly Regex MediaPathPattern = new Regex("(" + SystemDirectories.Media.TrimStart("~").EnsureEndsWith("/") + ".+?)(?:['\"]|$)", RegexOptions.IgnoreCase);
+        private static readonly Regex MediaPathPattern = new Regex($"({SystemDirectories.Media.TrimStart("~").EnsureEndsWith(" / ")}.+?)(?:['\"]|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Builds an IContent item from a dto and content type.


### PR DESCRIPTION
Fixes: #7317

Description
Fixes an issue in ContentBaseFactory where the path to the media-folder was hardcoded to /media (lowercase), with this fix we respect the setting in web.config when looking for media-paths inside a property.

I've also made it IgnoreCase to support scenarios where one might have a mix of /Media and /media-paths in the database. This also means removing "Compiled" from the RegEx which probably have a extremely small impact, maybe even boosts performance depending on how many times media files are saved. (Read about regex compile here: https://rimdev.io/regex-performance-with-and-without-regexoptions-compiled-using-dotnet-framework-48-and-net-core-31-december-2019/).

Cheers!
