### PR TITLE
Possible changes to behavior of saving content when a new default template is assigned

### DIFF
--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -59,6 +59,46 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Template_Assigned_When_Saved_After_Default_Template_Assigned()
+        {
+            var contentService = ServiceContext.ContentService;
+            var contentTypeService = ServiceContext.ContentTypeService;
+
+            var contentType = MockedContentTypes.CreateSimpleContentType();
+            contentTypeService.Save(contentType);
+
+            IContent root = MockedContent.CreateSimpleContent(contentType, "root", -1);
+            contentService.Save(root);
+            Assert.AreEqual(null, root.TemplateId);
+
+            for (int i = 0; i < 10; i++)
+            {
+                var content = MockedContent.CreateSimpleContent(contentType, "c" + i, root.Id);
+                contentService.Save(content);
+                Assert.AreEqual(null, content.TemplateId);
+            }
+
+            // set a default template - this does not automatically assign a template
+            // to all content for this content type
+            contentType.SetDefaultTemplate(new Template("Textpage", "textpage"));
+            ServiceContext.FileService.SaveTemplate(contentType.DefaultTemplate);
+            contentTypeService.Save(contentType);
+
+            //re-get
+            root = contentService.GetById(root.Id);
+            Assert.AreEqual(null, root.TemplateId);
+
+            contentService.SaveAndPublish(root);
+            //re-get
+            root = contentService.GetById(root.Id);
+
+            // just because we saved, doesn't mean that it suddenly has a template assigned because we
+            // assigned a default template to the content type ... but should it?
+            Assert.AreEqual(null, root.TemplateId);
+
+        }
+
+        [Test]
         public void Create_Blueprint()
         {
             var contentService = ServiceContext.ContentService;


### PR DESCRIPTION
based on this discussion: https://github.com/umbraco/Umbraco-CMS/issues/7451

The problem in the above is mostly a UX/JavaScript issue. This PR has a unit test which demonstrates what happens when you assign a default template to a content type when one wasn't previously assigned. What happens to content that is saved after a default template is assigned is .... **nothing**

In order for the IContent to have this template, the template property of the content must be assigned first.

In #7451 seb mentions that the reason this works in the UI is because the UI is auto-selecting the template in the drop down and this information is posted back to the server. This is why publishing and publish with descendants is different... it's nothing to do with c#.

So what do we do? Do we change how c# works and the result of this new test? We could, we could automatically assign the content type's default template to a content item if it's currently null. Will this cause problems? I'm not sure. IIRC we don't allow in the UI to un-assign a template from a content item if the content type has a template so IMO I don't think this would cause a problem but maybe people have other concerns?