### PR TITLE
#7452 Fixes schedule publish dialog for multilanguage sites

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -791,6 +791,7 @@
                             $scope.content.variants[i].expireDate = model.variants[i].expireDate;
                             $scope.content.variants[i].releaseDateFormatted = model.variants[i].releaseDateFormatted;
                             $scope.content.variants[i].expireDateFormatted = model.variants[i].expireDateFormatted;
+                            $scope.content.variants[i].save = model.variants[i].save;
                         }
 
                         model.submitButtonState = "busy";


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/7452

### Description
This fixes the error when you try to schedule content in a multilanguage site.

In the scheduled publishing dialog the save flag was set correctly on the variant. But when the schedule button is clicked the new value for this was not stored in the orignal variant. This PR fixes that.
