### PR TITLE
V8: nested content wasn't disabling the 'add content' box 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
@@ -41,7 +41,7 @@
         </div>
 
         <div class="umb-nested-content__footer-bar" ng-hide="vm.hasContentTypes === false">
-            <button class="btn-reset umb-nested-content__add-content umb-focus" ng-class="{ '--disabled': (!vm.scaffolds.length || vm.nodes.length >= maxItems) }" ng-click="vm.openNodeTypePicker($event)" prevent-default>
+            <button class="btn-reset umb-nested-content__add-content umb-focus" ng-class="{ '--disabled': (!vm.scaffolds.length || vm.nodes.length >= vm.maxItems) }" ng-click="vm.openNodeTypePicker($event)" prevent-default>
                 <localize key="grid_addElement"></localize>
             </button>
         </div>


### PR DESCRIPTION
…items

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
When nested content items are above the number of items it should disable the add content button. There was a bug where the expression for this wasn't using the new vm object and didn't work


<!-- Thanks for contributing to Umbraco CMS! -->
