### PR TITLE
Don't downcast `IPublishedSnapshot` unnecessarily in `PublishedContent`

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
@@ -326,7 +326,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
         // beware what you use that one for - you don't want to cache its result
         private IAppCache GetAppropriateCache()
         {
-            var publishedSnapshot = (PublishedSnapshot)_publishedSnapshotAccessor.PublishedSnapshot;
+            var publishedSnapshot = _publishedSnapshotAccessor.PublishedSnapshot;
             var cache = publishedSnapshot == null
                 ? null
                 : ((IsPreviewing == false || PublishedSnapshotService.FullCacheWhenPreviewing) && (ContentType.ItemType != PublishedItemType.Member)
@@ -337,7 +337,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
         private IAppCache GetCurrentSnapshotCache()
         {
-            var publishedSnapshot = (PublishedSnapshot)_publishedSnapshotAccessor.PublishedSnapshot;
+            var publishedSnapshot = _publishedSnapshotAccessor.PublishedSnapshot;
             return publishedSnapshot?.SnapshotCache;
         }
 


### PR DESCRIPTION
Just a tiny step on the way to make Umbraco more efficiently testable.  
The two downcasts doesn't do anything except hinder use of `PublishedContent` in unit tests.  
Feel free to bring into 8.5.3 with the other PR.

My goal with the slow but ongoing process is to make it as efficient as possible to test stuff using serialized content. IE. JSON files and as little stubbing as possible to keep tests clean.  
Things can be followed here if interested:  
https://github.com/lars-erik/umbraco-unit-testing-samples/tree/master-v8