### PR TITLE
Introduce Image URL Generator abstraction

### DIFF
--- a/src/Umbraco.Core/Composing/Current.cs
+++ b/src/Umbraco.Core/Composing/Current.cs
@@ -5,6 +5,7 @@ using Umbraco.Core.Dictionary;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Mapping;
+using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PackageActions;
 using Umbraco.Core.Packaging;
@@ -208,6 +209,8 @@ namespace Umbraco.Core.Composing
         public static IVariationContextAccessor VariationContextAccessor
             => Factory.GetInstance<IVariationContextAccessor>();
 
+        public static IImageUrlGenerator ImageUrlGenerator
+            => Factory.GetInstance<IImageUrlGenerator>();
         #endregion
     }
 }

--- a/src/Umbraco.Core/Models/IImageUrlGenerator.cs
+++ b/src/Umbraco.Core/Models/IImageUrlGenerator.cs
@@ -1,0 +1,7 @@
+﻿namespace Umbraco.Core.Models
+{
+    public interface IImageUrlGenerator
+    {
+        string GetImageUrl(ImageUrlGenerationOptions options);
+    }
+}

--- a/src/Umbraco.Core/Models/ImageUrlGenerationOptions.cs
+++ b/src/Umbraco.Core/Models/ImageUrlGenerationOptions.cs
@@ -1,8 +1,17 @@
 ﻿namespace Umbraco.Core.Models
 {
+    /// <summary>
+    /// These are options that are passed to the IImageUrlGenerator implementation to determine
+    /// the propery URL that is needed
+    /// </summary>
     public class ImageUrlGenerationOptions
     {
-        public string ImageUrl { get; set; }
+        public ImageUrlGenerationOptions (string imageUrl)
+        {
+            ImageUrl = imageUrl;
+        }
+
+        public string ImageUrl { get; }
         public int? Width { get; set; }
         public int? Height { get; set; }
         public decimal? WidthRatio { get; set; }
@@ -18,18 +27,40 @@
         public bool UpScale { get; set; } = true;
         public string AnimationProcessMode { get; set; }
 
+        /// <summary>
+        /// The focal point position, in whatever units the registered IImageUrlGenerator uses,
+        /// typically a percentage of the total image from 0.0 to 1.0.
+        /// </summary>
         public class FocalPointPosition
         {
-            public decimal Left { get; set; }
-            public decimal Top { get; set; }
+            public FocalPointPosition (decimal top, decimal left)
+            {
+                Left = left;
+                Top = top;
+            }
+
+            public decimal Left { get; }
+            public decimal Top { get; }
         }
 
+        /// <summary>
+        /// The bounds of the crop within the original image, in whatever units the registered
+        /// IImageUrlGenerator uses, typically a percentage between 0 and 100.
+        /// </summary>
         public class CropCoordinates
         {
-            public decimal X1 { get; set; }
-            public decimal Y1 { get; set; }
-            public decimal X2 { get; set; }
-            public decimal Y2 { get; set; }
+            public CropCoordinates (decimal x1, decimal y1, decimal x2, decimal y2)
+            {
+                X1 = x1;
+                Y1 = y1;
+                X2 = x2;
+                Y2 = y2;
+            }
+
+            public decimal X1 { get; }
+            public decimal Y1 { get; }
+            public decimal X2 { get; }
+            public decimal Y2 { get; }
         }
     }
 }

--- a/src/Umbraco.Core/Models/ImageUrlGenerationOptions.cs
+++ b/src/Umbraco.Core/Models/ImageUrlGenerationOptions.cs
@@ -1,0 +1,35 @@
+﻿namespace Umbraco.Core.Models
+{
+    public class ImageUrlGenerationOptions
+    {
+        public string ImageUrl { get; set; }
+        public int? Width { get; set; }
+        public int? Height { get; set; }
+        public decimal? WidthRatio { get; set; }
+        public decimal? HeightRatio { get; set; }
+        public int? Quality { get; set; }
+        public string ImageCropMode { get; set; }
+        public string ImageCropAnchor { get; set; }
+        public bool DefaultCrop { get; set; }
+        public FocalPointPosition FocalPoint { get; set; }
+        public CropCoordinates Crop { get; set; }
+        public string CacheBusterValue { get; set; }
+        public string FurtherOptions { get; set; }
+        public bool UpScale { get; set; } = true;
+        public string AnimationProcessMode { get; set; }
+
+        public class FocalPointPosition
+        {
+            public decimal Left { get; set; }
+            public decimal Top { get; set; }
+        }
+
+        public class CropCoordinates
+        {
+            public decimal X1 { get; set; }
+            public decimal Y1 { get; set; }
+            public decimal X2 { get; set; }
+            public decimal Y2 { get; set; }
+        }
+    }
+}

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -106,13 +106,14 @@ namespace Umbraco.Core.Models
 
             //use the custom avatar
             var avatarUrl = Current.MediaFileSystem.GetUrl(user.Avatar);
+            var urlGenerator = Current.ImageUrlGenerator;
             return new[]
             {
-                avatarUrl  + "?width=30&height=30&mode=crop",
-                avatarUrl  + "?width=60&height=60&mode=crop",
-                avatarUrl  + "?width=90&height=90&mode=crop",
-                avatarUrl  + "?width=150&height=150&mode=crop",
-                avatarUrl  + "?width=300&height=300&mode=crop"
+                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = avatarUrl, ImageCropMode = "crop", Width = 30, Height = 30 }),
+                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = avatarUrl, ImageCropMode = "crop", Width = 60, Height = 60 }),
+                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = avatarUrl, ImageCropMode = "crop", Width = 90, Height = 90 }),
+                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = avatarUrl, ImageCropMode = "crop", Width = 150, Height = 150 }),
+                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = avatarUrl, ImageCropMode = "crop", Width = 300, Height = 300 })
             };
 
         }

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -109,11 +109,11 @@ namespace Umbraco.Core.Models
             var urlGenerator = Current.ImageUrlGenerator;
             return new[]
             {
-                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = avatarUrl, ImageCropMode = "crop", Width = 30, Height = 30 }),
-                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = avatarUrl, ImageCropMode = "crop", Width = 60, Height = 60 }),
-                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = avatarUrl, ImageCropMode = "crop", Width = 90, Height = 90 }),
-                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = avatarUrl, ImageCropMode = "crop", Width = 150, Height = 150 }),
-                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = avatarUrl, ImageCropMode = "crop", Width = 300, Height = 300 })
+                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions(avatarUrl) { ImageCropMode = "crop", Width = 30, Height = 30 }),
+                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions(avatarUrl) { ImageCropMode = "crop", Width = 60, Height = 60 }),
+                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions(avatarUrl) { ImageCropMode = "crop", Width = 90, Height = 90 }),
+                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions(avatarUrl) { ImageCropMode = "crop", Width = 150, Height = 150 }),
+                urlGenerator.GetImageUrl(new ImageUrlGenerationOptions(avatarUrl) { ImageCropMode = "crop", Width = 300, Height = 300 })
             };
 
         }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/ImageCropperValue.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/ImageCropperValue.cs
@@ -67,15 +67,15 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
                 || crop != null && crop.Coordinates == null && HasFocalPoint()
                 || defaultCrop && HasFocalPoint())
             {
-                return new ImageUrlGenerationOptions { ImageUrl = url, FocalPoint = new ImageUrlGenerationOptions.FocalPointPosition { Left = FocalPoint.Left, Top = FocalPoint.Top } };
+                return new ImageUrlGenerationOptions(url) { FocalPoint = new ImageUrlGenerationOptions.FocalPointPosition(FocalPoint.Top, FocalPoint.Left) };
             }
             else if (crop != null && crop.Coordinates != null && preferFocalPoint == false)
             {
-                return new ImageUrlGenerationOptions { ImageUrl = url, Crop = new ImageUrlGenerationOptions.CropCoordinates { X1 = crop.Coordinates.X1, X2 = crop.Coordinates.X2, Y1 = crop.Coordinates.Y1, Y2 = crop.Coordinates.Y2 } };
+                return new ImageUrlGenerationOptions(url) { Crop = new ImageUrlGenerationOptions.CropCoordinates(crop.Coordinates.X1, crop.Coordinates.Y1, crop.Coordinates.X2, crop.Coordinates.Y2) };
             }
             else
             {
-                return new ImageUrlGenerationOptions { ImageUrl = url, DefaultCrop = true };
+                return new ImageUrlGenerationOptions(url) { DefaultCrop = true };
             }
         }
 

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/ImageCropperValue.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/ImageCropperValue.cs
@@ -7,6 +7,8 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Web;
 using Newtonsoft.Json;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Models;
 using Umbraco.Core.Serialization;
 
 namespace Umbraco.Core.PropertyEditors.ValueConverters
@@ -59,38 +61,34 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
                 : Crops.FirstOrDefault(x => x.Alias.InvariantEquals(alias));
         }
 
-        internal void AppendCropBaseUrl(StringBuilder url, ImageCropperCrop crop, bool defaultCrop, bool preferFocalPoint)
+        internal ImageUrlGenerationOptions GetCropBaseOptions(string url, ImageCropperCrop crop, bool defaultCrop, bool preferFocalPoint)
         {
             if (preferFocalPoint && HasFocalPoint()
                 || crop != null && crop.Coordinates == null && HasFocalPoint()
                 || defaultCrop && HasFocalPoint())
             {
-                url.Append("?center=");
-                url.Append(FocalPoint.Top.ToString(CultureInfo.InvariantCulture));
-                url.Append(",");
-                url.Append(FocalPoint.Left.ToString(CultureInfo.InvariantCulture));
-                url.Append("&mode=crop");
+                return new ImageUrlGenerationOptions { ImageUrl = url, FocalPoint = new ImageUrlGenerationOptions.FocalPointPosition { Left = FocalPoint.Left, Top = FocalPoint.Top } };
             }
             else if (crop != null && crop.Coordinates != null && preferFocalPoint == false)
             {
-                url.Append("?crop=");
-                url.Append(crop.Coordinates.X1.ToString(CultureInfo.InvariantCulture)).Append(",");
-                url.Append(crop.Coordinates.Y1.ToString(CultureInfo.InvariantCulture)).Append(",");
-                url.Append(crop.Coordinates.X2.ToString(CultureInfo.InvariantCulture)).Append(",");
-                url.Append(crop.Coordinates.Y2.ToString(CultureInfo.InvariantCulture));
-                url.Append("&cropmode=percentage");
+                return new ImageUrlGenerationOptions { ImageUrl = url, Crop = new ImageUrlGenerationOptions.CropCoordinates { X1 = crop.Coordinates.X1, X2 = crop.Coordinates.X2, Y1 = crop.Coordinates.Y1, Y2 = crop.Coordinates.Y2 } };
             }
             else
             {
-                url.Append("?anchor=center");
-                url.Append("&mode=crop");
+                return new ImageUrlGenerationOptions { ImageUrl = url, DefaultCrop = true };
             }
         }
 
         /// <summary>
         /// Gets the value image url for a specified crop.
         /// </summary>
-        public string GetCropUrl(string alias, bool useCropDimensions = true, bool useFocalPoint = false, string cacheBusterValue = null)
+        [Obsolete("Use the overload that takes an IImageUrlGenerator")]
+        public string GetCropUrl(string alias, bool useCropDimensions = true, bool useFocalPoint = false, string cacheBusterValue = null) => GetCropUrl(alias, Current.ImageUrlGenerator, useCropDimensions, useFocalPoint, cacheBusterValue);
+
+        /// <summary>
+        /// Gets the value image url for a specified crop.
+        /// </summary>
+        public string GetCropUrl(string alias, IImageUrlGenerator imageUrlGenerator, bool useCropDimensions = true, bool useFocalPoint = false, string cacheBusterValue = null)
         {
             var crop = GetCrop(alias);
 
@@ -98,38 +96,37 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
             if (crop == null && !string.IsNullOrWhiteSpace(alias))
                 return null;
 
-            var url = new StringBuilder();
-
-            AppendCropBaseUrl(url, crop, string.IsNullOrWhiteSpace(alias), useFocalPoint);
+            var options = GetCropBaseOptions(string.Empty, crop, string.IsNullOrWhiteSpace(alias), useFocalPoint);
 
             if (crop != null && useCropDimensions)
             {
-                url.Append("&width=").Append(crop.Width);
-                url.Append("&height=").Append(crop.Height);
+                options.Width = crop.Width;
+                options.Height = crop.Height;
             }
 
-            if (cacheBusterValue != null)
-                url.Append("&rnd=").Append(cacheBusterValue);
+            options.CacheBusterValue = cacheBusterValue;
 
-            return url.ToString();
+            return imageUrlGenerator.GetImageUrl(options);
         }
 
         /// <summary>
         /// Gets the value image url for a specific width and height.
         /// </summary>
-        public string GetCropUrl(int width, int height, bool useFocalPoint = false, string cacheBusterValue = null)
+        [Obsolete("Use the overload that takes an IImageUrlGenerator")]
+        public string GetCropUrl(int width, int height, bool useFocalPoint = false, string cacheBusterValue = null) => GetCropUrl(width, height, Current.ImageUrlGenerator, useFocalPoint, cacheBusterValue);
+
+        /// <summary>
+        /// Gets the value image url for a specific width and height.
+        /// </summary>
+        public string GetCropUrl(int width, int height, IImageUrlGenerator imageUrlGenerator, bool useFocalPoint = false, string cacheBusterValue = null)
         {
-            var url = new StringBuilder();
+            var options = GetCropBaseOptions(string.Empty, null, true, useFocalPoint);
 
-            AppendCropBaseUrl(url, null, true, useFocalPoint);
+            options.Width = width;
+            options.Height = height;
+            options.CacheBusterValue = cacheBusterValue;
 
-            url.Append("&width=").Append(width);
-            url.Append("&height=").Append(height);
-
-            if (cacheBusterValue != null)
-                url.Append("&rnd=").Append(cacheBusterValue);
-
-            return url.ToString();
+            return imageUrlGenerator.GetImageUrl(options);
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -132,6 +132,8 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\PropertyDataDto80.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\PropertyTypeDto80.cs" />
     <Compile Include="Migrations\Upgrade\V_8_6_0\AddMainDomLock.cs" />
+    <Compile Include="Models\IImageUrlGenerator.cs" />
+    <Compile Include="Models\ImageUrlGenerationOptions.cs" />
     <Compile Include="Runtime\IMainDomLock.cs" />
     <Compile Include="Runtime\MainDomSemaphoreLock.cs" />
     <Compile Include="Runtime\SqlMainDomLock.cs" />

--- a/src/Umbraco.Tests/Models/ImageProcessorImageUrlGeneratorTest.cs
+++ b/src/Umbraco.Tests/Models/ImageProcessorImageUrlGeneratorTest.cs
@@ -27,36 +27,36 @@ namespace Umbraco.Tests.Models
     public class ImageProcessorImageUrlGeneratorTest
     {
         private const string MediaPath = "/media/1005/img_0671.jpg";
-        private static readonly ImageUrlGenerationOptions.CropCoordinates Crop = new ImageUrlGenerationOptions.CropCoordinates { X1 = 0.58729977382575338m, Y1 = 0.055768992440203169m, X2 = 0m, Y2 = 0.32457553600198386m };
-        private static readonly ImageUrlGenerationOptions.FocalPointPosition Focus1 = new ImageUrlGenerationOptions.FocalPointPosition { Top = 0.80827067669172936m, Left = 0.96m };
-        private static readonly ImageUrlGenerationOptions.FocalPointPosition Focus2 = new ImageUrlGenerationOptions.FocalPointPosition { Top = 0.41m, Left = 0.4275m };
+        private static readonly ImageUrlGenerationOptions.CropCoordinates Crop = new ImageUrlGenerationOptions.CropCoordinates(0.58729977382575338m, 0.055768992440203169m, 0m, 0.32457553600198386m);
+        private static readonly ImageUrlGenerationOptions.FocalPointPosition Focus1 = new ImageUrlGenerationOptions.FocalPointPosition(0.80827067669172936m, 0.96m);
+        private static readonly ImageUrlGenerationOptions.FocalPointPosition Focus2 = new ImageUrlGenerationOptions.FocalPointPosition(0.41m, 0.4275m);
         private static readonly ImageProcessorImageUrlGenerator Generator = new ImageProcessorImageUrlGenerator();
 
         [Test]
         public void GetCropUrl_CropAliasTest()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, Crop = Crop, Width = 100, Height = 100 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { Crop = Crop, Width = 100, Height = 100 });
             Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&height=100", urlString);
         }
 
         [Test]
         public void GetCropUrl_WidthHeightTest()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus1, Width = 200, Height = 300 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = Focus1, Width = 200, Height = 300 });
             Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=200&height=300", urlString);
         }
 
         [Test]
         public void GetCropUrl_FocalPointTest()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus1, Width = 100, Height = 100 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = Focus1, Width = 100, Height = 100 });
             Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=100&height=100", urlString);
         }
 
         [Test]
         public void GetCropUrlFurtherOptionsTest()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus1, Width = 200, Height = 300, FurtherOptions = "&filter=comic&roundedcorners=radius-26|bgcolor-fff" });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = Focus1, Width = 200, Height = 300, FurtherOptions = "&filter=comic&roundedcorners=radius-26|bgcolor-fff" });
             Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=200&height=300&filter=comic&roundedcorners=radius-26|bgcolor-fff", urlString);
         }
 
@@ -76,7 +76,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrlEmptyTest()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions());
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(null));
             Assert.AreEqual("?mode=crop", urlString);
         }
 
@@ -86,7 +86,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetBaseCropUrlFromModelTest()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { Crop = Crop, Width = 100, Height = 100 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(null) { Crop = Crop, Width = 100, Height = 100 });
             Assert.AreEqual("?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&height=100", urlString);
         }
 
@@ -96,7 +96,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_CropAliasHeightRatioModeTest()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, Crop = Crop, Width = 100, HeightRatio = 1 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { Crop = Crop, Width = 100, HeightRatio = 1 });
             Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&heightratio=1&width=100", urlString);
         }
 
@@ -106,7 +106,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_WidthHeightRatioModeTest()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus1, Width = 300, HeightRatio = 0.5m });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = Focus1, Width = 300, HeightRatio = 0.5m });
             Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&heightratio=0.5&width=300", urlString);
         }
 
@@ -116,7 +116,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_HeightWidthRatioModeTest()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus1, Height = 150, WidthRatio = 2 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = Focus1, Height = 150, WidthRatio = 2 });
             Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&widthratio=2&height=150", urlString);
         }
 
@@ -126,11 +126,11 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_SpecifiedCropModeTest()
         {
-            var urlStringMin = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Min", Width = 300, Height = 150 });
-            var urlStringBoxPad = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "BoxPad", Width = 300, Height = 150 });
-            var urlStringPad = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Pad", Width = 300, Height = 150 });
-            var urlStringMax = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Max", Width = 300, Height = 150 });
-            var urlStringStretch = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Stretch", Width = 300, Height = 150 });
+            var urlStringMin = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = "Min", Width = 300, Height = 150 });
+            var urlStringBoxPad = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = "BoxPad", Width = 300, Height = 150 });
+            var urlStringPad = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = "Pad", Width = 300, Height = 150 });
+            var urlStringMax = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = "Max", Width = 300, Height = 150 });
+            var urlStringStretch = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = "Stretch", Width = 300, Height = 150 });
 
             Assert.AreEqual(MediaPath + "?mode=min&width=300&height=150", urlStringMin);
             Assert.AreEqual(MediaPath + "?mode=boxpad&width=300&height=150", urlStringBoxPad);
@@ -145,7 +145,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_UploadTypeTest()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Crop", ImageCropAnchor = "Center", Width = 100, Height = 270 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = "Crop", ImageCropAnchor = "Center", Width = 100, Height = 270 });
             Assert.AreEqual(MediaPath + "?mode=crop&anchor=center&width=100&height=270", urlString);
         }
 
@@ -155,7 +155,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_PreferFocalPointCenter()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, DefaultCrop = true, Width = 300, Height = 150 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { DefaultCrop = true, Width = 300, Height = 150 });
             Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&width=300&height=150", urlString);
         }
 
@@ -165,7 +165,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_PreDefinedCropNoCoordinatesWithWidth()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, DefaultCrop = true, Width = 200, HeightRatio = 0.5962962962962962962962962963m });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { DefaultCrop = true, Width = 200, HeightRatio = 0.5962962962962962962962962963m });
             Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&heightratio=0.5962962962962962962962962963&width=200", urlString);
         }
 
@@ -175,7 +175,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_PreDefinedCropNoCoordinatesWithWidthAndFocalPoint()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus2, Width = 200, HeightRatio = 0.5962962962962962962962962963m });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = Focus2, Width = 200, HeightRatio = 0.5962962962962962962962962963m });
             Assert.AreEqual(MediaPath + "?center=0.41,0.4275&mode=crop&heightratio=0.5962962962962962962962962963&width=200", urlString);
         }
 
@@ -185,7 +185,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_PreDefinedCropNoCoordinatesWithWidthAndFocalPointIgnore()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus2, Width = 270, Height = 161 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = Focus2, Width = 270, Height = 161 });
             Assert.AreEqual(MediaPath + "?center=0.41,0.4275&mode=crop&width=270&height=161", urlString);
         }
 
@@ -195,7 +195,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_PreDefinedCropNoCoordinatesWithHeight()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, DefaultCrop = true, Height = 200, WidthRatio = 1.6770186335403726708074534161m });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { DefaultCrop = true, Height = 200, WidthRatio = 1.6770186335403726708074534161m });
             Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&widthratio=1.6770186335403726708074534161&height=200", urlString);
         }
 
@@ -205,7 +205,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_WidthOnlyParameter()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, DefaultCrop = true, Width = 200 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { DefaultCrop = true, Width = 200 });
             Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&width=200", urlString);
         }
 
@@ -215,7 +215,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_HeightOnlyParameter()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, DefaultCrop = true, Height = 200 });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { DefaultCrop = true, Height = 200 });
             Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&height=200", urlString);
         }
 
@@ -225,7 +225,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void GetCropUrl_BackgroundColorParameter()
         {
-            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Pad", Width = 400, Height = 400, FurtherOptions = "&bgcolor=fff" });
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = "Pad", Width = 400, Height = 400, FurtherOptions = "&bgcolor=fff" });
             Assert.AreEqual(MediaPath + "?mode=pad&width=400&height=400&bgcolor=fff", urlString);
         }
     }

--- a/src/Umbraco.Tests/Models/ImageProcessorImageUrlGeneratorTest.cs
+++ b/src/Umbraco.Tests/Models/ImageProcessorImageUrlGeneratorTest.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Globalization;
+using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Configuration.UmbracoSettings;
+using Umbraco.Core.IO;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.PropertyEditors.ValueConverters;
+using Umbraco.Core.Services;
+using Umbraco.Tests.Components;
+using Umbraco.Tests.TestHelpers;
+using Umbraco.Web.Models;
+using Umbraco.Web;
+using Umbraco.Web.PropertyEditors;
+using System.Text;
+
+namespace Umbraco.Tests.Models
+{
+    [TestFixture]
+    public class ImageProcessorImageUrlGeneratorTest
+    {
+        private const string MediaPath = "/media/1005/img_0671.jpg";
+        private static readonly ImageUrlGenerationOptions.CropCoordinates Crop = new ImageUrlGenerationOptions.CropCoordinates { X1 = 0.58729977382575338m, Y1 = 0.055768992440203169m, X2 = 0m, Y2 = 0.32457553600198386m };
+        private static readonly ImageUrlGenerationOptions.FocalPointPosition Focus1 = new ImageUrlGenerationOptions.FocalPointPosition { Top = 0.80827067669172936m, Left = 0.96m };
+        private static readonly ImageUrlGenerationOptions.FocalPointPosition Focus2 = new ImageUrlGenerationOptions.FocalPointPosition { Top = 0.41m, Left = 0.4275m };
+        private static readonly ImageProcessorImageUrlGenerator Generator = new ImageProcessorImageUrlGenerator();
+
+        [Test]
+        public void GetCropUrl_CropAliasTest()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, Crop = Crop, Width = 100, Height = 100 });
+            Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&height=100", urlString);
+        }
+
+        [Test]
+        public void GetCropUrl_WidthHeightTest()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus1, Width = 200, Height = 300 });
+            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=200&height=300", urlString);
+        }
+
+        [Test]
+        public void GetCropUrl_FocalPointTest()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus1, Width = 100, Height = 100 });
+            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=100&height=100", urlString);
+        }
+
+        [Test]
+        public void GetCropUrlFurtherOptionsTest()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus1, Width = 200, Height = 300, FurtherOptions = "&filter=comic&roundedcorners=radius-26|bgcolor-fff" });
+            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=200&height=300&filter=comic&roundedcorners=radius-26|bgcolor-fff", urlString);
+        }
+
+        /// <summary>
+        /// Test that if a crop alias has been specified that doesn't exist the method returns null
+        /// </summary>
+        [Test]
+        public void GetCropUrlNullTest()
+        {
+            var urlString = Generator.GetImageUrl(null);
+            Assert.AreEqual(null, urlString);
+        }
+
+        /// <summary>
+        /// Test that if a crop alias has been specified that doesn't exist the method returns null
+        /// </summary>
+        [Test]
+        public void GetCropUrlEmptyTest()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions());
+            Assert.AreEqual("?mode=crop", urlString);
+        }
+
+        /// <summary>
+        /// Test the GetCropUrl method on the ImageCropDataSet Model
+        /// </summary>
+        [Test]
+        public void GetBaseCropUrlFromModelTest()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { Crop = Crop, Width = 100, Height = 100 });
+            Assert.AreEqual("?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&height=100", urlString);
+        }
+
+        /// <summary>
+        /// Test the height ratio mode with predefined crop dimensions
+        /// </summary>
+        [Test]
+        public void GetCropUrl_CropAliasHeightRatioModeTest()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, Crop = Crop, Width = 100, HeightRatio = 1 });
+            Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&heightratio=1&width=100", urlString);
+        }
+
+        /// <summary>
+        /// Test the height ratio mode with manual width/height dimensions
+        /// </summary>
+        [Test]
+        public void GetCropUrl_WidthHeightRatioModeTest()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus1, Width = 300, HeightRatio = 0.5m });
+            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&heightratio=0.5&width=300", urlString);
+        }
+
+        /// <summary>
+        /// Test the height ratio mode with width/height dimensions
+        /// </summary>
+        [Test]
+        public void GetCropUrl_HeightWidthRatioModeTest()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus1, Height = 150, WidthRatio = 2 });
+            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&widthratio=2&height=150", urlString);
+        }
+
+        /// <summary>
+        /// Test that if Crop mode is specified as anything other than Crop the image doesn't use the crop
+        /// </summary>
+        [Test]
+        public void GetCropUrl_SpecifiedCropModeTest()
+        {
+            var urlStringMin = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Min", Width = 300, Height = 150 });
+            var urlStringBoxPad = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "BoxPad", Width = 300, Height = 150 });
+            var urlStringPad = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Pad", Width = 300, Height = 150 });
+            var urlStringMax = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Max", Width = 300, Height = 150 });
+            var urlStringStretch = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Stretch", Width = 300, Height = 150 });
+
+            Assert.AreEqual(MediaPath + "?mode=min&width=300&height=150", urlStringMin);
+            Assert.AreEqual(MediaPath + "?mode=boxpad&width=300&height=150", urlStringBoxPad);
+            Assert.AreEqual(MediaPath + "?mode=pad&width=300&height=150", urlStringPad);
+            Assert.AreEqual(MediaPath + "?mode=max&width=300&height=150", urlStringMax);
+            Assert.AreEqual(MediaPath + "?mode=stretch&width=300&height=150", urlStringStretch);
+        }
+
+        /// <summary>
+        /// Test for upload property type
+        /// </summary>
+        [Test]
+        public void GetCropUrl_UploadTypeTest()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Crop", ImageCropAnchor = "Center", Width = 100, Height = 270 });
+            Assert.AreEqual(MediaPath + "?mode=crop&anchor=center&width=100&height=270", urlString);
+        }
+
+        /// <summary>
+        /// Test for preferFocalPoint when focal point is centered
+        /// </summary>
+        [Test]
+        public void GetCropUrl_PreferFocalPointCenter()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, DefaultCrop = true, Width = 300, Height = 150 });
+            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&width=300&height=150", urlString);
+        }
+
+        /// <summary>
+        /// Test to check if height ratio is returned for a predefined crop without coordinates and focal point in centre when a width parameter is passed
+        /// </summary>
+        [Test]
+        public void GetCropUrl_PreDefinedCropNoCoordinatesWithWidth()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, DefaultCrop = true, Width = 200, HeightRatio = 0.5962962962962962962962962963m });
+            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&heightratio=0.5962962962962962962962962963&width=200", urlString);
+        }
+
+        /// <summary>
+        /// Test to check if height ratio is returned for a predefined crop without coordinates and focal point is custom when a width parameter is passed
+        /// </summary>
+        [Test]
+        public void GetCropUrl_PreDefinedCropNoCoordinatesWithWidthAndFocalPoint()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus2, Width = 200, HeightRatio = 0.5962962962962962962962962963m });
+            Assert.AreEqual(MediaPath + "?center=0.41,0.4275&mode=crop&heightratio=0.5962962962962962962962962963&width=200", urlString);
+        }
+
+        /// <summary>
+        /// Test to check if crop ratio is ignored if useCropDimensions is true
+        /// </summary>
+        [Test]
+        public void GetCropUrl_PreDefinedCropNoCoordinatesWithWidthAndFocalPointIgnore()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, FocalPoint = Focus2, Width = 270, Height = 161 });
+            Assert.AreEqual(MediaPath + "?center=0.41,0.4275&mode=crop&width=270&height=161", urlString);
+        }
+
+        /// <summary>
+        /// Test to check if width ratio is returned for a predefined crop without coordinates and focal point in centre when a height parameter is passed
+        /// </summary>
+        [Test]
+        public void GetCropUrl_PreDefinedCropNoCoordinatesWithHeight()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, DefaultCrop = true, Height = 200, WidthRatio = 1.6770186335403726708074534161m });
+            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&widthratio=1.6770186335403726708074534161&height=200", urlString);
+        }
+
+        /// <summary>
+        /// Test to check result when only a width parameter is passed, effectivly a resize only
+        /// </summary>
+        [Test]
+        public void GetCropUrl_WidthOnlyParameter()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, DefaultCrop = true, Width = 200 });
+            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&width=200", urlString);
+        }
+
+        /// <summary>
+        /// Test to check result when only a height parameter is passed, effectivly a resize only
+        /// </summary>
+        [Test]
+        public void GetCropUrl_HeightOnlyParameter()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, DefaultCrop = true, Height = 200 });
+            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&height=200", urlString);
+        }
+
+        /// <summary>
+        /// Test to check result when using a background color with padding
+        /// </summary>
+        [Test]
+        public void GetCropUrl_BackgroundColorParameter()
+        {
+            var urlString = Generator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = MediaPath, ImageCropMode = "Pad", Width = 400, Height = 400, FurtherOptions = "&bgcolor=fff" });
+            Assert.AreEqual(MediaPath + "?mode=pad&width=400&height=400&bgcolor=fff", urlString);
+        }
+    }
+}

--- a/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
+++ b/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
@@ -5,9 +5,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 using Umbraco.Core;
-using Umbraco.Core.Cache;
 using Umbraco.Core.Composing;
-using Umbraco.Core.Configuration;
 using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
@@ -112,7 +110,7 @@ namespace Umbraco.Tests.PropertyEditors
         public void GetCropUrl_CropAliasTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, cropAlias: "Thumb", useCropDimensions: true);
-            Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&height=100", urlString);
+            Assert.AreEqual(MediaPath + "?c=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&w=100&h=100", urlString);
         }
 
         /// <summary>
@@ -122,28 +120,28 @@ namespace Umbraco.Tests.PropertyEditors
         public void GetCropUrl_CropAliasIgnoreWidthHeightTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, cropAlias: "Thumb", useCropDimensions: true, width: 50, height: 50);
-            Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&height=100", urlString);
+            Assert.AreEqual(MediaPath + "?c=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&w=100&h=100", urlString);
         }
 
         [Test]
         public void GetCropUrl_WidthHeightTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 200, height: 300);
-            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=200&height=300", urlString);
+            Assert.AreEqual(MediaPath + "?f=0.80827067669172936x0.96&w=200&h=300", urlString);
         }
 
         [Test]
         public void GetCropUrl_FocalPointTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, cropAlias: "thumb", preferFocalPoint: true, useCropDimensions: true);
-            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=100&height=100", urlString);
+            Assert.AreEqual(MediaPath + "?f=0.80827067669172936x0.96&w=100&h=100", urlString);
         }
 
         [Test]
         public void GetCropUrlFurtherOptionsTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 200, height: 300, furtherOptions: "&filter=comic&roundedcorners=radius-26|bgcolor-fff");
-            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=200&height=300&filter=comic&roundedcorners=radius-26|bgcolor-fff", urlString);
+            Assert.AreEqual(MediaPath + "?f=0.80827067669172936x0.96&w=200&h=300&filter=comic&roundedcorners=radius-26|bgcolor-fff", urlString);
         }
 
         /// <summary>
@@ -164,7 +162,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             var cropDataSet = CropperJson1.DeserializeImageCropperValue();
             var urlString = cropDataSet.GetCropUrl("thumb", new TestImageUrlGenerator());
-            Assert.AreEqual("?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&height=100", urlString);
+            Assert.AreEqual("?c=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&w=100&h=100", urlString);
         }
 
         /// <summary>
@@ -174,7 +172,7 @@ namespace Umbraco.Tests.PropertyEditors
         public void GetCropUrl_CropAliasHeightRatioModeTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, cropAlias: "Thumb", useCropDimensions: true, ratioMode:ImageCropRatioMode.Height);
-            Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&heightratio=1&width=100", urlString);
+            Assert.AreEqual(MediaPath + "?c=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&hr=1&w=100", urlString);
         }
 
         /// <summary>
@@ -184,7 +182,7 @@ namespace Umbraco.Tests.PropertyEditors
         public void GetCropUrl_WidthHeightRatioModeTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, ratioMode:ImageCropRatioMode.Height);
-            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&heightratio=0.5&width=300", urlString);
+            Assert.AreEqual(MediaPath + "?f=0.80827067669172936x0.96&hr=0.5&w=300", urlString);
         }
 
         /// <summary>
@@ -194,7 +192,7 @@ namespace Umbraco.Tests.PropertyEditors
         public void GetCropUrl_HeightWidthRatioModeTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, ratioMode: ImageCropRatioMode.Width);
-            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&widthratio=2&height=150", urlString);
+            Assert.AreEqual(MediaPath + "?f=0.80827067669172936x0.96&wr=2&h=150", urlString);
         }
 
         /// <summary>
@@ -209,11 +207,11 @@ namespace Umbraco.Tests.PropertyEditors
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode:ImageCropMode.Max);
             var urlStringStretch = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode: ImageCropMode.Stretch);
 
-            Assert.AreEqual(MediaPath + "?mode=min&width=300&height=150", urlStringMin);
-            Assert.AreEqual(MediaPath + "?mode=boxpad&width=300&height=150", urlStringBoxPad);
-            Assert.AreEqual(MediaPath + "?mode=pad&width=300&height=150", urlStringPad);
-            Assert.AreEqual(MediaPath + "?mode=max&width=300&height=150", urlString);
-            Assert.AreEqual(MediaPath + "?mode=stretch&width=300&height=150", urlStringStretch);
+            Assert.AreEqual(MediaPath + "?m=min&w=300&h=150", urlStringMin);
+            Assert.AreEqual(MediaPath + "?m=boxpad&w=300&h=150", urlStringBoxPad);
+            Assert.AreEqual(MediaPath + "?m=pad&w=300&h=150", urlStringPad);
+            Assert.AreEqual(MediaPath + "?m=max&w=300&h=150", urlString);
+            Assert.AreEqual(MediaPath + "?m=stretch&w=300&h=150", urlStringStretch);
         }
 
         /// <summary>
@@ -223,7 +221,7 @@ namespace Umbraco.Tests.PropertyEditors
         public void GetCropUrl_UploadTypeTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), width: 100, height: 270, imageCropMode: ImageCropMode.Crop, imageCropAnchor: ImageCropAnchor.Center);
-            Assert.AreEqual(MediaPath + "?mode=crop&anchor=center&width=100&height=270", urlString);
+            Assert.AreEqual(MediaPath + "?m=crop&a=center&w=100&h=270", urlString);
         }
 
         /// <summary>
@@ -235,7 +233,7 @@ namespace Umbraco.Tests.PropertyEditors
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\":\"thumb\",\"width\": 100,\"height\": 100,\"coordinates\": {\"x1\": 0.58729977382575338,\"y1\": 0.055768992440203169,\"x2\": 0,\"y2\": 0.32457553600198386}}]}";
 
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, width: 300, height: 150, preferFocalPoint:true);
-            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&width=300&height=150", urlString);
+            Assert.AreEqual(MediaPath + "?m=defaultcrop&w=300&h=150", urlString);
         }
 
         /// <summary>
@@ -247,7 +245,7 @@ namespace Umbraco.Tests.PropertyEditors
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, cropAlias: "home", width: 200);
-            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&heightratio=0.5962962962962962962962962963&width=200", urlString);
+            Assert.AreEqual(MediaPath + "?m=defaultcrop&hr=0.5962962962962962962962962963&w=200", urlString);
         }
 
         /// <summary>
@@ -259,7 +257,7 @@ namespace Umbraco.Tests.PropertyEditors
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.4275,\"top\": 0.41},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, cropAlias: "home", width: 200);
-            Assert.AreEqual(MediaPath + "?center=0.41,0.4275&mode=crop&heightratio=0.5962962962962962962962962963&width=200", urlString);
+            Assert.AreEqual(MediaPath + "?f=0.41x0.4275&hr=0.5962962962962962962962962963&w=200", urlString);
         }
 
         /// <summary>
@@ -271,7 +269,7 @@ namespace Umbraco.Tests.PropertyEditors
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.4275,\"top\": 0.41},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, cropAlias: "home", width: 200, useCropDimensions: true);
-            Assert.AreEqual(MediaPath + "?center=0.41,0.4275&mode=crop&width=270&height=161", urlString);
+            Assert.AreEqual(MediaPath + "?f=0.41x0.4275&w=270&h=161", urlString);
         }
 
         /// <summary>
@@ -283,7 +281,7 @@ namespace Umbraco.Tests.PropertyEditors
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, cropAlias: "home", height: 200);
-            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&widthratio=1.6770186335403726708074534161&height=200", urlString);
+            Assert.AreEqual(MediaPath + "?m=defaultcrop&wr=1.6770186335403726708074534161&h=200", urlString);
         }
 
         /// <summary>
@@ -295,7 +293,7 @@ namespace Umbraco.Tests.PropertyEditors
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, width: 200);
-            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&width=200", urlString);
+            Assert.AreEqual(MediaPath + "?m=defaultcrop&w=200", urlString);
         }
 
         /// <summary>
@@ -307,7 +305,7 @@ namespace Umbraco.Tests.PropertyEditors
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, height: 200);
-            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&height=200", urlString);
+            Assert.AreEqual(MediaPath + "?m=defaultcrop&h=200", urlString);
         }
 
         /// <summary>
@@ -319,10 +317,10 @@ namespace Umbraco.Tests.PropertyEditors
             var cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"" + MediaPath + "\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), 400, 400, cropperJson, imageCropMode: ImageCropMode.Pad, furtherOptions: "&bgcolor=fff");
-            Assert.AreEqual(MediaPath + "?mode=pad&width=400&height=400&bgcolor=fff", urlString);
+            Assert.AreEqual(MediaPath + "?m=pad&w=400&h=400&bgcolor=fff", urlString);
         }
 
-        private class TestImageUrlGenerator : IImageUrlGenerator
+        internal class TestImageUrlGenerator : IImageUrlGenerator
         {
             public string GetImageUrl(ImageUrlGenerationOptions options)
             {
@@ -330,42 +328,40 @@ namespace Umbraco.Tests.PropertyEditors
 
                 if (options.FocalPoint != null)
                 {
-                    imageProcessorUrl.Append("?center=");
+                    imageProcessorUrl.Append("?f=");
                     imageProcessorUrl.Append(options.FocalPoint.Top.ToString(CultureInfo.InvariantCulture));
-                    imageProcessorUrl.Append(",");
+                    imageProcessorUrl.Append("x");
                     imageProcessorUrl.Append(options.FocalPoint.Left.ToString(CultureInfo.InvariantCulture));
-                    imageProcessorUrl.Append("&mode=crop");
                 }
                 else if (options.Crop != null)
                 {
-                    imageProcessorUrl.Append("?crop=");
+                    imageProcessorUrl.Append("?c=");
                     imageProcessorUrl.Append(options.Crop.X1.ToString(CultureInfo.InvariantCulture)).Append(",");
                     imageProcessorUrl.Append(options.Crop.Y1.ToString(CultureInfo.InvariantCulture)).Append(",");
                     imageProcessorUrl.Append(options.Crop.X2.ToString(CultureInfo.InvariantCulture)).Append(",");
                     imageProcessorUrl.Append(options.Crop.Y2.ToString(CultureInfo.InvariantCulture));
-                    imageProcessorUrl.Append("&cropmode=percentage");
                 }
                 else if (options.DefaultCrop)
                 {
-                    imageProcessorUrl.Append("?anchor=center&mode=crop");
+                    imageProcessorUrl.Append("?m=defaultcrop");
                 }
                 else
                 {
-                    imageProcessorUrl.Append("?mode=" + options.ImageCropMode.ToString().ToLower());
-                    if (options.ImageCropAnchor != null)imageProcessorUrl.Append("&anchor=" + options.ImageCropAnchor.ToString().ToLower());
+                    imageProcessorUrl.Append("?m=" + options.ImageCropMode.ToString().ToLower());
+                    if (options.ImageCropAnchor != null)imageProcessorUrl.Append("&a=" + options.ImageCropAnchor.ToString().ToLower());
                 }
 
-                var hasFormat = options.FurtherOptions != null && options.FurtherOptions.InvariantContains("&format=");
-                if (options.Quality != null && hasFormat == false) imageProcessorUrl.Append("&quality=" + options.Quality);
-                if (options.HeightRatio != null) imageProcessorUrl.Append("&heightratio=" + options.HeightRatio.Value.ToString(CultureInfo.InvariantCulture));
-                if (options.WidthRatio != null) imageProcessorUrl.Append("&widthratio=" + options.WidthRatio.Value.ToString(CultureInfo.InvariantCulture));
-                if (options.Width != null) imageProcessorUrl.Append("&width=" + options.Width);
-                if (options.Height != null) imageProcessorUrl.Append("&height=" + options.Height);
-                if (options.UpScale == false) imageProcessorUrl.Append("&upscale=false");
-                if (options.AnimationProcessMode != null) imageProcessorUrl.Append("&animationprocessmode=" + options.AnimationProcessMode);
+                var hasFormat = options.FurtherOptions != null && options.FurtherOptions.InvariantContains("&f=");
+                if (options.Quality != null && hasFormat == false) imageProcessorUrl.Append("&q=" + options.Quality);
+                if (options.HeightRatio != null) imageProcessorUrl.Append("&hr=" + options.HeightRatio.Value.ToString(CultureInfo.InvariantCulture));
+                if (options.WidthRatio != null) imageProcessorUrl.Append("&wr=" + options.WidthRatio.Value.ToString(CultureInfo.InvariantCulture));
+                if (options.Width != null) imageProcessorUrl.Append("&w=" + options.Width);
+                if (options.Height != null) imageProcessorUrl.Append("&h=" + options.Height);
+                if (options.UpScale == false) imageProcessorUrl.Append("&u=no");
+                if (options.AnimationProcessMode != null) imageProcessorUrl.Append("&apm=" + options.AnimationProcessMode);
                 if (options.FurtherOptions != null) imageProcessorUrl.Append(options.FurtherOptions);
-                if (options.Quality != null && hasFormat) imageProcessorUrl.Append("&quality=" + options.Quality);
-                if (options.CacheBusterValue != null) imageProcessorUrl.Append("&rnd=").Append(options.CacheBusterValue);
+                if (options.Quality != null && hasFormat) imageProcessorUrl.Append("&q=" + options.Quality);
+                if (options.CacheBusterValue != null) imageProcessorUrl.Append("&r=").Append(options.CacheBusterValue);
 
                 return imageProcessorUrl.ToString();
             }

--- a/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
+++ b/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
@@ -174,7 +174,7 @@ namespace Umbraco.Tests.PropertyEditors
         public void GetCropUrl_CropAliasHeightRatioModeTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, cropAlias: "Thumb", useCropDimensions: true, ratioMode:ImageCropRatioMode.Height);
-            Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&heightratio=1", urlString);
+            Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&heightratio=1&width=100", urlString);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Umbraco.Tests.PropertyEditors
         public void GetCropUrl_WidthHeightRatioModeTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, ratioMode:ImageCropRatioMode.Height);
-            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=300&heightratio=0.5", urlString);
+            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&heightratio=0.5&width=300", urlString);
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace Umbraco.Tests.PropertyEditors
         public void GetCropUrl_HeightWidthRatioModeTest()
         {
             var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, ratioMode: ImageCropRatioMode.Width);
-            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&height=150&widthratio=2", urlString);
+            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&widthratio=2&height=150", urlString);
         }
 
         /// <summary>

--- a/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
+++ b/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
@@ -21,6 +21,7 @@ using Umbraco.Tests.TestHelpers;
 using Umbraco.Web.Models;
 using Umbraco.Web;
 using Umbraco.Web.PropertyEditors;
+using System.Text;
 
 namespace Umbraco.Tests.PropertyEditors
 {
@@ -110,7 +111,7 @@ namespace Umbraco.Tests.PropertyEditors
         [Test]
         public void GetCropUrl_CropAliasTest()
         {
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, cropAlias: "Thumb", useCropDimensions: true);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, cropAlias: "Thumb", useCropDimensions: true);
             Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&height=100", urlString);
         }
 
@@ -120,28 +121,28 @@ namespace Umbraco.Tests.PropertyEditors
         [Test]
         public void GetCropUrl_CropAliasIgnoreWidthHeightTest()
         {
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, cropAlias: "Thumb", useCropDimensions: true, width: 50, height: 50);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, cropAlias: "Thumb", useCropDimensions: true, width: 50, height: 50);
             Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&height=100", urlString);
         }
 
         [Test]
         public void GetCropUrl_WidthHeightTest()
         {
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, width: 200, height: 300);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 200, height: 300);
             Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=200&height=300", urlString);
         }
 
         [Test]
         public void GetCropUrl_FocalPointTest()
         {
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, cropAlias: "thumb", preferFocalPoint: true, useCropDimensions: true);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, cropAlias: "thumb", preferFocalPoint: true, useCropDimensions: true);
             Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=100&height=100", urlString);
         }
 
         [Test]
         public void GetCropUrlFurtherOptionsTest()
         {
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, width: 200, height: 300, furtherOptions: "&filter=comic&roundedcorners=radius-26|bgcolor-fff");
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 200, height: 300, furtherOptions: "&filter=comic&roundedcorners=radius-26|bgcolor-fff");
             Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=200&height=300&filter=comic&roundedcorners=radius-26|bgcolor-fff", urlString);
         }
 
@@ -151,7 +152,7 @@ namespace Umbraco.Tests.PropertyEditors
         [Test]
         public void GetCropUrlNullTest()
         {
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, cropAlias: "Banner", useCropDimensions: true);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, cropAlias: "Banner", useCropDimensions: true);
             Assert.AreEqual(null, urlString);
         }
 
@@ -162,7 +163,7 @@ namespace Umbraco.Tests.PropertyEditors
         public void GetBaseCropUrlFromModelTest()
         {
             var cropDataSet = CropperJson1.DeserializeImageCropperValue();
-            var urlString = cropDataSet.GetCropUrl("thumb");
+            var urlString = cropDataSet.GetCropUrl("thumb", new TestImageUrlGenerator());
             Assert.AreEqual("?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&height=100", urlString);
         }
 
@@ -172,7 +173,7 @@ namespace Umbraco.Tests.PropertyEditors
         [Test]
         public void GetCropUrl_CropAliasHeightRatioModeTest()
         {
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, cropAlias: "Thumb", useCropDimensions: true, ratioMode:ImageCropRatioMode.Height);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, cropAlias: "Thumb", useCropDimensions: true, ratioMode:ImageCropRatioMode.Height);
             Assert.AreEqual(MediaPath + "?crop=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&cropmode=percentage&width=100&heightratio=1", urlString);
         }
 
@@ -182,7 +183,7 @@ namespace Umbraco.Tests.PropertyEditors
         [Test]
         public void GetCropUrl_WidthHeightRatioModeTest()
         {
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, width: 300, height: 150, ratioMode:ImageCropRatioMode.Height);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, ratioMode:ImageCropRatioMode.Height);
             Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=300&heightratio=0.5", urlString);
         }
 
@@ -192,7 +193,7 @@ namespace Umbraco.Tests.PropertyEditors
         [Test]
         public void GetCropUrl_HeightWidthRatioModeTest()
         {
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, width: 300, height: 150, ratioMode: ImageCropRatioMode.Width);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, ratioMode: ImageCropRatioMode.Width);
             Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&height=150&widthratio=2", urlString);
         }
 
@@ -202,11 +203,11 @@ namespace Umbraco.Tests.PropertyEditors
         [Test]
         public void GetCropUrl_SpecifiedCropModeTest()
         {
-            var urlStringMin = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode: ImageCropMode.Min);
-            var urlStringBoxPad = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode: ImageCropMode.BoxPad);
-            var urlStringPad = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode: ImageCropMode.Pad);
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode:ImageCropMode.Max);
-            var urlStringStretch = MediaPath.GetCropUrl(imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode: ImageCropMode.Stretch);
+            var urlStringMin = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode: ImageCropMode.Min);
+            var urlStringBoxPad = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode: ImageCropMode.BoxPad);
+            var urlStringPad = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode: ImageCropMode.Pad);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode:ImageCropMode.Max);
+            var urlStringStretch = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: CropperJson1, width: 300, height: 150, imageCropMode: ImageCropMode.Stretch);
 
             Assert.AreEqual(MediaPath + "?mode=min&width=300&height=150", urlStringMin);
             Assert.AreEqual(MediaPath + "?mode=boxpad&width=300&height=150", urlStringBoxPad);
@@ -221,7 +222,7 @@ namespace Umbraco.Tests.PropertyEditors
         [Test]
         public void GetCropUrl_UploadTypeTest()
         {
-            var urlString = MediaPath.GetCropUrl(width: 100, height: 270, imageCropMode: ImageCropMode.Crop, imageCropAnchor: ImageCropAnchor.Center);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), width: 100, height: 270, imageCropMode: ImageCropMode.Crop, imageCropAnchor: ImageCropAnchor.Center);
             Assert.AreEqual(MediaPath + "?mode=crop&anchor=center&width=100&height=270", urlString);
         }
 
@@ -233,7 +234,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\":\"thumb\",\"width\": 100,\"height\": 100,\"coordinates\": {\"x1\": 0.58729977382575338,\"y1\": 0.055768992440203169,\"x2\": 0,\"y2\": 0.32457553600198386}}]}";
 
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: cropperJson, width: 300, height: 150, preferFocalPoint:true);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, width: 300, height: 150, preferFocalPoint:true);
             Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&width=300&height=150", urlString);
         }
 
@@ -245,7 +246,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: cropperJson, cropAlias: "home", width: 200);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, cropAlias: "home", width: 200);
             Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&heightratio=0.5962962962962962962962962963&width=200", urlString);
         }
 
@@ -257,7 +258,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.4275,\"top\": 0.41},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: cropperJson, cropAlias: "home", width: 200);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, cropAlias: "home", width: 200);
             Assert.AreEqual(MediaPath + "?center=0.41,0.4275&mode=crop&heightratio=0.5962962962962962962962962963&width=200", urlString);
         }
 
@@ -269,7 +270,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.4275,\"top\": 0.41},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: cropperJson, cropAlias: "home", width: 200, useCropDimensions: true);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, cropAlias: "home", width: 200, useCropDimensions: true);
             Assert.AreEqual(MediaPath + "?center=0.41,0.4275&mode=crop&width=270&height=161", urlString);
         }
 
@@ -281,7 +282,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: cropperJson, cropAlias: "home", height: 200);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, cropAlias: "home", height: 200);
             Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&widthratio=1.6770186335403726708074534161&height=200", urlString);
         }
 
@@ -293,7 +294,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: cropperJson, width: 200);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, width: 200);
             Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&width=200", urlString);
         }
 
@@ -305,7 +306,7 @@ namespace Umbraco.Tests.PropertyEditors
         {
             const string cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
-            var urlString = MediaPath.GetCropUrl(imageCropperValue: cropperJson, height: 200);
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), imageCropperValue: cropperJson, height: 200);
             Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&height=200", urlString);
         }
 
@@ -317,8 +318,57 @@ namespace Umbraco.Tests.PropertyEditors
         {
             var cropperJson = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"" + MediaPath + "\",\"crops\": [{\"alias\": \"home\",\"width\": 270,\"height\": 161}]}";
 
-            var urlString = MediaPath.GetCropUrl(400, 400, cropperJson, imageCropMode: ImageCropMode.Pad, furtherOptions: "&bgcolor=fff");
+            var urlString = MediaPath.GetCropUrl(new TestImageUrlGenerator(), 400, 400, cropperJson, imageCropMode: ImageCropMode.Pad, furtherOptions: "&bgcolor=fff");
             Assert.AreEqual(MediaPath + "?mode=pad&width=400&height=400&bgcolor=fff", urlString);
+        }
+
+        private class TestImageUrlGenerator : IImageUrlGenerator
+        {
+            public string GetImageUrl(ImageUrlGenerationOptions options)
+            {
+                var imageProcessorUrl = new StringBuilder(options.ImageUrl ?? string.Empty);
+
+                if (options.FocalPoint != null)
+                {
+                    imageProcessorUrl.Append("?center=");
+                    imageProcessorUrl.Append(options.FocalPoint.Top.ToString(CultureInfo.InvariantCulture));
+                    imageProcessorUrl.Append(",");
+                    imageProcessorUrl.Append(options.FocalPoint.Left.ToString(CultureInfo.InvariantCulture));
+                    imageProcessorUrl.Append("&mode=crop");
+                }
+                else if (options.Crop != null)
+                {
+                    imageProcessorUrl.Append("?crop=");
+                    imageProcessorUrl.Append(options.Crop.X1.ToString(CultureInfo.InvariantCulture)).Append(",");
+                    imageProcessorUrl.Append(options.Crop.Y1.ToString(CultureInfo.InvariantCulture)).Append(",");
+                    imageProcessorUrl.Append(options.Crop.X2.ToString(CultureInfo.InvariantCulture)).Append(",");
+                    imageProcessorUrl.Append(options.Crop.Y2.ToString(CultureInfo.InvariantCulture));
+                    imageProcessorUrl.Append("&cropmode=percentage");
+                }
+                else if (options.DefaultCrop)
+                {
+                    imageProcessorUrl.Append("?anchor=center&mode=crop");
+                }
+                else
+                {
+                    imageProcessorUrl.Append("?mode=" + options.ImageCropMode.ToString().ToLower());
+                    if (options.ImageCropAnchor != null)imageProcessorUrl.Append("&anchor=" + options.ImageCropAnchor.ToString().ToLower());
+                }
+
+                var hasFormat = options.FurtherOptions != null && options.FurtherOptions.InvariantContains("&format=");
+                if (options.Quality != null && hasFormat == false) imageProcessorUrl.Append("&quality=" + options.Quality);
+                if (options.HeightRatio != null) imageProcessorUrl.Append("&heightratio=" + options.HeightRatio.Value.ToString(CultureInfo.InvariantCulture));
+                if (options.WidthRatio != null) imageProcessorUrl.Append("&widthratio=" + options.WidthRatio.Value.ToString(CultureInfo.InvariantCulture));
+                if (options.Width != null) imageProcessorUrl.Append("&width=" + options.Width);
+                if (options.Height != null) imageProcessorUrl.Append("&height=" + options.Height);
+                if (options.UpScale == false) imageProcessorUrl.Append("&upscale=false");
+                if (options.AnimationProcessMode != null) imageProcessorUrl.Append("&animationprocessmode=" + options.AnimationProcessMode);
+                if (options.FurtherOptions != null) imageProcessorUrl.Append(options.FurtherOptions);
+                if (options.Quality != null && hasFormat) imageProcessorUrl.Append("&quality=" + options.Quality);
+                if (options.CacheBusterValue != null) imageProcessorUrl.Append("&rnd=").Append(options.CacheBusterValue);
+
+                return imageProcessorUrl.ToString();
+            }
         }
     }
 }

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTestBase.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTestBase.cs
@@ -12,6 +12,7 @@ using Umbraco.Web.PropertyEditors;
 using Umbraco.Core.Services;
 using Umbraco.Web;
 using Umbraco.Web.Templates;
+using Umbraco.Web.Models;
 
 namespace Umbraco.Tests.PublishedContent
 {
@@ -46,7 +47,7 @@ namespace Umbraco.Tests.PublishedContent
             var pastedImages = new RichTextEditorPastedImages(umbracoContextAccessor, logger, Mock.Of<IMediaService>(), Mock.Of<IContentTypeBaseServiceProvider>());
             var localLinkParser = new HtmlLocalLinkParser(umbracoContextAccessor);
             var dataTypeService = new TestObjects.TestDataTypeService(
-                new DataType(new RichTextPropertyEditor(logger, umbracoContextAccessor, imageSourceParser, localLinkParser, pastedImages)) { Id = 1 });
+                new DataType(new RichTextPropertyEditor(logger, umbracoContextAccessor, imageSourceParser, localLinkParser, pastedImages, Mock.Of<IImageUrlGenerator>())) { Id = 1 });
 
             var publishedContentTypeFactory = new PublishedContentTypeFactory(Mock.Of<IPublishedModelFactory>(), converters, dataTypeService);
 

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -22,6 +22,7 @@ using Umbraco.Tests.Testing;
 using Umbraco.Web.Models.PublishedContent;
 using Umbraco.Web.PropertyEditors;
 using Umbraco.Web.Templates;
+using Umbraco.Web.Models;
 
 namespace Umbraco.Tests.PublishedContent
 {
@@ -53,7 +54,7 @@ namespace Umbraco.Tests.PublishedContent
             var dataTypeService = new TestObjects.TestDataTypeService(
                 new DataType(new VoidEditor(logger)) { Id = 1 },
                 new DataType(new TrueFalsePropertyEditor(logger)) { Id = 1001 },
-                new DataType(new RichTextPropertyEditor(logger, umbracoContextAccessor, imageSourceParser, linkParser, pastedImages)) { Id = 1002 },
+                new DataType(new RichTextPropertyEditor(logger, umbracoContextAccessor, imageSourceParser, linkParser, pastedImages, Mock.Of<IImageUrlGenerator>())) { Id = 1002 },
                 new DataType(new IntegerPropertyEditor(logger)) { Id = 1003 },
                 new DataType(new TextboxPropertyEditor(logger)) { Id = 1004 },
                 new DataType(new MediaPickerPropertyEditor(logger)) { Id = 1005 });

--- a/src/Umbraco.Tests/Runtimes/StandaloneTests.cs
+++ b/src/Umbraco.Tests/Runtimes/StandaloneTests.cs
@@ -97,6 +97,7 @@ namespace Umbraco.Tests.Runtimes
             composition.Register<IVariationContextAccessor, TestVariationContextAccessor>(Lifetime.Singleton);
             composition.Register<IDefaultCultureAccessor, TestDefaultCultureAccessor>(Lifetime.Singleton);
             composition.Register<ISiteDomainHelper>(_ => Mock.Of<ISiteDomainHelper>(), Lifetime.Singleton);
+            composition.Register(_ => Mock.Of<IImageUrlGenerator>(), Lifetime.Singleton);
             composition.RegisterUnique(f => new DistributedCache());
             composition.WithCollectionBuilder<UrlProviderCollectionBuilder>().Append<DefaultUrlProvider>();
             composition.RegisterUnique<IDistributedCacheBinder, DistributedCacheBinder>();

--- a/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
@@ -43,6 +43,7 @@ using Current = Umbraco.Core.Composing.Current;
 using FileSystems = Umbraco.Core.IO.FileSystems;
 using Umbraco.Web.Templates;
 using Umbraco.Web.PropertyEditors;
+using Umbraco.Core.Models;
 
 namespace Umbraco.Tests.Testing
 {
@@ -248,6 +249,7 @@ namespace Umbraco.Tests.Testing
             var runtimeStateMock = new Mock<IRuntimeState>();
             runtimeStateMock.Setup(x => x.Level).Returns(RuntimeLevel.Run);
             Composition.RegisterUnique(f => runtimeStateMock.Object);
+            Composition.Register(_ => Mock.Of<IImageUrlGenerator>());
 
             // ah...
             Composition.WithCollectionBuilder<ActionCollectionBuilder>();

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="ModelsBuilder\UmbracoApplicationTests.cs" />
     <Compile Include="Models\ContentScheduleTests.cs" />
     <Compile Include="Models\CultureImpactTests.cs" />
+    <Compile Include="Models\ImageProcessorImageUrlGeneratorTest.cs" />
     <Compile Include="Models\PathValidationTests.cs" />
     <Compile Include="Models\VariationTests.cs" />
     <Compile Include="Persistence\Mappers\MapperTestBase.cs" />

--- a/src/Umbraco.Web.UI.Client/src/common/resources/imageurlgenerator.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/imageurlgenerator.resource.js
@@ -1,0 +1,36 @@
+﻿/**
+ * @ngdoc service
+ * @name umbraco.resources.imageUrlGeneratorResource
+ * @function
+ *
+ * @description
+ * Used by the various controllers to get an image URL formatted correctly for the current image URL generator
+ */
+(function () {
+    'use strict';
+
+    function imageUrlGeneratorResource($http, umbRequestHelper) {
+
+        function getCropUrl(mediaPath, width, height, imageCropMode, animationProcessMode) {
+
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "imageUrlGeneratorApiBaseUrl",
+                        "GetCropUrl",
+                        { mediaPath, width, height, imageCropMode, animationProcessMode })),
+                'Failed to get crop URL');
+        }
+
+
+        var resource = {
+            getCropUrl: getCropUrl
+        };
+
+        return resource;
+
+    }
+
+    angular.module('umbraco.resources').factory('imageUrlGeneratorResource', imageUrlGeneratorResource);
+
+})();

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/Media.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/Media.cshtml
@@ -2,20 +2,24 @@
 @using Umbraco.Web.Templates
 
 @if (Model.value != null)
-{   
+{
     var url = Model.value.image;
     if(Model.editor.config != null && Model.editor.config.size != null){
-        url += "?width=" + Model.editor.config.size.width;
-        url += "&height=" + Model.editor.config.size.height;
-
-        if(Model.value.focalPoint != null){
-            url += "&center=" + Model.value.focalPoint.top +"," + Model.value.focalPoint.left;
-            url += "&mode=crop";
-        }
+        url = ImageCropperTemplateExtensions.GetCropUrl(url,
+            width: Model.editor.config.size.width,
+            height: Model.editor.config.size.height,
+            cropDataSet: Model.value.focalPoint == null ? null : new Umbraco.Core.PropertyEditors.ValueConverters.ImageCropperValue
+            {
+                FocalPoint = new Umbraco.Core.PropertyEditors.ValueConverters.ImageCropperValue.ImageCropperFocalPoint
+                {
+                    Top = Model.value.focalPoint.top,
+                    Left = Model.value.focalPoint.left
+                }
+            });
     }
 
     var altText = Model.value.altText ?? Model.value.caption ?? string.Empty;
-    
+
     <img src="@url" alt="@altText">
     
     if (Model.value.caption != null)

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -314,6 +314,10 @@ namespace Umbraco.Web.Editors
                             "tinyMceApiBaseUrl", _urlHelper.GetUmbracoApiServiceBaseUrl<TinyMceController>(
                                 controller => controller.UploadImage())
                         },
+                        {
+                            "imageUrlGeneratorApiBaseUrl", _urlHelper.GetUmbracoApiServiceBaseUrl<ImageUrlGeneratorController>(
+                                controller => controller.GetCropUrl(null, null, null, null, null))
+                        },
                     }
                 },
                 {

--- a/src/Umbraco.Web/Editors/ImageUrlGeneratorController.cs
+++ b/src/Umbraco.Web/Editors/ImageUrlGeneratorController.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Models;
+using Umbraco.Web.Models;
+using Umbraco.Web.Mvc;
+
+namespace Umbraco.Web.Editors
+{
+    /// <summary>
+    /// The API controller used for getting URLs for images with parameters
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This controller allows for retrieving URLs for processed images, such as resized, cropped,
+    /// or otherwise altered.  These can be different based on the IImageUrlGenerator
+    /// implementation in use, and so back-office could should not rely on hard-coded string
+    /// building to generate correct URLs
+    /// </para>
+    /// </remarks>
+    [PluginController("UmbracoApi")]
+    public class ImageUrlGeneratorController
+    {
+        private readonly IImageUrlGenerator _imageUrlGenerator;
+
+        public ImageUrlGeneratorController(IImageUrlGenerator imageUrlGenerator)
+        {
+            _imageUrlGenerator = imageUrlGenerator;
+        }
+
+        public string GetCropUrl(string mediaPath, int? width = null, int? height = null, ImageCropMode? imageCropMode = null, string animationProcessMode = null)
+        {
+            return mediaPath.GetCropUrl(_imageUrlGenerator, null, width: width, height: height, imageCropMode: imageCropMode, animationProcessMode: animationProcessMode);
+        }
+    }
+}

--- a/src/Umbraco.Web/Editors/ImageUrlGeneratorController.cs
+++ b/src/Umbraco.Web/Editors/ImageUrlGeneratorController.cs
@@ -16,12 +16,11 @@ namespace Umbraco.Web.Editors
     /// <para>
     /// This controller allows for retrieving URLs for processed images, such as resized, cropped,
     /// or otherwise altered.  These can be different based on the IImageUrlGenerator
-    /// implementation in use, and so back-office could should not rely on hard-coded string
+    /// implementation in use, and so the BackOffice could should not rely on hard-coded string
     /// building to generate correct URLs
     /// </para>
     /// </remarks>
-    [PluginController("UmbracoApi")]
-    public class ImageUrlGeneratorController
+    public class ImageUrlGeneratorController : UmbracoAuthorizedJsonController
     {
         private readonly IImageUrlGenerator _imageUrlGenerator;
 

--- a/src/Umbraco.Web/Editors/ImagesController.cs
+++ b/src/Umbraco.Web/Editors/ImagesController.cs
@@ -84,7 +84,7 @@ namespace Umbraco.Web.Editors
             }
 
             var rnd = imageLastModified.HasValue ? $"&rnd={imageLastModified:yyyyMMddHHmmss}" : null;
-            var imageUrl = _imageUrlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = imagePath, UpScale = false, Width = width, AnimationProcessMode = "first", ImageCropMode = "max", CacheBusterValue = rnd });
+            var imageUrl = _imageUrlGenerator.GetImageUrl(new ImageUrlGenerationOptions(imagePath) { UpScale = false, Width = width, AnimationProcessMode = "first", ImageCropMode = "max", CacheBusterValue = rnd });
 
             response.Headers.Location = new Uri(imageUrl, UriKind.RelativeOrAbsolute);
             return response;

--- a/src/Umbraco.Web/Editors/ImagesController.cs
+++ b/src/Umbraco.Web/Editors/ImagesController.cs
@@ -2,8 +2,10 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using Umbraco.Core.Composing;
 using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.IO;
+using Umbraco.Core.Models;
 using Umbraco.Web.Media;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
@@ -19,11 +21,17 @@ namespace Umbraco.Web.Editors
     {
         private readonly IMediaFileSystem _mediaFileSystem;
         private readonly IContentSection _contentSection;
+        private readonly IImageUrlGenerator _imageUrlGenerator;
 
-        public ImagesController(IMediaFileSystem mediaFileSystem, IContentSection contentSection)
+        [Obsolete("This constructor will be removed in a future release.  Please use the constructor with the IImageUrlGenerator overload")]
+        public ImagesController(IMediaFileSystem mediaFileSystem, IContentSection contentSection) : this (mediaFileSystem, contentSection, Current.ImageUrlGenerator)
+        {
+        }
+        public ImagesController(IMediaFileSystem mediaFileSystem, IContentSection contentSection, IImageUrlGenerator imageUrlGenerator)
         {
             _mediaFileSystem = mediaFileSystem;
             _contentSection = contentSection;
+            _imageUrlGenerator = imageUrlGenerator;
         }
 
         /// <summary>
@@ -75,12 +83,10 @@ namespace Umbraco.Web.Editors
                 // so ignore and we won't set a last modified date.
             }
 
-            // TODO: When we abstract imaging for netcore, we are actually just going to be abstracting a URI builder for images, this
-            // is one of those places where this can be used.
+            var rnd = imageLastModified.HasValue ? $"&rnd={imageLastModified:yyyyMMddHHmmss}" : null;
+            var imageUrl = _imageUrlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = imagePath, UpScale = false, Width = width, AnimationProcessMode = "first", ImageCropMode = "max", CacheBusterValue = rnd });
 
-            var rnd = imageLastModified.HasValue ? $"&rnd={imageLastModified:yyyyMMddHHmmss}" : string.Empty;
-
-            response.Headers.Location = new Uri($"{imagePath}?upscale=false&width={width}&animationprocessmode=first&mode=max{rnd}", UriKind.RelativeOrAbsolute);
+            response.Headers.Location = new Uri(imageUrl, UriKind.RelativeOrAbsolute);
             return response;
         }
         

--- a/src/Umbraco.Web/ImageCropperTemplateCoreExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateCoreExtensions.cs
@@ -343,9 +343,8 @@ namespace Umbraco.Web
             }
             else
             {
-                options = new ImageUrlGenerationOptions
+                options = new ImageUrlGenerationOptions (imageUrl)
                 {
-                    ImageUrl = imageUrl,
                     ImageCropMode = (imageCropMode ?? ImageCropMode.Pad).ToString().ToLowerInvariant(),
                     ImageCropAnchor = imageCropAnchor?.ToString().ToLowerInvariant()
                 };

--- a/src/Umbraco.Web/ImageCropperTemplateCoreExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateCoreExtensions.cs
@@ -306,7 +306,8 @@ namespace Umbraco.Web
             string cacheBusterValue = null,
             string furtherOptions = null,
             ImageCropRatioMode? ratioMode = null,
-            bool upScale = true)
+            bool upScale = true,
+            string animationProcessMode = null)
         {
             if (string.IsNullOrEmpty(imageUrl)) return string.Empty;
 
@@ -353,6 +354,7 @@ namespace Umbraco.Web
             options.Quality = quality;
             options.Width = ratioMode != null && ratioMode.Value == ImageCropRatioMode.Width ? null : width;
             options.Height = ratioMode != null && ratioMode.Value == ImageCropRatioMode.Height ? null : height;
+            options.AnimationProcessMode = animationProcessMode;
 
             if (ratioMode == ImageCropRatioMode.Width && height != null)
             {

--- a/src/Umbraco.Web/Models/ImageProcessorImageUrlGenerator.cs
+++ b/src/Umbraco.Web/Models/ImageProcessorImageUrlGenerator.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+
+namespace Umbraco.Web.Models
+{
+    internal class ImageProcessorImageUrlGenerator : IImageUrlGenerator
+    {
+        public string GetImageUrl(ImageUrlGenerationOptions options)
+        {
+            var imageProcessorUrl = new StringBuilder(options.ImageUrl ?? string.Empty);
+
+            if (options.FocalPoint != null)
+            {
+                imageProcessorUrl.Append("?center=");
+                imageProcessorUrl.Append(options.FocalPoint.Top.ToString(CultureInfo.InvariantCulture));
+                imageProcessorUrl.Append(",");
+                imageProcessorUrl.Append(options.FocalPoint.Left.ToString(CultureInfo.InvariantCulture));
+                imageProcessorUrl.Append("&mode=crop");
+            }
+            else if (options.Crop != null)
+            {
+                imageProcessorUrl.Append("?crop=");
+                imageProcessorUrl.Append(options.Crop.X1.ToString(CultureInfo.InvariantCulture)).Append(",");
+                imageProcessorUrl.Append(options.Crop.Y1.ToString(CultureInfo.InvariantCulture)).Append(",");
+                imageProcessorUrl.Append(options.Crop.X2.ToString(CultureInfo.InvariantCulture)).Append(",");
+                imageProcessorUrl.Append(options.Crop.Y2.ToString(CultureInfo.InvariantCulture));
+                imageProcessorUrl.Append("&cropmode=percentage");
+            }
+            else if (options.DefaultCrop)
+            {
+                imageProcessorUrl.Append("?anchor=center");
+                imageProcessorUrl.Append("&mode=crop");
+            }
+            else
+            {
+                imageProcessorUrl.Append("?mode=" + options.ImageCropMode.ToString().ToLower());
+
+                if (options.ImageCropAnchor != null)
+                {
+                    imageProcessorUrl.Append("&anchor=" + options.ImageCropAnchor.ToString().ToLower());
+                }
+            }
+
+            var hasFormat = options.FurtherOptions != null && options.FurtherOptions.InvariantContains("&format=");
+
+            //Only put quality here, if we don't have a format specified.
+            //Otherwise we need to put quality at the end to avoid it being overridden by the format.
+            if (options.Quality != null && hasFormat == false)
+            {
+                imageProcessorUrl.Append("&quality=" + options.Quality);
+            }
+
+            if (options.HeightRatio != null)
+            {
+                imageProcessorUrl.Append("&heightratio=" + options.HeightRatio.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (options.WidthRatio != null)
+            {
+                imageProcessorUrl.Append("&widthratio=" + options.WidthRatio.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (options.Width != null)
+            {
+                imageProcessorUrl.Append("&width=" + options.Width);
+            }
+
+            if (options.Height != null)
+            {
+                imageProcessorUrl.Append("&height=" + options.Height);
+            }
+
+            if (options.UpScale == false)
+            {
+                imageProcessorUrl.Append("&upscale=false");
+            }
+
+            if (options.AnimationProcessMode != null)
+            {
+                imageProcessorUrl.Append("&animationprocessmode=" + options.AnimationProcessMode);
+            }
+
+            if (options.FurtherOptions != null)
+            {
+                imageProcessorUrl.Append(options.FurtherOptions);
+            }
+
+            //If furtherOptions contains a format, we need to put the quality after the format.
+            if (options.Quality != null && hasFormat)
+            {
+                imageProcessorUrl.Append("&quality=" + options.Quality);
+            }
+
+            if (options.CacheBusterValue != null)
+            {
+                imageProcessorUrl.Append("&rnd=").Append(options.CacheBusterValue);
+            }
+
+            return imageProcessorUrl.ToString();
+        }
+    }
+}

--- a/src/Umbraco.Web/Models/ImageProcessorImageUrlGenerator.cs
+++ b/src/Umbraco.Web/Models/ImageProcessorImageUrlGenerator.cs
@@ -13,26 +13,9 @@ namespace Umbraco.Web.Models
 
             var imageProcessorUrl = new StringBuilder(options.ImageUrl ?? string.Empty);
 
-            if (options.FocalPoint != null)
-            {
-                imageProcessorUrl.Append("?center=");
-                imageProcessorUrl.Append(options.FocalPoint.Top.ToString(CultureInfo.InvariantCulture)).Append(",");
-                imageProcessorUrl.Append(options.FocalPoint.Left.ToString(CultureInfo.InvariantCulture));
-                imageProcessorUrl.Append("&mode=crop");
-            }
-            else if (options.Crop != null)
-            {
-                imageProcessorUrl.Append("?crop=");
-                imageProcessorUrl.Append(options.Crop.X1.ToString(CultureInfo.InvariantCulture)).Append(",");
-                imageProcessorUrl.Append(options.Crop.Y1.ToString(CultureInfo.InvariantCulture)).Append(",");
-                imageProcessorUrl.Append(options.Crop.X2.ToString(CultureInfo.InvariantCulture)).Append(",");
-                imageProcessorUrl.Append(options.Crop.Y2.ToString(CultureInfo.InvariantCulture));
-                imageProcessorUrl.Append("&cropmode=percentage");
-            }
-            else if (options.DefaultCrop)
-            {
-                imageProcessorUrl.Append("?anchor=center&mode=crop");
-            }
+            if (options.FocalPoint != null) AppendFocalPoint(imageProcessorUrl, options);
+            else if (options.Crop != null) AppendCrop(imageProcessorUrl, options);
+            else if (options.DefaultCrop) imageProcessorUrl.Append("?anchor=center&mode=crop");
             else
             {
                 imageProcessorUrl.Append("?mode=").Append((options.ImageCropMode ?? "crop").ToLower());
@@ -58,6 +41,24 @@ namespace Umbraco.Web.Models
             if (options.CacheBusterValue != null) imageProcessorUrl.Append("&rnd=").Append(options.CacheBusterValue);
 
             return imageProcessorUrl.ToString();
+        }
+
+        private void AppendFocalPoint(StringBuilder imageProcessorUrl, ImageUrlGenerationOptions options)
+        {
+            imageProcessorUrl.Append("?center=");
+            imageProcessorUrl.Append(options.FocalPoint.Top.ToString(CultureInfo.InvariantCulture)).Append(",");
+            imageProcessorUrl.Append(options.FocalPoint.Left.ToString(CultureInfo.InvariantCulture));
+            imageProcessorUrl.Append("&mode=crop");
+        }
+
+        private void AppendCrop(StringBuilder imageProcessorUrl, ImageUrlGenerationOptions options)
+        {
+            imageProcessorUrl.Append("?crop=");
+            imageProcessorUrl.Append(options.Crop.X1.ToString(CultureInfo.InvariantCulture)).Append(",");
+            imageProcessorUrl.Append(options.Crop.Y1.ToString(CultureInfo.InvariantCulture)).Append(",");
+            imageProcessorUrl.Append(options.Crop.X2.ToString(CultureInfo.InvariantCulture)).Append(",");
+            imageProcessorUrl.Append(options.Crop.Y2.ToString(CultureInfo.InvariantCulture));
+            imageProcessorUrl.Append("&cropmode=percentage");
         }
     }
 }

--- a/src/Umbraco.Web/Models/ImageProcessorImageUrlGenerator.cs
+++ b/src/Umbraco.Web/Models/ImageProcessorImageUrlGenerator.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using System.Text;
-using System.Threading.Tasks;
 using Umbraco.Core;
 using Umbraco.Core.Models;
 
@@ -13,13 +9,14 @@ namespace Umbraco.Web.Models
     {
         public string GetImageUrl(ImageUrlGenerationOptions options)
         {
+            if (options == null) return null;
+
             var imageProcessorUrl = new StringBuilder(options.ImageUrl ?? string.Empty);
 
             if (options.FocalPoint != null)
             {
                 imageProcessorUrl.Append("?center=");
-                imageProcessorUrl.Append(options.FocalPoint.Top.ToString(CultureInfo.InvariantCulture));
-                imageProcessorUrl.Append(",");
+                imageProcessorUrl.Append(options.FocalPoint.Top.ToString(CultureInfo.InvariantCulture)).Append(",");
                 imageProcessorUrl.Append(options.FocalPoint.Left.ToString(CultureInfo.InvariantCulture));
                 imageProcessorUrl.Append("&mode=crop");
             }
@@ -34,73 +31,31 @@ namespace Umbraco.Web.Models
             }
             else if (options.DefaultCrop)
             {
-                imageProcessorUrl.Append("?anchor=center");
-                imageProcessorUrl.Append("&mode=crop");
+                imageProcessorUrl.Append("?anchor=center&mode=crop");
             }
             else
             {
-                imageProcessorUrl.Append("?mode=" + options.ImageCropMode.ToString().ToLower());
+                imageProcessorUrl.Append("?mode=").Append((options.ImageCropMode ?? "crop").ToLower());
 
-                if (options.ImageCropAnchor != null)
-                {
-                    imageProcessorUrl.Append("&anchor=" + options.ImageCropAnchor.ToString().ToLower());
-                }
+                if (options.ImageCropAnchor != null) imageProcessorUrl.Append("&anchor=").Append(options.ImageCropAnchor.ToLower());
             }
 
             var hasFormat = options.FurtherOptions != null && options.FurtherOptions.InvariantContains("&format=");
 
             //Only put quality here, if we don't have a format specified.
             //Otherwise we need to put quality at the end to avoid it being overridden by the format.
-            if (options.Quality != null && hasFormat == false)
-            {
-                imageProcessorUrl.Append("&quality=" + options.Quality);
-            }
-
-            if (options.HeightRatio != null)
-            {
-                imageProcessorUrl.Append("&heightratio=" + options.HeightRatio.Value.ToString(CultureInfo.InvariantCulture));
-            }
-
-            if (options.WidthRatio != null)
-            {
-                imageProcessorUrl.Append("&widthratio=" + options.WidthRatio.Value.ToString(CultureInfo.InvariantCulture));
-            }
-
-            if (options.Width != null)
-            {
-                imageProcessorUrl.Append("&width=" + options.Width);
-            }
-
-            if (options.Height != null)
-            {
-                imageProcessorUrl.Append("&height=" + options.Height);
-            }
-
-            if (options.UpScale == false)
-            {
-                imageProcessorUrl.Append("&upscale=false");
-            }
-
-            if (options.AnimationProcessMode != null)
-            {
-                imageProcessorUrl.Append("&animationprocessmode=" + options.AnimationProcessMode);
-            }
-
-            if (options.FurtherOptions != null)
-            {
-                imageProcessorUrl.Append(options.FurtherOptions);
-            }
+            if (options.Quality != null && hasFormat == false) imageProcessorUrl.Append("&quality=").Append(options.Quality);
+            if (options.HeightRatio != null) imageProcessorUrl.Append("&heightratio=").Append(options.HeightRatio.Value.ToString(CultureInfo.InvariantCulture));
+            if (options.WidthRatio != null) imageProcessorUrl.Append("&widthratio=").Append(options.WidthRatio.Value.ToString(CultureInfo.InvariantCulture));
+            if (options.Width != null) imageProcessorUrl.Append("&width=").Append(options.Width);
+            if (options.Height != null) imageProcessorUrl.Append("&height=").Append(options.Height);
+            if (options.UpScale == false) imageProcessorUrl.Append("&upscale=false");
+            if (options.AnimationProcessMode != null) imageProcessorUrl.Append("&animationprocessmode=").Append(options.AnimationProcessMode);
+            if (options.FurtherOptions != null) imageProcessorUrl.Append(options.FurtherOptions);
 
             //If furtherOptions contains a format, we need to put the quality after the format.
-            if (options.Quality != null && hasFormat)
-            {
-                imageProcessorUrl.Append("&quality=" + options.Quality);
-            }
-
-            if (options.CacheBusterValue != null)
-            {
-                imageProcessorUrl.Append("&rnd=").Append(options.CacheBusterValue);
-            }
+            if (options.Quality != null && hasFormat) imageProcessorUrl.Append("&quality=").Append(options.Quality);
+            if (options.CacheBusterValue != null) imageProcessorUrl.Append("&rnd=").Append(options.CacheBusterValue);
 
             return imageProcessorUrl.ToString();
         }

--- a/src/Umbraco.Web/PropertyEditors/RichTextEditorPastedImages.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextEditorPastedImages.cs
@@ -36,7 +36,7 @@ namespace Umbraco.Web.PropertyEditors
         /// <param name="mediaParentFolder"></param>
         /// <param name="userId"></param>
         /// <returns></returns>
-        internal string FindAndPersistPastedTempImages(string html, Guid mediaParentFolder, int userId)
+        internal string FindAndPersistPastedTempImages(string html, Guid mediaParentFolder, int userId, IImageUrlGenerator imageUrlGenerator)
         {
             // Find all img's that has data-tmpimg attribute
             // Use HTML Agility Pack - https://html-agility-pack.net
@@ -109,7 +109,7 @@ namespace Umbraco.Web.PropertyEditors
 
                 if (width != int.MinValue && height != int.MinValue)
                 {
-                    location = $"{location}?width={width}&height={height}&mode=max";
+                    location = imageUrlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = location, ImageCropMode = "max", Width = width, Height = height });
                 }
 
                 img.SetAttributeValue("src", location);

--- a/src/Umbraco.Web/PropertyEditors/RichTextEditorPastedImages.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextEditorPastedImages.cs
@@ -109,7 +109,7 @@ namespace Umbraco.Web.PropertyEditors
 
                 if (width != int.MinValue && height != int.MinValue)
                 {
-                    location = imageUrlGenerator.GetImageUrl(new ImageUrlGenerationOptions { ImageUrl = location, ImageCropMode = "max", Width = width, Height = height });
+                    location = imageUrlGenerator.GetImageUrl(new ImageUrlGenerationOptions(location) { ImageCropMode = "max", Width = width, Height = height });
                 }
 
                 img.SetAttributeValue("src", location);

--- a/src/Umbraco.Web/Runtime/WebInitialComposer.cs
+++ b/src/Umbraco.Web/Runtime/WebInitialComposer.cs
@@ -38,6 +38,8 @@ using Umbraco.Web.Trees;
 using Umbraco.Web.WebApi;
 using Current = Umbraco.Web.Composing.Current;
 using Umbraco.Web.PropertyEditors;
+using Umbraco.Core.Models;
+using Umbraco.Web.Models;
 
 namespace Umbraco.Web.Runtime
 {
@@ -189,6 +191,8 @@ namespace Umbraco.Web.Runtime
 
             composition.MediaUrlProviders()
                 .Append<DefaultMediaUrlProvider>();
+
+            composition.RegisterUnique<IImageUrlGenerator, ImageProcessorImageUrlGenerator>();
 
             composition.RegisterUnique<IContentLastChanceFinder, ContentFinderByConfigured404>();
 

--- a/src/Umbraco.Web/Templates/TemplateUtilities.cs
+++ b/src/Umbraco.Web/Templates/TemplateUtilities.cs
@@ -52,6 +52,6 @@ namespace Umbraco.Web.Templates
 
         [Obsolete("Use " + nameof(HtmlImageSourceParser) + "." + nameof(RichTextEditorPastedImages.FindAndPersistPastedTempImages) + " instead")]
         internal static string FindAndPersistPastedTempImages(string html, Guid mediaParentFolder, int userId, IMediaService mediaService, IContentTypeBaseServiceProvider contentTypeBaseServiceProvider, ILogger logger)
-            => Current.Factory.GetInstance<RichTextEditorPastedImages>().FindAndPersistPastedTempImages(html, mediaParentFolder, userId);
+            => Current.Factory.GetInstance<RichTextEditorPastedImages>().FindAndPersistPastedTempImages(html, mediaParentFolder, userId, Current.Factory.GetInstance<IImageUrlGenerator>());
     }
 }

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Editors\BackOfficePreviewModel.cs" />
     <Compile Include="Editors\Filters\ContentSaveModelValidator.cs" />
     <Compile Include="Editors\Filters\MediaSaveModelValidator.cs" />
+    <Compile Include="Editors\ImageUrlGeneratorController.cs" />
     <Compile Include="Editors\PackageController.cs" />
     <Compile Include="Editors\KeepAliveController.cs" />
     <Compile Include="Editors\MacrosController.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Editors\MacrosController.cs" />
     <Compile Include="Editors\RelationTypeController.cs" />
     <Compile Include="Editors\TinyMceController.cs" />
+    <Compile Include="ImageCropperTemplateCoreExtensions.cs" />
     <Compile Include="IUmbracoContextFactory.cs" />
     <Compile Include="Install\ChangesMonitor.cs" />
     <Compile Include="Logging\WebProfiler.cs" />
@@ -223,6 +224,7 @@
     <Compile Include="Models\ContentEditing\MacroDisplay.cs" />
     <Compile Include="Models\ContentEditing\MacroParameterDisplay.cs" />
     <Compile Include="Models\ContentEditing\UrlAndAnchors.cs" />
+    <Compile Include="Models\ImageProcessorImageUrlGenerator.cs" />
     <Compile Include="Models\Mapping\CommonMapper.cs" />
     <Compile Include="Models\Mapping\MapperContextExtensions.cs" />
     <Compile Include="Models\PublishedContent\HybridVariationContextAccessor.cs" />


### PR DESCRIPTION
### Prerequisites

- [ X ] I have added steps to test this contribution in the description below

This resolves issue #7538 

### Description

I created an IImageUrlGenerator interface, along with an ImageProcessorImageUrlGenerator implementation.  I injected that implementation at startup, reworked the ImageCropperTemplateExtensions and ImageCropperValue classes to use it, and then updated other classes and tests that were hard-coded with image URL parameters so that they used the implementation.  This included adding constructors to various classes so that they could accept an injected IImageUrlGenerator implementation, and then obsoleting the previous constructor so that we can delete it in the .NET Core project.

To test this you should spin up a new site with the starter pack, and verify that cropped media show up correctly on the front end.  Specifically, test the following:

- A simple cropped image used directly in a template
- A cropped image used within an RTE
- A cropped image used within an RTE inside a grid
- A custom user avatar in the back-office

Existing unit tests for ImageCropper have been updated to use the new class, but no new unit tests were added.