### PR TITLE
Hotfix - Missing registration in IOC when running external MB

### DIFF
--- a/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComposer.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComposer.cs
@@ -22,6 +22,9 @@ namespace Umbraco.ModelsBuilder.Embedded.Compose
         {
             var isLegacyModelsBuilderInstalled = IsLegacyModelsBuilderInstalled();
 
+
+            composition.Configs.Add<IModelsBuilderConfig>(() => new ModelsBuilderConfig());
+
             if (isLegacyModelsBuilderInstalled)
             {
                 ComposeForLegacyModelsBuilder(composition);
@@ -30,7 +33,7 @@ namespace Umbraco.ModelsBuilder.Embedded.Compose
 
             composition.Components().Append<ModelsBuilderComponent>();
             composition.Register<UmbracoServices>(Lifetime.Singleton);
-            composition.Configs.Add<IModelsBuilderConfig>(() => new ModelsBuilderConfig());
+
             composition.RegisterUnique<ModelsGenerator>();
             composition.RegisterUnique<LiveModelsProvider>();
             composition.RegisterUnique<OutOfDateModelsStatus>();


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/7457

We need to register the config no matter what which MB is used. The config is used to avoid execution of methods in the internal MB