### PR TITLE
Use the editor icon for data type trees

### DIFF
--- a/src/Umbraco.Core/Constants-Icons.cs
+++ b/src/Umbraco.Core/Constants-Icons.cs
@@ -20,6 +20,11 @@
             public const string ContentType = "icon-item-arrangement";
 
             /// <summary>
+            /// System list view icon
+            /// </summary>
+            public const string ListView = "icon-thumbnail-list";
+
+            /// <summary>
             /// System macro icon
             /// </summary>
             public const string Macro = "icon-settings-alt";

--- a/src/Umbraco.Core/Constants-Icons.cs
+++ b/src/Umbraco.Core/Constants-Icons.cs
@@ -20,16 +20,6 @@
             public const string ContentType = "icon-item-arrangement";
 
             /// <summary>
-            /// System data type icon
-            /// </summary>
-            public const string DataType = "icon-autofill";
-
-            /// <summary>
-            /// System list view icon
-            /// </summary>
-            public const string ListView = "icon-thumbnail-list";
-
-            /// <summary>
             /// System macro icon
             /// </summary>
             public const string Macro = "icon-settings-alt";

--- a/src/Umbraco.Core/Constants-Icons.cs
+++ b/src/Umbraco.Core/Constants-Icons.cs
@@ -20,6 +20,11 @@
             public const string ContentType = "icon-item-arrangement";
 
             /// <summary>
+            /// System data type icon
+            /// </summary>
+            public const string DataType = "icon-autofill";
+
+            /// <summary>
             /// System list view icon
             /// </summary>
             public const string ListView = "icon-thumbnail-list";

--- a/src/Umbraco.Web/Trees/DataTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/DataTypeTreeController.cs
@@ -60,19 +60,20 @@ namespace Umbraco.Web.Trees
             //System ListView nodes
             var systemListViewDataTypeIds = GetNonDeletableSystemListViewDataTypeIds();
 
+            var children = Services.EntityService.GetChildren(intId.Result, UmbracoObjectTypes.DataType).ToArray();
+            var dataTypes = Services.DataTypeService.GetAll(children.Select(c => c.Id).ToArray()).ToDictionary(dt => dt.Id);
+
             nodes.AddRange(
-                Services.EntityService.GetChildren(intId.Result, UmbracoObjectTypes.DataType)
+                children
                     .OrderBy(entity => entity.Name)
                     .Select(dt =>
                     {
-                        var node = CreateTreeNode(dt.Id.ToInvariantString(), id, queryStrings, dt.Name, Constants.Icons.DataType, false);
+                        var dataType = dataTypes[dt.Id];
+                        var node = CreateTreeNode(dt.Id.ToInvariantString(), id, queryStrings, dt.Name, dataType.Editor.Icon, false);
                         node.Path = dt.Path;
-                        if (systemListViewDataTypeIds.Contains(dt.Id))
-                        {
-                            node.Icon = Constants.Icons.ListView;
-                        }
                         return node;
-                    }));
+                    })
+            );
 
             return nodes;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
With the same arguments as in #7358 I would propose to use the editor icons in the data type tree. This will make it a lot easier to find data types, and make a better overview of what kind of editors you are using.

![billede](https://user-images.githubusercontent.com/3726467/71246175-78227c00-2316-11ea-8d57-810316110826.png)

To test:
Verify that the data type tree uses different icons for the data types.
