### PR TITLE
Fix typo in contentTypeSavedHeader French label

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
@@ -1180,7 +1180,7 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="contentTypePropertyTypeCreated">Type de propriété créé</key>
     <key alias="contentTypePropertyTypeCreatedText"><![CDATA[Nom : %0% <br /> Type de données : %1%]]></key>
     <key alias="contentTypePropertyTypeDeleted">Type de propriété supprimé</key>
-    <key alias="contentTypeSavedHeader">Type de documet sauvegardé</key>
+    <key alias="contentTypeSavedHeader">Type de document sauvegardé</key>
     <key alias="contentTypeTabCreated">Onglet créé</key>
     <key alias="contentTypeTabDeleted">Onglet supprimé</key>
     <key alias="contentTypeTabDeletedText">Onglet avec l'ID : %0% supprimé</key>


### PR DESCRIPTION
### Description

Just a small typo in the contentTypePropertyTypeDeleted label in the French language file : 
"Type de documet sauvegardé" should read "Type de document sauvegardé".

Steps to reproduce : 

1. Open Umbraco backoffice
2. Set language to French
3. Open the "Settings" section
4. Edit and save any document type
5. There's a typo in the word "documet" in the confirmation label (missing a "n").


