### PR TITLE
Remove obsolete Stylesheet constant and references

### DIFF
--- a/src/Umbraco.Abstractions/Constants-ObjectTypes.cs
+++ b/src/Umbraco.Abstractions/Constants-ObjectTypes.cs
@@ -68,9 +68,6 @@ namespace Umbraco.Core
 
                 public const string IdReservation = "92849B1E-3904-4713-9356-F646F87C25F4";
 
-                [Obsolete("This no longer exists in the database")]
-                public const string Stylesheet = "9F68DA4F-A3A8-44C2-8226-DCBD125E4840";
-
                 // ReSharper restore MemberHidesStaticFromOuterClass
             }
 

--- a/src/Umbraco.Abstractions/Models/UmbracoObjectTypes.cs
+++ b/src/Umbraco.Abstractions/Models/UmbracoObjectTypes.cs
@@ -84,14 +84,6 @@ namespace Umbraco.Core.Models
         RecycleBin,
 
         /// <summary>
-        /// Stylesheet
-        /// </summary>
-        [UmbracoObjectType(Constants.ObjectTypes.Strings.Stylesheet)]
-        [FriendlyName("Stylesheet")]
-        [UmbracoUdiType(Constants.UdiEntityType.Stylesheet)]
-        Stylesheet,
-
-        /// <summary>
         /// Member
         /// </summary>
         [UmbracoObjectType(Constants.ObjectTypes.Strings.Member, typeof(IMember))]

--- a/src/Umbraco.Abstractions/UdiEntityTypeHelper.cs
+++ b/src/Umbraco.Abstractions/UdiEntityTypeHelper.cs
@@ -38,8 +38,6 @@ namespace Umbraco.Core
                     return Constants.UdiEntityType.MemberType;
                 case UmbracoObjectTypes.MemberGroup:
                     return Constants.UdiEntityType.MemberGroup;
-                case UmbracoObjectTypes.Stylesheet:
-                    return Constants.UdiEntityType.Stylesheet;
                 case UmbracoObjectTypes.RelationType:
                     return Constants.UdiEntityType.RelationType;
                 case UmbracoObjectTypes.FormsForm:
@@ -86,8 +84,6 @@ namespace Umbraco.Core
                     return UmbracoObjectTypes.MemberType;
                 case Constants.UdiEntityType.MemberGroup:
                     return UmbracoObjectTypes.MemberGroup;
-                case Constants.UdiEntityType.Stylesheet:
-                    return UmbracoObjectTypes.Stylesheet;
                 case Constants.UdiEntityType.RelationType:
                     return UmbracoObjectTypes.RelationType;
                 case Constants.UdiEntityType.FormsForm:

--- a/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
@@ -88,7 +88,6 @@ namespace Umbraco.Core.Services.Implement
                 saveEventArgs.CanCancel = false;
                 scope.Events.Dispatch(SavedStylesheet, this, saveEventArgs);
 
-                Audit(AuditType.Save, userId, -1, UmbracoObjectTypes.Stylesheet.GetName());
                 scope.Complete();
             }
         }
@@ -116,7 +115,6 @@ namespace Umbraco.Core.Services.Implement
                 deleteEventArgs.CanCancel = false;
                 scope.Events.Dispatch(DeletedStylesheet, this, deleteEventArgs);
 
-                Audit(AuditType.Delete, userId, -1, UmbracoObjectTypes.Stylesheet.GetName());
                 scope.Complete();
             }
         }

--- a/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
@@ -87,6 +87,7 @@ namespace Umbraco.Core.Services.Implement
                 _stylesheetRepository.Save(stylesheet);
                 saveEventArgs.CanCancel = false;
                 scope.Events.Dispatch(SavedStylesheet, this, saveEventArgs);
+                Audit(AuditType.Save, userId, -1, "Stylesheet");
 
                 scope.Complete();
             }
@@ -114,6 +115,7 @@ namespace Umbraco.Core.Services.Implement
                 _stylesheetRepository.Delete(stylesheet);
                 deleteEventArgs.CanCancel = false;
                 scope.Events.Dispatch(DeletedStylesheet, this, deleteEventArgs);
+                Audit(AuditType.Delete, userId, -1, "Stylesheet");
 
                 scope.Complete();
             }

--- a/src/Umbraco.Web/Editors/RelationTypeController.cs
+++ b/src/Umbraco.Web/Editors/RelationTypeController.cs
@@ -96,7 +96,6 @@ namespace Umbraco.Web.Editors
                 new ObjectType{Id = UmbracoObjectTypes.MemberType.GetGuid(), Name = UmbracoObjectTypes.MemberType.GetFriendlyName()},
                 new ObjectType{Id = UmbracoObjectTypes.DataType.GetGuid(), Name = UmbracoObjectTypes.DataType.GetFriendlyName()},
                 new ObjectType{Id = UmbracoObjectTypes.MemberGroup.GetGuid(), Name = UmbracoObjectTypes.MemberGroup.GetFriendlyName()},
-                new ObjectType{Id = UmbracoObjectTypes.Stylesheet.GetGuid(), Name = UmbracoObjectTypes.Stylesheet.GetFriendlyName()},
                 new ObjectType{Id = UmbracoObjectTypes.ROOT.GetGuid(), Name = UmbracoObjectTypes.ROOT.GetFriendlyName()},
                 new ObjectType{Id = UmbracoObjectTypes.RecycleBin.GetGuid(), Name = UmbracoObjectTypes.RecycleBin.GetFriendlyName()},
             };


### PR DESCRIPTION
### Prerequisites
Fixes for #7368

### Description
Removes an obsolete Stylesheet constant, the Stylesheet UmbracoObjectTypes enum value which used it, and references to that enum value.