### PR TITLE
remove duplicate method canAdd

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.controller.js
@@ -53,10 +53,6 @@
             });
         }
 
-        $scope.canAdd = function () {
-            return !$scope.model.docTypes || !$scope.model.value || $scope.model.value.length < $scope.model.docTypes.length;
-        }
-
         $scope.remove = function (index) {
             $scope.model.value.splice(index, 1);
         }
@@ -112,6 +108,7 @@
                 });
             });
         }
+
         $scope.canAdd = function () {
             return !$scope.model.value || _.some($scope.model.elemTypes, function (elType) {
                 return !_.find($scope.model.value, function (c) {
@@ -119,7 +116,6 @@
                 });
             });
         }
-
 
         $scope.openElemTypeModal = function ($event, config) {
 


### PR DESCRIPTION
### Prerequisites

- [ x] I have added steps to test this contribution in the description below

### Description
I came across a duplicate method (method **canAdd**) in the angular controller for nested content which I removed.

Functionality should remain unchanged, which I tested with datatype "Product - Features - Nested Content" from the default starter kit.

_Note: this PR replaces [PR7162](https://github.com/umbraco/Umbraco-CMS/pull/7162)_
