### PR TITLE
V8: Display MNTP "Allow items of type" correctly when a start node is set

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.controller.js
@@ -19,15 +19,16 @@ angular.module('umbraco')
             };
         }
 
-		if($scope.model.value.id && $scope.model.value.type !== "member"){
-			entityResource.getById($scope.model.value.id, entityType()).then(function(item){
+        if($scope.model.value.id && $scope.model.value.type !== "member"){
+            entityResource.getById($scope.model.value.id, entityType()).then(function(item){
                 populate(item);
-			});
+            });
         }
-
-	    $timeout(function () {
-	        treeSourceChanged();
-	    }, 100);
+        else {
+            $timeout(function () {
+                treeSourceChanged();
+            }, 100);
+        }
 
         function entityType() {
 			var ent = "Document";

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.controller.js
@@ -7,7 +7,6 @@ function TreeSourceTypePickerController($scope, contentTypeResource, mediaTypeRe
 
     var allItemTypes = null;
     var currentItemType = null;
-    var initialLoad = true;
 
     function init() {
         vm.loading = true;
@@ -86,13 +85,12 @@ function TreeSourceTypePickerController($scope, contentTypeResource, mediaTypeRe
     }
 
     eventsService.on("treeSourceChanged", function (e, args) {
-        currentItemType = args.value;
         // reset the model value if we changed node type (but not on the initial load)
-        if (!initialLoad) {
+        if (!!currentItemType && currentItemType !== args.value) {
             vm.itemTypes = [];
             updateModel();
         }
-        initialLoad = false;
+        currentItemType = args.value;
         init();
     });
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7328

### Description

If you've set a start node for an MNTP config, the node types in "Allow items of type" aren't displayed correctly. Every so often you might see them flicker into view before they disappear, but most often they'll just appear to be removed:

![allow-items-of-type-before](https://user-images.githubusercontent.com/7405322/70976032-68ebc600-20ab-11ea-9b6f-e47f4b908a5b.gif)

It happens because the "Node type" configuration and the "Allow items of type" configuration are connected via events, so "Allow items of type" automatically resets when the "Node type" changes. Unfortunately this event is emitted twice when a start node is present, forcing an unfortunate reset for "Allow items of type".

This PR refactors the event handling somewhat so things start working again:

![allow-items-of-type-after](https://user-images.githubusercontent.com/7405322/70975923-304bec80-20ab-11ea-827c-37415e320141.gif)
