### PR TITLE
V8/feature/multiurlpicker enhancements

### DIFF
--- a/src/Umbraco.Web/Models/Link.cs
+++ b/src/Umbraco.Web/Models/Link.cs
@@ -2,12 +2,49 @@
 
 namespace Umbraco.Web.Models
 {
+    /// <summary>
+    /// Represents a link (e.g. to content, media or an external URL).
+    /// </summary>
     public class Link
     {
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target.
+        /// </summary>
+        /// <value>
+        /// The target.
+        /// </value>
         public string Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of link.
+        /// </summary>
+        /// <value>
+        /// The type of link.
+        /// </value>
         public LinkType Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UDI.
+        /// </summary>
+        /// <value>
+        /// The UDI.
+        /// </value>
         public Udi Udi { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL.
+        /// </summary>
+        /// <value>
+        /// The URL.
+        /// </value>
         public string Url { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/Link.cs
+++ b/src/Umbraco.Web/Models/Link.cs
@@ -1,4 +1,5 @@
 ﻿using Umbraco.Core;
+using Umbraco.Core.Models.PublishedContent;
 
 namespace Umbraco.Web.Models
 {
@@ -38,6 +39,14 @@ namespace Umbraco.Web.Models
         /// The UDI.
         /// </value>
         public Udi Udi { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content.
+        /// </summary>
+        /// <value>
+        /// The content.
+        /// </value>
+        public IPublishedContent Content { get; set; }
 
         /// <summary>
         /// Gets or sets the URL.

--- a/src/Umbraco.Web/Models/LinkType.cs
+++ b/src/Umbraco.Web/Models/LinkType.cs
@@ -1,9 +1,21 @@
 ﻿namespace Umbraco.Web.Models
 {
+    /// <summary>
+    /// Represents the type of link.
+    /// </summary>
     public enum LinkType
     {
+        /// <summary>
+        /// Represents a link to content.
+        /// </summary>
         Content,
+        /// <summary>
+        /// Represents a link to media.
+        /// </summary>
         Media,
+        /// <summary>
+        /// Represents a link to an external URL.
+        /// </summary>
         External
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -50,6 +50,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
                 foreach (var dto in dtos)
                 {
+                    var name = dto.Name;
                     var type = LinkType.External;
                     var url = dto.Url;
                     IPublishedContent content = null;
@@ -77,12 +78,17 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                             continue;
                         }
 
+                        if (string.IsNullOrEmpty(name))
+                        {
+                            name = content.Name;
+                        }
+
                         url = content.Url();
                     }
 
                     links.Add(new Link
                     {
-                        Name = dto.Name,
+                        Name = name,
                         Target = dto.Target,
                         Type = type,
                         Udi = dto.Udi,

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -1,8 +1,7 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models.PublishedContent;
@@ -15,30 +14,29 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
     public class MultiUrlPickerValueConverter : PropertyValueConverterBase
     {
         private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
-        private readonly IProfilingLogger _proflog;
+        private readonly IProfilingLogger _profilingLogger;
 
-        public MultiUrlPickerValueConverter(IPublishedSnapshotAccessor publishedSnapshotAccessor, IProfilingLogger proflog)
+        public MultiUrlPickerValueConverter(IPublishedSnapshotAccessor publishedSnapshotAccessor, IProfilingLogger profilingLogger)
         {
             _publishedSnapshotAccessor = publishedSnapshotAccessor ?? throw new ArgumentNullException(nameof(publishedSnapshotAccessor));
-            _proflog = proflog ?? throw new ArgumentNullException(nameof(proflog));
+            _profilingLogger = profilingLogger ?? throw new ArgumentNullException(nameof(profilingLogger));
         }
 
         public override bool IsConverter(IPublishedPropertyType propertyType) => Constants.PropertyEditors.Aliases.MultiUrlPicker.Equals(propertyType.EditorAlias);
 
-        public override Type GetPropertyValueType(IPublishedPropertyType propertyType) =>
-            propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>().MaxNumber == 1 ?
-                typeof(Link) :
-                typeof(IEnumerable<Link>);
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>().MaxNumber == 1
+            ? typeof(Link)
+            : typeof(IEnumerable<Link>);
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Snapshot;
 
-        public override bool? IsValue(object value, PropertyValueLevel level) => value?.ToString() != "[]";
+        public override bool? IsValue(object value, PropertyValueLevel level) => value?.ToString() is var jsonValue && !string.IsNullOrEmpty(jsonValue) && jsonValue != "[]";
 
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview) => source?.ToString();
 
         public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
         {
-            using (_proflog.DebugDuration<MultiUrlPickerValueConverter>($"ConvertPropertyToLinks ({propertyType.DataType.Id})"))
+            using (_profilingLogger.DebugDuration<MultiUrlPickerValueConverter>($"ConvertPropertyToLinks ({propertyType.DataType.Id})"))
             {
                 var maxNumber = propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>().MaxNumber;
 
@@ -54,34 +52,43 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                 {
                     var type = LinkType.External;
                     var url = dto.Url;
+                    IPublishedContent content = null;
 
                     if (dto.Udi != null)
                     {
-                        type = dto.Udi.EntityType == Core.Constants.UdiEntityType.Media
-                            ? LinkType.Media
-                            : LinkType.Content;
-
-                        var content = type == LinkType.Media ?
-                             _publishedSnapshotAccessor.PublishedSnapshot.Media.GetById(preview, dto.Udi.Guid) :
-                             _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(preview, dto.Udi.Guid);
+                        switch (dto.Udi.EntityType)
+                        {
+                            case Core.Constants.UdiEntityType.Document:
+                                type = LinkType.Content;
+                                content = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(preview, dto.Udi.Guid);
+                                break;
+                            case Core.Constants.UdiEntityType.Media:
+                                type = LinkType.Media;
+                                content = _publishedSnapshotAccessor.PublishedSnapshot.Media.GetById(preview, dto.Udi.Guid);
+                                break;
+                            default:
+                                // Skip unsupported entity types
+                                continue;
+                        }
 
                         if (content == null || content.ContentType.ItemType == PublishedItemType.Element)
                         {
+                            // Skip unavailable content and elements (in case the type has changed)
                             continue;
                         }
+
                         url = content.Url();
                     }
 
-                    links.Add(
-                        new Link
-                        {
-                            Name = dto.Name,
-                            Target = dto.Target,
-                            Type = type,
-                            Udi = dto.Udi,
-                            Url = url + dto.QueryString,
-                        }
-                    );
+                    links.Add(new Link
+                    {
+                        Name = dto.Name,
+                        Target = dto.Target,
+                        Type = type,
+                        Udi = dto.Udi,
+                        Content = content,
+                        Url = url + dto.QueryString,
+                    });
                 }
 
                 if (maxNumber == 1) return links.FirstOrDefault();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This is a Umbraco 8 re-implementation of PR https://github.com/umbraco/Umbraco-CMS/pull/5449.

**1. `Content` property on the `Link` model (as commented on https://github.com/umbraco/Umbraco-CMS/pull/2323#discussion_r249716153)**
Adding the `Content` property was quite simple, as the `MultiUrlPickerPropertyConverter` already gets the content or media as `IPublishedContent`. This allows easy access to any additional properties, e.g. an overview image that's rendered with the linked content or a thumbnail (with alt-text) of the linked media item.

Steps to test:
- Add links to content, media and external URL on a 'Umbraco.MultiUrlPicker' property
- Check whether the correct properties on the `Link` model that's returned from the PVC are set:
  - `Content` should only be `null` for external URLs
  - `Content.Key` should have the same GUID as in the `Udi`

**2. Only save manually entered link name**
The current link picker overlay sets the link name to the selected content or media item, but this has the following problems:
- Entering a (custom) link name and then selecting a node overwrites the entered text (as the name/title input is shown before the node pickers, this is a quite common/understandable order of doing things);
- If the linked node name is changed, the link name is not automatically updated, so editors might have to find all referencing links to update the link name;
- Because of the above, translating content (by duplicating and editing or using other tools) requires more text to be changed and when changing the links to point to the duplicated child nodes, require the custom text to be stored somewhere, so it's not overwritten (this obviously only applies to translations using multiple root nodes and not when using culture variants).

The interface/AngularJS part of this feature need to be changed, but the PVC already sets the content name when the link title/name is empty. When this is ready, I'll add testing steps and mark this PR as ready to review. Stay tuned!