### PR TITLE
fixes info notifications to appear in blue

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/notifications.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/notifications.service.js
@@ -148,7 +148,7 @@ angular.module('umbraco.services')
                     break;
                 case 1:
                     //info
-                    this.success(args.header, args.message);
+                    this.info(args.header, args.message);
                     break;
                 case 2:
                     //error

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -448,7 +448,7 @@
 @successBorder:           transparent;
 
 @infoText:                @white;
-@infoBackground:          @turquoise-d1;
+@infoBackground:          @blueDark;
 @infoBorder:              transparent;
 
 @alertBorderRadius:       0;

--- a/src/Umbraco.Web.UI.Client/test/unit/common/services/notifications.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/services/notifications.spec.js
@@ -14,17 +14,19 @@ describe('notification tests', function () {
         var not1 = notifications.success("success", "something great happened");
         var not2 = notifications.error("error", "something great happened");
         var not3 = notifications.warning("warning", "something great happened");
-        var not4 = notifications.warning("warning", "");
+          var not4 = notifications.warning("warning", "");
+          var not5 = notifications.info("info", "something informative happened");
 
-        expect(notifications.getCurrent().length).toBe(4);
+        expect(notifications.getCurrent().length).toBe(5);
 
         //remove at index 0
         notifications.remove(0);
 
-        expect(notifications.getCurrent().length).toEqual(3);
+        expect(notifications.getCurrent().length).toEqual(4);
         expect(notifications.getCurrent()[0].headline).toBe("error: ");
         expect(notifications.getCurrent()[1].headline).toBe("warning: ");
-        expect(notifications.getCurrent()[2].headline).toBe("warning");
+          expect(notifications.getCurrent()[2].headline).toBe("warning");
+          expect(notifications.getCurrent()[3].headline).toBe("info: ");
 
         notifications.removeAll();
         expect(notifications.getCurrent().length).toEqual(0);


### PR DESCRIPTION
https://github.com/umbraco/Umbraco-CMS/issues/7343

### Prerequisites

- Added a test to the .spec file

### Description
Update the notifications so that they appear in the standard umbraco info blue

![info-fix](https://user-images.githubusercontent.com/7046713/71014081-4bd5e800-20e9-11ea-8f91-1614c69747af.gif)

