### PR TITLE
Property Actions for Property Editor with Controllers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
@@ -16,9 +16,6 @@ angular.module("umbraco.directives")
             replace: true,
             templateUrl: 'views/components/property/umb-property.html',
             link: function (scope) {
-
-                scope.propertyActions = [];
-
                 userService.getCurrentUser().then(function (u) {
                     var isAdmin = u.userGroups.indexOf('admin') !== -1;
                     scope.propertyAlias = (Umbraco.Sys.ServerVariables.isDebuggingEnabled === true || isAdmin) ? scope.property.alias : null;
@@ -36,6 +33,7 @@ angular.module("umbraco.directives")
                     $scope.property.propertyErrorMessage = errorMsg;
                 };
 
+                $scope.propertyActions = [];
                 self.setPropertyActions = function(actions) {
                     $scope.propertyActions = actions;
                 };

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyeditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyeditor.directive.js
@@ -26,7 +26,7 @@ function umbPropEditor(umbPropEditorHelper) {
                 //we'll also maintain the current form name.
                 scope[ctrl[0].$name] = ctrl[0];
 
-                // We will capture a reference to umbProperty in this Directive and parse it on to the Scope, so Property-Editor controllers can use it.
+                // We will capture a reference to umbProperty in this Directive and pass it on to the Scope, so Property-Editor controllers can use it.
                 scope["umbProperty"] = ctrl[1];
 
                 if(!scope.model.alias){

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyeditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyeditor.directive.js
@@ -15,7 +15,7 @@ function umbPropEditor(umbPropEditorHelper) {
                 preview: "<"
             },
             
-            require: "^^form",
+            require: ["^^form", "?^umbProperty"],
             restrict: 'E',
             replace: true,      
             templateUrl: 'views/components/property/umb-property-editor.html',
@@ -24,7 +24,10 @@ function umbPropEditor(umbPropEditorHelper) {
                 //we need to copy the form controller val to our isolated scope so that
                 //it get's carried down to the child scopes of this!
                 //we'll also maintain the current form name.
-                scope[ctrl.$name] = ctrl;
+                scope[ctrl[0].$name] = ctrl[0];
+
+                // We will capture a reference to umbProperty in this Directive and parse it on to the Scope, so Property-Editor controllers can use it.
+                scope["umbProperty"] = ctrl[1];
 
                 if(!scope.model.alias){
                    scope.model.alias = Math.random().toString(36).slice(2);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -99,6 +99,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
 
         function sync() {
             $scope.model.value = $scope.ids.join();
+            removeAllEntriesAction.isDisabled = $scope.ids.length === 0;
         };
 
         function setDirty() {
@@ -245,6 +246,31 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                 }
             }
             return true;
+        }
+
+        function removeAllEntries() {
+            $scope.mediaItems.length = 0;// AngularJS way to empty the array.
+            $scope.ids.length = 0;// AngularJS way to empty the array.
+            sync();
+            setDirty();
+        }
+
+        var removeAllEntriesAction = {
+            labelKey: 'clipboard_labelForRemoveAllEntries',
+            labelTokens: [],
+            icon: 'trash',
+            method: removeAllEntries,
+            isDisabled: false
+        };
+        
+        if (multiPicker === true) {
+            var propertyActions = [
+                removeAllEntriesAction
+            ];
+
+            if ($scope.umbProperty) {
+                $scope.umbProperty.setPropertyActions(propertyActions);
+            }
         }
 
         $scope.sortableOptions = {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -260,7 +260,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
             labelTokens: [],
             icon: 'trash',
             method: removeAllEntries,
-            isDisabled: false
+            isDisabled: true
         };
         
         if (multiPicker === true) {


### PR DESCRIPTION
This PR exposes a reference to umbProperty on the property scope, so Property Editors can access properties on umbProperty. This will allow Property-Editors made with a Controller to add Property Actions.

This PR as well implements a Property Action for Media Picker in multi-mode, to prove that the implementation works.

Screenshot from solution:
![image](https://user-images.githubusercontent.com/6791648/71258962-a5335680-2337-11ea-97d8-72946e817aaf.png)


Test notes:
— Have a Document Type with a Media Picker configured to select multiple media.
— See that Property Actions appear on the Media Picker property.
— Test that the action can be used to clear your picks.
— Test that the action is disabled when the Media Picker is empty.
— Test that picks made after a clear is begin saved and that the correct data is still present after a reload.