### PR TITLE
Add component unique ids

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
@@ -75,7 +75,7 @@
             scope.displayLabelOff = "";
 
             function onInit() {
-                scope.inputId = scope.inputId || String.CreateGuid();
+                scope.inputId = scope.inputId || "umb-toggle_" + String.CreateGuid();
 
                 setLabelText();
                 // must wait until the current digest cycle is finished before we emit this event on init, 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
@@ -75,6 +75,8 @@
             scope.displayLabelOff = "";
 
             function onInit() {
+                scope.inputId = scope.inputId || String.CreateGuid();
+
                 setLabelText();
                 // must wait until the current digest cycle is finished before we emit this event on init, 
                 // otherwise other property editors might not yet be ready to receive the event

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -46,7 +46,7 @@
         vm.change = change;
 
         function onInit() {
-            vm.inputId = vm.inputId || String.CreateGuid();
+            vm.inputId = vm.inputId || "umb-check_" + String.CreateGuid();
 
             // If a labelKey is passed let's update the returned text if it's does not contain an opening square bracket [
             if (vm.labelKey) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -46,6 +46,8 @@
         vm.change = change;
 
         function onInit() {
+            vm.inputId = vm.inputId || String.CreateGuid();
+
             // If a labelKey is passed let's update the returned text if it's does not contain an opening square bracket [
             if (vm.labelKey) {
                  localizationService.localize(vm.labelKey).then(function (data) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -44,6 +44,8 @@
         vm.change = change;
 
         function onInit() {
+            vm.inputId = vm.inputId || String.CreateGuid();
+
             // If a labelKey is passed let's update the returned text if it's does not contain an opening square bracket [
             if (vm.labelKey) {
                  localizationService.localize(vm.labelKey).then(function (data) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -44,7 +44,7 @@
         vm.change = change;
 
         function onInit() {
-            vm.inputId = vm.inputId || String.CreateGuid();
+            vm.inputId = vm.inputId || "umb-radio_" + String.CreateGuid();
 
             // If a labelKey is passed let's update the returned text if it's does not contain an opening square bracket [
             if (vm.labelKey) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/7374

### Description
This PR add a unique id when `input-id` is empty, so it doesn't render empty `id` attributes. I have also added a prefix for these.