### PR TITLE
Fix jumping section name on focus

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/sections.less
+++ b/src/Umbraco.Web.UI.Client/src/less/sections.less
@@ -41,13 +41,13 @@ ul.sections {
 
             &:focus .section__name {
                 .tabbing-active & {
-                    border: 1px solid;
-                    border-color: @gray-9;
+                    border: 1px solid @gray-9;
                 }
             }
         }
 
         .section__name {
+            border: 1px solid transparent;
             border-radius: 3px;
             margin-top: 1px;
             padding: 3px 10px 4px 10px;
@@ -75,9 +75,9 @@ ul.sections {
                 opacity: 0.6;
                 transition: opacity .1s linear;
             }
-            
+
             &:hover i {
-                opacity:1;
+                opacity: 1;
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When using keyboard to navigate through the sections, these are jumping a bit, because the section name get a border on focus, but no by default. So on focus it is moved a few pixels.
Adding a transparent border ensure the section name not jump on focus.

**Before**

![2020-02-06_17-39-25](https://user-images.githubusercontent.com/2919859/73958133-be07c380-4907-11ea-81e4-a273866f7642.gif)


**After**

![2020-02-06_17-34-20](https://user-images.githubusercontent.com/2919859/73957888-58b3d280-4907-11ea-8304-ec4eadc7df28.gif)
