### PR TITLE
V8: Don't append empty file names to search results

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
@@ -177,12 +177,9 @@ namespace Umbraco.Web.Models.Mapping
 
             target.Name = source.Values.ContainsKey("nodeName") ? source.Values["nodeName"] : "[no name]";
 
-            if (source.Values.TryGetValue(UmbracoExamineIndex.UmbracoFileFieldName, out var umbracoFile))
+            if (source.Values.TryGetValue(UmbracoExamineIndex.UmbracoFileFieldName, out var umbracoFile) && umbracoFile.IsNullOrWhiteSpace() == false)
             {
-                if (umbracoFile != null)
-                {
-                    target.Name = $"{target.Name} ({umbracoFile})";
-                }
+                target.Name = $"{target.Name} ({umbracoFile})";
             }
 
             if (source.Values.ContainsKey(UmbracoExamineIndex.NodeKeyFieldName))


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

With #6579 we started appending the actual file names of uploaded files in the search result. Unfortunately this wasn't tested with media folder search results:

![image](https://user-images.githubusercontent.com/7405322/70787531-2797a580-1d8f-11ea-80a1-9b4f325be9bc.png)

...so this PR ensures that we only append file names that aren't empty:

![image](https://user-images.githubusercontent.com/7405322/70787567-3bdba280-1d8f-11ea-8cf1-32ac66f7b3d0.png)
