### PR TITLE
V8: Fix JS errors for Nested Content in single mode

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -265,6 +265,9 @@
         };
 
         vm.getName = function (idx) {
+            if (!model.value || !model.value.length) {
+                return "";
+            }
 
             var name = "";
 
@@ -314,6 +317,10 @@
         };
 
         vm.getIcon = function (idx) {
+            if (!model.value || !model.value.length) {
+                return "";
+            }
+
             var scaffold = getScaffold(model.value[idx].ncContentTypeAlias);
             return scaffold && scaffold.icon ? iconHelper.convertFromLegacyIcon(scaffold.icon) : "icon-folder";
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If your content type has a Nested Content property that's configured in single mode (at least I believe single mode is the culprit here), the content type editor throws an endless series of JS errors in the console:

![nested-content-single-mode-js-errors](https://user-images.githubusercontent.com/7405322/72156464-e5757a00-33b5-11ea-95a8-cc2458ab1f61.gif)

This is related to the preview of the Nested Content property and does not happen when Nested Content is configured with multiple element types.

### Steps to reproduce

1. Create a Nested Content datatype configured with only one element type (a.k.a. single mode).
2. Add the property to a content type and save.
3. Reload the content type editor and have a look at the JS console.