### PR TITLE
8.6RC: Support culture variant URLs in multi URL picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -144,16 +144,6 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
         if ($scope.model.validation && $scope.model.validation.mandatory && !$scope.model.config.minNumber) {
             $scope.model.config.minNumber = 1;
         }
-
-        _.each($scope.model.value, function (item){
-            // we must reload the "document" link URLs to match the current editor culture
-            if (item.udi.indexOf("/document/") > 0) {
-                item.url = null;
-                entityResource.getUrlByUdi(item.udi).then(function (data) {
-                    item.url = data;
-                });
-            }
-        });
     }
 
     init();

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -79,7 +79,7 @@ namespace Umbraco.Web.PropertyEditors
                         if (entity is IDocumentEntitySlim documentEntity)
                         {
                             icon = documentEntity.ContentTypeIcon;
-                            published = culture == null ? documentEntity.Published : documentEntity.PublishedCultures.Contains(culture);
+                            published = culture == null || !documentEntity.Variations.VariesByCulture() ? documentEntity.Published : documentEntity.PublishedCultures.Contains(culture);
                             udi = new GuidUdi(Constants.UdiEntityType.Document, documentEntity.Key);
                             url = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(entity.Key)?.Url(culture) ?? "#";
                             trashed = documentEntity.Trashed;

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Web.PropertyEditors
                             icon = documentEntity.ContentTypeIcon;
                             published = culture == null ? documentEntity.Published : documentEntity.PublishedCultures.Contains(culture);
                             udi = new GuidUdi(Constants.UdiEntityType.Document, documentEntity.Key);
-                            url = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(entity.Key)?.Url() ?? "#";
+                            url = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(entity.Key)?.Url(culture) ?? "#";
                             trashed = documentEntity.Trashed;
                         }
                         else if(entity is IContentEntitySlim contentEntity)
@@ -89,7 +89,7 @@ namespace Umbraco.Web.PropertyEditors
                             icon = contentEntity.ContentTypeIcon;
                             published = !contentEntity.Trashed;
                             udi = new GuidUdi(Constants.UdiEntityType.Media, contentEntity.Key);
-                            url = _publishedSnapshotAccessor.PublishedSnapshot.Media.GetById(entity.Key)?.Url() ?? "#";
+                            url = _publishedSnapshotAccessor.PublishedSnapshot.Media.GetById(entity.Key)?.Url(culture) ?? "#";
                             trashed = contentEntity.Trashed;
                         }
                         else


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/7114.

### Description
This corrects PR https://github.com/umbraco/Umbraco-CMS/pull/7130, as that throws JavaScript errors after adding an external link: `Cannot read property 'indexOf' of null`.

The Multi URL Picker already fetches the current URL in the `MultiUrlPickerValueEditor`, but didn't pass the culture to the `Url()` method. So this also removes the need for an additional API call (per linked content/media item!) to fetch the URL in the current culture...

While testing, I also noticed culture invariant content was displayed as unpublished on a culture variant node. This PR also ensures the `MultiUrlPickerValueEditor` checks whether the linked content is culture variant and only then checks the published cultures.

---
_This item has been added to our backlog [AB#4906](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/4906)_