### PR TITLE
V8/feature/ab4550 segments ui variant picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
@@ -137,6 +137,24 @@
                     }
                 }
             );
+
+            $scope.propertyEditorDisabled = function (property) {
+                if (property.unlockInvariantValue) {
+                    return false;
+                }
+                
+                var contentLanguage = $scope.content.language;
+
+                var canEditCulture = !contentLanguage ||
+                    // If the property culture equals the content culture it can be edited
+                    property.culture === contentLanguage.culture ||
+                    // A culture-invariant property can only be edited by the default language variant
+                    (property.culture == null && contentLanguage.isDefault);                
+
+                var canEditSegment = property.segment === $scope.content.segment;
+
+                return !canEditCulture || !canEditSegment;
+            }
         }
 
         var directive = {

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
@@ -394,40 +394,59 @@
              */
             formatContentGetData: function(displayModel) {
 
-                //We need to check for invariant properties among the variant variants.
-                //When we detect this, we want to make sure that the property object instance is the
-                //same reference object between all variants instead of a copy (which it will be when
-                //return from the JSON structure).
+                // We need to check for invariant properties among the variant variants,
+                // as the value of an invariant property is shared between different variants.
+                // A property can be culture invariant, segment invariant, or both.
+                // When we detect this, we want to make sure that the property object instance is the
+                // same reference object between all variants instead of a copy (which it will be when
+                // return from the JSON structure).
 
                 if (displayModel.variants && displayModel.variants.length > 1) {
+                    // Collect all invariant properties from the variants that are either the
+                    // default language variant or the default segment variant.
+                    var defaultVariants = _.filter(displayModel.variants, function (variant) {                      
+                        var isDefaultLanguage = variant.language && variant.language.isDefault;
+                        var isDefaultSegment = variant.segment == null;
 
-                    var invariantProperties = [];
-
-                    //collect all invariant properties on the first first variant
-                    var firstVariant = displayModel.variants[0];
-                    _.each(firstVariant.tabs, function(tab, tabIndex) {
-                        _.each(tab.properties, function (property, propIndex) {
-                            //in theory if there's more than 1 variant, that means they would all have a language
-                            //but we'll do our safety checks anyways here
-                            if (firstVariant.language && !property.culture && !property.segment) {
-                                invariantProperties.push({
-                                    tabIndex: tabIndex,
-                                    propIndex: propIndex,
-                                    property: property
-                                });
-                            }
-                        });
+                        return isDefaultLanguage || isDefaultSegment;
                     });
 
+                    if (defaultVariants.length > 0) {
+                        _.each(defaultVariants, function (defaultVariant) {
+                            var invariantProps = [];
 
-                    //now assign this same invariant property instance to the same index of the other variants property array
-                    for (var j = 1; j < displayModel.variants.length; j++) {
-                        var variant = displayModel.variants[j];
+                            _.each(defaultVariant.tabs, function (tab, tabIndex) {
+                                _.each(tab.properties, function (property, propIndex) {
+                                    // culture == null -> property is culture invariant
+                                    // segment == null -> property is *possibly* segment invariant
+                                    if (!property.culture || !property.segment) {
+                                        invariantProps.push({
+                                            tabIndex: tabIndex,
+                                            propIndex: propIndex,
+                                            property: property
+                                        });
+                                    }
+                                });
+                            });
 
-                        _.each(invariantProperties, function (invProp) {
-                            var tab = variant.tabs[invProp.tabIndex];
+                            var otherVariants = _.filter(displayModel.variants, function (variant) {
+                                return variant !== defaultVariant;
+                            });
 
-                            tab.properties[invProp.propIndex] = invProp.property;
+                            // now assign this same invariant property instance to the same index of the other variants property array                            
+                            _.each(otherVariants, function (variant) {
+                                _.each(invariantProps, function (invProp) {
+                                    var tab = variant.tabs[invProp.tabIndex];
+                                    var prop = tab.properties[invProp.propIndex];
+
+                                    var inheritsCulture = prop.culture === invProp.property.culture && prop.segment == null && invProp.property.segment == null;
+                                    var inheritsSegment = prop.segment === invProp.property.segment && !prop.culture;
+
+                                    if (inheritsCulture || inheritsSegment) {
+                                        tab.properties[invProp.propIndex] = invProp.property;
+                                    }
+                                });
+                            });
                         });
                     }
                 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
@@ -302,6 +302,7 @@ button.umb-variant-switcher__toggle {
         .umb-variant-switcher__name-wrapper::after {
             left: 55px;// overwrite left to achieve same indentation on the dashed border as language.
         }
+    }
 
     .umb-variant-switcher__name-wrapper {
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
@@ -11,13 +11,13 @@
                     data-element="property-{{property.alias}}"
                     ng-repeat="property in group.properties track by property.alias"
                     property="property"
-                    show-inherit="variantNodeModel.variants.length > 1 && ((content.language && !content.language.isDefault && !property.culture) || (content.segment && !property.segment)) && !property.unlockInvariantValue"
+                    show-inherit="propertyEditorDisabled(property)"
                     inherits-from="defaultVariant.language.name">
 
-                    <div ng-class="{'o-40 cursor-not-allowed': variantNodeModel.variants.length > 1 && ((content.language && !content.language.isDefault && !property.culture) || (content.segment && !property.segment)) && !property.unlockInvariantValue}">
+                    <div ng-class="{'o-40 cursor-not-allowed': propertyEditorDisabled(property) }">
                         <umb-property-editor
                             model="property"
-                            preview="variantNodeModel.variants.length > 1 && ((content.language && !content.language.isDefault && !property.culture) || (content.segment && !property.segment)) && !property.unlockInvariantValue">
+                            preview="propertyEditorDisabled(property)">
                         </umb-property-editor>
                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
@@ -11,13 +11,13 @@
                     data-element="property-{{property.alias}}"
                     ng-repeat="property in group.properties track by property.alias"
                     property="property"
-                    show-inherit="variantNodeModel.variants.length > 1 && ((!content.language.isDefault && !property.culture) || (content.segment && !property.segment)) && !property.unlockInvariantValue"
+                    show-inherit="variantNodeModel.variants.length > 1 && ((content.language && !content.language.isDefault && !property.culture) || (content.segment && !property.segment)) && !property.unlockInvariantValue"
                     inherits-from="defaultVariant.language.name">
 
-                    <div ng-class="{'o-40 cursor-not-allowed': variantNodeModel.variants.length > 1 && ((!content.language.isDefault && !property.culture) || (content.segment && !property.segment)) && !property.unlockInvariantValue}">
+                    <div ng-class="{'o-40 cursor-not-allowed': variantNodeModel.variants.length > 1 && ((content.language && !content.language.isDefault && !property.culture) || (content.segment && !property.segment)) && !property.unlockInvariantValue}">
                         <umb-property-editor
                             model="property"
-                            preview="variantNodeModel.variants.length > 1 && ((!content.language.isDefault && !property.culture) || (content.segment && !property.segment)) && !property.unlockInvariantValue">
+                            preview="variantNodeModel.variants.length > 1 && ((content.language && !content.language.isDefault && !property.culture) || (content.segment && !property.segment)) && !property.unlockInvariantValue">
                         </umb-property-editor>
                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -60,7 +60,7 @@
                                 <i class="icon icon-navigation-right" ng-if="!entry.open"></i>
                             </button>
                             <button type="button" class="umb-variant-switcher__name-wrapper umb-outline" ng-click="selectVariant($event, entry.variant)" prevent-default>
-                                <span class="umb-variant-switcher__name" ng-bind="entry.variant.language ? entry.variant.language.name : entry.variant.segment"></span>
+                                <span class="umb-variant-switcher__name" ng-bind="getVariantDisplayName(entry.variant)"></span>
                                 <umb-variant-state variant="entry.variant" class="umb-variant-switcher__state"></umb-variant-state>
                             </button>
                             <div ng-if="splitViewOpen !== true && !entry.variant.active" class="umb-variant-switcher__split-view" ng-click="openInSplitView($event, entry.variant)">Open in split view</div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.controller.js
@@ -39,7 +39,7 @@
             var published = !(variant.state === "NotCreated" || variant.state === "Draft");
             
             // is this variant mandatory:
-            if (variant.language.isMandatory && !published && !variant.publish) {
+            if (variant.language && variant.language.isMandatory && !published && !variant.publish) {
                 //if a mandatory variant isn't published or set to be published
                 //then we cannot continue
                 

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -1874,7 +1874,8 @@ namespace Umbraco.Web.Editors
                     ? variant.PropertyCollectionDto
                     : new ContentPropertyCollectionDto
                     {
-                        Properties = variant.PropertyCollectionDto.Properties.Where(x => !x.Culture.IsNullOrWhiteSpace())
+                        Properties = variant.PropertyCollectionDto.Properties.Where(
+                            x => !x.Culture.IsNullOrWhiteSpace() || !x.Segment.IsNullOrWhiteSpace())
                     };
 
                 //for each variant, map the property values


### PR DESCRIPTION
### Description
@nielslyngsoe Amazing work already, looks great! I was checking it for a bit and in the process already made some fixes for stuff I ran into hope that's OK. Sending you these as a PR so you can easily view / test them yourself.

The fixes are mainly for situations where "Vary by culture" is not enabled on property-level or on content-type level.  With certain combinations the UI regarding "Inherited by <language>" was not correct and fields were not properly disabled. In addition, in splitview mode where multiple variants are saved/published a variant with culture `null` and some segment `s` was not being saved at all. 

There are probably some more things that need to be refined, for example the `getVariantDisplayName` function in Angular might be removed if we introduce a `DisplayName` (or similar) property on the `ContentVariantDisplay` class in C# instead. This saves binding to functions in AngularJS which isn't great for performance.