### PR TITLE
V8/bugfix/main dom dead lock

### DIFF
--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -147,7 +147,7 @@ namespace Umbraco.Core.Runtime
                 // TODO: remove this in netcore, this is purely backwards compat hacks with the empty ctor
                 if (MainDom == null)
                 {
-                    MainDom = new MainDom(Logger, new MainDomSemaphoreLock());
+                    MainDom = new MainDom(Logger, new MainDomSemaphoreLock(Logger));
                 }
                 
 

--- a/src/Umbraco.Core/Runtime/IMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/IMainDomLock.cs
@@ -16,9 +16,8 @@ namespace Umbraco.Core.Runtime
         /// </summary>
         /// <param name="millisecondsTimeout"></param>
         /// <returns>
-        /// A disposable object which will be disposed in order to release the lock
+        /// An awaitable boolean value which will be false if the elapsed millsecondsTimeout value is exceeded
         /// </returns>
-        /// <exception cref="TimeoutException">Throws a <see cref="TimeoutException"/> if the elapsed millsecondsTimeout value is exceeded</exception>
         Task<bool> AcquireLockAsync(int millisecondsTimeout);
 
         /// <summary>

--- a/src/Umbraco.Core/Runtime/MainDom.cs
+++ b/src/Umbraco.Core/Runtime/MainDom.cs
@@ -145,7 +145,7 @@ namespace Umbraco.Core.Runtime
             _logger.Info<MainDom>("Acquiring.");
 
             // Get the lock 
-            var acquired = _mainDomLock.AcquireLockAsync(LockTimeoutMilliseconds).Result;
+            var acquired = _mainDomLock.AcquireLockAsync(LockTimeoutMilliseconds).GetAwaiter().GetResult();
 
             if (!acquired)
             {

--- a/src/Umbraco.Core/Runtime/MainDom.cs
+++ b/src/Umbraco.Core/Runtime/MainDom.cs
@@ -151,7 +151,7 @@ namespace Umbraco.Core.Runtime
             {
                 _logger.Info<MainDom>("Cannot acquire (timeout).");
 
-                // TODO: In previous versions we'd let a TimeoutException be thrown
+                // In previous versions we'd let a TimeoutException be thrown
                 // and the appdomain would not start. We have the opportunity to allow it to
                 // start without having MainDom? This would mean that it couldn't write
                 // to nucache/examine and would only be ok if this was a super short lived appdomain.

--- a/src/Umbraco.Tests/Cache/SnapDictionaryTests.cs
+++ b/src/Umbraco.Tests/Cache/SnapDictionaryTests.cs
@@ -9,47 +9,6 @@ using Umbraco.Web.PublishedCache.NuCache.Snap;
 
 namespace Umbraco.Tests.Cache
 {
-    /// <summary>
-    /// Used for tests
-    /// </summary>
-    public static class SnapDictionaryExtensions
-    {        
-        internal static void Set<TKey, TValue>(this SnapDictionary<TKey, TValue> d, TKey key, TValue value)
-            where TValue : class
-        {
-            using (d.GetScopedWriteLock(GetScopeProvider()))
-            {
-                d.SetLocked(key, value);
-            }
-        }
-
-        internal static void Clear<TKey, TValue>(this SnapDictionary<TKey, TValue> d)
-            where TValue : class
-        {
-            using (d.GetScopedWriteLock(GetScopeProvider()))
-            {
-                d.ClearLocked();
-            }
-        }
-
-        internal static void Clear<TKey, TValue>(this SnapDictionary<TKey, TValue> d, TKey key)
-            where TValue : class
-        {
-            using (d.GetScopedWriteLock(GetScopeProvider()))
-            {
-                d.ClearLocked(key);
-            }
-        }
-
-        private static IScopeProvider GetScopeProvider()
-        {
-            var scopeProvider = Mock.Of<IScopeProvider>();
-            Mock.Get(scopeProvider)
-                .Setup(x => x.Context).Returns(() => null);
-            return scopeProvider;
-        }
-    }
-
     [TestFixture]
     public class SnapDictionaryTests
     {
@@ -1181,6 +1140,47 @@ namespace Umbraco.Tests.Cache
             var scopeProvider = Mock.Of<IScopeProvider>();
             Mock.Get(scopeProvider)
                 .Setup(x => x.Context).Returns(scopeContext);
+            return scopeProvider;
+        }
+    }
+
+    /// <summary>
+    /// Used for tests so that we don't have to wrap every Set/Clear call in locks
+    /// </summary>
+    public static class SnapDictionaryExtensions
+    {
+        internal static void Set<TKey, TValue>(this SnapDictionary<TKey, TValue> d, TKey key, TValue value)
+            where TValue : class
+        {
+            using (d.GetScopedWriteLock(GetScopeProvider()))
+            {
+                d.SetLocked(key, value);
+            }
+        }
+
+        internal static void Clear<TKey, TValue>(this SnapDictionary<TKey, TValue> d)
+            where TValue : class
+        {
+            using (d.GetScopedWriteLock(GetScopeProvider()))
+            {
+                d.ClearLocked();
+            }
+        }
+
+        internal static void Clear<TKey, TValue>(this SnapDictionary<TKey, TValue> d, TKey key)
+            where TValue : class
+        {
+            using (d.GetScopedWriteLock(GetScopeProvider()))
+            {
+                d.ClearLocked(key);
+            }
+        }
+
+        private static IScopeProvider GetScopeProvider()
+        {
+            var scopeProvider = Mock.Of<IScopeProvider>();
+            Mock.Get(scopeProvider)
+                .Setup(x => x.Context).Returns(() => null);
             return scopeProvider;
         }
     }

--- a/src/Umbraco.Tests/Cache/SnapDictionaryTests.cs
+++ b/src/Umbraco.Tests/Cache/SnapDictionaryTests.cs
@@ -9,6 +9,47 @@ using Umbraco.Web.PublishedCache.NuCache.Snap;
 
 namespace Umbraco.Tests.Cache
 {
+    /// <summary>
+    /// Used for tests
+    /// </summary>
+    public static class SnapDictionaryExtensions
+    {        
+        internal static void Set<TKey, TValue>(this SnapDictionary<TKey, TValue> d, TKey key, TValue value)
+            where TValue : class
+        {
+            using (d.GetScopedWriteLock(GetScopeProvider()))
+            {
+                d.SetLocked(key, value);
+            }
+        }
+
+        internal static void Clear<TKey, TValue>(this SnapDictionary<TKey, TValue> d)
+            where TValue : class
+        {
+            using (d.GetScopedWriteLock(GetScopeProvider()))
+            {
+                d.ClearLocked();
+            }
+        }
+
+        internal static void Clear<TKey, TValue>(this SnapDictionary<TKey, TValue> d, TKey key)
+            where TValue : class
+        {
+            using (d.GetScopedWriteLock(GetScopeProvider()))
+            {
+                d.ClearLocked(key);
+            }
+        }
+
+        private static IScopeProvider GetScopeProvider()
+        {
+            var scopeProvider = Mock.Of<IScopeProvider>();
+            Mock.Get(scopeProvider)
+                .Setup(x => x.Context).Returns(() => null);
+            return scopeProvider;
+        }
+    }
+
     [TestFixture]
     public class SnapDictionaryTests
     {
@@ -223,7 +264,7 @@ namespace Umbraco.Tests.Cache
         {
             var d = new SnapDictionary<int, string>();
             d.Test.CollectAuto = false;
-
+            
             // gen 1
             d.Set(1, "one");
             Assert.AreEqual(1, d.Test.GetValues(1).Length);
@@ -321,7 +362,7 @@ namespace Umbraco.Tests.Cache
         {
             var d = new SnapDictionary<int, string>();
             d.Test.CollectAuto = false;
-
+            
             Assert.AreEqual(0, d.Test.GetValues(1).Length);
 
             // gen 1
@@ -416,7 +457,7 @@ namespace Umbraco.Tests.Cache
         {
             var d = new SnapDictionary<int, string>();
             d.Test.CollectAuto = false;
-
+            
             // gen 1
             d.Set(1, "one");
             Assert.AreEqual(1, d.Test.GetValues(1).Length);
@@ -578,7 +619,7 @@ namespace Umbraco.Tests.Cache
         {
             var d = new SnapDictionary<int, string>();
             d.Test.CollectAuto = false;
-
+            
             d.Set(1, "one");
             d.Set(2, "two");
 
@@ -689,7 +730,7 @@ namespace Umbraco.Tests.Cache
             {
                 // gen 3
                 Assert.AreEqual(2, d.Test.GetValues(1).Length);
-                d.Set(1, "ein");
+                d.SetLocked(1, "ein");
                 Assert.AreEqual(3, d.Test.GetValues(1).Length);
 
                 Assert.AreEqual(3, d.Test.LiveGen);
@@ -727,31 +768,25 @@ namespace Umbraco.Tests.Cache
             using (var w1 = d.GetScopedWriteLock(scopeProvider))
             {
                 Assert.AreEqual(1, t.LiveGen);
-                Assert.AreEqual(1, t.WLocked);
+                Assert.IsTrue(t.IsLocked);
                 Assert.IsTrue(t.NextGen);
 
-                using (var w2 = d.GetScopedWriteLock(scopeProvider))
+                Assert.Throws<InvalidOperationException>(() =>
                 {
-                    Assert.AreEqual(1, t.LiveGen);
-                    Assert.AreEqual(2, t.WLocked);
-                    Assert.IsTrue(t.NextGen);
-
-                    Assert.AreNotSame(w1, w2); // get a new writer each time
-
-                    d.Set(1, "one");
-
-                    Assert.AreEqual(0, d.CreateSnapshot().Gen);
-                }
+                    using (var w2 = d.GetScopedWriteLock(scopeProvider))
+                    {
+                    }
+                });
 
                 Assert.AreEqual(1, t.LiveGen);
-                Assert.AreEqual(1, t.WLocked);
+                Assert.IsTrue(t.IsLocked);
                 Assert.IsTrue(t.NextGen);
 
                 Assert.AreEqual(0, d.CreateSnapshot().Gen);
             }
 
             Assert.AreEqual(1, t.LiveGen);
-            Assert.AreEqual(0, t.WLocked);
+            Assert.IsFalse(t.IsLocked);
             Assert.IsTrue(t.NextGen);
 
             Assert.AreEqual(1, d.CreateSnapshot().Gen);
@@ -772,11 +807,14 @@ namespace Umbraco.Tests.Cache
 
             using (var w1 = d.GetScopedWriteLock(scopeProvider))
             {
+                // This one is interesting, although we don't allow recursive locks, since this is
+                // using the same ScopeContext/key, the lock acquisition is only done once
+
                 using (var w2 = d.GetScopedWriteLock(scopeProvider))
                 {
                     Assert.AreSame(w1, w2);
 
-                    d.Set(1, "one");
+                    d.SetLocked(1, "one");
                 }
             }
         }
@@ -797,19 +835,16 @@ namespace Umbraco.Tests.Cache
             using (var w1 = d.GetScopedWriteLock(scopeProvider1))
             {
                 Assert.AreEqual(1, t.LiveGen);
-                Assert.AreEqual(1, t.WLocked);
+                Assert.IsTrue(t.IsLocked);
                 Assert.IsTrue(t.NextGen);
 
-                using (var w2 = d.GetScopedWriteLock(scopeProvider2))
+                Assert.Throws<InvalidOperationException>(() =>
                 {
-                    Assert.AreEqual(1, t.LiveGen);
-                    Assert.AreEqual(2, t.WLocked);
-                    Assert.IsTrue(t.NextGen);
+                    using (var w2 = d.GetScopedWriteLock(scopeProvider2))
+                    {
+                    }
+                });
 
-                    Assert.AreNotSame(w1, w2);
-
-                    d.Set(1, "one");
-                }
             }
         }
 
@@ -848,13 +883,13 @@ namespace Umbraco.Tests.Cache
             Assert.IsFalse(d.Test.NextGen);
             Assert.AreEqual("uno", s2.Get(1));
 
-            var scopeProvider = GetScopeProvider();
 
+            var scopeProvider = GetScopeProvider();
             using (d.GetScopedWriteLock(scopeProvider))
             {
                 // gen 3
                 Assert.AreEqual(2, d.Test.GetValues(1).Length);
-                d.Set(1, "ein");
+                d.SetLocked(1, "ein");
                 Assert.AreEqual(3, d.Test.GetValues(1).Length);
 
                 Assert.AreEqual(3, d.Test.LiveGen);
@@ -881,6 +916,7 @@ namespace Umbraco.Tests.Cache
         {
             var d = new SnapDictionary<int, string>();
             d.Test.CollectAuto = false;
+            
 
             // gen 1
             d.Set(1, "one");
@@ -894,12 +930,11 @@ namespace Umbraco.Tests.Cache
             Assert.AreEqual("uno", s2.Get(1));
 
             var scopeProvider = GetScopeProvider();
-
             using (d.GetScopedWriteLock(scopeProvider))
             {
                 // creating a snapshot in a write-lock does NOT return the "current" content
                 // it uses the previous snapshot, so new snapshot created only on release
-                d.Set(1, "ein");
+                d.SetLocked(1, "ein");
                 var s3 = d.CreateSnapshot();
                 Assert.AreEqual(2, s3.Gen);
                 Assert.AreEqual("uno", s3.Get(1));
@@ -934,12 +969,11 @@ namespace Umbraco.Tests.Cache
 
             var scopeContext = new ScopeContext();
             var scopeProvider = GetScopeProvider(scopeContext);
-
             using (d.GetScopedWriteLock(scopeProvider))
             {
                 // creating a snapshot in a write-lock does NOT return the "current" content
                 // it uses the previous snapshot, so new snapshot created only on release
-                d.Set(1, "ein");
+                d.SetLocked(1, "ein");
                 var s3 = d.CreateSnapshot();
                 Assert.AreEqual(2, s3.Gen);
                 Assert.AreEqual("uno", s3.Get(1));
@@ -967,7 +1001,7 @@ namespace Umbraco.Tests.Cache
             var d = new SnapDictionary<int, string>();
             var t = d.Test;
             t.CollectAuto = false;
-
+            
             // gen 1
             d.Set(1, "one");
             var s1 = d.CreateSnapshot();
@@ -984,12 +1018,11 @@ namespace Umbraco.Tests.Cache
 
             var scopeContext = new ScopeContext();
             var scopeProvider = GetScopeProvider(scopeContext);
-
             using (d.GetScopedWriteLock(scopeProvider))
             {
                 // creating a snapshot in a write-lock does NOT return the "current" content
                 // it uses the previous snapshot, so new snapshot created only on release
-                d.Set(1, "ein");
+                d.SetLocked(1, "ein");
                 var s3 = d.CreateSnapshot();
                 Assert.AreEqual(2, s3.Gen);
                 Assert.AreEqual("uno", s3.Get(1));
@@ -997,7 +1030,7 @@ namespace Umbraco.Tests.Cache
                 // we made some changes, so a next gen is required
                 Assert.AreEqual(3, t.LiveGen);
                 Assert.IsTrue(t.NextGen);
-                Assert.AreEqual(1, t.WLocked);
+                Assert.IsTrue(t.IsLocked);
 
                 // but live snapshot contains changes
                 var ls = t.LiveSnapshot;
@@ -1008,7 +1041,7 @@ namespace Umbraco.Tests.Cache
             // nothing is committed until scope exits
             Assert.AreEqual(3, t.LiveGen);
             Assert.IsTrue(t.NextGen);
-            Assert.AreEqual(1, t.WLocked);
+            Assert.IsTrue(t.IsLocked);
 
             // no changes until exit
             var s4 = d.CreateSnapshot();
@@ -1020,7 +1053,7 @@ namespace Umbraco.Tests.Cache
             // now things have changed
             Assert.AreEqual(2, t.LiveGen);
             Assert.IsFalse(t.NextGen);
-            Assert.AreEqual(0, t.WLocked);
+            Assert.IsFalse(t.IsLocked);
 
             // no changes since not completed
             var s5 = d.CreateSnapshot();
@@ -1097,9 +1130,10 @@ namespace Umbraco.Tests.Cache
             // writer is scope contextual and scoped
             //  when disposed, nothing happens
             //  when the context exists, the writer is released
+
             using (d.GetScopedWriteLock(scopeProvider))
             {
-                d.Set(1, "ein");
+                d.SetLocked(1, "ein");
                 Assert.IsTrue(d.Test.NextGen);
                 Assert.AreEqual(3, d.Test.LiveGen);
                 Assert.IsNotNull(d.Test.GenObj);
@@ -1107,7 +1141,7 @@ namespace Umbraco.Tests.Cache
             }
 
             // writer has not released
-            Assert.AreEqual(1, d.Test.WLocked);
+            Assert.IsTrue(d.Test.IsLocked);
             Assert.IsNotNull(d.Test.GenObj);
             Assert.AreEqual(2, d.Test.GenObj.Gen);
 
@@ -1118,7 +1152,7 @@ namespace Umbraco.Tests.Cache
             // panic!
             var s2 = d.CreateSnapshot();
 
-            Assert.AreEqual(1, d.Test.WLocked);
+            Assert.IsTrue(d.Test.IsLocked);
             Assert.IsNotNull(d.Test.GenObj);
             Assert.AreEqual(2, d.Test.GenObj.Gen);
             Assert.AreEqual(3, d.Test.LiveGen);
@@ -1127,7 +1161,7 @@ namespace Umbraco.Tests.Cache
             // release writer
             scopeContext.ScopeExit(true);
 
-            Assert.AreEqual(0, d.Test.WLocked);
+            Assert.IsFalse(d.Test.IsLocked);
             Assert.IsNotNull(d.Test.GenObj);
             Assert.AreEqual(2, d.Test.GenObj.Gen);
             Assert.AreEqual(3, d.Test.LiveGen);
@@ -1135,7 +1169,7 @@ namespace Umbraco.Tests.Cache
 
             var s3 = d.CreateSnapshot();
 
-            Assert.AreEqual(0, d.Test.WLocked);
+            Assert.IsFalse(d.Test.IsLocked);
             Assert.IsNotNull(d.Test.GenObj);
             Assert.AreEqual(3, d.Test.GenObj.Gen);
             Assert.AreEqual(3, d.Test.LiveGen);

--- a/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
@@ -462,6 +462,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
         /// </exception>
         public void UpdateDataTypesLocked(IEnumerable<int> dataTypeIds, Func<int, IPublishedContentType> getContentType)
         {
+            EnsureLocked();
+
             var contentTypes = _contentTypesById
                     .Where(kvp =>
                         kvp.Value.Value != null &&

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshot.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshot.cs
@@ -39,15 +39,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
         public void Resync()
         {
-            // This is annoying since this can cause deadlocks. Since this will be cleared if something happens in the same
-            // thread after that calls Elements, it will re-lock the _storesLock but that might already be locked again
-            // and since we're most likely in a ContentStore write lock, the other thread is probably wanting that one too.
-
             // no lock - published snapshots are single-thread
-
-            // TODO: Instead of clearing, we could hold this value in another var in case the above call to GetElements() Or potentially
-            // a new TryGetElements() fails (since we might be shutting down). In that case we can use the old value.
-
             _elements?.Dispose();
             _elements = null;
         }

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshot.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshot.cs
@@ -39,7 +39,15 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
         public void Resync()
         {
+            // This is annoying since this can cause deadlocks. Since this will be cleared if something happens in the same
+            // thread after that calls Elements, it will re-lock the _storesLock but that might already be locked again
+            // and since we're most likely in a ContentStore write lock, the other thread is probably wanting that one too.
+
             // no lock - published snapshots are single-thread
+
+            // TODO: Instead of clearing, we could hold this value in another var in case the above call to GetElements() Or potentially
+            // a new TryGetElements() fails (since we might be shutting down). In that case we can use the old value.
+
             _elements?.Dispose();
             _elements = null;
         }

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -670,15 +670,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 publishedChanged = publishedChanged2;
             }
 
-            // TODO: These resync's are a problem, they cause deadlocks because when this is called, it's generally called within a writelock
-            // and then we clear out the snapshot and then if there's some event handler that needs the content cache, it tries to re-get it
-            // which first tries locking on the _storesLock which may have already been acquired and in this case we deadlock because
-            // we're still holding the write lock.
-            // We resync at the end of a ScopedWriteLock
-            // BUT if we don't resync here then the current snapshot is out of date for any event handlers that wish to use the most up to date
-            // data...
-            // so we need to figure out how to deal with the _storesLock
-
+            
             if (draftChanged || publishedChanged)
                 ((PublishedSnapshot)CurrentPublishedSnapshot)?.Resync();
         }

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -943,14 +943,14 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 using (var scope = _scopeProvider.CreateScope())
                 {
                     scope.ReadLock(Constants.Locks.ContentTree);
-                    _contentStore.UpdateDataTypes(idsA, id => CreateContentType(PublishedItemType.Content, id));
+                    _contentStore.UpdateDataTypesLocked(idsA, id => CreateContentType(PublishedItemType.Content, id));
                     scope.Complete();
                 }
 
                 using (var scope = _scopeProvider.CreateScope())
                 {
                     scope.ReadLock(Constants.Locks.MediaTree);
-                    _mediaStore.UpdateDataTypes(idsA, id => CreateContentType(PublishedItemType.Media, id));
+                    _mediaStore.UpdateDataTypesLocked(idsA, id => CreateContentType(PublishedItemType.Media, id));
                     scope.Complete();
                 }
             }
@@ -1073,7 +1073,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     ? Array.Empty<ContentNodeKit>()
                     : _dataSource.GetTypeContentSources(scope, refreshedIds).ToArray();
 
-                _contentStore.UpdateContentTypes(removedIds, typesA, kits);
+                _contentStore.UpdateContentTypesLocked(removedIds, typesA, kits);
                 if (!otherIds.IsCollectionEmpty())
                     _contentStore.UpdateContentTypesLocked(CreateContentTypes(PublishedItemType.Content, otherIds.ToArray()));
                 if (!newIds.IsCollectionEmpty())
@@ -1104,7 +1104,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     ? Array.Empty<ContentNodeKit>()
                     : _dataSource.GetTypeMediaSources(scope, refreshedIds).ToArray();
 
-                _mediaStore.UpdateContentTypes(removedIds, typesA, kits);
+                _mediaStore.UpdateContentTypesLocked(removedIds, typesA, kits);
                 if (!otherIds.IsCollectionEmpty())
                     _mediaStore.UpdateContentTypesLocked(CreateContentTypes(PublishedItemType.Media, otherIds.ToArray()).ToArray());
                 if (!newIds.IsCollectionEmpty())

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -384,7 +384,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             var contentTypes = _serviceContext.ContentTypeService.GetAll()
                 .Select(x => _publishedContentTypeFactory.CreateContentType(x));
 
-            _contentStore.SetAllContentTypes(contentTypes);
+            _contentStore.SetAllContentTypesLocked(contentTypes);
 
             using (_logger.TraceDuration<PublishedSnapshotService>("Loading content from database"))
             {
@@ -395,7 +395,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
                 // IMPORTANT GetAllContentSources sorts kits by level + parentId + sortOrder
                 var kits = _dataSource.GetAllContentSources(scope);
-                return onStartup ? _contentStore.SetAllFastSorted(kits, true) : _contentStore.SetAll(kits);
+                return onStartup ? _contentStore.SetAllFastSortedLocked(kits, true) : _contentStore.SetAllLocked(kits);
             }
         }
 
@@ -403,7 +403,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
         {
             var contentTypes = _serviceContext.ContentTypeService.GetAll()
                     .Select(x => _publishedContentTypeFactory.CreateContentType(x));
-            _contentStore.SetAllContentTypes(contentTypes);
+            _contentStore.SetAllContentTypesLocked(contentTypes);
 
             using (_logger.TraceDuration<PublishedSnapshotService>("Loading content from local cache file"))
             {
@@ -455,7 +455,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
             var mediaTypes = _serviceContext.MediaTypeService.GetAll()
                 .Select(x => _publishedContentTypeFactory.CreateContentType(x));
-            _mediaStore.SetAllContentTypes(mediaTypes);
+            _mediaStore.SetAllContentTypesLocked(mediaTypes);
 
             using (_logger.TraceDuration<PublishedSnapshotService>("Loading media from database"))
             {
@@ -467,7 +467,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 _logger.Debug<PublishedSnapshotService>("Loading media from database...");
                 // IMPORTANT GetAllMediaSources sorts kits by level + parentId + sortOrder
                 var kits = _dataSource.GetAllMediaSources(scope);
-                return onStartup ? _mediaStore.SetAllFastSorted(kits, true) : _mediaStore.SetAll(kits);
+                return onStartup ? _mediaStore.SetAllFastSortedLocked(kits, true) : _mediaStore.SetAllLocked(kits);
             }
         }
 
@@ -475,7 +475,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
         {
             var mediaTypes = _serviceContext.MediaTypeService.GetAll()
                     .Select(x => _publishedContentTypeFactory.CreateContentType(x));
-            _mediaStore.SetAllContentTypes(mediaTypes);
+            _mediaStore.SetAllContentTypesLocked(mediaTypes);
 
             using (_logger.TraceDuration<PublishedSnapshotService>("Loading media from local cache file"))
             {
@@ -516,7 +516,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 return false;
             }
 
-            return onStartup ? store.SetAllFastSorted(kits, false) : store.SetAll(kits);
+            return onStartup ? store.SetAllFastSortedLocked(kits, false) : store.SetAllLocked(kits);
         }
 
         // keep these around - might be useful
@@ -713,7 +713,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
                 if (payload.ChangeTypes.HasType(TreeChangeTypes.Remove))
                 {
-                    if (_contentStore.Clear(payload.Id))
+                    if (_contentStore.ClearLocked(payload.Id))
                         draftChanged = publishedChanged = true;
                     continue;
                 }
@@ -736,7 +736,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                         // ?? should we do some RV check here?
                         // IMPORTANT GetbranchContentSources sorts kits by level and by sort order
                         var kits = _dataSource.GetBranchContentSources(scope, capture.Id);
-                        _contentStore.SetBranch(capture.Id, kits);
+                        _contentStore.SetBranchLocked(capture.Id, kits);
                     }
                     else
                     {
@@ -744,11 +744,11 @@ namespace Umbraco.Web.PublishedCache.NuCache
                         var kit = _dataSource.GetContentSource(scope, capture.Id);
                         if (kit.IsEmpty)
                         {
-                            _contentStore.Clear(capture.Id);
+                            _contentStore.ClearLocked(capture.Id);
                         }
                         else
                         {
-                            _contentStore.Set(kit);
+                            _contentStore.SetLocked(kit);
                         }
                     }
 
@@ -806,7 +806,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
                 if (payload.ChangeTypes.HasType(TreeChangeTypes.Remove))
                 {
-                    if (_mediaStore.Clear(payload.Id))
+                    if (_mediaStore.ClearLocked(payload.Id))
                         anythingChanged = true;
                     continue;
                 }
@@ -829,7 +829,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                         // ?? should we do some RV check here?
                         // IMPORTANT GetbranchContentSources sorts kits by level and by sort order
                         var kits = _dataSource.GetBranchMediaSources(scope, capture.Id);
-                        _mediaStore.SetBranch(capture.Id, kits);
+                        _mediaStore.SetBranchLocked(capture.Id, kits);
                     }
                     else
                     {
@@ -837,11 +837,11 @@ namespace Umbraco.Web.PublishedCache.NuCache
                         var kit = _dataSource.GetMediaSource(scope, capture.Id);
                         if (kit.IsEmpty)
                         {
-                            _mediaStore.Clear(capture.Id);
+                            _mediaStore.ClearLocked(capture.Id);
                         }
                         else
                         {
-                            _mediaStore.Set(kit);
+                            _mediaStore.SetLocked(kit);
                         }
                     }
 

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -622,7 +622,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 .Where(x => x.RootContentId.HasValue && x.LanguageIsoCode.IsNullOrWhiteSpace() == false)
                 .Select(x => new Domain(x.Id, x.DomainName, x.RootContentId.Value, CultureInfo.GetCultureInfo(x.LanguageIsoCode), x.IsWildcard)))
             {
-                _domainStore.Set(domain.Id, domain);
+                _domainStore.SetLocked(domain.Id, domain);
             }
         }
 
@@ -980,7 +980,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                             }
                             break;
                         case DomainChangeTypes.Remove:
-                            _domainStore.Clear(payload.Id);
+                            _domainStore.ClearLocked(payload.Id);
                             break;
                         case DomainChangeTypes.Refresh:
                             var domain = _serviceContext.DomainService.GetById(payload.Id);
@@ -988,7 +988,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                             if (domain.RootContentId.HasValue == false) continue; // anomaly
                             if (domain.LanguageIsoCode.IsNullOrWhiteSpace()) continue; // anomaly
                             var culture = CultureInfo.GetCultureInfo(domain.LanguageIsoCode);
-                            _domainStore.Set(domain.Id, new Domain(domain.Id, domain.DomainName, domain.RootContentId.Value, culture, domain.IsWildcard));
+                            _domainStore.SetLocked(domain.Id, new Domain(domain.Id, domain.DomainName, domain.RootContentId.Value, culture, domain.IsWildcard));
                             break;
                     }
                 }
@@ -1075,9 +1075,9 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
                 _contentStore.UpdateContentTypes(removedIds, typesA, kits);
                 if (!otherIds.IsCollectionEmpty())
-                    _contentStore.UpdateContentTypes(CreateContentTypes(PublishedItemType.Content, otherIds.ToArray()));
+                    _contentStore.UpdateContentTypesLocked(CreateContentTypes(PublishedItemType.Content, otherIds.ToArray()));
                 if (!newIds.IsCollectionEmpty())
-                    _contentStore.NewContentTypes(CreateContentTypes(PublishedItemType.Content, newIds.ToArray()));
+                    _contentStore.NewContentTypesLocked(CreateContentTypes(PublishedItemType.Content, newIds.ToArray()));
                 scope.Complete();
             }
         }
@@ -1106,9 +1106,9 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
                 _mediaStore.UpdateContentTypes(removedIds, typesA, kits);
                 if (!otherIds.IsCollectionEmpty())
-                    _mediaStore.UpdateContentTypes(CreateContentTypes(PublishedItemType.Media, otherIds.ToArray()).ToArray());
+                    _mediaStore.UpdateContentTypesLocked(CreateContentTypes(PublishedItemType.Media, otherIds.ToArray()).ToArray());
                 if (!newIds.IsCollectionEmpty())
-                    _mediaStore.NewContentTypes(CreateContentTypes(PublishedItemType.Media, newIds.ToArray()).ToArray());
+                    _mediaStore.NewContentTypesLocked(CreateContentTypes(PublishedItemType.Media, newIds.ToArray()).ToArray());
                 scope.Complete();
             }
         }

--- a/src/Umbraco.Web/PublishedCache/NuCache/readme.md
+++ b/src/Umbraco.Web/PublishedCache/NuCache/readme.md
@@ -1,10 +1,6 @@
 ﻿NuCache Documentation
 ======================
 
-NOTE - RENAMING
-Facade = PublishedSnapshot
-and everything needs to be renamed accordingly
-
 HOW IT WORKS
 -------------
 
@@ -22,12 +18,12 @@ When reading the cache, we read views up the chain until we find a value (which 
 null) for the given id, and finally we read the store itself.
 
 
-The FacadeService manages a ContentStore for content, and another for media.
-When a Facade is created, the FacadeService gets ContentView objects from the stores.
+The PublishedSnapshotService manages a ContentStore for content, and another for media.
+When a PublishedSnapshot is created, the PublishedSnapshotService gets ContentView objects from the stores.
 Views provide an immutable snapshot of the content and media.
 
-When the FacadeService is notified of changes, it notifies the stores.
-Then it resync the current Facade, so that it requires new views, etc.
+When the PublishedSnapshotService is notified of changes, it notifies the stores.
+Then it resync the current PublishedSnapshot, so that it requires new views, etc.
 
 Whenever a content, media or member is modified or removed, the cmsContentNu table
 is updated with a json dictionary of alias => property value, so that a content,
@@ -50,32 +46,32 @@ Each ContentStore has a _freezeLock object used to protect the 'Frozen'
 state of the store. It's a disposable object that releases the lock when disposed,
 so usage would be: using (store.Frozen) { ... }.
 
-The FacadeService has a _storesLock object used to guarantee atomic access to the
+The PublishedSnapshotService has a _storesLock object used to guarantee atomic access to the
 set of content, media stores.
 
 
 CACHE
 ------
 
-For each set of views, the FacadeService creates a SnapshotCache. So a SnapshotCache
+For each set of views, the PublishedSnapshotService creates a SnapshotCache. So a SnapshotCache
 is valid until anything changes in the content or media trees. In other words, things
 that go in the SnapshotCache stay until a content or media is modified.
 
-For each Facade, the FacadeService creates a FacadeCache. So a FacadeCache is valid
-for the duration of the Facade (usually, the request). In other words, things that go
-in the FacadeCache stay (and are visible to) for the duration of the request only.
+For each PublishedSnapshot, the PublishedSnapshotService creates a PublishedSnapshotCache. So a PublishedSnapshotCache is valid
+for the duration of the PublishedSnapshot (usually, the request). In other words, things that go
+in the PublishedSnapshotCache stay (and are visible to) for the duration of the request only.
 
-The FacadeService defines a static constant FullCacheWhenPreviewing, that defines
+The PublishedSnapshotService defines a static constant FullCacheWhenPreviewing, that defines
 how caches operate when previewing:
 - when true, the caches in preview mode work normally.
-- when false, everything that would go to the SnapshotCache goes to the FacadeCache.
+- when false, everything that would go to the SnapshotCache goes to the PublishedSnapshotCache.
 At the moment it is true in the code, which means that eg converted values for
 previewed content will go in the SnapshotCache. Makes for faster preview, but uses
 more memory on the long term... would need some benchmarking to figure out what is
 best.
 
-Members only live for the duration of the Facade. So, for members SnapshotCache is
-never used, and everything goes to the FacadeCache.
+Members only live for the duration of the PublishedSnapshot. So, for members SnapshotCache is
+never used, and everything goes to the PublishedSnapshotCache.
 
 All cache keys are computed in the CacheKeys static class.
 
@@ -85,15 +81,15 @@ TESTS
 
 For testing purposes the following mechanisms exist:
 
-The Facade type has a static Current property that is used to obtain the 'current'
-facade in many places, going through the PublishedCachesServiceResolver to get the
-current service, and asking the current service for the current facade, which by
+The PublishedSnapshot type has a static Current property that is used to obtain the 'current'
+PublishedSnapshot in many places, going through the PublishedCachesServiceResolver to get the
+current service, and asking the current service for the current PublishedSnapshot, which by
 default relies on UmbracoContext. For test purposes, it is possible to override the
-entire mechanism by defining Facade.GetCurrentFacadeFunc which should return a facade.
+entire mechanism by defining PublishedSnapshot.GetCurrentPublishedSnapshotFunc which should return a PublishedSnapshot.
 
 A PublishedContent keeps only id-references to its parent and children, and needs a
 way to retrieve the actual objects from the cache - which depends on the current
-facade. It is possible to override the entire mechanism by defining PublishedContent.
+PublishedSnapshot. It is possible to override the entire mechanism by defining PublishedContent.
 GetContentByIdFunc or .GetMediaByIdFunc.
 
 Setting these functions must be done before Resolution is frozen.
@@ -110,7 +106,7 @@ possible to support detached contents & properties, even those that do not have 
 int id, but again this should be refactored entirely anyway.
 
 Not doing any row-version checks (see XmlStore) when reloading from database, though it
-is maintained in the database. Two FIXME in FacadeService. Should we do it?
+is maintained in the database. Two FIXME in PublishedSnapshotService. Should we do it?
 
 There is no on-disk cache at all so everything is reloaded from the cmsContentNu table
 when the site restarts. This is pretty fast, but we should experiment with solutions to

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -1216,7 +1216,7 @@
     <EmbeddedResource Include="JavaScript\PreviewInitialize.js" />
     <None Include="JavaScript\TinyMceInitialize.js" />
     <!--<Content Include="umbraco.presentation\umbraco\users\PermissionEditor.aspx" />-->
-    <Content Include="PublishedCache\NuCache\notes.txt" />
+    <None Include="PublishedCache\NuCache\readme.md" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Web References\org.umbraco.update\checkforupgrade.disco" />

--- a/src/Umbraco.Web/UmbracoApplication.cs
+++ b/src/Umbraco.Web/UmbracoApplication.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Web
 
             var mainDomLock = appSettingMainDomLock == "SqlMainDomLock"
                 ? (IMainDomLock)new SqlMainDomLock(logger)
-                : new MainDomSemaphoreLock();
+                : new MainDomSemaphoreLock(logger);
             
             var runtime = new WebRuntime(this, logger, new MainDom(logger, mainDomLock));
 


### PR DESCRIPTION
Fixing deadlock issue https://github.com/umbraco/Umbraco-CMS/issues/7404

The fix has been backported for 8.4.1 which is the bare minimum changes required for this https://github.com/umbraco/Umbraco-CMS/issues/7404

There are a lot of changes here because I've discovered a bunch of oddities that should be handled plus the changes strive to make it easier to debug and read some of the code.

Note that this PR targets another WIP branch but this PR should be reviewed separately to that one since this is primarily about cleanup up these locks.

* No more recursive locks allowed. Previously we were allowing recursive locks in the ContentStore and SnapDictionary which gets ultra confusing. This is also why there was code to count how many locks there were which is simply unnecessary if you don't allow lock recursion. As it turns out, we didn't even need lock recursion. Lock recursion is difficult to debug and can also lead to deadlocks.
  * So any methods in ContentStore/SnapDictionary that are required to be called within a lock are suffixed with the term `Locked` which was the previous practice. We now also ensure that we are locked when calling these methods, else an exception is thrown. We also throw an exception if any of these methods are called recursively. I've checked through all of the code and as far as I've discovered it is not possible to call these methods recursively therefore causing a recursive lock.
  * Ensure we have try/finally for exiting a lock, previously there was no guarantee that an exception couldn't be thrown in the `Release` methods
  * Updates tests to show we don't allow recursive locks and that we require locking around these methods explicitly
* Change readlocks in both ContentStore/SnapDictionary (`_rlocko`) to use the standard c# `lock` mechanism. There was no reason at all to use the long-hand way that it was doing before. The write lock is still the long-hand way because the lock is created and exited in a scope.
* `WriteLockInfo.Count` is removed because we no longer need to count how many recursive locks we had
* There was 2x erroneous calls to `Interlocked.CompareExchange` which served zero purpose except for additional overhead.
* Changes the MainDom timeout to be 40 seconds instead of 1min 30 seconds. Seems insane that any app would take more than 40 seconds to shutdown. Perhaps this was an old setting based on previous assumptions that Examine could hold the app restart up if indexes were rebuilding during shutdown... which is no longer the case. 40 seconds is still super long but much better than before.
* Adds some additional logging

