### PR TITLE
V8: Don't load languages in treepicker unless they're needed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -75,18 +75,20 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
          */
         function onInit () {
 
-            // load languages
-            languageResource.getAll().then(function (languages) {
-                vm.languages = languages;
+            if (vm.showLanguageSelector) {
+                // load languages
+                languageResource.getAll().then(function (languages) {
+                    vm.languages = languages;
 
-                // set the default language
-                vm.languages.forEach(function (language) {
-                    if (language.isDefault) {
-                        vm.selectedLanguage = language;
-                        vm.languageSelectorIsOpen = false;
-                    }
+                    // set the default language
+                    vm.languages.forEach(function (language) {
+                        if (language.isDefault) {
+                            vm.selectedLanguage = language;
+                            vm.languageSelectorIsOpen = false;
+                        }
+                    });
                 });
-            });
+            }
 
             if (vm.treeAlias === "content") {
                 vm.entityType = "Document";
@@ -211,7 +213,7 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
             if (vm.dataTypeKey) {
                 queryParams["dataTypeKey"] = vm.dataTypeKey;
             }
-                
+
             var queryString = $.param(queryParams); //create the query string from the params object
             
             if (!queryString) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7313

### Description

The problem described in #7313 basically happens because the treepicker loads all languages by default, in case it is configured to display an embedded language picker. 

If it isn't configured to do that (which is the default), those loaded languages are never used. So it seems really silly to load them, specially as they're now causing problems. 

This PR ensures that the languages are only loaded if they're required by the treepicker configuration. When applied, the MNTP starts behaving like you'd expect it to - both with and without start nodes configured:

![treepicker-load-languages](https://user-images.githubusercontent.com/7405322/70713672-cae0b000-1ce6-11ea-8a39-2cbf7fb4a6d5.gif)

*Note: In reality the problem described in #7313 is dependent on client rendering timing. Sometimes the languages are loaded before the treepicker fetches its nodes, sometimes after - and this determines if the nodes are fetched in the default language or the current editor language.*

### To clean up, or not to clean up?

That is the question!

I would really like to clean up the whole language selector feature of the treepicker. It isn't used anywhere anymore, it's a reminiscent of previously being able to toggle languages explicitly in the treepicker. 

However - cleaning it all up would be considered a breaking change on the clientside. 3rd party packages *could* in theory be using the feature.

But then again: If the feature isn't used by the core, it won't get regression tested and is bound to stop working at some point (as a matter of fact I don't even know if it works now).

I'll raise another issue where we can debate this.