### PR TITLE
V8: AB3893 Updates the HTML Razor Partial View for grid cell items that use Embed

### DIFF
--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/Embed.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/Embed.cshtml
@@ -1,7 +1,14 @@
 ﻿@model dynamic
 @using Umbraco.Web.Templates
-
+@{
+    var embedValue = string.Empty;
+    try {
+        embedValue = Model.value.preview;
+    } catch(Exception ex) {
+        embedValue = Model.value;
+    }
+}
 
 <div class="video-wrapper">
-	@Html.Raw(Model.value)
+	@Html.Raw(embedValue)
 </div>

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/Embed.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/Embed.cshtml
@@ -1,12 +1,8 @@
 ﻿@model dynamic
 @using Umbraco.Web.Templates
 @{
-    var embedValue = string.Empty;
-    try {
-        embedValue = Model.value.preview;
-    } catch(Exception ex) {
-        embedValue = Model.value;
-    }
+    string embedValue = Convert.ToString(Model.value);
+    embedValue = embedValue.DetectIsJson() ? Model.value.preview : Model.value;
 }
 
 <div class="video-wrapper">


### PR DESCRIPTION
Updates the HTML Razor Partial View for grid cell items that use Embed

It has been recently updated in 8.2.0 that the Value stored is a JSON object containing width, height & the raw HTML returned by the oEmbed that was done in PR #4899

This fixes reported bug #7178
