### PR TITLE
Migrations - Create temporary index on umbracoPropertyData

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/Common/CreateKeysAndIndexes.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/Common/CreateKeysAndIndexes.cs
@@ -12,6 +12,7 @@ namespace Umbraco.Core.Migrations.Upgrade.Common
         {
             // remove those that may already have keys
             Delete.KeysAndIndexes(Constants.DatabaseSchema.Tables.KeyValue).Do();
+            Delete.KeysAndIndexes(Constants.DatabaseSchema.Tables.PropertyData).Do();
 
             // re-create *all* keys and indexes
             foreach (var x in DatabaseSchemaCreator.OrderedTables)


### PR DESCRIPTION
Breaking up #6191 into easier pieces

Create a temporary index on umbracoPropertyData to speed up remaining migrations.