### PR TITLE
V8: Fix JS error when trying to insert a link in an empty RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -184,7 +184,7 @@ function entityResource($q, $http, umbRequestHelper) {
         getAnchors: function (rteContent) {
 
             if (!rteContent || rteContent.length === 0) {
-                return [];
+                return $q.when([]);
             }
 
             return umbRequestHelper.resourcePromise(


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you attempt to insert a link in an empty RTE, a JS error is thrown:

![empty-rte-linkpicker-error-before](https://user-images.githubusercontent.com/7405322/71975592-a52ac600-3214-11ea-8067-5cf6bd685b4c.gif)

Turns out `getAnchors.getAnchors(...)` has varying return types; it returns an empty array if the RTE is empty and a promise if the RTE is _not_ empty. 

This PR ensures that `getAnchors.getAnchors(...)` always returns a promise, and thus the linkpicker no longer throws an error:

![empty-rte-linkpicker-error-after](https://user-images.githubusercontent.com/7405322/71975699-e7ec9e00-3214-11ea-88f9-894e5bfc1191.gif)

_Note: Inserting a link in the RTE without a selection results in a sort of weird behavior where the link text is empty. This should probably be addressed in another PR as it affects non-empty RTEs as well._