### PR TITLE
V8: Remove "double tabbing" on context menu items (regression)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-contextmenu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-contextmenu.html
@@ -5,12 +5,12 @@
 
     <div class='umb-modalcolumn-body'>
         <ul class="umb-actions">
-            <li data-element="action-{{action.alias}}" ng-click="executeMenuItem(action)" class="umb-action" ng-class="{sep:action.separator, '-opens-dialog': action.opensDialog}" ng-repeat="action in menuActions">
-                <button class="umb-action-link btn-reset umb-outline" prevent-default umb-auto-focus ng-if="$index === 0">
+            <li data-element="action-{{action.alias}}" class="umb-action" ng-class="{sep:action.separator, '-opens-dialog': action.opensDialog}" ng-repeat="action in menuActions">
+                <button ng-click="executeMenuItem(action)" class="umb-action-link btn-reset umb-outline" prevent-default umb-auto-focus ng-if="$index === 0">
                     <i class="icon icon-{{action.cssclass}}"></i>
                     <span class="menu-label">{{action.name}}</span>
                 </button>
-                <button class="umb-action-link btn-reset umb-outline" prevent-default ng-if="$index !== 0">
+                <button ng-click="executeMenuItem(action)" class="umb-action-link btn-reset umb-outline" prevent-default ng-if="$index !== 0">
                     <i class="icon icon-{{action.cssclass}}"></i>
                     <span class="menu-label">{{action.name}}</span>
                 </button>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#5729 adds some really nice improvements to keyboard navigation through the trees. Unfortunately an unintended side effect is that the tree context menu items now require two tab strokes each:

![context-menu-tab-before](https://user-images.githubusercontent.com/7405322/71326787-22a9c300-2500-11ea-92cc-c6e4b8d0a196.gif)

With this PR we're back to one per item:

![context-menu-tab-after](https://user-images.githubusercontent.com/7405322/71326797-305f4880-2500-11ea-98b0-cb625cf6a356.gif)
