### PR TITLE
v8: Punctuation and grammar fix on the install screen

### DIFF
--- a/src/Umbraco.Web/Install/InstallSteps/SetUmbracoVersionStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/SetUmbracoVersionStep.cs
@@ -13,7 +13,7 @@ using Umbraco.Web.Security;
 namespace Umbraco.Web.Install.InstallSteps
 {
     [InstallSetupStep(InstallationType.NewInstall | InstallationType.Upgrade,
-        "UmbracoVersion", 50, "Installation is complete!, get ready to be redirected to your new CMS.",
+        "UmbracoVersion", 50, "Installation is complete! Get ready to be redirected to your new CMS.",
         PerformsAppRestart = true)]
     internal class SetUmbracoVersionStep : InstallSetupStep<object>
     {


### PR DESCRIPTION
This message bugged me so I fixed it. 

It used to say "Installation is complete!, get ready..."

but now it says,

"Installation is complete! Get ready..."