### PR TITLE
V8: Only show culture for content links if there is more than one culture

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -328,6 +328,9 @@
                     // invariant nodes
                     scope.currentUrls = scope.node.urls;
                 }
+
+                // figure out if multiple cultures apply across the content urls
+                scope.currentUrlsHaveMultipleCultures = _.keys(_.groupBy(scope.currentUrls, url => url.culture)).length > 1;
             }
 
             // load audit trail and redirects when on the info tab

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -8,13 +8,13 @@
                 <ul class="nav nav-stacked" style="margin-bottom: 0;">
                     <li ng-repeat="url in currentUrls">
                         <a href="{{url.text}}" target="_blank" ng-if="url.isUrl">
-                            <span ng-if="node.variants.length === 1 && url.culture" style="font-size: 13px; color: #cccccc; width: 50px;display: inline-block">{{url.culture}}</span>
+                            <span ng-if="currentUrlsHaveMultipleCultures && url.culture" style="font-size: 13px; color: #cccccc; width: 50px;display: inline-block">{{url.culture}}</span>
                             <i class="icon icon-out"></i>
                             <span>{{url.text}}</span>
                         </a>
                         <div ng-if="!url.isUrl" style="margin-top: 4px;">
 
-                            <span ng-if="node.variants.length === 1 && url.culture" style="font-size: 13px; color: #cccccc; width: 50px;display: inline-block">{{url.culture}}</span>
+                            <span ng-if="currentUrlsHaveMultipleCultures && url.culture" style="font-size: 13px; color: #cccccc; width: 50px;display: inline-block">{{url.culture}}</span>
                             <em>{{url.text}}</em>
 
                         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The content links on the Info app for culture invariant content always seem to show specific culture indicators, even there is only one culture that applies:

![content-link-culture-before](https://user-images.githubusercontent.com/7405322/74180353-a601ae00-4c3f-11ea-9945-07b2410c6890.png)

This seems a bit silly, so this PR removes those culture indicator unless there's an actual culture difference between the content links:

![content-link-culture-after](https://user-images.githubusercontent.com/7405322/74180452-d21d2f00-4c3f-11ea-9b3b-ab4a2166c349.png)

#### Steps to reproduce

1. Create a site with only one language.
2. Edit any content on the site.
3. The culture indicators are shown.

#### Stuff to test

1. The steps above should not yield any culture indicators for the content.
2. Adding a second language *and* binding a hostname to that language should result in hostname specific culture indicators for the same content.
