### PR TITLE
Access document, media and member types by guid and udi

### DIFF
--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -77,15 +77,58 @@ namespace Umbraco.Web.Editors
             return Services.ContentTypeService.HasContentNodes(id);
         }
 
+        /// <summary>
+        /// Gets the document type a given id
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
         public DocumentTypeDisplay GetById(int id)
         {
-            var ct = Services.ContentTypeService.Get(id);
-            if (ct == null)
+            var contentType = Services.ContentTypeService.Get(id);
+            if (contentType == null)
             {
                 throw new HttpResponseException(HttpStatusCode.NotFound);
             }
 
-            var dto = Mapper.Map<IContentType, DocumentTypeDisplay>(ct);
+            var dto = Mapper.Map<IContentType, DocumentTypeDisplay>(contentType);
+            return dto;
+        }
+
+        /// <summary>
+        /// Gets the document type a given guid
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public DocumentTypeDisplay GetById(Guid id)
+        {
+            var contentType = Services.ContentTypeService.Get(id);
+            if (contentType == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+
+            var dto = Mapper.Map<IContentType, DocumentTypeDisplay>(contentType);
+            return dto;
+        }
+
+        /// <summary>
+        /// Gets the document type a given udi
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public DocumentTypeDisplay GetById(Udi id)
+        {
+            var guidUdi = id as GuidUdi;
+            if (guidUdi == null)
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+
+            var contentType = Services.ContentTypeService.Get(guidUdi.Guid);
+            if (contentType == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+
+            var dto = Mapper.Map<IContentType, DocumentTypeDisplay>(contentType);
             return dto;
         }
 

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -45,7 +45,7 @@ namespace Umbraco.Web.Editors
     [PluginController("UmbracoApi")]
     [UmbracoTreeAuthorize(Constants.Trees.DocumentTypes)]
     [EnableOverrideAuthorization]
-    [ContentTypeControllerControllerConfiguration]
+    [ContentTypeControllerConfiguration]
     public class ContentTypeController : ContentTypeControllerBase<IContentType>
     {
         private readonly IEntityXmlSerializer _serializer;
@@ -70,7 +70,7 @@ namespace Umbraco.Web.Editors
         /// <summary>
         /// Configures this controller with a custom action selector
         /// </summary>
-        private class ContentTypeControllerControllerConfigurationAttribute : Attribute, IControllerConfiguration
+        private class ContentTypeControllerConfigurationAttribute : Attribute, IControllerConfiguration
         {
             public void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
             {

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using System.Web.Http;
+using System.Web.Http.Controllers;
 using System.Xml;
 using System.Xml.Linq;
 using Umbraco.Core;
@@ -44,6 +45,7 @@ namespace Umbraco.Web.Editors
     [PluginController("UmbracoApi")]
     [UmbracoTreeAuthorize(Constants.Trees.DocumentTypes)]
     [EnableOverrideAuthorization]
+    [ContentTypeControllerControllerConfiguration]
     public class ContentTypeController : ContentTypeControllerBase<IContentType>
     {
         private readonly IEntityXmlSerializer _serializer;
@@ -63,6 +65,17 @@ namespace Umbraco.Web.Editors
             _serializer = serializer;
             _propertyEditors = propertyEditors;
             _scopeProvider = scopeProvider;
+        }
+
+        /// <summary>
+        /// Configures this controller with a custom action selector
+        /// </summary>
+        private class ContentTypeControllerControllerConfigurationAttribute : Attribute, IControllerConfiguration
+        {
+            public void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+            {
+                controllerSettings.Services.Replace(typeof(IHttpActionSelector), new ParameterSwapControllerActionSelector(
+                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetById", "id", typeof(int), typeof(Guid), typeof(Udi))));            }
         }
 
         public int GetCount()

--- a/src/Umbraco.Web/Editors/MediaTypeController.cs
+++ b/src/Umbraco.Web/Editors/MediaTypeController.cs
@@ -49,6 +49,7 @@ namespace Umbraco.Web.Editors
             public void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
             {
                 controllerSettings.Services.Replace(typeof(IHttpActionSelector), new ParameterSwapControllerActionSelector(
+                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetById", "id", typeof(int), typeof(Guid), typeof(Udi)),
                     new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetAllowedChildren", "contentId", typeof(int), typeof(Guid), typeof(Udi))));
             }
         }
@@ -58,21 +59,66 @@ namespace Umbraco.Web.Editors
             return Services.ContentTypeService.Count();
         }
 
+        /// <summary>
+        /// Gets the media type a given id
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
         [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
         public MediaTypeDisplay GetById(int id)
         {
-            var ct = Services.MediaTypeService.Get(id);
-            if (ct == null)
+            var mediaType = Services.MediaTypeService.Get(id);
+            if (mediaType == null)
             {
                 throw new HttpResponseException(HttpStatusCode.NotFound);
             }
 
-            var dto = Mapper.Map<IMediaType, MediaTypeDisplay>(ct);
+            var dto = Mapper.Map<IMediaType, MediaTypeDisplay>(mediaType);
             return dto;
         }
 
         /// <summary>
-        /// Deletes a media type with a given ID
+        /// Gets the media type a given guid
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
+        public MediaTypeDisplay GetById(Guid id)
+        {
+            var mediaType = Services.MediaTypeService.Get(id);
+            if (mediaType == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+
+            var dto = Mapper.Map<IMediaType, MediaTypeDisplay>(mediaType);
+            return dto;
+        }
+
+        /// <summary>
+        /// Gets the media type a given udi
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
+        public MediaTypeDisplay GetById(Udi id)
+        {
+            var guidUdi = id as GuidUdi;
+            if (guidUdi == null)
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+
+            var mediaType = Services.MediaTypeService.Get(guidUdi.Guid);
+            if (mediaType == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+
+            var dto = Mapper.Map<IMediaType, MediaTypeDisplay>(mediaType);
+            return dto;
+        }
+
+        /// <summary>
+        /// Deletes a media type with a given id
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>

--- a/src/Umbraco.Web/Editors/MemberTypeController.cs
+++ b/src/Umbraco.Web/Editors/MemberTypeController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Web.Http;
+using System.Web.Http.Controllers;
 using System.Web.Security;
 using Umbraco.Core;
 using Umbraco.Core.Cache;
@@ -16,6 +17,7 @@ using Umbraco.Core.Security;
 using Umbraco.Core.Services;
 using Umbraco.Web.Models.ContentEditing;
 using Umbraco.Web.Mvc;
+using Umbraco.Web.WebApi;
 using Umbraco.Web.WebApi.Filters;
 using Constants = Umbraco.Core.Constants;
 
@@ -27,6 +29,7 @@ namespace Umbraco.Web.Editors
     /// </summary>
     [PluginController("UmbracoApi")]
     [UmbracoTreeAuthorize(new string[] { Constants.Trees.MemberTypes, Constants.Trees.Members})]
+    [MemberTypeControllerConfiguration]
     public class MemberTypeController : ContentTypeControllerBase<IMemberType>
     {
         public MemberTypeController(ICultureDictionaryFactory cultureDictionaryFactory, IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper)
@@ -34,23 +37,80 @@ namespace Umbraco.Web.Editors
         {
         }
 
+        /// <summary>
+        /// Configures this controller with a custom action selector
+        /// </summary>
+        private class MemberTypeControllerConfigurationAttribute : Attribute, IControllerConfiguration
+        {
+            public void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+            {
+                controllerSettings.Services.Replace(typeof(IHttpActionSelector), new ParameterSwapControllerActionSelector(
+                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetById", "id", typeof(int), typeof(Guid), typeof(Udi))));
+            }
+        }
+
         private readonly MembershipProvider _provider = Core.Security.MembershipProviderExtensions.GetMembersMembershipProvider();
 
+        /// <summary>
+        /// Gets the member type a given id
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
         [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
         public MemberTypeDisplay GetById(int id)
         {
-            var ct = Services.MemberTypeService.Get(id);
-            if (ct == null)
+            var memberType = Services.MemberTypeService.Get(id);
+            if (memberType == null)
             {
                 throw new HttpResponseException(HttpStatusCode.NotFound);
             }
 
-            var dto = Mapper.Map<IMemberType, MemberTypeDisplay>(ct);
+            var dto = Mapper.Map<IMemberType, MemberTypeDisplay>(memberType);
             return dto;
         }
 
         /// <summary>
-        /// Deletes a document type with a given ID
+        /// Gets the member type a given guid
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
+        public MemberTypeDisplay GetById(Guid id)
+        {
+            var memberType = Services.MemberTypeService.Get(id);
+            if (memberType == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+
+            var dto = Mapper.Map<IMemberType, MemberTypeDisplay>(memberType);
+            return dto;
+        }
+
+        /// <summary>
+        /// Gets the member type a given udi
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        [UmbracoTreeAuthorize(Constants.Trees.MemberTypes)]
+        public MemberTypeDisplay GetById(Udi id)
+        {
+            var guidUdi = id as GuidUdi;
+            if (guidUdi == null)
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+
+            var memberType = Services.MemberTypeService.Get(guidUdi.Guid);
+            if (memberType == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+
+            var dto = Mapper.Map<IMemberType, MemberTypeDisplay>(memberType);
+            return dto;
+        }
+
+        /// <summary>
+        /// Deletes a document type with a given id
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR enable the option to access document, media and member types by guid and udi and not only by id.

At the moment this it already possible for content, media and member nodes (and in Umbraco Forms as I remember) ... and also for datatypes and macros https://github.com/umbraco/Umbraco-CMS/pull/6847
