### PR TITLE
Grant access to Packages section for any user groups with access to the Developer section

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -166,6 +166,7 @@ namespace Umbraco.Core.Migrations.Upgrade
             .As("{0576E786-5C30-4000-B969-302B61E90CA3}");
 
             To<FixLanguageIsoCodeLength>("{48AD6CCD-C7A4-4305-A8AB-38728AD23FC5}");
+            To<AddPackagesSectionAccess>("{DF470D86-E5CA-42AC-9780-9D28070E25F9}");
 
             // finish migrating from v7 - recreate all keys and indexes
             To<CreateKeysAndIndexes>("{3F9764F5-73D0-4D45-8804-1240A66E43A2}");

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/AddPackagesSectionAccess.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/AddPackagesSectionAccess.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
+{
+    public class AddPackagesSectionAccess : MigrationBase
+    {
+        public AddPackagesSectionAccess(IMigrationContext context)
+            : base(context)
+        { }
+
+        public override void Migrate()
+        {
+            // Any user group which had access to the Developer section should have access to Packages
+            Database.Execute($@"
+                insert into {Constants.DatabaseSchema.Tables.UserGroup2App}
+                select userGroupId, '{Constants.Applications.Packages}'
+                from {Constants.DatabaseSchema.Tables.UserGroup2App}
+                where app='developer'");
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Manifest\ManifestFilterCollectionBuilder.cs" />
     <Compile Include="Mapping\MapperContext.cs" />
     <Compile Include="Migrations\Upgrade\Common\DeleteKeysAndIndexes.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_0_0\AddPackagesSectionAccess.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\ContentPickerPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\DecimalPreValueMigrator.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\DataTypes\IPreValueMigrator.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Version 8 promotes Packages from a tree in the Developer section to a section of its own, but when migrating from v7 no users will have access to the new section. This PR ensures that any user group which could access the Developer section in v7 is granted access to the Packages section in v8.

Testing:
- In 7.15.3, ensure that you have access to the Developer section.
- Migrate to v8.
- Check that you can access the Packages section.