### PR TITLE
V8: Disable the actions menu button until there are actions available

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button.less
@@ -31,6 +31,11 @@
    margin-left: 5px;
 }
 
+.umb-button__button[disabled] .umb-button__caret {
+    border-top-color: @gray-7;
+    border-bottom-color: @gray-7;
+}
+
 .umb-button__progress {
    position: absolute;
    left: 50%;

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -73,6 +73,11 @@
     height: @editorHeaderHeight;
 }
 
+.umb-editor-header .umb-button__button[disabled] {
+    // do not dim down the background color of disabled buttons in the header
+    background-color: unset;
+}
+
 .umb-editor-header__back {
     background: transparent;
     border: 0;

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-menu.html
@@ -8,6 +8,7 @@
         show-caret="true"
         has-popup="true"
         is-expanded="dropdown.isOpen"
+        disabled="!actions || !actions.length"
         >
     </umb-button>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR replaces #7312 

### Description

As discussed on #7312, the  actions menu button in the editor header shouldn't be enabled until there are any actions to show. 

This PR implements that. When applied, the actions menu button is disabled and subtly dimmed down until the actions for the current content loads:

![disable-actions-button-until-actions-load](https://user-images.githubusercontent.com/7405322/72153826-3afa5880-33af-11ea-9a87-2d94898e67c8.gif)

If no actions are loaded, the actions menu button simply remains disabled and dimmed down.