### PR TITLE
V8: Fix Nested Content JS errors when enforcing min items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -480,10 +480,12 @@
                 }
 
                 // Enforce min items if we only have one scaffold type
+                var modelWasChanged = false;
                 if (vm.nodes.length < vm.minItems && vm.scaffolds.length === 1) {
                     for (var i = vm.nodes.length; i < model.config.minItems; i++) {
                         addNode(vm.scaffolds[0].contentTypeAlias);
                     }
+                    modelWasChanged = true;
                 }
 
                 // If there is only one item, set it as current node
@@ -494,6 +496,10 @@
                 validate();
 
                 vm.inited = true;
+
+                if (modelWasChanged) {
+                    updateModel();
+                }
 
                 updatePropertyActionStates();
                 checkAbilityToPasteContent();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If a Nested Content property is configured with only one element type and with a minimum number of items required, the editor throws a bunch of JS errors when creating new content:

![image](https://user-images.githubusercontent.com/7405322/74167399-7d21ee80-4c28-11ea-8405-641ac47bc4b6.png)

This happens because the underlying property model isn't updated correctly after the minimum number of items has been enforced by the editor. The errors keep going and going until you collapse one of the added items.

This PR ensures that the underlying property model is updated if items are added to it when the property editor loads.

#### Testing this PR

1. Create a content type with a Nested Content property configured with:
   - Only one element type
   - Minimum number of elements >= 1 
2. Create some content based on this content type.
3. Verify that the JS console is error free.