### PR TITLE
Renamed "DermineIsChildOfListView" to "DetermineIsChildOfListView"

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -80,7 +80,7 @@ namespace Umbraco.Web.Models.Mapping
             target.Icon = source.ContentType.Icon;
             target.Id = source.Id;
             target.IsBlueprint = source.Blueprint;
-            target.IsChildOfListView = DermineIsChildOfListView(source);
+            target.IsChildOfListView = DetermineIsChildOfListView(source);
             target.IsContainer = source.ContentType.IsContainer;
             target.IsElement = source.ContentType.IsElement;
             target.Key = source.Key;
@@ -211,7 +211,7 @@ namespace Umbraco.Web.Models.Mapping
             return source.CultureInfos.TryGetValue(culture, out var name) && !name.Name.IsNullOrWhiteSpace() ? name.Name : $"({source.Name})";
         }
 
-        private bool DermineIsChildOfListView(IContent source)
+        private bool DetermineIsChildOfListView(IContent source)
         {
             // map the IsChildOfListView (this is actually if it is a descendant of a list view!)
             var parent = _contentService.GetParent(source);

--- a/src/Umbraco.Web/Models/Mapping/MediaMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MediaMapDefinition.cs
@@ -56,7 +56,7 @@ namespace Umbraco.Web.Models.Mapping
             target.CreateDate = source.CreateDate;
             target.Icon = source.ContentType.Icon;
             target.Id = source.Id;
-            target.IsChildOfListView = DermineIsChildOfListView(source);
+            target.IsChildOfListView = DetermineIsChildOfListView(source);
             target.Key = source.Key;
             target.MediaLink = string.Join(",", source.GetUrls(Current.Configs.Settings().Content, _logger));
             target.Name = source.Name;
@@ -95,7 +95,7 @@ namespace Umbraco.Web.Models.Mapping
             target.VariesByCulture = source.ContentType.VariesByCulture();
         }
 
-        private bool DermineIsChildOfListView(IMedia source)
+        private bool DetermineIsChildOfListView(IMedia source)
         {
             // map the IsChildOfListView (this is actually if it is a descendant of a list view!)
             var parent = _mediaService.GetParent(source);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7548 

### Description

Renamed "DermineIsChildOfListView" to "DetermineIsChildOfListView" in MediaMapDefinition and ContentMapDefinition (both private methods)

Testing: nothing to test - simple rename of private variables and rebuild.

<!-- Thanks for contributing to Umbraco CMS! -->
