### PR TITLE
Obsolete CreatorName and WriterName on IPublishedContent

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedContent.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedContent.cs
@@ -63,6 +63,7 @@ namespace Umbraco.Core.Models.PublishedContent
         /// <summary>
         /// Gets the name of the user who created the content item.
         /// </summary>
+        [Obsolete("Use CreatorName(IUserService) extension instead")]
         string CreatorName { get; }
 
         /// <summary>
@@ -78,6 +79,7 @@ namespace Umbraco.Core.Models.PublishedContent
         /// <summary>
         /// Gets the name of the user who last updated the content item.
         /// </summary>
+        [Obsolete("Use WriterName(IUserService) extension instead")]
         string WriterName { get; }
 
         /// <summary>

--- a/src/Umbraco.Web/Macros/PublishedContentHashtableConverter.cs
+++ b/src/Umbraco.Web/Macros/PublishedContentHashtableConverter.cs
@@ -248,8 +248,10 @@ namespace Umbraco.Web.Macros
 
             public string UrlSegment => throw new NotImplementedException();
 
+            [Obsolete("Use WriterName(IUserService) extension instead")]
             public string WriterName { get; }
 
+            [Obsolete("Use CreatorName(IUserService) extension instead")]
             public string CreatorName { get; }
 
             public int WriterId => _inner.WriterId;

--- a/src/Umbraco.Web/Models/PublishedContentBase.cs
+++ b/src/Umbraco.Web/Models/PublishedContentBase.cs
@@ -54,6 +54,8 @@ namespace Umbraco.Web.Models
         public abstract int CreatorId { get; }
 
         /// <inheritdoc />
+        [Obsolete("Use CreatorName(IUserService) extension instead")]
+
         public abstract string CreatorName { get; }
 
         /// <inheritdoc />
@@ -63,6 +65,8 @@ namespace Umbraco.Web.Models
         public abstract int WriterId { get; }
 
         /// <inheritdoc />
+        [Obsolete("Use WriterName(IUserService) extension instead")]
+
         public abstract string WriterName { get; }
 
         /// <inheritdoc />

--- a/src/Umbraco.Web/Models/PublishedContentBase.cs
+++ b/src/Umbraco.Web/Models/PublishedContentBase.cs
@@ -55,7 +55,6 @@ namespace Umbraco.Web.Models
 
         /// <inheritdoc />
         [Obsolete("Use CreatorName(IUserService) extension instead")]
-
         public abstract string CreatorName { get; }
 
         /// <inheritdoc />
@@ -66,7 +65,6 @@ namespace Umbraco.Web.Models
 
         /// <inheritdoc />
         [Obsolete("Use WriterName(IUserService) extension instead")]
-
         public abstract string WriterName { get; }
 
         /// <inheritdoc />

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
@@ -163,6 +163,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
         public override int CreatorId => _contentNode.CreatorId;
 
         /// <inheritdoc />
+        [Obsolete("Use CreatorName(IUserService) extension instead")]
+
         public override string CreatorName => GetProfileNameById(_contentNode.CreatorId);
 
         /// <inheritdoc />
@@ -172,6 +174,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
         public override int WriterId => ContentData.WriterId;
 
         /// <inheritdoc />
+        [Obsolete("Use WriterName(IUserService) extension instead")]
+
         public override string WriterName => GetProfileNameById(ContentData.WriterId);
 
         /// <inheritdoc />

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
@@ -164,7 +164,6 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
         /// <inheritdoc />
         [Obsolete("Use CreatorName(IUserService) extension instead")]
-
         public override string CreatorName => GetProfileNameById(_contentNode.CreatorId);
 
         /// <inheritdoc />
@@ -175,7 +174,6 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
         /// <inheritdoc />
         [Obsolete("Use WriterName(IUserService) extension instead")]
-
         public override string WriterName => GetProfileNameById(ContentData.WriterId);
 
         /// <inheritdoc />

--- a/src/Umbraco.Web/PublishedCache/PublishedMember.cs
+++ b/src/Umbraco.Web/PublishedCache/PublishedMember.cs
@@ -140,9 +140,13 @@ namespace Umbraco.Web.PublishedCache
         public override string UrlSegment => throw new NotSupportedException();
 
         // TODO: ARGH! need to fix this - this is not good because it uses ApplicationContext.Current
+        [Obsolete("Use WriterName(IUserService) extension instead")]
+
         public override string WriterName => _member.GetCreatorProfile().Name;
 
         // TODO: ARGH! need to fix this - this is not good because it uses ApplicationContext.Current
+        [Obsolete("Use CreatorName(IUserService) extension instead")]
+
         public override string CreatorName => _member.GetCreatorProfile().Name;
 
         public override int WriterId => _member.CreatorId;

--- a/src/Umbraco.Web/PublishedCache/PublishedMember.cs
+++ b/src/Umbraco.Web/PublishedCache/PublishedMember.cs
@@ -141,12 +141,10 @@ namespace Umbraco.Web.PublishedCache
 
         // TODO: ARGH! need to fix this - this is not good because it uses ApplicationContext.Current
         [Obsolete("Use WriterName(IUserService) extension instead")]
-
         public override string WriterName => _member.GetCreatorProfile().Name;
 
         // TODO: ARGH! need to fix this - this is not good because it uses ApplicationContext.Current
         [Obsolete("Use CreatorName(IUserService) extension instead")]
-
         public override string CreatorName => _member.GetCreatorProfile().Name;
 
         public override int WriterId => _member.CreatorId;

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1018,8 +1018,8 @@ namespace Umbraco.Web
                                     { "NodeTypeAlias", n.ContentType.Alias },
                                     { "CreateDate", n.CreateDate },
                                     { "UpdateDate", n.UpdateDate },
-                                    { "CreatorName", n.CreatorName(services.UserService) },
-                                    { "WriterName", n.WriterName(services.UserService) },
+                                    { "CreatorName", n.CreatorName },
+                                    { "WriterName", n.WriterName },
                                     { "Url", n.Url() }
                                 };
 

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -28,6 +28,20 @@ namespace Umbraco.Web
         private static UmbracoContext UmbracoContext => Current.UmbracoContext;
         private static ISiteDomainHelper SiteDomainHelper => Current.Factory.GetInstance<ISiteDomainHelper>();
 
+        #region Creator/Writer Names
+
+        public static string CreatorName(this IPublishedContent content, IUserService userService)
+        {
+            return userService.GetProfileById(content.CreatorId)?.Name;
+        }
+
+        public static string WriterName(this IPublishedContent content, IUserService userService)
+        {
+            return userService.GetProfileById(content.WriterId)?.Name;
+        }
+
+        #endregion
+
         #region IsComposedOf
 
         /// <summary>
@@ -1004,8 +1018,8 @@ namespace Umbraco.Web
                                     { "NodeTypeAlias", n.ContentType.Alias },
                                     { "CreateDate", n.CreateDate },
                                     { "UpdateDate", n.UpdateDate },
-                                    { "CreatorName", n.CreatorName },
-                                    { "WriterName", n.WriterName },
+                                    { "CreatorName", n.CreatorName(services.UserService) },
+                                    { "WriterName", n.WriterName(services.UserService) },
                                     { "Url", n.Url() }
                                 };
 


### PR DESCRIPTION
_Creating this PR to trigger a discussion on the impact of removing CreatorName and WriterName from IPublishedContent_

### Description

We've been looking at things that make the move to netcore more difficult. One of the things that came up is PublishedContent's dependency on IUserService. 

It seemed to the Unicore team that CreatorName and WriterName are rarely used and could easily be replaced by an extension method. This would remove service location from IPublishedContent implementations and a bunch of TODOs and other code that feels a bit hacky.

If we were to remove them in future making them obsolete now would seem sensible so Umbraco developers could see that these are going to vanish and update now. 
