### PR TITLE
Missing onClose for tour

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour/umbtourstep.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour/umbtourstep.directive.js
@@ -18,9 +18,10 @@
 
         function link(scope, element, attrs, ctrl) {
 
-            scope.close = function() {
-                if(scope.onClose) {
-                    scope.onClose();
+
+            scope.close = function () {
+                if (scope.onClose) {
+                   scope.onClose();
                 }
             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour/umbtourstep.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour/umbtourstep.directive.js
@@ -18,7 +18,6 @@
 
         function link(scope, element, attrs, ctrl) {
 
-
             scope.close = function () {
                 if (scope.onClose) {
                    scope.onClose();

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-tour.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-tour.html
@@ -70,7 +70,7 @@
 
         <!-- Dom element not found error -->
         <div ng-if="elementNotFound && !loadingStep">
-            <umb-tour-step class="tc">
+            <umb-tour-step class="tc" on-close="model.endTour()">
                 <umb-tour-step-header>
                     <h4 class="bold color-red">Oh, we got lost!</h4>
                 </umb-tour-step-header>

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umbtour/umb-tour-step.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umbtour/umb-tour-step.html
@@ -1,8 +1,7 @@
 <div class="umb-tour-step umb-tour-step--{{size}}">
 
-
     <div ng-if="hideClose !== true">
-        <button class="icon-wrong umb-tour-step__close" ng-click="close()">
+        <button type="button" class="icon-wrong umb-tour-step__close" ng-click="close()">
             <span class="sr-only">
                 <localize key="general_close">Close</localize>
             </span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umbtour/umb-tour-step.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umbtour/umb-tour-step.html
@@ -1,7 +1,7 @@
 <div class="umb-tour-step umb-tour-step--{{size}}">
 
     <div ng-if="hideClose !== true">
-        <button type="button" class="icon-wrong umb-tour-step__close" ng-click="close()">
+        <button type="button" class="icon-wrong umb-tour-step__close" hotkey="esc" ng-click="close()">
             <span class="sr-only">
                 <localize key="general_close">Close</localize>
             </span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In a clean Umbraco install with no content nodes and running the tour "Create content", it stops after step 2 because it can't find a homepage node and you get the tour step error "Oh, we got lost!". The button "End tour" close the overlay, while the close button does nothing, because there is no `on-close` implemented for this tour step.

![chrome_2020-02-06_13-22-21](https://user-images.githubusercontent.com/2919859/73939359-96096780-48e9-11ea-909b-af4b3c6b175f.png)

![chrome_2020-02-06_13-23-24](https://user-images.githubusercontent.com/2919859/73939374-9dc90c00-48e9-11ea-9d55-af466c894aae.png)

Not sure if it makes sense this tour look for a homepage node? I guess some might take this tour to know how to get started creating content?

It would be great if it also was possible to close the tour by using `esc` shortcut like with other overlays in backoffice.