### PR TITLE
V8: Don't allow editing trashed media items from the media picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -36,7 +36,7 @@
                 </umb-file-icon>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
-                    <button aria-label="Edit media" ng-if="allowEditMedia" class="umb-sortable-thumbnails__action btn-reset" data-element="action-edit" ng-click="vm.editItem(media)">
+                    <button aria-label="Edit media" ng-if="allowEditMedia && !media.trashed" class="umb-sortable-thumbnails__action btn-reset" data-element="action-edit" ng-click="vm.editItem(media)">
                         <i class="icon icon-edit" aria-hidden="true"></i>
                     </button>
                     <button aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="vm.remove($index)">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The media picker shows an edit button even for trashed and deleted items:

![image](https://user-images.githubusercontent.com/7405322/71716017-ad00f980-2e13-11ea-8109-c9e9765f9c61.png)

It makes little sense to edit a trashed item. And if the item is completely deleted, the media editor throws an error and keeps loading indefinitely: 

![image](https://user-images.githubusercontent.com/7405322/71715931-5f848c80-2e13-11ea-8fde-44a313f8644e.png)

This PR removes the media picker edit button for trashed (and deleted) media items:

![image](https://user-images.githubusercontent.com/7405322/71715788-dff6bd80-2e12-11ea-9f11-03a2a8e5f9c2.png)

...and it works for both single and multi modes:

![image](https://user-images.githubusercontent.com/7405322/71715808-ec7b1600-2e12-11ea-8094-0e3370b825f5.png)

