### PR TITLE
[FIX] Corrected Create method so that String UDI is correctly identified

### DIFF
--- a/src/Umbraco.Core/Udi.cs
+++ b/src/Umbraco.Core/Udi.cs
@@ -316,7 +316,7 @@ namespace Umbraco.Core
 
             if (udiType == UdiType.GuidUdi)
                 return new GuidUdi(uri);
-            if (udiType == UdiType.GuidUdi)
+            if (udiType == UdiType.StringUdi)
                 return new StringUdi(uri);
 
             throw new ArgumentException(string.Format("Uri \"{0}\" is not a valid udi.", uri));


### PR DESCRIPTION
 - [FIX] Changed check of UDI type to check for GUID type and then String type as previously was checking for
GUID type twice. This resulted in the method never creating a String UDI if needed.
 - [ISSUE] Github Issue #7507 https://github.com/umbraco/Umbraco-CMS/issues/7507

### Description

The change is exactly that described in the issue, however could not find where the code is used within the core to fully test it, but appears related to the UdiRangeJsonConverter 


<!-- Thanks for contributing to Umbraco CMS! -->
