### PR TITLE
V8: Rollback fails for content with numeric or decimal property values

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.controller.js
@@ -130,8 +130,8 @@
                     }
 
                     // diff requires a string
-                    property.value = property.value ? property.value : "";
-                    oldProperty.value = oldProperty.value ? oldProperty.value : "";
+                    property.value = property.value ? property.value + "" : "";
+                    oldProperty.value = oldProperty.value ? oldProperty.value + "" : "";
 
                     var diffProperty = {
                         "alias": property.alias,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If content contains properties of type numeric or decimal (and possibly more), the rollback dialog logs errors in the JS console and the "Rollback" button never gets enabled:

![image](https://user-images.githubusercontent.com/7405322/74154831-b439d500-4c13-11ea-9aee-5d4a1248a597.png)

![image](https://user-images.githubusercontent.com/7405322/74154816-a97f4000-4c13-11ea-9f91-f5e1476c0155.png)

#### Steps to reproduce

For content with a numeric or decimal property:

1. Enter a value in the numeric/decimal property.
2. Save the content.
3. Reload the browser window.
4. Attempt to rollback the content to a previous version.

This PR ensures that the diff is always performed on string values, thus fixing the error and re-enabling rollback for the content:

![image](https://user-images.githubusercontent.com/7405322/74155020-11358b00-4c14-11ea-93dc-c6efa6587258.png)

