### PR TITLE
Upgrade to 8.4.0 causes 503 errors on Authorize Upgrade page

### DIFF
--- a/build/NuSpecs/tools/Web.config.install.xdt
+++ b/build/NuSpecs/tools/Web.config.install.xdt
@@ -191,8 +191,8 @@
   </location>
   <location path="umbraco" xdt:Locator="Match(path)">
     <system.webServer>
-      <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" xdt:Transform="SetAttributes(doStaticCompression,doDynamicCompression,dynamicCompressionBeforeCache)" />
-      <httpErrors errorMode="Custom" existingResponse="PassThrough" xdt:Transform="SetAttributes(errorMode,existingResponse)"/>
+      <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" xdt:Transform="SetAttributes" />
+      <httpErrors existingResponse="Auto" xdt:Transform="SetAttributes" />
     </system.webServer>
   </location>
   
@@ -208,8 +208,8 @@
   </location>
   <location path="App_Plugins" xdt:Locator="Match(path)">
     <system.webServer>
-      <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" xdt:Transform="SetAttributes(doStaticCompression,doDynamicCompression,dynamicCompressionBeforeCache)" />
-      <httpErrors errorMode="Custom" existingResponse="PassThrough" xdt:Transform="SetAttributes(errorMode,existingResponse)"/>
+      <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" xdt:Transform="SetAttributes" />
+      <httpErrors existingResponse="Auto" xdt:Transform="SetAttributes" />
     </system.webServer>
   </location>
 

--- a/build/NuSpecs/tools/Web.config.install.xdt
+++ b/build/NuSpecs/tools/Web.config.install.xdt
@@ -181,15 +181,35 @@
 
   <location path="umbraco" xdt:Locator="Match(path)" xdt:Transform="InsertIfMissing" />
   <location path="umbraco" xdt:Locator="Match(path)">
-    <system.webServer xdt:Transform="InsertIfMissing">
-      <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" xdt:Transform="SetAttributes(doStaticCompression,doDynamicCompression,dynamicCompressionBeforeCache)" />
+    <system.webServer xdt:Transform="InsertIfMissing" />
+  </location>
+  <location path="umbraco" xdt:Locator="Match(path)">
+    <system.webServer>
+      <urlCompression xdt:Transform="InsertIfMissing" />
+      <httpErrors xdt:Transform="InsertIfMissing" />
     </system.webServer>
   </location>
-
+  <location path="umbraco" xdt:Locator="Match(path)">
+    <system.webServer>
+      <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" xdt:Transform="SetAttributes(doStaticCompression,doDynamicCompression,dynamicCompressionBeforeCache)" />
+      <httpErrors errorMode="Custom" existingResponse="PassThrough" xdt:Transform="SetAttributes(errorMode,existingResponse)"/>
+    </system.webServer>
+  </location>
+  
   <location path="App_Plugins" xdt:Locator="Match(path)" xdt:Transform="InsertIfMissing" />
   <location path="App_Plugins" xdt:Locator="Match(path)">
-    <system.webServer xdt:Transform="InsertIfMissing">
+    <system.webServer xdt:Transform="InsertIfMissing" />
+  </location>
+  <location path="App_Plugins" xdt:Locator="Match(path)">
+    <system.webServer>
+      <urlCompression xdt:Transform="InsertIfMissing" />
+      <httpErrors xdt:Transform="InsertIfMissing" />
+    </system.webServer>
+  </location>
+  <location path="App_Plugins" xdt:Locator="Match(path)">
+    <system.webServer>
       <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" xdt:Transform="SetAttributes(doStaticCompression,doDynamicCompression,dynamicCompressionBeforeCache)" />
+      <httpErrors errorMode="Custom" existingResponse="PassThrough" xdt:Transform="SetAttributes(errorMode,existingResponse)"/>
     </system.webServer>
   </location>
 

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -259,11 +259,13 @@
     <location path="umbraco">
         <system.webServer>
             <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" />
+            <httpErrors errorMode="Custom" existingResponse="PassThrough" />
         </system.webServer>
     </location>
     <location path="App_Plugins">
         <system.webServer>
             <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" />
+            <httpErrors errorMode="Custom" existingResponse="PassThrough" />
         </system.webServer>
     </location>
 

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -259,13 +259,13 @@
     <location path="umbraco">
         <system.webServer>
             <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" />
-            <httpErrors errorMode="Custom" existingResponse="PassThrough" />
+            <httpErrors existingResponse="Auto" />
         </system.webServer>
     </location>
     <location path="App_Plugins">
         <system.webServer>
             <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" />
-            <httpErrors errorMode="Custom" existingResponse="PassThrough" />
+            <httpErrors existingResponse="Auto" />
         </system.webServer>
     </location>
 


### PR DESCRIPTION
The introduction of a new status code in #6334 has led to some people with custom error handling to have problems while upgrading.

It's difficult to predict all the people do with their configurations, but we can definitely help here by always expecting the "correct" handling in the `/umbraco` folder. For backoffice routes, we rely on default behaviors to make the backoffice run smoothly.

Note: I noticed that the config transform for disabling dynamic compression for `/umbraco` and `/App_Plugins` was not working correctly either, so I've updated those to actually create elements if they don't yet exist.

I have chosen to also ignore custom error for the `App_Plugins` directory, again because Umbraco is quite reliant on plugins returning proper 404s etc. 

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7320

### Description
To test:

1. Install Umbraco 8.4.0 from NuGet
2. Create a build of the 8.6.0 NuGet packages (Powershell run `./build/build.ps1)`)
3. Copy the 8.6 nupkg files to a directory like D:\NuGetRepo
4. Update Umbraco using a command pointing at this directory: `Update-Package UmbracoCms -Source D:\NuGetRepo`
5. Note that the web.config file now has `<httpErrors errorMode="Custom" existingResponse="PassThrough" />` in both `<location>` elements

For an easier test of the actual transforms:
1. Take any 8.4.0 web.config file
2. Paste it in the first box here: https://webconfigtransformationtester.apphb.com/
3. Paste `build/NuSpecs/tools/Web.config.install.xdt` in the second box
4. Use the Transform button and inspect the result



