### PR TITLE
yesno-property-with-default-value (issue #7409)

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
@@ -22,6 +22,12 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
             // typically the converter does not need to handle anything else ("true"...)
             // however there are cases where the value passed to the converter could be a non-string object, e.g. int, bool
 
+            if (source == null)
+            {
+                // if source is null fall back to default-value of data type
+                source = propertyType?.DataType?.ConfigurationAs<dynamic>()?.Default;
+            }
+            
             if (source is string s)
             {
                 if (s.Length == 0 || s == "0")


### PR DESCRIPTION
Hi,

**References**
Issue #7409 

**Problem**
If I add a Checkbox-property with a default value to an already existing and in-use Doctype, the default value is not used as a fallback in the ValueConverter of the property.

This is not a problem when the default value of the data type is ```false```, because in the ```Umbraco.Core.PropertyEditors.ValueConverters.YesNoValueConverter it ultimately``` (when ```source``` is ```null```) falls back to ```false```. However when the default value is set to ```true``` the ValueConverter still defaults to ```false```, which is not expected.

**Solution**
What I did to solve this was, I added logic to the   ```Umbraco.Core.PropertyEditors.ValueConverters.YesNoValueConverter``` that gets and falls back to the default value of the data type when ```source``` is ```null```.

Since there is no ```TrueFalseConfiguration``` in ```Umbraco.Core``` (only in ```Umbraco.Web``` which I cannot reference from within ```Umbraco.Core```) I used ```dynamic``` to get the default value of the data type. I know ```dynamic``` is a bit "filthy", so a cleaner way to get the default value would be neat!