### PR TITLE
add dialog for change password, shift form from user details view int…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/users.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/users.resource.js
@@ -405,6 +405,43 @@
                     formattedSaveData),
                 "Failed to save user");
         }
+        
+        /**
+          * @ngdoc method
+          * @name umbraco.resources.usersResource#changePassword
+          * @methodOf umbraco.resources.usersResource
+          *
+          * @description
+          * Changes a user's password
+          *
+          * ##usage
+          * <pre>
+          * usersResource.changePassword(changePasswordModel)
+          *    .then(function() {
+          *        // password changed
+          *    });
+          * </pre>
+          * 
+          * @param {Object} model object to save
+          * @returns {Promise} resourcePromise object containing the updated user.
+          *
+          */        
+        function changePassword(changePasswordModel) {
+            if (!changePasswordModel) {
+                throw "password model not specified";
+            }
+
+            //need to convert the password data into the correctly formatted save data - it is *not* the same and we don't want to over-post
+            var formattedPasswordData = umbDataFormatter.formatChangePasswordModel(changePasswordModel);
+
+            return umbRequestHelper.resourcePromise(
+                $http.post(
+                    umbRequestHelper.getApiUrl(
+                        "userApiBaseUrl",
+                        "PostChangePassword"),
+                    formattedPasswordData),
+                "Failed to save user");
+        }        
 
         /**
           * @ngdoc method
@@ -447,6 +484,7 @@
             createUser: createUser,
             inviteUser: inviteUser,
             saveUser: saveUser,
+            changePassword: changePassword,
             deleteNonLoggedInUser: deleteNonLoggedInUser,
             clearAvatar: clearAvatar
         };

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
@@ -152,8 +152,7 @@
             formatUserPostData: function (displayModel) {
 
                 //create the save model from the display model
-                var saveModel = _.pick(displayModel, 'id', 'parentId', 'name', 'username', 'culture', 'email', 'startContentIds', 'startMediaIds', 'userGroups', 'message', 'changePassword');
-                saveModel.changePassword = this.formatChangePasswordModel(saveModel.changePassword);
+                var saveModel = _.pick(displayModel, 'id', 'parentId', 'name', 'username', 'culture', 'email', 'startContentIds', 'startMediaIds', 'userGroups', 'message');
 
                 //make sure the userGroups are just a string array
                 var currGroups = saveModel.userGroups;

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/changepassword/changepassword.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/changepassword/changepassword.html
@@ -1,0 +1,6 @@
+<ng-form name="passwordForm" class="block-form" val-form-manager>
+
+  <change-password password-values="model.changePassword" config="model.config">
+  </change-password>
+
+</ng-form>

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -125,9 +125,31 @@
         }
 
         function toggleChangePassword() {
-          vm.changePasswordModel.isChanging = !vm.changePasswordModel.isChanging;
-          //reset it
-          vm.user.changePassword = null;
+            //reset it
+            vm.user.changePassword = null;
+
+            localizationService.localizeMany(["general_cancel", "general_confirm", "general_changePassword"])
+                .then(function (data) {
+                    const overlay = {
+                        view: "changepassword",
+                        title: data[2],
+                        changePassword: vm.user.changePassword,
+                        config: vm.changePasswordModel.config,
+                        closeButtonLabel: data[0],
+                        submitButtonLabel: data[1],
+                        submitButtonStyle: 'success',
+                        close: function () {
+                            overlayService.close();
+                        },
+                        submit: function (model) {
+                            overlayService.close();
+                            if (model.changePassword.newPassword !== model.changePassword.oldPassword) {
+                                save();
+                            }
+                        }
+                    };
+                    overlayService.open(overlay);
+              });
         }
 
         function save() {

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -143,9 +143,8 @@
                         },
                         submit: function (model) {
                             overlayService.close();
-                            if (model.changePassword.newPassword !== model.changePassword.oldPassword) {
-                                save();
-                            }
+                            vm.user.changePassword = model.changePassword;
+                            save();                            
                         }
                     };
                     overlayService.open(overlay);

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -258,7 +258,7 @@
                     </div>
                     <div>
 
-                        <umb-button type="button" ng-if="model.user.userDisplayState.key !== 'Invited' && model.changePasswordModel.isChanging === false"
+                        <umb-button type="button" ng-if="model.user.userDisplayState.key !== 'Invited'"
                                     button-style="[action,block]"
                                     action="model.toggleChangePassword()"
                                     label="Change password"
@@ -277,21 +277,6 @@
                                     size="s">
                         </umb-button>
                     </div>
-
-                    <ng-form ng-if="model.changePasswordModel.isChanging" name="passwordForm" class="block-form" val-form-manager>
-
-                        <change-password password-values="model.user.changePassword"
-                                         config="model.changePasswordModel.config">
-                        </change-password>
-
-                        <umb-button type="button"
-                                    action="model.toggleChangePassword()"
-                                    label="Cancel"
-                                    label-key="general_cancel"
-                                    button-style="cancel">
-                        </umb-button>
-
-                    </ng-form>
 
                     <div ng-if="model.user.resetPasswordValue">
                         <p><br />Password reset to value: <strong>{{model.user.resetPasswordValue}}</strong></p>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -732,6 +732,7 @@
     <key alias="sort">Sort</key>
     <key alias="status">Status</key>
     <key alias="submit">Submit</key>
+    <key alias="success">Success</key>
     <key alias="type">Type</key>
     <key alias="typeToSearch">Type to search...</key>
     <key alias="under">under</key>
@@ -1829,7 +1830,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="password">Password</key>
     <key alias="resetPassword">Reset password</key>
     <key alias="passwordChanged">Your password has been changed!</key>
-    <key alias="passwordConfirm">Please confirm the new password</key>
+    <key alias="passwordChangedGeneric">Password changed</key>
+    <key alias="passwordConfirm">Please confirm the new password</key>      
     <key alias="passwordEnterNew">Enter your new password</key>
     <key alias="passwordIsBlank">Your new password cannot be blank!</key>
     <key alias="passwordCurrent">Current password</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -737,6 +737,7 @@
     <key alias="sort">Sort</key>
     <key alias="status">Status</key>
     <key alias="submit">Submit</key>
+    <key alias="success">Success</key>
     <key alias="type">Type</key>
     <key alias="typeToSearch">Type to search...</key>
     <key alias="under">under</key>
@@ -1842,6 +1843,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="password">Password</key>
     <key alias="resetPassword">Reset password</key>
     <key alias="passwordChanged">Your password has been changed!</key>
+    <key alias="passwordChangedGeneric">Password changed</key>
     <key alias="passwordConfirm">Please confirm the new password</key>
     <key alias="passwordEnterNew">Enter your new password</key>
     <key alias="passwordIsBlank">Your new password cannot be blank!</key>

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -26,6 +26,7 @@ using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Security;
 using Umbraco.Core.Services;
 using Umbraco.Web.Editors.Filters;
+using Umbraco.Web.Models;
 using Umbraco.Web.Models.ContentEditing;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
@@ -549,29 +550,7 @@ namespace Umbraco.Web.Editors
             if (Current.Configs.Settings().Security.UsernameIsEmail && found.Username == found.Email && userSave.Username != userSave.Email)
             {
                 userSave.Username = userSave.Email;
-            }
-
-            if (userSave.ChangePassword != null)
-            {
-                var passwordChanger = new PasswordChanger(Logger, Services.UserService, UmbracoContext.HttpContext);
-
-                //this will change the password and raise appropriate events
-                var passwordChangeResult = await passwordChanger.ChangePasswordWithIdentityAsync(Security.CurrentUser, found, userSave.ChangePassword, UserManager);
-                if (passwordChangeResult.Success)
-                {
-                    //need to re-get the user
-                    found = Services.UserService.GetUserById(intId.Result);
-                }
-                else
-                {
-                    hasErrors = true;
-
-                    foreach (var memberName in passwordChangeResult.Result.ChangeError.MemberNames)
-                    {
-                        ModelState.AddModelError(memberName, passwordChangeResult.Result.ChangeError.ErrorMessage);
-                    }
-                }
-            }
+            }          
 
             if (hasErrors)
                 throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, ModelState));
@@ -586,6 +565,51 @@ namespace Umbraco.Web.Editors
             display.AddSuccessNotification(Services.TextService.Localize("speechBubbles/operationSavedHeader"), Services.TextService.Localize("speechBubbles/editUserSaved"));
             return display;
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="changingPasswordModel"></param>
+        /// <returns></returns>
+        public async Task<ModelWithNotifications<string>> PostChangePassword(ChangingPasswordModel changingPasswordModel)
+        {
+            changingPasswordModel = changingPasswordModel ?? throw new ArgumentNullException(nameof(changingPasswordModel));            
+
+            if (ModelState.IsValid == false)
+            {
+                throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, ModelState));
+            }
+
+            var intId = changingPasswordModel.Id.TryConvertTo<int>();
+            if (intId.Success == false)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+
+            var found = Services.UserService.GetUserById(intId.Result);
+            if (found == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+
+            var passwordChanger = new PasswordChanger(Logger, Services.UserService, UmbracoContext.HttpContext);
+            var passwordChangeResult = await passwordChanger.ChangePasswordWithIdentityAsync(Security.CurrentUser, found, changingPasswordModel, UserManager);
+
+            if (passwordChangeResult.Success)
+            {
+                var result = new ModelWithNotifications<string>(passwordChangeResult.Result.ResetPassword);
+                result.AddSuccessNotification(Services.TextService.Localize("general/success"), Services.TextService.Localize("user/passwordChangedGeneric"));
+                return result;
+            }
+
+            foreach (var memberName in passwordChangeResult.Result.ChangeError.MemberNames)
+            {
+                ModelState.AddModelError(memberName, passwordChangeResult.Result.ChangeError.ErrorMessage);
+            }
+
+            throw new HttpResponseException(Request.CreateValidationErrorResponse(ModelState));
+        }
+
 
         /// <summary>
         /// Disables the users with the given user ids

--- a/src/Umbraco.Web/Models/ChangingPasswordModel.cs
+++ b/src/Umbraco.Web/Models/ChangingPasswordModel.cs
@@ -49,5 +49,11 @@ namespace Umbraco.Web.Models
         /// </summary>
         [DataMember(Name = "generatedPassword")]
         public string GeneratedPassword { get; set; }
+
+        /// <summary>
+        /// The id of the user - required to allow changing password without the entire UserSave model
+        /// </summary>
+        [DataMember(Name = "id")]
+        public int Id { get; set; }
     }
 }


### PR DESCRIPTION
…o dialog

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7013 

### Description
PR does what @nielslyngsoe demoed in the gif attached to the issue - change password opens in a dialog rather than inline in the sidebar.

To test, edit a user, click change password, update details in the dialog (check validation all works), click confirm, user is saved with new password.