### PR TITLE
Align icon in mini search

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-mini-search.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-mini-search.less
@@ -4,16 +4,21 @@
 
     .icon {
         position: absolute;
-        padding: 5px 8px;
+        width: 30px;
+        height: 30px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin: 1px;
+        padding: 0;
         pointer-events: none;
-        top: 2px;
         color: @ui-action-discreet-type;
         transition: color .1s linear;
     }
 
     input {
         width: 0px;
-        padding-left:24px;
+        padding-left: 24px;
         margin-bottom: 0px;
         background-color: transparent;
         border-color: @ui-action-discreet-border;

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-search/umb-mini-search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-search/umb-mini-search.html
@@ -1,5 +1,5 @@
 <ng-form class="umb-mini-search" ng-class="{'--has-value': vm.model !== null && vm.model !== ''}" novalidate>
-    <i class="icon icon-search"></i>
+    <i class="icon icon-search" aria-hidden="true"></i>
     <input
         class="form-control search-input"
         type="text"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR align the search icon a bit more in center of the search input and also add `aria-hidden="true"` to the icon. Also note that the height of the search box previous didn't align with the height of the layout selector button.

**Before**

![image](https://user-images.githubusercontent.com/2919859/73878544-03ba8280-485b-11ea-9961-223b20f5c865.png)

![image](https://user-images.githubusercontent.com/2919859/73878561-0b7a2700-485b-11ea-82ba-d0a0cd3dc55e.png)

**After**
![image](https://user-images.githubusercontent.com/2919859/73878349-af170780-485a-11ea-91e3-2bb6513f6346.png)

![image](https://user-images.githubusercontent.com/2919859/73878386-bd652380-485a-11ea-94cc-fd7f88e8182a.png)
