### PR TITLE
V8: Empty asset URLs in plugin manifests should not break the backoffice

### DIFF
--- a/src/Umbraco.Web/JavaScript/AssetInitialization.cs
+++ b/src/Umbraco.Web/JavaScript/AssetInitialization.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Web;
 using ClientDependency.Core;
 using ClientDependency.Core.Config;
+using Umbraco.Core;
 using Umbraco.Web.Composing;
 using Umbraco.Web.PropertyEditors;
 
@@ -35,7 +36,7 @@ namespace Umbraco.Web.JavaScript
             var requestUrl = httpContext.Request.Url;
             if (requestUrl == null) throw new ArgumentException("HttpContext.Request.Url is null.", nameof(httpContext));
 
-            var dependencies = assets.Select(x =>
+            var dependencies = assets.Where(x => x.IsNullOrWhiteSpace() == false).Select(x =>
             {
                 // most declarations with be made relative to the /umbraco folder, so things
                 // like lib/blah/blah.js so we need to turn them into absolutes here


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7578

### Description

See an excellent issue description in #7578. 

#### Steps to test

1. Add a folder under `App_Plugins` containing a `package.manifest` file with the following contents:
```
{
  javascript: [
    ""
  ]
}
```
2. Restart the site.
3. Verify that the JS console remains error free.