### PR TITLE
8.6RC: Prevent multi URL picker from crashing for non-local links

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -147,7 +147,7 @@ function multiUrlPickerController($scope, angularHelper, localizationService, en
 
         _.each($scope.model.value, function (item){
             // we must reload the "document" link URLs to match the current editor culture
-            if (item.udi.indexOf("/document/") > 0) {
+            if (item.udi && item.udi.indexOf("/document/") > 0) {
                 item.url = null;
                 entityResource.getUrlByUdi(item.udi).then(function (data) {
                     item.url = data;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As described in #7543, the changes in #7130 causes the multi URL picker to crash with JS errors when it contains non-local (absolute) links.

#### Steps to reproduce

For a piece of content with a multi URL picker:

1. Add a new item to the multi URL picker and enter e.g. "https://somewhere.com" in the link field:
![image](https://user-images.githubusercontent.com/7405322/74152226-20b1d580-4c0e-11ea-8cd2-6ffcdde109f2.png)
2. Save the content item.
3. Reload the browser.
4. The multi URL picker is not displays as empty, and the JS console is full of errors:
![image](https://user-images.githubusercontent.com/7405322/74152330-61115380-4c0e-11ea-80a1-62fb89b04e52.png)

When this PR is applied, the multi URL picker displays all added items after saving the content and reloading the browser:

![image](https://user-images.githubusercontent.com/7405322/74152032-bc8f1180-4c0d-11ea-8144-803d05d2f2fd.png)
