### PR TITLE
Changed from using nodetype to tree alias because sometimes we have t…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -91,7 +91,7 @@ angular.module("umbraco.directives")
                 }
 
                 // checking the nodeType to ensure that this node and actionNode is from the same treeAlias
-                if (actionNode && actionNode.nodeType === node.nodeType) {
+                if (actionNode && actionNode.metaData.treeAlias === node.metaData.treeAlias) {
 
                     if (actionNode.id === node.id && String(node.id) !== "-1") {
                         css.push("active");


### PR DESCRIPTION
Changed from using nodetype to tree alias because sometimes we have the same nodetype in different trees.

### Prerequisites

- [x] I have added steps to test this contribution in the description below
Steps:
1) create custom section
2) create 2 custom trees in that section
3) create two nodes in each tree that have the same id

Fixes #7423

When editing each node, you will notice that the 'active' flag gets set for both trees.

If there's an existing issue for this PR then this fixes N/A

### Description
When we were porting our Umbraco LMS to version 8, we noticed that this problem exists as we have a utility section that has 4 or 5 small trees in it.  You will see the issue in the screenshot attached a before and after shot.
 
<!-- Thanks for contributing to Umbraco CMS! -->
![screenshot 45](https://user-images.githubusercontent.com/48035881/71850774-18acc600-30a3-11ea-9fdb-edd8c2fe2611.jpg)
![screenshot 43](https://user-images.githubusercontent.com/48035881/71850775-18acc600-30a3-11ea-8f18-888810fc46f3.jpg)
