### PR TITLE
Fix typo in DE "installFinish" caption

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
@@ -1173,7 +1173,7 @@
     <key alias="installed">Installiert</key>
     <key alias="installedPackages">Installierte Pakete</key>
     <key alias="installLocal">Lokale Installation</key>
-    <key alias="installFinish">Benenden</key>
+    <key alias="installFinish">Abschließen</key>
     <key alias="noConfigurationView">Diese Paket hat keine Einstellungen</key>
     <key alias="noPackagesCreated">Es wurden noche keine Pakete angelegt</key>
     <key alias="noPackages">Sie haben keine Pakete installiert</key>


### PR DESCRIPTION
(and improve wording: "Abschließen" (~ completing something) instead of "Quit" or "Close" as it was; EN is "Finishing")