### PR TITLE
update angular-aria to 1.7.9

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -1109,9 +1109,9 @@
       "integrity": "sha512-kU/fHIGf2a4a3bH7E1tzALTHk+QfoUSCK9fEcMFisd6ZWvNDwPzXWAilItqOC3EDiAXPmGHaNc9/aXiD9xrAxQ=="
     },
     "angular-aria": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/angular-aria/-/angular-aria-1.7.5.tgz",
-      "integrity": "sha512-X2dGRw+PK7hrV7/X1Ns4e5P3KC/OBFi1l7z//D/v7zbZObsAx48qBoX7unsck+s4+mnO+ikNNkHG5N49VfAyRw=="
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/angular-aria/-/angular-aria-1.7.9.tgz",
+      "integrity": "sha512-luI3Jemd1AbOQW0krdzfEG3fM0IFtLY0bSSqIDEx3POE0XjKIC1MkrO8Csyq9PPgueLphyAPofzUwZ8YeZ88SA=="
     },
     "angular-chart.js": {
       "version": "1.1.1",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -13,7 +13,7 @@
     "ace-builds": "1.4.2",
     "angular": "1.7.9",
     "angular-animate": "1.7.5",
-    "angular-aria": "1.7.5",
+    "angular-aria": "1.7.9",
     "angular-chart.js": "^1.1.1",
     "angular-cookies": "1.7.5",
     "angular-dynamic-locale": "0.1.37",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7572 

### Description
Without going into long boring details, the issue was caused by angular-aria, which didn't like finding `contenteditable` elements inside an element decorated with `ng-click`. There are a couple of confusing GitHub issues for anyone looking for a long read...

Bumping angular-aria to 1.7.9 fixes the problem. Happy days.

Can be verified by setting a grid RTE to distraction-free mode, then typing like a sensible person who puts spaces in their sentences. 😃 