### PR TITLE
Slider format function should return a number

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -56,7 +56,7 @@
                     return value.toFixed(stepDecimalPlaces);
                 },
                 from: function (value) {
-                    return value;
+                    return Number(value);
                 }
             },
             "range": {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7564

### Description
In noUiSlider configuration, the format `from` function should return a number. Returning a string works as long as the minimum is non-negative, but causes strange behaviour when minimum is negative.

Testing:
- Create a slider property with the minimum set to any negative number.
- The slider should behave normally, not jump to the maximum and minimum values as seen in #7564.