### PR TITLE
Fixing Ambiguous extension method signature between embedded and external ModelsBuilder

### DIFF
--- a/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComposer.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComposer.cs
@@ -1,33 +1,67 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections;
+using System.Linq;
 using System.Reflection;
+using System.Web;
+using System.Web.Compilation;
+using System.Web.WebPages.Razor;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.ModelsBuilder.Embedded.Building;
+using Umbraco.ModelsBuilder.Embedded.Compose;
 using Umbraco.ModelsBuilder.Embedded.Configuration;
 using Umbraco.Web;
 using Umbraco.Web.PublishedCache.NuCache;
 using Umbraco.Web.Features;
 
+//[assembly: PreApplicationStartMethod(typeof(ModelsBuilderComposer), "Initialize")]
+
 namespace Umbraco.ModelsBuilder.Embedded.Compose
 {
 
+    //public class MyBuildProvider : RazorBuildProvider
+    //{
+    //    public override void GenerateCode(AssemblyBuilder assemblyBuilder)
+    //    {
+    //        base.GenerateCode(assemblyBuilder);
+    //    }
+
+    //    protected override WebPageRazorHost CreateHost()
+    //    {
+    //        return base.CreateHost();
+    //    }
+
+    //    public override CompilerType CodeCompilerType
+    //    {
+    //        get
+    //        {
+    //            var asdf =  base.CodeCompilerType;
+    //            return asdf;
+    //        }
+    //    }
+    //}
 
     [ComposeBefore(typeof(NuCacheComposer))]
     [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
     public sealed class ModelsBuilderComposer : ICoreComposer
     {
+        //public static void Initialize()
+        //{
+        //    BuildProvider.RegisterBuildProvider(".cshtml", typeof(MyBuildProvider));
+        //}
+
         public void Compose(Composition composition)
         {
             var isLegacyModelsBuilderInstalled = IsLegacyModelsBuilderInstalled();
-
 
             composition.Configs.Add<IModelsBuilderConfig>(() => new ModelsBuilderConfig());
 
             if (isLegacyModelsBuilderInstalled)
             {
                 ComposeForLegacyModelsBuilder(composition);
+                ConfigureRazorBuildProviderForLegacyModelsBuilder();
                 return;
             }
 
@@ -58,6 +92,77 @@ namespace Umbraco.ModelsBuilder.Embedded.Compose
             }
 
             return legacyMbAssembly != null;
+        }
+
+        /// <summary>
+        /// Adds custom event handling to the RazorBuildProvider to deal with ambiguous method calls
+        /// </summary>
+        /// <remarks>
+        /// Because the embedded models builder and the legacy models builder share the same namespaces and method names
+        /// we can get ambiguous method name exceptions.
+        /// When in legacy mode will just ensure that the embedded assembly is not added to the references assemblies collection
+        /// during razor view compilation.
+        /// Unfortunately this process isn't that pretty because the APIs they expose aren't very flexible. 
+        /// </remarks>
+        private void ConfigureRazorBuildProviderForLegacyModelsBuilder()
+        {
+            // Bind to the CompilingPath event of the RazorBuildProvider. There are 3x events:
+            // CompilingPath = occurs first
+            // CodeGenerationCompleted = occurs second
+            // CodeGenerationStarted = occurs last -- yes that is true
+            // Removing the assembly in CodeGenerationStarted is too late since the ReferencedAssemblies have already been passed to it's underlying
+            // AssemblyBuilder class which is used to generate the csc.exe command with all of the referenced assemblies so we will remove the embedded
+            // assembly in CompilingPath. When in legacy mode, there's no code within the embedded assembly that should run, this effectively removes
+            // this assembly from the app domain for razor views - this will *not* solve the ambiguous issue for other dynamically compiled code
+            // such as code in App_Code. It would be possible to solve that issue with a custom build provider.
+            RazorBuildProvider.CompilingPath += (sender, args) =>
+            {
+                if (!(sender is RazorBuildProvider provider)) return;
+
+                var assemblySet = provider.GetType().GetProperty("ReferencedAssemblies", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(provider);
+                var removeMethod = assemblySet.GetType().GetMethod("Remove", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                removeMethod.Invoke(assemblySet, new object[] { this.GetType().Assembly });
+            };
+
+            //RazorBuildProvider.CodeGenerationStarted += (sender, args) =>
+            //{
+            //    if (!(sender is RazorBuildProvider provider)) return;
+
+            //    if (isLegacyModelsBuilderInstalled)
+            //    {
+            //        var assemblySet = provider.GetType().GetProperty("ReferencedAssemblies", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(provider);
+            //        var removeMethod = assemblySet.GetType().GetMethod("Remove", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            //        removeMethod.Invoke(assemblySet, new object[] { this.GetType().Assembly });
+            //        //provider.AssemblyBuilder.AddAssemblyReference();
+
+            //    }
+            //};
+
+            //RazorBuildProvider.CodeGenerationCompleted += (sender, args) =>
+            //{
+            //    if (!(sender is RazorBuildProvider provider)) return;
+
+            //    if (isLegacyModelsBuilderInstalled)
+            //    {
+            //        var assemblies = provider.CodeCompilerType.CompilerParameters.ReferencedAssemblies;
+
+            //        var assemblySet = provider.GetType().GetProperty("ReferencedAssemblies", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(provider);
+            //        var removeMethod = assemblySet.GetType().GetMethod("Remove", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            //        removeMethod.Invoke(assemblySet, new object[] { this.GetType().Assembly });
+            //        //provider.AssemblyBuilder.AddAssemblyReference();
+
+            //    }
+            //};
+
+            //AppDomain.CurrentDomain.TypeResolve += (sender, args) =>
+            //{
+            //    return null;
+            //};
+
+            //AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+            //{
+            //    return null;
+            //};
         }
 
         private void ComposeForLegacyModelsBuilder(Composition composition)

--- a/src/Umbraco.ModelsBuilder.Embedded/ImplementPropertyTypeAttribute.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/ImplementPropertyTypeAttribute.cs
@@ -7,7 +7,7 @@ namespace Umbraco.ModelsBuilder.Embedded
     /// </summary>
     /// <remarks>And therefore it should not be generated.</remarks>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-    public sealed class ImplementPropertyTypeAttribute : Attribute
+    public class ImplementPropertyTypeAttribute : Attribute
     {
         public ImplementPropertyTypeAttribute(string alias)
         {

--- a/src/Umbraco.ModelsBuilder.Embedded/ModelsBuilderPublishedElementExtensions.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/ModelsBuilderPublishedElementExtensions.cs
@@ -12,8 +12,11 @@ namespace Umbraco.Web
     /// <summary>
     /// Provides extension methods to models.
     /// </summary>
-    public static class PublishedElementExtensions
+    public static class ModelsBuilderPublishedElementExtensions
     {
+        // NOTE: The orig name of this class is was PublishedElementExtensions but this overlaps with the legacy MB which can cause ambiguous naming issues
+        // changing this name at least provides a way to call the ext methods statically
+
         /// <summary>
         /// Gets the value of a property.
         /// </summary>

--- a/src/Umbraco.ModelsBuilder.Embedded/PublishedElementExtensions.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/PublishedElementExtensions.cs
@@ -23,8 +23,7 @@ namespace Umbraco.Web
             var alias = GetAlias(model, property);
             return model.Value<TValue>(alias, culture, segment, fallback, defaultValue);
         }
-
-        // fixme that one should be public so ppl can use it
+        
         private static string GetAlias<TModel, TValue>(TModel model, Expression<Func<TModel, TValue>> property)
         {
             if (property.NodeType != ExpressionType.Lambda)

--- a/src/Umbraco.ModelsBuilder.Embedded/PublishedElementExtensions.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/PublishedElementExtensions.cs
@@ -17,14 +17,14 @@ namespace Umbraco.Web
         /// <summary>
         /// Gets the value of a property.
         /// </summary>
-        public static TValue ValueByExpression<TModel, TValue>(this TModel model, Expression<Func<TModel, TValue>> property, string culture = null, string segment = null, Fallback fallback = default, TValue defaultValue = default)
+        public static TValue Value<TModel, TValue>(this TModel model, Expression<Func<TModel, TValue>> property, string culture = null, string segment = null, Fallback fallback = default, TValue defaultValue = default)
             where TModel : IPublishedElement
         {
             var alias = GetAlias(model, property);
             return model.Value<TValue>(alias, culture, segment, fallback, defaultValue);
         }
 
-        //This cannot be public due to ambiguous issue with external ModelsBuilder if we do not rename.
+        // fixme that one should be public so ppl can use it
         private static string GetAlias<TModel, TValue>(TModel model, Expression<Func<TModel, TValue>> property)
         {
             if (property.NodeType != ExpressionType.Lambda)
@@ -45,7 +45,7 @@ namespace Umbraco.Web
             var attribute = member.GetCustomAttribute<ImplementPropertyTypeAttribute>();
             if (attribute == null)
                 throw new InvalidOperationException("Property is not marked with ImplementPropertyType attribute.");
-
+            
             return attribute.Alias;
         }
     }

--- a/src/Umbraco.ModelsBuilder.Embedded/Umbraco.ModelsBuilder.Embedded.csproj
+++ b/src/Umbraco.ModelsBuilder.Embedded/Umbraco.ModelsBuilder.Embedded.csproj
@@ -69,7 +69,7 @@
     <Compile Include="ModelsBuilderAssemblyAttribute.cs" />
     <Compile Include="ModelsBuilderDashboard.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="PublishedElementExtensions.cs" />
+    <Compile Include="ModelsBuilderPublishedElementExtensions.cs" />
     <Compile Include="ReferencedAssemblies.cs" />
     <Compile Include="TypeExtensions.cs" />
     <Compile Include="HashCombiner.cs" />


### PR DESCRIPTION
fixes: https://github.com/umbraco/Umbraco-CMS/issues/7469

This is a work around which works for razor views. If the legacy MB is detected this will remove the embedded MB from the referenced DLLs for razor compilation.

This works fine in my tests, however this issue would still be present if there was code in App_Code since that is dynamically compiled and unfortunately there's no way to override the behavior of how that compilation occurs... I've gone very deep to try and although we can get close unfortunatley MS has hard coded type checks for `SourceFileBuildProvider` which is what they use to compile App_Code so it cannot be overridden. 

For compiled code, if this error occurs then the full extension method class name can be used to call the method instead. This PR changes the class name so that they can be differentiated.

In the near future, i would propose that we ship a new version of the legacy `Umbraco.ModelsBuilder` package that doesn't ship with this extension. We should actually ship both an Umbraco version and a Umbraco.ModelsBuilder version at the same time (lets say it's 8.5.3), then this Umbraco.ModelsBuilder version can have a min requirement of 8.5.3 and 8.5.3 can remove this code check. Make sense?
