### PR TITLE
V8 Hide the Nested Content "add" button until the editor has loaded

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
@@ -1,6 +1,6 @@
 ﻿<div id="umb-nested-content--{{model.id}}" class="umb-nested-content" ng-class="{'umb-nested-content--narrow':!vm.wideMode, 'umb-nested-content--wide':vm.wideMode}">
 
-    <umb-load-indicator ng-if="!vm.inited"></umb-load-indicator>
+    <umb-load-indicator class="mt2" ng-if="!vm.inited"></umb-load-indicator>
 
     <ng-form name="nestedContentForm">
 
@@ -40,7 +40,7 @@
             </div>
         </div>
 
-        <div class="umb-nested-content__footer-bar" ng-hide="vm.hasContentTypes === false">
+        <div class="umb-nested-content__footer-bar" ng-hide="!vm.inited || vm.hasContentTypes === false">
             <button class="btn-reset umb-nested-content__add-content umb-focus" ng-class="{ '--disabled': (!vm.scaffolds.length || vm.nodes.length >= maxItems) }" ng-click="vm.openNodeTypePicker($event)" prevent-default>
                 <localize key="grid_addElement"></localize>
             </button>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Just noticed this on 8.4... the Nested Content "Add content" button is always displayed and active, even while the editor is loading (fetching element types). As a result the load indicator is displayed on top of the add button, which looks rather odd:

![nc-hide-add-until-loaded-before](https://user-images.githubusercontent.com/7405322/70992540-34d3cd80-20ca-11ea-8ed6-180206f9a450.gif)

This PR fixes it:

![nc-hide-add-until-loaded-after](https://user-images.githubusercontent.com/7405322/70992546-38ffeb00-20ca-11ea-9d61-279cac84f9a0.gif)
