### PR TITLE
Replaced instances of Current.Services.MediaService in more Unit Tests

### DIFF
--- a/src/Umbraco.Tests/Cache/PublishedCache/PublishedMediaCacheTests.cs
+++ b/src/Umbraco.Tests/Cache/PublishedCache/PublishedMediaCacheTests.cs
@@ -99,7 +99,7 @@ namespace Umbraco.Tests.Cache.PublishedCache
 
             //var publishedMedia = PublishedMediaTests.GetNode(mRoot.Id, GetUmbracoContext("/test", 1234));
             var umbracoContext = GetUmbracoContext("/test");
-            var cache = new PublishedMediaCache(new XmlStore((XmlDocument)null, null, null, null, HostingEnvironment), Current.Services.MediaService, Current.Services.UserService, new DictionaryAppCache(), ContentTypesCache, Factory.GetInstance<IEntityXmlSerializer>(), Factory.GetInstance<IUmbracoContextAccessor>(), VariationContextAccessor);
+            var cache = new PublishedMediaCache(new XmlStore((XmlDocument)null, null, null, null, HostingEnvironment), ServiceContext.MediaService, ServiceContext.UserService, new DictionaryAppCache(), ContentTypesCache, Factory.GetInstance<IEntityXmlSerializer>(), Factory.GetInstance<IUmbracoContextAccessor>(), VariationContextAccessor);
             var publishedMedia = cache.GetById(mRoot.Id);
             Assert.IsNotNull(publishedMedia);
 

--- a/src/Umbraco.Tests/LegacyXmlPublishedCache/PublishedMediaCache.cs
+++ b/src/Umbraco.Tests/LegacyXmlPublishedCache/PublishedMediaCache.cs
@@ -545,7 +545,7 @@ namespace Umbraco.Tests.LegacyXmlPublishedCache
             // was library.GetMedia which had its own cache, but MediaService *also* caches
             // so, library.GetMedia is gone and now we directly work with MediaService
             // (code below copied from what library was doing)
-            var media = Current.Services.MediaService.GetById(parentId);
+            var media = _mediaService.GetById(parentId);
             if (media == null)
             {
                 return Enumerable.Empty<IPublishedContent>();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This helps to reduce the references to Current.Services as mentioned in https://github.com/umbraco/Umbraco-CMS/issues/7369

### Description
<!-- 
    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
 Replaced instances of MediaService with ServiceContext or existing injected MediaService in more unit tests. Using ServiceContext as per the remainder of the first test, and the mediaService field as per the existing code in the second test.

<!-- Thanks for contributing to Umbraco CMS! -->
