### PR TITLE
Changed the styles from warning to danger for the confirm delete button, added localization keys

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowdeleteconfirm.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowdeleteconfirm.html
@@ -1,53 +1,45 @@
 <div class="usky-grid usky-grid-configuration" ng-controller="Umbraco.PropertyEditors.GridPrevalueEditor.DeleteRowConfirmController">
 
+    <umb-editor-view>
+        <umb-editor-container>
+            <umb-box>
+                <umb-box-content>
+                    <h3 class="alert alert-danger ng-scope"><localize key="grid_warning">Warning!</localize></h3>
 
-        <umb-editor-view>
+                    <p>
+                        <localize key="grid_youAreDeleting">You are deleting the row configuration </localize> <strong>{{model.dialogData.rowName}}</strong>
+                    </p>
 
-            <umb-editor-container>
-                <umb-box>
-                    <umb-box-content>
+                    <p>
+                        <localize key="grid_deletingARow">
+                            Modifying a row configuration name will result in loss of
+                            data for any existing content that is based on this configuration.
+                        </localize>
+                    </p>
 
+                    <p>
+                        <localize key="general_areyousure">Are you sure?</localize>
+                    </p>
 
+                </umb-box-content>
+            </umb-box>
+        </umb-editor-container>
 
-   <h3 class="alert alert-warn ng-scope">Warning!</h3>
-
-   <p>
-      You are deleting the row configuration '<strong>{{model.dialogData.rowName}}</strong>'
-   </p>
-
-   <p>
-      Modifying a row configuration name will result in loss of
-      data for any existing content that is based on this configuration.
-   </p>
-
-   <p>
-      <localize key="general_areyousure">Are you sure?</localize>
-   </p>
-
-
-
-
-                            </umb-box-content>
-                        </umb-box>
-                    </umb-editor-container>
-
-                    <umb-editor-footer>
-                    <umb-editor-footer-content-right>
-                        <umb-button
-                            type="button"
+        <umb-editor-footer>
+            <umb-editor-footer-content-right>
+                <umb-button type="button"
                             button-style="link"
                             label-key="general_close"
                             shortcut="esc"
                             action="close()">
-                        </umb-button>
-                        <umb-button
-                            type="button"
-                            button-style="warning"
+                </umb-button>
+                <umb-button type="button"
+                            button-style="danger"
                             label-key="general_delete"
                             action="submit(model)">
-                        </umb-button>
-                </umb-editor-footer-content-right>
-            </umb-editor-footer>
+                </umb-button>
+            </umb-editor-footer-content-right>
+        </umb-editor-footer>
 
     </umb-editor-view>
 

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1572,6 +1572,11 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="chooseExtra">Choose extra</key>
     <key alias="chooseDefault">Choose default</key>
     <key alias="areAdded">are added</key>
+        <key alias="warning">Warning</key>
+        <key alias="youAreDeleting">You are deleting the row configuration</key>
+        <key alias="deletingARow">
+            Deleting a row configuration name will result in loss of data for any existing content that is based on this configuration.
+        </key>
   </area>
   <area alias="contentTypeEditor">
     <key alias="compositions">Compositions</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1586,6 +1586,11 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="chooseExtra">Choose extra</key>
     <key alias="chooseDefault">Choose default</key>
     <key alias="areAdded">are added</key>
+        <key alias="warning">Warning</key>
+        <key alias="youAreDeleting">You are deleting the row configuration</key>
+        <key alias="deletingARow">
+            Deleting a row configuration name will result in loss of data for any existing content that is based on this configuration.
+        </key>
   </area>
   <area alias="contentTypeEditor">
     <key alias="compositions">Compositions</key>


### PR DESCRIPTION
This is the PR https://github.com/umbraco/Umbraco-CMS/pull/6959 re-done as the merge went bad there again.

In the grid datatype when you try to delete a row config, the overlay uses warning style all over. Since the application uses danger for deletes I have changed it to danger style. I have also added localization keys