### PR TITLE
Uses AppSettings.Path constant for SystemDirectories.Umbraco

### DIFF
--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -42,6 +42,21 @@ namespace Umbraco.Core
             public const string Path = "Umbraco.Core.Path";
 
             /// <summary>
+            /// Gets the path to umbraco's root directory (/umbraco by default).
+            /// </summary>
+            public const string CssPath = "umbracoCssPath";
+
+            /// <summary>
+            /// Gets the path to umbraco's root directory (/umbraco by default).
+            /// </summary>
+            public const string ScriptsPath = "umbracoScriptsPath";
+
+            /// <summary>
+            /// Gets the path to umbraco's root directory (/umbraco by default).
+            /// </summary>
+            public const string MediaPath = "umbracoMediaPath";
+
+            /// <summary>
             /// The reserved urls from web.config.
             /// </summary>
             public const string ReservedUrls = "Umbraco.Core.ReservedUrls";

--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -42,17 +42,17 @@ namespace Umbraco.Core
             public const string Path = "Umbraco.Core.Path";
 
             /// <summary>
-            /// Gets the path to umbraco's root directory (/umbraco by default).
+            /// Gets the path to the css directory (/css by default).
             /// </summary>
             public const string CssPath = "umbracoCssPath";
 
             /// <summary>
-            /// Gets the path to umbraco's root directory (/umbraco by default).
+            /// Gets the path to the scripts directory (/scripts by default).
             /// </summary>
             public const string ScriptsPath = "umbracoScriptsPath";
 
             /// <summary>
-            /// Gets the path to umbraco's root directory (/umbraco by default).
+            /// Gets the path to  media directory (/media by default).
             /// </summary>
             public const string MediaPath = "umbracoMediaPath";
 

--- a/src/Umbraco.Core/IO/SystemDirectories.cs
+++ b/src/Umbraco.Core/IO/SystemDirectories.cs
@@ -29,11 +29,11 @@ namespace Umbraco.Core.IO
 
         public static string MacroPartials => MvcViews + "/MacroPartials/";
 
-        public static string Media => IOHelper.ReturnPath("umbracoMediaPath", "~/media");
+        public static string Media => IOHelper.ReturnPath(Constants.AppSettings.MediaPath, "~/media");
 
-        public static string Scripts => IOHelper.ReturnPath("umbracoScriptsPath", "~/scripts");
+        public static string Scripts => IOHelper.ReturnPath(Constants.AppSettings.ScriptsPath, "~/scripts");
 
-        public static string Css => IOHelper.ReturnPath("umbracoCssPath", "~/css");
+        public static string Css => IOHelper.ReturnPath(Constants.AppSettings.CssPath, "~/css");
 
         public static string Umbraco => IOHelper.ReturnPath(Constants.AppSettings.Path, "~/umbraco");
 

--- a/src/Umbraco.Core/IO/SystemDirectories.cs
+++ b/src/Umbraco.Core/IO/SystemDirectories.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Core.IO
 
         public static string Css => IOHelper.ReturnPath("umbracoCssPath", "~/css");
 
-        public static string Umbraco => IOHelper.ReturnPath("umbracoPath", "~/umbraco");
+        public static string Umbraco => IOHelper.ReturnPath(Constants.AppSettings.Path, "~/umbraco");
 
         public static string Packages => Data + "/packages";
 


### PR DESCRIPTION
- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/7336

Changes the magic string in Umbraco.Core.IO.SystemDirectories.Umbraco to use the global constant for the AppSettings.Path. This results in the css being pulled from the correct location when the backoffice is launched.

Tested with these settings:
![Capture](https://user-images.githubusercontent.com/12752608/72019574-f8fad680-3237-11ea-82ae-6875efd1ed19.PNG)

Then the css files loaded from the correct location:
![image](https://user-images.githubusercontent.com/12752608/72019972-bab1e700-3238-11ea-80a8-a5b6664d0bac.png)

