### PR TITLE
V8: Align "Field is mandatory" label with the toggle button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
@@ -56,7 +56,8 @@
                 "validation_validateAsEmail", 
                 "validation_validateAsNumber", 
                 "validation_validateAsUrl", 
-                "validation_enterCustomValidation"
+                "validation_enterCustomValidation",
+                "validation_fieldIsMandatory"
             ];
 
             localizationService.localizeMany(labels)
@@ -66,6 +67,7 @@
                     vm.labels.validateAsNumber = data[1];
                     vm.labels.validateAsUrl = data[2];
                     vm.labels.customValidation = data[3];
+                    vm.labels.fieldIsMandatory = data[4];
 
                     vm.validationTypes = [
                         {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -84,14 +84,15 @@
 
                             <h5><localize key="validation_validation"></localize></h5>
 
-                            <label>
-                                <localize key="validation_fieldIsMandatory"></localize>
-                            </label>
-
                             <umb-toggle data-element="validation_mandatory"
                                         checked="model.property.validation.mandatory"
-                                        on-click="vm.toggleValidation()">
+                                        on-click="vm.toggleValidation()"
+                                        label-on="{{vm.labels.fieldIsMandatory}}"
+                                        label-off="{{vm.labels.fieldIsMandatory}}"
+                                        show-labels="true"
+                                        label-position="right"
                                         focus-when="{{vm.focusOnMandatoryField}}"
+                                        class="mb1">
                             </umb-toggle>
 
                             <input type="text"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I'm not sure why the "Field is mandatory" label for properties isn't set as a label for the toggle button... it seems odd, specially with the recently introduced custom error message text field below:

![property-mandatory-label-position-before](https://user-images.githubusercontent.com/7405322/74180810-68515500-4c40-11ea-87a3-02b5d2cf4ec5.png)

This PR changes things around so the label becomes part of the toggle button:

![property-mandatory-label-position-after](https://user-images.githubusercontent.com/7405322/74180949-aa7a9680-4c40-11ea-8d9a-428f7b361b8b.png)
