### PR TITLE
make icon of umb-preview-node align vertically.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
@@ -29,7 +29,8 @@
 .umb-node-preview__icon {
     display: flex;
     width: 25px;
-    height: 25px;
+    min-height: 25px;
+    height: 100%;
     justify-content: center;
     align-items: center;
     font-size: 20px;


### PR DESCRIPTION
Making the icon of umb-node-preview align vertically.

![image](https://user-images.githubusercontent.com/6791648/73346011-64f3bc00-4285-11ea-9c8c-0f2a96870328.png)
