### PR TITLE
V8: Wildcards in tree searches causes YSODs

### DIFF
--- a/src/Umbraco.Core/Persistence/Querying/ExpressionVisitorBase.cs
+++ b/src/Umbraco.Core/Persistence/Querying/ExpressionVisitorBase.cs
@@ -744,7 +744,9 @@ namespace Umbraco.Core.Persistence.Querying
 
             var c = exp[0];
             return (c == '"' || c == '`' || c == '\'') && exp[exp.Length - 1] == c
-                ? exp.Substring(1, exp.Length - 2)
+                ? exp.Length == 1
+                    ? string.Empty
+                    : exp.Substring(1, exp.Length - 2)
                 : exp;
         }
     }

--- a/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
+++ b/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
@@ -171,8 +171,8 @@ namespace Umbraco.Web.Search
 
             var allLangs = _languageService.GetAllLanguages().Select(x => x.IsoCode.ToLowerInvariant()).ToList();
 
-            // wildcards in the query will mess everything up so let's remove those
-            query = query.Replace("*", "");
+            // the chars [*-_] in the query will mess everything up so let's remove those
+            query = Regex.Replace(query, "[\\*\\-_]", "");
 
             //check if text is surrounded by single or double quotes, if so, then exact match
             var surroundedByQuotes = Regex.IsMatch(query, "^\".*?\"$")

--- a/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
+++ b/src/Umbraco.Web/Search/UmbracoTreeSearcher.cs
@@ -171,6 +171,9 @@ namespace Umbraco.Web.Search
 
             var allLangs = _languageService.GetAllLanguages().Select(x => x.IsoCode.ToLowerInvariant()).ToList();
 
+            // wildcards in the query will mess everything up so let's remove those
+            query = query.Replace("*", "");
+
             //check if text is surrounded by single or double quotes, if so, then exact match
             var surroundedByQuotes = Regex.IsMatch(query, "^\".*?\"$")
                                      || Regex.IsMatch(query, "^\'.*?\'$");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you try to use a `*` in any search field (global search, copy/move dialog search, treepicker search, ...), things tend to go horribly wrong:

![image](https://user-images.githubusercontent.com/7405322/70785919-be626300-1d8b-11ea-885d-e56a6763d8b3.png)

This PR explicitly removes the `*` character in the search queries to avoid that:

![image](https://user-images.githubusercontent.com/7405322/70785996-e356d600-1d8b-11ea-9784-71ddfc213c71.png)

This doesn't change the fact that the tree searcher still performs wildcard queries:

![image](https://user-images.githubusercontent.com/7405322/70786044-084b4900-1d8c-11ea-9726-c8e7be27eb71.png)
