### PR TITLE
V8: Nested Content can't add multiple items 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -221,6 +221,7 @@
             if (vm.overlayMenu.availableItems.length === 1 && vm.overlayMenu.pasteItems.length === 0) {
                 // only one scaffold type - no need to display the picker
                 addNode(vm.scaffolds[0].contentTypeAlias);
+                vm.overlayMenu = null;
                 return;
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If Nested Content is configured with only one element type, the editor only lets you add a single item - regardless of any upper (or lower) limit being set or not.

The workaround: Add the items one at a time and reload the browser window between adds 😆 

This PR fixes the problem.