### PR TITLE
Adjust child selector sorting

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbchildselector.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbchildselector.directive.js
@@ -99,13 +99,18 @@ Use this directive to render a ui component for selecting child items to a paren
 @param {string} parentName (<code>binding</code>): The parent name.
 @param {string} parentIcon (<code>binding</code>): The parent icon.
 @param {number} parentId (<code>binding</code>): The parent id.
-@param {callback} onRemove (<code>binding</code>): Callback when the remove button is clicked on an item.
+@param {callback} onRemove (<code>binding</code>): Callback when removing an item.
     <h3>The callback returns:</h3>
     <ul>
         <li><code>child</code>: The selected item.</li>
         <li><code>$index</code>: The selected item index.</li>
     </ul>
-@param {callback} onAdd (<code>binding</code>): Callback when the add button is clicked.
+@param {callback} onAdd (<code>binding</code>): Callback when adding an item.
+    <h3>The callback returns:</h3>
+    <ul>
+        <li><code>$event</code>: The select event.</li>
+    </ul>
+@param {callback} onSort (<code>binding</code>): Callback when sorting an item.
     <h3>The callback returns:</h3>
     <ul>
         <li><code>$event</code>: The select event.</li>
@@ -174,16 +179,15 @@ Use this directive to render a ui component for selecting child items to a paren
             eventBindings.push(scope.$watch('parentName', function(newValue, oldValue){
 
               if (newValue === oldValue) { return; }
-              if ( oldValue === undefined || newValue === undefined) { return; }
+              if (oldValue === undefined || newValue === undefined) { return; }
 
               syncParentName();
-
             }));
 
             eventBindings.push(scope.$watch('parentIcon', function(newValue, oldValue){
 
               if (newValue === oldValue) { return; }
-              if ( oldValue === undefined || newValue === undefined) { return; }
+              if (oldValue === undefined || newValue === undefined) { return; }
 
               syncParentIcon();
             }));

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbchildselector.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbchildselector.directive.js
@@ -191,6 +191,7 @@ Use this directive to render a ui component for selecting child items to a paren
             // sortable options for allowed child content types
             scope.sortableOptions = {
                 axis: "y",
+                cancel: ".unsortable",
                 containment: "parent",
                 distance: 10,
                 opacity: 0.7,
@@ -199,7 +200,7 @@ Use this directive to render a ui component for selecting child items to a paren
                 zIndex: 6000,
                 update: function (e, ui) {
                     if(scope.onSort) {
-                        scope.onSort();
+                       scope.onSort();
                     }
                 }
             };

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-child-selector.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-child-selector.less
@@ -19,12 +19,13 @@
   cursor: pointer;
   text-align: center;
   justify-content: center;
-  
-  color:@ui-action-type;
+  width: 100%;
+  color: @ui-action-type;
+
   &:hover {
-      color:@ui-action-type-hover;
-      border-color:@ui-action-type-hover;
-      text-decoration:none;
+      color: @ui-action-type-hover;
+      border-color: @ui-action-type-hover;
+      text-decoration: none;
   }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-child-selector.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-child-selector.less
@@ -16,7 +16,6 @@
 .umb-child-selector__child.-placeholder {
   border: 1px dashed @gray-8;
   background: none;
-  cursor: pointer;
   text-align: center;
   justify-content: center;
   width: 100%;
@@ -67,7 +66,6 @@
 }
 
 .umb-child-selector__child-remove {
-  cursor: pointer;
   background: none;
   border: none;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-child-selector.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-child-selector.less
@@ -29,10 +29,11 @@
 }
 
 .umb-child-selector__children-container {
-  margin-left: 30px;
-  .umb-child-selector__child {
-      cursor: move;
-  }
+    margin-left: 30px;
+
+    .umb-child-selector__child.ui-sortable-handle {
+        cursor: move;
+    }
 }
 
 .umb-child-selector__child-description {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-child-selector.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-child-selector.less
@@ -67,4 +67,6 @@
 
 .umb-child-selector__child-remove {
   cursor: pointer;
+  background: none;
+  border: none;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
@@ -28,9 +28,9 @@
             </div>
         </div>
 
-        <a href="" class="umb-child-selector__child -placeholder unsortable" ng-click="addChild($event)" hotkey="alt+shift+c">
+        <button type="button" class="umb-child-selector__child -placeholder unsortable" ng-click="addChild($event)" hotkey="alt+shift+c">
             <div class="umb-child-selector__child-name -blue"><strong><localize key="shortcuts_addChild">Add Child</localize></strong></div>
-        </a>
+        </button>
 
     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
@@ -28,7 +28,7 @@
             </div>
         </div>
 
-        <a href="" class="umb-child-selector__child -placeholder" ng-click="addChild($event)" hotkey="alt+shift+c">
+        <a href="" class="umb-child-selector__child -placeholder unsortable" ng-click="addChild($event)" hotkey="alt+shift+c">
             <div class="umb-child-selector__child-name -blue"><strong><localize key="shortcuts_addChild">Add Child</localize></strong></div>
         </a>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
@@ -19,12 +19,14 @@
         <div class="umb-child-selector__child" ng-repeat="selectedChild in selectedChildren">
             <div class="umb-child-selector__child-description">
                 <div class="umb-child-selector__child-icon-holder">
-                    <i class="umb-child-selector__child-icon {{ selectedChild.icon }}"></i>
+                    <i class="umb-child-selector__child-icon {{selectedChild.icon}}" aria-hidden="true"></i>
                 </div>
-                <span class="umb-child-selector__child-name"> {{ selectedChild.name }}</span>
+                <span class="umb-child-selector__child-name">{{selectedChild.name}}</span>
             </div>
             <div class="umb-child-selector__child-actions">
-                <i class="umb-child-selector__child-remove icon-trash" ng-click="removeChild(selectedChild, $index)"></i>
+                <button type="button" class="umb-child-selector__child-remove" ng-click="removeChild(selectedChild, $index)">
+                    <i class="icon-trash" aria-hidden="true"></i>
+                </button>
             </div>
         </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR https://github.com/umbraco/Umbraco-CMS/pull/4927 introduced sorting on the child elements in `umb-child-selector` component. However with these changed add also added the `move` cursor on the add button.

The changes in this PR ensure only the child elements that can be sorted get the `move` cursor, while the add-button still has the `pointer` cursor.
It also add documentation of the previous added `onSort` function.

Furthermore it has a few changed to update buttons using `button` element and add `aria-hidden="true"` to icons.