### PR TITLE
V8: Open rollback in a medium sized panel

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -525,7 +525,7 @@ When building a custom infinite editor view you can use the same components as a
 
         function rollback(editor) {
             editor.view = "views/common/infiniteeditors/rollback/rollback.html";
-            if (!editor.size) editor.size = "small";
+            if (!editor.size) editor.size = "medium";
             open(editor);
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It doesn't take a whole lot of effort to make the rollback panel overflow due to the content of the diffs:

![image](https://user-images.githubusercontent.com/7405322/74155437-e4ce3e80-4c14-11ea-908e-4d8078575178.png)

This PR turns the panel from `small` to `medium` to give a little more space for the diff:

![image](https://user-images.githubusercontent.com/7405322/74155338-b8b2bd80-4c14-11ea-99cf-2dea4606ed50.png)
