### PR TITLE
Use strongtyped Models as grid and RTE config

### DIFF
--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridArea.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridArea.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Umbraco.Web.Models.PropertyEditorsConfigs
+{
+    public class GridArea
+    {
+        public int Grid { get; set; }
+        public bool AllowAll { get; set; }
+        public List<string> Allowed { get; set; }
+    }
+}

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridBasic.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridBasic.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Umbraco.Web.Models.PropertyEditorsConfigs
+{
+    public class GridBasic
+    {
+        public string Label { get; set; }
+        public string Description { get; set; }
+        public string Key { get; set; }
+        public string View { get; set; }
+        public string Modifier { get; set; }
+        public object ApplyTo { get; set; }
+        public List<string> Prevalues{ get; set; }
+    }
+}

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridBasic.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridBasic.cs
@@ -10,6 +10,6 @@ namespace Umbraco.Web.Models.PropertyEditorsConfigs
         public string View { get; set; }
         public string Modifier { get; set; }
         public object ApplyTo { get; set; }
-        public List<string> Prevalues{ get; set; }
+        public IList<string> Prevalues { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridConfig.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridConfig.cs
@@ -1,0 +1,7 @@
+namespace Umbraco.Web.Models.PropertyEditorsConfigs
+{
+    public class GridConfig : GridBasic
+    {
+ 
+    }
+}

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridItems.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridItems.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Umbraco.Web.Models.PropertyEditorsConfigs
+{
+    public class GridItems
+    {
+        public List<GridStyle> Styles;
+        public List<GridConfig> Config;
+        public int Columns;
+        public List<GridTemplate> Templates;
+        public List<GridLayout> Layouts;
+
+    }
+}

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridItems.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridItems.cs
@@ -4,11 +4,11 @@ namespace Umbraco.Web.Models.PropertyEditorsConfigs
 {
     public class GridItems
     {
-        public List<GridStyle> Styles;
-        public List<GridConfig> Config;
-        public int Columns;
-        public List<GridTemplate> Templates;
-        public List<GridLayout> Layouts;
+        public IList<GridStyle> Styles { get; set; }
+        public IList<GridConfig> Config { get; set; }
+        public int Columns { get; set; }
+        public IList<GridTemplate> Templates { get; set; }
+        public IList<GridLayout> Layouts { get; set; }
 
     }
 }

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridLayout.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridLayout.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Umbraco.Web.Models.PropertyEditorsConfigs
+{
+    public class GridLayout
+    {
+        public string Name { get; set; }
+        public List<GridArea> Areas{ get; set; }
+    }
+}

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridLayout.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridLayout.cs
@@ -5,6 +5,6 @@ namespace Umbraco.Web.Models.PropertyEditorsConfigs
     public class GridLayout
     {
         public string Name { get; set; }
-        public List<GridArea> Areas{ get; set; }
+        public IList<GridArea> Areas { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridSection.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridSection.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Umbraco.Web.Models.PropertyEditorsConfigs
+{
+    public class GridSection
+    {
+        public int grid { set; get; }
+        public bool AllowAll { get; set; }
+        public List<string> Allowed { get; set; }
+    }
+}

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridSection.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridSection.cs
@@ -6,6 +6,6 @@ namespace Umbraco.Web.Models.PropertyEditorsConfigs
     {
         public int Grid { set; get; }
         public bool AllowAll { get; set; }
-        public List<string> Allowed { get; set; }
+        public IList<string> Allowed { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridSection.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridSection.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Web.Models.PropertyEditorsConfigs
 {
     public class GridSection
     {
-        public int grid { set; get; }
+        public int Grid { set; get; }
         public bool AllowAll { get; set; }
         public List<string> Allowed { get; set; }
     }

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridStyle.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridStyle.cs
@@ -1,0 +1,7 @@
+namespace Umbraco.Web.Models.PropertyEditorsConfigs
+{
+    public class GridStyle : GridBasic
+    {
+
+    }
+}

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridTemplate.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridTemplate.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Umbraco.Web.Models.PropertyEditorsConfigs
+{
+    public class GridTemplate
+    {
+        public string Name { get; set; }
+        public List<GridSection> Sections{ get; set; }
+    }
+}

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridTemplate.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/GridTemplate.cs
@@ -5,6 +5,6 @@ namespace Umbraco.Web.Models.PropertyEditorsConfigs
     public class GridTemplate
     {
         public string Name { get; set; }
-        public List<GridSection> Sections{ get; set; }
+        public IList<GridSection> Sections { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/RichTextSettings.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/RichTextSettings.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Umbraco.Web.Models.PropertyEditorsConfigs
+{
+    public class RichTextSettings
+    {
+        public string Mode { get; set; }
+        public int MaxImageSize { get; set; }
+        public List<string> Toolbar { get; set; }
+        public List<string> stylesheets { get; set; }
+    }
+}

--- a/src/Umbraco.Web/Models/PropertyEditorsConfigs/RichTextSettings.cs
+++ b/src/Umbraco.Web/Models/PropertyEditorsConfigs/RichTextSettings.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Web.Models.PropertyEditorsConfigs
     {
         public string Mode { get; set; }
         public int MaxImageSize { get; set; }
-        public List<string> Toolbar { get; set; }
-        public List<string> stylesheets { get; set; }
+        public IList<string> Toolbar { get; set; }
+        public IList<string> Stylesheets { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/GridConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using Umbraco.Core;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Web.Models.PropertyEditorsConfigs;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -9,13 +10,11 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class GridConfiguration : IIgnoreUserStartNodesConfig
     {
-        // TODO: Make these strongly typed, for now this works though
         [ConfigurationField("items", "Grid", "views/propertyeditors/grid/grid.prevalues.html", Description = "Grid configuration")]
-        public JObject Items { get; set; }
+        public GridItems Items { get; set; }
 
-        // TODO: Make these strongly typed, for now this works though
         [ConfigurationField("rte", "Rich text editor", "views/propertyeditors/rte/rte.prevalues.html", Description = "Rich text editor configuration", HideLabel = true)]
-        public JObject Rte { get; set; }
+        public RichTextSettings RichText { get; set; }
 
         [ConfigurationField(Core.Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes,
             "Ignore User Start Nodes", "boolean",

--- a/src/Umbraco.Web/PropertyEditors/RichTextConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using Umbraco.Core;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Web.Models.PropertyEditorsConfigs;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -9,9 +10,8 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class RichTextConfiguration : IIgnoreUserStartNodesConfig
     {
-        // TODO: Make these strongly typed, for now this works though
         [ConfigurationField("editor", "Editor", "views/propertyeditors/rte/rte.prevalues.html", HideLabel = true)]
-        public JObject Editor { get; set; }
+        public RichTextSettings Editor { get; set; }
 
         [ConfigurationField("hideLabel", "Hide Label", "boolean")]
         public bool HideLabel { get; set; }

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -225,6 +225,15 @@
     <Compile Include="Models\ContentEditing\UrlAndAnchors.cs" />
     <Compile Include="Models\Mapping\CommonMapper.cs" />
     <Compile Include="Models\Mapping\MapperContextExtensions.cs" />
+    <Compile Include="Models\PropertyEditorsConfigs\GridArea.cs" />
+    <Compile Include="Models\PropertyEditorsConfigs\GridBasic.cs" />
+    <Compile Include="Models\PropertyEditorsConfigs\GridConfig.cs" />
+    <Compile Include="Models\PropertyEditorsConfigs\GridItems.cs" />
+    <Compile Include="Models\PropertyEditorsConfigs\GridLayout.cs" />
+    <Compile Include="Models\PropertyEditorsConfigs\GridSection.cs" />
+    <Compile Include="Models\PropertyEditorsConfigs\GridStyle.cs" />
+    <Compile Include="Models\PropertyEditorsConfigs\GridTemplate.cs" />
+    <Compile Include="Models\PropertyEditorsConfigs\RichTextSettings.cs" />
     <Compile Include="Models\PublishedContent\HybridVariationContextAccessor.cs" />
     <Compile Include="Models\TemplateQuery\QueryConditionExtensions.cs" />
     <Compile Include="Mvc\HttpUmbracoFormRouteStringException.cs" />
@@ -1259,7 +1268,6 @@
       <CachedSettingsPropName>umbraco_org_umbraco_update_CheckForUpgrade</CachedSettingsPropName>
     </WebReferenceUrl>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!--
     copied from Microsoft.CSharp.targets


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
When I was working for one of the internal projects in my Company I had a need to use strong type models in a grid configuration and I notice in Umbraco source code comment which was saying:
`// TODO: Make these strongly typed, for now this works though`
And I decide to make PRs with my models, which I am using to set up grid configs.