### PR TITLE
Add an Active State for Expand (...) in the Top Section Navigation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
@@ -133,6 +133,17 @@ function sectionsDirective($timeout, $window, navigationService, treeService, se
                 }
             };
 
+            scope.currentSectionInOverflow = function () {
+                if (scope.overflowingSections === 0) {
+                    return false;
+                }
+
+                var currentSection = scope.sections.filter(s => s.alias === scope.currentSection);
+
+                return (scope.sections.indexOf(currentSection[0]) >= scope.maxSections);
+
+            };
+
             loadSections();
 
         }

--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -55,7 +55,7 @@ ul.sections {
             transition: opacity .1s linear, box-shadow .1s;
         }
 
-        &.current a {
+        &.current > a {
             color: @ui-active;
 
             &::after {
@@ -75,9 +75,16 @@ ul.sections {
                 opacity: 0.6;
                 transition: opacity .1s linear;
             }
-            
+
+            &.current {
+                i {
+                    opacity: 1;
+                    background: @ui-active;
+                }
+            }
+
             &:hover i {
-                opacity:1;
+                opacity: 1;
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-sections.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-sections.html
@@ -11,7 +11,7 @@
                 </a>
             </li>
 
-            <li data-element="section-expand" class="expand" ng-class="{ 'open': showTray === true }" ng-show="needTray">
+            <li data-element="section-expand" class="expand" ng-class="{ 'open': showTray === true, current: currentSectionInOverflow() }" ng-show="needTray">
                 <a href="#" ng-click="trayClick()" prevent-default>
                     <span class="section__name"><i></i><i></i><i></i></span>
                 </a>


### PR DESCRIPTION
### Prerequisites

- This PR is intended to fix #7473.

### Description

- The `expand` element now receives the `current` class if the currently active section is found in the overflow.

- If the active section is found in the overflow, the `expand` element shares the same visual appearance.

- Made some of the CSS rulesets more specific, so they didn't cascade to all links underneath the `expand` element.

### Questions / Comments

- To determine if the `current` element should have the class `current` applied, I couldn't find a way to do this with a simple one-liner in the template. I wrote a function `currentSectionInOverflow`. If this is not ideal please give me feedback on how I might update this to a preferred solution.