### PR TITLE
Change the icon in the Document Types Tree to be the chosen icon instead of a default one.

### DIFF
--- a/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
@@ -69,15 +69,18 @@ namespace Umbraco.Web.Trees
                     .OrderBy(entity => entity.Name)
                     .Select(dt =>
                     {
+                        // get the content type here so we can get the icon from it to use when we create the tree node
+                        // and we can enrich the result with content type data that's not available in the entity service output
+                        var contentType = contentTypes[dt.Id];
+
                         // since 7.4+ child type creation is enabled by a config option. It defaults to on, but can be disabled if we decide to.
                         // need this check to keep supporting sites where children have already been created.
                         var hasChildren = dt.HasChildren;
-                        var node = CreateTreeNode(dt, Constants.ObjectTypes.DocumentType, id, queryStrings, Constants.Icons.ContentType, hasChildren);
+                        var node = CreateTreeNode(dt, Constants.ObjectTypes.DocumentType, id, queryStrings, contentType.Icon, hasChildren);
 
                         node.Path = dt.Path;
 
-                        // enrich the result with content type data that's not available in the entity service output
-                        var contentType = contentTypes[dt.Id];
+                        // now we can enrich the result with content type data that's not available in the entity service output
                         node.Alias = contentType.Alias;
                         node.AdditionalData["isElement"] = contentType.IsElement;
 

--- a/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTypeTreeController.cs
@@ -76,7 +76,7 @@ namespace Umbraco.Web.Trees
                         // since 7.4+ child type creation is enabled by a config option. It defaults to on, but can be disabled if we decide to.
                         // need this check to keep supporting sites where children have already been created.
                         var hasChildren = dt.HasChildren;
-                        var node = CreateTreeNode(dt, Constants.ObjectTypes.DocumentType, id, queryStrings, contentType.Icon, hasChildren);
+                        var node = CreateTreeNode(dt, Constants.ObjectTypes.DocumentType, id, queryStrings, contentType?.Icon ?? Constants.Icons.ContentType, hasChildren);
 
                         node.Path = dt.Path;
 

--- a/src/Umbraco.Web/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTypeTreeController.cs
@@ -25,10 +25,12 @@ namespace Umbraco.Web.Trees
     public class MediaTypeTreeController : TreeController, ISearchableTree
     {
         private readonly UmbracoTreeSearcher _treeSearcher;
+        private readonly IMediaTypeService _mediaTypeService;
 
-        public MediaTypeTreeController(UmbracoTreeSearcher treeSearcher, IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper) : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper)
+        public MediaTypeTreeController(UmbracoTreeSearcher treeSearcher, IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper, IMediaTypeService mediaTypeService) : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper)
         {
             _treeSearcher = treeSearcher;
+            _mediaTypeService = mediaTypeService;
         }
 
         protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
@@ -54,6 +56,8 @@ namespace Umbraco.Web.Trees
             // if the request is for folders only then just return
             if (queryStrings["foldersonly"].IsNullOrWhiteSpace() == false && queryStrings["foldersonly"] == "1") return nodes;
 
+            var mediaTypes = _mediaTypeService.GetAll();
+
             nodes.AddRange(
                 Services.EntityService.GetChildren(intId.Result, UmbracoObjectTypes.MediaType)
                     .OrderBy(entity => entity.Name)
@@ -62,7 +66,8 @@ namespace Umbraco.Web.Trees
                         // since 7.4+ child type creation is enabled by a config option. It defaults to on, but can be disabled if we decide to.
                         // need this check to keep supporting sites where children have already been created.
                         var hasChildren = dt.HasChildren;
-                        var node = CreateTreeNode(dt, Constants.ObjectTypes.MediaType, id, queryStrings, Constants.Icons.MediaType, hasChildren);
+                        var mt = mediaTypes.FirstOrDefault(x => x.Id == dt.Id);
+                        var node = CreateTreeNode(dt, Constants.ObjectTypes.MediaType, id, queryStrings,  mt?.Icon ?? Constants.Icons.MediaType, hasChildren);
 
                         node.Path = dt.Path;
                         return node;

--- a/src/Umbraco.Web/Trees/MemberTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/MemberTypeTreeController.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Web.Trees
         {
             return Services.MemberTypeService.GetAll()
                 .OrderBy(x => x.Name)
-                .Select(dt => CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings, dt.Icon, false));
+                .Select(dt => CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings, dt?.Icon ?? Constants.Icons.MemberType, false));
         }
     }
 }

--- a/src/Umbraco.Web/Trees/MemberTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/MemberTypeTreeController.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Web.Trees
         {
             return Services.MemberTypeService.GetAll()
                 .OrderBy(x => x.Name)
-                .Select(dt => CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings, Constants.Icons.MemberType, false));
+                .Select(dt => CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings, dt.Icon, false));
         }
     }
 }


### PR DESCRIPTION
In the Settings section, Document Types tree we see all document types with the exact same default icon like this

![image](https://user-images.githubusercontent.com/9142936/71089091-fdcbed80-2197-11ea-9b0f-f2b824340643.png)

In the content type picker that was recently added we can see the icon for the doc type and its colour like this:

![image](https://user-images.githubusercontent.com/9142936/71089148-20f69d00-2198-11ea-8f71-9c4051d106f2.png)

As a developer / architect of an umbraco site it would be so useful to be able to see which icons and colours have been chosen for a document type at the tree level. It would save us clicking through to each document type to see which icon has been chosen for it. Also it would give continuity to what we have with the content type picker, showing the icon and colour.

My PR fixes this issue and shows us the chosen icon with its colour instead of just a black default doc type icon. Here is what it will look like:

![image](https://user-images.githubusercontent.com/9142936/71089648-38825580-2199-11ea-8487-bb165ccd105b.png)
