### PR TITLE
keep umb-editor inside viewport width

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
@@ -11,6 +11,7 @@
     .absolute();
     background: @brownGrayLight;
     z-index: @zIndexEditor;
+    max-width: 100%;
 
     &--infiniteMode {
         transform: none;


### PR DESCRIPTION
This change adds max-width:100%; to the .umb-editor css-class. This is done to ensure that umb-editor in infinite editing stays inside the viewport-width. See medium sized editors.

Should be tested to see if this change affect other parts of the system where umb-editor is used.