### PR TITLE
V8: fix route change issue when editing image on new node

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -73,14 +73,14 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
         
         var content = $scope.content;
         
-        // we need to check wether an app is present in the current data, if not we will present the default app.
+        // we need to check whether an app is present in the current data, if not we will present the default app.
         var isAppPresent = false;
         
         // on first init, we dont have any apps. but if we are re-initializing, we do, but ...
         if ($scope.app) {
             
             // lets check if it still exists as part of our apps array. (if not we have made a change to our docType, even just a re-save of the docType it will turn into new Apps.)
-            _.forEach(content.apps, function(app) {
+            content.apps.forEach(app => {
                 if (app === $scope.app) {
                     isAppPresent = true;
                 }
@@ -88,7 +88,7 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
             
             // if we did reload our DocType, but still have the same app we will try to find it by the alias.
             if (isAppPresent === false) {
-                _.forEach(content.apps, function(app) {
+                content.apps.forEach(app => {
                     if (app.alias === $scope.app.alias) {
                         isAppPresent = true;
                         app.active = true;
@@ -182,24 +182,26 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
 
                     formHelper.resetForm({ scope: $scope });
 
-                    contentEditingHelper.handleSuccessfulSave({
-                        scope: $scope,
-                        savedContent: data,
-                        rebindCallback: contentEditingHelper.reBindChangedProperties($scope.content, data)
-                    });
-
-                    editorState.set($scope.content);
-                    
-                    syncTreeNode($scope.content, data.path);
-
-                    init();
-
-                    $scope.page.saveButtonState = "success";
-
                     // close the editor if it's infinite mode
+                    // submit function manages rebinding changes
                     if(infiniteMode && $scope.model.submit) {
                         $scope.model.mediaNode = $scope.content;
                         $scope.model.submit($scope.model);
+                    } else {
+                        // if not infinite mode, rebind changed props etc
+                        contentEditingHelper.handleSuccessfulSave({
+                            scope: $scope,
+                            savedContent: data,
+                            rebindCallback: contentEditingHelper.reBindChangedProperties($scope.content, data)
+                        });
+
+                        editorState.set($scope.content);
+
+                        syncTreeNode($scope.content, data.path);
+                        
+                        $scope.page.saveButtonState = "success";
+
+                        init();
                     }
 
                 }, function(err) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -48,49 +48,45 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                     // This is done by remapping the int/guid ids into a new array of items, where we create "Deleted item" placeholders
                     // when there is no match for a selected id. This will ensure that the values being set on save, are the same as before.
 
-                    medias = _.map(ids,
-                        function (id) {
-                            var found = _.find(medias,
-                                function (m) {
-                                    // We could use coercion (two ='s) here .. but not sure if this works equally well in all browsers and
-                                    // it's prone to someone "fixing" it at some point without knowing the effects. Rather use toString()
-                                    // compares and be completely sure it works.
-                                    return m.udi.toString() === id.toString() || m.id.toString() === id.toString();
-                                });
-                            if (found) {
-                                return found;
-                            } else {
-                                return {
-                                    name: vm.labels.deletedItem,
-                                    id: $scope.model.config.idType !== "udi" ? id : null,
-                                    udi: $scope.model.config.idType === "udi" ? id : null,
-                                    icon: "icon-picture",
-                                    thumbnail: null,
-                                    trashed: true
-                                };
-                            }
-                        });
+                    medias = ids.map(id => {
+                        var found = medias.find(m =>
+                            // We could use coercion (two ='s) here .. but not sure if this works equally well in all browsers and
+                            // it's prone to someone "fixing" it at some point without knowing the effects. Rather use toString()
+                            // compares and be completely sure it works.
+                            m.udi.toString() === id.toString() || m.id.toString() === id.toString());
+                        
+                        if (found) {
+                            return found;
+                        } else {
+                            return {
+                                name: vm.labels.deletedItem,
+                                id: $scope.model.config.idType !== "udi" ? id : null,
+                                udi: $scope.model.config.idType === "udi" ? id : null,
+                                icon: "icon-picture",
+                                thumbnail: null,
+                                trashed: true
+                            };
+                        }
+                    });
 
-                    _.each(medias,
-                        function (media, i) {
+                    medias.forEach(media => {
+                        if (!media.extension && media.id && media.metaData) {
+                            media.extension = mediaHelper.getFileExtension(media.metaData.MediaPath);
+                        }
 
-                            if (!media.extension && media.id && media.metaData) {
-                                media.extension = mediaHelper.getFileExtension(media.metaData.MediaPath);
-                            }
+                        // if there is no thumbnail, try getting one if the media is not a placeholder item
+                        if (!media.thumbnail && media.id && media.metaData) {
+                            media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
+                        }
 
-                            // if there is no thumbnail, try getting one if the media is not a placeholder item
-                            if (!media.thumbnail && media.id && media.metaData) {
-                                media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
-                            }
+                        $scope.mediaItems.push(media);
 
-                            $scope.mediaItems.push(media);
-
-                            if ($scope.model.config.idType === "udi") {
-                                $scope.ids.push(media.udi);
-                            } else {
-                                $scope.ids.push(media.id);
-                            }
-                        });
+                        if ($scope.model.config.idType === "udi") {
+                            $scope.ids.push(media.udi);
+                        } else {
+                            $scope.ids.push(media.id);
+                        }
+                    });
 
                     sync();
                 });
@@ -100,7 +96,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
         function sync() {
             $scope.model.value = $scope.ids.join();
             removeAllEntriesAction.isDisabled = $scope.ids.length === 0;
-        };
+        }
 
         function setDirty() {
             angularHelper.getCurrentForm($scope).$setDirty();
@@ -111,18 +107,17 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
             // reload. We only reload the images that is already picked but has been updated.
             // We have to get the entities from the server because the media 
             // can be edited without being selected
-            _.each($scope.images,
-                function (image, i) {
-                    if (updatedMediaNodes.indexOf(image.udi) !== -1) {
-                        image.loading = true;
-                        entityResource.getById(image.udi, "media")
-                            .then(function (mediaEntity) {
-                                angular.extend(image, mediaEntity);
-                                image.thumbnail = mediaHelper.resolveFileFromEntity(image, true);
-                                image.loading = false;
-                            });
-                    }
-                });
+            $scope.mediaItems.forEach(media => {
+                if (updatedMediaNodes.indexOf(media.udi) !== -1) {
+                    media.loading = true;
+                    entityResource.getById(media.udi, "Media")
+                        .then(function (mediaEntity) {
+                            angular.extend(media, mediaEntity);
+                            media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
+                            media.loading = false;
+                        });
+                }
+            });
         }
 
         function init() {
@@ -177,20 +172,20 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                     // the media picker is using media entities so we get the
                     // entity so we easily can format it for use in the media grid
                     if (model && model.mediaNode) {
-                        entityResource.getById(model.mediaNode.id, "media")
+                        entityResource.getById(model.mediaNode.id, "Media")
                             .then(function (mediaEntity) {
                                 // if an image is selecting more than once 
                                 // we need to update all the media items
-                                angular.forEach($scope.images, function (image) {
-                                    if (image.id === model.mediaNode.id) {
-                                        angular.extend(image, mediaEntity);
-                                        image.thumbnail = mediaHelper.resolveFileFromEntity(image, true);
+                                $scope.mediaItems.forEach(media => {
+                                    if (media.id === model.mediaNode.id) {
+                                        angular.extend(media, mediaEntity);
+                                        media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
                                     }
                                 });
                             });
                     }
                 },
-                close: function (model) {
+                close: function () {
                     editorService.close();
                 }
             };
@@ -210,7 +205,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
 
                     editorService.close();
 
-                    _.each(model.selection, function (media, i) {
+                    model.selection.forEach(media => {
                         // if there is no thumbnail, try getting one if the media is not a placeholder item
                         if (!media.thumbnail && media.id && media.metaData) {
                             media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
@@ -280,16 +275,14 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
             disabled: !multiPicker,
             items: "li:not(.add-wrapper)",
             cancel: ".unsortable",
-            update: function (e, ui) {
+            update: function () {
                 setDirty();
                 $timeout(function() {
                     // TODO: Instead of doing this with a timeout would be better to use a watch like we do in the
                     // content picker. Then we don't have to worry about setting ids, render models, models, we just set one and let the
                     // watch do all the rest.
-                    $scope.ids = _.map($scope.mediaItems,
-                        function (item) {
-                            return $scope.model.config.idType === "udi" ? item.udi : item.id;
-                        });
+                    $scope.ids = $scope.mediaItems.map(media => $scope.model.config.idType === "udi" ? media.udi : media.id);
+                    
                     sync();
                 });
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -36,16 +36,16 @@
                 </umb-file-icon>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
-                    <button aria-label="Edit media" ng-if="allowEditMedia" class="umb-sortable-thumbnails__action btn-reset" data-element="action-edit" ng-click="vm.editItem(media)">
+                    <button type="button" aria-label="Edit media" ng-if="allowEditMedia" class="umb-sortable-thumbnails__action btn-reset" data-element="action-edit" ng-click="vm.editItem(media)">
                         <i class="icon icon-edit" aria-hidden="true"></i>
                     </button>
-                    <button aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="vm.remove($index)">
+                    <button type="button" aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="vm.remove($index)">
                         <i class="icon icon-delete" aria-hidden="true"></i>
                     </button>
                 </div>
             </li>
             <li style="border: none;" class="add-wrapper unsortable" ng-if="vm.showAdd() && allowAddMedia">
-                <button aria-label="Open media picker" data-element="sortable-thumbnails-add" class="add-link btn-reset" ng-click="vm.add()" ng-class="{'add-link-square': (mediaItems.length === 0 || isMultiPicker)}" prevent-default>
+                <button type="button" aria-label="Open media picker" data-element="sortable-thumbnails-add" class="add-link btn-reset" ng-click="vm.add()" ng-class="{'add-link-square': (mediaItems.length === 0 || isMultiPicker)}" prevent-default>
                     <i class="icon icon-add large" aria-hidden="true"></i>
                 </button>
             </li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7377 

### Description
Per the issue description, this PR fixes the bug where (infinite) editing an image from a new (unsaved) content item causes a broken route change, causing a 404, causing a UI error message to display.

The bug was caused by calls to a few methods not required when editing in infinite mode (eg syncing the tree, updating editorState), which then caused unexpected behaviour by updating the ID in the route to that of the edited media item rather than the current content item, which threw the 404. I've fixed this by shifting the non-infinite bits behind the existing infiniteMode check. All seems to be working fine, both editing media in infinite and inline mode, and from new or existing content items.

Other changes in the PR remove Lodash functions replacing them with native JS, renaming some variables (from `image` to `media` as the variable is not always an image) and adding type attribute to buttons to prevent unwanted form submits.

There was also some unreachable code in the mediapicker controller, where a couple of loops referenced $scope.images, which didn't exist. I'm assuming that should be $scope.mediaItems, as that's the collection of media items assigned in the picker...

To test:
- create a new content node, DO NOT SAVE
- add a media item to the node
- edit the media item
- save and close the infinite editor
- get a happy green message
- edit media item again, to confirm changes saved
