### PR TITLE
V7: Backported/reimplemented fix for contentservice returning outdated results

### DIFF
--- a/src/Umbraco.Web/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Web/Cache/DistributedCacheExtensions.cs
@@ -109,7 +109,7 @@ namespace Umbraco.Web.Cache
         public static void RemoveTemplateCache(this DistributedCache dc, int templateId)
         {
             dc.Remove(DistributedCache.TemplateRefresherGuid, templateId);
-        } 
+        }
 
         #endregion
 
@@ -126,8 +126,8 @@ namespace Umbraco.Web.Cache
         }
 
         #endregion
-        
-        #region Data type cache     
+
+        #region Data type cache
 
         public static void RefreshDataTypeCache(this DistributedCache dc, IDataTypeDefinition dataType)
         {
@@ -172,12 +172,12 @@ namespace Umbraco.Web.Cache
 
         public static void RefreshUnpublishedPageCache(this DistributedCache dc, params IContent[] content)
         {
-            dc.Refresh(DistributedCache.UnpublishedPageCacheRefresherGuid, x => x.Id, content);
+            dc.RefreshByJson(DistributedCache.UnpublishedPageCacheRefresherGuid, UnpublishedPageCacheRefresher.SerializeToJsonPayload(UnpublishedPageCacheRefresher.OperationType.Refresh, content));
         }
 
         public static void RemoveUnpublishedPageCache(this DistributedCache dc, params IContent[] content)
         {
-            dc.Remove(DistributedCache.UnpublishedPageCacheRefresherGuid, x => x.Id, content);
+            dc.RefreshByJson(DistributedCache.UnpublishedPageCacheRefresherGuid, UnpublishedPageCacheRefresher.SerializeToJsonPayload(UnpublishedPageCacheRefresher.OperationType.Deleted, content));
         }
 
         public static void RemoveUnpublishedCachePermanently(this DistributedCache dc, params int[] contentIds)
@@ -197,7 +197,7 @@ namespace Umbraco.Web.Cache
         public static void RemoveMemberCache(this DistributedCache dc, params IMember[] members)
         {
             dc.Remove(DistributedCache.MemberCacheRefresherGuid, x => x.Id, members);
-        } 
+        }
 
         [Obsolete("Use the RefreshMemberCache with strongly typed IMember objects instead")]
         public static void RefreshMemberCache(this DistributedCache dc, int memberId)
@@ -209,7 +209,7 @@ namespace Umbraco.Web.Cache
         public static void RemoveMemberCache(this DistributedCache dc, int memberId)
         {
             dc.Remove(DistributedCache.MemberCacheRefresherGuid, memberId);
-        } 
+        }
 
         #endregion
 
@@ -228,7 +228,7 @@ namespace Umbraco.Web.Cache
         #endregion
 
         #region Media Cache
-        
+
         public static void RefreshMediaCache(this DistributedCache dc, params IMedia[] media)
         {
             dc.RefreshByJson(DistributedCache.MediaCacheRefresherGuid, MediaCacheRefresher.SerializeToJsonPayload(MediaCacheRefresher.OperationType.Saved, media));
@@ -285,7 +285,7 @@ namespace Umbraco.Web.Cache
             if (macro == null) return;
             dc.RefreshByJson(DistributedCache.MacroCacheRefresherGuid, MacroCacheRefresher.SerializeToJsonPayload(macro));
         }
-        
+
         public static void RemoveMacroCache(this DistributedCache dc, global::umbraco.cms.businesslogic.macro.Macro macro)
         {
             if (macro == null) return;
@@ -296,7 +296,7 @@ namespace Umbraco.Web.Cache
         {
             if (macro == null || macro.Model == null) return;
             dc.RefreshByJson(DistributedCache.MacroCacheRefresherGuid, MacroCacheRefresher.SerializeToJsonPayload(macro));
-        } 
+        }
 
         #endregion
 

--- a/src/Umbraco.Web/Cache/MediaCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/MediaCacheRefresher.cs
@@ -86,6 +86,7 @@ namespace Umbraco.Web.Cache
             var payload = new JsonPayload
             {
                 Id = media.Id,
+                Key = media.Key,
                 Path = media.Path,
                 Operation = operation
             };
@@ -108,6 +109,7 @@ namespace Umbraco.Web.Cache
             public string Path { get; set; }
             public int Id { get; set; }
             public OperationType Operation { get; set; }
+            public Guid? Key { get; set; }
         }
 
         #endregion
@@ -142,7 +144,7 @@ namespace Umbraco.Web.Cache
         public override void Remove(int id)
         {
             ClearCache(FromMedia(ApplicationContext.Current.Services.MediaService.GetById(id),
-                //NOTE: we'll just default to trashed for this one.    
+                //NOTE: we'll just default to trashed for this one.
                 OperationType.Trashed));
             base.Remove(id);
         }
@@ -150,7 +152,7 @@ namespace Umbraco.Web.Cache
         private static void ClearCache(params JsonPayload[] payloads)
         {
             if (payloads == null) return;
-            
+
             ApplicationContext.Current.ApplicationCache.ClearPartialViewCache();
 
             foreach (var payload in payloads)
@@ -159,7 +161,7 @@ namespace Umbraco.Web.Cache
                     ApplicationContext.Current.Services.IdkMap.ClearCache(payload.Id);
 
                 var mediaCache = ApplicationContext.Current.ApplicationCache.IsolatedRuntimeCache.GetCache<IMedia>();
-
+                mediaCache.Result.ClearCacheItem(RepositoryBase.GetCacheIdKey<IMedia>(payload.Key));
                 //if there's no path, then just use id (this will occur on permanent deletion like emptying recycle bin)
                 if (payload.Path.IsNullOrWhiteSpace())
                 {

--- a/src/Umbraco.Web/PublishedCache/XmlPublishedCache/PublishedMediaCache.cs
+++ b/src/Umbraco.Web/PublishedCache/XmlPublishedCache/PublishedMediaCache.cs
@@ -220,7 +220,7 @@ namespace Umbraco.Web.PublishedCache.XmlPublishedCache
                 catch (AlreadyClosedException)
                 {
                     //If the app domain is shutting down and the site is under heavy load the index reader will be closed and it really cannot
-                    //be re-opened since the app domain is shutting down. In this case we have no option but to try to load the data from the db.                    
+                    //be re-opened since the app domain is shutting down. In this case we have no option but to try to load the data from the db.
                 }
             }
             return null;

--- a/src/Umbraco.Web/Search/ExamineEvents.cs
+++ b/src/Umbraco.Web/Search/ExamineEvents.cs
@@ -436,6 +436,13 @@ namespace Umbraco.Web.Search
                                     DeleteIndexForEntity(payload.Id, false);
 
                                     break;
+                                case UnpublishedPageCacheRefresher.OperationType.Refresh:// RefreshNode or RefreshBranch (maybe trashed)
+                                    var c2 = ApplicationContext.Current.Services.ContentService.GetById(payload.Id);
+                                    if (c2 != null)
+                                    {
+                                        ReIndexForContent(c2, false);
+                                    }
+                                    break;
                                 default:
                                     throw new ArgumentOutOfRangeException();
                             }


### PR DESCRIPTION
Fix: [AB#4084](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/4084)
Backport of: https://github.com/umbraco/Umbraco-CMS/pull/6462

OBS: For some reason do my computer hate V7 formatting... I guess it is because my IDE follows the .editorconfig. - So remember to hide whitespace changes.

- Have updated all the `DistributedCacheExtensions ` for `UnpublishedPageCache` to use `RefreshByJson`
- Have added key to `MediaCacheRefrecher.JsonPayload`.  and clear the cache using key
  - OBS: ` DistributedCacheExtensions.RemoveMediaCache` still uses `dc.Remove(guid)`.
- Updated `UnpublishedPageCacheRefresher.Refresh(string jsonPayload)` to handle both delete and refrech
- Was forced to handle the the newly introduced operation type in `ExamineEvents`

The test case from https://github.com/umbraco/Umbraco-CMS/pull/6462 seems to work as expected now




