### PR TITLE
Migrations - In ConvertTinyMceAndGridMediaUrlsToLocalLink, avoid unnecessary updates

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
@@ -43,6 +43,8 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                 var value = property.TextValue;
                 if (string.IsNullOrWhiteSpace(value)) continue;
 
+
+                bool propertyChanged = false;
                 if (property.PropertyTypeDto.DataTypeDto.EditorAlias == Constants.PropertyEditors.Aliases.Grid)
                 {
                     try
@@ -55,7 +57,8 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                             var controlValue = control["value"];
                             if (controlValue?.Type == JTokenType.String)
                             {
-                                control["value"] = UpdateMediaUrls(mediaLinkPattern, controlValue.Value<string>());
+                                control["value"] = UpdateMediaUrls(mediaLinkPattern, controlValue.Value<string>(), out var controlChanged);
+                                propertyChanged |= controlChanged;
                             }
                         }
 
@@ -76,10 +79,11 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                 }
                 else
                 {
-                    property.TextValue = UpdateMediaUrls(mediaLinkPattern, value);
+                    property.TextValue = UpdateMediaUrls(mediaLinkPattern, value, out propertyChanged);
                 }
 
-                Database.Update(property);
+                if (propertyChanged)
+                    Database.Update(property);
             }
 
 
@@ -91,10 +95,14 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
             Context.AddPostMigration<RebuildPublishedSnapshot>();
         }
 
-        private string UpdateMediaUrls(Regex mediaLinkPattern, string value)
+        private string UpdateMediaUrls(Regex mediaLinkPattern, string value, out bool changed)
         {
-            return mediaLinkPattern.Replace(value, match =>
+            bool matched = false;
+
+            var result = mediaLinkPattern.Replace(value, match =>
             {
+                matched = true;
+
                 // match groups:
                 // - 1 = from the beginning of the a tag until href attribute value begins
                 // - 2 = the href attribute value excluding the querystring (if present)
@@ -106,6 +114,10 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                     ? match.Value
                     : $"{match.Groups[1].Value}/{{localLink:{media.GetUdi()}}}{match.Groups[3].Value}";
             });
+
+            changed = matched;
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
Breaking up #6191 into easier pieces

In ConvertTinyMceAndGridMediaUrlsToLocalLink, keep track of whether the value changed and don't update the database if there's nothing to update.