### PR TITLE
Update PropertyType.cs

### DIFF
--- a/src/Umbraco.Core/Models/PropertyType.cs
+++ b/src/Umbraco.Core/Models/PropertyType.cs
@@ -178,7 +178,7 @@ namespace Umbraco.Core.Models
         /// </summary>
         /// <remarks>For generic properties, the value is <c>null</c>.</remarks>
         [DataMember]
-        internal Lazy<int> PropertyGroupId
+        public Lazy<int> PropertyGroupId
         {
             get => _propertyGroupId;
             set => SetPropertyValueAndDetectChanges(value, ref _propertyGroupId, nameof(PropertyGroupId));


### PR DESCRIPTION
Please, *please* stop making things internal when it breaks legacy behaviour (such as obtaining properties by tab group, which is precisely what this allows for).

### Prerequisites
- [ ] I have added steps to test this contribution in the description below
- [X] Increasing an access modifier from internal to public will not break any tests.

### Description
Makes PropertyGroupId public.
