### PR TITLE
Obsolete Url on IPublishedContent

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedContent.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedContent.cs
@@ -97,6 +97,7 @@ namespace Umbraco.Core.Models.PublishedContent
         /// <para>The value of this property is contextual. It depends on the 'current' request uri,
         /// if any.</para>
         /// </remarks>
+        [Obsolete("Use the Url() extension instead")]
         string Url { get; }
 
         /// <summary>

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
@@ -94,6 +94,7 @@ namespace Umbraco.Core.Models.PublishedContent
         public virtual DateTime UpdateDate => _content.UpdateDate;
 
         /// <inheritdoc />
+        [Obsolete("Use the Url() extension instead")]
         public virtual string Url => _content.Url;
 
         /// <inheritdoc />

--- a/src/Umbraco.Tests/PublishedContent/SolidPublishedSnapshot.cs
+++ b/src/Umbraco.Tests/PublishedContent/SolidPublishedSnapshot.cs
@@ -199,6 +199,7 @@ namespace Umbraco.Tests.PublishedContent
         public DateTime UpdateDate { get; set; }
         public Guid Version { get; set; }
         public int Level { get; set; }
+        [Obsolete("Use the Url() extension instead")]
         public string Url { get; set; }
 
         public PublishedItemType ItemType => PublishedItemType.Content;

--- a/src/Umbraco.Web/Controllers/UmbLoginController.cs
+++ b/src/Umbraco.Web/Controllers/UmbLoginController.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Web.Controllers
                 // if it's not a local url we'll redirect to the root of the current site
                 return Redirect(Url.IsLocalUrl(model.RedirectUrl)
                     ? model.RedirectUrl
-                    : CurrentPage.AncestorOrSelf(1).Url);
+                    : CurrentPage.AncestorOrSelf(1).Url());
             }
 
             //redirect to current page by default

--- a/src/Umbraco.Web/Models/PublishedContentBase.cs
+++ b/src/Umbraco.Web/Models/PublishedContentBase.cs
@@ -69,6 +69,7 @@ namespace Umbraco.Web.Models
         public abstract DateTime UpdateDate { get; }
 
         /// <inheritdoc />
+        [Obsolete("Use the Url() extension instead")]
         public virtual string Url => this.Url();
 
         /// <inheritdoc />

--- a/src/Umbraco.Web/PropertyEditors/RichTextEditorPastedImages.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextEditorPastedImages.cs
@@ -101,7 +101,7 @@ namespace Umbraco.Web.PropertyEditors
                 if (mediaTyped == null)
                     throw new PanicException($"Could not find media by id {udi.Guid} or there was no UmbracoContext available.");
 
-                var location = mediaTyped.Url;
+                var location = mediaTyped.Url();
 
                 // Find the width & height attributes as we need to set the imageprocessor QueryString
                 var width = img.GetAttributeValue("width", int.MinValue);


### PR DESCRIPTION
### Description

Part of the asp-netcore dev work

The Url property on published content, which is very context dependant causes issue to move to netcore. There is already an extension method to replace it so seems sensible to remove it on the next major release. 

Marking obsolete here to start letting developers know that it's likely to be removed. 