### PR TITLE
Update button in package overview not to use flexbox

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-packages.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-packages.less
@@ -59,15 +59,12 @@
 
 .umb-package-link {
     display: block;
-    flex-wrap: wrap;
-    flex-direction: column;
-    justify-content: center;
     position: relative;
     box-sizing: border-box;
     height: 100%;
     width: 100%;
     border-radius: 3px;
-    border: 0 none;
+    border: 1px solid transparent;
     text-decoration: none !important;
     transition: border-color 100ms ease;
     background-color: @white;
@@ -77,8 +74,6 @@
         border-color: @blueMid;
     }
 }
-
-
 
 // Icon
 .umb-package-icon {
@@ -94,21 +89,19 @@
     border-top-right-radius: 3px;
     border-top-left-radius: 3px;
     min-height: 60px;
-}
 
-.umb-package-icon img {
-    max-width: 70px;
-    width: 70px;
-    height: auto;
+    img {
+        max-width: 70px;
+        width: 70px;
+        height: auto;
+    }
 }
-
 
 // Info
 .umb-package-info {
     padding: 15px;
     text-align: center;
 }
-
 
 // Name
 .umb-package-name {

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -44,26 +44,29 @@
                     <div class="umb-package" ng-repeat="package in vm.popular">
                         <button type="button" class="umb-package-link" ng-click="vm.showPackageDetails(package)">
 
-                            <div class="umb-package-icon">
-                                <img ng-src="{{package.icon}}" alt="" />
-                            </div>
-
-                            <div class="umb-package-info">
-                                <div class="umb-package-name">{{package.name}}</div>
-                                <div class="umb-package-description">{{package.excerpt | limitTo: 40}}<span ng-if="package.excerpt > (package.excerpt | limitTo: 40)">...</span></div>
-
-                                <div class="umb-package-numbers">
-                                    <small class="umb-package-downloads">
-                                        <i class="icon-download-alt" aria-hidden="true"></i>
-                                        <strong>{{package.downloads}}</strong>
-                                    </small>
-                                    <small class="umb-package-likes">
-                                        <i class="icon-hearts" aria-hidden="true"></i>
-                                        <strong>{{package.likes}}</strong>
-                                    </small>
+                            <div class="flex flex-column">
+                                <div class="umb-package-icon">
+                                    <img ng-src="{{package.icon}}" alt="" />
                                 </div>
 
+                                <div class="umb-package-info">
+                                    <div class="umb-package-name">{{package.name}}</div>
+                                    <div class="umb-package-description">{{package.excerpt | limitTo: 40}}<span ng-if="package.excerpt > (package.excerpt | limitTo: 40)">...</span></div>
+
+                                    <div class="umb-package-numbers">
+                                        <small class="umb-package-downloads">
+                                            <i class="icon-download-alt" aria-hidden="true"></i>
+                                            <strong>{{package.downloads}}</strong>
+                                        </small>
+                                        <small class="umb-package-likes">
+                                            <i class="icon-hearts" aria-hidden="true"></i>
+                                            <strong>{{package.likes}}</strong>
+                                        </small>
+                                    </div>
+
+                                </div>
                             </div>
+
                         </button>
                     </div> <!-- end package -->
 
@@ -80,26 +83,29 @@
                     <div class="umb-package" ng-repeat="package in vm.packages">
                         <button type="button" class="umb-package-link" ng-click="vm.showPackageDetails(package)">
 
-                            <div class="umb-package-icon">
-                                <img ng-src="{{package.icon}}" alt="" />
-                            </div>
-
-                            <div class="umb-package-info">
-                                <div class="umb-package-name">{{ package.name }}</div>
-                                <div class="umb-package-description">{{ package.excerpt | limitTo: 40 }}<span ng-if="package.excerpt > (package.excerpt | limitTo: 40)">...</span></div>
-
-                                <div class="umb-package-numbers">
-                                    <small class="umb-package-downloads">
-                                        <i class="icon-download-alt" aria-hidden="true"></i>
-                                        <strong>{{ package.downloads }}</strong>
-                                    </small>
-                                    <small class="umb-package-likes">
-                                        <i class="icon-hearts" aria-hidden="true"></i>
-                                        <strong>{{ package.likes }}</strong>
-                                    </small>
+                            <div class="flex flex-column">
+                                <div class="umb-package-icon">
+                                    <img ng-src="{{package.icon}}" alt="" />
                                 </div>
 
+                                <div class="umb-package-info">
+                                    <div class="umb-package-name">{{ package.name }}</div>
+                                    <div class="umb-package-description">{{ package.excerpt | limitTo: 40 }}<span ng-if="package.excerpt > (package.excerpt | limitTo: 40)">...</span></div>
+
+                                    <div class="umb-package-numbers">
+                                        <small class="umb-package-downloads">
+                                            <i class="icon-download-alt" aria-hidden="true"></i>
+                                            <strong>{{ package.downloads }}</strong>
+                                        </small>
+                                        <small class="umb-package-likes">
+                                            <i class="icon-hearts" aria-hidden="true"></i>
+                                            <strong>{{ package.likes }}</strong>
+                                        </small>
+                                    </div>
+
+                                </div>
                             </div>
+                            
                         </button>
                     </div> <!-- end package -->
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Tested in Chrome Version 79.0.3945.130

### Description
This PR update the button element in package overview to not use flexbox, but instead use flexbox for a inner wrapping div. The issues where the "umb-package-icon" overflow the container was affected after changes in this PR https://github.com/umbraco/Umbraco-CMS/pull/6955 where the anchor elements was changed to `button` elements.
It also ensure the border color change on hover works as previous.

In some browers it is not supported to use `button` element as flexbox container or doesn't allow to change its `display` value.
https://stackoverflow.com/a/35466231/1693918

> `<button>` is not implementable (by browsers) in pure CSS, so they are a bit of a black box, from the perspective of CSS. This means that they don't necessarily react in the same way that e.g. a `<div>` would.

https://github.com/philipwalton/flexbugs#flexbug-9



**Before**
![image](https://user-images.githubusercontent.com/2919859/73861313-22118580-483d-11ea-9408-9935561041eb.png)

![image](https://user-images.githubusercontent.com/2919859/73861385-39507300-483d-11ea-8aab-0cf849e5b0fe.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/73860873-84b65180-483c-11ea-933c-b7b101964045.png)

![image](https://user-images.githubusercontent.com/2919859/73862018-386c1100-483e-11ea-81ef-16256a00117f.png)
