### PR TITLE
V8: Fix the create dialog on empty installs (help newcomers)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -22,10 +22,14 @@ function contentCreateController($scope,
     function initialize() {
         $scope.loading = true;
         $scope.allowedTypes = null;
-        $scope.countTypes = contentTypeResource.getCount;
         
         var getAllowedTypes = contentTypeResource.getAllowedTypes($scope.currentNode.id).then(function (data) {
             $scope.allowedTypes = iconHelper.formatContentTypeIcons(data);
+            if ($scope.allowedTypes.length === 0) {
+                contentTypeResource.getCount().then(function(count) {
+                    $scope.countTypes = count;
+                });
+            }
         });
         var getCurrentUser = authResource.getCurrentUser().then(function (currentUser) {
             if (currentUser.allowedSections.indexOf("settings") > -1) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7571

### Description

The changes added to aid newcomers in #6573 don't exactly work; the create dialog on empty installs still looks very very empty:

![image](https://user-images.githubusercontent.com/7405322/74215712-48eb1400-4ca2-11ea-9de6-57baa220e071.png)

This PR fixes it, so the create dialog actually helps newcomers get on with creating content types:

![image](https://user-images.githubusercontent.com/7405322/74215737-61f3c500-4ca2-11ea-897d-40416d1323c8.png)

The "Create a new document type" of course only shows if the current editor has access to the Settings section.

If a one or more content types do exist but none are marked as allowed at root, the create dialog contains this message:

![image](https://user-images.githubusercontent.com/7405322/74215789-9a939e80-4ca2-11ea-9f00-d3c4e0bc017e.png)
